### PR TITLE
doc: Added additional information about using URLs, base64 strings

### DIFF
--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -253,6 +253,18 @@ Browsers don't all support the same [file types](/en-US/docs/Web/Media/Formats/C
 </audio>
 ```
 
+The `src` attribute can accept various types of audio sources:
+
+1. URLs: When using a URL, be aware that the browser will request the file from the server each time the user seeks within the audio. This can lead to increased server load and potential playback delays.
+
+2. Data URIs: You can use base64-encoded strings as the `src`. This embeds the audio data directly in the HTML, which can be useful for small audio files but isn't recommended for larger files as it increases the HTML file size.
+
+   ```html
+   <audio controls src="data:audio/mpeg;base64,AAAAAAAA..."></audio>
+   ```
+
+3. `MediaStream` objects: While supported, `MediaStream` sources have limitations. They are not seekable and only support a limited set of codecs. This is most commonly used for live audio streams or real-time audio processing.
+
 We offer a substantive and thorough [guide to media file types](/en-US/docs/Web/Media/Formats) and the [audio codecs that can be used within them](/en-US/docs/Web/Media/Formats/Audio_codecs). Also available is [a guide to the codecs supported for video](/en-US/docs/Web/Media/Formats/Video_codecs).
 
 Other usage notes:

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -240,35 +240,23 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ## Usage notes
 
-The `src` attribute can accept various types of audio sources:
+The audio source can be set to any valid [URL](/en-US/docs/Web/URI), including HTTP(S) URLs and [Data URLs](/en-US/docs/Web/URI/Schemes/data). When using HTTP(S) URLs, be aware that the browser's caching behavior will affect how often the file is requested from the server. Data URLs embed the audio data directly in the HTML, which can be useful for small audio files but isn't recommended for larger files as it increases the HTML file size.
 
-1. URLs: The `src` attribute can be set to any valid [URL](/en-US/docs/Web/URI), including HTTP(S) URLs and [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). When using HTTP(S) URLs, be aware that the browser's caching behavior will affect how often the file is requested from the server.
+You can also set the [`srcObject`](/en-US/docs/Web/API/HTMLMediaElement/srcObject) in JavaScript to a {{jsxref("MediaStream")}} object. This is commonly used for live audio streams or real-time audio processing.
 
-2. Data URLs: You can use base64-encoded strings as the `src`. This embeds the audio data directly in the HTML, which can be useful for small audio files but isn't recommended for larger files as it increases the HTML file size.
+```js
+const audioElement = document.querySelector("audio");
+navigator.mediaDevices
+ .getUserMedia({ audio: true })
+ .then((stream) => {
+   audioElement.srcObject = stream;
+ })
+ .catch((error) => {
+   console.error("Error accessing the microphone", error);
+ });
+```
 
-   ```html
-   <audio
-     controls
-     src="data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjI5LjEwMAAAAAAAAAAAAAAA//OEAAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAAUAAAiSAAYGBgYJCQkJCQwMDAwMDw8PDw8SUlJSUlVVVVVVWFhYWFhbW1tbW15eXl5eYaGhoaGkpKSkpKenp6enqqqqqqqtra2trbDw8PDw8/Pz8/P29vb29vn5+fn5/Pz8/Pz//////8AAAAATGF2YzU4LjU0AAAAAAAAAAAAAAAAJAYAAAAAAAAAIkjQ7jNkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
-     Your browser does not support the audio element.
-   </audio>
-   ```
-
-3. `MediaStream` objects: While not directly supported in HTML, `MediaStream` objects can be attached to an `<audio>` element using JavaScript. This is commonly used for live audio streams or real-time audio processing. Here's an example of how you might use it:
-
-   ```javascript
-   const audioElement = document.querySelector("audio");
-   navigator.mediaDevices
-     .getUserMedia({ audio: true })
-     .then((stream) => {
-       audioElement.srcObject = stream;
-     })
-     .catch((error) => {
-       console.error("Error accessing the microphone", error);
-     });
-   ```
-
-   Note that `MediaStream` sources have limitations: they are not seekable and only support a limited set of codecs.
+Note that `MediaStream` sources have limitations: they are not seekable and only support a limited set of codecs.
 
 We offer a substantive and thorough [guide to media file types](/en-US/docs/Web/Media/Formats) and the [audio codecs that can be used within them](/en-US/docs/Web/Media/Formats/Audio_codecs). Also available is [a guide to the codecs supported for video](/en-US/docs/Web/Media/Formats/Video_codecs).
 

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -240,9 +240,22 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ## Usage notes
 
+Browsers don't all support the same [file types](/en-US/docs/Web/Media/Formats/Containers) and [audio codecs](/en-US/docs/Web/Media/Formats/Audio_codecs); you can provide multiple sources inside nested {{htmlelement("source")}} elements, and the browser will then use the first one it understands:
+
+```html
+<audio controls>
+  <source src="myAudio.mp3" type="audio/mpeg" />
+  <source src="myAudio.ogg" type="audio/ogg" />
+  <p>
+    Download <a href="myAudio.mp3" download="myAudio.mp3">MP3</a> or
+    <a href="myAudio.ogg" download="myAudio.ogg">OGG</a> audio.
+  </p>
+</audio>
+```
+
 The audio source can be set to any valid [URL](/en-US/docs/Web/URI), including HTTP(S) URLs and [Data URLs](/en-US/docs/Web/URI/Schemes/data). When using HTTP(S) URLs, be aware that the browser's caching behavior will affect how often the file is requested from the server. Data URLs embed the audio data directly in the HTML, which can be useful for small audio files but isn't recommended for larger files as it increases the HTML file size.
 
-You can also set the [`srcObject`](/en-US/docs/Web/API/HTMLMediaElement/srcObject) in JavaScript to a {{jsxref("MediaStream")}} object. This is commonly used for live audio streams or real-time audio processing.
+You can also use the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) to directly generate and manipulate audio streams from JavaScript code rather than streaming pre-existing audio files. You can set the [`srcObject`](/en-US/docs/Web/API/HTMLMediaElement/srcObject) in JavaScript to a {{jsxref("MediaStream")}} object. This is commonly used for live audio streams or real-time audio processing.
 
 ```js
 const audioElement = document.querySelector("audio");
