### PR TITLE
Editorial review: Add WebGPU canvas config options

### DIFF
--- a/files/en-us/web/api/gpucanvascontext/configure/index.md
+++ b/files/en-us/web/api/gpucanvascontext/configure/index.md
@@ -34,7 +34,19 @@ configure(configuration)
     - `device`
       - : The {{domxref("GPUDevice")}} that the rendering information for the context will come from.
     - `format`
+
       - : The format that textures returned by `getCurrentTexture()` will have. This can be `bgra8unorm`, `rgba8unorm`, or `rgba16float`. The optimal canvas texture format for the current system can be returned by {{domxref("GPU.getPreferredCanvasFormat()")}}. Using this is recommended — if you don't use the preferred format when configuring the canvas context, you may incur additional overhead, such as additional texture copies, depending on the platform.
+
+    - `toneMapping` {{optional_inline}}
+
+      - : An object specifying parameters that define the tone mapping for the context — how the content of associated textures are to be displayed. Possible properties are:
+        - `mode` {{optional_inline}}
+          - : The tone mapping mode for the canvas. Possible values include:
+            - `standard`
+              - : The default value. Restricts rendered content to the Standard Dynamic Range (SDR) of the display.
+            - `extended`
+              - : Allows content to be rendered in the full High Dynamic Range (HDR) of the display, where available. HDR mode allows a wider range of colors and brightness levels to be diplayed, with more precise instructions as to what color should be displayed in each case.
+
     - `usage` {{optional_inline}}
 
       - : {{glossary("Bitwise flags")}} specifying the allowed usage for textures returned by `getCurrentTexture()`. Possible values are:

--- a/files/en-us/web/api/gpucanvascontext/configure/index.md
+++ b/files/en-us/web/api/gpucanvascontext/configure/index.md
@@ -39,13 +39,13 @@ configure(configuration)
 
     - `toneMapping` {{optional_inline}}
 
-      - : An object specifying parameters that define the tone mapping for the context — how the content of associated textures are to be displayed. Possible properties are:
+      - : An object specifying parameters that define the tone mapping for the context — how the content of associated textures are to be displayed. This allows WebGPU to draw colors brighter than `white` (`#FFFFFF`). Possible properties are:
         - `mode` {{optional_inline}}
-          - : The tone mapping mode for the canvas. Possible values include:
+          - : An emumerated value specifying the tone mapping mode for the canvas. Possible values include:
             - `standard`
-              - : The default value. Restricts rendered content to the Standard Dynamic Range (SDR) of the display.
+              - : The default value. Restricts rendered content to the Standard Dynamic Range (SDR) of the display. This mode is accomplished by clamping all color values in the color space of the screen to the `[0, 1]` interval.
             - `extended`
-              - : Allows content to be rendered in the full High Dynamic Range (HDR) of the display, where available. HDR mode allows a wider range of colors and brightness levels to be diplayed, with more precise instructions as to what color should be displayed in each case.
+              - : Allows content to be rendered in the full High Dynamic Range (HDR) of the display, where available. HDR mode allows a wider range of colors and brightness levels to be diplayed, with more precise instructions as to what color should be displayed in each case. This mode matches `"standard"` in the `[0, 1]` range of the screen. Clamping or projection is done to the extended dynamic range of the screen but not `[0, 1]`.
 
     - `usage` {{optional_inline}}
 
@@ -68,6 +68,8 @@ None (`undefined`).
 
 ## Examples
 
+### Basic usage
+
 ```js
 const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
@@ -78,6 +80,10 @@ context.configure({
   alphaMode: "premultiplied",
 });
 ```
