### PR TITLE
Release notes for Firefox 131 for WebDriver conformance changes.

### DIFF
--- a/files/en-us/mozilla/firefox/releases/131/index.md
+++ b/files/en-us/mozilla/firefox/releases/131/index.md
@@ -65,9 +65,16 @@ This article provides information about the changes in Firefox 131 that affect d
 
 #### General
 
+- For both WebDriver Classic and BiDi the `keyUp` and `keyDown` actions will no longer accept multiple characters for the `value` ([Firefox bug 1910352](https://bugzil.la/1910352)).
+
 #### WebDriver BiDi
 
-#### Marionette
+- Added support for remaining arguments of `network.continueResponse` command:
+  - The cookies and headers arguments ([Firefox bug 1853887](https://bugzil.la/1853887)).
+  - The `statusCode` (e.g., 200, 304) and `reasonPhrase` (e.g., "OK", "Not modified") arguments ([Firefox bug 1913737](https://bugzil.la/1913737)).
+- The `browsingContext.navigate` command will now return if the `wait` argument is `none` and a beforeunload prompt is triggered ([Firefox bug 1763134](https://bugzil.la/1763134)).
+- The `browsingContext.navigate` command will return an `unknown error` in all cases where a navigation failure occurs, as required by the specification ([Firefox bug 1905083](https://bugzil.la/1905083)).
+- The `session.new` command will no longer include the `unhandledPromptBehavior` capability in its response if it was not specified by the client as an argument ([Firefox bug 1909455](https://bugzil.la/1909455)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
This updates the WebDriver section of the Firefox 131 release notes for all the [note-worthy WebDriver changes in this release](https://bugzilla.mozilla.org/buglist.cgi?o1=equals&f3=cf_status_firefox130&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&o2=notsubstring&f5=status_whiteboard&f4=status_whiteboard&component=Agent&component=Marionette&component=WebDriver%20BiDi&f1=cf_status_firefox131&query_format=advanced&f2=status_whiteboard&o3=notequals&o5=notsubstring&resolution=FIXED&list_id=17241123&o4=substring&v2=%5Bwptsync%20downstream%5D&product=Remote%20Protocol&v1=fixed&v4=relnote&v5=lang&v3=fixed).