### PR TITLE
fix(css): remove content:contents

### DIFF
--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -78,7 +78,7 @@ The keywords and data types mentioned above are described in more detail below:
 
 - `normal`
 
-  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to the element’s descendants.
+  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to the element's descendants.
 
 - {{cssxref("&lt;string&gt;")}}
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -66,7 +66,7 @@ The value can be:
 
 - One of two keywords — `none` or `normal`
 - `<content-replacement>` when replacing a DOM node. `<content-replacement>` is always an `<image>`.
-- A `<content-list>` when replacing pseudo-elements and margin boxes. A content-list is a list of one or more anonymous inline boxes appearing in the order specified. Each `<content-list>` item is either `contents` or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
+- A `<content-list>` when replacing pseudo-elements and margin boxes. A content-list is a list of one or more anonymous inline boxes appearing in the order specified. Each `<content-list>` item is of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
 - An optional alternative text value of a `<string>` or `<counter>`, preceded by a slash (`/`).
 
 The keywords and data types mentioned above are described in more detail below:
@@ -79,10 +79,6 @@ The keywords and data types mentioned above are described in more detail below:
 - `normal`
 
   - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to `contents`.
-
-- `contents`
-
-  - : Adds the contents of the element itself to the generated content value.
 
 - {{cssxref("&lt;string&gt;")}}
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -64,9 +64,9 @@ content: unset;
 
 The value can be:
 
-- One of two keywords — `none` or `normal`
+- One of two keywords — `none` or `normal`.
 - `<content-replacement>` when replacing a DOM node. `<content-replacement>` is always an `<image>`.
-- A `<content-list>` when replacing pseudo-elements and margin boxes. A content-list is a list of one or more anonymous inline boxes appearing in the order specified. Each `<content-list>` item is of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
+- A `<content-list>` when replacing pseudo-elements and margin boxes. A `<content-list>` is a list of one or more anonymous inline boxes appearing in the order specified. Each `<content-list>` item is of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
 - An optional alternative text value of a `<string>` or `<counter>`, preceded by a slash (`/`).
 
 The keywords and data types mentioned above are described in more detail below:

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -78,7 +78,7 @@ The keywords and data types mentioned above are described in more detail below:
 
 - `normal`
 
-  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to `contents`.
+  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to the element’s descendants.
 
 - {{cssxref("&lt;string&gt;")}}
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/36333

The `contents` value hasn't been implemented in any user agent. Also it [may change](https://drafts.csswg.org/css-content/#issue-a8fbc981) in future:
> Issue 3: Should the contents keyword be replaced with [content()](https://drafts.csswg.org/css-content/#funcdef-content)?