+
+### HDR `toneMapping` demos
+
+See the [Particles (HDR)](https://webgpu.github.io/webgpu-samples/?sample=particles) sample and [HDR support](https://ccameron-chromium.github.io/webgpu-hdr/example.html) test.
 
 ## Specifications
 

--- a/files/en-us/web/api/gpucanvascontext/getconfiguration/index.md
+++ b/files/en-us/web/api/gpucanvascontext/getconfiguration/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-An object containing the configuration options set on the context (i.e., via the {{domxref("GPUCanvasContext.configure()")}} method), or `null` if no configuration was previously set.
+An object containing the configuration options set on the context (i.e., via the {{domxref("GPUCanvasContext.configure()")}} method), or `null` if no configuration is set (either no configuration was previously set, or a configuration was set and then {{domxref("GPUCanvasContext.unconfigure()")}} was called on the context).
 
 ## Examples
 
@@ -33,42 +33,38 @@ An object containing the configuration options set on the context (i.e., via the
 const canvas = document.querySelector("canvas");
 const context = canvas.getContext("webgpu");
 
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-  if (!adapter) {
-    throw Error("Couldn't request WebGPU adapter.");
-  }
-
-  const device = await adapter.requestDevice();
-
-  context.configure({
-    device: device,
-    format: navigator.gpu.getPreferredCanvasFormat(),
-    alphaMode: "premultiplied",
-  });
-
-  console.log(context.getConfiguration());
-
-  /*
-  Logs something like:
-
-  {
-    "alphaMode": "premultiplied",
-    "colorSpace": "srgb",
-    "device": { ... },
-    "format": "bgra8unorm",
-    "toneMapping": {
-        "mode": "standard"
-    },
-    "usage": 16,
-    "viewFormats": []
-  }
-  */
+if (!navigator.gpu) {
+  throw Error("WebGPU not supported.");
 }
+
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
+}
+
+const device = await adapter.requestDevice();
+
+context.configure({
+  device: device,
+  format: navigator.gpu.getPreferredCanvasFormat(),
+  alphaMode: "premultiplied",
+});
+
+console.log(context.getConfiguration());
+/* Logs something like:
+
+{
+  "alphaMode": "premultiplied",
+  "colorSpace": "srgb",
+  "device": { ... },
+  "format": "bgra8unorm",
+  "toneMapping": {
+      "mode": "standard"
+  },
+  "usage": 16,
+  "viewFormats": []
+}
+*/
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpucanvascontext/getconfiguration/index.md
+++ b/files/en-us/web/api/gpucanvascontext/getconfiguration/index.md
@@ -1,0 +1,85 @@
+---
+title: "GPUCanvasContext: getConfiguration() method"
+short-title: getConfiguration()
+slug: Web/API/GPUCanvasContext/getConfiguration
+page-type: web-api-instance-method
+status:
+  - experimental
+browser-compat: api.GPUCanvasContext.getConfiguration
+---
+
+{{APIRef("WebGPU API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+The **`getConfiguration()`** method of the
+{{domxref("GPUCanvasContext")}} interface returns the current configuration set for the context.
+
+## Syntax
+
+```js-nolint
+getConfiguration()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+An object containing the configuration options set on the context (i.e., via the {{domxref("GPUCanvasContext.configure()")}} method), or `null` if no configuration was previously set.
+
+## Examples
+
+```js
+const canvas = document.querySelector("canvas");
+const context = canvas.getContext("webgpu");
+
+async function init() {
+  if (!navigator.gpu) {
+    throw Error("WebGPU not supported.");
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) {
+    throw Error("Couldn't request WebGPU adapter.");
+  }
+
+  const device = await adapter.requestDevice();
+
+  context.configure({
+    device: device,
+    format: navigator.gpu.getPreferredCanvasFormat(),
+    alphaMode: "premultiplied",
+  });
+
+  console.log(context.getConfiguration());
+
+  /*
+  Logs something like:
+
+  {
+    "alphaMode": "premultiplied",
+    "colorSpace": "srgb",
+    "device": { ... },
+    "format": "bgra8unorm",
+    "toneMapping": {
+        "mode": "standard"
+    },
+    "usage": 16,
+    "viewFormats": []
+  }
+  */
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("GPUCanvasContext.configure()")}}
+- The [WebGPU API](/en-US/docs/Web/API/WebGPU_API)

--- a/files/en-us/web/api/gpucanvascontext/index.md
+++ b/files/en-us/web/api/gpucanvascontext/index.md
@@ -22,6 +22,8 @@ The **`GPUCanvasContext`** interface of the {{domxref("WebGPU API", "WebGPU API"
 
 - {{domxref("GPUCanvasContext.configure", "configure()")}} {{Experimental_Inline}}
   - : Configures the context to use for rendering with a given {{domxref("GPUDevice")}} and clears the canvas to transparent black.
+- {{domxref("GPUCanvasContext.getConfiguration", "getConfiguration()")}} {{Experimental_Inline}}
+  - : Returns the current configuration set for the context.
 - {{domxref("GPUCanvasContext.getCurrentTexture", "getCurrentTexture()")}} {{Experimental_Inline}}
   - : Returns the next {{domxref("GPUTexture")}} to be composited to the document by the canvas context.
 - {{domxref("GPUCanvasContext.unconfigure", "unconfigure()")}} {{Experimental_Inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds two new [WebGPU](https://gpuweb.github.io/gpuweb) features added recently in Chrome:

- The [`GPUCanvasContext.getConfiguration()`](https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getconfiguration) method, added in Chrome 131 (see relevant [ChromeStatus](https://chromestatus.com/feature/6195110870777856) entry).
- The `GPUCanvasContext` configuration [`toneMapping`](https://gpuweb.github.io/gpuweb/#dom-gpucanvasconfiguration-tonemapping) option, added in Chrome 129 (see relevant [ChromeStatus](https://chromestatus.com/feature/6196313866895360) entry).

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
