### PR TITLE
Update `VideoDecoderConfig` docs to correctly reflect optional fields

### DIFF
--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -32,7 +32,7 @@ configure(config)
       - : An integer representing the horizontal dimension of the {{domxref("VideoFrame")}} in pixels when displayed.
     - `displayAspectHeight` {{optional_inline}}
       - : An integer representing the vertical dimension of the {{domxref("VideoFrame")}} in pixels when displayed.
-    - `colorSpace`
+    - `colorSpace` {{optional_inline}}
       - : An object representing a {{domxref("VideoColorSpace")}}, containing the following members:
         - `primaries`
           - : A string representing the color {{glossary("gamut")}} of the video sample. One of:
@@ -50,12 +50,12 @@ configure(config)
             - `"bt709"`
             - `"bt470bg"`
             - `"smpte170m"`
-    - `hardwareAcceleration`
+    - `hardwareAcceleration` {{optional_inline}}
       - : A hint as to the hardware acceleration method to use. One of:
         - `"no-preference"`
         - `"prefer-hardware"`
         - `"prefer-software"`
-    - `optimizeForLatency`
+    - `optimizeForLatency` {{optional_inline}}
       - : A boolean. If `true` this is a hint that the selected decoder should be optimized to minimize the number of {{domxref("EncodedVideoChunk")}} objects that have to be decoded before a {{domxref("VideoFrame")}} is output.
 
 > [!NOTE]


### PR DESCRIPTION
Per the [WebCodecs W3C Spec](https://w3c.github.io/webcodecs/#video-decoder-config), the `VideoDecoderConfig` dictionary only requires the `codec` field. 

This commit updates the documentation to reflect this, as fields like `optimizeForLatency` or `hardwareAcceleration` are currently incorrectly marked as required. [See current documentation.](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/configure)
