### PR TITLE
Remove incorrect info about setting password before username on URL instance

### DIFF
--- a/files/en-us/web/api/url/password/index.md
+++ b/files/en-us/web/api/url/password/index.md
@@ -11,9 +11,6 @@ browser-compat: api.URL.password
 The **`password`** property of the {{domxref("URL")}} interface
 is a string containing the password specified before the domain name.
 
-If it is set without first setting the {{domxref("URL.username", "username")}}
-property, it silently fails.
-
 ## Value
 
 A string.


### PR DESCRIPTION
### Description

Remove incorrect info about setting password before username on URL instance: "If it is set without first setting the username property, it silently fails".

### Motivation

Remove incorrect info (see issue)

### Additional details

See issue

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/36005