### PR TITLE
Mention the safe range of 'time' param value of timeout()

### DIFF
--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -73,4 +73,4 @@ try {
 
 ## See also
 
-- [`Number.isSafeInteger()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger)
+- [`Number.isSafeInteger()`](/en-US/docs/web/javascript/reference/global_objects/number/issafeinteger)

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -27,7 +27,7 @@ AbortSignal.timeout(time)
 
 - `time`
   - : The "active" time in milliseconds before the returned {{domxref("AbortSignal")}} will abort.
-    The value must be within range of 0 and {{jsxref("Number.MAX_SAFE_INTEGER")}}
+    The value must be within range of 0 and {{jsxref("Number.MAX_SAFE_INTEGER")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -73,4 +73,4 @@ try {
 
 ## See also
 
-- [`Number.isSafeInteger()`](/en-US/docs/web/javascript/reference/global_objects/number/issafeinteger)
+- [`Number.isSafeInteger()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger)

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -70,3 +70,7 @@ try {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`Number.isSafeInteger()`](/en-US/docs/web/javascript/reference/global_objects/number/issafeinteger)

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -27,6 +27,7 @@ AbortSignal.timeout(time)
 
 - `time`
   - : The "active" time in milliseconds before the returned {{domxref("AbortSignal")}} will abort.
+    The value must be within range of 0 and {{jsxref("Number.MAX_SAFE_INTEGER")}}
 
 ### Return value
 

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -70,7 +70,3 @@ try {
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [`Number.isSafeInteger()`](/en-US/docs/web/javascript/reference/global_objects/number/issafeinteger)


### PR DESCRIPTION
This pull request fixes #36044 

It adds the brief note of a range of value that can be passed to `timeout()` method.
Because the `time` should be of type `unsigned long`, I described it as the range of 0 `Number.MAX_SAFE_INTEGER`.