@@ -264,7 +277,6 @@ Other usage notes:
 
 - If you don't specify the `controls` attribute, the audio player won't include the browser's default controls. You can, however, create your own custom controls using JavaScript and the {{domxref("HTMLMediaElement")}} API.
 - To allow precise control over your audio content, `HTMLMediaElement`s fire many different [events](/en-US/docs/Web/API/HTMLMediaElement#events). This also provides a way to monitor the audio's fetching process so you can watch for errors or detect when enough is available to begin to play or manipulate it.
-- You can also use the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) to directly generate and manipulate audio streams from JavaScript code rather than streaming pre-existing audio files.
 - `<audio>` elements can't have subtitles or captions associated with them in the same way that `<video>` elements can. See [WebVTT and Audio](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/) by Ian Devlin for some useful information and workarounds.
 - To test the fallback content on browsers that support the element, you can replace `<audio>` with a non-existing element like `<notanaudio>`.
 

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -240,30 +240,35 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ## Usage notes
 
-Browsers don't all support the same [file types](/en-US/docs/Web/Media/Formats/Containers) and [audio codecs](/en-US/docs/Web/Media/Formats/Audio_codecs); you can provide multiple sources inside nested {{htmlelement("source")}} elements, and the browser will then use the first one it understands:
-
-```html
-<audio controls>
-  <source src="myAudio.mp3" type="audio/mpeg" />
-  <source src="myAudio.ogg" type="audio/ogg" />
-  <p>
-    Download <a href="myAudio.mp3" download="myAudio.mp3">MP3</a> or
-    <a href="myAudio.ogg" download="myAudio.ogg">OGG</a> audio.
-  </p>
-</audio>
-```
-
 The `src` attribute can accept various types of audio sources:
 
