### PR TITLE
Fix misleading Content-Disposition filename* example

### DIFF
--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -39,8 +39,8 @@ The first parameter in the HTTP context is either `inline` (default value, indic
 ```http
 Content-Disposition: inline
 Content-Disposition: attachment
-Content-Disposition: attachment; filename="filename.jpg"
-Content-Disposition: attachment; filename*="filename.jpg"
+Content-Disposition: attachment; filename="file name.jpg"
+Content-Disposition: attachment; filename*=utf-8''file%20name.jpg
 ```
 
 The quotes around the filename are optional, but are necessary if you use special characters in the filename, such as spaces.

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -61,7 +61,7 @@ Content-Disposition: form-data; name="fieldName"
 Content-Disposition: form-data; name="fieldName"; filename="filename.jpg"
 ```
 
-### Directives
+#### Directives
 
 - `name`
 

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -40,7 +40,7 @@ The first parameter in the HTTP context is either `inline` (default value, indic
 Content-Disposition: inline
 Content-Disposition: attachment
 Content-Disposition: attachment; filename="file name.jpg"
-Content-Disposition: attachment; filename*=utf-8''file%20name.jpg
+Content-Disposition: attachment; filename*=UTF-8''file%20name.jpg
 ```
 
 The quotes around the filename are optional, but are necessary if you use special characters in the filename, such as spaces.

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -45,7 +45,9 @@ Content-Disposition: attachment; filename*=UTF-8''file%20name.jpg
 
 The quotes around the filename are optional, but are necessary if you use special characters in the filename, such as spaces.
 
-The parameters `filename` and `filename*` differ only in that `filename*` uses the encoding defined in [RFC 5987](https://datatracker.ietf.org/doc/html/rfc5987). When both `filename` and `filename*` are present in a single header field value, `filename*` is preferred over `filename` when both are understood. It's recommended to include both for maximum compatibility, and you can convert `filename*` to `filename` by substituting non-ASCII characters with ASCII equivalents (such as converting `é` to `e`). You may want to avoid percent escape sequences in `filename`, because they are handled inconsistently across browsers. (Firefox and Chrome decode them, while Safari does not.)
+The parameters `filename` and `filename*` differ only in that `filename*` uses the encoding defined in [RFC 5987, section 3.2](hhttps://www.rfc-editor.org/rfc/rfc5987.html#section-3.2).
+When both `filename` and `filename*` are present in a single header field value, `filename*` is preferred over `filename` when both are understood. It's recommended to include both for maximum compatibility, and you can convert `filename*` to `filename` by substituting non-ASCII characters with ASCII equivalents (such as converting `é` to `e`).
+You may want to avoid percent escape sequences in `filename`, because they are handled inconsistently across browsers. (Firefox and Chrome decode them, while Safari does not.)
 
 Browsers may apply transformations to conform to the file system requirements, such as converting path separators (`/` and `\`) to underscores (`_`).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

While the text correctly states that the `filename*` encoding is specified by RFC 5987, the example does not reflect that and uses the same encoding as `filename`. While some browsers may support it, I haven't checked, this is not supported by the specification, so using it as the example is not great.

I have added a space into the example file name, to make the difference between the two encodings more apparent.

### Motivation

The example was misleading.

### Additional details

The underlying specification is in [RFC6266](https://httpwg.org/specs/rfc6266.html#rfc.section.4.1) and in [RFC5987](https://www.rfc-editor.org/rfc/rfc5987.html#section-3.2.1). These are linked from the page itself, so I am assuming that they are correct and actual.

It is possible that I have missed some detail which makes the current example up to spec, in which case it might be good to point this out on the page. But I am not aware of any such specification.

### Related issues and pull requests

The example has been added recently by #34304.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
