### PR TITLE
Add link to another relevant WebGL function in page for `WebGLRenderbuffer`

### DIFF
--- a/files/en-us/web/api/webglrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderbuffer/index.md
@@ -13,7 +13,7 @@ The **WebGLRenderbuffer** interface is part of the [WebGL API](/en-US/docs/Web/A
 
 ## Description
 
-The `WebGLRenderbuffer` object does not define any methods or properties of its own and its content is not directly accessible. When working with `WebGLRenderbuffer` objects, the following methods of the {{domxref("WebGLRenderingContext")}} are useful:
+The `WebGLRenderbuffer` object does not define any methods or properties of its own and its content is not directly accessible. When working with `WebGLRenderbuffer` objects, the following methods are useful:
 
 - {{domxref("WebGLRenderingContext.bindRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.createRenderbuffer()")}}
@@ -22,6 +22,7 @@ The `WebGLRenderbuffer` object does not define any methods or properties of its 
 - {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
 - {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
+- {{domxref("WebGL2RenderingContext.renderbufferStorageMultisample()")}}
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This adds a link to the function [WebGL2RenderingContext.renderbufferStorageMultisample()](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/renderbufferStorageMultisample) on the page for [WebGLRenderbuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderbuffer). It also rewords the preceding paragraph slightly to allow this addition.

### Motivation

This is a useful function which is omitted from the list, perhaps because it is only available in a `WebGL2RenderingContext`. As someone who has just spent some time trying to find it, I recommend including it here regardless.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
n/a

### Related issues and pull requests

n/a
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
