### PR TITLE
Add MathML ARIA roles information

### DIFF
--- a/files/en-us/web/mathml/element/annotation-xml/index.md
+++ b/files/en-us/web/mathml/element/annotation-xml/index.md
@@ -21,6 +21,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `src` {{deprecated_inline}}
   - : The location of an external source for semantic information.
 
+## Accessibility
+
+The `<annotation-xml>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Example
 
 ```css hidden

--- a/files/en-us/web/mathml/element/annotation-xml/index.md
+++ b/files/en-us/web/mathml/element/annotation-xml/index.md
@@ -21,10 +21,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `src` {{deprecated_inline}}
   - : The location of an external source for semantic information.
 
-## Accessibility
-
-The `<annotation-xml>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Example
 
 ```css hidden
@@ -82,6 +78,19 @@ body {
 ```
 
 {{ EmbedLiveSample('example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/annotation/index.md
+++ b/files/en-us/web/mathml/element/annotation/index.md
@@ -21,6 +21,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `src` {{deprecated_inline}}
   - : The location of an external source for semantic information.
 
+## Accessibility
+
+The `<annotation>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Example
 
 ```css hidden

--- a/files/en-us/web/mathml/element/annotation/index.md
+++ b/files/en-us/web/mathml/element/annotation/index.md
@@ -21,10 +21,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `src` {{deprecated_inline}}
   - : The location of an external source for semantic information.
 
-## Accessibility
-
-The `<annotation>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Example
 
 ```css hidden
@@ -60,6 +56,19 @@ body {
 ```
 
 {{ EmbedLiveSample('example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -30,6 +30,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `selection` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The child element currently visible, only taken into account for `actiontype="toggle"` or non-standard `actiontype` values. The default value is `1`, which is the first child element.
 
+## Accessibility
+
+The `<maction>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 The following example uses the "toggle" `actiontype`:

--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -30,10 +30,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `selection` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The child element currently visible, only taken into account for `actiontype="toggle"` or non-standard `actiontype` values. The default value is `1`, which is the first child element.
 
-## Accessibility
-
-The `<maction>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 The following example uses the "toggle" `actiontype`:
@@ -72,6 +68,19 @@ The following example uses the "toggle" `actiontype`:
 ```
 
 {{EmbedLiveSample('Examples', 700, 200)}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -25,6 +25,73 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
     If not present, its default value is `inline`.
 
+## Accessibility
+
+The `<math>` element has an implicit [`math` ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles/math_role). Assistive technologies can use this role to identify the content as a mathematical expression and convey it to users.
+
+```css hidden
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+}
+```
+
+For example, screen readers will represent the following quadratic formula similar to:
+
+> x equals fraction start, negative b square root of b squared minus 4 a c, end of root, over 2 a, end of fraction, maths
+
+<details>
+<summary>Markup for the quadratic formula</summary>
+
+```html
+<math display="block">
+  <mrow>
+    <mi>x</mi>
+    <mo>=</mo>
+    <mfrac>
+      <mrow>
+        <mrow>
+          <mo>−</mo>
+          <mi>b</mi>
+        </mrow>
+        <mo>±</mo>
+        <msqrt>
+          <mrow>
+            <msup>
+              <mi>b</mi>
+              <mn>2</mn>
+            </msup>
+            <mo>−</mo>
+            <mrow>
+              <mn>4</mn>
+              <mo>⁢</mo>
+              <mi>a</mi>
+              <mo>⁢</mo>
+              <mi>c</mi>
+            </mrow>
+          </mrow>
+        </msqrt>
+      </mrow>
+      <mrow>
+        <mn>2</mn>
+        <mo>⁢</mo>
+        <mi>a</mi>
+      </mrow>
+    </mfrac>
+  </mrow>
+</math>
+```
+
+</details>
+
+{{ EmbedLiveSample('accessibility') }}
+
 ## Examples
 
 This example contains two MathML formula. The first one is rendered in its own centered block, taking as much space as needed. The second one is rendered inside the paragraph of text, with reduced size and spacing in order to minimize its height.

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -137,6 +137,21 @@ This example contains two MathML formula. The first one is rendered in its own c
 
 {{ EmbedLiveSample('math_example', 700, 200, "", "") }}
 
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/math_role">
+        <code>math</code>
+      </a>
+    </td>
+  </tr>
+</table>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -44,7 +44,7 @@ body {
 
 For example, screen readers will represent the following quadratic formula similar to:
 
-> x equals fraction start, negative b square root of b squared minus 4 a c, end of root, over 2 a, end of fraction, maths
+> x equals fraction start, negative b plus or minus square root of b squared minus 4 a c, end of root, over 2 a, end of fraction, maths
 
 <details>
 <summary>Markup for the quadratic formula</summary>

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -38,10 +38,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
     | `updiagonalarrow`    | ![Arrow pointing up and to the right.](updiagonalarrow.png) | <math><menclose notation="updiagonalarrow"><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></menclose></math>    | diagonal arrow                                                                                                      |
     | `phasorangle`        | ![Screenshot of the phasorangle notation](phasorangle.png)  | <math><menclose notation="phasorangle"><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></menclose></math>        | phasor angle                                                                                                        |
 
-## Accessibility
-
-The `<menclose>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -55,6 +51,19 @@ The `<menclose>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibili
 ```
 
 {{ EmbedLiveSample('menclose_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -38,6 +38,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
     | `updiagonalarrow`    | ![Arrow pointing up and to the right.](updiagonalarrow.png) | <math><menclose notation="updiagonalarrow"><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></menclose></math>    | diagonal arrow                                                                                                      |
     | `phasorangle`        | ![Screenshot of the phasorangle notation](phasorangle.png)  | <math><menclose notation="phasorangle"><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></menclose></math>        | phasor angle                                                                                                        |
 
+## Accessibility
+
+The `<menclose>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/merror/index.md
+++ b/files/en-us/web/mathml/element/merror/index.md
@@ -13,10 +13,6 @@ The **`<merror>`** [MathML](/en-US/docs/Web/MathML) element is used to display c
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<merror>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 In the following example, `<merror>` is used to indicate a parsing error for some LaTeX-like input:
@@ -33,6 +29,19 @@ In the following example, `<merror>` is used to indicate a parsing error for som
 ```
 
 {{ EmbedLiveSample('merror_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/merror/index.md
+++ b/files/en-us/web/mathml/element/merror/index.md
@@ -13,6 +13,10 @@ The **`<merror>`** [MathML](/en-US/docs/Web/MathML) element is used to display c
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<merror>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 In the following example, `<merror>` is used to indicate a parsing error for some LaTeX-like input:

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -26,6 +26,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `separators`
   - : A sequence of zero or more characters to be used for different separators, optionally divided by white space, which is ignored. The default value is ",". By specifying more than one character, it is possible to set different separators for each argument in the expression. If there are too many separators, all excess is ignored. If there are too few separators in the expression, the last specified separator is repeated.
 
+## Accessibility
+
+The `<mfenced>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### The last separator is repeated (`,`)

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -26,10 +26,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `separators`
   - : A sequence of zero or more characters to be used for different separators, optionally divided by white space, which is ignored. The default value is ",". By specifying more than one character, it is possible to set different separators for each argument in the expression. If there are too many separators, all excess is ignored. If there are too few separators in the expression, the last specified separator is repeated.
 
-## Accessibility
-
-The `<mfenced>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### The last separator is repeated (`,`)
@@ -71,6 +67,19 @@ Sample rendering: ![[a|b|c|d|e]](mfenced02.png)
 Rendering in your browser:
 
 {{ EmbedLiveSample('mfenced_example1', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -32,10 +32,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `linethickness` attribute, some browsers may also accept the deprecated values `medium`, `thin` and `thick` (whose exact interpretation is left to implementers) or [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<mfrac>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Simple fraction
@@ -80,6 +76,19 @@ The following MathML code should render as a [binomial coefficient](https://en.w
 ```
 
 {{ EmbedLiveSample('Fraction_without_bar', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -32,6 +32,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `linethickness` attribute, some browsers may also accept the deprecated values `medium`, `thin` and `thick` (whose exact interpretation is left to implementers) or [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<mfrac>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Simple fraction

--- a/files/en-us/web/mathml/element/mi/index.md
+++ b/files/en-us/web/mathml/element/mi/index.md
@@ -66,10 +66,6 @@ In order to use a particular form of a character such as bold/italic, serif, san
 
 This element also accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mi>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -95,6 +91,19 @@ The `<mi>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARI
 ```
 
 {{ EmbedLiveSample('mi_example', 400, 100) }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mi/index.md
+++ b/files/en-us/web/mathml/element/mi/index.md
@@ -66,6 +66,10 @@ In order to use a particular form of a character such as bold/italic, serif, san
 
 This element also accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mi>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -40,6 +40,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<mmultiscripts>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Using `<mprescripts>`

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -40,10 +40,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<mmultiscripts>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Using `<mprescripts>`
@@ -145,6 +141,19 @@ body {
 ```
 
 {{ EmbedLiveSample('order_of_scripts', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mn/index.md
+++ b/files/en-us/web/mathml/element/mn/index.md
@@ -13,10 +13,6 @@ The **`<mn>`** [MathML](/en-US/docs/Web/MathML) element represents a **numeric**
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mn>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -42,6 +38,19 @@ The `<mn>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARI
 ```
 
 {{ EmbedLiveSample('mi_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mn/index.md
+++ b/files/en-us/web/mathml/element/mn/index.md
@@ -13,6 +13,10 @@ The **`<mn>`** [MathML](/en-US/docs/Web/MathML) element represents a **numeric**
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mn>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -44,6 +44,10 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 > [!NOTE]
 > For the `lspace`, `maxsize`, `minsize` and `rspace` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<mo>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html-nolint

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -44,10 +44,6 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 > [!NOTE]
 > For the `lspace`, `maxsize`, `minsize` and `rspace` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<mo>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html-nolint
@@ -73,6 +69,19 @@ The `<mo>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARI
 ```
 
 {{ EmbedLiveSample('mo_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -16,6 +16,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accent`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the over script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
+## Accessibility
+
+The `<mover>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -16,10 +16,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accent`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the over script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
-## Accessibility
-
-The `<mover>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -38,6 +34,19 @@ The `<mover>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/
 ```
 
 {{ EmbedLiveSample('mover_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -36,6 +36,10 @@ For the `depth`, `height`, `lspace`, `voffset` and `width` attributes, some brow
    - A pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α times the corresponding dimension of the content.
    - A percent sign followed by a pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α% the corresponding dimension of the content.
 
+## Accessibility
+
+The `<mpadded>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Dimensions and offsets

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -36,10 +36,6 @@ For the `depth`, `height`, `lspace`, `voffset` and `width` attributes, some brow
    - A pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α times the corresponding dimension of the content.
    - A percent sign followed by a pseudo-unit `width`, `height` or `depth`. The specified value is interpreted as α% the corresponding dimension of the content.
 
-## Accessibility
-
-The `<mpadded>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Dimensions and offsets
@@ -89,6 +85,19 @@ The `<mpadded>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibilit
 ```
 
 {{ EmbedLiveSample('legacy_syntax_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mphantom/index.md
+++ b/files/en-us/web/mathml/element/mphantom/index.md
@@ -13,10 +13,6 @@ The **`<mphantom>`** [MathML](/en-US/docs/Web/MathML) element is rendered invisi
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mphantom>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -34,6 +30,19 @@ The `<mphantom>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibili
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mphantom/index.md
+++ b/files/en-us/web/mathml/element/mphantom/index.md
@@ -13,6 +13,10 @@ The **`<mphantom>`** [MathML](/en-US/docs/Web/MathML) element is rendered invisi
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mphantom>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mprescripts/index.md
+++ b/files/en-us/web/mathml/element/mprescripts/index.md
@@ -13,10 +13,6 @@ The **`<mprescripts>`** [MathML](/en-US/docs/Web/MathML) element is used within 
 
 This element supports [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mprescripts>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Example
 
 The first `<mmultiscripts>` child element becomes a base expression. The remaining children by default become post-scripts elements (a, b). `<mprescripts>` acts as a separator, and children after it become pre-scripts elements (c, d).
@@ -48,6 +44,19 @@ body {
 ```
 
 {{ EmbedLiveSample('example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mprescripts/index.md
+++ b/files/en-us/web/mathml/element/mprescripts/index.md
@@ -13,6 +13,10 @@ The **`<mprescripts>`** [MathML](/en-US/docs/Web/MathML) element is used within 
 
 This element supports [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mprescripts>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Example
 
 The first `<mmultiscripts>` child element becomes a base expression. The remaining children by default become post-scripts elements (a, b). `<mprescripts>` acts as a separator, and children after it become pre-scripts elements (c, d).

--- a/files/en-us/web/mathml/element/mroot/index.md
+++ b/files/en-us/web/mathml/element/mroot/index.md
@@ -13,6 +13,10 @@ The **`<mroot>`** [MathML](/en-US/docs/Web/MathML) element is used to display ro
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mroot>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mroot/index.md
+++ b/files/en-us/web/mathml/element/mroot/index.md
@@ -13,10 +13,6 @@ The **`<mroot>`** [MathML](/en-US/docs/Web/MathML) element is used to display ro
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mroot>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -29,6 +25,19 @@ The `<mroot>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mrow/index.md
+++ b/files/en-us/web/mathml/element/mrow/index.md
@@ -18,10 +18,6 @@ When writing a MathML expression, you should group elements within an `<mrow>` i
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mrow>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -53,6 +49,19 @@ The `<mrow>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/A
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mrow/index.md
+++ b/files/en-us/web/mathml/element/mrow/index.md
@@ -18,6 +18,10 @@ When writing a MathML expression, you should group elements within an `<mrow>` i
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mrow>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -22,6 +22,10 @@ Some browsers may also support the following deprecated attributes and will rend
 - `rquote`
   - : The closing quote to enclose the content. The default value is `&quot;`.
 
+## Accessibility
+
+The `<ms>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Default rendering

--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -22,10 +22,6 @@ Some browsers may also support the following deprecated attributes and will rend
 - `rquote`
   - : The closing quote to enclose the content. The default value is `&quot;`.
 
-## Accessibility
-
-The `<ms>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Default rendering
@@ -47,6 +43,19 @@ The `<ms>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARI
 ```
 
 {{ EmbedLiveSample('legacy_quote_attributes', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -23,6 +23,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `depth`, `height`, `width` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<mspace>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -23,10 +23,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `depth`, `height`, `width` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<mspace>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -42,6 +38,19 @@ The `<mspace>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/msqrt/index.md
+++ b/files/en-us/web/mathml/element/msqrt/index.md
@@ -13,10 +13,6 @@ The **`<msqrt>`** [MathML](/en-US/docs/Web/MathML) element is used to display sq
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<msqrt>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -28,6 +24,19 @@ The `<msqrt>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/msqrt/index.md
+++ b/files/en-us/web/mathml/element/msqrt/index.md
@@ -13,6 +13,10 @@ The **`<msqrt>`** [MathML](/en-US/docs/Web/MathML) element is used to display sq
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<msqrt>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -27,6 +27,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `fontweight` {{deprecated_inline}} {{Non-standard_Inline}}
   - : Use {{cssxref("font-weight")}} instead.
 
+## Accessibility
+
+The `<mstyle>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Attributes mapped to CSS

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -27,10 +27,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `fontweight` {{deprecated_inline}} {{Non-standard_Inline}}
   - : Use {{cssxref("font-weight")}} instead.
 
-## Accessibility
-
-The `<mstyle>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Attributes mapped to CSS
@@ -90,6 +86,19 @@ The following example shows a formula with [`font-size`](/en-US/docs/Web/CSS/fon
 ```
 
 {{EmbedLiveSample('Legacy script attributes', 700, 400)}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -21,6 +21,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `subscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<msub>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -21,10 +21,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `subscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<msub>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -37,6 +33,19 @@ The `<msub>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/A
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -23,10 +23,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<msubsup>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -40,6 +36,19 @@ The `<msubsup>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibilit
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -23,6 +23,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<msubsup>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -21,10 +21,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `superscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<msup>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -37,6 +33,19 @@ The `<msup>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/A
 ```
 
 {{EmbedLiveSample('Examples')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -21,6 +21,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `superscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<msup>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -48,10 +48,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `width` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
-## Accessibility
-
-The `<mtable>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Alignment with row number
@@ -78,6 +74,19 @@ The `<mtable>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility
 ```
 
 {{EmbedLiveSample('Alignment with row number')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -48,6 +48,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 > [!NOTE]
 > For the `width` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 
+## Accessibility
+
+The `<mtable>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Alignment with row number

--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -27,10 +27,6 @@ Some browsers may also support the following attributes:
   - : Specifies the vertical alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
 
-## Accessibility
-
-The `<mtd>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ### Matrix using mtable, mrow, mtr and mtd
@@ -67,6 +63,19 @@ The `<mtd>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/AR
 ```
 
 {{EmbedLiveSample('Alignment with row number')}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -27,6 +27,10 @@ Some browsers may also support the following attributes:
   - : Specifies the vertical alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
 
+## Accessibility
+
+The `<mtd>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ### Matrix using mtable, mrow, mtr and mtd

--- a/files/en-us/web/mathml/element/mtext/index.md
+++ b/files/en-us/web/mathml/element/mtext/index.md
@@ -15,10 +15,6 @@ To display text _with_ notational meaning, use {{ MathMLElement("mi") }}, {{ Mat
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<mtext>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -32,6 +28,19 @@ The `<mtext>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/
 ```
 
 {{ EmbedLiveSample('mtext_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/mtext/index.md
+++ b/files/en-us/web/mathml/element/mtext/index.md
@@ -15,6 +15,10 @@ To display text _with_ notational meaning, use {{ MathMLElement("mi") }}, {{ Mat
 
 This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<mtext>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mtr/index.md
+++ b/files/en-us/web/mathml/element/mtr/index.md
@@ -9,6 +9,10 @@ browser-compat: mathml.elements.mtr
 
 The **`<mtr>`** [MathML](/en-US/docs/Web/MathML) element represents a row in a table or a matrix. It may only appear in a {{ MathMLElement("mtable") }} element and its children are {{ MathMLElement("mtd") }} elements representing cells. This element is similar to the {{ HTMLElement("tr") }} element of [HTML](/en-US/docs/Web/HTML).
 
+## Accessibility
+
+The `<mtr>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Attributes
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes). Some browsers may also support the following attributes:

--- a/files/en-us/web/mathml/element/mtr/index.md
+++ b/files/en-us/web/mathml/element/mtr/index.md
@@ -9,10 +9,6 @@ browser-compat: mathml.elements.mtr
 
 The **`<mtr>`** [MathML](/en-US/docs/Web/MathML) element represents a row in a table or a matrix. It may only appear in a {{ MathMLElement("mtable") }} element and its children are {{ MathMLElement("mtd") }} elements representing cells. This element is similar to the {{ HTMLElement("tr") }} element of [HTML](/en-US/docs/Web/HTML).
 
-## Accessibility
-
-The `<mtr>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Attributes
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes). Some browsers may also support the following attributes:
@@ -21,6 +17,19 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
   - : Overrides the horizontal alignment of cells specified by {{ MathMLElement("mtable") }} for this row. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnalign="left center right"`). Possible values are: `left`, `center` and `right`.
 - `rowalign` {{Non-standard_Inline}}
   - : Overrides the vertical alignment of cells specified by {{ MathMLElement("mtable") }} for this row. Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -16,6 +16,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accentunder`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the under script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
+## Accessibility
+
+The `<munder>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -16,10 +16,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accentunder`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the under script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
-## Accessibility
-
-The `<munder>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -38,6 +34,19 @@ The `<munder>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility
 ```
 
 {{ EmbedLiveSample('munder_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -20,6 +20,10 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accentunder`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the under script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
+## Accessibility
+
+The `<munderover>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -20,10 +20,6 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `accentunder`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the under script should be treated as an accent (i.e. drawn bigger and closer to the base expression).
 
-## Accessibility
-
-The `<munderover>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Examples
 
 ```html
@@ -44,6 +40,19 @@ The `<munderover>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibi
 ```
 
 {{ EmbedLiveSample('munderover_example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -39,10 +39,6 @@ semantics > :not(:first-child) {
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-## Accessibility
-
-The `<semantics>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
-
 ## Example
 
 ```css hidden
@@ -97,6 +93,19 @@ body {
 ```
 
 {{ EmbedLiveSample('example', 700, 200, "", "") }}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      None
+    </td>
+  </tr>
+</table>
 
 ## Specifications
 

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -39,6 +39,10 @@ semantics > :not(:first-child) {
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
+## Accessibility
+
+The `<semantics>` element has no implicit [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles).
+
 ## Example
 
 ```css hidden


### PR DESCRIPTION
### Description

Adds ARIA roles info to MathML elements:

- Only the `<math>` element has one
- The rest get the “no implicit role” section

### Motivation

To start documenting MathML accessibility on MDN.

### Additional details

I used the following sources of information:

- https://w3c.github.io/mathml-aam/
- https://w3c.github.io/mathml-docs/gap-analysis/
- https://mathml-refresh.github.io/discussion-papers/accessibility.html