### PR TITLE
fix: remove the extra element in the CSS `ellipse()` function

### DIFF
--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -32,7 +32,7 @@ clip-path: view-box;
 /* <basic-shape> values */
 clip-path: inset(100px 50px);
 clip-path: circle(50px at 0 100px);
-clip-path: ellipse(50px 60px at 0 10% 20%);
+clip-path: ellipse(50px 60px at 10% 20%);
 clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
 clip-path: path(
   "M0.5,1 C0.5,1,0,0.7,0,0.3 A0.25,0.25,1,1,1,0.5,0.3 A0.25,0.25,1,1,1,1,0.3 C1,0.7,0.5,1,0.5,1 Z"


### PR DESCRIPTION
### Description

Downstream PR: mdn/translated-content#23410. The `0` in the CSS `ellipse()` function should be removed, as the `<position>` syntax given in [`ellipse()` CSS function](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/ellipse#formal_syntax) does not support such a format (three value).