-1. URLs: When using a URL, be aware that the browser will request the file from the server each time the user seeks within the audio. This can lead to increased server load and potential playback delays.
+1. URLs: The `src` attribute can be set to any valid [URL](/en-US/docs/Web/URI), including HTTP(S) URLs and [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). When using HTTP(S) URLs, be aware that the browser's caching behavior will affect how often the file is requested from the server.
 
-2. Data URIs: You can use base64-encoded strings as the `src`. This embeds the audio data directly in the HTML, which can be useful for small audio files but isn't recommended for larger files as it increases the HTML file size.
+2. Data URLs: You can use base64-encoded strings as the `src`. This embeds the audio data directly in the HTML, which can be useful for small audio files but isn't recommended for larger files as it increases the HTML file size.
 
    ```html
-   <audio controls src="data:audio/mpeg;base64,AAAAAAAA..."></audio>
+   <audio
+     controls
+     src="data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjI5LjEwMAAAAAAAAAAAAAAA//OEAAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAAUAAAiSAAYGBgYJCQkJCQwMDAwMDw8PDw8SUlJSUlVVVVVVWFhYWFhbW1tbW15eXl5eYaGhoaGkpKSkpKenp6enqqqqqqqtra2trbDw8PDw8/Pz8/P29vb29vn5+fn5/Pz8/Pz//////8AAAAATGF2YzU4LjU0AAAAAAAAAAAAAAAAJAYAAAAAAAAAIkjQ7jNkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
+     Your browser does not support the audio element.
+   </audio>
    ```
 
-3. `MediaStream` objects: While supported, `MediaStream` sources have limitations. They are not seekable and only support a limited set of codecs. This is most commonly used for live audio streams or real-time audio processing.
+3. `MediaStream` objects: While not directly supported in HTML, `MediaStream` objects can be attached to an `<audio>` element using JavaScript. This is commonly used for live audio streams or real-time audio processing. Here's an example of how you might use it:
+
+   ```javascript
+   const audioElement = document.querySelector("audio");
+   navigator.mediaDevices
+     .getUserMedia({ audio: true })
+     .then((stream) => {
+       audioElement.srcObject = stream;
+     })
+     .catch((error) => {
+       console.error("Error accessing the microphone", error);
+     });
+   ```
+
+   Note that `MediaStream` sources have limitations: they are not seekable and only support a limited set of codecs.
 
 We offer a substantive and thorough [guide to media file types](/en-US/docs/Web/Media/Formats) and the [audio codecs that can be used within them](/en-US/docs/Web/Media/Formats/Audio_codecs). Also available is [a guide to the codecs supported for video](/en-US/docs/Web/Media/Formats/Video_codecs).
 

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -247,13 +247,13 @@ You can also set the [`srcObject`](/en-US/docs/Web/API/HTMLMediaElement/srcObjec
 ```js
 const audioElement = document.querySelector("audio");
 navigator.mediaDevices
- .getUserMedia({ audio: true })
- .then((stream) => {
-   audioElement.srcObject = stream;
- })
- .catch((error) => {
-   console.error("Error accessing the microphone", error);
- });
+  .getUserMedia({ audio: true })
+  .then((stream) => {
+    audioElement.srcObject = stream;
+  })
+  .catch((error) => {
+    console.error("Error accessing the microphone", error);
+  });
 ```
 
 Note that `MediaStream` sources have limitations: they are not seekable and only support a limited set of codecs.


### PR DESCRIPTION
### Description
Updated the `<audio>` element documentation to include more detailed information about different source options and their implications.

### Motivation
These changes provide readers with a more comprehensive understanding of the `<audio>` element's capabilities and limitations, particularly regarding different source types like URLs, base64-encoded strings, and MediaStream objects.

### Additional details
- Added information about URL sources and their impact on server requests during seeking
- Included details about using base64-encoded strings as audio sources
- Mentioned limitations of MediaStream sources
- Provided a functional example of a base64-encoded audio file

### Related issues and pull requests
Fixes #36338
<!-- Note: Replace [issue number] with the actual issue number if one exists. If there's no specific issue, you can remove this line. -->

These changes aim to address gaps in the existing documentation and provide more practical, real-world examples for developers working with the `<audio>` element.