### PR TITLE
Content-Security-Policy `report-to` update csp level

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -18,7 +18,7 @@ The server must separately provide the mapping between endpoint names and their 
   <tbody>
     <tr>
       <th scope="row">CSP version</th>
-      <td>1</td>
+      <td>3</td>
     </tr>
     <tr>
       <th scope="row">Directive type</th>


### PR DESCRIPTION

### Description

`report-to` is actually a directive introduced in CSP Level 3

### Motivation

The CSP level listed is incorrect

### Additional details

The following document contains this statement
https://www.w3.org/TR/CSP3/#changes-from-level-2
```
6. The report-uri directive is deprecated in favor of the new report-to directive, which relies on
   [REPORTING] as infrastructure.
 ```

Confirmed that `report-to` does not appear in CSP's past level documentation.

https://www.w3.org/TR/CSP2/
https://www.w3.org/TR/2012/CR-CSP-20121115/


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
