### PR TITLE
Update MPEG-2 Licensing - remove the Philippines.

### DIFF
--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -1484,7 +1484,7 @@ However, few web browsers support MPEG-2 without the support of a plugin, and wi
     <tr>
       <th scope="row">Licensing</th>
       <td>
-        Proprietary; all patents have expired worldwide with the exception of in Malaysia (as of October 1, 2024), so MPEG-2 can be used freely outside of Malaysia
+        Proprietary; all patents have expired worldwide with the exception of in Malaysia (as of October 1, 2024), so MPEG-2 can be used freely outside of Malaysia.
         Patents are licensed by <a href="https://www.via-la.com/licensing-2/mpeg-2/">Via LA</a>.
       </td>
     </tr>

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -1459,12 +1459,7 @@ However, few web browsers support MPEG-2 without the support of a plugin, and wi
     <tr>
       <th scope="row">Container support</th>
       <td>
-        <a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>,
-        MPEG-TS (MPEG Transport Stream),
-        <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg-4_mp4">MP4</a>,
-        <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime"
-          >QuickTime</a
-        >
+        <a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>, MPEG-TS (MPEG Transport Stream), <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg-4_mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a>
       </td>
     </tr>
     <tr>
@@ -1477,27 +1472,20 @@ However, few web browsers support MPEG-2 without the support of a plugin, and wi
     <tr>
       <th scope="row">Supporting/Maintaining organization</th>
       <td>
-        <a href="https://mpeg.chiariglione.org/">MPEG</a> /
-        <a href="https://www.itu.int/">ITU</a>
+        <a href="https://mpeg.chiariglione.org/">MPEG</a> / <a href="https://www.itu.int/">ITU</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Specification</th>
       <td>
-        <a href="https://www.itu.int/rec/T-REC-H.262"
-          >https://www.itu.int/rec/T-REC-H.262</a
-        ><br /><a href="https://www.iso.org/standard/61152.html"
-          >https://www.iso.org/standard/61152.html</a
-        >
+        <a href="https://www.itu.int/rec/T-REC-H.262">https://www.itu.int/rec/T-REC-H.262</a><br /><a href="https://www.iso.org/standard/61152.html">https://www.iso.org/standard/61152.html</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Licensing</th>
       <td>
-        Proprietary; all patents have expired worldwide with the exception of in
-        Malaysia as of October 1, 2024, so MPEG-2 can be used
-        freely outside that country. Patents are licensed by
-        <a href="https://www.via-la.com/licensing-2/mpeg-2/">Via LA</a>.
+        Proprietary; all patents have expired worldwide with the exception of in Malaysia (as of October 1, 2024), so MPEG-2 can be used freely outside of Malaysia
+        Patents are licensed by <a href="https://www.via-la.com/licensing-2/mpeg-2/">Via LA</a>.
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -1495,8 +1495,8 @@ However, few web browsers support MPEG-2 without the support of a plugin, and wi
       <th scope="row">Licensing</th>
       <td>
         Proprietary; all patents have expired worldwide with the exception of in
-        Malaysia and the Philippines as of April 1, 2019, so MPEG-2 can be used
-        freely outside those two countries. Patents are licensed by
+        Malaysia as of October 1, 2024, so MPEG-2 can be used
+        freely outside that country. Patents are licensed by
         <a href="https://www.via-la.com/licensing-2/mpeg-2/">Via LA</a>.
       </td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Update the Licensing situation of MPEG-2 Part 2 Video, removing the Philippines.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The last Filipino MPEG-2 patent administered by VIA Licensing Alliance has expired back in February 13, 2020.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://www.via-la.com/licensing-2/mpeg-2/mpeg-2-patent-list/
https://www.via-la.com/wp-content/uploads/Final-October-1-2024-MPEG-2-Attachment-1.pdf

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
