### PR TITLE
See also: remove text, add modules

### DIFF
--- a/files/en-us/web/css/bottom/index.md
+++ b/files/en-us/web/css/bottom/index.md
@@ -132,6 +132,9 @@ div {
 
 ## See also
 
-- {{cssxref("inset")}} shorthand related properties: {{cssxref("top")}}, {{cssxref("left")}}, and {{cssxref("right")}}
-- The mapped logical properties: {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}} and the shorthands {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
+- {{cssxref("top")}}, {{cssxref("left")}}, and {{cssxref("right")}}
+- {{cssxref("inset")}} shorthand
+- {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}}
+- {{cssxref("inset-block")}} and {{cssxref("inset-inline")}} shorthands
 - {{cssxref("position")}}
+- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -147,5 +147,5 @@ div {
 - {{cssxref("anchor-size()")}}
 - {{cssxref("clamp", "clamp()")}}
 - {{cssxref("clamp", "minmax()")}}
-- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -140,11 +140,12 @@ div {
 
 ## See also
 
-- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("width")}}
 - {{cssxref("box-sizing")}}
 - {{cssxref("min-height")}}, {{cssxref("max-height")}}
-- The mapped logical properties: {{cssxref("block-size")}}, {{cssxref("inline-size")}}
+- {{cssxref("block-size")}}, {{cssxref("inline-size")}}
 - {{cssxref("anchor-size()")}}
 - {{cssxref("clamp", "clamp()")}}
 - {{cssxref("clamp", "minmax()")}}
+- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/inset/index.md
+++ b/files/en-us/web/css/inset/index.md
@@ -105,7 +105,7 @@ div {
 
 ## See also
 
-- {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}.
+- {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}
 - {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
 - {{cssxref("position")}}
 - [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module

--- a/files/en-us/web/css/inset/index.md
+++ b/files/en-us/web/css/inset/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.inset
 
 The **`inset`** [CSS](/en-US/docs/Web/CSS) property is a shorthand that corresponds to the {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, and/or {{cssxref("left")}} properties. It has the same multi-value syntax of the {{cssxref("margin")}} shorthand.
 
-This {{glossary("inset properties", "inset property")}} has no effect on non-positioned elements.
+This {{glossary("inset properties")}}, including `inset`, have no effect on non-positioned elements.
 
 {{EmbedInteractiveExample("pages/css/inset.html")}}
 
@@ -105,6 +105,8 @@ div {
 
 ## See also
 
-- The longhand box offset properties: {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}.
-- The mapped logical shorthands: {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
-- The {{cssxref("margin")}} shorthand multi-value syntax.
+- {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}.
+- {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
+- {{cssxref("position")}}
+- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module
+- [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values)

--- a/files/en-us/web/css/left/index.md
+++ b/files/en-us/web/css/left/index.md
@@ -208,6 +208,9 @@ pre {
 
 ## See also
 
-- {{cssxref("inset")}}, the shorthand for all related properties: {{cssxref("top")}}, {{cssxref("bottom")}}, and {{cssxref("right")}}
-- The mapped logical properties: {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}} and the shorthands {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
+- {{cssxref("top")}}, {{cssxref("bottom")}}, and {{cssxref("right")}}
+- {{cssxref("inset")}} shorthand
+- {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}}
+- {{cssxref("inset-block")}} and {{cssxref("inset-inline")}} shorthands
 - {{cssxref("position")}}
+- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module

--- a/files/en-us/web/css/margin-bottom/index.md
+++ b/files/en-us/web/css/margin-bottom/index.md
@@ -115,5 +115,8 @@ div {
 
 ## See also
 
-- {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, and {{cssxref("margin-left")}} and the {{cssxref("margin")}} shorthand
-- The mapped logical properties: {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the shorthands {{cssxref("margin-block")}} and {{cssxref("margin-inline")}}
+- {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, and {{cssxref("margin-left")}}
+- {{cssxref("margin")}} shorthand
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
+- {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -191,4 +191,4 @@ Percentage values for `margin-left` are relative to the container's inline size.
 ## See also
 
 - {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, and {{cssxref("margin-bottom")}} and the {{cssxref("margin")}} shorthand
-- The mapped logical properties: {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the shorthands {{cssxref("margin-block")}} and {{cssxref("margin-inline")}}
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -190,5 +190,7 @@ Percentage values for `margin-left` are relative to the container's inline size.
 
 ## See also
 
-- {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, and {{cssxref("margin-bottom")}} and the {{cssxref("margin")}} shorthand
-- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, and {{cssxref("margin-bottom")}}
+- {{cssxref("margin")}} shorthand
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
+- {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -194,3 +194,4 @@ Percentage values for `margin-left` are relative to the container's inline size.
 - {{cssxref("margin")}} shorthand
 - {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
 - {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/margin-right/index.md
+++ b/files/en-us/web/css/margin-right/index.md
@@ -173,3 +173,4 @@ The `margin-right` property is specified as the keyword `auto`, or a `<length>`,
 - {{cssxref("margin")}} shorthand
 - {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
 - {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/margin-right/index.md
+++ b/files/en-us/web/css/margin-right/index.md
@@ -169,5 +169,7 @@ The `margin-right` property is specified as the keyword `auto`, or a `<length>`,
 
 ## See also
 
-- {{cssxref("margin-top")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}} and the {{cssxref("margin")}} shorthand
-- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- {{cssxref("margin-top")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
+- {{cssxref("margin")}} shorthand
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
+- {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands

--- a/files/en-us/web/css/margin-right/index.md
+++ b/files/en-us/web/css/margin-right/index.md
@@ -170,4 +170,4 @@ The `margin-right` property is specified as the keyword `auto`, or a `<length>`,
 ## See also
 
 - {{cssxref("margin-top")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}} and the {{cssxref("margin")}} shorthand
-- The mapped logical properties: {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the shorthands {{cssxref("margin-block")}} and {{cssxref("margin-inline")}}
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands

--- a/files/en-us/web/css/margin-top/index.md
+++ b/files/en-us/web/css/margin-top/index.md
@@ -82,5 +82,5 @@ The `margin-top` property is specified as the keyword `auto`, or a `<length>`, o
 
 - {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
 - {{cssxref("margin")}} shorthand
-- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, and the {{cssxref("margin-block")}} shorthand
-- {{cssxref("margin-inline-start")}}, {{cssxref("margin-inline-end")}}, and the {{cssxref("margin-inline")}} shorthand
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
+- {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands

--- a/files/en-us/web/css/margin-top/index.md
+++ b/files/en-us/web/css/margin-top/index.md
@@ -80,5 +80,7 @@ The `margin-top` property is specified as the keyword `auto`, or a `<length>`, o
 
 ## See also
 
-- {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}} and the {{cssxref("margin")}} shorthand
-- The mapped logical properties: {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the shorthands {{cssxref("margin-block")}} and {{cssxref("margin-inline")}}
+- {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
+- {{cssxref("margin")}} shorthand
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, and the {{cssxref("margin-block")}} shorthand
+- {{cssxref("margin-inline-start")}}, {{cssxref("margin-inline-end")}}, and the {{cssxref("margin-inline")}} shorthand

--- a/files/en-us/web/css/margin-top/index.md
+++ b/files/en-us/web/css/margin-top/index.md
@@ -84,3 +84,4 @@ The `margin-top` property is specified as the keyword `auto`, or a `<length>`, o
 - {{cssxref("margin")}} shorthand
 - {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
 - {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/margin/index.md
+++ b/files/en-us/web/css/margin/index.md
@@ -150,7 +150,9 @@ margin: auto; /* top and bottom: 0 margin     */
 
 ## See also
 
+- {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
+- {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
+- {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-- {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
-- The mapped logical properties: {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}} and the shorthands {{cssxref("margin-block")}} and {{cssxref("margin-inline")}}
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/margin/index.md
+++ b/files/en-us/web/css/margin/index.md
@@ -153,6 +153,6 @@ margin: auto; /* top and bottom: 0 margin     */
 - {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
 - {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
 - {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
+- [Mastering margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -102,6 +102,7 @@ form {
 
 ## See also
 
-- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), {{cssxref("box-sizing")}}
 - {{Cssxref("height")}}, {{Cssxref("min-height")}}
-- The mapped logical properties: {{cssxref("max-inline-size")}}, {{cssxref("max-block-size")}}
+- {{cssxref("max-inline-size")}}, {{cssxref("max-block-size")}}
+- {{cssxref("box-sizing")}}
+- [The CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -102,7 +102,10 @@ form {
 
 ## See also
 
-- {{Cssxref("height")}}, {{Cssxref("min-height")}}
-- {{cssxref("max-inline-size")}}, {{cssxref("max-block-size")}}
+- {{Cssxref("min-height")}}
+- {{Cssxref("height")}}
+- {{cssxref("max-inline-size")}}
+- {{cssxref("max-block-size")}}
 - {{cssxref("box-sizing")}}
-- [The CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -123,6 +123,7 @@ In this example, the "child" will be either 150 pixels wide or the width of the 
 
 ## See also
 
-- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), {{cssxref("box-sizing")}}
+- {{cssxref("box-sizing")}}
 - {{cssxref("width")}}, {{cssxref("min-width")}}
-- The mapped logical properties: {{cssxref("max-inline-size")}}, {{cssxref("max-block-size")}}
+- {{cssxref("max-inline-size")}}, {{cssxref("max-block-size")}}
+- [The CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -123,7 +123,10 @@ In this example, the "child" will be either 150 pixels wide or the width of the 
 
 ## See also
 
+- {{Cssxref("min-width")}}
+- {{Cssxref("width")}}
+- {{cssxref("max-inline-size")}}
+- {{cssxref("max-block-size")}}
 - {{cssxref("box-sizing")}}
-- {{cssxref("width")}}, {{cssxref("min-width")}}
-- {{cssxref("max-inline-size")}}, {{cssxref("max-block-size")}}
-- [The CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/min-height/index.md
+++ b/files/en-us/web/css/min-height/index.md
@@ -94,5 +94,10 @@ form {
 
 ## See also
 
-- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), {{cssxref("box-sizing")}}
-- {{cssxref("height")}}, {{cssxref("max-height")}}
+- {{Cssxref("max-height")}}
+- {{Cssxref("height")}}
+- {{cssxref("min-inline-size")}}
+- {{cssxref("min-block-size")}}
+- {{cssxref("box-sizing")}}
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/min-width/index.md
+++ b/files/en-us/web/css/min-width/index.md
@@ -98,5 +98,10 @@ form {
 
 ## See also
 
-- {{Cssxref("width")}}, {{Cssxref("max-width")}}
-- The [box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), {{Cssxref("box-sizing")}}
+- {{Cssxref("max-width")}}
+- {{Cssxref("width")}}
+- {{cssxref("min-inline-size")}}
+- {{cssxref("min-block-size")}}
+- {{cssxref("box-sizing")}}
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -132,4 +132,8 @@ p {
 
 ## See also
 
-- [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior/#full-demo)
+- {{cssxref("overscroll-behavior")}}
+- {{cssxref("overscroll-behavior-x")}}
+- {{cssxref("overscroll-behavior-y")}}
+- {{cssxref("overscroll-behavior-inline")}}
+- [CSS overscroll behavior](/en-US/docs/Web/CSS/CSS_overscroll_behavior) module

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -132,4 +132,8 @@ p {
 
 ## See also
 
-- [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior/#demo)
+- {{cssxref("overscroll-behavior")}}
+- {{cssxref("overscroll-behavior-x")}}
+- {{cssxref("overscroll-behavior-y")}}
+- {{cssxref("overscroll-behavior-block")}}
+- [CSS overscroll behavior](/en-US/docs/Web/CSS/CSS_overscroll_behavior) module

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -76,7 +76,7 @@ main > div {
 
 ## See also
 
-- {{cssxref("overscroll-behavior-x")}}
+- {{cssxref("overscroll-behavior")}}
 - {{cssxref("overscroll-behavior-y")}}
 - {{cssxref("overscroll-behavior-inline")}}
 - {{cssxref("overscroll-behavior-block")}}

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -76,5 +76,8 @@ main > div {
 
 ## See also
 
-- [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior/#full-demo)
-- The mapped logical properties: {{cssxref("overscroll-behavior-inline")}}, {{cssxref("overscroll-behavior-block")}}
+- {{cssxref("overscroll-behavior-x")}}
+- {{cssxref("overscroll-behavior-y")}}
+- {{cssxref("overscroll-behavior-inline")}}
+- {{cssxref("overscroll-behavior-block")}}
+- [CSS overscroll behavior](/en-US/docs/Web/CSS/CSS_overscroll_behavior) module

--- a/files/en-us/web/css/overscroll-behavior-y/index.md
+++ b/files/en-us/web/css/overscroll-behavior-y/index.md
@@ -70,5 +70,8 @@ See {{cssxref("overscroll-behavior")}} for a full example and explanation.
 
 ## See also
 
-- [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior/#demo)
-- The mapped logical properties: {{cssxref("overscroll-behavior-inline")}}, {{cssxref("overscroll-behavior-block")}}
+- {{cssxref("overscroll-behavior")}}
+- {{cssxref("overscroll-behavior-x")}}
+- {{cssxref("overscroll-behavior-inline")}}
+- {{cssxref("overscroll-behavior-block")}}
+- [CSS overscroll behavior](/en-US/docs/Web/CSS/CSS_overscroll_behavior) module

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -103,4 +103,5 @@ html {
 
 ## See also
 
+- [CSS overscroll behavior](/en-US/docs/Web/CSS/CSS_overscroll_behavior) module
 - [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior) on developer.chrome.com (2017)

--- a/files/en-us/web/css/padding-bottom/index.md
+++ b/files/en-us/web/css/padding-bottom/index.md
@@ -78,5 +78,7 @@ The `padding-bottom` property is specified as a single value chosen from the lis
 ## See also
 
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-left")}} and the {{cssxref("padding")}} shorthand
-- The mapped logical properties: {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}} and the shorthands {{cssxref("padding-block")}} and {{cssxref("padding-inline")}}
+- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, and {{cssxref("padding-left")}}
+- {{cssxref("padding")}} shorthand
+- {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
+- {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands

--- a/files/en-us/web/css/padding-bottom/index.md
+++ b/files/en-us/web/css/padding-bottom/index.md
@@ -77,8 +77,9 @@ The `padding-bottom` property is specified as a single value chosen from the lis
 
 ## See also
 
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, and {{cssxref("padding-left")}}
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-left/index.md
+++ b/files/en-us/web/css/padding-left/index.md
@@ -76,5 +76,7 @@ The `padding-left` property is specified as a single value chosen from the list 
 ## See also
 
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} and the {{cssxref("padding")}} shorthand
-- The mapped logical properties: {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}} and the shorthands {{cssxref("padding-block")}} and {{cssxref("padding-inline")}}
+- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, and {{cssxref("padding-bottom")}}
+- {{cssxref("padding")}} shorthand
+- {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
+- {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands

--- a/files/en-us/web/css/padding-left/index.md
+++ b/files/en-us/web/css/padding-left/index.md
@@ -75,8 +75,9 @@ The `padding-left` property is specified as a single value chosen from the list 
 
 ## See also
 
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, and {{cssxref("padding-bottom")}}
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-right/index.md
+++ b/files/en-us/web/css/padding-right/index.md
@@ -76,5 +76,7 @@ The `padding-right` property is specified as a single value chosen from the list
 ## See also
 
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- {{cssxref("padding-top")}}, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}} and the {{cssxref("padding")}} shorthand
-- The mapped logical properties: {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}} and the shorthands {{cssxref("padding-block")}} and {{cssxref("padding-inline")}}
+- {{cssxref("padding-top")}}, {{cssxref("padding-bottom")}}, and {{cssxref("padding-left")}}
+- {{cssxref("padding")}} shorthand
+- {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
+- {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands

--- a/files/en-us/web/css/padding-right/index.md
+++ b/files/en-us/web/css/padding-right/index.md
@@ -75,8 +75,9 @@ The `padding-right` property is specified as a single value chosen from the list
 
 ## See also
 
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("padding-top")}}, {{cssxref("padding-bottom")}}, and {{cssxref("padding-left")}}
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-top/index.md
+++ b/files/en-us/web/css/padding-top/index.md
@@ -77,8 +77,9 @@ The `padding-top` property is specified as a single value chosen from the list b
 
 ## See also
 
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-top/index.md
+++ b/files/en-us/web/css/padding-top/index.md
@@ -78,5 +78,7 @@ The `padding-top` property is specified as a single value chosen from the list b
 ## See also
 
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}} and the {{cssxref("padding")}} shorthand
-- The mapped logical properties: {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}} and the shorthands {{cssxref("padding-block")}} and {{cssxref("padding-inline")}}
+- {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}
+- {{cssxref("padding")}} shorthand
+- {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
+- {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands

--- a/files/en-us/web/css/padding/index.md
+++ b/files/en-us/web/css/padding/index.md
@@ -129,7 +129,8 @@ padding: 1em 3px 30px 5px; /* top:    1em padding  */
 
 ## See also
 
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, and {{cssxref("padding-left")}}.
+- {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, and {{cssxref("padding-left")}}
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding/index.md
+++ b/files/en-us/web/css/padding/index.md
@@ -131,4 +131,5 @@ padding: 1em 3px 30px 5px; /* top:    1em padding  */
 
 - [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, and {{cssxref("padding-left")}}.
-- The mapped logical properties: {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}} and the shorthands {{cssxref("padding-block")}} and {{cssxref("padding-inline")}}
+- {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
+- {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands

--- a/files/en-us/web/css/right/index.md
+++ b/files/en-us/web/css/right/index.md
@@ -167,6 +167,8 @@ div {
 
 ## See also
 
-- {{cssxref("inset")}}, the shorthand for all related properties: {{cssxref("top")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}
-- The mapped logical properties: {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}} and the shorthands {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
+- {{cssxref("top")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}
+- {{cssxref("inset")}} shorthand
+- {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}}
+- {{cssxref("inset-block")}} and {{cssxref("inset-inline")}} shorthands
 - {{cssxref("position")}}

--- a/files/en-us/web/css/right/index.md
+++ b/files/en-us/web/css/right/index.md
@@ -172,3 +172,4 @@ div {
 - {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}}
 - {{cssxref("inset-block")}} and {{cssxref("inset-inline")}} shorthands
 - {{cssxref("position")}}
+- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module

--- a/files/en-us/web/css/top/index.md
+++ b/files/en-us/web/css/top/index.md
@@ -113,6 +113,8 @@ div {
 
 ## See also
 
-- {{cssxref("inset")}}, the shorthand for all related properties: {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("right")}}
-- The mapped logical properties: {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}} and the shorthands {{cssxref("inset-block")}} and {{cssxref("inset-inline")}}
+- {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("right")}}
+- {{cssxref("inset")}} shorthand
+- {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}}
+- {{cssxref("inset-block")}} and {{cssxref("inset-inline")}} shorthands
 - {{cssxref("position")}}

--- a/files/en-us/web/css/top/index.md
+++ b/files/en-us/web/css/top/index.md
@@ -118,3 +118,4 @@ div {
 - {{cssxref("inset-block-start")}}, {{cssxref("inset-block-end")}}, {{cssxref("inset-inline-start")}}, and {{cssxref("inset-inline-end")}}
 - {{cssxref("inset-block")}} and {{cssxref("inset-inline")}} shorthands
 - {{cssxref("position")}}
+- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -186,5 +186,5 @@ p.minblue {
 - {{cssxref("height")}}
 - {{cssxref("box-sizing")}}
 - {{cssxref("min-width")}}, {{cssxref("max-width")}}
-- The mapped logical properties: {{cssxref("block-size")}}, {{cssxref("inline-size")}}
+- {{cssxref("block-size")}}, {{cssxref("inline-size")}}
 - {{cssxref("anchor-size()")}}

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -182,9 +182,10 @@ p.minblue {
 
 ## See also
 
-- [The box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - {{cssxref("height")}}
 - {{cssxref("box-sizing")}}
 - {{cssxref("min-width")}}, {{cssxref("max-width")}}
 - {{cssxref("block-size")}}, {{cssxref("inline-size")}}
 - {{cssxref("anchor-size()")}}
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module


### PR DESCRIPTION
per : https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#see_also_section, removed "mapped logical properties" text in see also sections. 
ordered the see also in some cases, also added the module or other related props when missing.