### PR TITLE
Fix typos around commas

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -214,7 +214,7 @@ dodecahedron.position.x = 25;
 scene.add(dodecahedron);
 ```
 
-This time, we are creating a dodecahedron, a shape containing twelve flat faces. The parameter, `DodecahedronGeometry()` defines the size of the object. We're using a Lambert material, similar to Phong, but should be less glossy. Again it's black, for now. We're moving the object to the right, so it's not in the same position as the box, or torus.
+This time, we are creating a dodecahedron, a shape containing twelve flat faces. The parameter to `DodecahedronGeometry()` defines the size of the object. We're using a Lambert material, similar to Phong, but should be less glossy. Again it's black, for now. We're moving the object to the right, so it's not in the same position as the box, or torus.
 
 As mentioned above, the new objects currently just look black. To have both, the Phong and Lambert materials properly visible, we need to introduce a source of light.
 
@@ -250,7 +250,7 @@ This rotates the cube on every frame, by a tiny bit, so the animation looks smoo
 
 ### Scaling
 
-We can also scale an object. Applying a constant value, we would make it grow, or shrink just once. Let's make things more interesting. First, we implement a helper variable, called `t` for counting elapsed time. Add it right before the `render()` function:
+We can also scale an object. Applying a constant value, we would make it grow, or shrink just once. Let's make things more interesting. First, we implement a helper variable called `t` for counting elapsed time. Add it right before the `render()` function:
 
 ```js
 let t = 0;

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -214,7 +214,7 @@ dodecahedron.position.x = 25;
 scene.add(dodecahedron);
 ```
 
-This time, we are creating a dodecahedron, a shape containing twelve flat faces. The parameter, `DodecahedronGeometry(),` defines the size of the object. We're using a Lambert material, similar to Phong, but should be less glossy. Again it's black, for now. We're moving the object to the right, so it's not in the same position as the box, or torus.
+This time, we are creating a dodecahedron, a shape containing twelve flat faces. The parameter, `DodecahedronGeometry()` defines the size of the object. We're using a Lambert material, similar to Phong, but should be less glossy. Again it's black, for now. We're moving the object to the right, so it's not in the same position as the box, or torus.
 
 As mentioned above, the new objects currently just look black. To have both, the Phong and Lambert materials properly visible, we need to introduce a source of light.
 
@@ -250,7 +250,7 @@ This rotates the cube on every frame, by a tiny bit, so the animation looks smoo
 
 ### Scaling
 
-We can also scale an object. Applying a constant value, we would make it grow, or shrink just once. Let's make things more interesting. First, we implement a helper variable, called `t,` for counting elapsed time. Add it right before the `render()` function:
+We can also scale an object. Applying a constant value, we would make it grow, or shrink just once. Let's make things more interesting. First, we implement a helper variable, called `t` for counting elapsed time. Add it right before the `render()` function:
 
 ```js
 let t = 0;

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -495,7 +495,7 @@ The value pairs to iterate over can be defined in one of the following ways:
 
 ### Set-like methods
 
