### PR TITLE
Large bounds are not required to cause rounding

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -29,7 +29,7 @@ A floating-point, pseudo-random number between 0 (inclusive) and 1 (exclusive).
 
 ## Examples
 
-Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. If extremely large bounds are chosen (2<sup>53</sup> or higher), it's possible in _extremely_ rare cases to reach the usually-excluded upper bound, especially if large bounds are chosen.
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. If extremely large bounds are chosen (2<sup>53</sup> or higher), it's possible in _extremely_ rare cases to reach the usually-excluded upper bound. This is because floating point precision decreases as magnitude increases, so a tiny difference between the maximum attainable value and the upper bound may not be representable at the requested maximum, therefore causing the upper bound to become attainable.
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -29,7 +29,7 @@ A floating-point, pseudo-random number between 0 (inclusive) and 1 (exclusive).
 
 ## Examples
 
-Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact.
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. Usually, the claimed upper bound is not attainable, but floating point precision decreases as magnitude increases, so if `Math.random()` returns a number very close to 1, the tiny difference may not be representable at the requested maximum, therefore causing the upper bound to be attained.
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -29,7 +29,7 @@ A floating-point, pseudo-random number between 0 (inclusive) and 1 (exclusive).
 
 ## Examples
 
-Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. 
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact.
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -29,7 +29,7 @@ A floating-point, pseudo-random number between 0 (inclusive) and 1 (exclusive).
 
 ## Examples
 
-Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. If extremely large bounds are chosen (2<sup>53</sup> or higher), it's possible in _extremely_ rare cases to reach the usually-excluded upper bound.
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. If extremely large bounds are chosen (2<sup>53</sup> or higher), it's possible in _extremely_ rare cases to reach the usually-excluded upper bound, especially if large bounds are chosen.
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -29,7 +29,7 @@ A floating-point, pseudo-random number between 0 (inclusive) and 1 (exclusive).
 
 ## Examples
 
-Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. Usually, the claimed upper bound is not attainable, but floating point precision decreases as magnitude increases, so if `Math.random()` returns a number very close to 1, the tiny difference may not be representable at the requested maximum, therefore causing the upper bound to be attained.
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. Usually, the claimed upper bound is not attainable, but if `Math.random()` returns a number very close to 1, the tiny difference may not be representable at the requested maximum, therefore causing the upper bound to be attained.
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.md
@@ -29,7 +29,7 @@ A floating-point, pseudo-random number between 0 (inclusive) and 1 (exclusive).
 
 ## Examples
 
-Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. If extremely large bounds are chosen (2<sup>53</sup> or higher), it's possible in _extremely_ rare cases to reach the usually-excluded upper bound. This is because floating point precision decreases as magnitude increases, so a tiny difference between the maximum attainable value and the upper bound may not be representable at the requested maximum, therefore causing the upper bound to become attainable.
+Note that as numbers in JavaScript are IEEE 754 floating point numbers with round-to-nearest-even behavior, the ranges claimed for the functions below (excluding the one for `Math.random()` itself) aren't exact. 
 
 ### Getting a random number between 0 (inclusive) and 1 (exclusive)
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

edited `If extremely large bounds are chosen (2**53 or higher), it's possible in extremely rare cases to reach the usually-excluded upper bound.` 
to 
`f extremely large bounds are chosen (2**53 or higher), it's possible in extremely rare cases to reach the usually-excluded upper bound, especially if large bounds are chosen.`

fixes https://github.com/mdn/content/issues/35933

