### PR TITLE
API Reference method page template - add description

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -132,7 +132,7 @@ Here is an example where a method can raise a `DOMException` with a name of `Ind
 ## Description
 
 _Detailed description of how the method behaves_
-_Section omitted if an introductory paraphgraph (or two) at the top of the page are sufficient._
+_Section omitted if an introductory paragraph (or two) at the top of the page is sufficient._
 
 ## Examples
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -129,6 +129,11 @@ Here is an example where a method can raise a `DOMException` with a name of `Ind
 - {{jsxref("TypeError")}}
   - : Thrown …
 
+## Description
+
+_Detailed description of how the method behaves_
+_Section omitted if an introductory paraphgraph (or two) at the top of the page are sufficient._
+
 ## Examples
 
 Note that we use the plural "Examples" even if the page only contains one example.


### PR DESCRIPTION
This adds a "Description" heading to the API ref page template for methods. 

FWIW I think we should not be too concerned about this - if you can create an adequate description in 3 or 4 paragraphs up the top of the page then that is better for users than having to navigate down to another section for detail. On the other hand, if it is a much bigger section, it makes sense to push it below the fold so people can jump to the detail earlier.
However if this exists it should be in this position.