### PR TITLE
fix: Update <tr> page samples that are missing standard markup

### DIFF
--- a/files/en-us/web/html/element/tr/index.md
+++ b/files/en-us/web/html/element/tr/index.md
@@ -61,26 +61,28 @@ Four `<tr>` elements are used to create four table rows. Each row contains three
 
 ```html
 <table>
-  <tr>
-    <th scope="row">A</th>
-    <td>Alfa</td>
-    <td>AL fah</td>
-  </tr>
-  <tr>
-    <th scope="row">B</th>
-    <td>Bravo</td>
-    <td>BRAH voh</td>
-  </tr>
-  <tr>
-    <th scope="row">C</th>
-    <td>Charlie</td>
-    <td>CHAR lee</td>
-  </tr>
-  <tr>
-    <th scope="row">D</th>
-    <td>Delta</td>
-    <td>DELL tah</td>
-  </tr>
+  <tbody>
+    <tr>
+      <th scope="row">A</th>
+      <td>Alfa</td>
+      <td>AL fah</td>
+    </tr>
+    <tr>
+      <th scope="row">B</th>
+      <td>Bravo</td>
+      <td>BRAH voh</td>
+    </tr>
+    <tr>
+      <th scope="row">C</th>
+      <td>Charlie</td>
+      <td>CHAR lee</td>
+    </tr>
+    <tr>
+      <th scope="row">D</th>
+      <td>Delta</td>
+      <td>DELL tah</td>
+    </tr>
+  <tbody>
 </table>
 ```
 
@@ -128,31 +130,35 @@ An additional table row (`<tr>`) is added as the first row of the table with col
 
 ```html
 <table>
-  <tr>
-    <th scope="col">Symbol</th>
-    <th scope="col">Code word</th>
-    <th scope="col">Pronunciation</th>
-  </tr>
-  <tr>
-    <th scope="row">A</th>
-    <td>Alfa</td>
-    <td>AL fah</td>
-  </tr>
-  <tr>
-    <th scope="row">B</th>
-    <td>Bravo</td>
-    <td>BRAH voh</td>
-  </tr>
-  <tr>
-    <th scope="row">C</th>
-    <td>Charlie</td>
-    <td>CHAR lee</td>
-  </tr>
-  <tr>
-    <th scope="row">D</th>
-    <td>Delta</td>
-    <td>DELL tah</td>
-  </tr>
+  <thead>
+    <tr>
+      <th scope="col">Symbol</th>
+      <th scope="col">Code word</th>
+      <th scope="col">Pronunciation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">A</th>
+      <td>Alfa</td>
+      <td>AL fah</td>
+    </tr>
+    <tr>
+      <th scope="row">B</th>
+      <td>Bravo</td>
+      <td>BRAH voh</td>
+    </tr>
+    <tr>
+      <th scope="row">C</th>
+      <td>Charlie</td>
+      <td>CHAR lee</td>
+    </tr>
+    <tr>
+      <th scope="row">D</th>
+      <td>Delta</td>
+      <td>DELL tah</td>
+    </tr>
+  </tbody>
 </table>
 ```
 

--- a/files/en-us/web/html/element/tr/index.md
+++ b/files/en-us/web/html/element/tr/index.md
@@ -82,7 +82,9 @@ Four `<tr>` elements are used to create four table rows. Each row contains three
       <td>Delta</td>
       <td>DELL tah</td>
     </tr>
-  <tbody>
+  </tbody>
+
+  <tbody></tbody>
 </table>
 ```
 

--- a/files/en-us/web/html/element/tr/index.md
+++ b/files/en-us/web/html/element/tr/index.md
@@ -83,8 +83,6 @@ Four `<tr>` elements are used to create four table rows. Each row contains three
       <td>DELL tah</td>
     </tr>
   </tbody>
-
-  <tbody></tbody>
 </table>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Samples for `<tr>` should promote proper explicit markup

But even if we're going to show examples of an implicit markup, the descriptions for these samples explicitly mention grouping in the body and header

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

implicit tbody is not something we should be actively promoting to the kinds of users that need a `<tr>` page in the first place. there is _never_ a case where writing

```html
<table>
  <tr>
    <td>
    </td>
  </tr>
</table>
```

will ever be rendered that way. the browser will _always_ fix it. and newcomers are going to be the ones confused

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Relates to #33505 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
