### PR TITLE
Fix incorrect information about textarea value attribute

### DIFF
--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -16,7 +16,10 @@ The above example demonstrates a number of features of `<textarea>`:
 - An `id` attribute to allow the `<textarea>` to be associated with a {{htmlelement("label")}} element for accessibility purposes
 - A `name` attribute to set the name of the associated data point submitted to the server when the form is submitted.
 - `rows` and `cols` attributes to allow you to specify an exact size for the `<textarea>` to take. Setting these is a good idea for consistency, as browser defaults can differ.
-- Default content entered between the opening and closing tags. `<textarea>` does not support the `value` attribute.
+- Default content entered between the opening and closing tags.
+- The `<textarea>` element handles its content differently in HTML and JavaScript contexts:
+  - In HTML, the initial content of a `<textarea>` is specified between its opening and closing tags, not as a value attribute.
+  - In JavaScript, `<textarea>` elements have a value property that can be used to get or set the current content of the textarea. 
 
 The `<textarea>` element also accepts several attributes common to form `<input>`s, such as `autocapitalize`, `autocomplete`, `autofocus`, `disabled`, `placeholder`, `readonly`, and `required`.
 

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -18,7 +18,7 @@ The above example demonstrates a number of features of `<textarea>`:
 - `rows` and `cols` attributes to allow you to specify an exact size for the `<textarea>` to take. Setting these is a good idea for consistency, as browser defaults can differ.
 - The `<textarea>` element specifies its content differently in HTML and JavaScript contexts:
   - In HTML, the initial content of a `<textarea>` is specified between its opening and closing tags, not as a `value` attribute.
-  - In JavaScript, `<textarea>` elements have a [`value`](/en-US/docs/Web/API/HTMLTextAreaElement/value) property that can be used to get or set the current content of the textarea, and [`defaultValue`](/en-US/docs/Web/API/HTMLTextAreaElement/defaultValue) to get and set its initial value (equivalent to setting the HTML element's text content).
+  - In JavaScript, `<textarea>` elements have a [`value`](/en-US/docs/Web/API/HTMLTextAreaElement/value) property that can be used to get or set the current content, and [`defaultValue`](/en-US/docs/Web/API/HTMLTextAreaElement/defaultValue) to get and set its initial value (equivalent to accessing the HTML element's text content).
 
 The `<textarea>` element also accepts several attributes common to form `<input>`s, such as `autocapitalize`, `autocomplete`, `autofocus`, `disabled`, `placeholder`, `readonly`, and `required`.
 

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -16,10 +16,9 @@ The above example demonstrates a number of features of `<textarea>`:
 - An `id` attribute to allow the `<textarea>` to be associated with a {{htmlelement("label")}} element for accessibility purposes
 - A `name` attribute to set the name of the associated data point submitted to the server when the form is submitted.
 - `rows` and `cols` attributes to allow you to specify an exact size for the `<textarea>` to take. Setting these is a good idea for consistency, as browser defaults can differ.
-- Default content entered between the opening and closing tags.
-- The `<textarea>` element handles its content differently in HTML and JavaScript contexts:
-  - In HTML, the initial content of a `<textarea>` is specified between its opening and closing tags, not as a value attribute.
-  - In JavaScript, `<textarea>` elements have a value property that can be used to get or set the current content of the textarea. 
+- The `<textarea>` element specifies its content differently in HTML and JavaScript contexts:
+  - In HTML, the initial content of a `<textarea>` is specified between its opening and closing tags, not as a `value` attribute.
+  - In JavaScript, `<textarea>` elements have a [`value`](/en-US/docs/Web/API/HTMLTextAreaElement/value) property that can be used to get or set the current content of the textarea, and [`defaultValue`](/en-US/docs/Web/API/HTMLTextAreaElement/defaultValue) to get and set its initial value (equivalent to setting the HTML element's text content).
 
 The `<textarea>` element also accepts several attributes common to form `<input>`s, such as `autocapitalize`, `autocomplete`, `autofocus`, `disabled`, `placeholder`, `readonly`, and `required`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The current documentation states: "`<textarea>` does not support the value attribute."
 -  This is incorrect and needs some clarification. I have updated the documentation to correctly reflect the behaviour of the `<textarea>` element in both HTML and JavaScript contexts.



### Motivation

The incorrect statement could lead to confusion for developers. 
-  `<textarea>` does not use the `value` attribute in HTML to define its initial content, but it has a `value` property in JavaScript. Clarifying this distinction is crucial for users to understand how to work with `<textarea>` properly in both contexts.


### Additional details

HTML Attribute vs. JavaScript Property:

- In HTML, `<textarea>` elements don't use a `value` attribute to set their initial content. Instead, the content is placed between the opening and closing tags.

- In JavaScript, `<textarea>` elements have a `value` property that can be accessed and modified via JavaScript.

### Proposed Documentation Update

- Remove the statement: "`<textarea>` does not support the value attribute."
- Add clarification: "`<textarea>` handles its content differently in HTML and JavaScript contexts:


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
