### PR TITLE
Update microtasks guide

### DIFF
--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.md
@@ -104,7 +104,7 @@ Executing this code twice in a row gives the following results.
 When the data is not cached:
 
 ```plain
-Fetching data
+Fetching data…
 Data fetched
 Loaded data
 ```
@@ -112,7 +112,7 @@ Loaded data
 When the data is cached:
 
 ```plain
-Fetching data
+Fetching data…
 Loaded data
 Data fetched
 ```


### PR DESCRIPTION
Because the console output has a minor typo and needs an ellipsis to match the sample code.
