### PR TITLE
Add HEVC for VideoDecoder/VideoEncoder

### DIFF
--- a/files/en-us/web/api/videodecoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/videodecoder/isconfigsupported_static/index.md
@@ -41,7 +41,13 @@ The following example tests if the browser supports accelerated and un-accelerat
 versions of several video codecs.
 
 ```js
-const codecs = ["avc1.42001E", "vp8", "vp09.00.10.08", "av01.0.04M.08"];
+const codecs = [
+  "avc1.42001E",
+  "hvc1.1.6.L123.00",
+  "vp8",
+  "vp09.00.10.08",
+  "av01.0.04M.08",
+];
 const accelerations = ["prefer-hardware", "prefer-software"];
 
 const configs = [];

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -38,6 +38,10 @@ encode(frame, options)
       - : Encode options for the [AVC (H.264)](/en-US/docs/Web/Media/Formats/Video_codecs#avc_h.264) codec.
         - `quantizer`
           - : Frame quantizer value 0 to 51. Only effective if {{domxref("VideoEncoder")}} was configured with `quantizer` bitrate mode.
+    - `hevc` {{optional_inline}}
+      - : Encode options for the [HEVC (H.265)](/en-US/docs/Web/Media/Formats/Video_codecs#hevc_h.265) codec.
+        - `quantizer`
+          - : Frame quantizer value 0 to 51. Only effective if {{domxref("VideoEncoder")}} was configured with `quantizer` bitrate mode.
 
 ### Return value
 
@@ -81,6 +85,8 @@ if (codec.includes("vp09")) {
   encodeOptions.av1 = { quantizer: qp };
 } else if (codec.includes("avc")) {
   encodeOptions.avc = { quantizer: qp };
+} else if (codec.includes("hvc1" || codec.includes("hev1"))) {
+  encodeOptions.hevc = { quantizer: qp };
 }
 
 encoder.encode(frame, encodeOptions);

--- a/files/en-us/web/api/videoencoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported_static/index.md
@@ -41,7 +41,13 @@ The following example tests if the browser supports accelerated and un-accelerat
 versions of several video codecs.
 
 ```js
-const codecs = ["avc1.42001E", "vp8", "vp09.00.10.08", "av01.0.04M.08"];
+const codecs = [
+  "avc1.420034",
+  "hvc1.1.6.L123.00",
+  "vp8",
+  "vp09.00.10.08",
+  "av01.0.04M.08",
+];
 const accelerations = ["prefer-hardware", "prefer-software"];
 
 const configs = [];


### PR DESCRIPTION
HEVC WebCodecs encoding support has been enabled by default since Chrome 130
(https://chromium-review.googlesource.com/c/chromium/src/+/5827845).

Safari/WebKit also already supported HEVC WebCodecs API last year, so add the document for HEVC.
