### PR TITLE
delete deprecated clip example

### DIFF
--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -182,6 +182,7 @@ and this CSS:
 
 ```css
 .visually-hidden {
+  clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -191,7 +191,6 @@ and this CSS:
   width: 1px;
 }
 
-
 input.visually-hidden:is(:focus, :focus-within) + label {
   outline: thin dotted;
 }

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -186,7 +186,6 @@ and this CSS:
   height: 1px;
   width: 1px;
   overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
 }
 
 input.visually-hidden:is(:focus, :focus-within) + label {

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -182,11 +182,15 @@ and this CSS:
 
 ```css
 .visually-hidden {
-  position: absolute !important;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   height: 1px;
-  width: 1px;
   overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
+
 
 input.visually-hidden:is(:focus, :focus-within) + label {
   outline: thin dotted;

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -182,7 +182,6 @@ and this CSS:
 
 ```css
 .visually-hidden {
-  clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

`clip` is deprecated; deleted it from the CSS example in this page https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications 

fixes https://github.com/mdn/content/issues/35743

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I have learnt so much from MDN docs and want to contribute back. Deleting deprecated examples with help reader learn relevant stuff.

