### PR TITLE
Exclude the upper bound of range

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -134,7 +134,10 @@ Array.from({ length: 5 }, (v, i) => i);
 ```js
 // Sequence generator function (commonly referred to as "range", e.g. Python, Clojure, etc.)
 const range = (start, stop, step) =>
-  Array.from({ length: Math.ceil((stop - start) / step - 1) + 1 }, (_, i) => start + i * step);
+  Array.from(
+    { length: Math.ceil((stop - start) / step - 1) + 1 },
+    (_, i) => start + i * step,
+  );
 
 // Generate numbers from 0 (inclusive) to 4 (exclusive) with step 1
 range(0, 5, 1);

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -135,7 +135,7 @@ Array.from({ length: 5 }, (v, i) => i);
 // Sequence generator function (commonly referred to as "range", e.g. Python, Clojure, etc.)
 const range = (start, stop, step) =>
   Array.from(
-    { length: Math.ceil((stop - start) / step - 1) + 1 },
+    { length: Math.ceil((stop - start) / step) },
     (_, i) => start + i * step,
   );
 

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -132,20 +132,20 @@ Array.from({ length: 5 }, (v, i) => i);
 ### Sequence generator (range)
 
 ```js
-// Sequence generator function (commonly referred to as "range", e.g. Clojure, PHP, etc.)
+// Sequence generator function (commonly referred to as "range", e.g. Python, Clojure, etc.)
 const range = (start, stop, step) =>
-  Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
+  Array.from({ length: Math.ceil((stop - start) / step - 1) + 1 }, (_, i) => start + i * step);
 
-// Generate numbers range 0..4
-range(0, 4, 1);
+// Generate numbers from 0 (inclusive) to 4 (exclusive) with step 1
+range(0, 5, 1);
 // [0, 1, 2, 3, 4]
 
-// Generate numbers range 1..10 with step of 2
+// Generate numbers from 1 (inclusive) to 10 (exclusive) with step 2
 range(1, 10, 2);
 // [1, 3, 5, 7, 9]
 
-// Generate the alphabet using Array.from making use of it being ordered as a sequence
-range("A".charCodeAt(0), "Z".charCodeAt(0), 1).map((x) =>
+// Generate the alphabet making use of it being ordered as a sequence
+range("A".charCodeAt(0), "Z".charCodeAt(0) + 1, 1).map((x) =>
   String.fromCharCode(x),
 );
 // ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]


### PR DESCRIPTION
### Description

We make the `stop` upper bound of the `range(start, stop, step)` function exclusive in the example given in the [`Array.from()` page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).

### Motivation

The built-in [Python](https://docs.python.org/3/library/stdtypes.html#range) and [Clojure](https://clojuredocs.org/clojure.core/range) `range(start, stop, step)` functions use the preferred range convention that includes the lower bound and excludes the upper bound (cf. Edsger Dijkstra’s notes [*Why Numbering Should Start at Zero*](https://stackoverflow.com/a/78958366/2326961) for the rationale). The built-in [PHP](https://www.php.net/manual/en/function.range.php) `range(start, stop, step)` function uses another range convention that includes both the lower bound and upper bound so should not be mentioned.

### Additional details

More complete [TypeScript implementations](https://stackoverflow.com/a/78957603/2326961) of `range(start, stop, step)` with the `range(stop)` overload (the first one is not lazy and the second one is lazy).