### PR TITLE
Add contentful background-image to Element Timing supported elements

### DIFF
--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -20,7 +20,7 @@ The API supports timing information on the following elements:
 - {{htmlelement("img")}} elements,
 - {{SVGElement("image")}} elements inside an {{SVGElement("svg")}},
 - [poster](/en-US/docs/Web/HTML/Element/video#poster) images of {{htmlelement("video")}} elements,
-- elements which have a contentful {{cssxref("background-image")}} (url valued and available), and
+- elements which have a contentful {{cssxref("background-image")}} property with a URL value for a resource that is actually available, and
 - groups of text nodes, such as a {{htmlelement("p")}}.
 
 The author flags an element for observation by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute on the element.

--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -20,7 +20,7 @@ The API supports timing information on the following elements:
 - {{htmlelement("img")}} elements,
 - {{SVGElement("image")}} elements inside an {{SVGElement("svg")}},
 - [poster](/en-US/docs/Web/HTML/Element/video#poster) images of {{htmlelement("video")}} elements,
-- elements which have a {{cssxref("background-image")}} (excludes {{cssxref("gradient")}}), and
+- elements which have a contentful {{cssxref("background-image")}} (url valued and available), and
 - groups of text nodes, such as a {{htmlelement("p")}}.
 
 The author flags an element for observation by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute on the element.

--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -20,7 +20,7 @@ The API supports timing information on the following elements:
 - {{htmlelement("img")}} elements,
 - {{SVGElement("image")}} elements inside an {{SVGElement("svg")}},
 - [poster](/en-US/docs/Web/HTML/Element/video#poster) images of {{htmlelement("video")}} elements,
-- elements which have a {{cssxref("background-image")}} (excluding {{cssxref("gradient")}}, and
+- elements which have a {{cssxref("background-image")}} (excludes {{cssxref("gradient")}}), and
 - groups of text nodes, such as a {{htmlelement("p")}}.
 
 The author flags an element for observation by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute on the element.

--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -20,7 +20,7 @@ The API supports timing information on the following elements:
 - {{htmlelement("img")}} elements,
 - {{SVGElement("image")}} elements inside an {{SVGElement("svg")}},
 - [poster](/en-US/docs/Web/HTML/Element/video#poster) images of {{htmlelement("video")}} elements,
-- elements which have a {{cssxref("background-image")}}, and
+- elements which have a {{cssxref("background-image")}} (excluding {{cssxref("gradient")}}, and
 - groups of text nodes, such as a {{htmlelement("p")}}.
 
 The author flags an element for observation by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute on the element.


### PR DESCRIPTION
### Description

The [PerformanceElementTiming](https://developer.mozilla.org/docs/Web/API/PerformanceElementTiming) documentation states that:

> The API supports timing information on the following elements:
> - [...]
> - elements which have a [background-image](https://developer.mozilla.org/docs/Web/CSS/background-image)

I want to clarify that API is not supported on elements that use a gradient as a background-image, for example:

```css
// not supported
.example {
  background-image: linear-gradient(black, white);
}

// supported
.example{
  background-image: url("/image.jpg");
}
```

### Motivation

To assist developers in understanding good use-cases for this API.

### Additional details

### Related issues and pull requests