-An interface may be defined as _set-like_, meaning that it represents an _ordered set of values_ will have the following methods: `entries()`, `keys()`, `values()`, `forEach(),` and `has()` (it also has the `size` property). They also supports the use of {{jsxref("Statements/for...of", "for...of")}} on an object implementing this interface. The set-like can be prefixed `readonly` or not. If not read-only, the methods to modify the set are also implemented: `add()`, `clear()`, and `delete()`.
+An interface may be defined as _set-like_, meaning that it represents an _ordered set of values_ will have the following methods: `entries()`, `keys()`, `values()`, `forEach()`, and `has()` (it also has the `size` property). They also supports the use of {{jsxref("Statements/for...of", "for...of")}} on an object implementing this interface. The set-like can be prefixed `readonly` or not. If not read-only, the methods to modify the set are also implemented: `add()`, `clear()`, and `delete()`.
 
 ```webidl
 setlike<valueType>

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/haslistener/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/haslistener/index.md
@@ -23,7 +23,7 @@ events.Event.hasListener(listener)
 
 ### Return value
 
-A boolean value: `true` if the listener is registered to the event. Otherwise,`false`.
+A boolean value: `true` if the listener is registered to the event. Otherwise, `false`.
 
 ## Browser compatibility
 

--- a/files/en-us/web/accessibility/aria/roles/feed_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/feed_role/index.md
@@ -27,7 +27,7 @@ Unlike the document structure elements that represent static HTML elements, the 
 
 If the number of articles is known, set [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) on the articles themselves. However, if the total number is extremely large, indefinite, or changes often, set `aria-setsize="-1"` to indicate that the size of the feed is not known.
 
-Another feature of the feed pattern is skim reading: Articles within a feed can contain both an accessible name with the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) and a description with an `aria-describedby,` suggesting to screen readers which elements to speak after the label when navigating by article. By identifying the elements inside an article that provide the title and the primary content, assistive technologies can provide functions that enable users to jump from article to article and efficiently discern which articles they want to read.
+Another feature of the feed pattern is skim reading: Articles within a feed can contain both an accessible name with the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) and a description with an `aria-describedby`, suggesting to screen readers which elements to speak after the label when navigating by article. By identifying the elements inside an article that provide the title and the primary content, assistive technologies can provide functions that enable users to jump from article to article and efficiently discern which articles they want to read.
 
 The feed pattern enables reliable assistive technology reading mode interaction by establishing the following interoperability agreement between the web page and assistive technologies:
 

--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -39,7 +39,7 @@ delete(request, options)
         and `HEAD` are allowed.) It defaults to `false`.
     - `ignoreVary`
       - : A boolean value that, when set to
-        `true,` tells the matching operation not to perform `VARY`
+        `true`, tells the matching operation not to perform `VARY`
         header matching. In other words, if the URL matches you will get a match
         regardless of whether the {{domxref("Response")}} object has a `VARY`
         header. It defaults to `false`.

--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -49,7 +49,7 @@ keys(request, options)
         and `HEAD` are allowed.) It defaults to `false`.
     - `ignoreVary`
       - : A boolean value that, when set to
-        `true,` tells the matching operation not to perform `VARY`
+        `true`, tells the matching operation not to perform `VARY`
         header matching. In other words, if the URL matches you will get a match
         regardless of whether the {{domxref("Response")}} object has a `VARY`
         header. It defaults to `false`.

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -48,7 +48,7 @@ match(request, options)
         and `HEAD` are allowed.) It defaults to `false`.
     - `ignoreVary`
       - : A boolean value that, when set to
-        `true,` tells the matching operation not to perform `VARY`
+        `true`, tells the matching operation not to perform `VARY`
         header matching. In other words, if the URL matches you will get a match
         regardless of whether the {{domxref("Response")}} object has a `VARY`
         header or not. It defaults to `false`.

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -319,7 +319,7 @@ While you can't play with the worklet's script, you can alter the custom propert
 
 ## Adding complexity
 
-The above examples might not seem very exciting, as you could recreate them in a few different ways with existing CSS properties, e.g. by positioning some decorative [generated content](/en-US/docs/Learn/CSS/Howto/Generated_content) with `::before,` or including `background: linear-gradient(yellow, yellow) 0 15px / 200px 20px no-repeat;` What makes the CSS Painting API so interesting and powerful is that you can create complex images, passing variables, that automatically resize.
+The above examples might not seem very exciting, as you could recreate them in a few different ways with existing CSS properties, e.g. by positioning some decorative [generated content](/en-US/docs/Learn/CSS/Howto/Generated_content) with `::before`, or including `background: linear-gradient(yellow, yellow) 0 15px / 200px 20px no-repeat;` What makes the CSS Painting API so interesting and powerful is that you can create complex images, passing variables, that automatically resize.
 
 Let's take a look at a more complex paint example.
 

--- a/files/en-us/web/api/htmltablerowelement/align/index.md
+++ b/files/en-us/web/api/htmltablerowelement/align/index.md
@@ -28,7 +28,7 @@ The possible values are:
 - `justify`
   - : Spread the text across the cell. Use `text-align: justify` instead.
 - `char`
-  - : Never fully supported, align text to a specified character. Use `text-align: <string>,` where the string is a single character, when supported.
+  - : Never fully supported, align text to a specified character. Use `text-align: <string>`, where the string is a single character, when supported.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltextareaelement/setrangetext/index.md
+++ b/files/en-us/web/api/htmltextareaelement/setrangetext/index.md
@@ -13,7 +13,7 @@ range of text in an {{HTMLElement("textarea")}} element with new text passed as 
 
 Additional optional parameters include the start of the section of text to change, the end of the section, and a keyword defining what part of the `<textarea>` should be selected after the text is updated. If the `startSelection` and `endSelection` arguments are not provided, the range is assumed to be the selection.
 
-The final argument determines how the selection will be set after the text has been replaced. The possible values are `"select"`, which selects the newly inserted text, `"start"`, which moves the selection to just before the inserted text,`"end"`, which moves the selection to just after the inserted text, or the default, `"preserve"` , which tries to preserve the selection.
+The final argument determines how the selection will be set after the text has been replaced. The possible values are `"select"`, which selects the newly inserted text, `"start"`, which moves the selection to just before the inserted text, `"end"`, which moves the selection to just after the inserted text, or the default, `"preserve"`, which tries to preserve the selection.
 
 In addition, the {{domxref("HTMLTextAreaElement.select_event", "select")}} and {{domxref("HTMLTextAreaElement.selectionchange_event", "selectchange")}} events are fired.
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -155,7 +155,7 @@ Now you can figure out what **DECODED** means depending on your application.
 
 The FIN and opcode fields work together to send a message split up into separate frames. This is called message fragmentation. Fragmentation is only available on opcodes `0x0` to `0x2`.
 
-Recall that the opcode tells what a frame is meant to do. If it's `0x1`, the payload is text. If it's `0x2`, the payload is binary data. However, if it's `0x0,` the frame is a continuation frame; this means the server should concatenate the frame's payload to the last frame it received from that client. Here is a rough sketch, in which a server reacts to a client sending text messages. The first message is sent in a single frame, while the second message is sent across three frames. FIN and opcode details are shown only for the client:
+Recall that the opcode tells what a frame is meant to do. If it's `0x1`, the payload is text. If it's `0x2`, the payload is binary data. However, if it's `0x0`, the frame is a continuation frame; this means the server should concatenate the frame's payload to the last frame it received from that client. Here is a rough sketch, in which a server reacts to a client sending text messages. The first message is sent in a single frame, while the second message is sent across three frames. FIN and opcode details are shown only for the client:
 
 ```plain
 Client: FIN=1, opcode=0x1, msg="hello"

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
@@ -30,7 +30,7 @@ Using a value of `auto` will display the content with no scrollbars if the conte
 
 {{EmbedGHLiveSample("css-examples/flow/overflow/auto.html", '100%', 700)}}
 
