### PR TITLE
Add Wasm return_call demo

### DIFF
--- a/files/en-us/webassembly/reference/control_flow/call/index.md
+++ b/files/en-us/webassembly/reference/control_flow/call/index.md
@@ -8,7 +8,15 @@ page-type: webassembly-instruction
 
 **`call`** calls a function, `return_call` being the tail-call version of it. `call_indirect` calls a function in a table with the `return_call_indirect` tail-call version as well.
 
+## Examples
+
+Calling the `greet` function imported from JavaScript using `call`:
+
 {{EmbedInteractiveExample("pages/wat/call.html", "tabbed-standard")}}
+
+Calculating factorial for a number using `return_call` and logging the result using the exported `fac` function:
+
+{{EmbedInteractiveExample("pages/wat/return_call.html", "tabbed-standard")}}
 
 ## Syntax
 


### PR DESCRIPTION
### Description

- Adds a new factorial demo
- Explains existing demo

### Motivation

Part of the [Firefox 121 release notes task](https://github.com/mdn/content/issues/30333) that got delayed due to the platform’s lack of support.

### Additional details

- [x] [Demos to be merged first](https://github.com/mdn/interactive-examples/pull/2693).