### PR TITLE
Mute default :focus form highlight

### DIFF
--- a/files/en-us/learn/forms/your_first_form/index.md
+++ b/files/en-us/learn/forms/your_first_form/index.md
@@ -225,6 +225,8 @@ textarea {
 
 input:focus,
 textarea:focus {
+  /* Mute default highlight */
+  outline: none;
   /* Additional highlight for focused elements */
   border-color: #000;
 }

--- a/files/en-us/learn/forms/your_first_form/index.md
+++ b/files/en-us/learn/forms/your_first_form/index.md
@@ -225,10 +225,10 @@ textarea {
 
 input:focus,
 textarea:focus {
-  /* Mute default highlight */
-  outline: none;
-  /* Additional highlight for focused elements */
-  border-color: #000;
+  /* Set the outline width and style /
+  outline-style: solid;
+  /* To give a little highlight on active elements */
+  outline-color: #000;
 }
 
 textarea {

--- a/files/en-us/learn/forms/your_first_form/index.md
+++ b/files/en-us/learn/forms/your_first_form/index.md
@@ -225,7 +225,7 @@ textarea {
 
 input:focus,
 textarea:focus {
-  /* Set the outline width and style /
+  /* Set the outline width and style */
   outline-style: solid;
   /* To give a little highlight on active elements */
   outline-color: #000;


### PR DESCRIPTION
The applied border colour (border-color: #000;) is cascaded by the default border highlight (blue colour in Chrome). Therefore I reckon the default styling needs to be muted.