-As we have already learned, using any of these values, other than the default of `visible,` will create a new Block Formatting Context.
+As we have already learned, using any of these values, other than the default of `visible`, will create a new Block Formatting Context.
 
 Note: In the [Working Draft of Overflow Level 3](https://www.w3.org/TR/css-overflow-3/), there is an additional value `overflow: clip`. This will act like `overflow: hidden` however it does not allow for programmatic scrolling, the box becomes non-scrollable. In addition it does not create a Block Formatting Context.
 

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
@@ -26,7 +26,7 @@ While certain languages will use a particular writing mode or text direction, we
 
 ## Block flow direction
 
-The {{cssxref("writing-mode")}} property accepts the values `horizontal-tb`, `vertical-rl` and `vertical-lr`. These values control the direction that blocks flow on the page. The initial value is `horizontal-tb,` which is a top to bottom block flow direction with a horizontal inline direction. Left to right languages, such as English, and Right to left languages, such as Arabic, are all `horizontal-tb`.
+The {{cssxref("writing-mode")}} property accepts the values `horizontal-tb`, `vertical-rl` and `vertical-lr`. These values control the direction that blocks flow on the page. The initial value is `horizontal-tb`, which is a top to bottom block flow direction with a horizontal inline direction. Left to right languages, such as English, and Right to left languages, such as Arabic, are all `horizontal-tb`.
 
 The following example shows blocks using `horizontal-tb`.
 

--- a/files/en-us/web/css/line-style/index.md
+++ b/files/en-us/web/css/line-style/index.md
@@ -206,7 +206,7 @@ Notice that the black border is not always black.
 
 ### Defining line styles and colors
 
-This example demonstrates line-style and color choice. With some `<line-style>` keyword values, the color of the line may not be what you expect. To create the required "3D" effect of `groove,` `ridge`, `inset`, and `outset` styles when displaying these values in black or white, user agents use different color calculations than any other color-line combinations.
+This example demonstrates line-style and color choice. With some `<line-style>` keyword values, the color of the line may not be what you expect. To create the required "3D" effect of `groove`, `ridge`, `inset`, and `outset` styles when displaying these values in black or white, user agents use different color calculations than any other color-line combinations.
 
 #### HTML
 

--- a/files/en-us/web/css/text-spacing-trim/index.md
+++ b/files/en-us/web/css/text-spacing-trim/index.md
@@ -45,7 +45,7 @@ text-spacing-trim: unset;
       - : Behaves as `normal`, except that CJK full-width opening punctuation characters are set to be half-width at the start of each line.
 
     > [!NOTE]
-    > The [CSS Text](/en-US/docs/Web/CSS/CSS_text) module also defines `trim-both,` `trim-all,` and `auto` values. However, these are not currently implemented in any browser.
+    > The [CSS Text](/en-US/docs/Web/CSS/CSS_text) module also defines `trim-both`, `trim-all`, and `auto` values. However, these are not currently implemented in any browser.
 
 ## Description
 

--- a/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
+++ b/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
@@ -99,7 +99,7 @@ The `stroke-dasharray` attribute can take a series of comma and/or whitespace se
 
 The first number specifies a distance for the filled area, and the second a distance for the unfilled area. So in the above example, the second path fills 5 pixel units, with 5 blank units until the next dash of 5 units. You can specify more numbers if you would like a more complicated dash pattern. The first example specifies three numbers, in which case the renderer loops the numbers twice to create an even pattern. So the first path renders 5 filled, 10 empty, 5 filled, and then loops back to create 5 empty, 10 filled, 5 empty. The pattern then repeats.
 
-There are additional `stroke` and `fill` properties available, including `fill-rule,` which specifies how to color in shapes that overlap themselves; [`stroke-miterlimit`](/en-US/docs/Web/SVG/Attribute/stroke-miterlimit), which determines if a stroke should draw miters; and [stroke-dashoffset](/en-US/docs/Web/SVG/Attribute/stroke-dashoffset), which specifies where to start a dasharray on a line.
+There are additional `stroke` and `fill` properties available, including `fill-rule`, which specifies how to color in shapes that overlap themselves; [`stroke-miterlimit`](/en-US/docs/Web/SVG/Attribute/stroke-miterlimit), which determines if a stroke should draw miters; and [stroke-dashoffset](/en-US/docs/Web/SVG/Attribute/stroke-dashoffset), which specifies where to start a dasharray on a line.
 
 ### Paint order
 

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -131,7 +131,7 @@ Starting with geckodriver 0.26.0 additional capabilities exist if Firefox or an 
 #### `androidPackage` (string, required)
 
 The package name of Firefox, e.g. `org.mozilla.firefox`,
-`org.mozilla.firefox_beta,` or `org.mozilla.fennec` depending on the release
+`org.mozilla.firefox_beta`, or `org.mozilla.fennec` depending on the release
 channel, or the package name of the application embedding GeckoView, e.g. `org.mozilla.geckoview_example`.
 
 #### `androidActivity` (string, optional)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix a whole bunch of minor typos near commas.

### Motivation

Not applicable.

### Additional details

Not applicable.

### Related issues and pull requests

None.
