### PR TITLE
Fix code bug

### DIFF
--- a/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.md
+++ b/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.md
@@ -35,7 +35,7 @@ A generic {{domxref("Event")}}.
 This example creates an event handler for `selectedcandidatepairchange` that updates a display providing the user information about the progress of the ICE negotiation for an {{domxref("RTCPeerConnection")}} called `pc`.
 
 ```js
-let iceTransport = pc.getSenders[0].transport.iceTransport;
+let iceTransport = pc.getSenders()[0].transport.iceTransport;
 let localProtoElem = document.getElementById("local-protocol");
 let remoteProtoElem = document.getElementById("remote-protocol");
 
@@ -53,7 +53,7 @@ iceTransport.addEventListener(
 This can also be done by setting the `onselectedcandidatepairchange` event handler property directly.
 
 ```js
-let iceTransport = pc.getSenders[0].transport.iceTransport;
+let iceTransport = pc.getSenders()[0].transport.iceTransport;
 let localProtoElem = document.getElementById("local-protocol");
 let remoteProtoElem = document.getElementById("remote-protocol");
 


### PR DESCRIPTION
### Description
The getSenders-function is never called, but just accessed as if it was a getter-property. The proposed change correctly adds parentheses after "getSenders", so the method is properly called.

### Motivation
So they won't make the same mistake I did :-)

### Additional details

Link to definition of "getSenders" inn the RTCIceTransport-class. It's defined as a method, and not a property:
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getSenders
