### PR TITLE
More examples of timeslice being inexact, 1st mention of oversized ch…

### DIFF
--- a/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
@@ -34,7 +34,9 @@ object that contains the data. This occurs in four situations:
   produce multiple same-length blobs plus other shorter blobs as well.
 
 > [!NOTE]
-> Like other time values in web APIs, `timeslice` is not exact and the real intervals may be slightly delayed due to other pending tasks. Therefore, don't rely on `timeslice` and the number of chunks received to calculate the time elapsed, because errors may accumulate. Instead, keep a separate timer using {{domxref("Event.timeStamp")}} or similar, that records the total time elapsed since starting. The intervals may also be heavily delayed by browser features (pausing the camera and microphone in Safari), browser specific behaviours (locking the screen while recording on Chrome on Android pauses the `dataavailable` event) or browser bugs. Such scenarios can also lead to significantly larger chunks.
+> Like other time values in web APIs, `timeslice` is not exact and the real intervals may be delayed due to other pending tasks, browser features (pausing the camera and microphone in Safari), browser-specific behaviors (locking the screen while recording on Chrome on Android pauses the `dataavailable` event), or other browser bugs. Such scenarios can also lead to significantly larger chunks.
+>
+> Therefore, don't rely on `timeslice` and the number of chunks received to calculate the time elapsed, because errors may accumulate. Instead, keep a separate timer using {{domxref("Event.timeStamp")}} or similar, that records the total time elapsed since starting.
 
 The {{domxref("Blob")}} containing the media data is available in the `dataavailable` event's `data` property.
 

--- a/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
@@ -92,4 +92,4 @@ mediaRecorder.ondataavailable = (e) => {
   getUserMedia + Web Audio API visualization demo, by [Chris Mills](https://github.com/chrisdavidmills) ([source on GitHub](https://github.com/mdn/dom-examples/tree/main/media/web-dictaphone).)
 - [simpl.info MediaStream Recording demo](https://simpl.info/mediarecorder/), by [Sam Dutton](https://github.com/samdutton).
 - {{domxref("Navigator.getUserMedia()")}}
-- [Dealing With Huge MediaRecorder Chunks](https://blog.addpipe.com/dealing-with-huge-mediarecorder-slices/)
+- [Dealing with huge MediaRecorder chunks](https://blog.addpipe.com/dealing-with-huge-mediarecorder-slices/) on addpipe.com (2024)

--- a/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
@@ -24,7 +24,7 @@ object that contains the data. This occurs in four situations:
 - If a `timeslice` property was passed into the
   {{domxref("MediaRecorder.start()")}} method that started media capture, a
   `dataavailable` event is fired every `timeslice` milliseconds.
-  That means that each blob will have a specific time duration (except the last blob,
+  That means that normally, each blob will have a specific time duration (except the last blob,
   which might be shorter, since it would be whatever is left over since the last event).
   So if the method call looked like this — `recorder.start(1000);` — the
   `dataavailable` event would fire after each second of media capture, and
@@ -34,7 +34,7 @@ object that contains the data. This occurs in four situations:
   produce multiple same-length blobs plus other shorter blobs as well.
 
 > [!NOTE]
-> Like other time values in web APIs, `timeslice` is not exact and the real intervals may be slightly delayed due to other pending tasks. Therefore, don't rely on `timeslice` and the number of chunks received to calculate the time elapsed, because errors may accumulate. Instead, keep a separate timer using {{domxref("Event.timeStamp")}} or similar, that records the total time elapsed since starting.
+> Like other time values in web APIs, `timeslice` is not exact and the real intervals may be slightly delayed due to other pending tasks. Therefore, don't rely on `timeslice` and the number of chunks received to calculate the time elapsed, because errors may accumulate. Instead, keep a separate timer using {{domxref("Event.timeStamp")}} or similar, that records the total time elapsed since starting. The intervals may also be heavily delayed by browser features (pausing the camera and microphone in Safari), browser specific behaviours (locking the screen while recording on Chrome on Android pauses the `dataavailable` event) or browser bugs. Such scenarios can also lead to significantly larger chunks.
 
 The {{domxref("Blob")}} containing the media data is available in the `dataavailable` event's `data` property.
 
@@ -90,3 +90,4 @@ mediaRecorder.ondataavailable = (e) => {
   getUserMedia + Web Audio API visualization demo, by [Chris Mills](https://github.com/chrisdavidmills) ([source on GitHub](https://github.com/mdn/dom-examples/tree/main/media/web-dictaphone).)
 - [simpl.info MediaStream Recording demo](https://simpl.info/mediarecorder/), by [Sam Dutton](https://github.com/samdutton).
 - {{domxref("Navigator.getUserMedia()")}}
+- [Dealing With Huge MediaRecorder Chunks](https://blog.addpipe.com/dealing-with-huge-mediarecorder-slices/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I've added more examples why one can't rely on the `timeslice` to be exact, and, introduced the notion of oversized chunks (chunk size can't be relied upon either). 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The information helps the read better understand what he can expect from the MediaStream Recording API in terms of chunk/slice length and size.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

* My research on the topic: https://blog.addpipe.com/dealing-with-huge-mediarecorder-slices/
* Safari bug report for audio data being collected while the camera & microphone are paused through the Safari UI. This leads to bigger chunks on resume. https://bugs.webkit.org/show_bug.cgi?id=279432
* Chromium bug report regarding `ondataavailable` not resuming after exiting sleep. This leads to a big chunk on stop. https://issues.chromium.org/issues/367915809

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
Fix https://github.com/mdn/content/issues/19369