### PR TITLE
Update docs of CSS property resize

### DIFF
--- a/files/en-us/web/css/resize/index.md
+++ b/files/en-us/web/css/resize/index.md
@@ -14,7 +14,7 @@ The **`resize`** [CSS](/en-US/docs/Web/CSS) property sets whether an element is 
 `resize` does not apply to the following:
 
 - Inline elements
-- Block elements for which the {{cssxref("overflow")}} property is set to `visible`
+- Block elements for which the {{cssxref("overflow")}} property is set to `visible` or `clip`
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Mention that the `resize` property does not apply to elements with an `overflow` set to `clip`

### Motivation

Improve accuracy.

### Additional details

-

### Related issues and pull requests

None that I'm aware of.