### PR TITLE
`Notification.silent`: Add Firefox 132 rel note, and improve documentation

### DIFF
--- a/files/en-us/mozilla/firefox/releases/132/index.md
+++ b/files/en-us/mozilla/firefox/releases/132/index.md
@@ -38,6 +38,8 @@ This article provides information about the changes in Firefox 132 that affect d
 
 ### APIs
 
+- The {{domxref("Notification.silent")}} property is now supported, which controls whether system notifications should be silent. When `silent: true` is specified in the {{domxref("Notification.Notification", "Notification()")}} constructor, the resulting system notification is issued without accompanying sounds or vibrations, regardless of device settings ([Firefox bug 1809028](https://bugzil.la/1809028)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/web/api/notification/index.md
+++ b/files/en-us/web/api/notification/index.md
@@ -58,7 +58,7 @@ _Also inherits properties from its parent interface, {{domxref("EventTarget")}}_
 - {{domxref("Notification.requireInteraction")}} {{ReadOnlyInline}}
   - : A boolean value indicating that a notification should remain active until the user clicks or dismisses it, rather than closing automatically.
 - {{domxref("Notification.silent")}} {{ReadOnlyInline}}
-  - : Specifies whether the notification should be silent — i.e. no sounds or vibrations should be issued, regardless of the device settings.
+  - : Specifies whether the notification should be silent — i.e., no sounds or vibrations should be issued regardless of the device settings.
 - {{domxref("Notification.tag")}} {{ReadOnlyInline}}
   - : The ID of the notification (if any) as specified in the constructor's `options` parameter.
 - {{domxref("Notification.timestamp")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/notification/index.md
+++ b/files/en-us/web/api/notification/index.md
@@ -58,7 +58,7 @@ _Also inherits properties from its parent interface, {{domxref("EventTarget")}}_
 - {{domxref("Notification.requireInteraction")}} {{ReadOnlyInline}}
   - : A boolean value indicating that a notification should remain active until the user clicks or dismisses it, rather than closing automatically.
 - {{domxref("Notification.silent")}} {{ReadOnlyInline}}
-  - : Specifies whether the notification should be silent — i.e., no sounds or vibrations should be issued, regardless of the device settings.
+  - : Specifies whether the notification should be silent — i.e. no sounds or vibrations should be issued, regardless of the device settings.
 - {{domxref("Notification.tag")}} {{ReadOnlyInline}}
   - : The ID of the notification (if any) as specified in the constructor's `options` parameter.
 - {{domxref("Notification.timestamp")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -50,7 +50,7 @@ new Notification(title, options)
     - `requireInteraction` {{optional_inline}}
       - : Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. The default value is `false`.
     - `silent` {{optional_inline}}
-      - : A boolean value specifying whether the notification should be silent, i.e. no sounds or vibrations should be issued, regardless of the device settings. If set to `true`, the notification is silent; if set to `null` (the default value), the device's default settings are respected.
+      - : A boolean value specifying whether the notification should be silent, i.e., no sounds or vibrations should be issued regardless of the device settings. If set to `true`, the notification is silent; if set to `null` (the default value), the device's default settings are respected.
     - `tag` {{optional_inline}}
       - : A string representing an identifying tag for the notification. The default is the empty string.
     - `timestamp` {{optional_inline}}

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -50,7 +50,7 @@ new Notification(title, options)
     - `requireInteraction` {{optional_inline}}
       - : Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically. The default value is `false`.
     - `silent` {{optional_inline}}
-      - : A boolean value specifying whether the notification is silent (no sounds or vibrations issued), regardless of the device settings. The default, `null`, means to respect device defaults. If `true`, then `vibrate` must not be present.
+      - : A boolean value specifying whether the notification should be silent, i.e. no sounds or vibrations should be issued, regardless of the device settings. If set to `true`, the notification is silent; if set to `null` (the default value), the device's default settings are respected.
     - `tag` {{optional_inline}}
       - : A string representing an identifying tag for the notification. The default is the empty string.
     - `timestamp` {{optional_inline}}

--- a/files/en-us/web/api/notification/silent/index.md
+++ b/files/en-us/web/api/notification/silent/index.md
@@ -10,29 +10,46 @@ browser-compat: api.Notification.silent
 
 The **`silent`** read-only property of the
 {{domxref("Notification")}} interface specifies whether the notification should be
-silent, i.e., no sounds or vibrations should be issued, regardless of the device
-settings. This is specified in the `silent` option of the
+silent, i.e. no sounds or vibrations should be issued, regardless of the device
+settings. This is controlled via the `silent` option of the
 {{domxref("Notification.Notification","Notification()")}} constructor.
 
 ## Value
 
-A boolean value or `null`. If `true`, the notification is silent; if `null`, the device's default settings are respected.
+A boolean value or `null`. If set to `true`, the notification is silent; if set to `null` (the default value), the device's default settings are respected.
 
 ## Examples
 
-The following snippet is intended to fire a silent notification; a simple
-`options` object is created, and then the notification is fired using the
-{{DOMxRef("Notification.Notification","Notification()")}} constructor.
+The following snippet fires a silent notification. An
+`options` object is created, and the notification is fired in response to a button click using the
+{{DOMxRef("Notification.Notification","Notification()")}} constructor. The code also includes rudimentary permissions handling, requesting permission from the user to fire notifications if it has not already been granted.
 
 ```js
+const btn = document.querySelector("button");
+
 const options = {
-  body: "Your code submission has received 3 new review comments.",
+  body: "No annoying pings or vibrations?",
   silent: true,
 };
 
-const n = new Notification("New review activity", options);
+function requestSilentNotification() {
+  const n = new Notification("Silent notification", options);
+  console.log(n.silent); // should return true
+}
 
-console.log(n.silent); // true
+btn.addEventListener("click", () => {
+  if (Notification.permission === "granted") {
+    requestSilentNotification();
+  } else {
+    Notification.requestPermission().then((permission) => {
+      if (permission === "granted") {
+        requestSilentNotification();
+      } else {
+        console.log("Notification permission was not granted");
+      }
+    });
+  }
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/notification/silent/index.md
+++ b/files/en-us/web/api/notification/silent/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Notification.silent
 
 The **`silent`** read-only property of the
 {{domxref("Notification")}} interface specifies whether the notification should be
-silent, i.e. no sounds or vibrations should be issued, regardless of the device
+silent, i.e., no sounds or vibrations should be issued regardless of the device
 settings. This is controlled via the `silent` option of the
 {{domxref("Notification.Notification","Notification()")}} constructor.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Firefox 132 supports the [`Notification.silent`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/silent) property.

This PR:

- Adds an entry for it to the Fx132 rel notes.
- Cleans up some of the descriptive text.
- Adds a slightly better example (the existing snippet was a bit useless as it didn't handle the permissions request necessary to be able to fire a system notification).

See the shipping bug at https://bugzilla.mozilla.org/show_bug.cgi?id=1809028 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Docs issue: https://github.com/mdn/content/issues/36119

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
