### PR TITLE
Fix: AudioBufferSourceNode Syntax

### DIFF
--- a/files/en-us/web/api/response/arraybuffer/index.md
+++ b/files/en-us/web/api/response/arraybuffer/index.md
@@ -77,7 +77,7 @@ function getData() {
     })
     .then((buffer) => audioCtx.decodeAudioData(buffer))
     .then((decodedData) => {
-      const source = new AudioBufferSourceNode();
+      const source = new AudioBufferSourceNode(audioCtx);
       source.buffer = decodedData;
       source.connect(audioCtx.destination);
       return source;


### PR DESCRIPTION
### Description

Fixes #36292 - Fixed `AudioBufferSourceNode` syntax.