### PR TITLE
FF132 Add webgl2rendering unpackColorSpace

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/drawingbuffercolorspace/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawingbuffercolorspace/index.md
@@ -1,0 +1,46 @@
+---
+title: "WebGL2RenderingContext: drawingBufferColorSpace property"
+short-title: drawingBufferColorSpace
+slug: Web/API/WebGL2RenderingContext/drawingBufferColorSpace
+page-type: web-api-instance-property
+browser-compat: api.WebGL2RenderingContext.drawingBufferColorSpace
+---
+
+{{APIRef("WebGL")}}{{AvailableInWorkers}}
+
+The **`WebGL2RenderingContext.drawingBufferColorSpace`** property specifies the color space of the WebGL drawing buffer. Along with the default (`srgb`), the `display-p3` color space can be used.
+
+See [`WebGL2RenderingContext.unpackColorSpace`](/en-US/docs/Web/API/WebGL2RenderingContext/unpackColorSpace) for specifying the color space for textures.
+
+## Value
+
+This property can have the following values:
+
+- `"srgb"` selects the [sRGB color space](https://en.wikipedia.org/wiki/SRGB). This is the default value.
+- `"display-p3"` selects the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+
+If an invalid value is specified, then the value of `drawingBufferColorSpace` will remain unchanged.
+
+## Examples
+
+### Setting the drawing buffer color space to draw a Display P3 red
+
+```js
+const canvas = document.getElementById("canvas");
+const gl = canvas.getContext("webgl");
+gl.drawingBufferColorSpace = "display-p3";
+gl.clearColor(1, 0, 0, 1);
+gl.clear(gl.COLOR_BUFFER_BIT);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`WebGL2RenderingContext.unpackColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/unpackColorSpace)

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -94,6 +94,13 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 - {{domxref("WebGL2RenderingContext.vertexAttribIPointer()")}}
   - : Specifies integer data formats and locations of vertex attributes in a vertex attributes array.
 
+## Color spaces
+
+- {{domxref("WebGL2RenderingContext.drawingBufferColorSpace")}}
+  - : Specifies the color space of the WebGL drawing buffer.
+- {{domxref("WebGL2RenderingContext.unpackColorSpace")}}
+  - : Specifies the color space to convert to when importing textures.
+
 ## Drawing buffers
 
 - {{domxref("WebGL2RenderingContext.vertexAttribDivisor()")}}

--- a/files/en-us/web/api/webgl2renderingcontext/unpackcolorspace/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/unpackcolorspace/index.md
@@ -1,16 +1,16 @@
 ---
-title: "WebGLRenderingContext: unpackColorSpace property"
+title: "WebGL2RenderingContext: unpackColorSpace property"
 short-title: unpackColorSpace
-slug: Web/API/WebGLRenderingContext/unpackColorSpace
+slug: Web/API/WebGL2RenderingContext/unpackColorSpace
 page-type: web-api-instance-property
 status:
   - experimental
-browser-compat: api.WebGLRenderingContext.unpackColorSpace
+browser-compat: api.WebGL2RenderingContext.unpackColorSpace
 ---
 
 {{APIRef("WebGL")}}{{SeeCompatTable}}{{AvailableInWorkers}}
 
-The **`WebGLRenderingContext.unpackColorSpace`** property specifies the color space to convert to when importing textures. Along with the default (`srgb`), the `display-p3` color space can be used.
+The **`WebGL2RenderingContext.unpackColorSpace`** property specifies the color space to convert to when importing textures. Along with the default (`srgb`), the `display-p3` color space can be used.
 
 Texture image sources can be the following:
 
@@ -22,7 +22,7 @@ Texture image sources can be the following:
 - [`OffscreenCanvas`](/en-US/docs/Web/API/OffscreenCanvas)
 - [`VideoFrame`](/en-US/docs/Web/API/VideoFrame)
 
-Textures are imported using the [`WebGL2RenderingContext.texImage2D()`](/en-US/docs/Web/API/WebGLRenderingContext/texImage2D) and [`WebGL2RenderingContext.texSubImage2D()`](/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D) methods and conversion to the specified `unpackColorSpace` color space happens during import.
+Textures are imported using the [`WebGL2RenderingContext.texImage2D()`](/en-US/docs/Web/API/WebGL2RenderingContext/texImage2D) and [`WebGL2RenderingContext.texSubImage2D()`](/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage2D) methods and conversion to the specified `unpackColorSpace` color space happens during import.
 
 Note that this doesn't apply to [`HTMLImageElement`](/en-US/docs/Web/API/HTMLImageElement) when the `UNPACK_COLORSPACE_CONVERSION_WEBGL` pixel storage parameter is set to `NONE`.
 
@@ -75,4 +75,4 @@ gl.texImage2D(
 
 ## See also
 
-- [`WebGLRenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGLRenderingContext/drawingBufferColorSpace)
+- [`WebGL2RenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGL2RenderingContext/drawingBufferColorSpace)


### PR DESCRIPTION
FF123 adds support for gl.unpackColorSpace and `drawingBufferColorSpace()`. This copies the docs from the `WebGLRenderingContext` to `WebGL2RenderingContext`.

Note that the docs story in WebGL is a bit confusing. `WebGL2RenderingContext` is built on top of `WebGLRenderingContext` and includes everything it has plus some additions (new stuff and new additions to the old stuff). But for docs mostly the second version does not duplicate the original - but there are some exceptions. I think we should duplicate everything because it makes things more sane and the sidebar makes more sense.

Anyway, given that there was some duplication I chose to copy these two as well.

This is part of #36112