### PR TITLE
Remove reference to `mode: "websocket"` in `RequestInit`

### DIFF
--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -155,8 +155,6 @@ You can also construct a `Request` with a `RequestInit`, and pass the `Request` 
       - : The request must be a [simple request](/en-US/docs/Web/HTTP/CORS#simple_requests), which restricts the headers that may be set to {{glossary("CORS-safelisted request header", "CORS-safelisted request headers")}}, and restricts methods to `GET`, `HEAD`, and `POST`.
     - `navigate`
       - : Used only by HTML navigation. A `navigate` request is created only while navigating between documents.
-    - `websocket`
-      - : Used only when establishing a [WebSocket](/en-US/docs/Web/API/WebSockets_API) connection.
 
     See [Making cross-origin requests](/en-US/docs/Web/API/Fetch_API/Using_Fetch#making_cross-origin_requests) for more details.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Title's self-explanatory

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
In https://fetch.spec.whatwg.org/#request-class, there's an explicit note that this value is excluded from the `RequestMode` enum as it's not intended to be observable from JS.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
I was working on my spec suggestion in https://github.com/whatwg/websockets/issues/16#issuecomment-2394868344, was going through you to a relevant section of the `fetch` spec, and was surprised the mode existed. I then cross-referenced the spec with you all, and found that your listing of that mode was erroneous.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
