### PR TITLE
WebExt: fix missing anchor

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -24,7 +24,7 @@ chrome.extension.sendRequest(
 )
 ```
 
-This API is also available as `browser.extension.sendRequest()` in a [version that returns a promise](/en-US/docs/Mozilla/Add-ons/WebExtensions/API#callbacks_and_promises).
+This API is also available as `browser.extension.sendRequest()` in a version that returns a promise.
 
 ### Parameters
 


### PR DESCRIPTION
## Description

removal of the anchored link

## References

- File `files/en-us/mozilla/add-ons/webextensions/api/index.md` no longer have the anchor `#callbacks_and_promises`, leaving async function references at L25 only.
- File `files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md` is the only one to have referenced this anchor, so not sure what should we do to resolve it.