### PR TITLE
Fix post-merge hook echo command

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -7,7 +7,7 @@ if [ -f ".husky/_/history" ]; then
   lastHash=$(cat ./.husky/_/history)
   isUpdated=$(git diff $lastHash HEAD -- ./package.json)
   if [ "$isUpdated" != "" ]; then
-    echo "\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
+    echo -e "\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
   fi
 else
   yarn install

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -7,7 +7,8 @@ if [ -f ".husky/_/history" ]; then
   lastHash=$(cat ./.husky/_/history)
   isUpdated=$(git diff $lastHash HEAD -- ./package.json)
   if [ "$isUpdated" != "" ]; then
-    echo -e "\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
+    echo
+    echo "⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
   fi
 else
   yarn install


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add the `-e` flag to the `echo ...` command in the post-merge hook.

### Motivation

`post-merge` is outputting a message like,

```console
$ git pull
[...]
\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥
```

(With the literal `\n` being visible at the front of the output.)
### Additional details

Bourne shell `echo` requires `-e` to process backslash escapes.

