### PR TITLE
Fix wrong property in example for `RTCIceTransport.getLocalCandidates`

### DIFF
--- a/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.md
+++ b/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.md
@@ -36,9 +36,7 @@ This simple example gets the local candidate list from the {{domxref("RTCIceTran
 ```js
 const localCandidates = pc
   .getSenders()[0]
-  .transport
-  .iceTransport
-  .getLocalCandidates();
+  .transport.iceTransport.getLocalCandidates();
 
 localCandidates.forEach((candidate, index) => {
   console.log(`Candidate ${index}: ${candidate.candidate}`);

--- a/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.md
+++ b/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.md
@@ -36,7 +36,9 @@ This simple example gets the local candidate list from the {{domxref("RTCIceTran
 ```js
 const localCandidates = pc
   .getSenders()[0]
-  .transport.transport.getLocalCandidates();
+  .transport
+  .iceTransport
+  .getLocalCandidates();
 
 localCandidates.forEach((candidate, index) => {
   console.log(`Candidate ${index}: ${candidate.candidate}`);


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

[Example on MDN for WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceTransport/getLocalCandidates#examples) (`RTCIceTransport.getLocalCandidates` method) fixed to access correct property.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Example is incorrect, see #35587.

### Additional details

According to the example, the following classes/interfaces were accessed:

```js
const localCandidates = pc    // 1
  .getSenders()[0]            // 2
  .transport                  // 3
  .iceTransport               // 4
  .getLocalCandidates();      // 5
```

1. https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection
2. https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getSenders
3. https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/transport
4. https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/iceTransport
5. https://developer.mozilla.org/en-US/docs/Web/API/RTCIceTransport/getLocalCandidates

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Closes #35587.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
