### PR TITLE
Add a separate MathML mprescripts page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12814,7 +12814,6 @@
 /en-US/docs/Web/MathML/Element/annotation	/en-US/docs/Web/MathML/Element/semantics
 /en-US/docs/Web/MathML/Element/annotation-xml	/en-US/docs/Web/MathML/Element/semantics
 /en-US/docs/Web/MathML/Element/menclosed	/en-US/docs/Web/MathML/Element/menclose
-/en-US/docs/Web/MathML/Element/mprescripts	/en-US/docs/Web/MathML/Element/mmultiscripts
 /en-US/docs/Web/MathML/Element/none	/en-US/docs/Web/MathML/Element/mmultiscripts
 /en-US/docs/Web/MathML/Fonts/Test	/en-US/docs/Web/MathML/Fonts
 /en-US/docs/Web/MathML/Global_attributes/mathvariant	/en-US/docs/Web/MathML/Element/mi#mathvariant

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -126,16 +126,16 @@ body {
 ```html-nolint
 <math display="block">
   <mmultiscripts>
-    <mtext>X</mtext> <!-- base expression -->
-    <mtext>1</mtext> <!-- post-sub-script-1 -->
-    <mtext>2</mtext> <!-- post-sup-script-1 -->
-    <mtext>3</mtext> <!-- post-sub-script-2 -->
-    <mtext>4</mtext> <!-- post-sup-script-2 -->
+    <mi>X</mi> <!-- base expression -->
+    <mn>1</mn> <!-- post-sub-script-1 -->
+    <mn>2</mn> <!-- post-sup-script-1 -->
+    <mn>3</mn> <!-- post-sub-script-2 -->
+    <mn>4</mn> <!-- post-sup-script-2 -->
     <mprescripts />
-    <mtext>5</mtext> <!-- pre-sub-script-1 -->
-    <mtext>6</mtext> <!-- pre-sup-script-1 -->
-    <mtext>7</mtext> <!-- pre-sub-script-2 -->
-    <mtext>8</mtext> <!-- pre-sup-script-2 -->
+    <mn>5</mn> <!-- pre-sub-script-1 -->
+    <mn>6</mn> <!-- pre-sup-script-1 -->
+    <mn>7</mn> <!-- pre-sub-script-2 -->
+    <mn>8</mn> <!-- pre-sup-script-2 -->
   </mmultiscripts>
 </math>
 ```

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -7,24 +7,24 @@ browser-compat: mathml.elements.mmultiscripts
 
 {{MathMLRef}}
 
-The **`<mmultiscripts>`** [MathML](/en-US/docs/Web/MathML) element is used to attach an arbitrary number of subscripts and superscripts to an expression at once, generalizing the {{ MathMLElement("msubsup") }} element. Scripts can be either prescripts (placed before the expression) or postscripts (placed after it).
+The **`<mmultiscripts>`** [MathML](/en-US/docs/Web/MathML) element is used to attach an arbitrary number of subscripts and superscripts to an expression at once, generalizing the {{ MathMLElement("msubsup") }} element. Scripts can be either pre-scripts (placed **before** the expression) or post-scripts (placed **after** it).
 
-MathML uses the syntax below, that is a base expression, followed by an arbitrary number of postsubscript-postsuperscript pairs (attached in the given order) optionally followed by an `<mprescripts>` and an arbitrary number of presubscript-presuperscript pairs (attached in the given order). In addition, empty `<mrow>` elements can be used to represent absent scripts.
+MathML uses the syntax below, that is a base expression, followed by an arbitrary number of post-subscript and post-superscript pairs (attached in the given order) optionally followed by an {{ MathMLElement("mprescripts") }} element and an arbitrary number of pre-subscript and pre-superscript pairs (attached in the given order). In addition, empty {{ MathMLElement("mrow") }} elements can be used to represent absent scripts.
 
 ```html-nolint
 <mmultiscripts>
   base
-  postsubscript1 postsuperscript1
-  postsubscript2 postsuperscript2
-  postsubscript3 postsuperscript3
+  post-sub-script-1 post-sup-script-1
+  post-sub-script-2 post-sup-script-2
+  post-sub-script-3 post-sup-script-3
   ...
-  postsubscriptN postsuperscriptN
-  <mprescripts/>                ⎫
-  presubscript1 presuperscript1 ⎪
-  presubscript2 presuperscript2 ⎬ Optional
-  presubscript3 presuperscript3 ⎪
-  ...                           ⎪
-  presubscriptM presuperscriptM ⎭
+  post-sub-script-N post-sup-script-N
+  <mprescripts />                    ⎫
+  pre-sub-script-1 pre-sup-script-1  ⎪
+  pre-sub-script-2 pre-sup-script-2  ⎬ Optional
+  pre-sub-script-3 pre-sup-script-3  ⎪
+  ...                                ⎪
+  pre-sub-script-M pre-sup-script-N  ⎭
 </mmultiscripts>
 ```
 
@@ -42,72 +42,105 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ## Examples
 
-### Using `<mprescripts/>`
+### Using `<mprescripts>`
 
-Children after the `<mprescripts/>` element are placed as pre-scripts (before the base expression):
+Children after the `<mprescripts>` element are placed as pre-scripts (before the base expression):
+
+```css hidden
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+}
+```
 
 ```html-nolint
 <math display="block">
   <mmultiscripts>
-    <mi>X</mi>      <!-- base expression -->
-    <mi>d</mi>      <!-- postsubscript -->
-    <mi>c</mi>      <!-- postsuperscript -->
+    <mi>X</mi> <!-- base expression -->
+    <mi>a</mi> <!-- post-sub-script -->
+    <mi>b</mi> <!-- post-sup-script -->
     <mprescripts />
-    <mi>b</mi>      <!-- presubscript -->
-    <mi>a</mi>      <!-- presuperscript -->
+    <mi>c</mi> <!-- pre-sub-script -->
+    <mi>d</mi> <!-- pre-sup-script -->
   </mmultiscripts>
 </math>
 ```
 
-{{ EmbedLiveSample('mprescripts_example', 700, 200, "", "") }}
+{{ EmbedLiveSample('using_mprescripts', 700, 200, "", "") }}
 
 ### Empty scripts
 
 Empty `<mrow>` elements can be used to represent absent scripts:
 
+```css hidden
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+}
+```
+
 ```html-nolint
 <math display="block">
   <mmultiscripts>
-    <mi>X</mi>      <!-- base expression -->
-    <mrow></mrow>   <!-- postsubscript -->
-    <mi>c</mi>      <!-- postsuperscript -->
+    <mi>X</mi>    <!-- base expression -->
+    <mrow></mrow> <!-- post-sub-script -->
+    <mi>b</mi>    <!-- post-sup-script -->
     <mprescripts />
-    <mi>b</mi>      <!-- presubscript -->
-    <mrow></mrow>   <!-- presuperscript -->
+    <mi>c</mi>    <!-- pre-sub-script -->
+    <mrow></mrow> <!-- pre-sup-script -->
   </mmultiscripts>
 </math>
 ```
 
-{{ EmbedLiveSample('none_example', 700, 200, "", "") }}
+{{ EmbedLiveSample('empty_scripts', 700, 200, "", "") }}
 
 ### Order of scripts
 
 Here is a more complex example with many scripts, so you can see in which order they are attached to the base:
 
-```html
+```css hidden
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+}
+```
+
+```html-nolint
 <math display="block">
   <mmultiscripts>
