### PR TITLE
Declare the special handling of promise arguments only for the resolve function

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
@@ -26,7 +26,7 @@ new Promise(executor)
 
 ### Return value
 
-When called via `new`, the `Promise` constructor returns a promise object. The promise object will become _resolved_ when either of the functions `resolveFunc` or `rejectFunc` are invoked. Note that if you call `resolveFunc` or `rejectFunc` and pass another `Promise` object as an argument, it can be said to be "resolved", but still not "settled". See the [Promise description](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#description) for more explanation.
+When called via `new`, the `Promise` constructor returns a promise object. The promise object will become _resolved_ when either of the functions `resolveFunc` or `rejectFunc` are invoked. Note that if you call `resolveFunc` and pass another promise object as an argument, the initial promise can be said to be "resolved", but still not "settled". See the [Promise description](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#description) for more explanation.
 
 ## Description
 


### PR DESCRIPTION
### Description

Only the `resolve` function of the `Promise` constructor can set the initial promise in the fulfilled, rejected, or pending state for promise arguments. The `reject` function always sets the initial promise in the rejected state for promise arguments (and any other arguments).

### Motivation

Behaviour of the `resolve` function:

```javascript
> new Promise(resolve => resolve())
Promise {<fulfilled>: undefined}
> new Promise(resolve => resolve(Promise.resolve()))
Promise {<fulfilled>: undefined}
> new Promise(resolve => resolve(Promise.reject()))
Promise {<rejected>: undefined}
> new Promise(resolve => resolve(new Promise(resolve => setTimeout(resolve))))
Promise {<pending>}
```

Behaviour of the `reject` function:

```javascript
> new Promise((_, reject) => reject())
Promise {<rejected>: undefined}
> new Promise((_, reject) => reject(Promise.resolve()))
Promise {<rejected>: Promise}
> new Promise((_, reject) => reject(Promise.reject()))
Promise {<rejected>: Promise}
> new Promise((_, reject) => reject(new Promise(resolve => setTimeout(resolve))))
Promise {<rejected>: Promise}
```