### PR TITLE
Add warnings on isInputPending

### DIFF
--- a/files/en-us/learn/performance/javascript/index.md
+++ b/files/en-us/learn/performance/javascript/index.md
@@ -208,11 +208,11 @@ async function main() {
 }
 ```
 
-To improve this further, we can use {{domxref("Scheduler.yield")}} when available to allow this code to continue executing ahead of other less critical tasks in the queue:
+To improve this further, we can use {{domxref("Scheduler.yield")}} where available to allow this code to continue executing ahead of other less critical tasks in the queue:
 
 ```js
 function yield() {
-  // Use scheduler.yield if it exists:
+  // Use scheduler.yield() if available
   if ("scheduler" in window && "yield" in scheduler) {
     return scheduler.yield();
   }

--- a/files/en-us/learn/performance/javascript/index.md
+++ b/files/en-us/learn/performance/javascript/index.md
@@ -208,29 +208,21 @@ async function main() {
 }
 ```
 
-To improve this further, we can use {{domxref("Scheduling.isInputPending", "navigator.scheduling.isInputPending()")}} to run the `yield()` function only when the user is attempting to interact with the page:
+To improve this further, we can use {{domxref("Scheduler.yield")}} when available to allow this code to continue executing ahead of other less critical tasks in the queue:
 
 ```js
-async function main() {
-  // Create an array of functions to run
-  const tasks = [a, b, c, d, e];
-
-  while (tasks.length > 0) {
-    // Yield to a pending user input
-    if (navigator.scheduling.isInputPending()) {
-      await yield();
-    } else {
-      // Shift the first task off the tasks array
-      const task = tasks.shift();
-
-      // Run the task
-      task();
-    }
+function yield() {
+  // Use scheduler.yield if it exists:
+  if ("scheduler" in window && "yield" in scheduler) {
+    return scheduler.yield();
   }
+
+  // Fall back to setTimeout:
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }
 ```
-
-This allows you to avoid blocking the main thread when the user is actively interacting with the page, potentially providing a smoother user experience. However, by only yielding when necessary, we can continue running the current task when there are no user inputs to process. This also avoids tasks being placed at the back of the queue behind other non-essential browser-initiated tasks that were scheduled after the current one.
 
 ## Handling JavaScript animations
 

--- a/files/en-us/web/api/navigator/scheduling/index.md
+++ b/files/en-us/web/api/navigator/scheduling/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.scheduling
 The **`scheduling`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Scheduling")}} object for the current document, which provides methods and properties to control scheduling tasks.
 
 > [!WARNING]
-> The {{domxref("Scheduling")}} interface (which includes the `isInputPending()` method) has been superseded by the {{domxref("Scheduler")}} interface, the features of which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
+> The {{domxref("Scheduling")}} interface (which includes the {{domxref("Scheduling.isInputPending()", "isInputPending()")}} method) has been superseded by the {{domxref("Scheduler")}} interface, the features of which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
 
 ## Value
 

--- a/files/en-us/web/api/navigator/scheduling/index.md
+++ b/files/en-us/web/api/navigator/scheduling/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.scheduling
 The **`scheduling`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Scheduling")}} object for the current document, which provides methods and properties to control scheduling tasks.
 
 > [!WARNING]
-> This is an older interface and newer scheduling APIs are available using the {{domxref("Scheduler")}} interface. Some [no longer recommend using `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending).
+> The {{domxref("Scheduling")}} interface (which includes the `isInputPending()` method) has been superseded by the {{domxref("Scheduler")}} interface, the features of which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
 
 ## Value
 

--- a/files/en-us/web/api/navigator/scheduling/index.md
+++ b/files/en-us/web/api/navigator/scheduling/index.md
@@ -12,6 +12,9 @@ browser-compat: api.Navigator.scheduling
 
 The **`scheduling`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Scheduling")}} object for the current document, which provides methods and properties to control scheduling tasks.
 
+> [!WARNING]
+> This is an older interface and newer scheduling APIs are available using the {{domxref("Scheduler")}} interface. Some [no longer recommend using `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending).
+
 ## Value
 
 A {{domxref("Scheduling")}} object.
@@ -30,6 +33,8 @@ See the {{domxref("Scheduling.isInputPending()")}} page for a full example.
 
 ## See also
 
+- {{domxref("Scheduler")}} interface
+- {{domxref("Prioritized_task_scheduling_api", "Prioritized Task Scheduling API")}}
 - [Faster input events with Facebook's first browser API contribution](https://engineering.fb.com/2019/04/22/developer-tools/isinputpending-api/) on engineering.fb.com (2019)
 - [Better JS scheduling with isInputPending()](https://developer.chrome.com/docs/capabilities/web-apis/isinputpending) on developer.chrome.com (2020)
-- [Optimizing long tasks](https://web.dev/articles/optimize-long-tasks#yield_only_when_necessary) on web.dev (2022)
+- [Optimizing long tasks](https://web.dev/articles/optimize-long-tasks) on web.dev (2022)

--- a/files/en-us/web/api/scheduling/index.md
+++ b/files/en-us/web/api/scheduling/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Scheduling
 The **`Scheduling`** object provides methods and properties to control scheduling tasks within the current document.
 
 > [!WARNING]
-> This is an older interface and newer scheduling APIs are available using the {{domxref("Scheduler")}} interface. Some [no longer recommend using `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending).
+> The `Scheduling` interface has been superseded by the {{domxref("Scheduler")}} interface, the features of which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
 
 ## Instance methods
 

--- a/files/en-us/web/api/scheduling/index.md
+++ b/files/en-us/web/api/scheduling/index.md
@@ -11,6 +11,9 @@ browser-compat: api.Scheduling
 
 The **`Scheduling`** object provides methods and properties to control scheduling tasks within the current document.
 
+> [!WARNING]
+> This is an older interface and newer scheduling APIs are available using the {{domxref("Scheduler")}} interface. Some [no longer recommend using `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending).
+
 ## Instance methods
 
 - {{domxref("Scheduling.isInputPending", "isInputPending()")}} {{Experimental_Inline}}
@@ -30,6 +33,8 @@ See the {{domxref("Scheduling.isInputPending()")}} page for a full example.
 
 ## See also
 
+- {{domxref("Scheduler")}} interface
+- {{domxref("Prioritized_task_scheduling_api", "Prioritized Task Scheduling API")}}
 - [Faster input events with Facebook's first browser API contribution](https://engineering.fb.com/2019/04/22/developer-tools/isinputpending-api/) on engineering.fb.com (2019)
 - [Better JS scheduling with isInputPending()](https://developer.chrome.com/docs/capabilities/web-apis/isinputpending) on developer.chrome.com (2020)
-- [Optimizing long tasks](https://web.dev/articles/optimize-long-tasks#yield_only_when_necessary) on web.dev (2022)
+- [Optimizing long tasks](https://web.dev/articles/optimize-long-tasks) on web.dev (2022)

--- a/files/en-us/web/api/scheduling/isinputpending/index.md
+++ b/files/en-us/web/api/scheduling/isinputpending/index.md
@@ -15,7 +15,7 @@ The **`isInputPending()`** method of the {{domxref("Scheduling")}} interface all
 This feature can be useful in situations where you have a queue of tasks to run, and you want to yield to the main thread regularly to allow user interaction to occur so that the app is kept as responsive and performant as possible. `isInputPending()` allows you to yield only when there is input pending, rather than having to do it at arbitrary intervals.
 
 > [!WARNING]
-> This is an older interface and newer scheduling APIs are available using the {{domxref("Scheduler")}} interface. Some [no longer recommend using `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending).
+> `isInputPending()` has been superseded by features available on the {{domxref("Scheduler")}} interface such as `yield()`, which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
 
 `isInputPending()` is called using `navigator.scheduling.isInputPending()`.
 

--- a/files/en-us/web/api/scheduling/isinputpending/index.md
+++ b/files/en-us/web/api/scheduling/isinputpending/index.md
@@ -12,7 +12,10 @@ browser-compat: api.Scheduling.isInputPending
 
 The **`isInputPending()`** method of the {{domxref("Scheduling")}} interface allows you to check whether there are pending input events in the event queue, indicating that the user is attempting to interact with the page.
 
-This feature is useful in situations where you have a queue of tasks to run, and you want to yield to the main thread regularly to allow user interaction to occur so that the app is kept as responsive and performant as possible. `isInputPending()` allows you to yield only when there is input pending, rather than having to do it at arbitrary intervals.
+This feature can be useful in situations where you have a queue of tasks to run, and you want to yield to the main thread regularly to allow user interaction to occur so that the app is kept as responsive and performant as possible. `isInputPending()` allows you to yield only when there is input pending, rather than having to do it at arbitrary intervals.
+
+> [!WARNING]
+> This is an older interface and newer scheduling APIs are available using the {{domxref("Scheduler")}} interface. Some [no longer recommend using `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending).
 
 `isInputPending()` is called using `navigator.scheduling.isInputPending()`.
 
@@ -76,6 +79,8 @@ This allows you to avoid blocking the main thread when the user is actively inte
 
 ## See also
 
+- {{domxref("Scheduler")}} interface
+- {{domxref("Prioritized_task_scheduling_api", "Prioritized Task Scheduling API")}}
 - [Faster input events with Facebook's first browser API contribution](https://engineering.fb.com/2019/04/22/developer-tools/isinputpending-api/) on engineering.fb.com (2019)
 - [Better JS scheduling with isInputPending()](https://developer.chrome.com/docs/capabilities/web-apis/isinputpending) on developer.chrome.com (2020)
 - [Optimizing long tasks](https://web.dev/articles/optimize-long-tasks#yield_only_when_necessary) on web.dev (2022)

--- a/files/en-us/web/api/scheduling/isinputpending/index.md
+++ b/files/en-us/web/api/scheduling/isinputpending/index.md
@@ -15,7 +15,7 @@ The **`isInputPending()`** method of the {{domxref("Scheduling")}} interface all
 This feature can be useful in situations where you have a queue of tasks to run, and you want to yield to the main thread regularly to allow user interaction to occur so that the app is kept as responsive and performant as possible. `isInputPending()` allows you to yield only when there is input pending, rather than having to do it at arbitrary intervals.
 
 > [!WARNING]
-> `isInputPending()` has been superseded by features available on the {{domxref("Scheduler")}} interface such as `yield()`, which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
+> The `isInputPending()` method has been superseded by features available on the {{domxref("Scheduler")}} interface such as {{domxref("Scheduler.yield()", "yield()")}}, which are better designed for addressing scheduling tasks. See [Don't use `isInputPending()`](https://web.dev/articles/optimize-long-tasks#isinputpending) for more details.
 
 `isInputPending()` is called using `navigator.scheduling.isInputPending()`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The only implementer of `isInputPending` is Chrome/Chromium which [no longer recommends this API](https://web.dev/articles/optimize-long-tasks#isinputpending). (Note I work on Chrome).

This PR adds this warning.

We also remove `isInputPending` from the [Learn Performance JavaScript](https://developer.mozilla.org/en-US/docs/Learn/Performance/JavaScript#breaking_down_long_tasks) and [Prioritized Task Scheduling API](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) pages and replace with `scheduler.yield` examples (see also #35960 recently merged - during that review some of this came up).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Warn developers thinking of using this API about the potential concerns.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://web.dev/articles/optimize-long-tasks#isinputpending

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
