### PR TITLE
Add form attribute to <mo> MathML element

### DIFF
--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -18,7 +18,7 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 - `fence`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.
 - `form`
-  - : An [enumerated](/en-US/docs/Glossary/Enumerated) attribute specifying how the operator is to be presented: depending on the value, a different amount of space is rendered on either side of the operator. It can have one of the following values:
+  - : An [enumerated](/en-US/docs/Glossary/Enumerated) attribute specifying how the operator is to be presented. For example, depending on the value, a different amount of space might be rendered on either side of the operator. It can have one of the following values:
     - `prefix`: The operator appears before its operands. For example, in the expression `+ a`, the `+` is a prefix operator.
     - `infix`: The operator appears between its operands. In the expression `a + b`, the `+` is an infix operator.
     - `postfix`: The operator appears after its operands. For example, in the expression `a +`, the `+` is a postfix operator.

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -15,13 +15,13 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 
 - `accent` {{Non-standard_Inline}}
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) (i.e. drawn bigger and closer to the base expression).
+- `fence`
+  - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.
 - `form`
   - : An [enumerated](/en-US/docs/Glossary/Enumerated) attribute specifying how the operator is to be presented: depending on the value, a different amount of space is rendered on either side of the operator. It can have one of the following values:
     - `prefix`: The operator appears before its operands. For example, in the expression `+ a`, the `+` is a prefix operator.
     - `infix`: The operator appears between its operands. In the expression `a + b`, the `+` is an infix operator.
     - `postfix`: The operator appears after its operands. For example, in the expression `a +`, the `+` is a postfix operator.
-- `fence`
-  - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.
 - `largeop`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator should be drawn bigger when [`math-style`](/en-US/docs/Web/CSS/math-style) is set to `normal`.
 - `lspace`

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -15,6 +15,11 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 
 - `accent` {{Non-standard_Inline}}
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) (i.e. drawn bigger and closer to the base expression).
+- `form`
+  - : A [enumerated](/en-US/docs/Glossary/Enumerated) attribute specifying how the operator is to be presented: depending on the value, a different amount of space is rendered on either side of the operator. It can have one of the following values:
+    - `prefix`: The operator appears before its operands. For example, in the expression `+ a`, the `+` is a prefix operator.
+    - `infix`: The operator appears between its operands. In the `a + b` expression, the `+` is an infix operator.
+    - `postfix`: The operator appears after its operands. For example, in the expression `a +`, the `+` is a postfix operator.
 - `fence`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.
 - `largeop`

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -16,9 +16,9 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 - `accent` {{Non-standard_Inline}}
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator should be treated as an accent when used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) (i.e. drawn bigger and closer to the base expression).
 - `form`
-  - : A [enumerated](/en-US/docs/Glossary/Enumerated) attribute specifying how the operator is to be presented: depending on the value, a different amount of space is rendered on either side of the operator. It can have one of the following values:
+  - : An [enumerated](/en-US/docs/Glossary/Enumerated) attribute specifying how the operator is to be presented: depending on the value, a different amount of space is rendered on either side of the operator. It can have one of the following values:
     - `prefix`: The operator appears before its operands. For example, in the expression `+ a`, the `+` is a prefix operator.
-    - `infix`: The operator appears between its operands. In the `a + b` expression, the `+` is an infix operator.
+    - `infix`: The operator appears between its operands. In the expression `a + b`, the `+` is an infix operator.
     - `postfix`: The operator appears after its operands. For example, in the expression `a +`, the `+` is a postfix operator.
 - `fence`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator is a fence (such as parentheses). There is no visual effect for this attribute.


### PR DESCRIPTION
### Description

Adds missing `form` attribute to `<mo>` MathML element.

### Motivation

- It’s available [in the MathML Core spec](https://w3c.github.io/mathml-core/#dfn-mo)
- It’s already [documented in BCD](https://github.com/mdn/browser-compat-data/blob/main/mathml/elements/mo.json#L71-L104)