### PR TITLE
Editorial review: Add docs for scroll snap events

### DIFF
--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -365,9 +365,9 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 - {{DOMxRef("Document/scrollend_event", "scrollend")}}
   - : Fired when the document view or an element has completed scrolling.
 - {{domxref("Document/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
-  - : Fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+  - : Fired on the scroll container at the end of a scrolling operation when a new scroll snap target has been selected.
 - {{domxref("Document/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
-  - : Fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends).
+  - : Fired on the scroll container when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
 ### Selection events
 

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -364,6 +364,10 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Fired when the document view or an element has been scrolled.
 - {{DOMxRef("Document/scrollend_event", "scrollend")}}
   - : Fired when the document view or an element has completed scrolling.
+- {{domxref("Document/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
+  - : Fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+- {{domxref("Document/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
+  - : Fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends).
 
 ### Selection events
 

--- a/files/en-us/web/api/document/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchange_event/index.md
@@ -39,6 +39,9 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 ## See also
 
 - {{domxref("Document/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{DOMxRef("Document/scrollend_event", "scrollend")}} event
 - {{domxref("SnapEvent")}}
+- CSS {{cssxref("scroll-snap-type")}} property
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/document/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchange_event/index.md
@@ -10,9 +10,23 @@ browser-compat: api.Document.scrollsnapchange_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchange`** event of the {{domxref("Document")}} interface is fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+The **`scrollsnapchange`** event of the {{domxref("Document")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) at the end of a scrolling operation when a new scroll snap target is selected.
 
-This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchange` event](/en-US/docs/Web/API/Element/scrollsnapchange_event) for more information.
+This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchange`](/en-US/docs/Web/API/Element/scrollsnapchange_event) event.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("scrollsnapchange", (event) => {});
+
+onscrollsnapchange = (event) => {};
+```
+
+## Event type
+
+A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchange_event/index.md
@@ -38,7 +38,7 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 
 ## See also
 
-- The {{domxref("Document/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Document/scrollsnapchanging_event", "scrollsnapchanging")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/document/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchange_event/index.md
@@ -1,0 +1,30 @@
+---
+title: "Document: scrollsnapchange event"
+short-title: scrollsnapchange
+slug: Web/API/Document/scrollsnapchange_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.Document.scrollsnapchange_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`scrollsnapchange`** event of the {{domxref("Document")}} interface is fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+
+This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchange` event](/en-US/docs/Web/API/Element/scrollsnapchange_event) for more information.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Document/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("SnapEvent")}}
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/document/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchange_event/index.md
@@ -10,9 +10,9 @@ browser-compat: api.Document.scrollsnapchange_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchange`** event of the {{domxref("Document")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) at the end of a scrolling operation when a new scroll snap target is selected.
+The **`scrollsnapchange`** event of the {{domxref("Document")}} interface is fired on the document [scroll container](/en-US/docs/Glossary/Scroll_container) at the end of a scrolling operation when a new scroll snap target is selected.
 
-This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchange`](/en-US/docs/Web/API/Element/scrollsnapchange_event) event.
+This event works in much the same way as the {{domxref("Element")}} interface's [`scrollsnapchange`](/en-US/docs/Web/API/Element/scrollsnapchange_event) event, except that the overall HTML document has to be set as the scroll snap container (i.e., {{cssxref("scroll-snap-type")}} is set on the {{htmlelement("html")}} element).
 
 ## Syntax
 
@@ -27,6 +27,44 @@ onscrollsnapchange = (event) => {};
 ## Event type
 
 A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
+
+## Examples
+
+### Basic usage
+
+Let's say we have a {{htmlelement("main")}} element containing significant content that causes it to scroll:
+
+```html
+<main>
+  <!-- Significant content -->
+</main>
+```
+
+The `<main>` element can be turned into a scroll container using a combination of CSS properties, for example:
+
+```css
+main {
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+}
+```
+
+We can then implement scroll snapping behavior on the scrolling content by specifying the {{cssxref("scroll-snap-type")}} property on the {{htmlelement("html")}} element:
+
+```css
+html {
+  scroll-snap-type: block mandatory;
+}
+```
+
+The following JavaScript snippet would cause the `scrollsnapchange` event to fire on the HTML document when a child of the `<main>` element becomes a newly-selected snap target. In the handler function, we set a `selected` class on the child referenced by the {{domxref("SnapEvent.snapTargetBlock")}}, which could be used to style it to look like it has been selected (for example, with an animation) when the event fires.
+
+```js
+document.addEventListener("scrollsnapchange", (event) => {
+  event.snapTargetBlock.classList.add("selected");
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/document/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchanging_event/index.md
@@ -38,7 +38,7 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 
 ## See also
 
-- The {{domxref("Document/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{domxref("Document/scrollsnapchange_event", "scrollsnapchange")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/document/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchanging_event/index.md
@@ -10,9 +10,23 @@ browser-compat: api.Document.scrollsnapchanging_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchanging`** event of the {{domxref("Document")}} interface is fired when the browser determines that a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is pending (i.e., it will be selected when the current scroll gesture ends).
+The **`scrollsnapchanging`** event of the {{domxref("Document")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
-This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchanging` event](/en-US/docs/Web/API/Element/scrollsnapchanging_event) for more information.
+This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchanging`](/en-US/docs/Web/API/Element/scrollsnapchanging_event) event.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("scrollsnapchanging", (event) => {});
+
+onscrollsnapchanging = (event) => {};
+```
+
+## Event type
+
+A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchanging_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Document.scrollsnapchanging_event
 
 The **`scrollsnapchanging`** event of the {{domxref("Document")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
-This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchanging`](/en-US/docs/Web/API/Element/scrollsnapchanging_event) event.
+This event works in much the same way as the {{domxref("Element")}} interface's [`scrollsnapchanging`](/en-US/docs/Web/API/Element/scrollsnapchanging_event) event, except that the overall HTML document has to be set as the scroll snap container (i.e., {{cssxref("scroll-snap-type")}} is set on the {{htmlelement("html")}} element).
 
 ## Syntax
 
@@ -27,6 +27,53 @@ onscrollsnapchanging = (event) => {};
 ## Event type
 
 A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
+
+## Examples
+
+### Basic usage
+
+Let's say we have a {{htmlelement("main")}} element containing significant content that causes it to scroll:
+
+```html
+<main>
+  <!-- Significant content -->
+</main>
+```
+
+The `<main>` element can be turned into a scroll container using a combination of CSS properties, for example:
+
+```css
+main {
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+}
+```
+
+We can then implement scroll snapping behavior on the scrolling content by specifying the {{cssxref("scroll-snap-type")}} property on the {{htmlelement("html")}} element:
+
+```css
+html {
+  scroll-snap-type: block mandatory;
+}
+```
+
+The following JavaScript snippet would cause the `scrollsnapchanging` event to fire on the HTML document when a child of the `<main>` element becomes a pending snap target. In the handler function, we set a `pending` class on the child referenced by the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} property, which could be used to style it differently when the event fires.
+
+```js
+document.addEventListener("scrollsnapchanging", (event) => {
+  // remove previously-set "pending" classes
+  const pendingElems = document.querySelectorAll(".pending");
+  pendingElems.forEach((elem) => {
+    elem.classList.remove("pending");
+  });
+
+  // Set current pending snap target class to "pending"
+  event.snapTargetBlock.classList.add("pending");
+});
+```
+
+At the start of the function, we select all elements that previously had the `pending` class applied and remove it, so that only the most recent pending snap target is styled.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchanging_event/index.md
@@ -1,0 +1,30 @@
+---
+title: "Document: scrollsnapchanging event"
+short-title: scrollsnapchanging
+slug: Web/API/Document/scrollsnapchanging_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.Document.scrollsnapchanging_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`scrollsnapchanging`** event of the {{domxref("Document")}} interface is fired when the browser determines that a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is pending (i.e., it will be selected when the current scroll gesture ends).
+
+This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchanging` event](/en-US/docs/Web/API/Element/scrollsnapchanging_event) for more information.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Document/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{domxref("SnapEvent")}}
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/document/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/document/scrollsnapchanging_event/index.md
@@ -39,6 +39,9 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 ## See also
 
 - {{domxref("Document/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{DOMxRef("Document/scrollend_event", "scrollend")}} event
 - {{domxref("SnapEvent")}}
+- CSS {{cssxref("scroll-snap-type")}} property
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -307,14 +307,6 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Fired before WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}) are dispatched.
 - {{domxref("Element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}}
   - : Fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment#skips_its_contents).
-- {{domxref("Element/scroll_event", "scroll")}}
-  - : Fired when the document view or an element has been scrolled.
-- {{domxref("Element/scrollend_event", "scrollend")}}
-  - : Fires when the document view has completed scrolling.
-- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
-  - : Fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
-- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
-  - : Fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends).
 - {{domxref("Element/securitypolicyviolation_event","securitypolicyviolation")}}
   - : Fired when a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) is violated.
 - {{domxref("Element/wheel_event","wheel")}}
@@ -441,6 +433,17 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Fired when a pointer changes any properties that don't fire {{domxref("Element/pointerdown_event", "pointerdown")}} or {{domxref("Element/pointerup_event", "pointerup")}} events.
 - {{domxref("Element/pointerup_event", "pointerup")}}
   - : Fired when a pointer is no longer active.
+
+### Scroll events
+
+- {{domxref("Element/scroll_event", "scroll")}}
+  - : Fired when the document view or an element has been scrolled.
+- {{domxref("Element/scrollend_event", "scrollend")}}
+  - : Fires when the document view has completed scrolling.
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
+  - : Fired on the scroll container at the end of a scrolling operation when a new scroll snap target has been selected.
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
+  - : Fired on the scroll container when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
 ### Touch events
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -311,6 +311,10 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Fired when the document view or an element has been scrolled.
 - {{domxref("Element/scrollend_event", "scrollend")}}
   - : Fires when the document view has completed scrolling.
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
+  - : Fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
+  - : Fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends).
 - {{domxref("Element/securitypolicyviolation_event","securitypolicyviolation")}}
   - : Fired when a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) is violated.
 - {{domxref("Element/wheel_event","wheel")}}

--- a/files/en-us/web/api/element/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchange_event/index.md
@@ -49,7 +49,9 @@ scrollingElem.addEventListener("scrollsnapchange", (event) => {
 ## See also
 
 - {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{DOMxRef("Document/scrollend_event", "scrollend")}} event
 - {{domxref("SnapEvent")}}
+- CSS {{cssxref("scroll-snap-type")}} property
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchange_event/index.md
@@ -10,12 +10,9 @@ browser-compat: api.Element.scrollsnapchange_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchange`** event of the {{domxref("Element")}} interface is fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+The **`scrollsnapchange`** event of the {{domxref("Element")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) at the end of a scrolling operation when a new scroll snap target has been selected, just before the corresponding {{domxref("Element/scrollend_event", "scrollend")}} event fires.
 
-Note that this event fires:
-
-- When a scrolling gesture is completed (i.e. the user has finished scrolling a scroll container and releases the gesture), but only if a new snap target is selected.
-- Just before the {{domxref("Element/scrollend_event", "scrollend")}} event fires.
+A scrolling operation ends when the user finishes scrolling within a scroll container — for example using a touch gesture or by dragging the mouse pointer on a scroll bar — and releases the gesture.
 
 ## Syntax
 
@@ -29,36 +26,17 @@ onscrollsnapchange = (event) => {};
 
 ## Event type
 
-A {{domxref("SnapEvent")}}.
+A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
 
 ## Examples
 
-In the following `scrollsnapchange` handler function snippet (set on a scrolling container element), we set a `select-section` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
-
-Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
+In the following `scrollsnapchange` handler function snippet, we set a `selected` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
 
 ```js
 scrollingElem.addEventListener("scrollsnapchange", (event) => {
-  if (document.querySelector(".select-section")) {
-    document.querySelector(".select-section").className = "deselect-section";
-  } else {
-    document.querySelector("section").className = "select-section";
-  }
-
-  event.snapTargetBlock.className = "select-section";
-
-  // Logs the id of the new block-direction snap target element
-  console.log(event.snapTargetBlock.id);
-
-  // Always logs the same ID; the inline-direction snap target
-  // element will always be the same
-  console.log(event.snapTargetInline.id);
+  event.snapTargetBlock.classList.add("selected");
 });
 ```
-
-At the start of the function, we also include an `if...else` block to look for a previously-selected snap target. If one is found, it has a `deselect-section` class applied to it, which for example could be used to apply a deselection animation. If not, the first snap target in the page is given the `select-section` class, which means that it will be given the appropriate selected styles when the page first loads.
-
-See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
 
 ## Specifications
 
@@ -73,4 +51,5 @@ See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scr
 - The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchange_event/index.md
@@ -30,9 +30,32 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 
 ## Examples
 
-In the following `scrollsnapchange` handler function snippet, we set a `selected` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
+### Basic usage
+
+Let's say we have a {{htmlelement("main")}} element containing significant content that causes it to scroll:
+
+```html
+<main>
+  <!-- Significant content -->
+</main>
+```
+
+The `<main>` element can be turned into a scroll container that snaps to its children when scrolled using a combination of the CSS {{cssxref("scroll-snap-type")}} property and other properties. For example:
+
+```css
+main {
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+  scroll-snap-type: block mandatory;
+}
+```
+
+The following JavaScript snippet would cause the `scrollsnapchange` event to fire on the `<main>` element when one of its children becomes a newly-selected snap target. In the handler function, we set a `selected` class on the child referenced by the {{domxref("SnapEvent.snapTargetBlock")}} property, which could be used to style it to look like it has been selected (for example, with an animation) when the event fires.
 
 ```js
+const scrollingElem = document.querySelector("main");
+
 scrollingElem.addEventListener("scrollsnapchange", (event) => {
   event.snapTargetBlock.classList.add("selected");
 });

--- a/files/en-us/web/api/element/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchange_event/index.md
@@ -1,0 +1,76 @@
+---
+title: "Element: scrollsnapchange event"
+short-title: scrollsnapchange
+slug: Web/API/Element/scrollsnapchange_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.Element.scrollsnapchange_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`scrollsnapchange`** event of the {{domxref("Element")}} interface is fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+
+Note that this event fires:
+
+- When a scrolling gesture is completed (i.e. the user has finished scrolling a scroll container and releases the gesture), but only if a new snap target is selected.
+- Just before the {{domxref("Element/scrollend_event", "scrollend")}} event fires.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("scrollsnapchange", (event) => {});
+
+onscrollsnapchange = (event) => {};
+```
+
+## Event type
+
+A {{domxref("SnapEvent")}}.
+
+## Examples
+
+In the following `scrollsnapchange` handler function snippet (set on a scrolling container element), we set a `select-section` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
+
+Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
+
+```js
+scrollingElem.addEventListener("scrollsnapchange", (event) => {
+  if (document.querySelector(".select-section")) {
+    document.querySelector(".select-section").className = "deselect-section";
+  } else {
+    document.querySelector("section").className = "select-section";
+  }
+
+  event.snapTargetBlock.className = "select-section";
+
+  // Logs the id of the new block-direction snap target element
+  console.log(event.snapTargetBlock.id);
+
+  // Always logs the same ID; the inline-direction snap target
+  // element will always be the same
+  console.log(event.snapTargetInline.id);
+});
+```
+
+At the start of the function, we also include an `if...else` block to look for a previously-selected snap target. If one is found, it has a `deselect-section` class applied to it, which for example could be used to apply a deselection animation. If not, the first snap target in the page is given the `select-section` class, which means that it will be given the appropriate selected styles when the page first loads.
+
+See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("SnapEvent")}}
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchange_event/index.md
@@ -48,7 +48,7 @@ scrollingElem.addEventListener("scrollsnapchange", (event) => {
 
 ## See also
 
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)

--- a/files/en-us/web/api/element/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchanging_event/index.md
@@ -10,11 +10,11 @@ browser-compat: api.Element.scrollsnapchanging_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchanging`** event of the {{domxref("Element")}} interface is fired when the browser determines that a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is pending (i.e., it will be selected when the current scroll gesture ends).
+The **`scrollsnapchanging`** event of the {{domxref("Element")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
-Note that this event fires during a scrolling gesture, each time the user moves over a potential new snap target — imagine a user scrolling slowly by dragging their finger on a touch screen device, or holding down the mouse button on a scroll bar and moving the mouse. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture.
+Note that this event fires during a scrolling gesture, each time the user moves over a potential new snap target. For example, the user could scroll slowly by dragging their finger on a touch screen device, or hold down the mouse button on a scroll bar and move the mouse. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture.
 
-However, `scrollsnapchanging` does not fire on all potential snap targets for a gesture that spans multiple snap targets at once — just the last target that the snapping will potentially rest on. In this case, imagine a user flicking their finger hard on the screen to scroll past several potential targets before starting to come to rest near a target further down the scroll container.
+However, `scrollsnapchanging` does not fire on all potential snap targets for a gesture that spans multiple snap targets at once — just the last target that the snapping will potentially rest on. For example, if a user flicks their finger hard on the screen to scroll past several potential targets before starting to come to rest near a target further down the scroll container, the `scrollsnapchanging` event will fire when the target near the end of the scroll container is reached.
 
 ## Syntax
 
@@ -28,37 +28,26 @@ onscrollsnapchanging = (event) => {};
 
 ## Event type
 
-A {{domxref("SnapEvent")}}.
+A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
 
 ## Examples
 
-In the following `scrollsnapchanging` handler function snippet (set on a scrolling container element), we set the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element's `class` attribute to `pending` using the {{domxref("Element.className")}} property, which could be used to style the element differently when it becomes a pending snap target.
-
-Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
+In the following `scrollsnapchanging` handler function snippet, we set a `pending` class on the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element, which could be used to style the element differently when it becomes a pending snap target.
 
 ```js
 scrollingElem.addEventListener("scrollsnapchanging", (event) => {
   // remove previously-set "pending" classes
   const pendingElems = document.querySelectorAll(".pending");
   pendingElems.forEach((elem) => {
-    elem.className = "";
+    elem.classList.remove("pending");
   });
 
   // Set current pending snap target class to "pending"
-  event.snapTargetBlock.className = "pending";
-
-  // Logs the id of the new block-direction snap target element
-  console.log(event.snapTargetBlock.id);
-
-  // Always logs the same ID; the inline-direction snap target
-  // element will always be the same
-  console.log(event.snapTargetInline.id);
+  event.snapTargetBlock.classList.add("pending");
 });
 ```
 
 At the start of the function, we select all elements that previously had the `pending` class applied and remove it, so that only the most recent pending snap target is styled.
-
-See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
 
 ## Specifications
 
@@ -73,4 +62,5 @@ See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scr
 - The {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchanging_event/index.md
@@ -12,9 +12,9 @@ browser-compat: api.Element.scrollsnapchanging_event
 
 The **`scrollsnapchanging`** event of the {{domxref("Element")}} interface is fired on the [scroll container](/en-US/docs/Glossary/Scroll_container) when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
-Note that this event fires during a scrolling gesture, each time the user moves over a potential new snap target. For example, the user could scroll slowly by dragging their finger on a touch screen device, or hold down the mouse button on a scroll bar and move the mouse. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture.
+Specifically, this event fires during a scrolling gesture, each time the user moves over potential new snap targets. For example, the user could scroll slowly by dragging their finger on a touch screen device, or hold down the mouse button on a scroll bar and move the mouse. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture.
 
-However, `scrollsnapchanging` does not fire on all potential snap targets for a gesture that spans multiple snap targets at once — just the last target that the snapping will potentially rest on. For example, if a user flicks their finger hard on the screen to scroll past several potential targets before starting to come to rest near a target further down the scroll container, the `scrollsnapchanging` event will fire when the target near the end of the scroll container is reached.
+However, it does not fire on all potential snap targets for a scrolling gesture that moves over multiple snap targets. Rather, it fires just for the last target that the snapping will potentially rest on.
 
 ## Syntax
 
@@ -59,7 +59,7 @@ At the start of the function, we select all elements that previously had the `pe
 
 ## See also
 
-- The {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)

--- a/files/en-us/web/api/element/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchanging_event/index.md
@@ -1,0 +1,76 @@
+---
+title: "Element: scrollsnapchanging event"
+short-title: scrollsnapchanging
+slug: Web/API/Element/scrollsnapchanging_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.Element.scrollsnapchanging_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`scrollsnapchanging`** event of the {{domxref("Element")}} interface is fired when the browser determines that a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is pending (i.e., it will be selected when the current scroll gesture ends).
+
+Note that this event fires during a scrolling gesture, each time the user moves over a potential new snap target — imagine a user scrolling slowly by dragging their finger on a touch screen device, or holding down the mouse button on a scroll bar and moving the mouse. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture.
+
+However, `scrollsnapchanging` does not fire on all potential snap targets for a gesture that spans multiple snap targets at once — just the last target that the snapping will potentially rest on. In this case, imagine a user flicking their finger hard on the screen to scroll past several potential targets before starting to come to rest near a target further down the scroll container.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("scrollsnapchanging", (event) => {});
+
+onscrollsnapchanging = (event) => {};
+```
+
+## Event type
+
+A {{domxref("SnapEvent")}}.
+
+## Examples
+
+In the following `scrollsnapchanging` handler function snippet (set on a scrolling container element), we set the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element's `class` attribute to `pending` using the {{domxref("Element.className")}} property, which could be used to style the element differently when it becomes a pending snap target.
+
+Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
+
+```js
+scrollingElem.addEventListener("scrollsnapchanging", (event) => {
+  // remove previously-set "pending" classes
+  const pendingElems = document.querySelectorAll(".pending");
+  pendingElems.forEach((elem) => {
+    elem.className = "";
+  });
+
+  // Set current pending snap target class to "pending"
+  event.snapTargetBlock.className = "pending";
+
+  // Logs the id of the new block-direction snap target element
+  console.log(event.snapTargetBlock.id);
+
+  // Always logs the same ID; the inline-direction snap target
+  // element will always be the same
+  console.log(event.snapTargetInline.id);
+});
+```
+
+At the start of the function, we select all elements that previously had the `pending` class applied and remove it, so that only the most recent pending snap target is styled.
+
+See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{domxref("SnapEvent")}}
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchanging_event/index.md
@@ -60,7 +60,9 @@ At the start of the function, we select all elements that previously had the `pe
 ## See also
 
 - {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{DOMxRef("Document/scrollend_event", "scrollend")}} event
 - {{domxref("SnapEvent")}}
+- CSS {{cssxref("scroll-snap-type")}} property
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/element/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/element/scrollsnapchanging_event/index.md
@@ -32,7 +32,28 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 
 ## Examples
 
-In the following `scrollsnapchanging` handler function snippet, we set a `pending` class on the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element, which could be used to style the element differently when it becomes a pending snap target.
+### Basic usage
+
+Let's say we have a {{htmlelement("main")}} element containing significant content that causes it to scroll:
+
+```html
+<main>
+  <!-- Significant content -->
+</main>
+```
+
+The `<main>` element can be turned into a scroll container that snaps to its children when scrolled using a combination of the CSS {{cssxref("scroll-snap-type")}} property and other properties. For example:
+
+```css
+main {
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+  scroll-snap-type: block mandatory;
+}
+```
+
+The following JavaScript snippet would cause the `scrollsnapchanging` event to fire on the `<main>` element when one of its children becomes a pending snap target. In the handler function, we set a `pending` class on the child referenced by the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} property, which could be used to style it differently when the event fires.
 
 ```js
 scrollingElem.addEventListener("scrollsnapchanging", (event) => {

--- a/files/en-us/web/api/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/index.md
@@ -11,7 +11,11 @@ browser-compat: api.SnapEvent
 
 The **`SnapEvent`** interface defines the event object for the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events. Respectively, these fire on on a [scroll container](/en-US/docs/Glossary/Scroll_container) when the browser determines that a new scroll snap target is pending (will be selected when the current scroll gesture ends), and when a new snap target is selected.
 
-These events can be used to run code in response to new elements being snapped to; `SnapEvent` exposes references to the element snapped to in the inline and/or block direction.
+These events can be used to run code in response to new elements being snapped to; `SnapEvent` exposes references to the element snapped to in the inline and/or block direction. The property values available on `SnapEvent` correspond directly to the value of the {{cssxref("scroll-snap-type")}} CSS property set on the scroll container:
+
+- If the snap axis is specified as `block` (or a physical axis value that equates to `block` in the current writing mode), only {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} returns an element reference.
+- If the snap axis is specified as `inline` (or a physical axis value that equates to `inline` in the current writing mode), only {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} returns an element reference.
+- If the snap axis is specified as `both`, `snapTargetBlock` and `snapTargetInline` return an element reference.
 
 {{InheritanceDiagram}}
 
@@ -25,9 +29,9 @@ These events can be used to run code in response to new elements being snapped t
 _Inherits properties from its parent, {{DOMxRef("Event")}}._
 
 - {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a reference to the element snapped to in the block direction when the event fired, or `null` if no element is snapped to in the block direction.
+  - : Returns a reference to the element snapped to in the block direction when the event fired, or `null` if scroll snapping only occurs in the inline direction so no element is snapped to in the block direction.
 - {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a reference to the element snapped to in the inline direction when the event fired, or `null` if no element is snapped to in the inline direction.
+  - : Returns a reference to the element snapped to in the inline direction when the event fired, or `null` if scroll snapping only occurs in the block direction so no element is snapped to in the inline direction.
 
 ## Examples
 

--- a/files/en-us/web/api/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/index.md
@@ -9,9 +9,9 @@ browser-compat: api.SnapEvent
 
 {{APIRef("Snap Events")}}{{SeeCompatTable}}
 
-The **`SnapEvent`** interface defines the event object for the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events, which are related to the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap). Respectively, these fire when the browser determines that a new snap target is pending (will be selected when the current scroll gesture ends), and when a new snap target is selected.
+The **`SnapEvent`** interface defines the event object for the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events. Respectively, these fire on on a [scroll container](/en-US/docs/Glossary/Scroll_container) when the browser determines that a new scroll snap target is pending (will be selected when the current scroll gesture ends), and when a new snap target is selected.
 
-These can be used to run code in response to new elements being snapped to; `SnapEvent` exposes references to the element snapped to in the inline and/or block direction.
+These events can be used to run code in response to new elements being snapped to; `SnapEvent` exposes references to the element snapped to in the inline and/or block direction.
 
 {{InheritanceDiagram}}
 
@@ -31,22 +31,14 @@ _Inherits properties from its parent, {{DOMxRef("Event")}}._
 
 ## Examples
 
-See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
-
 ### `scrollsnapchanging` example
 
-In the following `scrollsnapchanging` handler function snippet (set on a scrolling container element), we set the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element's `class` attribute to `pending` using the {{domxref("Element.className")}} property, which could be used to style the element differently when it becomes a pending snap target.
+In the following `scrollsnapchanging` handler function snippet, we set the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element's `class` attribute to `pending` using the {{domxref("Element.className")}} property, which could be used to style the element differently when it becomes a pending snap target.
 
 Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
 
 ```js
 scrollingElem.addEventListener("scrollsnapchanging", (event) => {
-  // remove previously-set "pending" classes
-  const pendingElems = document.querySelectorAll(".pending");
-  pendingElems.forEach((elem) => {
-    elem.className = "";
-  });
-
   // Set current pending snap target class to "pending"
   event.snapTargetBlock.className = "pending";
 
@@ -59,25 +51,15 @@ scrollingElem.addEventListener("scrollsnapchanging", (event) => {
 });
 ```
 
-At the start of the function, we select all elements that previously had the `pending` class applied and remove it, so that only the most recent pending snap target is styled.
-
 ### `scrollsnapchange` example
 
-In the following `scrollsnapchange` handler function snippet (again, set on a scrolling container element), we set a `select-section` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
+In the following `scrollsnapchange` handler function snippet, we set a `selected` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
 
 ```js
 scrollingElem.addEventListener("scrollsnapchange", (event) => {
-  if (document.querySelector(".select-section")) {
-    document.querySelector(".select-section").className = "deselect-section";
-  } else {
-    document.querySelector("section").className = "select-section";
-  }
-
-  event.snapTargetBlock.className = "select-section";
+  event.snapTargetBlock.className = "selected";
 });
 ```
-
-At the start of the function, we also include an `if...else` block to look for a previously-selected snap target. If one is found, it has a `deselect-section` class applied to it, which for example could be used to apply a deselection animation. If not, the first snap target in the page is given the `select-section` class, which means that it will be given the appropriate selected styles when the page first loads.
 
 ## Specifications
 
@@ -89,6 +71,7 @@ At the start of the function, we also include an `if...else` block to look for a
 
 ## See also
 
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/index.md
@@ -1,0 +1,94 @@
+---
+title: SnapEvent
+slug: Web/API/SnapEvent
+page-type: web-api-interface
+status:
+  - experimental
+browser-compat: api.SnapEvent
+---
+
+{{APIRef("Snap Events")}}{{SeeCompatTable}}
+
+The **`SnapEvent`** interface defines the event object for the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events, which are related to the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap). Respectively, these fire when the browser determines that a new snap target is pending (will be selected when the current scroll gesture ends), and when a new snap target is selected.
+
+These can be used to run code in response to new elements being snapped to; `SnapEvent` exposes references to the element snapped to in the inline and/or block direction.
+
+{{InheritanceDiagram}}
+
+## Constructor
+
+- {{domxref("SnapEvent.SnapEvent", "SnapEvent()")}} {{Experimental_Inline}}
+  - : Creates a new `SnapEvent` object instance.
+
+## Instance properties
+
+_Inherits properties from its parent, {{DOMxRef("Event")}}._
+
+- {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Returns a reference to the element snapped to in the block direction when the event fired.
+- {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Returns a reference to the element snapped to in the inline direction when the event fired.
+
+## Examples
+
+See the [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
+
+### `scrollsnapchanging` example
+
+In the following `scrollsnapchanging` handler function snippet (set on a scrolling container element), we set the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element's `class` attribute to `pending` using the {{domxref("Element.className")}} property, which could be used to style the element differently when it becomes a pending snap target.
+
+Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
+
+```js
+scrollingElem.addEventListener("scrollsnapchanging", (event) => {
+  // remove previously-set "pending" classes
+  const pendingElems = document.querySelectorAll(".pending");
+  pendingElems.forEach((elem) => {
+    elem.className = "";
+  });
+
+  // Set current pending snap target class to "pending"
+  event.snapTargetBlock.className = "pending";
+
+  // Logs the id of the new block-direction snap target element
+  console.log(event.snapTargetBlock.id);
+
+  // Always logs the same ID; the inline-direction snap target
+  // element will always be the same
+  console.log(event.snapTargetInline.id);
+});
+```
+
+At the start of the function, we select all elements that previously had the `pending` class applied and remove it, so that only the most recent pending snap target is styled.
+
+### `scrollsnapchange` example
+
+In the following `scrollsnapchange` handler function snippet (again, set on a scrolling container element), we set a `select-section` class on the {{domxref("SnapEvent.snapTargetBlock")}} element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
+
+```js
+scrollingElem.addEventListener("scrollsnapchange", (event) => {
+  if (document.querySelector(".select-section")) {
+    document.querySelector(".select-section").className = "deselect-section";
+  } else {
+    document.querySelector("section").className = "select-section";
+  }
+
+  event.snapTargetBlock.className = "select-section";
+});
+```
+
+At the start of the function, we also include an `if...else` block to look for a previously-selected snap target. If one is found, it has a `deselect-section` class applied to it, which for example could be used to apply a deselection animation. If not, the first snap target in the page is given the `select-section` class, which means that it will be given the appropriate selected styles when the page first loads.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/index.md
@@ -25,9 +25,9 @@ These events can be used to run code in response to new elements being snapped t
 _Inherits properties from its parent, {{DOMxRef("Event")}}._
 
 - {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a reference to the element snapped to in the block direction when the event fired.
+  - : Returns a reference to the element snapped to in the block direction when the event fired, or `null` if no element is snapped to in the block direction.
 - {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a reference to the element snapped to in the inline direction when the event fired.
+  - : Returns a reference to the element snapped to in the inline direction when the event fired, or `null` if no element is snapped to in the inline direction.
 
 ## Examples
 
@@ -35,19 +35,18 @@ _Inherits properties from its parent, {{DOMxRef("Event")}}._
 
 In the following `scrollsnapchanging` handler function snippet, we set the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} element's `class` attribute to `pending` using the {{domxref("Element.className")}} property, which could be used to style the element differently when it becomes a pending snap target.
 
-Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a left-to-right {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. The element snapped to in the inline direction will always be the same, therefore {{domxref("SnapEvent.snapTargetInline")}} will always contain a reference to the same element.
+Note that this handler is intended to be set on a block-direction scroll container (vertically-scrolling if the page is set to a horizontal {{cssxref("writing-mode")}}), therefore only the `snapTargetBlock` element will change between multiple events firing. {{domxref("SnapEvent.snapTargetInline")}} will return `null`, because no snapping occurs in the inline direction.
 
 ```js
 scrollingElem.addEventListener("scrollsnapchanging", (event) => {
   // Set current pending snap target class to "pending"
   event.snapTargetBlock.className = "pending";
 
-  // Logs the id of the new block-direction snap target element
-  console.log(event.snapTargetBlock.id);
+  // Logs the new pending block-direction snap target element
+  console.log(event.snapTargetBlock);
 
-  // Always logs the same ID; the inline-direction snap target
-  // element will always be the same
-  console.log(event.snapTargetInline.id);
+  // Logs null; no inline snapping occurs
+  console.log(event.snapTargetInline);
 });
 ```
 
@@ -71,7 +70,8 @@ scrollingElem.addEventListener("scrollsnapchange", (event) => {
 
 ## See also
 
-- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/snapevent/index.md
@@ -1,0 +1,60 @@
+---
+title: "SnapEvent: SnapEvent() constructor"
+short-title: SnapEvent()
+slug: Web/API/SnapEvent/SnapEvent
+page-type: web-api-constructor
+status:
+  - experimental
+browser-compat: api.SnapEvent.SnapEvent
+---
+
+{{APIRef("Snap Events")}}{{SeeCompatTable}}
+
+The **`SnapEvent()`** constructor creates a new
+{{domxref("SnapEvent")}} object instance.
+
+## Syntax
+
+```js-nolint
+new SnapEvent(type, init)
+```
+
+### Parameters
+
+- `type`
+  - : A string representing the type of event. For {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} events, this is `scrollsnapchanging`. For {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events, this is `scrollsnapchange`.
+- `init`
+  - : An object containing the following properties:
+    - `snapTargetBlock` {{optional_inline}}
+      - : Returns a reference to the element snapped to in the block direction when the event fired.
+    - `snapTargetInline` {{optional_inline}}
+      - : Returns a reference to the element snapped to in the inline direction when the event fired.
+
+## Examples
+
+A developer would not use this constructor manually. A new `SnapEvent` object is constructed when a handler is invoked as a result of the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} or {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events firing.
+
+For example:
+
+```js
+mainElem.addEventListener("scrollsnapchange", (event) => {
+  // ...
+
+  // Log a SnapEvent object instance to the console
+  console.log(event);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/snapevent/index.md
@@ -26,9 +26,9 @@ new SnapEvent(type, init)
 - `init`
   - : An object containing the following properties:
     - `snapTargetBlock` {{optional_inline}}
-      - : Returns a reference to the element snapped to in the block direction when the event fired, or `null` if no element is snapped to in the block direction.
+      - : Returns a reference to the element snapped to in the block direction when the event fired, or `null` if scroll snapping only occurs in the inline direction so no element is snapped to in the block direction.
     - `snapTargetInline` {{optional_inline}}
-      - : Returns a reference to the element snapped to in the inline direction when the event fired, or `null` if no element is snapped to in the inline direction.
+      - : Returns a reference to the element snapped to in the inline direction when the event fired, or `null` if scroll snapping only occurs in the block direction so no element is snapped to in the inline direction.
 
 ## Examples
 

--- a/files/en-us/web/api/snapevent/snapevent/index.md
+++ b/files/en-us/web/api/snapevent/snapevent/index.md
@@ -26,9 +26,9 @@ new SnapEvent(type, init)
 - `init`
   - : An object containing the following properties:
     - `snapTargetBlock` {{optional_inline}}
-      - : Returns a reference to the element snapped to in the block direction when the event fired.
+      - : Returns a reference to the element snapped to in the block direction when the event fired, or `null` if no element is snapped to in the block direction.
     - `snapTargetInline` {{optional_inline}}
-      - : Returns a reference to the element snapped to in the inline direction when the event fired.
+      - : Returns a reference to the element snapped to in the inline direction when the event fired, or `null` if no element is snapped to in the inline direction.
 
 ## Examples
 
@@ -55,6 +55,7 @@ mainElem.addEventListener("scrollsnapchange", (event) => {
 
 ## See also
 
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snaptargetblock/index.md
+++ b/files/en-us/web/api/snapevent/snaptargetblock/index.md
@@ -18,9 +18,11 @@ Specifically:
 - In the case of the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event, this refers to a pending block-direction snap target (i.e. it will be selected when the current scroll gesture ends).
 - In the case of the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event, this refers to a newly-selected block-direction snap target.
 
+The property values available on `SnapEvent` correspond directly to the value of the {{cssxref("scroll-snap-type")}} CSS property set on the scroll container. `snapTargetBlock` only returns an element reference if the snap axis is specified as `block` (or a physical axis value that equates to `block` in the current writing mode) or `both`.
+
 ## Value
 
-A {{domxref("Node")}} representing the snapped element, or `null` if no block-direction element is snapped to (i.e. scroll snapping only occurs in the inline direction).
+A {{domxref("Node")}} representing the snapped element, or `null` if scroll snapping only occurs in the inline direction so no element is snapped to in the block direction.
 
 If the snapped element was a pseudo-element, the returned `Node` will be the owning element of that pseudo-element.
 

--- a/files/en-us/web/api/snapevent/snaptargetblock/index.md
+++ b/files/en-us/web/api/snapevent/snaptargetblock/index.md
@@ -20,7 +20,7 @@ Specifically:
 
 ## Value
 
-A {{domxref("Node")}} representing the snapped element, or `null` if no block-direction element was snapped to.
+A {{domxref("Node")}} representing the snapped element, or `null` if no block-direction element is snapped to (i.e. scroll snapping only occurs in the inline direction).
 
 If the snapped element was a pseudo-element, the returned `Node` will be the owning element of that pseudo-element.
 
@@ -38,6 +38,7 @@ See the main {{domxref("SnapEvent")}} page for brief examples, and our [Using sc
 
 ## See also
 
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snaptargetblock/index.md
+++ b/files/en-us/web/api/snapevent/snaptargetblock/index.md
@@ -1,0 +1,43 @@
+---
+title: "SnapEvent: snapTargetBlock property"
+short-title: snapTargetBlock
+slug: Web/API/SnapEvent/snapTargetBlock
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.SnapEvent.snapTargetBlock
+---
+
+{{APIRef("Snap Events")}}{{SeeCompatTable}}
+
+The **`snapTargetBlock`** read-only property of the
+{{domxref("SnapEvent")}} interface returns a reference to the element snapped to in the block direction when the event fired.
+
+Specifically:
+
+- In the case of the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event, this refers to a pending block-direction snap target (i.e. it will be selected when the current scroll gesture ends).
+- In the case of the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event, this refers to a newly-selected block-direction snap target.
+
+## Value
+
+A {{domxref("Node")}} representing the snapped element, or `null` if no block-direction element was snapped to.
+
+If the snapped element was a pseudo-element, the returned `Node` will be the owning element of that pseudo-element.
+
+## Examples
+
+See the main {{domxref("SnapEvent")}} page for brief examples, and our [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snaptargetinline/index.md
+++ b/files/en-us/web/api/snapevent/snaptargetinline/index.md
@@ -20,7 +20,7 @@ Specifically:
 
 ## Value
 
-A {{domxref("Node")}} representing the snapped element, or `null` if no inline-direction element was snapped to.
+A {{domxref("Node")}} representing the snapped element, or `null` if no inline-direction element is snapped to (i.e. scroll snapping only occurs in the block direction).
 
 If the snapped element was a pseudo-element, the returned `Node` will be the owning element of that pseudo-element.
 
@@ -38,6 +38,7 @@ See the main {{domxref("SnapEvent")}} page for brief examples, and our [Using sc
 
 ## See also
 
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snaptargetinline/index.md
+++ b/files/en-us/web/api/snapevent/snaptargetinline/index.md
@@ -1,0 +1,43 @@
+---
+title: "SnapEvent: snapTargetInline property"
+short-title: snapTargetInline
+slug: Web/API/SnapEvent/snapTargetInline
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.SnapEvent.snapTargetInline
+---
+
+{{APIRef("Snap Events")}}{{SeeCompatTable}}
+
+The **`snapTargetInline`** read-only property of the
+{{domxref("SnapEvent")}} interface returns a reference to the element snapped to in the inline direction when the event fired.
+
+Specifically:
+
+- In the case of the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event, this refers to a pending inline-direction snap target (i.e. it will be selected when the current scroll gesture ends).
+- In the case of the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event, this refers to a newly-selected inline-direction snap target.
+
+## Value
+
+A {{domxref("Node")}} representing the snapped element, or `null` if no inline-direction element was snapped to.
+
+If the snapped element was a pseudo-element, the returned `Node` will be the owning element of that pseudo-element.
+
+## Examples
+
+See the main {{domxref("SnapEvent")}} page for brief examples, and our [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events) guide for full examples and explanation.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/snapevent/snaptargetinline/index.md
+++ b/files/en-us/web/api/snapevent/snaptargetinline/index.md
@@ -18,9 +18,11 @@ Specifically:
 - In the case of the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event, this refers to a pending inline-direction snap target (i.e. it will be selected when the current scroll gesture ends).
 - In the case of the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event, this refers to a newly-selected inline-direction snap target.
 
+The property values available on `SnapEvent` correspond directly to the value of the {{cssxref("scroll-snap-type")}} CSS property set on the scroll container. `snapTargetInline` only returns an element reference if the snap axis is specified as `inline` (or a physical axis value that equates to `inline` in the current writing mode) or `both`.
+
 ## Value
 
-A {{domxref("Node")}} representing the snapped element, or `null` if no inline-direction element is snapped to (i.e. scroll snapping only occurs in the block direction).
+A {{domxref("Node")}} representing the snapped element, or `null` if scroll snapping only occurs in the block direction so no element is snapped to in the inline direction.
 
 If the snapped element was a pseudo-element, the returned `Node` will be the owning element of that pseudo-element.
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -395,9 +395,9 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 ### Scroll events
 
 - {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
-  - : Fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+  - : Fired on the scroll container at the end of a scrolling operation when a new scroll snap target has been selected.
 - {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
-  - : Fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends).
+  - : Fired on the scroll container when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
 ### Deprecated events
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -392,6 +392,13 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 - {{domxref("Window/unhandledrejection_event", "unhandledrejection")}}
   - : Sent when a JavaScript {{jsxref("Promise")}} is rejected but there is no handler in place to catch the rejection.
 
+### Scroll events
+
+- {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
+  - : Fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+- {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
+  - : Fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends).
+
 ### Deprecated events
 
 - {{domxref("Window/orientationchange_event", "orientationchange")}} {{Deprecated_Inline}}

--- a/files/en-us/web/api/window/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchange_event/index.md
@@ -39,6 +39,9 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 ## See also
 
 - {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{DOMxRef("Document/scrollend_event", "scrollend")}} event
 - {{domxref("SnapEvent")}}
+- CSS {{cssxref("scroll-snap-type")}} property
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/window/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchange_event/index.md
@@ -10,9 +10,23 @@ browser-compat: api.Window.scrollsnapchange_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchange`** event of the {{domxref("Window")}} interface is fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+The **`scrollsnapchange`** event of the {{domxref("Window")}} interface is fired on the `window` at the end of a scrolling operation when a new scroll snap target is selected.
 
-This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchange` event](/en-US/docs/Web/API/Element/scrollsnapchange_event) for more information.
+This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchange`](/en-US/docs/Web/API/Element/scrollsnapchange_event) event.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("scrollsnapchange", (event) => {});
+
+onscrollsnapchange = (event) => {};
+```
+
+## Event type
+
+A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchange_event/index.md
@@ -38,7 +38,7 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 
 ## See also
 
-- The {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/window/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchange_event/index.md
@@ -1,0 +1,30 @@
+---
+title: "Window: scrollsnapchange event"
+short-title: scrollsnapchange
+slug: Web/API/Window/scrollsnapchange_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.Window.scrollsnapchange_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`scrollsnapchange`** event of the {{domxref("Window")}} interface is fired at the end of a scrolling operation when a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is selected.
+
+This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchange` event](/en-US/docs/Web/API/Element/scrollsnapchange_event) for more information.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Window/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("SnapEvent")}}
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/window/scrollsnapchange_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchange_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Window.scrollsnapchange_event
 
 The **`scrollsnapchange`** event of the {{domxref("Window")}} interface is fired on the `window` at the end of a scrolling operation when a new scroll snap target is selected.
 
-This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchange`](/en-US/docs/Web/API/Element/scrollsnapchange_event) event.
+This event works in much the same way as the {{domxref("Element")}} interface's [`scrollsnapchange`](/en-US/docs/Web/API/Element/scrollsnapchange_event) event, except that the overall HTML document has to be set as the scroll snap container (i.e., {{cssxref("scroll-snap-type")}} is set on the {{htmlelement("html")}} element).
 
 ## Syntax
 
@@ -27,6 +27,44 @@ onscrollsnapchange = (event) => {};
 ## Event type
 
 A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
+
+## Examples
+
+### Basic usage
+
+Let's say we have a {{htmlelement("main")}} element containing significant content that causes it to scroll:
+
+```html
+<main>
+  <!-- Significant content -->
+</main>
+```
+
+The `<main>` element can be turned into a scroll container using a combination of CSS properties, for example:
+
+```css
+main {
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+}
+```
+
+We can then implement scroll snapping behavior on the scrolling content by specifying the {{cssxref("scroll-snap-type")}} property on the {{htmlelement("html")}} element:
+
+```css
+html {
+  scroll-snap-type: block mandatory;
+}
+```
+
+The following JavaScript snippet would cause the `scrollsnapchange` event to fire on the HTML document when a child of the `<main>` element becomes a newly-selected snap target. In the handler function, we set a `selected` class on the child referenced by the {{domxref("SnapEvent.snapTargetBlock")}}, which could be used to style it to look like it has been selected (for example, with an animation) when the event fires.
+
+```js
+window.addEventListener("scrollsnapchange", (event) => {
+  event.snapTargetBlock.classList.add("selected");
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/window/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchanging_event/index.md
@@ -39,6 +39,9 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 ## See also
 
 - {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{DOMxRef("Document/scrollend_event", "scrollend")}} event
 - {{domxref("SnapEvent")}}
+- CSS {{cssxref("scroll-snap-type")}} property
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/window/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchanging_event/index.md
@@ -1,0 +1,30 @@
+---
+title: "Window: scrollsnapchanging event"
+short-title: scrollsnapchanging
+slug: Web/API/Window/scrollsnapchanging_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.Window.scrollsnapchanging_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`scrollsnapchanging`** event of the {{domxref("Window")}} interface is fired when the browser determines that a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is pending (i.e., it will be selected when the current scroll gesture ends).
+
+This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchanging` event](/en-US/docs/Web/API/Element/scrollsnapchanging_event) for more information.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{domxref("SnapEvent")}}
+- [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/api/window/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchanging_event/index.md
@@ -10,9 +10,23 @@ browser-compat: api.Window.scrollsnapchanging_event
 
 {{APIRef}}{{SeeCompatTable}}
 
-The **`scrollsnapchanging`** event of the {{domxref("Window")}} interface is fired when the browser determines that a new scroll snap target (as implemented using features of the [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)) is pending (i.e., it will be selected when the current scroll gesture ends).
+The **`scrollsnapchanging`** event of the {{domxref("Window")}} interface is fired on the `window` when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
-This event works in exactly the same way as its counterpart implemented on the {{domxref("Element")}} interface — see [`Element`: `scrollsnapchanging` event](/en-US/docs/Web/API/Element/scrollsnapchanging_event) for more information.
+This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchanging`](/en-US/docs/Web/API/Element/scrollsnapchanging_event) event.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("scrollsnapchanging", (event) => {});
+
+onscrollsnapchanging = (event) => {};
+```
+
+## Event type
+
+A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchanging_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Window.scrollsnapchanging_event
 
 The **`scrollsnapchanging`** event of the {{domxref("Window")}} interface is fired on the `window` when the browser determines a new scroll snap target is pending, i.e. it will be selected when the current scroll gesture ends.
 
-This event works in exactly the same way as the {{domxref("Element")}} interface's [`scrollsnapchanging`](/en-US/docs/Web/API/Element/scrollsnapchanging_event) event.
+This event works in much the same way as the {{domxref("Element")}} interface's [`scrollsnapchanging`](/en-US/docs/Web/API/Element/scrollsnapchanging_event) event, except that the overall HTML document has to be set as the scroll snap container (i.e., {{cssxref("scroll-snap-type")}} is set on the {{htmlelement("html")}} element).
 
 ## Syntax
 
@@ -27,6 +27,53 @@ onscrollsnapchanging = (event) => {};
 ## Event type
 
 A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}} type.
+
+## Examples
+
+### Basic usage
+
+Let's say we have a {{htmlelement("main")}} element containing significant content that causes it to scroll:
+
+```html
+<main>
+  <!-- Significant content -->
+</main>
+```
+
+The `<main>` element can be turned into a scroll container using a combination of CSS properties, for example:
+
+```css
+main {
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+}
+```
+
+We can then implement scroll snapping behavior on the scrolling content by specifying the {{cssxref("scroll-snap-type")}} property on the {{htmlelement("html")}} element:
+
+```css
+html {
+  scroll-snap-type: block mandatory;
+}
+```
+
+The following JavaScript snippet would cause the `scrollsnapchanging` event to fire on the HTML document when a child of the `<main>` element becomes a pending snap target. In the handler function, we set a `pending` class on the child referenced by the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} property, which could be used to style it differently when the event fires.
+
+```js
+window.addEventListener("scrollsnapchanging", (event) => {
+  // remove previously-set "pending" classes
+  const pendingElems = document.querySelectorAll(".pending");
+  pendingElems.forEach((elem) => {
+    elem.classList.remove("pending");
+  });
+
+  // Set current pending snap target class to "pending"
+  event.snapTargetBlock.classList.add("pending");
+});
+```
+
+At the start of the function, we select all elements that previously had the `pending` class applied and remove it, so that only the most recent pending snap target is styled.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/scrollsnapchanging_event/index.md
+++ b/files/en-us/web/api/window/scrollsnapchanging_event/index.md
@@ -38,7 +38,7 @@ A {{domxref("SnapEvent")}}, which inherits from the generic {{domxref("Event")}}
 
 ## See also
 
-- The {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} event
+- {{domxref("Window/scrollsnapchange_event", "scrollsnapchange")}} event
 - {{domxref("SnapEvent")}}
 - [CSS scroll snap module](/en-US/docs/Web/CSS/CSS_scroll_snap)
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/css/css_scroll_snap/index.md
+++ b/files/en-us/web/css/css_scroll_snap/index.md
@@ -68,6 +68,8 @@ To see the code for this example, [view the source on GitHub](https://github.com
 ### Interfaces
 
 - {{domxref("SnapEvent")}} {{experimental_inline}}
+  - {{domxref("SnapEvent.snapTargetBlock")}} {{experimental_inline}}
+  - {{domxref("SnapEvent.snapTargetInline")}} {{experimental_inline}}
 
 ## Guides
 

--- a/files/en-us/web/css/css_scroll_snap/index.md
+++ b/files/en-us/web/css/css_scroll_snap/index.md
@@ -62,6 +62,8 @@ To see the code for this example, [view the source on GitHub](https://github.com
 
 - [Basic concepts of CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap/Basic_concepts)
   - : An overview and examples of CSS scroll snap features.
+- [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
+  - : A guide to using the scroll snap events — {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} — to run JavaScript in response to the browser determining that a new snap target is pending or selected.
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_scroll_snap/index.md
+++ b/files/en-us/web/css/css_scroll_snap/index.md
@@ -2,7 +2,9 @@
 title: CSS scroll snap
 slug: Web/CSS/CSS_scroll_snap
 page-type: css-module
-spec-urls: https://drafts.csswg.org/css-scroll-snap/
+spec-urls:
+  - https://drafts.csswg.org/css-scroll-snap/
+  - https://drafts.csswg.org/css-scroll-snap-2/
 ---
 
 {{CSSRef}}
@@ -58,12 +60,21 @@ To see the code for this example, [view the source on GitHub](https://github.com
   - {{cssxref("scroll-margin-block-end")}}
 - {{cssxref("scroll-snap-stop")}}
 
+### Events
+
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} {{experimental_inline}}
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} {{experimental_inline}}
+
+### Interfaces
+
+- {{domxref("SnapEvent")}} {{experimental_inline}}
+
 ## Guides
 
 - [Basic concepts of CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap/Basic_concepts)
   - : An overview and examples of CSS scroll snap features.
 - [Using scroll snap events](/en-US/docs/Web/CSS/CSS_scroll_snap/Using_scroll_snap_events)
-  - : A guide to using the scroll snap events — {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} — to run JavaScript in response to the browser determining that a new snap target is pending or selected.
+  - : A guide to using the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} scroll snap events that are fired when the browser determines a new snap target is pending or selected.
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
+++ b/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
@@ -6,17 +6,17 @@ page-type: guide
 
 {{CSSRef}}
 
-The [CSS Scroll Snap Module Level 2](drafts.csswg.org/css-scroll-snap-2) specification defines **scroll snap events**: {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}}. These make it easy to run JavaScript in response to the browser determining that a new snap target is pending, and when a new snap target is selected, respectively.
+The [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module defines two **scroll snap events**: {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}}. These enable running JavaScript in response to the browser determining that new [scroll snap targets](/en-US/docs/Web/CSS/CSS_scroll_snap/Basic_concepts) are pending and selected, respectively.
 
-This article provides a guide to using these events, along with complete examples.
+This guide provides an overview of these events, along with complete examples.
 
 ## Events overview
 
-The two events are set on a scrolling container that contains potential scroll snap targets, and are as follows:
+Scroll snap events are set on a [scrolling container](/en-US/docs/Glossary/Scroll_container) that contains potential scroll snap targets:
 
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event is fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends). Specifically, this event fires during a scrolling gesture, each time the user moves over a potential new snap target. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture. However, `scrollsnapchanging` does not fire on all potential snap targets for a scrolling gesture that moves over multiple snap targets — just the last target that the snapping will potentially rest on.
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event is fired when the browser determines that a new scroll snap target will be selected when the current scroll gesture ends. This is the _pending_ scroll snap target. Specifically, this event fires during a scrolling gesture, each time the user moves over potential new snap targets. While the `scrollsnapchanging` event may fire multiple times for each scrolling gesture, it does not fire on all potential snap targets for a scrolling gesture that moves over multiple snap targets. Rather, it fires just for the last target that the snapping will potentially rest on.
 
-- The {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event is fired at the end of a scrolling operation when a new scroll snap target is selected. Specifically, this event fires when a scrolling gesture is completed, but only if a new snap target is selected. Also note that it fires just before the {{domxref("Element/scrollend_event", "scrollend")}} event fires.
+- The {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event is fired at the end of a scrolling operation when a new scroll snap target is selected. Specifically, this event fires when a scrolling gesture is completed, but only if a new snap target is selected. This event fires just before the {{domxref("Element/scrollend_event", "scrollend")}} event fires.
 
 Let's look at an example that shows the two events in action (you'll see how this is built later on in the article):
 
@@ -24,16 +24,16 @@ Let's look at an example that shows the two events in action (you'll see how thi
 
 Have a go at scrolling up and down the list of boxes:
 
-- Try slowly scrolling the container up and down, without releasing the scrolling gesture, For example, drag your finger(s) on a touch screen device or trackpad, or hold down the mouse button on the scroll bar and move the mouse. You should see the boxes you move over turn a darker gray color, and then return to normal as you move away from them again. This is the `scrollsnapchanging` event in action.
-- Now try releasing the scrolling gesture; the nearest box to your scrolling position should animate to a purple color, with white text. This is due to code run in response to the `scrollsnapchange` event firing.
-- Last of all, try scrolling fast, for example by flicking your finger hard on the screen, to scroll past several potential targets before starting to come to rest near a target further down the scroll container. You should only see one `scrollsnapchanging` event fire as the scrolling starts to slow, before the `scrollsnapchange` event then fires and the selected snap target turns purple.
+- Try slowly scrolling the container up and down, without releasing the scrolling gesture. For example, drag your finger(s) on a touchscreen device or trackpad, or hold down the mouse button on the scroll bar and move the mouse. The boxes you move over should turn a darker gray color as you move over them, and then return to normal as you move away from them again. This is the `scrollsnapchanging` event in action.
+- Now try releasing the scrolling gesture; the nearest box to your scrolling position should animate to a purple color, with white text. The animation occurs when the `scrollsnapchange` event fires.
+- Last of all, try scrolling fast, for example by flicking your finger hard on the screen, to scroll past several potential targets before starting to come to rest near a target further down the scroll container. You should only see one `scrollsnapchanging` event fire as the scrolling starts to slow, before the `scrollsnapchange` event fires and the selected snap target turns purple.
 
 ## The `SnapEvent` event object
 
-Both of the above events share the same event object: {{domxref("SnapEvent")}}. This has two distinct properties that are key to how scroll snap events work:
+Both of the above events share the {{domxref("SnapEvent")}} event object. This has two properties that are key to how scroll snap events work:
 
-- {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} returns a reference to the element snapped to in the block direction when the event fired.
-- {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} returns a reference to the element snapped to in the inline direction when the event fired.
+- {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} returns a reference to the element snapped to in the [block direction](/en-US/docs/Glossary/Flow_relative_values#block_direction) when the event fired.
+- {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} returns a reference to the element snapped to in the [inline direction](/en-US/docs/Glossary/Flow_relative_values#inline_direction) when the event fired.
 
 These properties enable event handler functions to report the element that has been snapped to (in the case of `scrollsnapchange`) or the element that _would be snapped to_ if the scrolling gesture were to be finished now (in the case of `scrollsnapchanging`) — in one- and two-dimensions. You can then manipulate these elements in any way you want, for example by directly setting styles on them via their {{domxref("HTMLElement.style", "style")}} properties, setting classes on them that have styles defined for them in a stylesheet, etc.
 

--- a/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
+++ b/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
@@ -24,22 +24,22 @@ Let's look at an example that shows the two events in action (you'll see how thi
 
 Have a go at scrolling up and down the list of boxes:
 
-- Try slowly scrolling the container up and down, without releasing the scrolling gesture. For example, drag your finger(s) on a touchscreen device or trackpad, or hold down the mouse button on the scroll bar and move the mouse. The boxes you move over should turn a darker gray color as you move over them, and then return to normal as you move away from them again. This is the `scrollsnapchanging` event in action.
+- Try slowly scrolling the container up and down without releasing the scrolling gesture. For example, drag your finger(s) over the scrolling area on a touchscreen device or trackpad, or hold down the mouse button on the scroll bar and move the mouse. The boxes you move over should turn a darker gray color as you move over them, and then return to normal as you move away from them again. This is the `scrollsnapchanging` event in action.
 - Now try releasing the scrolling gesture; the nearest box to your scrolling position should animate to a purple color, with white text. The animation occurs when the `scrollsnapchange` event fires.
-- Last of all, try scrolling fast, for example by flicking your finger hard on the screen, to scroll past several potential targets before starting to come to rest near a target further down the scroll container. You should only see one `scrollsnapchanging` event fire as the scrolling starts to slow, before the `scrollsnapchange` event fires and the selected snap target turns purple.
+- Finally try scrolling fast, for example by flicking your finger hard on the screen, to scroll past several potential targets before starting to come to rest near a target further down the scroll container. You should only see one `scrollsnapchanging` event fire as the scrolling starts to slow, before the `scrollsnapchange` event fires and the selected snap target turns purple.
 
 ## The `SnapEvent` event object
 
 Both of the above events share the {{domxref("SnapEvent")}} event object. This has two properties that are key to how scroll snap events work:
 
-- {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} returns a reference to the element snapped to in the [block direction](/en-US/docs/Glossary/Flow_relative_values#block_direction) when the event fired.
-- {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} returns a reference to the element snapped to in the [inline direction](/en-US/docs/Glossary/Flow_relative_values#inline_direction) when the event fired.
+- {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} returns a reference to the element snapped to in the [block direction](/en-US/docs/Glossary/Flow_relative_values#block_direction) when the event fired, or `null` if no element is snapped to in the block direction (i.e. scroll snapping only occurs in the inline direction).
+- {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} returns a reference to the element snapped to in the [inline direction](/en-US/docs/Glossary/Flow_relative_values#inline_direction) when the event fired, or `null` if no element is snapped to in the inline direction (i.e. scroll snapping only occurs in the block direction).
 
 These properties enable event handler functions to report the element that has been snapped to (in the case of `scrollsnapchange`) or the element that _would be snapped to_ if the scrolling gesture were to be finished now (in the case of `scrollsnapchanging`) — in one- and two-dimensions. You can then manipulate these elements in any way you want, for example by directly setting styles on them via their {{domxref("HTMLElement.style", "style")}} properties, setting classes on them that have styles defined for them in a stylesheet, etc.
 
 ### Handling one-dimensional scrollers
 
-If you are dealing with a horizontal scroller, only the event object's `snapTargetInline` property will change as the snapped element changes if the content has a horizonal {{cssxref("writing-mode")}}, or the `snapTargetBlock` property if the content has a vertical `writing-mode`. Conversely, if you are dealing with a vertical scroller, only the `snapTargetBlock` property will change as the snapped element changes if the content has a horizonal `writing-mode`, or the `snapTargetInline` property if the content has a vertical `writing-mode`.
+If you are dealing with a horizontal scroller, only the event object's `snapTargetInline` property will change as the snapped element changes if the content has a horizontal {{cssxref("writing-mode")}}, or the `snapTargetBlock` property if the content has a vertical `writing-mode`. Conversely, if you are dealing with a vertical scroller, only the `snapTargetBlock` property will change as the snapped element changes if the content has a horizontal `writing-mode`, or the `snapTargetInline` property if the content has a vertical `writing-mode`. In each case, the non-changing property of the two returns `null`.
 
 Let's look at an example snippet to show a typical one-dimensional scroll snap event handler function:
 
@@ -49,14 +49,14 @@ scrollingElem.addEventListener("scrollsnapchange", (event) => {
 });
 ```
 
-In this snippet, a `scrollsnapchange` handler function is set on a vertical scrolling container element that snap targets appear inside. When the event fires, we set a `select-section` class on the `snapTargetBlock` element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
+In this snippet, a `scrollsnapchange` handler function is set on a block-direction scrolling container element that snap targets appear inside. When the event fires, we set a `select-section` class on the `snapTargetBlock` element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
 
 ### Handling two-dimensional scrollers
 
-If you are dealing with a horizontal _and_ vertical scroller, the code gets more complex because the `snapTargetBlock` property _or_ the `snapTargetInline` property could change, depending on which direction you scroll in and the `writing-mode` of the content:
+If you are dealing with a horizontal _and_ vertical scroller, the code gets more complex because the `snapTargetBlock` property _or_ the `snapTargetInline` property values can change, depending on which direction you scroll in and the `writing-mode` of the content:
 
-- If the scroller is scrolled horizontally, the `snapTargetInline` property will change as the snapped element changes if the content has a horizonal {{cssxref("writing-mode")}}, or the `snapTargetBlock` property if the content has a vertical `writing-mode`.
-- If the scroller is scrolled vertically, the `snapTargetBlock` property will change as the snapped element changes if the content has a horizonal `writing-mode`, or the `snapTargetInline` property if the content has a vertical `writing-mode`.
+- If the scroller is scrolled horizontally, the `snapTargetInline` property will change as the snapped element changes if the content has a horizontal {{cssxref("writing-mode")}}, or the `snapTargetBlock` property if the content has a vertical `writing-mode`.
+- If the scroller is scrolled vertically, the `snapTargetBlock` property will change as the snapped element changes if the content has a horizontal `writing-mode`, or the `snapTargetInline` property if the content has a vertical `writing-mode`.
 
 To handle this, you will likely need to keep track of whether it was the `snapTargetBlock` or the `snapTargetInline` element that changed. Let's look at an example:
 
@@ -68,11 +68,15 @@ const prevState = {
 
 scrollingElem.addEventListener("scrollsnapchange", (event) => {
   if (!(prevState.snapTargetBlock === event.snapTargetBlock.id)) {
-    event.snapTargetBlock.className = "select-section";
+    console.log(
+      `The container was scrolled in the block direction to element ${event.snapTargetBlock.id}`,
+    );
   }
 
   if (!(prevState.snapTargetInline === event.snapTargetInline.id)) {
-    event.snapTargetInline.className = "select-section";
+    console.log(
+      `The container was scrolled in the block direction to element ${event.snapTargetBlock.id}`,
+    );
   }
 
   prevState.snapTargetBlock = event.snapTargetBlock.id;
@@ -87,7 +91,7 @@ In the event handler function, we use `if` statements to test whether:
 - The `prevState.snapTargetBlock` ID is equal to the ID of the current `event.snapTargetBlock` element.
 - The `prevState.snapTargetInline` ID is equal to the ID of the current `event.snapTargetInline` element.
 
-If the values are different, it means that the scroller has been scrolled in that direction (block or inline), and therefore we set a class of `select-section` on the element to style it in some way when it is snapped to.
+If the values are different, it means that the scroller has been scrolled in that direction (block or inline), and we log a message to console to indicate this. In a real example, you'd likely style the snapped element in some way to indicate that it has been snapped to.
 
 We then update the values of `prevState.snapTargetBlock` and `prevState.snapTargetInline`, ready for the next time the event handler is run.
 
@@ -181,7 +185,7 @@ The style changes mentioned above will be applied through classes applied to the
 
 ### JavaScript
 
-In the JavaScript, we start by grabbing a reference to the `<main>` element and defining the number of `<section>` elements to generate (21), and a variable to begin counting from. We then use a [`while`](/en-US/docs/Web/JavaScript/Reference/Statements/while) loop to generate the `<section>` elements, giving each one an ID of `s` plus the current value of `n`, and a child [`h2`](/en-US/docs/Web/HTML/Element/Heading_Elements) with text that reads `Section` plus the current value of `n`.
+In the JavaScript, we start by grabbing a reference to the `<main>` element and defining the number of `<section>` elements to generate (21), and a variable to begin counting from. We then use a [`while`](/en-US/docs/Web/JavaScript/Reference/Statements/while) loop to generate the `<section>` elements, giving each one a child [`h2`](/en-US/docs/Web/HTML/Element/Heading_Elements) with text that reads `Section` plus the current value of `n`.
 
 ```js
 const mainElem = document.querySelector("main");
@@ -190,7 +194,7 @@ let n = 1;
 
 while (n <= sectionCount) {
   mainElem.innerHTML += `
-    <section id="s${n}">
+    <section>
       <h2>Section ${n}</h2>
     </section>
   `;
@@ -215,7 +219,7 @@ mainElem.addEventListener("scrollsnapchanging", (event) => {
 ```
 
 > [!NOTE]
-> We don't need to worry about the `snapTargetInline` event object property for this demo — we are only scrolling vertically and the demo is using a horizontal writing mode, therefore only the `snapTargetBlock` value will change.
+> We don't need to worry about the `snapTargetInline` event object property for this demo — we are only scrolling vertically and the demo is using a horizontal writing mode, therefore only the `snapTargetBlock` value will change. `snapTargetInline` will always return `null`.
 
 When a scrolling gesture ends, and a `<section>` element is actually selected as a snap target, the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event handler function fires. This:
 
@@ -311,17 +315,23 @@ main {
 }
 ```
 
-Next, we are going to use CSS animations in this example instead of transtions. This results in more complex code, but enables more fine-grained control over the animations applied. We first define the classes that will be applied to signal that a snap target selection has been made or is pending. The `select-section` and `deselect-section` will be applied to signify a selection or deselection — these apply animations that animate from gray background and black (default) text color to purple background and white text color, and back again, respectively.
+Next, we are going to use CSS animations in this example instead of transtions. This results in more complex code, but enables more fine-grained control over the animations applied.
 
-The `pending` class will be applied to signify a pending snap target selection, as in the previous example.
+We first define the classes that will be applied to signal that a snap target selection has been made or is pending. The `select-section` and `deselect-section` classes will apply keyframe animations to signify a selection or deselection. The `pending` class will be applied to signify a pending snap target selection (it applies a darker gray background to the selection, as in the previous example).
+
+The {{cssxref("@keyframes")}} animate from a gray background and black (default) text color to a purple background and white text color, and back again, respectively. The latter animation is somewhat different from the first one — it also uses {{cssxref("opacity")}} to create a fade out/fade in effect.
 
 ```css
 .select-section {
-  animation: select 0.6s ease forwards;
+  animation: select 0.8s ease forwards;
 }
 
 .deselect-section {
-  animation: deselect 0.6s ease forwards;
+  animation: deselect 0.8s ease forwards;
+}
+
+.pending {
+  background-color: #ccc;
 }
 
 @keyframes select {
@@ -337,25 +347,29 @@ The `pending` class will be applied to signify a pending snap target selection, 
 }
 
 @keyframes deselect {
-  from {
+  0% {
     background: purple;
     color: white;
+    opacity: 1;
   }
 
-  to {
+  80% {
     background: #eee;
     color: black;
+    opacity: 0;
   }
-}
 
-.pending {
-  background-color: #ccc;
+  100% {
+    background: #eee;
+    color: black;
+    opacity: 1;
+  }
 }
 ```
 
 ### JavaScript
 
-In the JavaScript, we start off in the same way as with the previous example, except that this time we generate 49 `<section>` elements. With the grid layout we specified above, this gives us seven columns of seven `<section>`s.
+In the JavaScript, we start off in the same way as with the previous example, except that this time we generate 49 `<section>` elements, and we give each one an ID of `s` plus the current value of `n` to help track them later on. With the grid layout we specified above, this gives us seven columns of seven `<section>`s.
 
 ```js
 const mainElem = document.querySelector("main");
@@ -383,7 +397,7 @@ const prevState = {
 
 For example, let's say the scroll container is scrolled so that the ID of the new {{domxref("SnapEvent.snapTargetBlock")}} element has changed (it doesn't equal the ID stored in `prevState.snapTargetBlock`), but the ID of the new {{domxref("SnapEvent.snapTargetInline")}} element is still the same as the ID stored in `prevState.snapTargetInline`. This means that we've moved to a new snap target in the block direction, so we should style `SnapEvent.snapTargetBlock`, but we've not moved to a new snap target in the inline direction, so we shouldn't style `SnapEvent.snapTargetInline`.
 
-This time around, we'll explain the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event handler function first, as it'll make more sense that way. In this function, we:
+This time around, we'll explain the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event handler function first. In this function, we:
 
 1. Start by making sure that a previously-selected `<section>` element snap target (as signified by the presence of the `select-section` class) has the `deselect-section` class applied so it shows the deselection animation. If no snap target was previously selected, we apply the `select-section` class to the first `<section>` in the DOM so it shows up as selected when the page first loads.
 2. Compare the previously-selected snap target ID to the newly-selected snap target ID, for both the block _and_ inline selections. If they are different, it indicates that the selection has changed, so we apply the `select-section` class to the appropriate snap target to visually indicate this.
@@ -446,7 +460,8 @@ Try scrolling horizontally and vertically around the scroll container and observ
 
 ## See also
 
-- [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module
-- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event
+- {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event
 - {{domxref("SnapEvent")}}
+- [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module
 - [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)

--- a/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
+++ b/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
@@ -1,0 +1,480 @@
+---
+title: Using scroll snap events
+slug: Web/CSS/CSS_scroll_snap/Using_scroll_snap_events
+page-type: guide
+---
+
+{{CSSRef}}
+
+The [CSS Scroll Snap Module Level 2](drafts.csswg.org/css-scroll-snap-2) specification defines **scroll snap events**: {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}}. These make it easy to run JavaScript in response to the browser determining that a new snap target is pending, and when a new snap target is selected, respectively.
+
+This article provides a guide to using these events, along with complete examples.
+
+## Events overview
+
+The two events are set on a scrolling container that contains potential scroll snap targets, and are as follows:
+
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event is fired when the browser determines that a new scroll snap target is pending (i.e., it will be selected when the current scroll gesture ends). Specifically, this event fires during a scrolling gesture, each time the user moves over a potential new snap target. `scrollsnapchanging` can therefore fire multiple times for each scrolling gesture. However, `scrollsnapchanging` does not fire on all potential snap targets for a scrolling gesture that moves over multiple snap targets — just the last target that the snapping will potentially rest on.
+
+- The {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event is fired at the end of a scrolling operation when a new scroll snap target is selected. Specifically, this event fires when a scrolling gesture is completed, but only if a new snap target is selected. Also note that it fires just before the {{domxref("Element/scrollend_event", "scrollend")}} event fires.
+
+Let's look at an example that shows the two events in action (you'll see how this is built later on in the article):
+
+{{ EmbedLiveSample("One-dimensional scroller example", "100%", "500") }}
+
+Have a go at scrolling up and down the list of boxes:
+
+- Try slowly scrolling the container up and down, without releasing the scrolling gesture, For example, drag your finger(s) on a touch screen device or trackpad, or hold down the mouse button on the scroll bar and move the mouse. You should see the boxes you move over turn a darker gray color, and then return to normal as you move away from them again. This is the `scrollsnapchanging` event in action.
+- Now try releasing the scrolling gesture; the nearest box to your scrolling position should animate to a purple color, with white text. This is due to code run in response to the `scrollsnapchange` event firing.
+- Last of all, try scrolling fast, for example by flicking your finger hard on the screen, to scroll past several potential targets before starting to come to rest near a target further down the scroll container. You should only see one `scrollsnapchanging` event fire as the scrolling starts to slow, before the `scrollsnapchange` event then fires and the selected snap target turns purple.
+
+## The `SnapEvent` event object
+
+Both of the above events share the same event object: {{domxref("SnapEvent")}}. This has two distinct properties that are key to how scroll snap events work:
+
+- {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} returns a reference to the element snapped to in the block direction when the event fired.
+- {{domxref("SnapEvent.snapTargetInline", "snapTargetInline")}} returns a reference to the element snapped to in the inline direction when the event fired.
+
+These properties enable event handler functions to report the element that has been snapped to (in the case of `scrollsnapchange`) or the element that _would be snapped to_ if the scrolling gesture were to be finished now (in the case of `scrollsnapchanging`) — in one- and two-dimensions. You can then manipulate these elements in any way you want, for example by directly setting styles on them via their {{domxref("HTMLElement.style", "style")}} properties, setting classes on them that have styles defined for them in a stylesheet, etc.
+
+### Handling one-dimensional scrollers
+
+If you are dealing with a horizontal scroller, only the event object's `snapTargetInline` property will change as the snapped element changes if the content has a horizonal {{cssxref("writing-mode")}}, or the `snapTargetBlock` property if the content has a vertical `writing-mode`. Conversely, if you are dealing with a vertical scroller, only the `snapTargetBlock` property will change as the snapped element changes if the content has a horizonal `writing-mode`, or the `snapTargetInline` property if the content has a vertical `writing-mode`.
+
+Let's look at an example snippet to show a typical one-dimensional scroll snap event handler function:
+
+```js
+scrollingElem.addEventListener("scrollsnapchange", (event) => {
+  event.snapTargetBlock.className = "select-section";
+});
+```
+
+In this snippet, a `scrollsnapchange` handler function is set on a vertical scrolling container element that snap targets appear inside. When the event fires, we set a `select-section` class on the `snapTargetBlock` element, which could be used to style a newly-selected snap target to look like it has been selected (for example, with an animation).
+
+### Handling two-dimensional scrollers
+
+If you are dealing with a horizontal _and_ vertical scroller, the code gets more complex because the `snapTargetBlock` property _or_ the `snapTargetInline` property could change, depending on which direction you scroll in and the `writing-mode` of the content:
+
+- If the scroller is scrolled horizontally, the `snapTargetInline` property will change as the snapped element changes if the content has a horizonal {{cssxref("writing-mode")}}, or the `snapTargetBlock` property if the content has a vertical `writing-mode`.
+- If the scroller is scrolled vertically, the `snapTargetBlock` property will change as the snapped element changes if the content has a horizonal `writing-mode`, or the `snapTargetInline` property if the content has a vertical `writing-mode`.
+
+To handle this, you will likely need to keep track of whether it was the `snapTargetBLock` or the `snapTargetInline` element that changed. Let's look at an example:
+
+```js
+const prevState = {
+  snapTargetInline: "s1",
+  snapTargetBlock: "s1",
+};
+
+scrollingElem.addEventListener("scrollsnapchange", (event) => {
+  if (!(prevState.snapTargetBlock === event.snapTargetBlock.id)) {
+    event.snapTargetBlock.className = "select-section";
+  }
+
+  if (!(prevState.snapTargetInline === event.snapTargetInline.id)) {
+    event.snapTargetInline.className = "select-section";
+  }
+
+  prevState.snapTargetBlock = event.snapTargetBlock.id;
+  prevState.snapTargetInline = event.snapTargetInline.id;
+});
+```
+
+In this snippet, we first define an object (`prevState`) that stores the ID of the previous `snapTargetBlock` and `snapTargetInline` elements.
+
+In the event handler function, we use `if` statements to test whether:
+
+- The `prevState.snapTargetBlock` ID is equal to the ID of the current `event.snapTargetBlock` element.
+- The `prevState.snapTargetInline` ID is equal to the ID of the current `event.snapTargetInline` element.
+
+If the values are different, it means that the scroller has been scrolled in that direction (block or inline), and therefore we set a class of `select-section` on the element to style it in some way when it is snapped to.
+
+We then update the values of `prevState.snapTargetBlock` and `prevState.snapTargetInline`, ready for the next time the event handler is run.
+
+For the remainder of this article, we'll look at a couple of complete scroll snap event examples, which you can play with in the live rendered versions at the end of each section.
+
+## One-dimensional scroller example
+
+This example features a vertically-scrolling {{htmlelement("main")}} element containing multiple light gray {{htmlelement("section")}} elements, which are all scroll snap targets. When a new snap target is pending, it will turn a darker shade of gray. When a new snap target is selected, it will smoothly animate to purple with white text. If a different snap target was previously selected, it will smoothly animate back to gray with black text.
+
+### HTML
+
+The HTML for the example is a single `<main>` element. We will add the `<section>` elements dynamically with JavaScript later on, to save on page space.
+
+```html
+<main></main>
+```
+
+### CSS
+
+```css hidden
+* {
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+}
+
+h2 {
+  font-size: 1rem;
+  letter-spacing: 1px;
+}
+```
+
+In the CSS, we start off by using [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to center the `<main>` element inside the {{htmlelement("body")}}.
+
+```css
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: inherit;
+}
+```
+
+Next, we give the `<main>` element a chunky black {{cssxref("border")}} and a fixed {{cssxref("width")}} and {{cssxref("height")}}. We set its {{cssxref("overflow")}} value to `scroll` so overflowing content will be hidden and can be scrolled to, and set {{cssxref("scroll-snap-type")}} to `block mandatory` so that snap targets in the block direction only will always be snapped to.
+
+```css
+main {
+  border: 3px solid black;
+  width: 250px;
+  height: 450px;
+  overflow: scroll;
+  scroll-snap-type: block mandatory;
+}
+```
+
+Each `<section>` element is given fixed dimensions and some rudimentary styling, which we won't explain in detail. The most significant parts of this ruleset are:
+
+- We've given each one a {{cssxref("margin")}} of `50px` to separate out the `<section>` elements and make the scroll snapping behavior a bit easier to experience.
+- We've again used flexbox for centering. This time, we've used it to center the heading that appears inside each `<section>`.
+- We've used {{cssxref("scroll-snap-align")}} to specify that we want to snap to the center of each snap target.
+
+```css
+section {
+  font-family: Arial, Helvetica, sans-serif;
+  border-radius: 5px;
+  background: #eee;
+  box-shadow:
+    inset 1px 1px 4px rgb(255 255 255 / 0.5),
+    inset -1px -1px 4px rgb(0 0 0 / 0.5);
+  width: 150px;
+  height: 150px;
+
+  margin: 50px auto;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  scroll-snap-align: center;
+}
+```
+
+Next, we define the classes that will be applied to signal that a snap target selection has been made or is pending. The `select-section` and `deselect-section` will be applied to signify a selection or deselection — these apply animations that animate from gray background and black (default) text color to purple background and white text color, and back again, respectively. The `pending` class on the other hand will be applied to signify a pending snap target selection — this colors the target selection's background a darker gray.
+
+```css
+.select-section {
+  animation: select 0.6s ease forwards;
+}
+
+.deselect-section {
+  animation: deselect 0.6s ease forwards;
+}
+
+@keyframes select {
+  from {
+    background: #eee;
+    color: black;
+  }
+
+  to {
+    background: purple;
+    color: white;
+  }
+}
+
+@keyframes deselect {
+  from {
+    background: purple;
+    color: white;
+  }
+
+  to {
+    background: #eee;
+    color: black;
+  }
+}
+
+.pending {
+  background-color: #ccc;
+}
+```
+
+### JavaScript
+
+In the JavaScript, we start by grabbing a reference to the `<main>` element and defining the number of `<section>` elements to generate (21), and a variable to begin counting from. We then use a [`while`](/en-US/docs/Web/JavaScript/Reference/Statements/while) loop to generate the `<section>` elements, giving each one an ID of `s` plus the current value of `n`, and a child [`h2`](/en-US/docs/Web/HTML/Element/Heading_Elements) with text that reads `Section` plus the current value of `n`.
+
+```js
+const mainElem = document.querySelector("main");
+const sectionCount = 21;
+let n = 1;
+
+while (n <= sectionCount) {
+  mainElem.innerHTML += `
+    <section id="s${n}">
+      <h2>Section ${n}</h2>
+    </section>
+  `;
+  n++;
+}
+```
+
+Now on to the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event handler function. When a child of the `<main>` element (i.e. any `<section>` element) becomes a pending snap target selection, we:
+
+1. Check to see if any elements previously had the `pending` class applied. If so, we remove the `pending` class from them. This is so that only the current pending target is given the `pending` class and colored darker gray. We don't want previously-pending targets that are no longer pending to keep the styling.
+2. Give the element referenced by the {{domxref("SnapEvent.snapTargetBlock", "snapTargetBlock")}} property (which will be one of the `<section>` elements) the `pending` class so it turns a darker gray, but only if it has not already got the `select-section` class applied — we want a previously selected target to keep the purple selection styling until a new target is actually selected.
+
+```js
+mainElem.addEventListener("scrollsnapchanging", (event) => {
+  const pendingElems = document.querySelectorAll(".pending");
+  pendingElems.forEach((elem) => {
+    elem.className = "";
+  });
+
+  if (!(event.snapTargetBlock.className === "select-section")) {
+    event.snapTargetBlock.className = "pending";
+  }
+});
+```
+
+> [!NOTE]
+> We don't need to worry about the `snapTargetInline` event object property for this demo — we are only scrolling vertically and the demo is using a horizontal writing mode, therefore only the `snapTargetBlock` value will change.
+
+When a scrolling gesture ends, and a `<section>` element is actually selected as a snap target, the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event handler function fires. This:
+
+1. Checks to see if a snap target was previously selected — i.e. if a `select-section` class was previously applied to an element. If so, we replace the `select-section` class with the `deselect-section` class, so that the deselection animation is applied to the element and it animates back to light gray with black text. If not, we immediately apply the `select-section` class to the first `<section>` element in the DOM, so that it animates to selected when the page first loads.
+2. Applies the `select-section` class to the `<section>` element referenced in the `snapTargetBlock` property so that the snap target that was just selected will have the selection animation applied to it.
+
+```js
+mainElem.addEventListener("scrollsnapchange", (event) => {
+  if (document.querySelector(".select-section")) {
+    document.querySelector(".select-section").className = "deselect-section";
+  } else {
+    document.querySelector("section").className = "select-section";
+  }
+
+  event.snapTargetBlock.className = "select-section";
+});
+```
+
+### Result
+
+Try scrolling up and down the scroll container and observing the behavior described above:
+
+{{ EmbedLiveSample("One-dimensional scroller example", "100%", "500") }}
+
+## Two-dimensional scroller example
+
+This example is very similar to the previous one, except that it features a horizontally- _and_ vertically-scrolling {{htmlelement("main")}} element containing multiple light gray {{htmlelement("section")}} elements, which are all snap targets.
+
+The HTML for the example is the same as for the previous example — a single `<main>` element.
+
+```html hidden
+<main></main>
+```
+
+### CSS
+
+```css hidden
+* {
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: inherit;
+}
+
+section {
+  font-family: Arial, Helvetica, sans-serif;
+  border-radius: 5px;
+  background: #eee;
+  box-shadow:
+    inset 1px 1px 4px rgb(255 255 255 / 0.5),
+    inset -1px -1px 4px rgb(0 0 0 / 0.5);
+  width: 150px;
+  height: 150px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  scroll-snap-align: center;
+}
+
+h2 {
+  font-size: 1rem;
+  letter-spacing: 1px;
+}
+
+.select-section {
+  animation: select 0.6s ease forwards;
+}
+
+.deselect-section {
+  animation: deselect 0.6s ease forwards;
+}
+
+@keyframes select {
+  from {
+    background: #eee;
+    color: black;
+  }
+
+  to {
+    background: purple;
+    color: white;
+  }
+}
+
+@keyframes deselect {
+  from {
+    background: purple;
+    color: white;
+  }
+
+  to {
+    background: #eee;
+    color: black;
+  }
+}
+
+.pending {
+  background-color: #ccc;
+}
+```
+
+The CSS for this example is very nearly identical to the CSS in the previous example. The most significant difference is in the styling of the `<main>` element — we want the `<section>` elements to be laid out as a grid, so we use [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) to specify that we want them displayed in seven columns, using a {{cssxref("grid-template-columns")}} value of `repeat(7, 1fr)`. We also specify the space around the `<section>` elements by setting `padding` and {{cssxref("gap")}} on the `<main>` element rather than `margin` on the `<section>` elements.
+
+Finally, since we are scrolling in both directions in this example, we set {{cssxref("scroll-snap-type")}} to `both mandatory` so that snap targets in the block direction _and_ inline direction will always be snapped to.
+
+```css
+main {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  padding: 100px;
+  gap: 50px;
+  overflow: scroll;
+  border: 3px solid black;
+  width: 350px;
+  height: 350px;
+
+  scroll-snap-type: both mandatory;
+}
+```
+
+### JavaScript
+
+In the JavaScript, we start off in the same way as with the previous example, except that this time we generate 49 `<section>` elements. With the grid layout we specified above, this gives us seven columns of seven `<section>`s.
+
+```js
+const mainElem = document.querySelector("main");
+const sectionCount = 49;
+let n = 1;
+
+while (n <= sectionCount) {
+  mainElem.innerHTML += `
+    <section id="s${n}">
+      <h2>Section ${n}</h2>
+    </section>
+  `;
+  n++;
+}
+```
+
+Next we specify an object called `prevState`, which allows us to keep track of the previously-selected snap target at any point — its properties store the previous inline and block snap targets' IDs. This is important for figuring out if we need to style the new block target or the new inline target each time an event handler fires.
+
+```js
+const prevState = {
+  snapTargetInline: "s1",
+  snapTargetBlock: "s1",
+};
+```
+
+For example, let's say the scroll container is scrolled so that the ID of the new {{domxref("SnapEvent.snapTargetBlock")}} element has changed (it doesn't equal the ID stored in `prevState.snapTargetBlock`), but the ID of the new {{domxref("SnapEvent.snapTargetInline")}} element is still the same as the ID stored in `prevState.snapTargetInline`. This means that we've moved to a new snap target in the block direction, so we should style `SnapEvent.snapTargetBlock`, but we've not moved to a new snap target in the inline direction, so we shouldn't style `SnapEvent.snapTargetInline`.
+
+This time around, we'll explain the {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} event handler function first, as it'll make more sense that way. In this function, we:
+
+1. Start by running the same code as in the previous example — making sure that any previously-selected `<section>` element snap target (as signified by the presence of the `select-section` class) has the `deselect-section` class applied so it shows the deselection animation. If no snap target was previously selected, we apply the `select-section` class to the first `<section>` in the DOM so it shows up as selected when the page first loads.
+2. Compare the previously-selected snap target ID to the newly-selected snap target ID, for both the block _and_ inline selections. If they are different, it indicates that the selection has changed, so we apply the `select-section` class to the appropriate snap target to visually indicate this.
+3. Update `prevState.snapTargetBlock` and `prevState.snapTargetInline` to be equal to the IDs of the scroll snap targets that were just selected, so that when the event next fires, they will be the previous selections.
+
+```js
+mainElem.addEventListener("scrollsnapchange", (event) => {
+  if (document.querySelector(".select-section")) {
+    document.querySelector(".select-section").className = "deselect-section";
+  } else {
+    document.querySelector("section").className = "select-section";
+  }
+
+  if (!(prevState.snapTargetBlock === event.snapTargetBlock.id)) {
+    event.snapTargetBlock.className = "select-section";
+  }
+
+  if (!(prevState.snapTargetInline === event.snapTargetInline.id)) {
+    event.snapTargetInline.className = "select-section";
+  }
+
+  prevState.snapTargetBlock = event.snapTargetBlock.id;
+  prevState.snapTargetInline = event.snapTargetInline.id;
+});
+```
+
+When the {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} event handler function fires, we:
+
+1. Remove the `pending` class from all elements that previously had it applied, as before, so that only the current pending target is given the `pending` class and colored darker gray.
+2. Give the element that we have actually scrolled over the `pending` class so it turns a darker gray, but only if it has not already got the `select-section` class applied — we want a previously selected target to keep the purple selection styling until a new target is actually selected. Because we are scrolling in two dimensions, this could be the inline or block pending snap target. To figure out which one we include an extra check in the `if` statements — again, we compare the previous snap target to the current snap target in each case.
+
+```js
+mainElem.addEventListener("scrollsnapchanging", (event) => {
+  const pendingElems = document.querySelectorAll(".pending");
+  pendingElems.forEach((elem) => {
+    elem.className = "";
+  });
+
+  if (
+    !(event.snapTargetBlock.className === "select-section") &&
+    !(prevState.snapTargetBlock === event.snapTargetBlock.id)
+  ) {
+    event.snapTargetBlock.className = "pending";
+  }
+
+  if (
+    !(event.snapTargetInline.className === "select-section") &&
+    !(prevState.snapTargetInline === event.snapTargetInline.id)
+  ) {
+    event.snapTargetInline.className = "pending";
+  }
+});
+```
+
+### Result
+
+Try scrolling horizontally and vertically around the scroll container and observing the behavior described above:
+
+{{ EmbedLiveSample("Two-dimensional scroller example", "100%", "500") }}
+
+## See also
+
+- [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module
+- The {{domxref("Element/scrollsnapchanging_event", "scrollsnapchanging")}} and {{domxref("Element/scrollsnapchange_event", "scrollsnapchange")}} events
+- {{domxref("SnapEvent")}}
+- [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) on developer.chrome.com (2024)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Chrome 129 supports scroll snap events — [`scrollsnapchange`](https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchange) and [`scrollsnapchanging`](https://drafts.csswg.org/css-scroll-snap-2/#scrollsnapchanging), which enable code being fired in response to a new scroll snap target being snapped to, and the browser identifying a change in the next snap target to be snapped to (if the gesture were to end).

See the associated [ChromeStatus entry](https://chromestatus.com/feature/5826089036808192) and the [Scroll Snap Events](https://developer.chrome.com/blog/scroll-snap-events) blog post for more context and a guide. 

This PR adds:

- [x] The new events. I've written them up in detail in the versions defined on `Element`, but I've also put short pages for the events hanging off `Document` and `Window`, which link to the `Element` versions for the full details. See https://drafts.csswg.org/css-scroll-snap-2/#event-handlers-on-elements-document-and-window-objects.
- [x] The `SnapEvent` event object
- [x] A guide to using the events, hung off the CSS scroll snap module landing page. It is about JS much more than it is about CSS, but the events are defined in Scroll Snap Events level 2.


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
