### PR TITLE
Fix EmbedLiveSample

### DIFF
--- a/files/en-us/web/html/element/nav/index.md
+++ b/files/en-us/web/html/element/nav/index.md
@@ -25,7 +25,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 In this example, a `<nav>` block is used to contain an unordered list ({{HTMLElement("ul")}}) of links. With appropriate CSS, this can be presented as a sidebar, navigation bar, or drop-down menu.
 
-```html live-sample__unordered-list
+```html live-sample___unordered-list
 <nav class="menu">
   <ul>
     <li><a href="#">Home</a></li>
@@ -39,7 +39,7 @@ In this example, a `<nav>` block is used to contain an unordered list ({{HTMLEle
 
 The semantics of the `nav` element is that of providing links. However a `nav` element doesn't have to contain a list, it can contain other kinds of content as well. In this navigation block, links are provided in prose:
 
-```html live-sample__prose
+```html live-sample___prose
 <nav>
   <h2>Navigation</h2>
   <p>

--- a/files/en-us/web/html/element/nav/index.md
+++ b/files/en-us/web/html/element/nav/index.md
@@ -25,7 +25,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 In this example, a `<nav>` block is used to contain an unordered list ({{HTMLElement("ul")}}) of links. With appropriate CSS, this can be presented as a sidebar, navigation bar, or drop-down menu.
 
-```html
+```html live-sample__unordered-list
 <nav class="menu">
   <ul>
     <li><a href="#">Home</a></li>
@@ -35,9 +35,11 @@ In this example, a `<nav>` block is used to contain an unordered list ({{HTMLEle
 </nav>
 ```
 
+{{EmbedLiveSample('unordered-list')}}
+
 The semantics of the `nav` element is that of providing links. However a `nav` element doesn't have to contain a list, it can contain other kinds of content as well. In this navigation block, links are provided in prose:
 
-```html
+```html live-sample__prose
 <nav>
   <h2>Navigation</h2>
   <p>
@@ -60,9 +62,7 @@ The semantics of the `nav` element is that of providing links. However a `nav` e
 </nav>
 ```
 
-### Result
-
-{{EmbedLiveSample('Examples')}}
+{{EmbedLiveSample('prose')}}
 
 ## Technical summary
 


### PR DESCRIPTION
Split examples into two live samples for better results windows.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
When reviewing the results window, I expected to see the results of the previous block of code. Instead, it shows the results of the previous two blocks of code. I mistakenly thought that the nav element in the prose section was converting the prose into a list and rendering that before the prose was rendered. I would show two results windows--one under each code block. I would split the examples apart.

<!-- ✍️ Summarize your changes in one or two sentences -->

Removed Results heading to simplify the Examples section. Results of markup are shown under their respective code blocks.

<!-- ❓ Why are you making these changes and how do they help readers? -->

When reviewing the Results window, I expected to see the results of the previous block of code. Instead, it shows the results of the previous two blocks of code. I mistakenly thought that the nav element in the prose section was converting the prose into a list and rendering that before the prose was rendered.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes  #36049 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
