### PR TITLE
Change argument list from [arguments] to ...arguments or ...args

### DIFF
--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -16,7 +16,7 @@ The `super.prop` and `super[expr]` expressions are valid in any [method definiti
 ## Syntax
 
 ```js-nolint
-super([arguments]) // calls the parent constructor.
+super(...arguments) // calls the parent constructor.
 super.propertyOnParent
 super[expression]
 ```

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -16,7 +16,11 @@ The `super.prop` and `super[expr]` expressions are valid in any [method definiti
 ## Syntax
 
 ```js-nolint
-super(...arguments) // calls the parent constructor.
+super()
+super(arg1)
+super(arg1, arg2)
+super(arg1, arg2, /* …, */ argN)
+
 super.propertyOnParent
 super[expression]
 ```


### PR DESCRIPTION
### Motivation

Writing the arguments this way (as `[arguments]`) would mean that `super` accepts one argument as a list.