### PR TITLE
Improvement to customElements.whenDefined() javascript example

### DIFF
--- a/files/en-us/web/api/customelementregistry/whendefined/index.md
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.md
@@ -54,6 +54,7 @@ const placeholder = container.querySelector(".menu-placeholder");
 const undefinedElements = container.querySelectorAll(":not(:defined)");
 
 async function removePlaceholder() {
+  // Filter the elements down to unique localNames
   const tags = new Set(
     [...undefinedElements].map((button) => button.localName),
   );

--- a/files/en-us/web/api/customelementregistry/whendefined/index.md
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.md
@@ -54,9 +54,10 @@ const placeholder = container.querySelector(".menu-placeholder");
 const undefinedElements = container.querySelectorAll(":not(:defined)");
 
 async function removePlaceholder() {
-  const promises = [...undefinedElements].map((button) =>
-    customElements.whenDefined(button.localName),
+  const tags = new Set(
+    [...undefinedElements].map((button) => button.localName),
   );
+  const promises = [...tags].map((tag) => customElements.whenDefined(tag));
 
   // Wait for all the children to be upgraded
   await Promise.all(promises);


### PR DESCRIPTION
The current example doesn't filter the list and creates more Promises than it needs to.  `new Set()` seems like the best way to filter down to unique names.

btw - I noticed that Prettier broke my 80 character line `const tags...`, but not my 76 character line `const promises...`.  Is the limit 79?  I have a soft, personal limit of 80, partly as a tribute to the old Teletype printers.  Is that the reason for the Prettier limit here?  If so, 80 would be a better limit than 79 :-)

EDIT - now I see that it's the trailing comma added by Prettier that pushes it to 81 chars wide. I'm still not used to those trailing commas.  My ESLint doesn't like them either...