### PR TITLE
feat: handle paste event in contenteditable element with HTML and plain text fallback

### DIFF
--- a/files/en-us/web/api/inputevent/datatransfer/index.md
+++ b/files/en-us/web/api/inputevent/datatransfer/index.md
@@ -48,8 +48,16 @@ Try copying and pasting some of the content provided to see the effects.
 const editable = document.querySelector("p[contenteditable]");
 const result = document.querySelector(".result");
 
-editable.addEventListener("input", (e) => {
-  result.textContent = e.dataTransfer.getData("text/html");
+editable.addEventListener("paste", (e) => {
+  e.preventDefault();
+
+  let pastedContent = e.clipboardData.getData("text/html");
+
+  if (!pastedContent) {
+    pastedContent = e.clipboardData.getData("text/plain");
+  }
+
+  result.textContent = pastedContent;
 });
 ```
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

- Added `paste` event listener to the `contenteditable` paragraph
- Prevent default paste behavior to handle pasted content manually
- Retrieve pasted content as HTML, and fallback to plain text if no HTML is available
- Display the pasted content in a separate result div

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The changes enhance the behavior of the `contenteditable` element when handling pasted content. By preventing the default paste action and manually handling the content, we ensure that both HTML and plain text are processed correctly. This allows better control over pasted data, providing a more predictable experience for users and developers working with editable content.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

This change improves the handling of clipboard events, addressing cases where pasted content (HTML or plain text) is not handled correctly by default.

### Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #36276, where pasted content inside a `contenteditable` div was not handled correctly due to the improper use of the `dataTransfer` object.