### PR TITLE
Normalize GDPR link location

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
@@ -71,7 +71,7 @@ Once you have found a font, there are two main ways of using it:
 2. Download the font file to your own system, host the font yourself, and use your hosted copy in your website's code.
 
 > [!NOTE]
-> Serving fonts hosted on Google Fonts may be incompatible with the European Union's data privacy regulation [GDPR](https://gdpr.eu/what-is-gdpr/) as the font service exposes the user's IP address. If this is a potential problem for you, then either choose the second option or choose a font provider that is GDPR compliant, such as [Bunny Fonts](https://fonts.bunny.net/about).
+> Serving fonts hosted on Google Fonts may be incompatible with the European Union's data privacy regulation [GDPR](https://gdpr.eu/) as the font service exposes the user's IP address. If this is a potential problem for you, then either choose the second option or choose a font provider that is GDPR compliant, such as [Bunny Fonts](https://fonts.bunny.net/about).
 
 Alternatively you can use [safe web fonts](https://web.mit.edu/jmorzins/www/fonts.html) such as Arial, Times New Roman, or Courier New.
 

--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -248,7 +248,7 @@ See our [Third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies) artic
 
 Legislation or regulations that cover the use of cookies include:
 
-- The General Data Privacy Regulation (GDPR) in the European Union
+- The [General Data Privacy Regulation](https://gdpr.eu/) (GDPR) in the European Union
 - The ePrivacy Directive in the EU
 - The California Consumer Privacy Act
 

--- a/files/en-us/web/privacy/index.md
+++ b/files/en-us/web/privacy/index.md
@@ -126,7 +126,7 @@ The ethics of data collection can be broken down into three simple principles:
 - Delete the data once you have finished with it
 
 > [!NOTE]
-> The tips provided below make for a better, more privacy-aware user experience, but many of them are required by law to comply with regulations, for example the [GDPR](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679&from=EN) in the EU. You should make sure to find out what regulations apply to you in your locale, and what you need to do to comply with them.
+> The tips provided below make for a better, more privacy-aware user experience, but many of them are required by law to comply with regulations, for example the [GDPR](https://gdpr.eu/) in the EU. You should make sure to find out what regulations apply to you in your locale, and what you need to do to comply with them.
 
 ### Don't collect more data than you need
 

--- a/files/en-us/web/privacy/third-party_cookies/index.md
+++ b/files/en-us/web/privacy/third-party_cookies/index.md
@@ -60,7 +60,7 @@ In such cases, third-party cookies are referred to as _tracking cookies_.
 > [!NOTE]
 > User information gained through illegitimate means is also often sold to other third parties, multiplying the problem further.
 
-Legislation such as the [General Data Privacy Regulation](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) (GDPR) in the European Union and the [California Consumer Privacy Act](https://www.oag.ca.gov/privacy/ccpa) (CCPA) have helped by making it a legal requirement for companies to be transparent about the cookies they set and the information they collect. Examples include asking customers to opt into such data collection, allowing them to see what data a company holds on them, and delete the data if they wish. However, it is still not always clear to customers how their data is used.
+Legislation such as the [General Data Privacy Regulation](https://gdpr.eu/) (GDPR) in the European Union and the [California Consumer Privacy Act](https://www.oag.ca.gov/privacy/ccpa) (CCPA) have helped by making it a legal requirement for companies to be transparent about the cookies they set and the information they collect. Examples include asking customers to opt into such data collection, allowing them to see what data a company holds on them, and delete the data if they wish. However, it is still not always clear to customers how their data is used.
 
 ## How do browsers handle third-party cookies?
 

--- a/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
@@ -41,7 +41,7 @@ Security-conscious server-side frameworks tend to have built in mitigations for 
 
 ## Policy and requirements
 
-It would make sense to write a set of security and privacy requirements for your project team(s) that specify usage of such features to mitigate the associated risks. You should enlist the help of a web security expert to write these requirements, and consider both user needs and welfare, as well as other issues like policy and regulation enforced by legislation such as the [EU General Data Protection Regulation (GDPR)](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679&from=EN).
+It would make sense to write a set of security and privacy requirements for your project team(s) that specify usage of such features to mitigate the associated risks. You should enlist the help of a web security expert to write these requirements, and consider both user needs and welfare, as well as other issues like policy and regulation enforced by legislation such as the [EU General Data Protection Regulation](https://gdpr.eu/) (GDPR).
 
 ## See also
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/28245, consistently link to https://gdpr.eu which seems to be credible. The other link target is the legislation itself which is barely readable.