### PR TITLE
Change use of "lambda" to "function expression"

### DIFF
--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -48,7 +48,7 @@ The most flexible way to set an event handler on an element is to use the {{domx
 > [!NOTE]
 > The ability to add and remove event handlers allows you to, for example, have the same button performing different actions in different circumstances. In addition, in more complex programs cleaning up old/unused event handlers can improve efficiency.
 
-Below we show how a simple `greet()` function can be set as a listener/event handler for the `click` event (you could use a lambda function instead of a named function if desired). Note again that the event is passed as the first argument to the event handler.
+Below we show how a simple `greet()` function can be set as a listener/event handler for the `click` event (you could use an anonymous function expression instead of a named function if desired). Note again that the event is passed as the first argument to the event handler.
 
 ```js
 const btn = document.querySelector("button");

--- a/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
@@ -37,8 +37,7 @@ argument which does not have the expected type.
 This issue can also happen when providing a function that is stored as a property of an
 object as an argument to another function. In this case, the object that stores the
 function won't be the `this` target of that function when it is called by the
-other function. To work-around this issue, you will either need to provide a lambda
-which is making the call, or use the {{jsxref("Function.prototype.bind()")}} function to
+other function. To work-around this issue, you will either need to wrap the callback function in another function, or use the {{jsxref("Function.prototype.bind()")}} method to
 force the `this` argument to the expected object.
 
 ## Examples
@@ -68,7 +67,7 @@ const myFun = function () {
   console.log(this);
 };
 ["bar", "baz"].forEach((x) => myFun.bind(x));
-// This works using the "bind" function. It creates a lambda forwarding the argument.
+// This works using the "bind" function. It creates a new function forwarding the argument.
 ```
 
 ## See also


### PR DESCRIPTION
Remove use of "lambda"

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Change use of "lambda" to "function expression". I also included "anonymous" though I don't think that part really matters (lambdas tend to be if keeping in that same vein).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The term "lambda" is rarely used on MDN. It is not listed in the [glossary](https://developer.mozilla.org/en-US/docs/Glossary) nor is it mentioned anywhere in the [various](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions) [pages](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions) [covering](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function) [functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions). The term is also never mentioned in the [specification](https://tc39.es/ecma262/).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
