### PR TITLE
Fix typos and pseudo-typos 11

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/value/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/value/index.md
@@ -17,7 +17,7 @@ A string containing the value of the {{htmlelement("button")}} element.
 ## Examples
 
 ```js
-const buttonElement = document.getElementById("givenname");
+const buttonElement = document.getElementById("given-name");
 console.log(`value: ${buttonElement.value}`);
 ```
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -40,7 +40,7 @@ The following example shows how to transfer control to an {{domxref("OffscreenCa
 
 ```js
 const offscreen = document.querySelector("canvas").transferControlToOffscreen();
-const worker = new Worker("myworkerurl.js");
+const worker = new Worker("my-worker-url.js");
 worker.postMessage({ canvas: offscreen }, [offscreen]);
 ```
 

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -35,8 +35,8 @@ The first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching t
 ```html
 <div id="personal">
   <span name="title">Dr.</span>
-  <span name="firstname">Carina</span>
-  <span name="lastname">Anand</span>
+  <span name="first-name">Carina</span>
+  <span name="last-name">Anand</span>
   <span id="degree">(MD)</span>
 </div>
 ```
@@ -50,14 +50,14 @@ const container = document.getElementById("personal");
 const titleSpan = container.children.namedItem("title");
 
 // The following variants return undefined instead of null if there's no element with a matching name or id
-const firstnameSpan = container.children["firstname"];
-const lastnameSpan = container.children.lastname;
+const firstNameSpan = container.children["first-name"];
+const lastNameSpan = container.children["last-name"];
 
 // Returns the span element with the id "degree"
 const degreeSpan = container.children.namedItem("degree");
 
 const output = document.createElement("div");
-output.textContent = `Result: ${titleSpan.textContent} ${firstnameSpan.textContent} ${lastnameSpan.textContent} ${degreeSpan.textContent}`;
+output.textContent = `Result: ${titleSpan.textContent} ${firstNameSpan.textContent} ${lastNameSpan.textContent} ${degreeSpan.textContent}`;
 
 container.insertAdjacentElement("afterend", output);
 ```

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -29,7 +29,7 @@ The reset button has an event handler that closes the dialog; it has no impact o
       type="submit"
       aria-label="close"
       value="X"
-      name="Xbutton"
+      name="x-button"
       formnovalidate />
     <p>
       <label

--- a/files/en-us/web/api/htmlelement/dir/index.md
+++ b/files/en-us/web/api/htmlelement/dir/index.md
@@ -30,8 +30,8 @@ One of the following:
 ## Examples
 
 ```js
-const parg = document.getElementById("para1");
-parg.dir = "rtl";
+const para = document.getElementById("para1");
+para.dir = "rtl";
 // change the text direction on a paragraph identified as "para1"
 ```
 

--- a/files/en-us/web/api/htmlelement/drag_event/index.md
+++ b/files/en-us/web/api/htmlelement/drag_event/index.md
@@ -45,7 +45,7 @@ _In addition to the properties listed below, properties from the parent interfac
 <div class="dropzone">
   <div id="draggable" draggable="true">This div is draggable</div>
 </div>
-<div class="dropzone" id="droptarget"></div>
+<div class="dropzone" id="drop-target"></div>
 ```
 
 #### CSS
@@ -102,7 +102,7 @@ source.addEventListener("dragend", (event) => {
 });
 
 /* events fired on the drop targets */
-const target = document.getElementById("droptarget");
+const target = document.getElementById("drop-target");
 target.addEventListener(
   "dragover",
   (event) => {

--- a/files/en-us/web/api/htmlelement/dragenter_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragenter_event/index.md
@@ -51,7 +51,7 @@ However, in this partial example, we haven't implemented dropping: for a complet
 <div class="dropzone">
   <div id="draggable" draggable="true">This div is draggable</div>
 </div>
-<div class="dropzone" id="droptarget"></div>
+<div class="dropzone" id="drop-target"></div>
 ```
 
 #### CSS
@@ -83,7 +83,7 @@ body {
 #### JavaScript
 
 ```js
-const target = document.getElementById("droptarget");
+const target = document.getElementById("drop-target");
 target.addEventListener("dragenter", (event) => {
   // highlight potential drop target when the draggable element enters it
   if (event.target.classList.contains("dropzone")) {

--- a/files/en-us/web/api/htmlelement/dragleave_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragleave_event/index.md
@@ -51,7 +51,7 @@ However, in this partial example, we haven't implemented dropping: for a complet
 <div class="dropzone">
   <div id="draggable" draggable="true">This div is draggable</div>
 </div>
-<div class="dropzone" id="droptarget"></div>
+<div class="dropzone" id="drop-target"></div>
 ```
 
 #### CSS
@@ -83,7 +83,7 @@ body {
 #### JavaScript
 
 ```js
-const target = document.getElementById("droptarget");
+const target = document.getElementById("drop-target");
 target.addEventListener("dragenter", (event) => {
   // highlight potential drop target when the draggable element enters it
   if (event.target.classList.contains("dropzone")) {

--- a/files/en-us/web/api/htmlelement/dragover_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragover_event/index.md
@@ -55,7 +55,7 @@ For a complete example of drag and drop, see the page for the [`drag`](/en-US/do
 <div class="dropzone">
   <div id="draggable" draggable="true">This div is draggable</div>
 </div>
-<div class="dropzone" id="droptarget"></div>
+<div class="dropzone" id="drop-target"></div>
 ```
 
 #### CSS
@@ -91,7 +91,7 @@ source.addEventListener("dragstart", (event) => {
   dragged = event.target;
 });
 
-const target = document.getElementById("droptarget");
+const target = document.getElementById("drop-target");
 target.addEventListener("dragover", (event) => {
   // prevent default to allow drop
   event.preventDefault();

--- a/files/en-us/web/api/htmlelement/drop_event/index.md
+++ b/files/en-us/web/api/htmlelement/drop_event/index.md
@@ -55,7 +55,7 @@ For a more complete example of drag and drop, see the page for the [`drag`](/en-
 <div class="dropzone">
   <div id="draggable" draggable="true">This div is draggable</div>
 </div>
-<div class="dropzone" id="droptarget"></div>
+<div class="dropzone" id="drop-target"></div>
 ```
 
 #### CSS
@@ -91,7 +91,7 @@ source.addEventListener("dragstart", (event) => {
   dragged = event.target;
 });
 
-const target = document.getElementById("droptarget");
+const target = document.getElementById("drop-target");
 target.addEventListener("dragover", (event) => {
   // prevent default to allow drop
   event.preventDefault();

--- a/files/en-us/web/api/htmlelement/offsetleft/index.md
+++ b/files/en-us/web/api/htmlelement/offsetleft/index.md
@@ -37,7 +37,7 @@ This example shows a 'long' sentence that wraps within a div with a blue border,
 <div
   style="width: 300px; border-color:blue; border-style:solid; border-width:1;">
   <span>Short span. </span>
-  <span id="longspan">Long span that wraps within this div.</span>
+  <span id="long-span">Long span that wraps within this div.</span>
 </div>
 
 <div
@@ -46,11 +46,11 @@ This example shows a 'long' sentence that wraps within a div with a blue border,
 
 <script>
   const box = document.getElementById("box");
-  const longspan = document.getElementById("longspan");
-  box.style.left = longspan.offsetLeft + document.body.scrollLeft + "px";
-  box.style.top = longspan.offsetTop + document.body.scrollTop + "px";
-  box.style.width = longspan.offsetWidth + "px";
-  box.style.height = longspan.offsetHeight + "px";
+  const longSpan = document.getElementById("long-span");
+  box.style.left = longSpan.offsetLeft + document.body.scrollLeft + "px";
+  box.style.top = longSpan.offsetTop + document.body.scrollTop + "px";
+  box.style.width = longSpan.offsetWidth + "px";
+  box.style.height = longSpan.offsetHeight + "px";
 </script>
 ```
 

--- a/files/en-us/web/api/htmlformelement/acceptcharset/index.md
+++ b/files/en-us/web/api/htmlformelement/acceptcharset/index.md
@@ -19,7 +19,7 @@ A string.
 ## Examples
 
 ```js
-let inputs = document.forms["myform"].acceptCharset;
+let inputs = document.forms["my-form"].acceptCharset;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -187,10 +187,10 @@ Submit a `<form>` into a new window:
   <body>
     <form action="test.php" target="_blank">
       <p>
-        <label>First name: <input type="text" name="firstname" /></label>
+        <label>First name: <input type="text" name="first-name" /></label>
       </p>
       <p>
-        <label>Last name: <input type="text" name="lastname" /></label>
+        <label>Last name: <input type="text" name="last-name" /></label>
       </p>
       <p>
         <label><input type="password" name="pwd" /></label>

--- a/files/en-us/web/api/htmlformelement/method/index.md
+++ b/files/en-us/web/api/htmlformelement/method/index.md
@@ -20,7 +20,7 @@ A string.
 ## Examples
 
 ```js
-document.forms["myform"].method = "post";
+document.forms["my-form"].method = "post";
 
 const formElement = document.createElement("form"); // Create a form
 document.body.appendChild(formElement);

--- a/files/en-us/web/api/htmlformelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlformelement/reportvalidity/index.md
@@ -27,10 +27,10 @@ Returns `true` if the associated controls' values have no validity problems; oth
 ## Example
 
 ```js
-document.forms["myform"].addEventListener(
+document.forms["my-form"].addEventListener(
   "submit",
   () => {
-    document.forms["myform"].reportValidity();
+    document.forms["my-form"].reportValidity();
   },
   false,
 );

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -38,7 +38,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-document.getElementById("myform").reset();
+document.getElementById("my-form").reset();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -43,7 +43,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-document.forms["myform"].submit();
+document.forms["my-form"].submit();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlframesetelement/index.md
+++ b/files/en-us/web/api/htmlframesetelement/index.md
@@ -9,7 +9,7 @@ browser-compat: api.HTMLFrameSetElement
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 
-The **`HTMLFrameSetElement`** interface provides special properties (beyond those of the regular {{domxref("HTMLElement")}} interface they also inherit) for manipulating {{HTMLELEment("frameset")}} elements.
+The **`HTMLFrameSetElement`** interface provides special properties (beyond those of the regular {{domxref("HTMLElement")}} interface they also inherit) for manipulating {{HTMLElement("frameset")}} elements.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmliframeelement/browsingtopics/index.md
+++ b/files/en-us/web/api/htmliframeelement/browsingtopics/index.md
@@ -29,7 +29,7 @@ A boolean. The default value is `false`; set it to `true` to send the associated
 Set `browsingtopics` to `true` then load the `<iframe>` contents declaratively:
 
 ```html
-<iframe browsingtopics title="Advertising container" src="adtech1.example">
+<iframe browsingtopics title="Advertising container" src="ad-tech1.example">
   ...
 </iframe>
 ```
@@ -56,7 +56,7 @@ const iframeElem = document.querySelector("iframe");
 
 iframeElem.browsingTopics = true;
 iframeElem.title = "Advertising container";
-iframeElem.src = "adtech1.example";
+iframeElem.src = "ad-tech1.example";
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlimageelement/complete/index.md
+++ b/files/en-us/web/api/htmlimageelement/complete/index.md
@@ -65,7 +65,7 @@ async function loadImage(url, elem) {
 
 async function lightBox(url) {
   lightboxElem.style.display = "block";
-  await loadImage("https://somesite.net/huge-image.jpg", lightboxImgElem);
+  await loadImage("https://some-site.net/huge-image.jpg", lightboxImgElem);
   lightboxControlsElem.disabled = false;
 }
 

--- a/files/en-us/web/api/htmlinputelement/multiple/index.md
+++ b/files/en-us/web/api/htmlinputelement/multiple/index.md
@@ -17,11 +17,11 @@ A boolean value.
 ## Examples
 
 ```html
-<input id="myfileinput" type="file" multiple />
+<input id="my-file-input" type="file" multiple />
 ```
 
 ```js
-let fileInput = document.getElementById("myfileinput");
+let fileInput = document.getElementById("my-file-input");
 
 if (fileInput.multiple) {
   // Loop fileInput.files

--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.md
@@ -41,7 +41,7 @@ The example below shows how to get the text selected in an {{HTMLElement("input"
 
 ```html
 <div>
-  Enter and select text here:<br /><input id="mytext" rows="2" cols="20" />
+  Enter and select text here:<br /><input id="my-text" rows="2" cols="20" />
 </div>
 <div>selectionStart: <span id="start"></span></div>
 <div>selectionEnd: <span id="end"></span></div>
@@ -51,12 +51,12 @@ The example below shows how to get the text selected in an {{HTMLElement("input"
 ### JavaScript
 
 ```js
-const myinput = document.getElementById("mytext");
+const myInput = document.getElementById("my-text");
 
-myinput.addEventListener("selectionchange", () => {
-  document.getElementById("start").textContent = myinput.selectionStart;
-  document.getElementById("end").textContent = myinput.selectionEnd;
-  document.getElementById("direction").textContent = myinput.selectionDirection;
+myInput.addEventListener("selectionchange", () => {
+  document.getElementById("start").textContent = myInput.selectionStart;
+  document.getElementById("end").textContent = myInput.selectionEnd;
+  document.getElementById("direction").textContent = myInput.selectionDirection;
 });
 ```
 

--- a/files/en-us/web/api/htmlinputelement/value/index.md
+++ b/files/en-us/web/api/htmlinputelement/value/index.md
@@ -27,9 +27,9 @@ In this example, the log displays the current value as the user enters data into
 We include an {{htmlelement("input")}} and an associated {{htmlelement("label")}}, with a {{htmlelement("pre")}} container for our output.
 
 ```html
-<label for="givenname">Your name:</label>
+<label for="given-name">Your name:</label>
 
-<input name="givenname" id="givenname" />
+<input name="given-name" id="given-name" />
 
 <pre id="log"></pre>
 ```
@@ -40,7 +40,7 @@ The `<pre>` element's {{domxref("HTMLElement.innerText", "innerText")}} is updat
 
 ```js
 const logElement = document.getElementById("log");
-const inputElement = document.getElementById("givenname");
+const inputElement = document.getElementById("given-name");
 
 inputElement.addEventListener("keyup", () => {
   logElement.innerText = `Name: ${inputElement.value}`;

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -77,14 +77,14 @@ within the selected directory hierarchies is generated and displayed.
 ### HTML
 
 ```html
-<input type="file" id="filepicker" name="fileList" webkitdirectory multiple />
+<input type="file" id="file-picker" name="fileList" webkitdirectory multiple />
 <ul id="listing"></ul>
 ```
 
 ### JavaScript
 
 ```js
-document.getElementById("filepicker").addEventListener(
+document.getElementById("file-picker").addEventListener(
   "change",
   (event) => {
     let output = document.getElementById("listing");

--- a/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
@@ -44,7 +44,7 @@ degrading performance.
 
 ```js
 const preloadLink = document.createElement("link");
-preloadLink.href = "myimage.jpg";
+preloadLink.href = "my-image.jpg";
 preloadLink.rel = "preload";
 preloadLink.as = "image";
 preloadLink.fetchPriority = "high";

--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -82,7 +82,7 @@ handle blocked automatic playback:
 
 ```js
 let videoElem = document.getElementById("video");
-let playButton = document.getElementById("playbutton");
+let playButton = document.getElementById("play-button");
 
 playButton.addEventListener("click", handlePlayButton, false);
 playVideo();

--- a/files/en-us/web/api/htmltablecellelement/abbr/index.md
+++ b/files/en-us/web/api/htmltablecellelement/abbr/index.md
@@ -14,7 +14,7 @@ indicates an abbreviation associated with the cell. If the cell does not represe
 It reflects the `abbr` attribute of the {{HTMLElement("th")}} element.
 
 > [!NOTE]
-> This property doesn't have a visual effect in browsers. It adds information to help assistive technology like screenreaders that can use this abbreviation
+> This property doesn't have a visual effect in browsers. It adds information to help assistive technology like screen readers that can use this abbreviation
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/scope/index.md
+++ b/files/en-us/web/api/htmltablecellelement/scope/index.md
@@ -14,7 +14,7 @@ indicates the scope of a {{HTMLElement("th")}} cell.
 Header cells can be configured, using the `scope` attribute, to apply to a specified row or column, or to the not-yet-scoped cells within the current row group (that is, the same ancestor {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, or {{HTMLElement("tfoot")}} element). If no value is specified for `scope`, the header is not associated directly with cells in this way. Permitted values for `scope` are:
 
 > [!NOTE]
-> This property doesn't have a visual effect in browsers. It adds semantic information to help assistive technology like screenreaders to present the table in a more coherent way.
+> This property doesn't have a visual effect in browsers. It adds semantic information to help assistive technology like screen readers to present the table in a more coherent way.
 
 ## Value
 

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -36,8 +36,8 @@ None.
 ## Examples
 
 ```js
-let mybody = mytable.createTBody();
-// Now this should be true: mybody === mytable.tBodies.item(mytable.tBodies.length - 1)
+let myBody = myTable.createTBody();
+// Now this should be true: myBody === myTable.tBodies.item(myTable.tBodies.length - 1)
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -36,8 +36,8 @@ None.
 ## Examples
 
 ```js
-let myfoot = mytable.createTFoot();
-// Now this should be true: myfoot === mytable.tFoot
+let myFoot = myTable.createTFoot();
+// Now this should be true: myFoot === myTable.tFoot
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -36,8 +36,8 @@ None.
 ## Examples
 
 ```js
-let myhead = mytable.createTHead();
-// Now this should be true: myhead === mytable.tHead
+let myHead = myTable.createTHead();
+// Now this should be true: myHead === myTable.tHead
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmltableelement/rows/index.md
+++ b/files/en-us/web/api/htmltableelement/rows/index.md
@@ -27,9 +27,9 @@ without having to manually search for them.
 ## Examples
 
 ```js
-myrows = mytable.rows;
-firstRow = mytable.rows[0];
-lastRow = mytable.rows.item(mytable.rows.length - 1);
+myRows = myTable.rows;
+firstRow = myTable.rows[0];
+lastRow = myTable.rows.item(myTable.rows.length - 1);
 ```
 
 This demonstrates how you can use both indexed access and the

--- a/files/en-us/web/api/htmltableelement/tbodies/index.md
+++ b/files/en-us/web/api/htmltableelement/tbodies/index.md
@@ -37,7 +37,7 @@ A live {{domxref("HTMLCollection")}}.
 This snippet gets the number of bodies in a table.
 
 ```js
-mytable.tBodies.length;
+myTable.tBodies.length;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmltableelement/width/index.md
+++ b/files/en-us/web/api/htmltableelement/width/index.md
@@ -20,7 +20,7 @@ A string representing the width in number of pixels or as a percentage value.
 ## Examples
 
 ```js
-mytable.width = "75%";
+myTable.width = "75%";
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmltextareaelement/index.md
+++ b/files/en-us/web/api/htmltextareaelement/index.md
@@ -111,7 +111,7 @@ function autoGrow(field) {
 #### CSS
 
 ```css
-textarea.noscrollbars {
+textarea.no-scrollbars {
   overflow: hidden;
   width: 300px;
   height: 100px;
@@ -124,7 +124,7 @@ textarea.noscrollbars {
 <form>
   <fieldset>
     <legend>Your comments</legend>
-    <p><textarea class="noscrollbars" onkeyup="autoGrow(this);"></textarea></p>
+    <p><textarea class="no-scrollbars" onkeyup="autoGrow(this);"></textarea></p>
     <p><input type="submit" value="Send" /></p>
   </fieldset>
 </form>

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.md
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.md
@@ -42,7 +42,7 @@ The example below shows how to get the text selected in an {{HTMLElement("textar
 ```html
 <div>
   Enter and select text here:<br /><textarea
-    id="mytext"
+    id="my-text"
     rows="2"
     cols="20"></textarea>
 </div>
@@ -54,12 +54,12 @@ The example below shows how to get the text selected in an {{HTMLElement("textar
 ### JavaScript
 
 ```js
-const myinput = document.getElementById("mytext");
+const myInput = document.getElementById("my-text");
 
-myinput.addEventListener("selectionchange", () => {
-  document.getElementById("start").textContent = myinput.selectionStart;
-  document.getElementById("end").textContent = myinput.selectionEnd;
-  document.getElementById("direction").textContent = myinput.selectionDirection;
+myInput.addEventListener("selectionchange", () => {
+  document.getElementById("start").textContent = myInput.selectionStart;
+  document.getElementById("end").textContent = myInput.selectionEnd;
+  document.getElementById("direction").textContent = myInput.selectionDirection;
 });
 ```
 

--- a/files/en-us/web/api/htmltrackelement/cuechange_event/index.md
+++ b/files/en-us/web/api/htmltrackelement/cuechange_event/index.md
@@ -31,7 +31,7 @@ The underlying {{domxref("TextTrack")}}, indicated by the {{domxref("HTMLTrackEl
 If the track _is_ associated with a media element, using the {{HTMLElement("track")}} element as a child of the {{HTMLElement("audio")}} or {{HTMLElement("video")}} element, the `cuechange` event is also sent to the {{domxref("HTMLTrackElement")}}.
 
 ```js
-let textTrackElem = document.getElementById("texttrack");
+let textTrackElem = document.getElementById("text-track");
 
 textTrackElem.addEventListener("cuechange", (event) => {
   let cues = event.target.track.activeCues;
@@ -41,7 +41,7 @@ textTrackElem.addEventListener("cuechange", (event) => {
 Alternatively, you can use the `oncuechange` event handler:
 
 ```js
-let textTrackElem = document.getElementById("texttrack");
+let textTrackElem = document.getElementById("text-track");
 
 textTrackElem.oncuechange = (event) => {
   let cues = event.target.track.activeCues;

--- a/files/en-us/web/api/namednodemap/getnameditem/index.md
+++ b/files/en-us/web/api/namednodemap/getnameditem/index.md
@@ -41,7 +41,7 @@ const pre = document.querySelector("pre");
 const attrMap = pre.attributes;
 const value = attrMap.getNamedItem("test").value;
 pre.textContent = `The 'test' attribute contains ${value}.
-And 'boum' has ${attrMap["boum"] ? "been" : "not been"} found.`;
+And 'foo' has ${attrMap["foo"] ? "been" : "not been"} found.`;
 ```
 
 {{EmbedLiveSample("Example", "100%", 80)}}

--- a/files/en-us/web/api/navigator/activevrdisplays/index.md
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Navigator.activeVRDisplays
 The **`activeVRDisplays`** read-only property of the
 {{domxref("Navigator")}} interface returns an array containing every
 {{domxref("VRDisplay")}} object that is currently presenting
-({{domxref("VRDisplay.ispresenting")}} is `true`).
+({{domxref("VRDisplay.isPresenting")}} is `true`).
 
 > [!NOTE]
 > This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).

--- a/files/en-us/web/api/navigator/clipboard/index.md
+++ b/files/en-us/web/api/navigator/clipboard/index.md
@@ -24,14 +24,14 @@ The following code uses `navigator.clipboard` to access the system clipboard in 
 navigator.clipboard
   .readText()
   .then(
-    (clipText) => (document.querySelector(".cliptext").innerText = clipText),
+    (clipText) => (document.querySelector(".clip-text").innerText = clipText),
   );
 ```
 
-This snippet replaces the contents of the element whose class is `"cliptext"` with the text contents of the clipboard.
+This snippet replaces the contents of the element whose class is `"clip-text"` with the text contents of the clipboard.
 Perhaps this code is being used in a browser extension that displays the current clipboard contents, automatically updating periodically or when specific events fire.
 
-If the clipboard is empty or doesn't contain text, the `"cliptext"` element's contents are cleared.
+If the clipboard is empty or doesn't contain text, the `"clip-text"` element's contents are cleared.
 This happens because {{domxref("Clipboard.readText", "readText()")}} returns an empty string if the clipboard is empty or doesn't contain text.
 
 ## Specifications

--- a/files/en-us/web/api/navigator/hardwareconcurrency/index.md
+++ b/files/en-us/web/api/navigator/hardwareconcurrency/index.md
@@ -40,7 +40,7 @@ let workerList = [];
 
 for (let i = 0; i < window.navigator.hardwareConcurrency; i++) {
   let newWorker = {
-    worker: new Worker("cpuworker.js"),
+    worker: new Worker("cpu-worker.js"),
     inUse: false,
   };
   workerList.push(newWorker);

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -106,7 +106,7 @@ _Doesn't inherit any properties._
 ### Deprecated properties
 
 - {{domxref("Navigator.activeVRDisplays")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
-  - : Returns an array containing every {{domxref("VRDisplay")}} object that is currently presenting ({{domxref("VRDisplay.ispresenting")}} is `true`).
+  - : Returns an array containing every {{domxref("VRDisplay")}} object that is currently presenting ({{domxref("VRDisplay.isPresenting")}} is `true`).
 - {{domxref("Navigator.appCodeName")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : Always returns `'Mozilla'`, in any browser.
 - {{domxref("Navigator.appName")}} {{ReadOnlyInline}} {{Deprecated_Inline}}

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -26,7 +26,7 @@ requestMediaKeySystemAccess(keySystem, supportedConfigurations)
 
 - `keySystem`
   - : A string identifying the key system.
-    For example `com.example.somesystem` or `org.w3.clearkey`.
+    For example `com.example.some-system` or `org.w3.clearkey`.
 - `supportedConfigurations`
 
   - : A non-empty {{jsxref('Array')}} of objects conforming to the object returned by {{domxref("MediaKeySystemAccess.getConfiguration")}}.

--- a/files/en-us/web/api/ndefreader/write/index.md
+++ b/files/en-us/web/api/ndefreader/write/index.md
@@ -133,14 +133,14 @@ ndef.onreading = (event) => console.log("We read a tag!");
 
 function write(data, { timeout } = {}) {
   return new Promise((resolve, reject) => {
-    const ctlr = new AbortController();
-    ctlr.signal.onabort = () => reject("Time is up, bailing out!");
-    setTimeout(() => ctlr.abort(), timeout);
+    const controller = new AbortController();
+    controller.signal.onabort = () => reject("Time is up, bailing out!");
+    setTimeout(() => controller.abort(), timeout);
 
     ndef.addEventListener(
       "reading",
       (event) => {
-        ndef.write(data, { signal: ctlr.signal }).then(resolve, reject);
+        ndef.write(data, { signal: controller.signal }).then(resolve, reject);
       },
       { once: true },
     );

--- a/files/en-us/web/api/ndefreadingevent/message/index.md
+++ b/files/en-us/web/api/ndefreadingevent/message/index.md
@@ -25,17 +25,17 @@ const ndefReader = new NDEFReader();
 
 function read() {
   return new Promise((resolve, reject) => {
-    const ctlr = new AbortController();
-    ctlr.signal.onabort = reject;
+    const controller = new AbortController();
+    controller.signal.onabort = reject;
     ndefReader.addEventListener(
       "reading",
       (event) => {
-        ctlr.abort();
+        controller.abort();
         resolve(event);
       },
       { once: true },
     );
-    ndefReader.scan({ signal: ctlr.signal }).catch((err) => reject(err));
+    ndefReader.scan({ signal: controller.signal }).catch((err) => reject(err));
   });
 }
 

--- a/files/en-us/web/api/ndefreadingevent/serialnumber/index.md
+++ b/files/en-us/web/api/ndefreadingevent/serialnumber/index.md
@@ -25,17 +25,17 @@ const ndefReader = new NDEFReader();
 
 function read() {
   return new Promise((resolve, reject) => {
-    const ctlr = new AbortController();
-    ctlr.signal.onabort = reject;
+    const controller = new AbortController();
+    controller.signal.onabort = reject;
     ndefReader.addEventListener(
       "reading",
       (event) => {
-        ctlr.abort();
+        controller.abort();
         resolve(event);
       },
       { once: true },
     );
-    ndefReader.scan({ signal: ctlr.signal }).catch((err) => reject(err));
+    ndefReader.scan({ signal: controller.signal }).catch((err) => reject(err));
   });
 }
 

--- a/files/en-us/web/api/node/childnodes/index.md
+++ b/files/en-us/web/api/node/childnodes/index.md
@@ -47,11 +47,11 @@ A live {{domxref("NodeList")}} containing the children of the node.
 ### Simple usage
 
 ```js
-// Note that parg is an object reference to a <p> element
+// Note that para is an object reference to a <p> element
 
 // First check that the element has child nodes
-if (parg.hasChildNodes()) {
-  let children = parg.childNodes;
+if (para.hasChildNodes()) {
+  let children = para.childNodes;
 
   for (const node of children) {
     // Do something with each child as children[i]

--- a/files/en-us/web/api/node/nodename/index.md
+++ b/files/en-us/web/api/node/nodename/index.md
@@ -28,7 +28,7 @@ A string. Values for the different types of nodes are:
   - : The value of {{domxref("DocumentType.name")}}
 - {{domxref("Element")}}
   - : The value of {{domxref("Element.tagName")}}, that is the _uppercase_ name of the element tag if an HTML element,
-    or the _lowercase_ element tag if an XML element (like a SVG or MATHML element).
+    or the _lowercase_ element tag if an XML element (like a SVG or MathML element).
 - {{domxref("ProcessingInstruction")}}
   - : The value of {{domxref("ProcessingInstruction.target")}}
 - {{domxref("Text")}}

--- a/files/en-us/web/api/oes_standard_derivatives/index.md
+++ b/files/en-us/web/api/oes_standard_derivatives/index.md
@@ -49,11 +49,11 @@ Shader code that avoids artifacts when wrapping texture coordinates:
   #extension GL_OES_standard_derivatives : enable
 
   uniform sampler2D myTexture;
-  varying vec2 texcoord;
+  varying vec2 texCoord;
 
   void main(){
-    gl_FragColor = texture2DGradEXT(myTexture, mod(texcoord, vec2(0.1, 0.5)),
-                                    dFdx(texcoord), dFdy(texcoord));
+    gl_FragColor = texture2DGradEXT(myTexture, mod(texCoord, vec2(0.1, 0.5)),
+                                    dFdx(texCoord), dFdy(texCoord));
   }
 </script>
 ```

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -91,11 +91,11 @@ The `main.js` script (main thread) may look like this:
 const htmlCanvas = document.getElementById("canvas");
 const offscreen = htmlCanvas.transferControlToOffscreen();
 
-const worker = new Worker("offscreencanvas.js");
+const worker = new Worker("offscreen-canvas.js");
 worker.postMessage({ canvas: offscreen }, [offscreen]);
 ```
 
-While the `offscreencanvas.js` script (worker thread) can look like this:
+While the `offscreen-canvas.js` script (worker thread) can look like this:
 
 ```js
 onmessage = (evt) => {


### PR DESCRIPTION
I am fixing a lot of nits in content. The goal is to make our custom dictionaries as small as possible by eliminating things that could be better recognized as words. This not only helps with automation but helps with human readers too, especially those who may be slow to recognize words.

- About half of them are code not properly capitalized.
- There are some real typos.
- Occasionally I have to refactor the wording a bit.
- Where we are demonstrating real typos, I use inline `cSpell:ignore` to prevent it being ignored in other files.