### PR TITLE
Correct CSP source values

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -65,7 +65,7 @@ In Manifest V2, a source for a script directive is considered secure if it meets
 - Remote sources must not use wildcards for any domains in the [public suffix list](https://publicsuffix.org/list/) (so `*.co.uk` and `*.blogspot.com` are not allowed, although `*.foo.blogspot.com` is permitted).
 - All sources must specify a host.
 - The only permitted schemes for sources are `blob:`, `filesystem:`, `moz-extension:`, `https:`, and `wss:`.
-- The only permitted [keywords](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#sources) are: `'none'`, `'self'`, `'unsafe-eval'`, and `'wasm-unsafe-eval'`.
+- The only permitted [keywords](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources) are: `'none'`, `'self'`, `'unsafe-eval'`, and `'wasm-unsafe-eval'`.
 
 ## object-src directive
 

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -41,7 +41,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. A `<base>` element may set a base URI if its value matches any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `base-uri`:
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `base-uri`:
 
     - `<host-source>`
     - `<scheme-source>`

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -28,16 +28,21 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} **`base-uri`** directive rest
 
 ## Syntax
 
-One or more _sources_ can be allowed for the base-uri policy:
-
 ```http
-Content-Security-Policy: base-uri <source>;
-Content-Security-Policy: base-uri <source> <source>;
+Content-Security-Policy: base-uri 'none';
+Content-Security-Policy: base-uri <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-This directive uses the same [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources) syntax for arguments as other CSP directives. However, only values that match URLs make sense for `base-uri`, including `<host-source>`, `<scheme-source>`, `'self'`, and `'none'`.
+- the single keyword value `'none'`, meaning that no base URI may be set using a `<base>` element
+- a list of _source expression_ values, meaning that a `<base>` element may set a base URI if it matches any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `base-uri`:
+
+- `<host-source>`
+- `<scheme-source>`
+- the keyword value `'self'`.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -33,16 +33,19 @@ Content-Security-Policy: base-uri 'none';
 Content-Security-Policy: base-uri <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no base URI may be set using a `<base>` element
-- a list of _source expression_ values, meaning that a `<base>` element may set a base URI if it matches any of the given source expressions.
+- `'none'`
+  - : No base URI may be set using a `<base>` element. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `base-uri`:
+  - : A space-separated list of _source expression_ values. A `<base>` element may set a base URI if its value matches any of the given source expressions.
 
-- `<host-source>`
-- `<scheme-source>`
-- the keyword value `'self'`.
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `base-uri`:
+
+    - `<host-source>`
+    - `<scheme-source>`
+    - the keyword value `'self'`.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -40,12 +40,15 @@ Content-Security-Policy: child-src 'none';
 Content-Security-Policy: child-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -48,7 +48,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -35,18 +35,17 @@ network errors by the user agent.
 
 ## Syntax
 
-One or more sources can be allowed for the `child-src` policy:
-
 ```http
-Content-Security-Policy: child-src <source>;
-Content-Security-Policy: child-src <source> <source>;
+Content-Security-Policy: child-src 'none';
+Content-Security-Policy: child-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -9,14 +9,14 @@ browser-compat: http.headers.Content-Security-Policy.connect-src
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`connect-src`** directive restricts the URLs which can be
-loaded using script interfaces. The APIs that are restricted are:
+loaded using script interfaces. The following APIs are controlled by this directive:
 
-- {{HTMLElement("a")}} [`ping`](/en-US/docs/Web/HTML/Element/a#ping),
-- {{domxref("Window/fetch", "fetch()")}},
-- {{domxref("XMLHttpRequest")}},
-- {{domxref("WebSocket")}},
-- {{domxref("EventSource")}}, and
-- {{domxref("Navigator.sendBeacon()")}}.
+- The [`ping`](/en-US/docs/Web/HTML/Element/a#ping) attribute in {{htmlelement("a")}} elements
+- {{domxref("Window/fetch", "fetch()")}}
+- {{domxref("XMLHttpRequest")}}
+- {{domxref("WebSocket")}}
+- {{domxref("EventSource")}}
+- {{domxref("Navigator.sendBeacon()")}}
 
 > **Note:** `connect-src 'self'` does not resolve to websocket
 > schemes in all browsers, more info in this [issue](https://github.com/w3c/webappsec-csp/issues/7).
@@ -48,12 +48,15 @@ Content-Security-Policy: connect-src 'none';
 Content-Security-Policy: connect-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -54,8 +54,6 @@ Content-Security-Policy: connect-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -43,16 +43,17 @@ loaded using script interfaces. The APIs that are restricted are:
 
 ## Syntax
 
-One or more sources can be allowed for the connect-src policy:
-
 ```http
-Content-Security-Policy: connect-src <source>;
-Content-Security-Policy: connect-src <source> <source>;
+Content-Security-Policy: connect-src 'none';
+Content-Security-Policy: connect-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -56,7 +56,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -41,16 +41,17 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`default-src`** direc
 
 ## Syntax
 
-One or more sources can be allowed for the `default-src` policy:
-
 ```http
-Content-Security-Policy: default-src <source>;
-Content-Security-Policy: default-src <source> <source>;
+Content-Security-Policy: default-src 'none';
+Content-Security-Policy: default-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -52,8 +52,6 @@ Content-Security-Policy: default-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### No inheritance with default-src

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -54,7 +54,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -46,12 +46,15 @@ Content-Security-Policy: default-src 'none';
 Content-Security-Policy: default-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -33,16 +33,17 @@ valid sources for fonts loaded using {{cssxref("@font-face")}}.
 
 ## Syntax
 
-One or more sources can be allowed for the `font-src` policy:
-
 ```http
-Content-Security-Policy: font-src <source>;
-Content-Security-Policy: font-src <source> <source>;
+Content-Security-Policy: font-src 'none';
+Content-Security-Policy: font-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -46,7 +46,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -44,8 +44,6 @@ Content-Security-Policy: font-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -38,12 +38,15 @@ Content-Security-Policy: font-src 'none';
 Content-Security-Policy: font-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -36,16 +36,19 @@ Content-Security-Policy: form-action 'none';
 Content-Security-Policy: form-action <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no form submissions may be made
-- a list of _source expression_ values, meaning that form submissions may be made to URLs that match any of the given source expressions.
+- `'none'`
+  - : No form submissions may be made. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `form-action`:
+  - : A space-separated list of _source expression_ values. Form submissions may be made to URLs that match any of the given source expressions.
 
-- `<host-source>`
-- `<scheme-source>`
-- the keyword value `'self'`.
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `form-action`:
+
+    - `<host-source>`
+    - `<scheme-source>`
+    - the keyword value `'self'`.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -41,7 +41,11 @@ This directive may have either:
 - the single keyword value `'none'`, meaning that no form submissions may be made
 - a list of _source expression_ values, meaning that form submissions may be made to URLs that match any of the given source expressions.
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `form-action`:
+
+- `<host-source>`
+- `<scheme-source>`
+- the keyword value `'self'`.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -31,16 +31,17 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`form-action`** direc
 
 ## Syntax
 
-One or more sources can be set for the `form-action` policy:
-
 ```http
-Content-Security-Policy: form-action <source>;
-Content-Security-Policy: form-action <source> <source>;
+Content-Security-Policy: form-action 'none';
+Content-Security-Policy: form-action <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no form submissions may be made
+- a list of _source expression_ values, meaning that form submissions may be made to URLs that match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -42,8 +42,6 @@ Content-Security-Policy: form-action <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Meta tag configuration

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -44,7 +44,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Form submissions may be made to URLs that match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `form-action`:
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources). However, only the following subset of those values apply to `form-action`:
 
     - `<host-source>`
     - `<scheme-source>`

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -38,16 +38,17 @@ browsing contexts loading using elements such as {{HTMLElement("frame")}} and
 
 ## Syntax
 
-One or more sources can be allowed for the `frame-src` policy:
-
 ```http
-Content-Security-Policy: frame-src <source>;
-Content-Security-Policy: frame-src <source> <source>;
+Content-Security-Policy: frame-src 'none';
+Content-Security-Policy: frame-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -51,7 +51,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -43,12 +43,15 @@ Content-Security-Policy: frame-src 'none';
 Content-Security-Policy: frame-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -49,8 +49,6 @@ Content-Security-Policy: frame-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -42,8 +42,6 @@ Content-Security-Policy: img-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -36,12 +36,15 @@ Content-Security-Policy: img-src 'none';
 Content-Security-Policy: img-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -31,16 +31,17 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} **`img-src`** directive speci
 
 ## Syntax
 
-One or more sources can be allowed for the `img-src` policy:
-
 ```http
-Content-Security-Policy: img-src <source>;
-Content-Security-Policy: img-src <source> <source>;
+Content-Security-Policy: img-src 'none';
+Content-Security-Policy: img-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -44,7 +44,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -170,7 +170,7 @@ Reporting directives control the destination URL for CSP violation reports in `C
 ## Values
 
 An overview of the allowed values are listed below.
-For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources) and the documentation for individual directives.
+For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources) and the documentation for individual directives.
 
 ### Keyword values
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -47,7 +47,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -45,8 +45,6 @@ Content-Security-Policy: manifest-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -39,12 +39,15 @@ Content-Security-Policy: manifest-src 'none';
 Content-Security-Policy: manifest-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -34,16 +34,17 @@ to the resource.
 
 ## Syntax
 
-One or more sources can be allowed for the `manifest-src` policy:
-
 ```http
-Content-Security-Policy: manifest-src <source>;
-Content-Security-Policy: manifest-src <source> <source>;
+Content-Security-Policy: manifest-src 'none';
+Content-Security-Policy: manifest-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -46,7 +46,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -33,16 +33,17 @@ media using the {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements.
 
 ## Syntax
 
-One or more sources can be allowed for the `media-src` policy:
-
 ```http
-Content-Security-Policy: media-src <source>;
-Content-Security-Policy: media-src <source> <source>;
+Content-Security-Policy: media-src 'none';
+Content-Security-Policy: media-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -38,12 +38,15 @@ Content-Security-Policy: media-src 'none';
 Content-Security-Policy: media-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -44,8 +44,6 @@ Content-Security-Policy: media-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -40,16 +40,17 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}}
 
 ## Syntax
 
-One or more sources can be allowed for the `object-src` policy:
-
 ```http
-Content-Security-Policy: object-src <source>;
-Content-Security-Policy: object-src <source> <source>;
+Content-Security-Policy: object-src 'none';
+Content-Security-Policy: object-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -51,8 +51,6 @@ Content-Security-Policy: object-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -45,12 +45,15 @@ Content-Security-Policy: object-src 'none';
 Content-Security-Policy: object-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -53,7 +53,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -47,8 +47,6 @@ Content-Security-Policy: prefetch-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Example
 
 ### Prefetch resources do not match header

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -49,7 +49,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Example
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -36,16 +36,17 @@ be prefetched or prerendered.
 
 ## Syntax
 
-One or more sources can be allowed for the `prefetch-src` policy:
-
 ```http
-Content-Security-Policy: prefetch-src <source>;
-Content-Security-Policy: prefetch-src <source> <source>;
+Content-Security-Policy: prefetch-src 'none';
+Content-Security-Policy: prefetch-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Example
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -41,12 +41,15 @@ Content-Security-Policy: prefetch-src 'none';
 Content-Security-Policy: prefetch-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Example
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -35,12 +35,17 @@ It does not apply to other JavaScript sources that can trigger script execution,
 
 ## Syntax
 
-One or more sources can be allowed for the `script-src-attr` policy:
-
 ```http
-Content-Security-Policy: script-src-attr <source>;
-Content-Security-Policy: script-src-attr <source> <source>;
+Content-Security-Policy: script-src-attr 'none';
+Content-Security-Policy: script-src-attr <source-expression-list>;
 ```
+
+This directive may have either:
+
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `script-src-attr` can be used in conjunction with {{CSP("script-src")}}, and will override that directive for checks on inline handlers:
 
@@ -48,10 +53,6 @@ Content-Security-Policy: script-src-attr <source> <source>;
 Content-Security-Policy: script-src <source>;
 Content-Security-Policy: script-src-attr <source>;
 ```
-
-### Sources
-
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -53,8 +53,6 @@ Content-Security-Policy: script-src-attr <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation case

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -40,12 +40,15 @@ Content-Security-Policy: script-src-attr 'none';
 Content-Security-Policy: script-src-attr <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `script-src-attr` can be used in conjunction with {{CSP("script-src")}}, and will override that directive for checks on inline handlers:
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -48,7 +48,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `script-src-attr` can be used in conjunction with {{CSP("script-src")}}, and will override that directive for checks on inline handlers:
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -35,12 +35,17 @@ It does not apply to other JavaScript sources that can trigger script execution,
 
 ## Syntax
 
-One or more sources can be allowed for the `script-src-elem` policy:
-
 ```http
-Content-Security-Policy: script-src-elem <source>;
-Content-Security-Policy: script-src-elem <source> <source>;
+Content-Security-Policy: script-src-elem 'none';
+Content-Security-Policy: script-src-elem <source-expression-list>;
 ```
+
+This directive may have either:
+
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `script-src-elem` can be used in conjunction with {{CSP("script-src")}}:
 
@@ -48,10 +53,6 @@ Content-Security-Policy: script-src-elem <source> <source>;
 Content-Security-Policy: script-src <source>;
 Content-Security-Policy: script-src-elem <source>;
 ```
-
-### Sources
-
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -48,7 +48,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `script-src-elem` can be used in conjunction with {{CSP("script-src")}}:
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -40,12 +40,15 @@ Content-Security-Policy: script-src-elem 'none';
 Content-Security-Policy: script-src-elem <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `script-src-elem` can be used in conjunction with {{CSP("script-src")}}:
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -53,8 +53,6 @@ Content-Security-Policy: script-src-elem <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation case

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -36,12 +36,15 @@ Content-Security-Policy: script-src 'none';
 Content-Security-Policy: script-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -31,16 +31,17 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`script-src`** direct
 
 ## Syntax
 
-One or more sources can be allowed for the `script-src` policy:
-
 ```http
-Content-Security-Policy: script-src <source>;
-Content-Security-Policy: script-src <source> <source>;
+Content-Security-Policy: script-src 'none';
+Content-Security-Policy: script-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -44,7 +44,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -42,8 +42,6 @@ Content-Security-Policy: script-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Allowlisting resources from trusted domains

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -15,7 +15,7 @@ As well as fetch directives, some other CSP directives may take as a value a spa
 - {{CSP("form-action")}}
 - {{CSP("frame-ancestors")}}
 
-Directives that accept a list of source expressions may instead be given the single value `'none'`, indicating that no resources of the given type may be loaded (or, in the case of non-fetch directives, that the given ability is not allowed).
+Directives that accept a list of source expressions may instead be given the single value `'none'`, indicating that no resources of the given type may be loaded (or, in the case of non-fetch directives, that the associated feature is not allowed).
 
 ## Sources
 

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -15,6 +15,8 @@ As well as fetch directives, some other CSP directives may take as a value a spa
 - {{CSP("form-action")}}
 - {{CSP("frame-ancestors")}}
 
+Directives that accept a list of source expressions may instead be given the single value `'none'`, indicating that no resources of the given type may be loaded (or, in the case of non-fetch directives, that the given ability is not allowed).
+
 ## Sources
 
 - `<host-source>`

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -7,8 +7,13 @@ spec-urls: https://w3c.github.io/webappsec-csp/#framework-directive-source-list
 
 {{HTTPSidebar}}
 
-HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) header directives that specify a `<source>` from which resources may be loaded can use any one of the values listed below.
-Relevant directives include the {{Glossary("fetch directive", "fetch directives")}}, along with others [listed below](#relevant_directives).
+HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) [fetch directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#fetch_directives) may take as a value a space-separated list of _source expressions_. Each source expression can be any of the values listed below.
+
+As well as fetch directives, some other CSP directives may take as a value a space-separated list of source expressions, each of which may be a subset of the values listed below, namely: one of `<host-source>`, `<scheme-source>`, or the keyword `'self'`. These other directives are:
+
+- {{CSP("base-uri")}}
+- {{CSP("form-action")}}
+- {{CSP("frame-ancestors")}}
 
 ## Sources
 
@@ -64,12 +69,9 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
 - `'unsafe-inline'`
   - : Allows the use of inline resources, such as inline {{HTMLElement("script")}} elements, [`javascript:` URLs](/en-US/docs/Web/URI/Schemes/javascript), inline event handlers, and inline {{HTMLElement("style")}} elements.
     The single quotes are required.
-- `'none'`
-  - : Refers to the empty set; that is, no URLs match.
-    The single quotes are required.
 - `'nonce-<base64-value>'`
 
-  - : An allowlist for specific inline scripts using a cryptographic nonce (number used once).
+  - : An allowlist for specific scripts using a cryptographic nonce (number used once).
     The server must generate a unique nonce value each time it transmits a policy.
     It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial.
     See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example.
@@ -96,37 +98,3 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
 ## Specifications
 
 {{Specifications}}
-
-## Relevant directives
-
-Directives for which the above sources apply include:
-
-- {{Glossary("fetch directive", "Fetch directives")}}:
-
-  - {{CSP("default-src")}}
-  - {{CSP("child-src")}}
-  - {{CSP("connect-src")}}
-  - {{CSP("font-src")}}
-  - {{CSP("frame-src")}}
-  - {{CSP("img-src")}}
-  - {{CSP("manifest-src")}}
-  - {{CSP("media-src")}}
-  - {{CSP("object-src")}}
-  - {{CSP("prefetch-src")}}
-  - {{CSP("script-src")}}
-  - {{CSP("script-src-elem")}}
-  - {{CSP("script-src-attr")}}
-  - {{CSP("style-src")}}
-  - {{CSP("style-src-elem")}}
-  - {{CSP("style-src-attr")}}
-  - {{CSP("worker-src")}}
-
-- {{Glossary("Document directive", "Document directives")}}:
-
-  - {{CSP("base-uri")}}
-  - {{CSP("sandbox")}}
-
-- {{Glossary("Navigation directive", "Navigation directives")}}:
-
-  - {{CSP("form-action")}}
-  - {{CSP("frame-ancestors")}}

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -49,7 +49,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `style-src-attr` can be used in conjunction with {{CSP("style-src")}}:
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -41,12 +41,15 @@ Content-Security-Policy: style-src-attr 'none';
 Content-Security-Policy: style-src-attr <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `style-src-attr` can be used in conjunction with {{CSP("style-src")}}:
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -54,8 +54,6 @@ Content-Security-Policy: style-src-attr <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -36,12 +36,17 @@ These are set using {{CSP("style-src-elem")}} (and valid sources for all styles 
 
 ## Syntax
 
-One or more sources can be allowed for the `style-src-attr` policy:
-
 ```http
-Content-Security-Policy: style-src-attr <source>;
-Content-Security-Policy: style-src-attr <source> <source>;
+Content-Security-Policy: style-src-attr 'none';
+Content-Security-Policy: style-src-attr <source-expression-list>;
 ```
+
+This directive may have either:
+
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `style-src-attr` can be used in conjunction with {{CSP("style-src")}}:
 
@@ -49,10 +54,6 @@ Content-Security-Policy: style-src-attr <source> <source>;
 Content-Security-Policy: style-src <source>;
 Content-Security-Policy: style-src-attr <source>;
 ```
-
-### Sources
-
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -35,12 +35,17 @@ The directive does not set valid sources for inline style attributes; these are 
 
 ## Syntax
 
-One or more sources can be allowed for the `style-src-elem` policy:
-
 ```http
-Content-Security-Policy: style-src-elem <source>;
-Content-Security-Policy: style-src-elem <source> <source>;
+Content-Security-Policy: style-src-elem 'none';
+Content-Security-Policy: style-src-elem <source-expression-list>;
 ```
+
+This directive may have either:
+
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `style-src-elem` can be used in conjunction with {{CSP("style-src")}}:
 
@@ -48,10 +53,6 @@ Content-Security-Policy: style-src-elem <source> <source>;
 Content-Security-Policy: style-src <source>;
 Content-Security-Policy: style-src-elem <source>;
 ```
-
-### Sources
-
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -48,7 +48,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `style-src-elem` can be used in conjunction with {{CSP("style-src")}}:
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -53,8 +53,6 @@ Content-Security-Policy: style-src-elem <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -40,12 +40,15 @@ Content-Security-Policy: style-src-elem 'none';
 Content-Security-Policy: style-src-elem <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 `style-src-elem` can be used in conjunction with {{CSP("style-src")}}:
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -42,8 +42,6 @@ Content-Security-Policy: style-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -44,7 +44,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -36,12 +36,15 @@ Content-Security-Policy: style-src 'none';
 Content-Security-Policy: style-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -31,16 +31,17 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`style-src`** directi
 
 ## Syntax
 
-One or more sources can be allowed for the `style-src` policy:
-
 ```http
-Content-Security-Policy: style-src <source>;
-Content-Security-Policy: style-src <source> <source>;
+Content-Security-Policy: style-src 'none';
+Content-Security-Policy: style-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -52,7 +52,7 @@ This directive may have one of the following values:
 
   - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
 
-    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+    Source expressions are specified as keyword values or URL patterns: the syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -44,12 +44,15 @@ Content-Security-Policy: worker-src 'none';
 Content-Security-Policy: worker-src <source-expression-list>;
 ```
 
-This directive may have either:
+This directive may have one of the following values:
 
-- the single keyword value `'none'`, meaning that no resources of this type may be loaded
-- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
 
-The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions.
+
+    The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -39,16 +39,17 @@ scripts.
 
 ## Syntax
 
-One or more sources can be allowed for the `worker-src` policy:
-
 ```http
-Content-Security-Policy: worker-src <source>;
-Content-Security-Policy: worker-src <source> <source>;
+Content-Security-Policy: worker-src 'none';
+Content-Security-Policy: worker-src <source-expression-list>;
 ```
 
-### Sources
+This directive may have either:
 
-`<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
+- the single keyword value `'none'`, meaning that no resources of this type may be loaded
+- a list of _source expression_ values, meaning that resources of this type may be loaded if they match any of the given source expressions.
+
+The syntax for each source expression is given in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -50,8 +50,6 @@ Content-Security-Policy: worker-src <source> <source>;
 
 `<source>` can be any one of the values listed in [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources).
 
-Note that this same set of values can be used in all {{Glossary("fetch directive", "fetch directives")}} (and a [number of other directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#relevant_directives)).
-
 ## Examples
 
 ### Violation cases


### PR DESCRIPTION
This PR fixes a few errors in the documentation of CSP directive syntax.

- the page at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources says that the `sandbox` directive uses the source expression syntax, but I don't think it does: I think this directive just uses keyword values.
- the page at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources also says that the `base-uri`, `form-action`, and `frame-ancestors` directives use the source expression syntax, which is half true: they can use a subset of it
- the documentation says that `'none'` is one of the source expression values, which implies that you can combine `'none'` and other source expression values, but you can't: if you have `'none'`, it stands alone: https://w3c.github.io/webappsec-csp/#grammardef-serialized-source-list.
- nonces are not only for inline scripts. There's a lot more we could/should update around nonces but I'm not going there yet.

The page for [`frame-ancestors`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) does not point to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources, instead redefining the values. I have left this as it is for now, because the definition for this directive does use a different type (https://w3c.github.io/webappsec-csp/#directive-frame-ancestors) although it seems to be functionally identical. I think we should update this to point to the "sources" page, but before doing that I want to check there isn't some subtle reason why the syntax is redefined for this directive.

The changes are quite repetitive for the directives pages: I changed/corrected the syntax and removed the `### Sources` heading, as it seemed easier to talk about `'none'` without it.

In https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources I removed the list of fetch directives, since we already have that in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#fetch_directives, so that's just 2 places we have to maintain it.

