### PR TITLE
fix: "forward" instead of "forth"

### DIFF
--- a/files/en-us/learn/css/index.md
+++ b/files/en-us/learn/css/index.md
@@ -12,7 +12,7 @@ Cascading Style Sheets — or {{glossary("CSS")}} — is the first technology yo
 
 You should learn the basics of HTML before attempting any CSS. We recommend that you work through our [Introduction to HTML](/en-US/docs/Learn/HTML/Introduction_to_HTML) module first.
 
-Once you understand the fundamentals of HTML, we recommend that you learn further HTML and CSS at the same time, moving back and forth between the two topics. This is because HTML is far more interesting and much more fun to learn when you apply CSS, and you can't learn CSS without knowing HTML.
+Once you understand the fundamentals of HTML, we recommend that you learn further HTML and CSS at the same time, moving back and forward between the two topics. This is because HTML is far more interesting and much more fun to learn when you apply CSS, and you can't learn CSS without knowing HTML.
 
 Before starting this topic, you should also be familiar with using computers and using the web passively (i.e., just looking at it, consuming the content). You should have a basic work environment set up, as detailed in [Installing basic software](/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software), and understand how to create and manage files, as detailed in [Dealing with files](/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files) — both of which are parts of our [Getting started with the web](/en-US/docs/Learn/Getting_started_with_the_web) complete beginner's module.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

noun "forth" lay emphasis on coming out from inside of entity, seems like "nothing" changed to "something". such as "She brought forth a new idea."

another usage is "The soldiers marched forth.", "forth" following with "marched" could be more common-to-see

noun "forward" may just means opposite of `back`, for example, assume move back means B to A, then move forward means A to B.

### Motivation

meeting noun "forth" makes me feel a bit strange for first eye on it. I think it could be more friendly for readers if use a more simple and appropriate noun~ How about it?

btw a joke, I had thought it's an ordinary number until I search that.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
