### PR TITLE
Followup to PR 36256: clarify clarification about click events

### DIFF
--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -12,7 +12,7 @@ An element receives a **`click`** event when any of the following occurs:
 
 - A pointing-device button (such as a mouse's primary button) is both pressed and released while the pointer is located inside the element.
 - A touch gesture is performed on the element.
-- Any user interaction that is equivalent to a click occurs, such as pressing the <kbd>Space</kbd> key or <kbd>Enter</kbd> key while the element is focused. Note that this only applies for elements with a default key event handler, and therefore excludes other elements that have been made focusable by setting the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
+- Any user interaction that is equivalent to a click, such as pressing the <kbd>Space</kbd> key or <kbd>Enter</kbd> key while the element is focused. Note that this only applies to elements with a default key event handler, and therefore, excludes other elements that have been made focusable by setting the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 
 If the button is pressed on one element and the pointer is moved outside the element before the button is released, the event is fired on the most specific ancestor element that contained both elements.
 

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -12,10 +12,7 @@ An element receives a **`click`** event when any of the following occurs:
 
 - A pointing-device button (such as a mouse's primary button) is both pressed and released while the pointer is located inside the element.
 - A touch gesture is performed on the element.
-- Any user interaction that is equivalent to a click occurs, such as pressing the <kbd>Space</kbd> key or <kbd>Enter</kbd> key while the element is focused.
-
-> [!NOTE]
-> In practice, browsers don't fire the `click` event for custom controls (such as a `<div>` with `tabindex="0"`) when activated by keyboard. To check the reason behind this behavior, see this [Chromium issue](https://crbug.com/40776466).
+- Any user interaction that is equivalent to a click occurs, such as pressing the <kbd>Space</kbd> key or <kbd>Enter</kbd> key while the element is focused. Note that this only applies for elements with a default key event handler, and therefore excludes other elements that have been made focusable by setting the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 
 If the button is pressed on one element and the pointer is moved outside the element before the button is released, the event is fired on the most specific ancestor element that contained both elements.
 


### PR DESCRIPTION
Updates to the change made in https://github.com/mdn/content/pull/36256, per https://github.com/mdn/content/pull/36256#issuecomment-2400513490.

- de-notify so the qualification is more obviously attached to the bullet
- describe the qualification as if it is standard