-    <mtext>base</mtext>
-    <mtext>postsubscript1</mtext>
-    <mtext>postsupscript1</mtext>
-    <mtext>postsubscript2</mtext>
-    <mtext>postsupscript2</mtext>
-    <mtext>postsubscript3</mtext>
-    <mtext>postsupscript3</mtext>
-    <mtext>postsubscript4</mtext>
-    <mtext>postsupscript4</mtext>
+    <mtext>X</mtext> <!-- base expression -->
+    <mtext>1</mtext> <!-- post-sub-script-1 -->
+    <mtext>2</mtext> <!-- post-sup-script-1 -->
+    <mtext>3</mtext> <!-- post-sub-script-2 -->
+    <mtext>4</mtext> <!-- post-sup-script-2 -->
     <mprescripts />
-    <mtext>presubscript1</mtext>
-    <mtext>presupscript1</mtext>
-    <mtext>presubscript2</mtext>
-    <mtext>presupscript2</mtext>
-    <mtext>presubscript3</mtext>
-    <mtext>presupscript3</mtext>
+    <mtext>5</mtext> <!-- pre-sub-script-1 -->
+    <mtext>6</mtext> <!-- pre-sup-script-1 -->
+    <mtext>7</mtext> <!-- pre-sub-script-2 -->
+    <mtext>8</mtext> <!-- pre-sup-script-2 -->
   </mmultiscripts>
 </math>
 ```
 
-{{ EmbedLiveSample('order_of_scripts_example', 700, 200, "", "") }}
+{{ EmbedLiveSample('order_of_scripts', 700, 200, "", "") }}
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mprescripts/index.md
+++ b/files/en-us/web/mathml/element/mprescripts/index.md
@@ -1,0 +1,60 @@
+---
+title: <mprescripts>
+slug: Web/MathML/Element/mprescripts
+page-type: mathml-element
+browser-compat: mathml.elements.mprescripts
+---
+
+{{MathMLRef}}
+
+The **`<mprescripts>`** [MathML](/en-US/docs/Web/MathML) element is used within an {{ MathMLElement("mmultiscripts") }} element to indicate the start of the pre-scripts elements (subscripts and superscripts that are placed **before** the base expression).
+
+## Attributes
+
+This element supports [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
+## Example
+
+The first `<mmultiscripts>` child element becomes a base expression. The rest children by default become post-scripts elements (a, b). `<mprescripts>` acts as a separator, and children after it become pre-scripts elements (c, d).
+
+```css hidden
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+}
+```
+
+```html-nolint
+<math display="block">
+  <mmultiscripts>
+    <mi>X</mi> <!-- base expression -->
+    <mi>a</mi> <!-- post-sub-script -->
+    <mi>b</mi> <!-- post-sup-script -->
+    <mprescripts />
+    <mi>c</mi> <!-- pre-sub-script -->
+    <mi>d</mi> <!-- pre-sup-script -->
+  </mmultiscripts>
+</math>
+```
+
+{{ EmbedLiveSample('example', 700, 200, "", "") }}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{ MathMLElement("msub") }} (Subscript)
+- {{ MathMLElement("msup") }} (Superscript)
+- {{ MathMLElement("msubsup") }} (Subscript-superscript pair)

--- a/files/en-us/web/mathml/element/mprescripts/index.md
+++ b/files/en-us/web/mathml/element/mprescripts/index.md
@@ -15,7 +15,7 @@ This element supports [global MathML attributes](/en-US/docs/Web/MathML/Global_a
 
 ## Example
 
-The first `<mmultiscripts>` child element becomes a base expression. The rest children by default become post-scripts elements (a, b). `<mprescripts>` acts as a separator, and children after it become pre-scripts elements (c, d).
+The first `<mmultiscripts>` child element becomes a base expression. The remaining children by default become post-scripts elements (a, b). `<mprescripts>` acts as a separator, and children after it become pre-scripts elements (c, d).
 
 ```css hidden
 html,


### PR DESCRIPTION
### Description

MathML `<mprescripts>` is now separated from the `<mmultiscripts>` element reference.

### Motivation

- Improve `<mprescripts>` element’s discoverability
- Improve `<mmultiscripts>` demos

### Details

- _pre-_ and _post-_ prefixes are now separated with dashes for better readability.
- In some places, even _sub-scripts_ are separated to better catch _sub_ and _sup_ parts.
- I used natural content order (a, b, c, d) to better highlight reversed rendering order.