### PR TITLE
Update index.md - Added note due to accessibility issues with high contrast mode.

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
@@ -120,6 +120,9 @@ In this next example, we have added an empty string using the `::before` pseudo-
 
 The use of the `::before` and `::after` pseudo-elements along with the `content` property is referred to as "Generated Content" in CSS, and you will often see this technique being used for various tasks. A great example is the site [CSS Arrow Please](https://cssarrowplease.com/), which helps you to generate an arrow with CSS. Look at the CSS as you create your arrow and you will see the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements in use. Whenever you see these selectors, look at the {{cssxref("content")}} property to see what is being added to the HTML element.
 
+> [!NOTE]
+> Generating visual content like in the above mentioned example may not display the expected results, when high contrast mode is applied.
+
 ## Summary
 
 In this article we've introduced CSS pseudo-classes and pseudo-elements, which are special types of selectors.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
> [!NOTE]
> Generating visual content like in the above mentioned example may not display the expected results, when high contrast mode is applied.>

### Motivation
Support for high contrast mode is an important feature for accessibility.

Affected page: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements
Relevant section: "[Generating content with ::before and ::after](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements#generating_content_with_before_and_after)"
Relevant Paragraph: "A great example is the site [CSS Arrow Please](https://cssarrowplease.com/), which helps you to generate an arrow with CSS. Look at the CSS as you create your arrow and you will see the [::before](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [::after](https://developer.mozilla.org/en-US/docs/Web/CSS/::after) pseudo-elements in use. Whenever you see these selectors, look at the [content](https://developer.mozilla.org/en-US/docs/Web/CSS/content) property to see what is being added to the HTML element."