### PR TITLE
BodyInit also allows ReadableStream

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -89,6 +89,7 @@ You can supply the body as an instance of any of the following types:
 - {{domxref("File")}}
 - {{domxref("URLSearchParams")}}
 - {{domxref("FormData")}}
+- {{domxref("ReadableStream")}}
 
 Note that just like response bodies, request bodies are streams, and making the request reads the stream, so if a request contains a body, you can't make it twice:
 

--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -38,6 +38,7 @@ You can also construct a `Request` with a `RequestInit`, and pass the `Request` 
     - {{domxref("FormData")}}
     - {{jsxref("TypedArray")}}
     - {{domxref("URLSearchParams")}}
+    - {{domxref("ReadableStream")}}
 
     See [Setting a body](/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body) for more details.
 


### PR DESCRIPTION
### Description

The `body` option supplied to the `Request` constructor (`BodyInit`) also allows `ReadableStream` [according to the spec](https://fetch.spec.whatwg.org/#bodyinit-unions) (and implementations)

### Motivation

The above option appears to not be documented (unless I missed it?)
