### PR TITLE
relnote(Fx132): HTTP/2 Server Push deactivated by default

### DIFF
--- a/files/en-us/mozilla/firefox/releases/132/index.md
+++ b/files/en-us/mozilla/firefox/releases/132/index.md
@@ -32,6 +32,9 @@ This article provides information about the changes in Firefox 132 that affect d
 
 #### Removals
 
+- HTTP/2 Server Push is deactivated by default with the preference `network.http.http2.allow-push` now set to `false`.
+  This feature is no longer supported by any other major browser and the implementation may be completely removed in a future release ([Firefox bug 1915848](https://bugzil.la/1915848)).
+
 ### Security
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/132/index.md
+++ b/files/en-us/mozilla/firefox/releases/132/index.md
@@ -33,7 +33,7 @@ This article provides information about the changes in Firefox 132 that affect d
 #### Removals
 
 - HTTP/2 Server Push is deactivated by default with the preference `network.http.http2.allow-push` now set to `false`.
-  This feature is no longer supported by any other major browser and the implementation may be completely removed in a future release ([Firefox bug 1915848](https://bugzil.la/1915848)).
+  This feature is no longer supported by any other major browser, and the implementation may be completely removed in a future release. ([Firefox bug 1915848](https://bugzil.la/1915848)).
 
 ### Security
 


### PR DESCRIPTION
HTTP/2 Server Push is being unshipped everywhere. This is landing in the 132 Fx release.

https://groups.google.com/a/mozilla.org/g/dev-platform/c/vU9hJg343U8/m/4cZsHz7TAQAJ

Context:

>Two years ago Chrome disabled HTTP/2 push citing low use, and recommending the rel="preload" and 103 Early hints as a replacement.
Firefox has continued supporting HTTP/2 push as this wasn't too large of an effort until recently. However in the past few months we've encountered some webcompat bugs only affecting Firefox through HTTP/2 push: [bug 1915830](https://bugzilla.mozilla.org/show_bug.cgi?id=1915830). This means that if webservers and websites use push and don't test in Firefox, this feature can potentially cause websites to stop working only in Firefox (eg [bug 1913100](https://bugzilla.mozilla.org/show_bug.cgi?id=1913100))
> Though we will pref it off now, the implementation will remain in the tree for a while longer. Most likely we will remove it completely before we branch for ESR 140 in the spring of next year.

__Related issues and pull requests:__

- [x] Parent issue https://github.com/mdn/content/issues/36116