### PR TITLE
Linked normalized diagonal for SVG attribute

### DIFF
--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -16,7 +16,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("circle")}}
 - {{SVGElement("radialGradient")}}
 
-When the value is set as a percentage, it refers to the [normalized diagonal](https://svgwg.org/svg2-draft/coords.html#Units) of the current SVG viewport.
+Percentages refer to the normalized diagonal of the current SVG viewport, which is calculated as <math><mfrac><msqrt><mrow><msup><mi>&lt;width&gt;</mi><mn>2</mn></msup><mo>+</mo><msup><mi>&lt;height&gt;</mi><mn>2</mn></msup></mrow></msqrt><msqrt><mn>2</mn></msqrt></mfrac></math>.
 
 ## Example
 

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -16,7 +16,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("circle")}}
 - {{SVGElement("radialGradient")}}
 
-When the value is set as a percentage, it refers to the normalized diagonal of the current SVG viewport.
+When the value is set as a percentage, it refers to the [normalized diagonal](https://svgwg.org/svg2-draft/coords.html#Units) of the current SVG viewport.
 
 ## Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarified the explanation of the `r` attribute when its value is a percentage, linking to the normalized diagonal.

### Motivation

Helps readers understand how percentage values for the `r` attribute are calculated in relation to the SVG viewport.

### Additional details

Linked to the [normalized diagonal](https://svgwg.org/svg2-draft/coords.html#Units) in the relevant explanation.

### Related issues and pull requests

Fixes #35712