### PR TITLE
Include null and undefined elements in flat() example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
@@ -33,7 +33,7 @@ A new array with the sub-array elements concatenated into it.
 
 The `flat()` method is a [copying method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#copying_methods_and_mutating_methods). It does not alter `this` but instead returns a [shallow copy](/en-US/docs/Glossary/Shallow_copy) that contains the same elements as the ones from the original array.
 
-The `flat()` method ignores empty slots if the array being flattened is [sparse](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays). For example, if `depth` is 1, both empty slots in the root array and in the first level of nested arrays are ignored, but empty slots in further nested arrays are preserved with the arrays themselves.
+The `flat()` method removes empty slots if the array being flattened is [sparse](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays). For example, if `depth` is 1, both empty slots in the root array and in the first level of nested arrays are ignored, but empty slots in further nested arrays are preserved with the arrays themselves.
 
 The `flat()` method is [generic](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#generic_array_methods). It only expects the `this` value to have a `length` property and integer-keyed properties. However, its elements must be arrays if they are to be flattened.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
@@ -61,7 +61,7 @@ arr4.flat(Infinity);
 
 ### Using flat() on sparse arrays
 
-The `flat()` method removes empty slots in arrays:
+The `flat()` method removes [empty slots](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays) in arrays:
 
 ```js
 const arr5 = [1, 2, , 4, 5];
@@ -70,9 +70,9 @@ console.log(arr5.flat()); // [1, 2, 4, 5]
 const array = [1, , 3, ["a", , "c"]];
 console.log(array.flat()); // [ 1, 3, "a", "c" ]
 
-const array2 = [1, , 3, ["a", , ["d", , "e"]]];
-console.log(array2.flat()); // [ 1, 3, "a", ["d", empty, "e"] ]
-console.log(array2.flat(2)); // [ 1, 3, "a", "d", "e"]
+const array2 = [1, , 3, undefined, ["a", , ["d", , "e"]], null];
+console.log(array2.flat()); // [ 1, 3, undefined, "a", ["d", empty, "e"], null ]
+console.log(array2.flat(2)); // [ 1, 3, undefined, "a", "d", "e", null ]
 ```
 
 ### Calling flat() on non-array objects


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Include null and undefined elements in flat() examples

### Motivation

- I wasn't sure if `null`, `undefined`, and "empty" were equivalent in the eyes of the `flat()` method, so I tried it out in the console and learned that they are not.
- I've modified the example for sparse arrays to include these values so that others don't have to run their own experiments to learn this information. 
- I also included a link to the sparse array documentation. If the way `flat()` handles `null` and `undefined` confuses the reader, I think they are likely to click on this link to educate themselves.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
