### PR TITLE
chore(XRWebGLLayer): remove leftover TODO-like comment

### DIFF
--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.md
@@ -56,9 +56,6 @@ one half for each eye, setting the WebGL viewport to match the WebXR layer's vie
 will ensure that when rendering the scene for the current eye's pose, it is rendered
 into the correct half of the framebuffer.
 
-**<<<--- add link to appropriate section in the Cameras and views
-article --->>>**
-
 ```js
 function drawFrame(time, frame) {
   const session = frame.session;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes a leftover TODO-like comment from the pre-Markdown era.

### Motivation

This would cause a markdownlint error if it was on a single line, and our machine translator stumbles over it.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
