### PR TITLE
Update ReadableStream

### DIFF
--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -172,6 +172,7 @@ An object defining a body for the response can be `null` (which is the default v
     - {{domxref("URLSearchParams")}}
     - {{jsxref("String")}}
     - `string` literal
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -148,8 +148,8 @@ const stream = new ReadableStream({
 A useful way to construct a `ReadableStream` from a variety of input types is to use the body property of a {{domxref("Response.Response","Response")}} object
 
 ```js
-function newReadableStream(content){
-    return new Response(content).body;
+function newReadableStream(content) {
+  return new Response(content).body;
 }
 
 const newStream = newReadableStream("Hello World");

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -161,7 +161,6 @@ for await (const chunk of newStream) {
 }
 ```
 
-
 An object defining a body for the response can be `null` (which is the default value), or one of {{domxref("Blob")}}, {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, {{jsxref("DataView")}}, {{domxref("FormData")}}, {{domxref("ReadableStream")}}, {{domxref("URLSearchParams")}}, {{jsxref("String")}}, or `string` literal.
 
 ## Specifications

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -145,6 +145,32 @@ const stream = new ReadableStream({
 });
 ```
 
+A useful way to construct a `ReadableStream` from a variety of input types is to use the body property of a {{domxref("Response.Response","Response")}} object
+
+```js
+function newReadableStream(content){
+    return new Response(content).body;
+}
+
+const newStream = newReadableStream("Hello World");
+
+const decoder = new TextDecoder();
+
+for await (const chunk of newStream) {
+  console.log(decoder.decode(chunk)); //Hello World
+}
+```
+An object defining a body for the response can be `null` (which is the default value), or one of:
+
+    - {{domxref("Blob")}}
+    - {{jsxref("ArrayBuffer")}}
+    - {{jsxref("TypedArray")}}
+    - {{jsxref("DataView")}}
+    - {{domxref("FormData")}}
+    - {{domxref("ReadableStream")}}
+    - {{domxref("URLSearchParams")}}
+    - {{jsxref("String")}}
+    - `string` literal
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -160,6 +160,7 @@ for await (const chunk of newStream) {
   console.log(decoder.decode(chunk)); //Hello World
 }
 ```
+
 An object defining a body for the response can be `null` (which is the default value), or one of:
 
     - {{domxref("Blob")}}

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -161,17 +161,8 @@ for await (const chunk of newStream) {
 }
 ```
 
-An object defining a body for the response can be `null` (which is the default value), or one of:
 
-    - {{domxref("Blob")}}
-    - {{jsxref("ArrayBuffer")}}
-    - {{jsxref("TypedArray")}}
-    - {{jsxref("DataView")}}
-    - {{domxref("FormData")}}
-    - {{domxref("ReadableStream")}}
-    - {{domxref("URLSearchParams")}}
-    - {{jsxref("String")}}
-    - `string` literal
+An object defining a body for the response can be `null` (which is the default value), or one of {{domxref("Blob")}}, {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, {{jsxref("DataView")}}, {{domxref("FormData")}}, {{domxref("ReadableStream")}}, {{domxref("URLSearchParams")}}, {{jsxref("String")}}, or `string` literal.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Added example for constructing a ReadableStream using Response object

### Motivation

This a simple and concise way to construct a ReadableStream from a variety of sources. I find that it is easier to use than the actual constructor and, in my experience, most ReadableStream objects that you interact with are made this way.

### Additional details

Already added at the bottom of the page [here](https://developer.typescripts.org/en-US/docs/Web/API/ReadableStream/ReadableStream).
