### PR TITLE
chore(http): Revisit status page, add links, tidy up TCN references

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -49,7 +49,7 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### HTTP
 
-- The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code is enabled for [preconnecting](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to a particular origin (that the page is likely to need resources from).
+- The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [informational response](/en-US/docs/Web/HTTP/Status#informational_responses) status code is enabled for [preconnecting](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to a particular origin (that the page is likely to need resources from).
   For more details see [Firefox bug 1858712](https://bugzil.la/1858712).
 - Firefox supports the [Global Privacy Control](https://globalprivacycontrol.org/) {{HTTPHeader("Sec-GPC")}} request header, which may be sent to indicate that the user does not consent to a website or service selling or sharing their personal information with third parties.
   Users can enable the header, in both normal and private browsing modes, by setting the preference `privacy.globalprivacycontrol.enabled` to `true` (in `about:config`).

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -33,7 +33,7 @@ No notable changes.
 
 ### HTTP
 
-- The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code is now enabled for [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources that the page is likely to need while the server is still preparing the full response.
+- The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [informational response](/en-US/docs/Web/HTTP/Status#informational_responses) status code is now enabled for [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources that the page is likely to need while the server is still preparing the full response.
   This can significantly reduce page load time.
   Note that support for using the `103 Early Hints` header for [preconnecting](/en-US/docs/Web/HTML/Attributes/rel/preconnect) was added in [Firefox 120](/en-US/docs/Mozilla/Firefox/Releases/120#http).
   For more details see [Firefox bug 1874445](https://bugzil.la/1874445).

--- a/files/en-us/web/http/status/100/index.md
+++ b/files/en-us/web/http/status/100/index.md
@@ -7,7 +7,7 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.100
 
 {{HTTPSidebar}}
 
-The HTTP **`100 Continue`** [informational response](/en-US/docs/Web/HTTP/Status#information_responses) status code indicates that the initial part of a request has been received and has not yet been rejected by the server.
+The HTTP **`100 Continue`** [informational response](/en-US/docs/Web/HTTP/Status#informational_responses) status code indicates that the initial part of a request has been received and has not yet been rejected by the server.
 The client should continue with a request or discard the 100 response if the request is already finished.
 
 When a request has an {{HTTPHeader("Expect", "Expect: 100-continue")}} header, the 100 Continue response indicates that the server is ready or capable of receiving the request content.

--- a/files/en-us/web/http/status/101/index.md
+++ b/files/en-us/web/http/status/101/index.md
@@ -7,7 +7,7 @@ spec-urls: https://httpwg.org/specs/rfc9110.html#status.101
 
 {{HTTPSidebar}}
 
-The HTTP **`101 Switching Protocols`** [informational response](/en-US/docs/Web/HTTP/Status#information_responses) status code indicates the protocol that a server has switched to.
+The HTTP **`101 Switching Protocols`** [informational response](/en-US/docs/Web/HTTP/Status#informational_responses) status code indicates the protocol that a server has switched to.
 The protocol is specified in the {{HTTPHeader("Upgrade")}} request header received from a client.
 
 The server includes an {{HTTPHeader("Upgrade")}} header in this response to indicate the protocol it has agreed to switch to.

--- a/files/en-us/web/http/status/102/index.md
+++ b/files/en-us/web/http/status/102/index.md
@@ -7,7 +7,7 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc2518.html#section-10.1
 
 {{HTTPSidebar}}{{deprecated_header}}
 
-The HTTP **`102 Processing`** [informational response](/en-US/docs/Web/HTTP/Status#information_responses) status code indicates to client that a full request has been received and the server is working on it.
+The HTTP **`102 Processing`** [informational response](/en-US/docs/Web/HTTP/Status#informational_responses) status code indicates to client that a full request has been received and the server is working on it.
 This status code is only sent if the server expects the request to take significant time.
 
 > [!NOTE]

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -7,7 +7,7 @@ browser-compat: http.status.103
 
 {{HTTPSidebar}}
 
-The HTTP **`103 Early Hints`** [informational response](/en-US/docs/Web/HTTP/Status#information_responses) may be sent by a server while it is still preparing a response, with hints about the sites and resources that the server expects the final response will link to.
+The HTTP **`103 Early Hints`** [informational response](/en-US/docs/Web/HTTP/Status#informational_responses) may be sent by a server while it is still preparing a response, with hints about the sites and resources that the server expects the final response will link to.
 This allows a browser to [preconnect](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to sites or start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources even before the server has prepared and sent a final response.
 Preloaded resources indicated by early hints are fetched by the client as soon as the hints are received.
 
@@ -18,7 +18,7 @@ A server might send multiple `103` responses, for example, following a redirect.
 Browsers only process the first early hints response, and this response must be discarded if the request results in a cross-origin redirect.
 
 > [!NOTE]
-> For compatibility and security reasons, it is recommended to [only send HTTP `103 Early Hints` responses over HTTP/2 or later]((https://www.rfc-editor.org/rfc/rfc8297#section-3) unless the client is known to handle informational responses correctly.
+> For compatibility and security reasons, it is recommended to [only send HTTP `103 Early Hints` responses over HTTP/2 or later](https://www.rfc-editor.org/rfc/rfc8297#section-3) unless the client is known to handle informational responses correctly.
 >
 > Most browsers limit support to HTTP/2 or later for this reason. See [browser compatibility](#browser_compatibility) below.
 > Despite this, the examples below use HTTP/1.1-style notation as per usual convention.

--- a/files/en-us/web/http/status/300/index.md
+++ b/files/en-us/web/http/status/300/index.md
@@ -11,8 +11,8 @@ The HTTP **`300 Multiple Choices`** [redirection response](/en-US/docs/Web/HTTP/
 The user-agent or the user should choose one of them.
 
 > [!NOTE]
-> In Transparent Content Negotiation (TCN), a client and server collaboratively decide the best variant of a given resource when the server has multiple variants.
-> Most modern browsers have poor support due to complexity in implementations, lack of standardization of how clients automatically choose from responses, and the additional round-trips that slow down client-server interaction.
+> In [agent-driven content negotiation](/en-US/docs/Web/HTTP/Content_negotiation#agent-driven_negotiation), a client and server collaboratively decide the best variant of a given resource when the server has multiple variants.
+> Most clients lack a method for automatically choosing from responses, and the additional round-trips slow down client-server interaction.
 > [Server-driven content negotiation](/en-US/docs/Web/HTTP/Content_negotiation#server-driven_content_negotiation) is far more common, where a server chooses the most appropriate resource for the client based on the request headers ({{HTTPHeader("Accept-Language")}}, {{HTTPHeader("Accept")}}, etc.).
 
 The server should include content in the response that contains a list of resource metadata and URIs from which the user or user agent can choose.

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -11,6 +11,7 @@ The HTTP **`304 Not Modified`** [redirection response](/en-US/docs/Web/HTTP/Stat
 
 This response code is sent when the request is a [conditional](/en-US/docs/Web/HTTP/Conditional_requests) {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request with an {{HTTPHeader("If-None-Match")}} or an {{HTTPHeader("If-Modified-Since")}} header and the condition evaluates to 'false'.
 It confirms that the resource cached by the client is still valid and that the server would have sent a {{HTTPStatus("200", "200 OK")}} response with the resource if the condition evaluated to 'true'.
+See [HTTP caching](/en-US/docs/Web/HTTP/Caching) for more information.
 
 The response must not contain a body and must include the headers that would have been sent in an equivalent {{HTTPStatus("200")}} response, such as:
 

--- a/files/en-us/web/http/status/506/index.md
+++ b/files/en-us/web/http/status/506/index.md
@@ -7,12 +7,12 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc2295#section-8.1
 
 {{HTTPSidebar}}
 
-The HTTP **`506 Variant Also Negotiates`** [server error response](/en-US/docs/Web/HTTP/Status#server_error_responses) status code is returned during Transparent Content Negotiation (TCN) when there is recursive loop in the process of selecting a resource.
+The HTTP **`506 Variant Also Negotiates`** [server error response](/en-US/docs/Web/HTTP/Status#server_error_responses) status code is returned during content negotiation when there is recursive loop in the process of selecting a resource.
 
-Transparent Content Negotiation enables a client and server to collaboratively decide the best variant of a given resource when the server has multiple variants.
+Agent-driven content negotiation enables a client and server to collaboratively decide the best variant of a given resource when the server has multiple variants.
 A server sends a `506` status code due to server misconfiguration that results in circular references when creating responses.
 
-Transparent Content Negotiation is not supported in most modern browsers due to complexity in implementations, lack of standardization of how clients automatically choose from responses, and the additional round-trips that slow down client-server interaction.
+Lack of standardization of how clients automatically choose from responses, and the additional round-trips that slow down client-server interaction mean this mechanism is rarely used.
 [Server-driven content negotiation](/en-US/docs/Web/HTTP/Content_negotiation#server-driven_content_negotiation) is far more common, where a server directly chooses the most appropriate resource for the client based on the request headers ({{HTTPHeader("Accept-Language")}}, {{HTTPHeader("Accept")}}, etc.).
 
 ## Status

--- a/files/en-us/web/http/status/506/index.md
+++ b/files/en-us/web/http/status/506/index.md
@@ -9,7 +9,7 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc2295#section-8.1
 
 The HTTP **`506 Variant Also Negotiates`** [server error response](/en-US/docs/Web/HTTP/Status#server_error_responses) status code is returned during content negotiation when there is recursive loop in the process of selecting a resource.
 
-Agent-driven content negotiation enables a client and server to collaboratively decide the best variant of a given resource when the server has multiple variants.
+[Agent-driven content negotiation](/en-US/docs/Web/HTTP/Content_negotiation#agent-driven_negotiation) enables a client and server to collaboratively decide the best variant of a given resource when the server has multiple variants.
 A server sends a `506` status code due to server misconfiguration that results in circular references when creating responses.
 
 Lack of standardization of how clients automatically choose from responses, and the additional round-trips that slow down client-server interaction mean this mechanism is rarely used.

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -10,7 +10,7 @@ browser-compat: http.status
 HTTP response status codes indicate whether a specific [HTTP](/en-US/docs/Web/HTTP) request has been successfully completed.
 Responses are grouped in five classes:
 
-1. [Informational responses](#information_responses) (`100` – `199`)
+1. [Informational responses](#informational_responses) (`100` – `199`)
 2. [Successful responses](#successful_responses) (`200` – `299`)
 3. [Redirection messages](#redirection_messages) (`300` – `399`)
 4. [Client error responses](#client_error_responses) (`400` – `499`)
@@ -19,32 +19,29 @@ Responses are grouped in five classes:
 The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
 
 > [!NOTE]
-> If you receive a response that is not in [this list](#information_responses), it is a non-standard response, possibly custom to the server's software.
+> If you receive a response that is not listed here, it is a non-standard response, possibly custom to the server's software.
 
-## Information responses
+## Informational responses
 
 - {{HTTPStatus(100, "100 Continue")}}
   - : This interim response indicates that the client should continue the request or ignore the response if the request is already finished.
 - {{HTTPStatus(101, "101 Switching Protocols")}}
   - : This code is sent in response to an {{HTTPHeader("Upgrade")}} request header from the client and indicates the protocol the server is switching to.
-- {{HTTPStatus(102, "102 Processing")}} ({{Glossary("WebDAV")}})
-  - : This code indicates that the server has received and is processing the request, but no response is available yet.
+- {{HTTPStatus(102, "102 Processing")}} {{deprecated_inline}}
+  - : This code was used in {{Glossary("WebDAV")}} contexts to indicate that a request has been received by the server, but no status was available at the time of the response.
 - {{HTTPStatus(103, "103 Early Hints")}}
   - : This status code is primarily intended to be used with the {{HTTPHeader("Link")}} header, letting the user agent start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources while the server prepares a response or [preconnect](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to an origin from which the page will need resources.
 
 ## Successful responses
 
 - {{HTTPStatus(200, "200 OK")}}
-
-  - : The request succeeded. The result meaning of "success" depends on the HTTP method:
-
-    - `GET`: The resource has been fetched and transmitted in the message body.
-    - `HEAD`: The representation headers are included in the response without any message body.
-    - `PUT` or `POST`: The resource describing the result of the action is transmitted in the message body.
-    - `TRACE`: The message body contains the request message as received by the server.
-
+  - : The request succeeded. The result and meaning of "success" depends on the HTTP method:
+    - {{HTTPMethod("GET")}}: The resource has been fetched and transmitted in the message body.
+    - {{HTTPMethod("HEAD")}}: Representation headers are included in the response without any message body.
+    - {{HTTPMethod("PUT")}} or {{HTTPMethod("POST")}}: The resource describing the result of the action is transmitted in the message body.
+    - {{HTTPMethod("TRACE")}}: The message body contains the request as received by the server.
 - {{HTTPStatus(201, "201 Created")}}
-  - : The request succeeded, and a new resource was created as a result. This is typically the response sent after `POST` requests, or some `PUT` requests.
+  - : The request succeeded, and a new resource was created as a result. This is typically the response sent after {{HTTPMethod("POST")}} requests, or some {{HTTPMethod("PUT")}} requests.
 - {{HTTPStatus(202, "202 Accepted")}}
   - : The request has been received but not yet acted upon.
     It is noncommittal, since there is no way in HTTP to later send an asynchronous response indicating the outcome of the request.
@@ -52,46 +49,47 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
 - {{HTTPStatus(203, "203 Non-Authoritative Information")}}
   - : This response code means the returned metadata is not exactly the same as is available from the origin server, but is collected from a local or a third-party copy.
     This is mostly used for mirrors or backups of another resource.
-    Except for that specific case, the `200 OK` response is preferred to this status.
+    Except for that specific case, the {{HTTPStatus(200, "200 OK")}} response is preferred to this status.
 - {{HTTPStatus(204, "204 No Content")}}
-  - : There is no content to send for this request, but the headers may be useful.
+  - : There is no content to send for this request, but the headers are useful.
     The user agent may update its cached headers for this resource with the new ones.
 - {{HTTPStatus(205, "205 Reset Content")}}
   - : Tells the user agent to reset the document which sent this request.
 - {{HTTPStatus(206, "206 Partial Content")}}
-  - : This response code is used when the {{HTTPHeader("Range")}} header is sent from the client to request only part of a resource.
+  - : This response code is used in response to a [range request](/en-US/docs/Web/HTTP/Range_requests) when the client has requested a part or parts of a resource.
 - {{HTTPStatus(207, "207 Multi-Status")}} ({{Glossary("WebDAV")}})
   - : Conveys information about multiple resources, for situations where multiple status codes might be appropriate.
 - {{HTTPStatus(208, "208 Already Reported")}} ({{Glossary("WebDAV")}})
   - : Used inside a `<dav:propstat>` response element to avoid repeatedly enumerating the internal members of multiple bindings to the same collection.
 - {{HTTPStatus(226, "226 IM Used")}} ([HTTP Delta encoding](https://datatracker.ietf.org/doc/html/rfc3229))
-  - : The server has fulfilled a `GET` request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance.
+  - : The server has fulfilled a {{HTTPMethod("GET")}} request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance.
 
 ## Redirection messages
 
 - {{HTTPStatus(300, "300 Multiple Choices")}}
-  - : The request has more than one possible response. The user agent or user should choose one of them. (There is no standardized way of choosing one of the responses, but HTML links to the possibilities are recommended so the user can pick.)
+  - : In [agent-driven content negotiation](/en-US/docs/Web/HTTP/Content_negotiation#agent-driven_negotiation), the request has more than one possible response and the user agent or user should choose one of them.
+    There is no standardized way for clients to automatically choose one of the responses, so this is rarely used.
 - {{HTTPStatus(301, "301 Moved Permanently")}}
   - : The URL of the requested resource has been changed permanently. The new URL is given in the response.
 - {{HTTPStatus(302, "302 Found")}}
   - : This response code means that the URI of requested resource has been changed _temporarily_.
-    Further changes in the URI might be made in the future. Therefore, this same URI should be used by the client in future requests.
+    Further changes in the URI might be made in the future, so the same URI should be used by the client in future requests.
 - {{HTTPStatus(303, "303 See Other")}}
-  - : The server sent this response to direct the client to get the requested resource at another URI with a GET request.
+  - : The server sent this response to direct the client to get the requested resource at another URI with a {{HTTPMethod("GET")}} request.
 - {{HTTPStatus(304, "304 Not Modified")}}
   - : This is used for caching purposes.
-    It tells the client that the response has not been modified, so the client can continue to use the same cached version of the response.
+    It tells the client that the response has not been modified, so the client can continue to use the same [cached](/en-US/docs/Web/HTTP/Caching) version of the response.
 - `305 Use Proxy` {{deprecated_inline}}
   - : Defined in a previous version of the HTTP specification to indicate that a requested response must be accessed by a proxy.
     It has been deprecated due to security concerns regarding in-band configuration of a proxy.
 - `306 unused`
-  - : This response code is no longer used; it is just reserved. It was used in a previous version of the HTTP/1.1 specification.
+  - : This response code is no longer used; but is reserved. It was used in a previous version of the HTTP/1.1 specification.
 - {{HTTPStatus(307, "307 Temporary Redirect")}}
   - : The server sends this response to direct the client to get the requested resource at another URI with the same method that was used in the prior request.
-    This has the same semantics as the `302 Found` HTTP response code, with the exception that the user agent _must not_ change the HTTP method used: if a `POST` was used in the first request, a `POST` must be used in the second request.
+    This has the same semantics as the `302 Found` response code, with the exception that the user agent _must not_ change the HTTP method used: if a {{HTTPMethod("POST")}} was used in the first request, a `POST` must be used in the redirected request.
 - {{HTTPStatus(308, "308 Permanent Redirect")}}
-  - : This means that the resource is now permanently located at another URI, specified by the `Location:` HTTP Response header.
-    This has the same semantics as the `301 Moved Permanently` HTTP response code, with the exception that the user agent _must not_ change the HTTP method used: if a `POST` was used in the first request, a `POST` must be used in the second request.
+  - : This means that the resource is now permanently located at another URI, specified by the {{HTTPHeader("Location")}} response header.
+    This has the same semantics as the `301 Moved Permanently` HTTP response code, with the exception that the user agent _must not_ change the HTTP method used: if a {{HTTPMethod("POST")}} was used in the first request, a `POST` must be used in the second request.
 
 ## Client error responses
 
@@ -100,9 +98,8 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
 - {{HTTPStatus(401, "401 Unauthorized")}}
   - : Although the HTTP standard specifies "unauthorized", semantically this response means "unauthenticated".
     That is, the client must authenticate itself to get the requested response.
-- {{HTTPStatus(402, "402 Payment Required")}} {{experimental_inline}}
-  - : This response code is reserved for future use.
-    The initial aim for creating this code was using it for digital payment systems, however this status code is used very rarely and no standard convention exists.
+- {{HTTPStatus(402, "402 Payment Required")}}
+  - : The initial purpose of this code was for digital payment systems, however this status code is rarely used and no standard convention exists.
 - {{HTTPStatus(403, "403 Forbidden")}}
   - : The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource.
     Unlike `401 Unauthorized`, the client's identity is known to the server.
@@ -113,8 +110,8 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
     Servers may also send this response instead of `403 Forbidden` to hide the existence of a resource from an unauthorized client.
     This response code is probably the most well known due to its frequent occurrence on the web.
 - {{HTTPStatus(405, "405 Method Not Allowed")}}
-  - : The request method is known by the server but is not supported by the target resource.
-    For example, an API may not allow calling `DELETE` to remove a resource.
+  - : The [request method](/en-US/docs/Web/HTTP/Methods) is known by the server but is not supported by the target resource.
+    For example, an API may not allow `DELETE` on a resource, or the `TRACE` method entirely.
 - {{HTTPStatus(406, "406 Not Acceptable")}}
   - : This response is sent when the web server, after performing [server-driven content negotiation](/en-US/docs/Web/HTTP/Content_negotiation#server-driven_content_negotiation), doesn't find any content that conforms to the criteria given by the user agent.
 - {{HTTPStatus(407, "407 Proxy Authentication Required")}}
@@ -122,31 +119,32 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
 - {{HTTPStatus(408, "408 Request Timeout")}}
   - : This response is sent on an idle connection by some servers, even without any previous request by the client.
     It means that the server would like to shut down this unused connection.
-    This response is used much more since some browsers, like Chrome, Firefox 27+, or IE9, use HTTP pre-connection mechanisms to speed up surfing.
-    Also note that some servers merely shut down the connection without sending this message.
+    This response is used much more since some browsers use HTTP pre-connection mechanisms to speed up browsing.
+    Some servers may shut down a connection without sending this message.
 - {{HTTPStatus(409, "409 Conflict")}}
   - : This response is sent when a request conflicts with the current state of the server.
+    In {{glossary("WebDAV")}} remote web authoring, `409` responses are errors sent to the client so that a user might be able to resolve a conflict and resubmit the request.
 - {{HTTPStatus(410, "410 Gone")}}
   - : This response is sent when the requested content has been permanently deleted from server, with no forwarding address.
     Clients are expected to remove their caches and links to the resource.
     The HTTP specification intends this status code to be used for "limited-time, promotional services".
     APIs should not feel compelled to indicate resources that have been deleted with this status code.
 - {{HTTPStatus(411, "411 Length Required")}}
-  - : Server rejected the request because the `Content-Length` header field is not defined and the server requires it.
+  - : Server rejected the request because the {{HTTPHeader("Content-Length")}} header field is not defined and the server requires it.
 - {{HTTPStatus(412, "412 Precondition Failed")}}
-  - : The client has indicated preconditions in its headers which the server does not meet.
-- {{HTTPStatus(413, "413 Payload Too Large")}}
-  - : Request entity is larger than limits defined by server.
-    The server might close the connection or return an `Retry-After` header field.
+  - : In [conditional requests](/en-US/docs/Web/HTTP/Conditional_requests), the client has indicated preconditions in its headers which the server does not meet.
+- {{HTTPStatus(413, "413 Content Too Large")}}
+  - : The request body is larger than limits defined by server.
+    The server might close the connection or return an {{HTTPHeader("Retry-After")}} header field.
 - {{HTTPStatus(414, "414 URI Too Long")}}
   - : The URI requested by the client is longer than the server is willing to interpret.
 - {{HTTPStatus(415, "415 Unsupported Media Type")}}
   - : The media format of the requested data is not supported by the server, so the server is rejecting the request.
 - {{HTTPStatus(416, "416 Range Not Satisfiable")}}
-  - : The range specified by the `Range` header field in the request cannot be fulfilled.
-    It's possible that the range is outside the size of the target URI's data.
+  - : The [ranges](/en-US/docs/Web/HTTP/Range_requests) specified by the `Range` header field in the request cannot be fulfilled.
+    It's possible that the range is outside the size of the target resource's data.
 - {{HTTPStatus(417, "417 Expectation Failed")}}
-  - : This response code means the expectation indicated by the `Expect` request header field cannot be met by the server.
+  - : This response code means the expectation indicated by the {{HTTPHeader("Expect")}} request header field cannot be met by the server.
 - {{HTTPStatus(418, "418 I'm a teapot")}}
   - : The server refuses the attempt to brew coffee with a teapot.
 - {{HTTPStatus(421, "421 Misdirected Request")}}
@@ -164,10 +162,10 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
   - : The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.
     The server sends an {{HTTPHeader("Upgrade")}} header in a 426 response to indicate the required protocol(s).
 - {{HTTPStatus(428, "428 Precondition Required")}}
-  - : The origin server requires the request to be conditional.
-    This response is intended to prevent the 'lost update' problem, where a client `GET`s a resource's state, modifies it and `PUT`s it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict.
+  - : The origin server requires the request to be [conditional](/en-US/docs/Web/HTTP/Conditional_requests).
+    This response is intended to prevent the 'lost update' problem, where a client {{HTTPMethod("GET")}}s a resource's state, modifies it and {{HTTPMethod("PUT")}}s it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict.
 - {{HTTPStatus(429, "429 Too Many Requests")}}
-  - : The user has sent too many requests in a given amount of time ("rate limiting").
+  - : The user has sent too many requests in a given amount of time ({{Glossary("Rate_limit","rate limiting" )}}).
 - {{HTTPStatus(431, "431 Request Header Fields Too Large")}}
   - : The server is unwilling to process the request because its header fields are too large.
     The request may be resubmitted after reducing the size of the request header fields.
@@ -178,28 +176,29 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
 
 - {{HTTPStatus(500, "500 Internal Server Error")}}
   - : The server has encountered a situation it does not know how to handle.
+    This error is generic, indicating that the server cannot find a more appropriate `5XX` status code to respond with.
 - {{HTTPStatus(501, "501 Not Implemented")}}
-  - : The request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are `GET` and `HEAD`.
+  - : The request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}}.
 - {{HTTPStatus(502, "502 Bad Gateway")}}
   - : This error response means that the server, while working as a gateway to get a response needed to handle the request, got an invalid response.
 - {{HTTPStatus(503, "503 Service Unavailable")}}
   - : The server is not ready to handle the request.
     Common causes are a server that is down for maintenance or that is overloaded.
     Note that together with this response, a user-friendly page explaining the problem should be sent.
-    This response should be used for temporary conditions and the `Retry-After` HTTP header should, if possible, contain the estimated time before the recovery of the service.
+    This response should be used for temporary conditions and the {{HTTPHeader("Retry-After")}} HTTP header should, if possible, contain the estimated time before the recovery of the service.
     The webmaster must also take care about the caching-related headers that are sent along with this response, as these temporary condition responses should usually not be cached.
 - {{HTTPStatus(504, "504 Gateway Timeout")}}
   - : This error response is given when the server is acting as a gateway and cannot get a response in time.
 - {{HTTPStatus(505, "505 HTTP Version Not Supported")}}
   - : The HTTP version used in the request is not supported by the server.
 - {{HTTPStatus(506, "506 Variant Also Negotiates")}}
-  - : The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process.
+  - : The server has an internal configuration error: during content negotiation, the chosen variant is configured to engage in content negotiation itself, which results in circular references when creating responses.
 - {{HTTPStatus(507, "507 Insufficient Storage")}} ({{Glossary("WebDAV")}})
   - : The method could not be performed on the resource because the server is unable to store the representation needed to successfully complete the request.
 - {{HTTPStatus(508, "508 Loop Detected")}} ({{Glossary("WebDAV")}})
   - : The server detected an infinite loop while processing the request.
 - {{HTTPStatus(510, "510 Not Extended")}}
-  - : Further extensions to the request are required for the server to fulfill it.
+  - : The client request declares an HTTP Extension ({{RFC("2774")}}) that should be used to process the request, but the extension is not supported.
 - {{HTTPStatus(511, "511 Network Authentication Required")}}
   - : Indicates that the client needs to authenticate to gain network access.
 


### PR DESCRIPTION
### Description

A refresh of the Status Codes landing page. There are some follow-ups to reflect in the landing page after each sub-page was worked on.

### Motivation

Keeping content up-to-date and useful.

__Related issues and pull requests:__

- [x] https://github.com/mdn/content/pull/35023
- [x] https://github.com/mdn/content/pull/34422
- [x] https://github.com/mdn/content/pull/35353
- [x] https://github.com/mdn/content/pull/34620
- [x] https://github.com/mdn/content/pull/35361

