### PR TITLE
fix desc for `Keyboard.lock()`

### DIFF
--- a/files/en-us/web/api/keyboard/index.md
+++ b/files/en-us/web/api/keyboard/index.md
@@ -26,7 +26,7 @@ _Also inherits methods from its parent interface, {{DOMxRef("EventTarget")}}._
 - {{domxref('Keyboard.getLayoutMap()')}} {{experimental_inline}}
   - : Returns a {{jsxref('Promise')}} that resolves with an instance of {{domxref('KeyboardLayoutMap')}} which is a map-like object with functions for retrieving the strings associated with specific physical keys.
 - {{domxref('Keyboard.lock()')}} {{experimental_inline}}
-  - : Returns a {{jsxref('Promise')}} after enabling the capture of keypresses for any or all of the keys on the physical keyboard.
+  - : Returns a {{jsxref('Promise')}} that resolves after enabling the capture of keypresses for any or all of the keys on the physical keyboard.
 - {{domxref('Keyboard.unlock()')}} {{experimental_inline}}
   - : Unlocks all keys captured by the `lock()` method and returns synchronously.
 

--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Keyboard.lock
 {{APIRef("Keyboard API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **`lock()`** method of the
-{{domxref("Keyboard")}} interface returns a {{jsxref('Promise')}} after enabling the
+{{domxref("Keyboard")}} interface returns a {{jsxref('Promise')}} that resolves after enabling the
 capture of keypresses for any or all of the keys on the physical keyboard. This method
 can only capture keys that are granted access by the underlying operating
 system.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the return of `Keyboard.lock()` should return immediately and resolve when lock operation sucessfully, the *return value* section is correct

see https://github.com/mdn/translated-content/pull/23856#discussion_r1782077399

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
