### PR TITLE
Add notes describing media overflow

### DIFF
--- a/files/en-us/web/css/@media/overflow-block/index.md
+++ b/files/en-us/web/css/@media/overflow-block/index.md
@@ -10,12 +10,7 @@ browser-compat: css.at-rules.media.overflow-block
 The **`overflow-block`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) can be used to test how the output device handles content that overflows the initial [containing block](/en-US/docs/Web/CSS/Containing_block) along the block axis.
 
 > [!NOTE]
-> The `overflow-block` property is useful for understanding how a device manages
-> vertical overflowing content. It does not determine whether overflow occurs;
-> rather, it reveals the device's handling of such overflow. Typically, on most
-> devices and in browsers, the behavior will be "scroll": when content exceeds
-> the available vertical space, the device allows you to scroll to access the
-> overflowed content.
+> The `overflow-block` property does not determine whether overflow occurs; rather, it reveals the device's handling of such overflow. Typically, on screens in most browsers, the behavior will be "scroll": when content exceeds the available vertical space, the device allows you to scroll to access the overflowed content.
 
 ## Syntax
 

--- a/files/en-us/web/css/@media/overflow-block/index.md
+++ b/files/en-us/web/css/@media/overflow-block/index.md
@@ -9,6 +9,14 @@ browser-compat: css.at-rules.media.overflow-block
 
 The **`overflow-block`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) can be used to test how the output device handles content that overflows the initial [containing block](/en-US/docs/Web/CSS/Containing_block) along the block axis.
 
+> [!NOTE]
+> The `overflow-block` property is useful for understanding how a device manages
+> vertical overflowing content. It does not determine whether overflow occurs;
+> rather, it reveals the device's handling of such overflow. Typically, on most
+> devices and in browsers, the behavior will be "scroll": when content exceeds
+> the available vertical space, the device allows you to scroll to access the
+> overflowed content.
+
 ## Syntax
 
 The `overflow-block` feature is specified as a keyword value chosen from the list below.

--- a/files/en-us/web/css/@media/overflow-inline/index.md
+++ b/files/en-us/web/css/@media/overflow-inline/index.md
@@ -9,6 +9,14 @@ browser-compat: css.at-rules.media.overflow-inline
 
 The **`overflow-inline`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) can be used to test how the output device handles content that overflows the initial [containing block](/en-US/docs/Web/CSS/Containing_block) along the inline axis.
 
+> [!NOTE]
+> The `overflow-inline` property is useful for understanding how a device
+> manages horizontal overflowing content. It does not determine whether overflow
+> occurs; rather, it reveals the device's handling of such overflow. Typically,
+> on screens in most browsers, the behavior will be "scroll": when content
+> exceeds the available horizontal space, the device allows you to scroll to
+> access the overflowed content.
+
 ## Syntax
 
 The `overflow-inline` feature is specified as a keyword value chosen from the list below.

--- a/files/en-us/web/css/@media/overflow-inline/index.md
+++ b/files/en-us/web/css/@media/overflow-inline/index.md
@@ -10,12 +10,7 @@ browser-compat: css.at-rules.media.overflow-inline
 The **`overflow-inline`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) can be used to test how the output device handles content that overflows the initial [containing block](/en-US/docs/Web/CSS/Containing_block) along the inline axis.
 
 > [!NOTE]
-> The `overflow-inline` property is useful for understanding how a device
-> manages horizontal overflowing content. It does not determine whether overflow
-> occurs; rather, it reveals the device's handling of such overflow. Typically,
-> on screens in most browsers, the behavior will be "scroll": when content
-> exceeds the available horizontal space, the device allows you to scroll to
-> access the overflowed content.
+> The `overflow-inline` property does not determine whether overflow occurs; rather, it reveals the device's handling of such overflow. Typically, on screens in most browsers, the behavior will be "scroll": when content exceeds the available horizontal space, the device allows you to scroll to access the overflowed content.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This PR adds notes to describe in a little bit more detail what the `overflow-inline` and `overflow-block` actually detect.

### Motivation

I was investigating something and I stumbled upon the `@media (overflow-inline: scroll)`, I opened MDN and I totally missed what the `overflow-inline` actually detects and I wrongly thought that it detects whether there's overflow or not.   
I searched for others, and I found other people facing the same issue as I did.


### Additional details

- <https://csscade.com/can-you-detect-overflow-with-css/>

### Related issues and pull requests

N/A
