### PR TITLE
Fix a link fragment in the HTMLTemplateElement: shadowRootDelegatesFocus property

### DIFF
--- a/files/en-us/web/api/htmltemplateelement/shadowrootdelegatesfocus/index.md
+++ b/files/en-us/web/api/htmltemplateelement/shadowrootdelegatesfocus/index.md
@@ -16,7 +16,7 @@ Otherwise, if an `HTMLTemplateElement` is created, the value of this property is
 
 ## Value
 
-Reflects the value of the [`shadowrootdelegatesfocus`](/en-US/docs/Web/HTML/Element/template#shadowrootclonable) attribute of the associated [`<template>`](/en-US/docs/Web/HTML/Element/template) element.
+Reflects the value of the [`shadowrootdelegatesfocus`](/en-US/docs/Web/HTML/Element/template#shadowrootdelegatesfocus) attribute of the associated [`<template>`](/en-US/docs/Web/HTML/Element/template) element.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix a link fragment to `shadowrootdelegatesfocus`.

### Motivation

The link should be toward to `shadowrootdelegatesfocus`, but it links to `shadowrootclonable`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
