### PR TITLE
Fix typos and pseudo-typos 2

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -195,7 +195,7 @@ The recording steps using this tool are pretty simple:
 
 ### Other resources
 
-- [How to Add Custom Callouts to Screencast Videos in Screenflow](https://photography.tutsplus.com/tutorials/how-to-add-custom-callouts-to-screencast-videos-in-screenflow--cms-27122)
+- [How to Add Custom Callouts to Screencast Videos in ScreenFlow](https://photography.tutsplus.com/tutorials/how-to-add-custom-callouts-to-screencast-videos-in-screenflow--cms-27122)
 
 ## Workflow for creating videos
 

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/index.md
@@ -105,7 +105,7 @@ Examples:
   Usually only instance methods exist, in which case you can put these under the title "Methods".
 - We do not document inherited properties and methods of the interface: they are listed on the respective parent interface. We do hint at their existence though.
 - We do document properties and methods defined in mixins. Please see the [contribution guide for mixins](/en-US/docs/MDN/Writing_guidelines/Howto/Write_an_api_reference/Information_contained_in_a_WebIDL_file#mixins) for more details.
-- Special methods like the stringifier (`toString()`) and the jsonizer (`toJSON()`) are also listed if they do exist.
+- Special methods like the stringifier (`toString()`) and the jsonifier (`toJSON()`) are also listed if they do exist.
 - Named constructors (like `Image()` for {{domxref("HTMLImageElement")}}) are also listed, if relevant.
 
 #### Constructor pages

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -271,7 +271,7 @@ partial interface Blob {
 
 ### Not throwing exceptions
 
-When the semantics of Webidl is not followed, an exception is often thrown, even without `[SetterThrows]` or `[GetterThrows]` set. For example, in strict mode, if we try to set a read-only property to a new value, that is to call its implicit setter, a read-only property will throw in strict mode.
+When the semantics of WebIDL is not followed, an exception is often thrown, even without `[SetterThrows]` or `[GetterThrows]` set. For example, in strict mode, if we try to set a read-only property to a new value, that is to call its implicit setter, a read-only property will throw in strict mode.
 
 Mostly for compatibility purpose, this behavior is sometimes annoying. To prevent this by creating a no-op setter (that is by silently ignoring any attempt to set the property to a new value), the `[LenientSetter]` annotation can be used.
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
@@ -118,7 +118,7 @@ Usually, when teaching the specifics of CSS syntax, it is clearer and more obvio
   ```css
   /* duration | timing-function | delay | iteration-count
     direction | fill-mode | play-state | name */
-  animation: 3s ease-in 1s 2 reverse both paused slidein;
+  animation: 3s ease-in 1s 2 reverse both paused slide-in;
   ```
 
   In this example, the first value that can be parsed as a [`<time>`](/en-US/docs/Web/CSS/time) is assigned to the [`animation-duration`](/en-US/docs/Web/CSS/animation-duration) property, and the second value that can be parsed as time is assigned to [`animation-delay`](/en-US/docs/Web/CSS/animation-delay). (For more information, see [animation syntax](/en-US/docs/Web/CSS/animation#syntax) details.)

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -41,9 +41,9 @@ Set the document language using the [`lang`](/en-US/docs/Web/HTML/Global_attribu
 
 This is good for accessibility and search engines, helps with localizing content, and reminds people to use best practices.
 
-### Document characterset
+### Document character set
 
-You should also define your document's characterset like so:
+You should also define your document's character set like so:
 
 ```html example-good
 <meta charset="utf-8" />

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -708,6 +708,8 @@ For inserting values into strings, use [template literals](/en-US/docs/Web/JavaS
 
 Good variable names are essential to understanding code.
 
+<!-- cSpell:ignore acclmtr -->
+
 - Use short identifiers, and avoid non-common abbreviations. Good variable names are usually between 3 to 10-character long, but as a hint only. For example, `accelerometer` is more descriptive than abbreviating to `acclmtr` for the sake of character length.
 - Try to use real-world relevant examples where each variable has clear semantics. Only fall back to placeholder names like `foo` and `bar` when the example is simple and contrived.
 - Do not use the [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation) naming convention. Do not prefix the variable name with its type. For example, write `bought = car.buyer !== null` rather than `bBought = oCar.sBuyer != null` or `name = "John Doe"` instead of `sName = "John Doe"`.

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -368,6 +368,8 @@ In general, use the first entry at [Dictionary.com](https://www.dictionary.com/)
 For example, if you [look up "behaviour"](https://www.dictionary.com/browse/behaviour) (with an additional _u_ added to the American standard form), you find the phrase "Chiefly British" followed by a link to the American standard form, ["behavior"](https://www.dictionary.com/browse/behavior).
 Do not use variant spelling.
 
+<!-- cSpell:ignore localise behaviour colour -->
+
 - **Correct**: localize, behavior, color
 - **Incorrect**: localise, behaviour, colour
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
@@ -42,8 +42,8 @@ Events have three functions:
 Handle a change in captive portal status:
 
 ```js
-function handlePortalStatus(portalstatusInfo) {
-  console.log(`The portal status is now: ${portalstatusInfo.details}`);
+function handlePortalStatus(portalStatusInfo) {
+  console.log(`The portal status is now: ${portalStatusInfo.details}`);
 }
 
 browser.captivePortal.onStateChanged.addListener(handlePortalStatus);

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -30,7 +30,7 @@ The script gets access to a number of objects that help the injected script inte
 - `$0`
   - : Contains a reference to the element that's currently selected in the devtools Inspector.
 - `inspect()`
-  - : Given an object, if it is an DOM element in the page, selects it in the devtools Inspector, otherwise it creates an object preview in the webconsole.
+  - : Given an object, if it is an DOM element in the page, selects it in the devtools Inspector, otherwise it creates an object preview in the console.
 
 [See some examples.](#examples)
 
@@ -102,10 +102,10 @@ function handleResult(result) {
   }
 }
 
-const checkjQuery = "typeof jQuery !== 'undefined'";
+const checkJQuery = "typeof jQuery !== 'undefined'";
 
 evalButton.addEventListener("click", () => {
-  browser.devtools.inspectedWindow.eval(checkjQuery).then(handleResult);
+  browser.devtools.inspectedWindow.eval(checkJQuery).then(handleResult);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -23,7 +23,7 @@ This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/Java
 
 ```js-nolint
 browser.find.find(
-  queryphrase,       // string
+  queryPhrase,       // string
   options            // optional object
 )
 ```
@@ -47,7 +47,7 @@ browser.find.find(
     - `tabId`
       - : `integer`. ID of the tab to search. Defaults to the active tab.
 
-- `queryphrase`
+- `queryPhrase`
   - : `string`. The text to search for.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -56,11 +56,11 @@ Events have three functions:
 When the user clicks the page action, hide it, and navigate the active tab to "<https://giphy.com/explore/cat>":
 
 ```js
-let CATGIFS = "https://giphy.com/explore/cat";
+let catGifs = "https://giphy.com/explore/cat";
 
 browser.pageAction.onClicked.addListener((tab) => {
   browser.pageAction.hide(tab.id);
-  browser.tabs.update({ url: CATGIFS });
+  browser.tabs.update({ url: catGifs });
 });
 
 browser.pageAction.onClicked.addListener(() => {});

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -32,7 +32,7 @@ browser.theme.update(
 Sets the browser theme to use a sun graphic with a complementary background color:
 
 ```js
-const suntheme = {
+const sunTheme = {
   images: {
     theme_frame: "sun.jpg",
   },
@@ -42,7 +42,7 @@ const suntheme = {
   },
 };
 
-browser.theme.update(suntheme);
+browser.theme.update(sunTheme);
 ```
 
 Set the theme for the focused window only:

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -20,6 +20,8 @@ This example adds an `ondata` listener which replaces "Example" in the response 
 > [!NOTE]
 > This example only works for occurrences of "Example" that are entirely contained within a data chunk, and not ones that straddle two chunks (which might happen \~0.1% of the time for large documents). Additionally it only deals with UTF-8-coded documents. A real implementation of this would have to be more complex.
 
+<!-- cSpell:ignore Examp -->
+
 ```js
 function listener(details) {
   const filter = browser.webRequest.filterResponseData(details.requestId);

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -119,7 +119,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 
 If you need to exchange messages between the content scripts running in the target window and a devtools document, it's a good idea to use the {{WebExtAPIRef("runtime.connect()")}} and {{WebExtAPIRef("runtime.onConnect")}} to set up a connection between the background page and the devtools document. The background page can then maintain a mapping between tab IDs and {{WebExtAPIRef("runtime.Port")}} objects, and use this to route messages between the two scopes.
 
-![The background page tab ID is connected to the content script on the content page by a runtime.sendmessage() object. The Port of the background page is connected to the port of the Devtools document by a port.postMessage() object.](devtools-content-scripts.png)
+![The background page tab ID is connected to the content script on the content page by a runtime.sendMessage() object. The Port of the background page is connected to the port of the Devtools document by a port.postMessage() object.](devtools-content-scripts.png)
 
 ## Limitations of the devtools APIs
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -195,7 +195,7 @@ if (typeof browser == "undefined") {
   globalThis.browser = chrome;
 }
 browser.runtime.onInstalled.addListener(() => {
-  browser.tabs.create({ url: "http://example.com/firstrun.html" });
+  browser.tabs.create({ url: "http://example.com/first-run.html" });
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/host_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/host_permissions/index.md
@@ -62,7 +62,7 @@ The extra privileges include:
 - [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) and [fetch](/en-US/docs/Web/API/Fetch_API) access to those origins without cross-origin restrictions (though not for requests from content scripts, as was the case in Manifest V2).
 - the ability to read tab-specific metadata without the "tabs" permission, such as the `url`, `title`, and `favIconUrl` properties of {{WebExtAPIRef("tabs.Tab")}} objects.
 - the ability to inject scripts programmatically (using {{webextAPIref("tabs/executeScript", "tabs.executeScript()")}}) into pages served from those origins.
-- the ability to receive events from the {{webextAPIref("webrequest")}} API for these hosts.
+- the ability to receive events from the {{webextAPIref("webRequest")}} API for these hosts.
 - the ability to access cookies for that host using the {{webextAPIref("cookies")}} API, as long as the `"cookies"` API permission is also included.
 - bypassing tracking protection for extension pages where a host is specified as a full domain or with wildcards.
 

--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -66,12 +66,12 @@ For production use, [DOMPurify](https://github.com/cure53/DOMPurify) comes as a 
 "content_scripts": [
   {
     "matches" : ["<all_urls>"],
-    "js": ["purify.min.js", "myinjectionscript.js"]
+    "js": ["purify.min.js", "my-injection-script.js"]
   }
 ]
 ```
 
-Then, in myinjectionscript.js you can read the external HTML, sanitize it, and add it to a page's DOM:
+Then, in `my-injection-script.js` you can read the external HTML, sanitize it, and add it to a page's DOM:
 
 ```js
 let elem = document.createElement("div");

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/extension_pages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/extension_pages/index.md
@@ -46,7 +46,7 @@ When the window is no longer needed, it can be closed programmatically.
 For example, after the user clicks a button, you may pass the current window's id to {{WebExtAPIRef("windows.remove()")}}:
 
 ```js
-document.getElementById("closeme").addEventListener("click", () => {
+document.getElementById("close-me").addEventListener("click", () => {
   let winId = browser.windows.WINDOW_ID_CURRENT;
   let removing = browser.windows.remove(winId);
 });

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
@@ -29,12 +29,12 @@ To manage contextual identities, you use the {{WebExtAPIRef("contextualIdentitie
 Several extension APIs include the `cookieStoreId` in objects to enable extensions to associate these objects with specific contextual identities.
 
 - {{WebExtAPIRef("browsingData.removeCookies()")}} and {{WebExtAPIRef("browsingData.removeLocalStorage()")}} where you use {{WebExtAPIRef("browsingData.removalOptions")}} to set the cookie store items are removed from.
-- {{WebExtAPIRef("contentscripts.register")}} enables you to register a content script restricted to documents associated with one or more `cookieStoreIds`.
+- {{WebExtAPIRef("contentScripts.register")}} enables you to register a content script restricted to documents associated with one or more `cookieStoreIds`.
 - {{WebExtAPIRef("downloads")}} where you can associate a download with a cookie store.
 - {{WebExtAPIRef("proxy")}} where the details passed into the {{WebExtAPIRef("proxy.onRequest")}} listener identify the cookie store associated with the request.
 - {{WebExtAPIRef("tabs")}} where you can {{WebExtAPIRef("tabs.create","create")}} a tab in a container tab, {{WebExtAPIRef("tabs.tab","get")}} the `cookieStoreId` for a tab, and {{WebExtAPIRef("tabs.query","query")}} tabs based on their associated cookie store.
-- {{WebExtAPIRef("userscripts.register")}} enables you to register a content script restricted to documents associated with one or more `cookieStoreIds`.
-- {{WebExtAPIRef("webrequest")}} where all the events return the `cookieStoreId` of the request.
+- {{WebExtAPIRef("userScripts.register")}} enables you to register a content script restricted to documents associated with one or more `cookieStoreIds`.
+- {{WebExtAPIRef("webRequest")}} where all the events return the `cookieStoreId` of the request.
 - {{WebExtAPIRef("windows.create")}} where you can specify the cookie store for the tabs added to a window when it's created.
 
 ## Permissions

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -200,7 +200,7 @@ Finally, the document fragment is written to the `<div id="tabs-list">` element:
 Another related example feature is the "Alert active tab" info option that dumps all the {{WebExtAPIRef("tabs.Tab")}} object properties for the active tab into an alert:
 
 ```js
-else if (e.target.id === "tabs-alertinfo") {
+else if (e.target.id === "tabs-alert-info") {
   callOnActiveTab((tab) => {
     let props = "";
     for (const item in tab) {
@@ -278,7 +278,7 @@ But first, here is a demonstration of the feature in action:
 
     <a href="#" id="tabs-duplicate">Duplicate active tab</a><br />
     <a href="#" id="tabs-reload">Reload active tab</a><br />
-    <a href="#" id="tabs-alertinfo">Alert active tab info</a><br />
+    <a href="#" id="tabs-alert-info">Alert active tab info</a><br />
     ```
 
 - tabs.js

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -104,7 +104,7 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
 
 ### Hex boxes to display stray control characters
 
-This feature renders control characters (Unicode category Cc) other than _tab_ (`U+0009`), _line feed_ (`U+000A`), _form feed_ (`U+000C`), and _carriage return_ (`U+000D`) as a hexbox when they are not expected. (See [Firefox bug 1099557](https://bugzil.la/1099557) for more details.)
+This feature renders control characters (Unicode category Cc) other than _tab_ (`U+0009`), _line feed_ (`U+000A`), _form feed_ (`U+000C`), and _carriage return_ (`U+000D`) as a hex box when they are not expected. (See [Firefox bug 1099557](https://bugzil.la/1099557) for more details.)
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -78,7 +78,7 @@ This article provides information about the changes in Firefox 121 that affect d
 These features are newly shipped in Firefox 121 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
 - Custom element state pseudo-class: `dom.element.customstateset.enabled`
-  - : Custom elements can expose their internal state via the {{domxref("ElementInternals.states","states")}} property as a {{domxref("CustomStateSet")}}. A CSS custom state pseudo-class such as `:--somestate` can match that element's state. ([Firefox bug 1861466](https://bugzil.la/1861466))
+  - : Custom elements can expose their internal state via the {{domxref("ElementInternals.states","states")}} property as a {{domxref("CustomStateSet")}}. A CSS custom state pseudo-class such as `:--some-state` can match that element's state. ([Firefox bug 1861466](https://bugzil.la/1861466))
 - `showPicker()` method for HTML select elements: `dom.select.showPicker.enabled`
   - : The {{domxref("HTMLSelectElement.showPicker()")}} method programmatically launches the browser picker for a {{HTMLElement("select")}} element, triggered by user interaction. ([Firefox bug 1854112](https://bugzil.la/1854112))
 

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -59,7 +59,7 @@ No notable changes.
   Here are some additional details on the events for lost and restored canvas contexts:
 
   - Applications can monitor for [`contextlost`](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event) and [`contextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event) events, which are fired on at [`HTMLCanvasElement`](/en-US/docs/Web/API/HTMLCanvasElement) when the context is lost and recovered, respectively, and can also check the context using [`CanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/CanvasRenderingContext2D/isContextLost).
-  - After emitting `contentlost`, a browser will try and restart the lost context, by default, but code can prevent this by cancelling the event.
+  - After emitting `contextlost`, a browser will try and restart the lost context, by default, but code can prevent this by cancelling the event.
   - Offscreen canvases can be monitored in the same way, but using [`OffScreenCanvas`](/en-US/docs/Web/API/OffscreenCanvas) events [`contextlost`](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event) and [`contextrestored`](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event), along with [`OffscreenCanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#context).
 
 - Added support for the [`shadowrootclonable`](/en-US/docs/Web/HTML/Element/template#shadowrootclonable) attribute of the `<template>` element, and the [`shadowRootClonable`](/en-US/docs/Web/API/HTMLTemplateElement/shadowRootClonable) property of the `HTMLTemplateElement` interface that reflects it.

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -25,7 +25,7 @@ This article provides information about the changes in Firefox 128 that affect d
 
 ### JavaScript
 
-- Resizeable {{jsxref("ArrayBuffer")}} and growable {{jsxref("SharedArrayBuffer")}} are now supported, allowing the size of buffers to be changed without having to allocate a new buffer and copy data into it ([Firefox bug 1884150](https://bugzil.la/1884150)).
+- Resizable {{jsxref("ArrayBuffer")}} and growable {{jsxref("SharedArrayBuffer")}} are now supported, allowing the size of buffers to be changed without having to allocate a new buffer and copy data into it ([Firefox bug 1884150](https://bugzil.la/1884150)).
   The relevant methods and properties are:
 
   - Grow {{jsxref("SharedArrayBuffer")}} using the {{jsxref("SharedArrayBuffer.prototype.grow()")}} method.

--- a/files/en-us/mozilla/firefox/releases/15/index.md
+++ b/files/en-us/mozilla/firefox/releases/15/index.md
@@ -78,8 +78,8 @@ Firefox 15 shipped on August 28, 2012. This article lists key changes that are u
   - : `aModifiers` of `sendMouseEvent()`, `sendTouchEvent()`, `sendMouseEventToWindow()`, `sendMouseScrollEvent()` and `sendKeyEvent()` supports all modifier keys which are supported by [`KeyboardEvent.getModifierState()`](/en-US/docs/Web/API/KeyboardEvent#getmodifierstate%28%29). Use `MODIFIER_*` values. And now the 5th parameter of `sendKeyEvent()` is changed from `boolean` to `unsigned long`. For backward compatibility, if caller passes `true` or `false` to it, the behavior isn't changed. This change allows callers to specify the key's location.
 - `nsIBrowserHistory`
   - : The `hidePage()` method was never implemented, and has been removed entirely in this release. The `addPageWithDetails()` method has also been removed as part of the ongoing work to make all 'Places APIs' asynchronous; use `mozIAsyncHistory.updatePlaces()` instead. Also, the `count` attribute was removed; it had not returned an actual count in some time (instead, it was indicating whether or not any entries existed). You can use `nsINavHistoryService.hasHistoryEntries` instead.
-- `inIDOMUtils`
-  - : The `inlDOMUtils.parseStyleSheet()` method has been added and allows the (re-)parsing of Cascading Style Sheets.
+- `nsIDOMUtils`
+  - : The `nsIDOMUtils.parseStyleSheet()` method has been added and allows the (re-)parsing of Cascading Style Sheets.
 - `nsIINIParserWriter`
   - : The `nsIINIParserWriter.writeFile()` method now accepts a `flags` property. This currently offers only one option: you can now tell it to write the file in UTF-16 format instead of UTF-8, for better compatibility with Windows and certain installers.
 

--- a/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
@@ -199,4 +199,4 @@ Firefox 3.5 introduces support for adding and removing progress listeners that l
 ## For Theme developers
 
 - Check [Theme changes in Firefox 3.1](/en-US/Theme_changes_in_Firefox_3.1).
-- Go to the Mozillazine forum [Theme changes for FF3.1](https://forums.mozillazine.org/viewtopic.php?f=18&t=665138) to get an overview / listing of all changes between 3.0 and 3.1 that impact theme developers. This concerns new CSS features (like nth-child, -moz-box-shadow, etc.), changes to existing widgets, overall UI improvements, and new FF3.1 features (audio/video support, private browsing, extended session restore, box/window/text shadows).
+- Go to the MozillaZine forum [Theme changes for FF3.1](https://forums.mozillazine.org/viewtopic.php?f=18&t=665138) to get an overview / listing of all changes between 3.0 and 3.1 that impact theme developers. This concerns new CSS features (like nth-child, -moz-box-shadow, etc.), changes to existing widgets, overall UI improvements, and new FF3.1 features (audio/video support, private browsing, extended session restore, box/window/text shadows).

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_themes/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_themes/index.md
@@ -12,7 +12,7 @@ This article intends to help theme authors update Firefox-3.5-compatible themes 
 
 [`contents.rdf` is not supported anymore](https://www.oxymoronical.com/blog/2009/06/Farewell-contentsrdf/), you need to use `chrome.manifest` instead.
 
-## Emptytext styling
+## Empty text styling
 
 XUL textboxes don't have the `empty` attribute anymore, but `isempty` instead. So instead of `textbox[empty="true"]`, you need to use `textbox[isempty="true"]`.
 

--- a/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -58,7 +58,7 @@ Firefox 3 only allows web content to access items in the `chrome://browser/` and
 There is, however, a way for extensions to make their content web-accessible. They can specify a special flag in their `chrome.manifest` file, like this:
 
 ```plain
-content mypackage location/ contentaccessible=yes
+content my-package location/ contentaccessible=yes
 ```
 
 This shouldn't be something you need to do very often, but it's available for those rare cases in which it's needed. Note that it's possible that Firefox may alert the user that your extension uses the `contentaccessible` flag in this way, as it does constitute a potential security risk.
@@ -67,8 +67,8 @@ This shouldn't be something you need to do very often, but it's available for th
 > Because Firefox 2 doesn't understand the `contentaccessible` flag (it will ignore the entire line containing the flag), if you want your add-on to be compatible with both Firefox 2 and Firefox 3, you should do something like this:
 >
 > ```bash
-> content mypackage location/
-> content mypackage location/ contentaccessible=yes
+> content my-package location/
+> content my-package location/ contentaccessible=yes
 >
 > ```
 

--- a/files/en-us/mozilla/firefox/releases/3/xul_improvements_in_firefox_3/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/xul_improvements_in_firefox_3/index.md
@@ -32,13 +32,13 @@ Firefox 3 provides a number of new XUL elements, as well as improvements to exis
 ### Improvements to menus
 
 - The `image` attribute is now used consistently for setting images.
-- Menulists fire the `select` event when selecting an item.
+- Menu lists fire the `select` event when selecting an item.
 - The `inputField` and `editable` properties have been added to menulist
 - The `<menu>`, `<menuitem>` and `<menuseparator>` elements now have a readonly `selected` property which retrieves whether the item is selected in a \<menulist>
 - The `<menu>`, `<menuitem>` and `<menuseparator>` elements now have a readonly `control` property which returns the enclosing \<menulist>
 - The `<menu>`, `<menuitem>` and `<menuseparator>` elements now support the `accessKey`, `disabled`, `crop`, `image` and `label` properties which set the corresponding attribute
 - The \<menu> element now has methods to append, insert and remove menuitems. ([Firefox bug 372552](https://bugzil.la/372552))
-- Editable menulists now offer an `editor` property to get the internal `nsIEditor` for its text field.
+- Editable menu lists now offer an `editor` property to get the internal `nsIEditor` for its text field.
 - Menus may now be made translucent on platforms that support it ([Firefox bug 70798](https://bugzil.la/70798)).
 
 ### Improvements to textboxes

--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -59,7 +59,7 @@ _No change._
 
 ### Audio/Video
 
-- On Linux, Gstreamer 1.0 is now supported (instead of 0.10) ([Firefox bug 806917](https://bugzil.la/806917)).
+- On Linux, GStreamer 1.0 is now supported (instead of 0.10) ([Firefox bug 806917](https://bugzil.la/806917)).
 
 ## Security
 

--- a/files/en-us/mozilla/firefox/releases/33/index.md
+++ b/files/en-us/mozilla/firefox/releases/33/index.md
@@ -47,7 +47,7 @@ For details please [see the hacks post](https://hacks.mozilla.org/2014/07/event-
 - On Android, support for two new values for the [`name`](/en-US/docs/Web/HTML/Element/meta#name) attribute of {{HTMLElement("meta")}} has been added: `msapplication-TileImage` and `msapplication-TileColor` ([Firefox bug 1014712](https://bugzil.la/1014712)). Example:
 
   ```html
-  <meta name="msapplication-TileImage" content="images/benthepcguy-144.png" />
+  <meta name="msapplication-TileImage" content="images/my-img-144.png" />
   <meta name="msapplication-TileColor" content="#d83434" />
   ```
 

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -80,7 +80,7 @@ Highlights:
 
 - The {{domxref("MediaDevices")}} interface, containing the {{jsxref("Promise")}}-based version of {{domxref("MediaDevices.getUserMedia()", "getUserMedia()")}}, has been added. It is available via {{domxref("Navigator.mediaDevices")}} ([Firefox bug 1033885](https://bugzil.la/1033885)).
 - The EME-related {{domxref("Navigator.requestMediaKeySystemAccess()")}} method, and the related {{domxref("MediaKeySystemAccess")}}, is now supported ([Firefox bug 1095257](https://bugzil.la/1095257)).
-- The {{domxref("MediaKeySession/keystatuseschange_event", "keyschange")}} event is now sent when an EME-related CDM change keys in a session ([Firefox bug 1081755](https://bugzil.la/1081755)).
+- The {{domxref("MediaKeySession/keystatuseschange_event", "keystatuseschange")}} event is now sent when an EME-related CDM change keys in a session ([Firefox bug 1081755](https://bugzil.la/1081755)).
 - The default values of the options for {{domxref("MutationObserver.observe()")}} have been updated to match the latest specification ([Firefox bug 973638](https://bugzil.la/973638)).
 - Experimental support for virtual reality devices has landed behind the `dom.vr.enabled` preference, off by default ([Firefox bug 1036604](https://bugzil.la/1036604)).
 - The function associated with {{domxref("RTCPeerConnection.signalingstatechange_event", "RTCPeerConnection.onsignalingstatechange")}} now receives an event as parameter, as per spec ([Firefox bug 1075133](https://bugzil.la/1075133)).

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -80,7 +80,7 @@ Highlights:
 
 - The {{domxref("MediaDevices")}} interface, containing the {{jsxref("Promise")}}-based version of {{domxref("MediaDevices.getUserMedia()", "getUserMedia()")}}, has been added. It is available via {{domxref("Navigator.mediaDevices")}} ([Firefox bug 1033885](https://bugzil.la/1033885)).
 - The EME-related {{domxref("Navigator.requestMediaKeySystemAccess()")}} method, and the related {{domxref("MediaKeySystemAccess")}}, is now supported ([Firefox bug 1095257](https://bugzil.la/1095257)).
-- The {{domxref("MediaKeySession/keystatuseschange_event", "keystatuseschange")}} event is now sent when an EME-related CDM change keys in a session ([Firefox bug 1081755](https://bugzil.la/1081755)).
+- The {{domxref("MediaKeySession/keystatuseschange_event", "keyschange")}} event is now sent when an EME-related CDM change keys in a session ([Firefox bug 1081755](https://bugzil.la/1081755)).
 - The default values of the options for {{domxref("MutationObserver.observe()")}} have been updated to match the latest specification ([Firefox bug 973638](https://bugzil.la/973638)).
 - Experimental support for virtual reality devices has landed behind the `dom.vr.enabled` preference, off by default ([Firefox bug 1036604](https://bugzil.la/1036604)).
 - The function associated with {{domxref("RTCPeerConnection.signalingstatechange_event", "RTCPeerConnection.onsignalingstatechange")}} now receives an event as parameter, as per spec ([Firefox bug 1075133](https://bugzil.la/1075133)).

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -42,8 +42,8 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
 - {{HTMLElement("textarea")}} elements are now resizable by default; you can use the {{cssxref("resize")}} CSS property to disable this.
 - `canvas.getContext` and `canvas.toDataURL` no longer throw an exception when called with unrecognized arguments.
 - The {{HTMLElement("canvas")}} element now supports the Mozilla-specific `mozGetAsFile()` method, which lets you obtain a memory-based file containing an image of the canvas's contents. See {{domxref("HTMLCanvasElement")}} for details.
-- `canvas2dcontext.lineCap` and `canvas2dcontext.lineJoin` no longer throw an exception when set to an unrecognized value.
-- `canvas2dcontext.globalCompositeOperation` no longer throws an exception when set to an unrecognized value, and no longer supports the non-standard `darker` value.
+- `Canvas2DContext.lineCap` and `Canvas2DContext.lineJoin` no longer throw an exception when set to an unrecognized value.
+- `Canvas2DContext.globalCompositeOperation` no longer throws an exception when set to an unrecognized value, and no longer supports the non-standard `darker` value.
 - Support for the obsolete `<spacer>` element, which was absent in all other browsers, has been removed.
 - The `<isindex>` element, when created by calling {{domxref("document.createElement()")}}, is now created as a simple element with no properties or methods.
 - Gecko now supports calling `click()` on {{HTMLElement("input")}} elements to open the file picker. See the [example](/en-US/docs/Web/API/File_API/Using_files_from_web_applications#using_hidden_file_input_elements_using_the_click_method) in the article [Using files from web applications](/en-US/docs/Web/API/File_API/Using_files_from_web_applications).
@@ -375,7 +375,7 @@ Several changes were made to the `<xul:tabbrowser>` element that impact extensio
 - Added the new `getIcon` method, which lets you get a tab's favicon without having to pull up the `<xul:browser>` element.
 - Added the new `tabbrowser.tabs` property, which lets you easily get a list of the tabs in a `<xul:tabbrowser>` element.
 - The new `pinTab` and `unpinTab` methods let you pin and unpin tabs (that is, switch them between being app tabs and regular tabs).
-- Added the `getTabModalPromptBox` method and `tabmodalPromptShowing` attribute to the `<xul:tabbrowser>` to support tab-modal alerts.
+- Added the `getTabModalPromptBox` method and `tabModalPromptShowing` attribute to the `<xul:tabbrowser>` to support tab-modal alerts.
 
 #### Changes to popups
 

--- a/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
@@ -42,14 +42,14 @@ itemLabel.value = "Hello world!";
 To add the button only once, create a bool pref to check if it is the first run. [For example](https://stackoverflow.com/questions/4978188/how-do-i-detect-a-first-run-in-firefox-a-addon/4978512#4978512):
 
 ```js
-var firstrun = Services.prefs.getBoolPref("extensions.YOUREXT.firstrun");
+var firstRun = Services.prefs.getBoolPref("extensions.YOUREXT.firstRun");
 
 var curVersion = "0.0.0";
 
-if (firstrun) {
-  Services.prefs.setBoolPref("extensions.YOUREXT.firstrun", false);
+if (firstRun) {
+  Services.prefs.setBoolPref("extensions.YOUREXT.firstRun", false);
   Services.prefs.setCharPref("extensions.YOUREXT.installedVersion", curVersion);
-  /* Code related to firstrun */
+  /* Code related to firstRun */
 } else {
   try {
     var installedVersion = Services.prefs.getCharPref(
@@ -73,7 +73,7 @@ if (firstrun) {
 Adding support for the add-on bar while staying compatible with Firefox 3.6 and older will require using two overlays. The [chrome.manifest](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration) file can specify which file is used by which Firefox version by using [manifest flags](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration#Manifest_Flags):
 
 ```plain
-overlay chrome://browser/content/browser.xul chrome://myaddon/content/myaddon/overlayold.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion<4.0
+overlay chrome://browser/content/browser.xul chrome://myaddon/content/myaddon/overlay-old.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion<4.0
 overlay chrome://browser/content/browser.xul chrome://myaddon/content/myaddon/overlay.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion>=4.0
 ```
 

--- a/files/en-us/mozilla/firefox/releases/40/index.md
+++ b/files/en-us/mozilla/firefox/releases/40/index.md
@@ -62,7 +62,7 @@ _No change._
 - [`\u{xxxxxx}`](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#unicode_code_point_escapes) Unicode code point escapes have been added ([Firefox bug 320500](https://bugzil.la/320500)).
 - {{jsxref("String.prototype.includes", "String.prototype.contains", "#String.prototype.contains")}} has been replaced with {{jsxref("String.prototype.includes")}}, `String.prototype.contains` is kept as an alias ([Firefox bug 1102219](https://bugzil.la/1102219)).
 - If the {{jsxref("DataView")}} constructor is called as a function without the {{ jsxref("Operators/new", "new") }} operator, a {{jsxref("TypeError")}} is now thrown as per the ES2015 specification.
-- An issue regressed in Firefox 21, where proxyfied arrays without the `get` trap were not working properly, has been fixed. If the `get` trap in a {{jsxref("Proxy")}} was not defined, {{jsxref("Array.length")}} returned `0` and the `set` trap didn't get called. A workaround was to add the `get` trap even if was not necessary in your code. This issue has been fixed now ([Firefox bug 895223](https://bugzil.la/895223)).
+- An issue regressed in Firefox 21, where proxified arrays without the `get` trap were not working properly, has been fixed. If the `get` trap in a {{jsxref("Proxy")}} was not defined, {{jsxref("Array.length")}} returned `0` and the `set` trap didn't get called. A workaround was to add the `get` trap even if was not necessary in your code. This issue has been fixed now ([Firefox bug 895223](https://bugzil.la/895223)).
 - `WeakMap.prototype` and `WeakSet.prototype` have been updated to be just ordinary objects, per ES2015 specification ([Firefox bug 1055473](https://bugzil.la/1055473)).
 
 ### Interfaces/APIs/DOM

--- a/files/en-us/mozilla/firefox/releases/50/index.md
+++ b/files/en-us/mozilla/firefox/releases/50/index.md
@@ -19,7 +19,7 @@ Firefox 50 was released on November 15, 2016. This article lists key changes tha
 
 ### CSS
 
-- Border-radiused corners with dashed and dotted styles are now rendered with the specified style instead of a solid style ([Firefox bug 382721](https://bugzil.la/382721)).
+- Corners with border-radius and with dashed and dotted styles are now rendered with the specified style instead of a solid style ([Firefox bug 382721](https://bugzil.la/382721)).
 - The non-standard `:-moz-full-screen-ancestor` pseudo-class selector has been removed ([Firefox bug 1199529](https://bugzil.la/1199529)).
 - The {{cssxref("box-sizing")}}`: padding-box` has been removed, since it's no longer a part of the spec and Firefox was the only major browser implementing it ([Firefox bug 1166728](https://bugzil.la/1166728)).
 - The three values `isolate`, `isolate-override`, and `plaintext` of the {{cssxref("unicode-bidi")}} property have been unprefixed ([Firefox bug 1141895](https://bugzil.la/1141895)).

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -40,7 +40,7 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 
 - The `@-moz-document` property has a new `regexp()` function, which lets you match the document's URL to a [regular expression](/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
 - The {{ cssxref("azimuth") }} CSS property is no longer supported, as we have removed what little code we had for the `aural` media group. It was never significantly implemented, so it made more sense to remove the crufty implementation for the time being rather than try to patch it up.
-- In the past, the {{ cssxref(":hover") }} pseudoclass was not applied to class selectors when in quirks mode; for example, `.someclass:hover` did not work. This quirk has been removed.
+- In the past, the {{ cssxref(":hover") }} pseudoclass was not applied to class selectors when in quirks mode; for example, `.some-class:hover` did not work. This quirk has been removed.
 - The {{ cssxref(":indeterminate") }} pseudo-class can be applied to {{ HTMLElement("progress") }} elements. This is non-standard, but we hope it will be adopted by other browsers, because it will be useful.
 - The `-moz-win-exclude-glass` value has been added to the `-moz-appearance` CSS property in order to exclude opaque regions in Aero Glass glaze effects on Windows systems.
 - [Firefox bug 658949](https://bugzil.la/658949) changed how the hash (#) symbol is treated in data URLs which may break CSS stylesheets which contain such a symbol if it is not escaped.

--- a/files/en-us/mozilla/firefox/releases/70/index.md
+++ b/files/en-us/mozilla/firefox/releases/70/index.md
@@ -123,7 +123,7 @@ This article provides information about the changes in Firefox 70 that will affe
 ### API changes
 
 - Added a new parameter to the [`topSites.get()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/topSites/get) method that causes the method to return the list of pages that appear when the user opens a new tab ([Firefox bug 1568617](https://bugzil.la/1568617)).
-- The [`privacy.network`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy/network) property's `WebRTCIPHandlingPolicy` sub-property's permitted values have been amended (in [Firefox bug 1452713](https://bugzil.la/1452713)) to match the behavior seen in Chrome as follows:
+- The [`privacy.network`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy/network) property's `webRTCIPHandlingPolicy` sub-property's permitted values have been amended (in [Firefox bug 1452713](https://bugzil.la/1452713)) to match the behavior seen in Chrome as follows:
 
   - `disable_non_proxied_udp` previously prevented the use of WebRTC if no proxy was configured. Now a proxy is always used if one is configured, but otherwise a non-proxied connection is permitted.
   - `proxy_only` can be used to provide the old behavior; this has the effect of only allowing ICE negotiation over TURN on TCP using a proxy; no other connections are allowed.

--- a/files/en-us/mozilla/firefox/releases/74/index.md
+++ b/files/en-us/mozilla/firefox/releases/74/index.md
@@ -90,7 +90,7 @@ _No changes._
 ### API changes
 
 - Shortcut keys can now be unassigned in {{WebExtAPIRef("Commands.update")}} by passing an empty value of `shortcut` [Firefox bug 1475043](https://bugzil.la/1475043).
-- `urlclassification`s are now returned as part of the `details` in each event of {{WebExtAPIRef("webrequest")}}, providing information on whether a request is classified as fingerprinting or tracking [Firefox bug 1589494](https://bugzil.la/1589494).
+- `urlClassification`s are now returned as part of the `details` in each event of {{WebExtAPIRef("webRequest")}}, providing information on whether a request is classified as fingerprinting or tracking [Firefox bug 1589494](https://bugzil.la/1589494).
 
 ### Manifest changes
 

--- a/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
@@ -27,7 +27,7 @@ Starting in Firefox 9, you should call the new `nsIChromeFrameMessageManager.rem
 
 ```js
 browser.messageManager.removeDelayedFrameScript(
-  "chrome://myextension/content/somescript.js",
+  "chrome://my-extension/content/some-script.js",
 );
 ```
 

--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
@@ -49,8 +49,8 @@ This point in time does not have to be one of the values returned by `getMediaTi
 In the third and final step, a snapshot is rendered into an HTML {{htmlelement("div")}} using `imsc.renderHTML()`:
 
 ```js
-const vdiv = document.getElementById("render-div");
-imsc.renderHTML(isd, vdiv);
+const renderDiv = document.getElementById("render-div");
+imsc.renderHTML(isd, renderDiv);
 ```
 
 ## Building an IMSC player
@@ -271,7 +271,7 @@ For the first problem there is a straightforward CSS solution. We need to set th
 
 This has the effect that pointer events are going "through" the overlay (see [reference documentation for point events](/en-US/docs/Web/CSS/pointer-events) for more details).
 
-The caption user interface problem is a bit harder to solve. Although we can listen to events, activating a track using the caption user interface will also activate the rendering of corresponding WebVTT. As we are using VTTCues for IMSC rendering, this can course undesired presentation behavior. The text property of the VTTCue has always the empty string as value but in some browser this may lead nonetheless to the rendering of artefacts.
+The caption user interface problem is a bit harder to solve. Although we can listen to events, activating a track using the caption user interface will also activate the rendering of corresponding WebVTT. As we are using VTTCues for IMSC rendering, this can course undesired presentation behavior. The text property of the VTTCue has always the empty string as value but in some browser this may lead nonetheless to the rendering of artifacts.
 
 the best solution is to building your own custom controls. Find out how in our [Creating a cross-browser video player](/en-US/docs/Web/Media/Audio_and_video_delivery/cross_browser_video_player) tutorial.
 


### PR DESCRIPTION
I am fixing a lot of nits in content. The goal is to make our custom dictionaries as small as possible by eliminating things that could be better recognized as words. This not only helps with automation but helps with human readers too, especially those who may be slow to recognize words.

- About half of them are code not properly capitalized.
- There are some real typos.
- Occasionally I have to refactor the wording a bit.
- Where we are demonstrating real typos, I use inline `cSpell:ignore` to prevent it being ignored in other files.