### PR TITLE
Change less precise 'direction' to 'axis'

### DIFF
--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -28,7 +28,7 @@ The example below demonstrates scroll snapping along the vertical axis, which is
 
 ## Using scroll-snap-type
 
-The {{CSSxRef("scroll-snap-type")}} property needs to know the axis in which scroll snapping happens. This can be `x`, `y`, or the logical mappings `block` or `inline`. You can also use the keyword `both` to have scroll snapping work along both axes.
+The {{CSSxRef("scroll-snap-type")}} property needs to know the axis along which scroll snapping happens. This can be `x`, `y`, or the logical mappings `block` or `inline`. You can also use the keyword `both` to have scroll snapping work along both axes.
 
 You can also pass in the keywords `mandatory` or `proximity`. The `mandatory` keyword tells the browser whether the content _has_ to snap to a certain point, no matter where the scroll is. The `proximity` keyword means that the content may snap to the point, but does not have to.
 

--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -28,7 +28,7 @@ The example below demonstrates scroll snapping along the vertical axis, which is
 
 ## Using scroll-snap-type
 
-The {{CSSxRef("scroll-snap-type")}} property needs to know the direction in which scroll snapping happens. This can be `x`, `y`, or the logical mappings `block` or `inline`. You can also use the keyword `both` to have scroll snapping work along both axes.
+The {{CSSxRef("scroll-snap-type")}} property needs to know the axis in which scroll snapping happens. This can be `x`, `y`, or the logical mappings `block` or `inline`. You can also use the keyword `both` to have scroll snapping work along both axes.
 
 You can also pass in the keywords `mandatory` or `proximity`. The `mandatory` keyword tells the browser whether the content _has_ to snap to a certain point, no matter where the scroll is. The `proximity` keyword means that the content may snap to the point, but does not have to.
 


### PR DESCRIPTION
`scroll-snap-type` requires an axis (x, y, etc.), not a direction (up, down, etc.). At first I thought scroll-snapping could be directionally-tuned (e.g. only for scrolling down instead of up) because of the use of 'direction' here.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed the word 'direction' to the more precise 'axis'.

### Motivation

I initially misunderstood that scroll-snapping could be set to only work in a specific scroll direction (e.g. only when scrolling down). This doesn't appear to be the case. I hope to prevent others from being similarly confused.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->