### PR TITLE
docs: updated GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-bug.yml
+++ b/.github/ISSUE_TEMPLATE/content-bug.yml
@@ -8,7 +8,7 @@ body:
         ### Before you start
 
         **Want to change a page yourself?** This content is open source!
-        ↩ Look for the _Edit on GitHub_ link on any MDN page.
+        ↩ Look for the _View this page on GitHub_ link on any MDN page to edit the content on GitHub.com afterwards.
 
         **Is your issue about a browser compatibility table?**
         ↩ Use the _Report problems with this compatibility data on GitHub_ link next to a compatibility table.

--- a/.github/ISSUE_TEMPLATE/page-report.yml
+++ b/.github/ISSUE_TEMPLATE/page-report.yml
@@ -8,7 +8,7 @@ body:
         ### Before you start
 
         **Want to change this page yourself?** This content is open source!
-        ↩ Go back and use the _Edit on GitHub_ link on the page.
+        ↩ Go back and use the _View this page on GitHub_ link on the page to edit the content on GitHub.com afterwards.
 
         **Is your issue about the browser compatibility table?**
         ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

A link with the phrase "Edit on GitHub" link doesn't seem to exist (anymore) on the MDN pages, but only "View this page on GitHub" (see e.g. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role#see_also).

### Motivation

Clarity. If a link with that text doesn't exist on MDN pages, it's not possible to search for that phrase and find it easily.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
