### PR TITLE
Reference for stage-3 arraybuffer-base64

### DIFF
--- a/files/en-us/web/api/window/atob/index.md
+++ b/files/en-us/web/api/window/atob/index.md
@@ -15,7 +15,7 @@ data which may otherwise cause communication problems, then transmit it and use 
 `atob()` method to decode the data again. For example, you can encode,
 transmit, and decode control characters such as {{Glossary("ASCII")}} values 0 through 31.
 
-For use with arbitrary Unicode strings, see _The "Unicode Problem"_ in the {{Glossary("Base64")}} glossary entry.
+Also consider using the {{jsxref("Uint8Array.fromBase64()")}} method, which creates a `Uint8Array` object from a base64-encoded string. It results in a byte array, which is easier to work with than a string containing raw bytes.
 
 ## Syntax
 
@@ -44,6 +44,8 @@ const encodedData = window.btoa("Hello, world"); // encode a string
 const decodedData = window.atob(encodedData); // decode the string
 ```
 
+For more examples, see the {{domxref("Window.btoa()")}} method.
+
 ## Specifications
 
 {{Specifications}}
@@ -58,3 +60,4 @@ const decodedData = window.atob(encodedData); // decode the string
 - [`data` URLs](/en-US/docs/Web/URI/Schemes/data)
 - {{domxref("WorkerGlobalScope.atob()")}}: the same method, but in worker scopes.
 - {{domxref("Window.btoa()")}}
+- {{jsxref("Uint8Array.fromBase64()")}}

--- a/files/en-us/web/api/workerglobalscope/atob/index.md
+++ b/files/en-us/web/api/workerglobalscope/atob/index.md
@@ -15,8 +15,6 @@ data which may otherwise cause communication problems, then transmit it and use 
 `atob()` method to decode the data again. For example, you can encode,
 transmit, and decode control characters such as {{Glossary("ASCII")}} values 0 through 31.
 
-For use with arbitrary Unicode strings, see _The "Unicode Problem"_ section in {{Glossary("Base64")}} glossary entry.
-
 ## Syntax
 
 ```js-nolint
@@ -58,3 +56,4 @@ const decodedData = self.atob(encodedData); // decode the string
 - [`data` URLs](/en-US/docs/Web/URI/Schemes/data)
 - {{domxref("Window.atob()")}}: the same method, but in window scopes.
 - {{domxref("WorkerGlobalScope.btoa()")}}
+- {{jsxref("Uint8Array.fromBase64()")}}

--- a/files/en-us/web/api/workerglobalscope/btoa/index.md
+++ b/files/en-us/web/api/workerglobalscope/btoa/index.md
@@ -8,13 +8,9 @@ browser-compat: api.btoa
 
 {{APIRef("HTML DOM")}}{{AvailableInWorkers("worker")}}
 
-The **`btoa()`** method of the {{domxref("WorkerGlobalScope")}} interface creates a
-{{glossary("Base64")}}-encoded {{Glossary("ASCII")}} string from a _binary string_ (i.e., a
-string in which each character in the string is treated as a byte
-of binary data).
+The **`btoa()`** method of the {{domxref("WorkerGlobalScope")}} interface creates a {{glossary("Base64")}}-encoded {{Glossary("ASCII")}} string from a _binary string_ (i.e., a string in which each character in the string is treated as a byte of binary data).
 
-You can use this method to encode data which may otherwise cause communication
-problems, transmit it, then use the {{domxref("WorkerGlobalScope.atob()")}} method to decode the data again.
+You can use this method to encode data which may otherwise cause communication problems, transmit it, then use the {{domxref("WorkerGlobalScope.atob()")}} method to decode the data again.
 For example, you can encode control characters such as ASCII values 0 through 31.
 
 ## Syntax
@@ -46,21 +42,11 @@ const decodedData = self.atob(encodedData); // decode the string
 
 ## Unicode strings
 
-Base64, by design, expects binary data as its input. In terms of JavaScript strings,
-this means strings in which the code point of each character occupies only one byte. So if you pass a
-string into `btoa()` containing characters that occupy more than one byte,
-you will get an error, because this is not considered binary data:
+Base64, by design, expects binary data as its input.
+In terms of JavaScript strings, this means strings in which the code point of each character occupies only one byte.
+So if you pass a string into `btoa()` containing characters that occupy more than one byte, you will get an error, because this is not considered binary data.
 
-```js
-const ok = "a";
-console.log(ok.codePointAt(0).toString(16)); //   61: occupies < 1 byte
-
-const notOK = "✓";
-console.log(notOK.codePointAt(0).toString(16)); // 2713: occupies > 1 byte
-
-console.log(self.btoa(ok)); // YQ==
-console.log(self.btoa(notOK)); // error
-```
+For more information and workarounds see [`Window.btoa()`](/en-US/docs/Web/API/Window/btoa#unicode_strings).
 
 ## Specifications
 

--- a/files/en-us/web/api/workerglobalscope/btoa/index.md
+++ b/files/en-us/web/api/workerglobalscope/btoa/index.md
@@ -62,8 +62,6 @@ console.log(self.btoa(ok)); // YQ==
 console.log(self.btoa(notOK)); // error
 ```
 
-For how to work around this limitation when dealing with arbitrary Unicode text, see _The "Unicode Problem"_ in the {{Glossary("Base64")}} glossary entry.
-
 ## Specifications
 
 {{Specifications}}
@@ -78,4 +76,5 @@ For how to work around this limitation when dealing with arbitrary Unicode text,
 - [`data` URLs](/en-US/docs/Web/URI/Schemes/data)
 - {{domxref("WorkerGlobalScope.atob()")}}
 - {{domxref("Window.btoa()")}}: the same method, but in window scopes.
+- {{jsxref("Uint8Array.prototype.toBase64()")}}
 - {{Glossary("Base64")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/frombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/frombase64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Uint8Array.fromBase64
 
 The **`Uint8Array.fromBase64()`** static method creates a new {{jsxref("Uint8Array")}} object from a [base64](/en-US/docs/Glossary/Base64)-encoded string.
 
-For the general concepts around base64 strings, see the [base64](/en-US/docs/Glossary/Base64) glossary entry. This method should be preferred over {{domxref("Window.atob()")}} because it results in a byte array, which is easier to work with than a string containing raw bytes. If you already have an array buffer allocated and you want to populate it, use the instance method {{jsxref("Uint8Array.prototype.setFromBase64()")}} instead.
+This method should be preferred over {{domxref("Window.atob()")}} because it results in a byte array, which is easier to work with than a string containing raw bytes, unless your decoded binary data is actually intended to be ASCII text. If you already have an array buffer allocated and you want to populate it, use the instance method {{jsxref("Uint8Array.prototype.setFromBase64()")}} instead.
 
 ## Syntax
 
@@ -21,7 +21,7 @@ Uint8Array.fromBase64(string, options)
 ### Parameters
 
 - `string`
-  - : A base64-encoded string to convert to a `Uint8Array`. The string must only contain characters in the base64 alphabet, which includes A–Z, a–z, 0–9, and two special characters, which are either `+` and `/` (if using `alphabet: "base64"` in `options`) or `-` and `_` (if using `alphabet: "base64url"` in `options`). Any ASCII white space characters within the string are ignored.
+  - : A base64 string encoding bytes to convert to a `Uint8Array`. The string must only contain characters in the base64 alphabet, which includes A–Z, a–z, 0–9, and two special characters, which are either `+` and `/` (if using `alphabet: "base64"` in `options`) or `-` and `_` (if using `alphabet: "base64url"` in `options`). It may have padding `=` characters at the end. Any ASCII white space characters within the string are ignored.
 - `options` {{optional_inline}}
   - : An object customizing the base64 string interpretation process. It can contain the following properties:
     - `alphabet` {{optional_inline}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/frombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/frombase64/index.md
@@ -59,9 +59,9 @@ A new `Uint8Array` object containing the decoded bytes from the base64-encoded s
 
 This example uses the default `alphabet` and `lastChunkHandling` options to decode a base64 string. Note that:
 
-- The string has 14 base64 characters, not a multiple of 4.
 - The whitespace in the space is ignored.
-- The last chunk, `Ph`, ends in the character `h` which is `0b100001` in base64, so the last `0001` bits are "overflow bits" and are ignored.
+- The string has 14 base64 characters, not a multiple of 4. This is only valid and decodable with `lastChunkHandling: "loose"`.
+- The last chunk, `Ph`, ends in the character `h` which is `0b100001` in base64, so the last `0001` bits are "overflow bits" and are ignored. This is only valid and decodable with `lastChunkHandling: "loose"`.
 
 ```js
 const uint8Array = Uint8Array.fromBase64("PGI+ TURO PC9i Ph");
@@ -84,17 +84,17 @@ console.log(uint8Array); // Uint8Array(10) [60, 98, 62, 77, 68, 78, 60, 47, 98, 
 This example uses the `lastChunkHandling` option to decode a base64 string, where the last chunk must be exactly 4 characters long with padding `=` characters, and the overflow bits must be 0.
 
 ```js
-const array1 = Uint8Array.fromBase64("PGI+TUROPC9iPg==", {
+const array1 = Uint8Array.fromBase64("PGI+ TURO PC9i Pg==", {
   lastChunkHandling: "strict",
 });
 console.log(array1); // Uint8Array(10) [60, 98, 62, 77, 68, 78, 60, 47, 98, 62]
 
-const array2 = Uint8Array.fromBase64("PGI+TUROPC9iPh==", {
+const array2 = Uint8Array.fromBase64("PGI+ TURO PC9i Ph==", {
   lastChunkHandling: "strict",
 });
 // Throws a SyntaxError because h is 0b100001, where the last 4 bits are not 0
 
-const array3 = Uint8Array.fromBase64("PGI+TUROPC9iPg", {
+const array3 = Uint8Array.fromBase64("PGI+ TURO PC9i Pg", {
   lastChunkHandling: "strict",
 });
 // Throws a SyntaxError because the last chunk is not exactly 4 characters long

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/frombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/frombase64/index.md
@@ -1,0 +1,141 @@
+---
+title: Uint8Array.fromBase64()
+slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64
+page-type: javascript-static-method
+browser-compat: javascript.builtins.Uint8Array.fromBase64
+---
+
+{{JSRef}}
+
+The **`Uint8Array.fromBase64()`** static method creates a new {{jsxref("Uint8Array")}} object from a [base64](/en-US/docs/Glossary/Base64)-encoded string.
+
+For the general concepts around base64 strings, see the [base64](/en-US/docs/Glossary/Base64) glossary entry. This method should be preferred over {{domxref("Window.atob()")}} because it results in a byte array, which is easier to work with than a string containing raw bytes. If you already have an array buffer allocated and you want to populate it, use the instance method {{jsxref("Uint8Array.prototype.setFromBase64()")}} instead.
+
+## Syntax
+
+```js-nolint
+Uint8Array.fromBase64(string)
+Uint8Array.fromBase64(string, options)
+```
+
+### Parameters
+
+- `string`
+  - : A base64-encoded string to convert to a `Uint8Array`. The string must only contain characters in the base64 alphabet, which includes A–Z, a–z, 0–9, and two special characters, which are either `+` and `/` (if using `alphabet: "base64"` in `options`) or `-` and `_` (if using `alphabet: "base64url"` in `options`). Any ASCII white space characters within the string are ignored.
+- `options` {{optional_inline}}
+  - : An object customizing the base64 string interpretation process. It can contain the following properties:
+    - `alphabet` {{optional_inline}}
+      - : A string specifying the base64 alphabet to use. It can be one of the following:
+        - `"base64"` (default)
+          - : Accept `+` and `/` as `0x3E` and `0x3F`, respectively.
+        - `"base64url"`
+          - : Accept `-` and `_` as `0x3E` and `0x3F`, respectively.
+    - `lastChunkHandling` {{optional_inline}}
+      - : A string specifying how to handle the last chunk of the base64 string. Because every 4 characters in base64 encodes 3 bytes, the string is separated into chunks of 4 characters. If the last chunk has fewer than 4 characters, it needs to be handled differently. It can be one of the following:
+        - `"loose"` (default)
+          - : The last chunk can either be 2 or 3 base64 characters, or exactly 4 characters long with padding `=` characters. The last chunk is decoded and appended to the result.
+        - `"strict"`
+          - : The last chunk must be exactly 4 characters long with padding `=` characters. Furthermore, [overflow bits](/en-US/docs/Glossary/Base64#last_chunk) (trailing bits from the base64 characters that don't represent any data) must be 0. The last chunk is decoded and appended to the result.
+        - `"stop-before-partial"`
+          - : If the last chunk is exactly 4 characters long with padding `=` characters, then it's decoded and appended to the result. Otherwise, the last partial chunk is ignored (but if it contains one base64 character followed by `=`, then a syntax error is still thrown). This is useful if the string is coming from a stream and the last chunk is not yet complete.
+
+### Return value
+
+A new `Uint8Array` object containing the decoded bytes from the base64-encoded string.
+
+### Exceptions
+
+- {{jsxref("SyntaxError")}}
+  - : Thrown if the input string contains characters outside the specified alphabet, or if the last chunk does not satisfy the `lastChunkHandling` option.
+- {{jsxref("TypeError")}}
+  - : Thrown in one of the following cases:
+    - The input string is not a string.
+    - The `options` object is not an object or `undefined`.
+    - The options are not of the expected values or `undefined`.
+
+## Examples
+
+### Decoding a base64 string
+
+This example uses the default `alphabet` and `lastChunkHandling` options to decode a base64 string. Note that:
+
+- The string has 10 base64 characters, not a multiple of 4.
+- The whitespace in the space is ignored.
+- The last chunk, `ld`, ends in the character `d` which is `0b011101` in base64, so the `1101` bits are "overflow bits" and are ignored.
+
+```js
+const uint8Array = Uint8Array.fromBase64("Hello World");
+console.log(uint8Array); // Uint8Array(7) [29, 233, 101, 161, 106, 43, 149]
+```
+
+### Decoding a URL-safe base64 string
+
+This example uses the `alphabet` option to decode a URL-safe base64 string.
+
+```js
+const uint8Array = Uint8Array.fromBase64("Hello-World", {
+  alphabet: "base64url",
+});
+console.log(uint8Array); // Uint8Array(8) [29, 233, 101, 163, 229, 168, 174, 87]
+```
+
+### Decoding a base64 string with strict last chunk handling
+
+This example uses the `lastChunkHandling` option to decode a base64 string, where the last chunk must be exactly 4 characters long with padding `=` characters, and the overflow bits must be 0.
+
+```js
+const array1 = Uint8Array.fromBase64("VQ==", { lastChunkHandling: "strict" });
+console.log(array1); // Uint8Array(1) [85]
+
+const array2 = Uint8Array.fromBase64("VR==", { lastChunkHandling: "strict" });
+// Throws a SyntaxError because R is 0b010001, where the last 4 bits are not 0
+
+const array3 = Uint8Array.fromBase64("VQ", { lastChunkHandling: "strict" });
+// Throws a SyntaxError because the last chunk is not exactly 4 characters long
+```
+
+### Decoding a base64 string with partial last chunk handling
+
+This example uses the `lastChunkHandling` option to decode a base64 string, ignoring any partial last chunk.
+
+```js
+// The last chunk is complete
+const array1 = Uint8Array.fromBase64("VQ==", {
+  lastChunkHandling: "stop-before-partial",
+});
+console.log(array1); // Uint8Array(1) [85]
+
+// The last chunk is partial
+const array2 = Uint8Array.fromBase64("VQ", {
+  lastChunkHandling: "stop-before-partial",
+});
+console.log(array2); // Uint8Array(0) []
+
+// The last chunk is partial with padding
+const array3 = Uint8Array.fromBase64("VQ=", {
+  lastChunkHandling: "stop-before-partial",
+});
+console.log(array3); // Uint8Array(0) []
+
+// The last chunk is partial, but it contains one base64 character followed by `=`
+const array4 = Uint8Array.fromBase64("V=", {
+  lastChunkHandling: "stop-before-partial",
+});
+// Throws a SyntaxError because this cannot possibly be a valid base64 string
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Polyfill of `Uint8Array.fromBase64` in `core-js`](https://github.com/zloirock/core-js#uint8array-to--from-base64-and-hex)
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8Array.prototype.setFromBase64()")}}
+- {{jsxref("Uint8Array.prototype.toBase64()")}}
+- {{domxref("Window.atob()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
@@ -20,7 +20,7 @@ Uint8Array.fromHex(string)
 ### Parameters
 
 - `string`
-  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters.
+  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters.Unlike {{jsxref("Uint8Array.fromBase64()")}}, the input cannot contain whitespace.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
@@ -1,0 +1,70 @@
+---
+title: Uint8Array.fromHex()
+slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/fromHex
+page-type: javascript-static-method
+browser-compat: javascript.builtins.Uint8Array.fromHex
+---
+
+{{JSRef}}
+
+The **`Uint8Array.fromHex()`** static method creates a new {{jsxref("Uint8Array")}} object from a hexadecimal string.
+
+This method parses the string into a byte array. To convert the string into a single number, use the {{jsxref("Global_Objects/parseInt", "parseInt()")}} function with `radix` set to `16` instead.
+
+## Syntax
+
+```js-nolint
+Uint8Array.fromHex(string)
+```
+
+### Parameters
+
+- `string`
+  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters.
+
+### Return value
+
+A new `Uint8Array` object containing the decoded bytes from the hexadecimal string.
+
+### Exceptions
+
+- {{jsxref("SyntaxError")}}
+  - : Thrown if the input string contains characters outside the hex alphabet, or its length is odd.
+- {{jsxref("TypeError")}}
+  - : Thrown if the input string is not a string.
+
+## Examples
+
+### Decoding a hexadecimal string
+
+This example decodes a hexadecimal string into a `Uint8Array`.
+
+```js
+const hexString = "cafed00d";
+const bytes = Uint8Array.fromHex(hexString);
+console.log(bytes); // Uint8Array [ 202, 254, 208, 13 ]
+```
+
+Uppercase characters are also supported:
+
+```js
+const hexString = "CAFEd00d";
+const bytes = Uint8Array.fromHex(hexString);
+console.log(bytes); // Uint8Array [ 202, 254, 208, 13 ]
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Polyfill of `Uint8Array.fromHex` in `core-js`](https://github.com/zloirock/core-js#uint8array-to--from-base64-and-hex)
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8Array.prototype.setFromHex()")}}
+- {{jsxref("Uint8Array.prototype.toHex()")}}
+- {{jsxref("Global_Objects/parseInt", "parseInt()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
@@ -20,7 +20,12 @@ Uint8Array.fromHex(string)
 ### Parameters
 
 - `string`
-  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters. Unlike {{jsxref("Uint8Array.fromBase64()")}}, the input cannot contain whitespace.
+
+  - : A hexadecimal string encoding bytes to convert to a `Uint8Array`. The string must:
+
+    - Have an even number of characters because two characters encode one byte.
+    - Only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive).
+    - Not contain whitespace (unlike {{jsxref("Uint8Array.prototype.setFromBase64()")}}).
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/fromhex/index.md
@@ -20,7 +20,7 @@ Uint8Array.fromHex(string)
 ### Parameters
 
 - `string`
-  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters.Unlike {{jsxref("Uint8Array.fromBase64()")}}, the input cannot contain whitespace.
+  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters. Unlike {{jsxref("Uint8Array.fromBase64()")}}, the input cannot contain whitespace.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -11,6 +11,13 @@ The **`Uint8Array`** typed array represents an array of 8-bit unsigned integers.
 
 `Uint8Array` is a subclass of the hidden {{jsxref("TypedArray")}} class.
 
+## Description
+
+`Uint8Array` is currently the only `TypedArray` subclass that has additional methods compared to other typed arrays. Because of its nature as a generic byte array, it is the most suitable for working with arbitrary binary data. It supports two sets of methods for the creation, serialization, and modification of `Uint8Array` data to/from hex strings and base64 strings.
+
+- {{jsxref("Uint8Array.fromBase64()")}}, {{jsxref("Uint8Array.prototype.toBase64()")}}, and {{jsxref("Uint8Array.prototype.setFromBase64()")}} for working with [base64](/en-US/docs/Glossary/Base64) strings, where 3 bytes are encoded by 4 characters that are either 0–9, A–Z, a–z, "+", and "/" (or "-" and "\_", if using URL-safe base64).
+- {{jsxref("Uint8Array.fromHex()")}}, {{jsxref("Uint8Array.prototype.toHex()")}}, and {{jsxref("Uint8Array.prototype.setFromHex()")}} for working with hex strings, where every byte is encoded by two characters that's either 0–9 or A–F (case-insensitive).
+
 ## Constructor
 
 - {{jsxref("Uint8Array/Uint8Array", "Uint8Array()")}}
@@ -27,6 +34,11 @@ _Also inherits static properties from its parent {{jsxref("TypedArray")}}_.
 
 _Inherits static methods from its parent {{jsxref("TypedArray")}}_.
 
+- {{jsxref("Uint8Array.fromBase64()")}}
+  - : Creates a new `Uint8Array` object from a base64-encoded string.
+- {{jsxref("Uint8Array.fromHex()")}}
+  - : Creates a new `Uint8Array` object from a hex-encoded string.
+
 ## Instance properties
 
 _Also inherits instance properties from its parent {{jsxref("TypedArray")}}_.
@@ -41,6 +53,15 @@ These properties are defined on `Uint8Array.prototype` and shared by all `Uint8A
 ## Instance methods
 
 _Inherits instance methods from its parent {{jsxref("TypedArray")}}_.
+
+- {{jsxref("Uint8Array.prototype.setFromBase64()")}}
+  - : Populates this `Uint8Array` object with bytes from a base64-encoded string, returning an object containing how many bytes were read and written.
+- {{jsxref("Uint8Array.prototype.setFromHex()")}}
+  - : Populates this `Uint8Array` object with bytes from a hex-encoded string, returning an object containing how many bytes were read and written.
+- {{jsxref("Uint8Array.prototype.toBase64()")}}
+  - : Returns a base64-encoded string based on the data in this `Uint8Array` object.
+- {{jsxref("Uint8Array.prototype.toHex()")}}
+  - : Returns a hex-encoded string based on the data in this `Uint8Array` object.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -55,9 +55,9 @@ These properties are defined on `Uint8Array.prototype` and shared by all `Uint8A
 _Inherits instance methods from its parent {{jsxref("TypedArray")}}_.
 
 - {{jsxref("Uint8Array.prototype.setFromBase64()")}}
-  - : Populates this `Uint8Array` object with bytes from a base64-encoded string, returning an object containing how many bytes were read and written.
+  - : Populates this `Uint8Array` object with bytes from a base64-encoded string, returning an object indicating how many bytes were read and written.
 - {{jsxref("Uint8Array.prototype.setFromHex()")}}
-  - : Populates this `Uint8Array` object with bytes from a hex-encoded string, returning an object containing how many bytes were read and written.
+  - : Populates this `Uint8Array` object with bytes from a hex-encoded string, returning an object indicating how many bytes were read and written.
 - {{jsxref("Uint8Array.prototype.toBase64()")}}
   - : Returns a base64-encoded string based on the data in this `Uint8Array` object.
 - {{jsxref("Uint8Array.prototype.toHex()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -16,7 +16,7 @@ The **`Uint8Array`** typed array represents an array of 8-bit unsigned integers.
 `Uint8Array` is currently the only `TypedArray` subclass that has additional methods compared to other typed arrays. Because of its nature as a generic byte array, it is the most suitable for working with arbitrary binary data. It supports two sets of methods for the creation, serialization, and modification of `Uint8Array` data to/from hex strings and base64 strings.
 
 - {{jsxref("Uint8Array.fromBase64()")}}, {{jsxref("Uint8Array.prototype.toBase64()")}}, and {{jsxref("Uint8Array.prototype.setFromBase64()")}} for working with [base64](/en-US/docs/Glossary/Base64) strings, where 3 bytes are encoded by 4 characters that are either 0–9, A–Z, a–z, "+", and "/" (or "-" and "\_", if using URL-safe base64).
-- {{jsxref("Uint8Array.fromHex()")}}, {{jsxref("Uint8Array.prototype.toHex()")}}, and {{jsxref("Uint8Array.prototype.setFromHex()")}} for working with hex strings, where every byte is encoded by two characters that's either 0–9 or A–F (case-insensitive).
+- {{jsxref("Uint8Array.fromHex()")}}, {{jsxref("Uint8Array.prototype.toHex()")}}, and {{jsxref("Uint8Array.prototype.setFromHex()")}} for working with hex strings, where every byte is encoded by two characters, each one being either 0–9 or A–F (case-insensitive).
 
 ## Constructor
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
@@ -87,7 +87,7 @@ console.log(uint8Array);
 
 ### Stream decoding
 
-This example is adapted from the [original proposal](https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs), showcasing how to implement streaming in userland. It mimics the {{domxref("TextDecoder")}} API with the `stream` option. Note the use of `lastChunkHandling: "stop-before-partial"` to handle incomplete chunks.
+This example is adapted from the [original proposal](https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs). It mimics the {{domxref("TextDecoder")}} API with the `stream` option. Note the use of `lastChunkHandling: "stop-before-partial"` to handle incomplete chunks.
 
 ```js
 class Base64Decoder {

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
@@ -1,0 +1,125 @@
+---
+title: Uint8Array.prototype.setFromBase64()
+slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/setFromBase64
+page-type: javascript-instance-method
+browser-compat: javascript.builtins.Uint8Array.setFromBase64
+---
+
+{{JSRef}}
+
+The **`setFromBase64()`** method of {{jsxref("Uint8Array")}} instances populates this `Uint8Array` object with bytes from a [base64](/en-US/docs/Glossary/Base64)-encoded string, returning an object containing how many bytes were read and written.
+
+For the general concepts around base64 strings, see the [base64](/en-US/docs/Glossary/Base64) glossary entry. This method is most suitable for populating a pre-allocated array buffer. If you just want to create a new `Uint8Array` object from a base64-encoded string, use the static method {{jsxref("Uint8Array.fromBase64()")}} instead.
+
+## Syntax
+
+```js-nolint
+setFromBase64(string)
+setFromBase64(string, options)
+```
+
+### Parameters
+
+- `string`
+  - : A base64-encoded string to convert to a `Uint8Array`. It has the same requirements as the [`string` parameter of `Uint8Array.fromBase64()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64#string). Note that the string is only read up to the point where the array is filled, so any invalid base64 syntax after that point is ignored.
+- `options` {{optional_inline}}
+  - : An object customizing the base64 string interpretation process. It has the same requirements as the [`options` parameter of `Uint8Array.fromBase64()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64#options).
+
+### Return value
+
+An object containing the following properties:
+
+- `read`
+  - : The number of base64 characters read from the input string. It is either the length of the input string (including padding), if the decoded data fits into the array, or a multiple of 4 up to the last complete 4-character chunk that fits into the array. If a chunk has more data than the remainder of the array can hold, that chunk will never be split (because the remaining bits cannot be partially "put back" into the base64 without completely re-encoding it); it will be entirely ignored, resulting in the last one or two bytes of the array not being written.
+- `written`
+  - : The number of bytes written to the `Uint8Array`. Will never be greater than this `Uint8Array`'s {{jsxref("TypedArray/byteLength", "byteLength")}}.
+
+### Exceptions
+
+- {{jsxref("SyntaxError")}}
+  - : Thrown if the input string contains characters outside the specified alphabet, or if the last chunk does not satisfy the `lastChunkHandling` option.
+- {{jsxref("TypeError")}}
+  - : Thrown in one of the following cases:
+    - The input string is not a string.
+    - The `options` object is not an object or `undefined`.
+    - The options are not of the expected values or `undefined`.
+
+## Examples
+
+### Decoding a base64 string
+
+This example uses the default `alphabet` and `lastChunkHandling` options to decode a base64 string into an existing `Uint8Array`.
+
+```js
+const uint8Array = new Uint8Array(8);
+const result = uint8Array.setFromBase64("Hello World");
+console.log(result); // { read: 11, written: 7 }
+console.log(uint8Array); // Uint8Array(8) [29, 233, 101, 161, 106, 43, 149, 0]
+```
+
+### Decoding a big string into a small array
+
+If the string contains more data than the array can hold, the method will only write as many bytes as the array can hold, without discarding any bits.
+
+```js
+const uint8Array = new Uint8Array(4);
+const result = uint8Array.setFromBase64("Hello World");
+console.log(result); // { read: 4, written: 3 }
+console.log(uint8Array); // Uint8Array(4) [29, 233, 101, 0]
+```
+
+Note how the last byte of the array is not written, because to decode that byte, we need to read two more base64 characters, which represent 12 bits, resulting in 4 trailing bits being discarded. Therefore, only the first 4-character chunk is decoded into 3 bytes.
+
+### Implementing stream decoding
+
+This example is adapted from the [original proposal](https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs), showcasing how to implement streaming in userland. It mimics the {{domxref("TextDecoder")}} API with the `stream` option. Note the use of `lastChunkHandling: "stop-before-partial"` to handle incomplete chunks.
+
+```js
+class Base64Decoder {
+  #extra = "";
+
+  decode(chunk = "", options = {}) {
+    const opts = { ...options };
+    // match TextEncoder API
+    if (opts.stream) {
+      opts.lastChunkHandling = "stop-before-partial";
+    }
+    chunk = this.#extra + chunk;
+    this.#extra = "";
+    // For simplicity, allocate new memory every time
+    // the calculation below is guaranteed to be enough,
+    // but may be too much if there is whitespace
+    // if you're really concerned about memory, a TextDecoder style API is a bad choice
+    let buffer = new Uint8Array(Math.ceil((chunk.length * 3) / 4));
+    const { read, written } = buffer.setFromBase64(chunk, opts);
+    buffer = buffer.subarray(0, written);
+    this.#extra = chunk.slice(read);
+    return buffer;
+  }
+}
+
+const decoder = new Base64Decoder();
+
+console.log(decoder.decode("SG Vsb ", { stream: true }));
+// Uint8Array(3) [72, 101, 108]
+console.log(decoder.decode("G8gV29ybGR ", { stream: true }));
+// Uint8Array(6) [108, 111, 32, 87, 111, 114]
+console.log(decoder.decode(""));
+// Uint8Array(2) [108, 100]
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Polyfill of `Uint8Array.setFromBase64` in `core-js`](https://github.com/zloirock/core-js#uint8array-to--from-base64-and-hex)
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8Array.fromBase64()")}}
+- {{jsxref("Uint8Array.prototype.toBase64()")}}
+- {{domxref("Window.atob()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
@@ -85,7 +85,7 @@ console.log(uint8Array);
 // Uint8Array(16) [0, 0, 60, 98, 62, 77, 68, 78, 60, 47, 98, 62, 0, 0, 0, 0]
 ```
 
-### Implementing stream decoding
+### Stream decoding
 
 This example is adapted from the [original proposal](https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs), showcasing how to implement streaming in userland. It mimics the {{domxref("TextDecoder")}} API with the `stream` option. Note the use of `lastChunkHandling: "stop-before-partial"` to handle incomplete chunks.
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfrombase64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Uint8Array.setFromBase64
 
 The **`setFromBase64()`** method of {{jsxref("Uint8Array")}} instances populates this `Uint8Array` object with bytes from a [base64](/en-US/docs/Glossary/Base64)-encoded string, returning an object indicating how many bytes were read and written.
 
-For the general concepts around base64 strings, see the [base64](/en-US/docs/Glossary/Base64) glossary entry. This method is most suitable for populating a pre-allocated array buffer. If you just want to create a new `Uint8Array` object from a base64-encoded string, use the static method {{jsxref("Uint8Array.fromBase64()")}} instead.
+This method is most suitable for populating a pre-allocated array buffer. If you just want to create a new `Uint8Array` object from a base64-encoded string, use the static method {{jsxref("Uint8Array.fromBase64()")}} instead.
 
 ## Syntax
 
@@ -21,7 +21,7 @@ setFromBase64(string, options)
 ### Parameters
 
 - `string`
-  - : A base64-encoded string to convert to a `Uint8Array`. It has the same requirements as the [`string` parameter of `Uint8Array.fromBase64()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64#string). Note that the string is only read up to the point where the array is filled, so any invalid base64 syntax after that point is ignored.
+  - : A base64 string encoding bytes to write into a `Uint8Array`. It has the same requirements as the [`string` parameter of `Uint8Array.fromBase64()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64#string). Note that the string is only read up to the point where the array is filled, so any invalid base64 syntax after that point is ignored.
 - `options` {{optional_inline}}
   - : An object customizing the base64 string interpretation process. It has the same requirements as the [`options` parameter of `Uint8Array.fromBase64()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64#options).
 
@@ -30,7 +30,7 @@ setFromBase64(string, options)
 An object containing the following properties:
 
 - `read`
-  - : The number of base64 characters read from the input string. It is either the length of the input string (including padding), if the decoded data fits into the array, or up to the last complete 4-character chunk that fits into the array. Chunks will never be split (because the remaining bits cannot be partially "put back" into the base64 without completely re-encoding it); if the next chunk cannot fit into the remainder of the array, it will be entirely unread, resulting in the last one or two bytes of the array not being written.
+  - : The number of base64 characters read from the input string. If the decoded data fits into the array, this is the length of the input string (including padding); otherwise, it is the length up to the last complete 4-character chunk that fits into the array. Chunks will never be split (because the remaining bits cannot be partially "put back" into the base64 without completely re-encoding it); if the next chunk cannot fit into the remainder of the array, it will be entirely unread, resulting in the last one or two bytes of the array not being written.
 - `written`
   - : The number of bytes written to the `Uint8Array`. Will never be greater than this `Uint8Array`'s {{jsxref("TypedArray/byteLength", "byteLength")}}.
 
@@ -70,7 +70,7 @@ console.log(uint8Array);
 // Uint8Array(8) [60, 98, 62, 77, 68, 78, 0, 0]
 ```
 
-Note how the last two bytes of the array are not written, because to decode the next two bytes, we need to read three more base64 characters, which represent 18 bits, resulting in 2 trailing bits being discarded. Therefore, we can only write 2 chunks, or 6 bytes, to the array.
+Note how the last two bytes of the array are not written. To decode these two bytes, we need to read at least three more base64 characters, which represent 18 bits. These can't fit into the remaining two bytes of the array, so we can only write 2 chunks, or 6 bytes.
 
 ### Setting data at a specific offset
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
@@ -27,7 +27,7 @@ setFromHex(string)
 An object containing the following properties:
 
 - `read`
-  - : The number of hex characters read from the input string. It is either the length of the input string (including padding), if the decoded data fits into the array, or a multiple of 2 up to the last 2-character chunk that fits into the array.
+  - : The number of hex characters read from the input string. It is either the length of the input string, if the decoded data fits into the array, or a multiple of 2 up to the last 2-character chunk that fits into the array.
 - `written`
   - : The number of bytes written to the `Uint8Array`. Will never be greater than this `Uint8Array`'s {{jsxref("TypedArray/byteLength", "byteLength")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
@@ -1,0 +1,81 @@
+---
+title: Uint8Array.setFromHex()
+slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/setFromHex
+page-type: javascript-instance-method
+browser-compat: javascript.builtins.Uint8Array.setFromHex
+---
+
+{{JSRef}}
+
+The **`setFromHex()`** method of {{jsxref("Uint8Array")}} instances populates this `Uint8Array` object with bytes from a hex-encoded string, returning an object containing how many bytes were read and written.
+
+This method parses the string into a byte array. To convert the string into a single number, use the {{jsxref("Global_Objects/parseInt", "parseInt()")}} function with `radix` set to `16` instead.
+
+## Syntax
+
+```js-nolint
+setFromHex(string)
+```
+
+### Parameters
+
+- `string`
+  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters. Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
+
+### Return value
+
+An object containing the following properties:
+
+- `read`
+  - : The number of hex characters read from the input string. It is either the length of the input string (including padding), if the decoded data fits into the array, or a multiple of 2 up to the last 2-character chunk that fits into the array.
+- `written`
+  - : The number of bytes written to the `Uint8Array`. Will never be greater than this `Uint8Array`'s {{jsxref("TypedArray/byteLength", "byteLength")}}.
+
+### Exceptions
+
+- {{jsxref("SyntaxError")}}
+  - : Thrown if the input string contains characters outside the hex alphabet, or its length is odd.
+- {{jsxref("TypeError")}}
+  - : Thrown if the input string is not a string.
+
+## Examples
+
+### Decoding a hexadecimal string
+
+This example decodes a hexadecimal string into an existing `Uint8Array`.
+
+```js
+const uint8Array = new Uint8Array(8);
+const result = uint8Array.setFromHex("cafed00d");
+console.log(result); // { read: 8, written: 4 }
+console.log(uint8Array); // Uint8Array(8) [202, 254, 208, 13, 0, 0, 0, 0]
+```
+
+### Decoding a big string into a small array
+
+If the string contains more data than the array can hold, the method will only write as many bytes as the array can hold.
+
+```js
+const uint8Array = new Uint8Array(4);
+const result = uint8Array.setFromHex("cafed00d-some random stuff");
+console.log(result); // { read: 8, written: 4 }
+console.log(uint8Array); // Uint8Array(4) [202, 254, 208, 13]
+```
+
+Excess characters are ignored, even if they are invalid. However the total length of the input string must be even.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Polyfill of `Uint8Array.setFromHex` in `core-js`](https://github.com/zloirock/core-js#uint8array-to--from-base64-and-hex)
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8Array.fromHex()")}}
+- {{jsxref("Uint8Array.prototype.toHex()")}}
+- {{jsxref("Global_Objects/parseInt", "parseInt()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
@@ -20,7 +20,7 @@ setFromHex(string)
 ### Parameters
 
 - `string`
-  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters.Unlike {{jsxref("Uint8Array.prototype.setFromBase64()")}}, the input cannot contain whitespace. Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
+  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters. Unlike {{jsxref("Uint8Array.prototype.setFromBase64()")}}, the input cannot contain whitespace. Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
 
 ### Return value
 
@@ -63,6 +63,19 @@ console.log(uint8Array); // Uint8Array(4) [202, 254, 208, 13]
 ```
 
 Excess characters are ignored, even if they are invalid. However the total length of the input string must be even.
+
+### Setting data at a specific offset
+
+The `setFromHex()` method always starts writing at the beginning of the `Uint8Array`. If you want to write to the middle of the array, you can write to a {{jsxref("TypedArray.prototype.subarray()")}} instead.
+
+```js
+const uint8Array = new Uint8Array(8);
+// Start writing at offset 2
+const result = uint8Array.subarray(2).setFromHex("cafed00d");
+console.log(result); // { read: 8, written: 4 }
+console.log(uint8Array);
+// Uint8Array(8) [0, 0, 202, 254, 208, 13, 0, 0]
+```
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Uint8Array.setFromHex
 
 {{JSRef}}
 
-The **`setFromHex()`** method of {{jsxref("Uint8Array")}} instances populates this `Uint8Array` object with bytes from a hex-encoded string, returning an object containing how many bytes were read and written.
+The **`setFromHex()`** method of {{jsxref("Uint8Array")}} instances populates this `Uint8Array` object with bytes from a hex-encoded string, returning an object indicating how many bytes were read and written.
 
 This method parses the string into a byte array. To convert the string into a single number, use the {{jsxref("Global_Objects/parseInt", "parseInt()")}} function with `radix` set to `16` instead.
 
@@ -20,7 +20,7 @@ setFromHex(string)
 ### Parameters
 
 - `string`
-  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters. Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
+  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters.Unlike {{jsxref("Uint8Array.prototype.setFromBase64()")}}, the input cannot contain whitespace. Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
@@ -20,14 +20,21 @@ setFromHex(string)
 ### Parameters
 
 - `string`
-  - : A hexadecimal string to convert to a `Uint8Array`. The string must only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive). It must have an even number of characters. Unlike {{jsxref("Uint8Array.prototype.setFromBase64()")}}, the input cannot contain whitespace. Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
+
+  - : A hexadecimal string encoding bytes to write into a `Uint8Array`. The string must:
+
+    - Have an even number of characters because two characters encode one byte.
+    - Only contain characters in the hexadecimal alphabet, which includes 0–9 and A–F (case-insensitive).
+    - Not contain whitespace (unlike {{jsxref("Uint8Array.prototype.setFromBase64()")}}).
+
+    Note that the string is only read up to the point where the array is filled, so any invalid hex syntax after that point is ignored.
 
 ### Return value
 
 An object containing the following properties:
 
 - `read`
-  - : The number of hex characters read from the input string. It is either the length of the input string, if the decoded data fits into the array, or a multiple of 2 up to the last 2-character chunk that fits into the array.
+  - : The number of hex characters read from the input string. If the decoded data fits into the array, it is the length of the input string: otherwise, it is the number of complete hex characters that fit into the array.
 - `written`
   - : The number of bytes written to the `Uint8Array`. Will never be greater than this `Uint8Array`'s {{jsxref("TypedArray/byteLength", "byteLength")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/tobase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/tobase64/index.md
@@ -1,0 +1,153 @@
+---
+title: Uint8Array.prototype.toBase64()
+slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64
+page-type: javascript-instance-method
+browser-compat: javascript.builtins.Uint8Array.toBase64
+---
+
+{{JSRef}}
+
+The **`toBase64()`** method of {{jsxref("Uint8Array")}} instances returns a [base64](/en-US/docs/Glossary/Base64)-encoded string based on the data in this `Uint8Array` object.
+
+For the general concepts around base64 strings, see the [base64](/en-US/docs/Glossary/Base64) glossary entry. This method should be preferred over {{domxref("Window.btoa()")}}, especially if you already have a `Uint8Array` holding the object, because you don't need to convert it to a string first.
+
+## Syntax
+
+```js-nolint
+toBase64()
+toBase64(options)
+```
+
+### Parameters
+
+- `options` {{optional_inline}}
+  - : An object customizing the base64 string format. It can contain the following properties:
+    - `alphabet` {{optional_inline}}
+      - : A string specifying the base64 alphabet to use. It can be one of the following:
+        - `"base64"` (default)
+          - : Use `+` and `/` as `0x3E` and `0x3F`, respectively.
+        - `"base64url"`
+          - : Use `-` and `_` as `0x3E` and `0x3F`, respectively.
+    - `omitPadding` {{optional_inline}}
+      - : A boolean specifying whether to omit padding characters (`=`) at the end of the base64 string. The default is `false`.
+
+### Return value
+
+A base64-encoded string representing the data in the `Uint8Array`.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown in one of the following cases:
+    - The `options` object is not an object or `undefined`.
+    - The `options.alphabet` is not of the expected values or `undefined`.
+
+## Examples
+
+### Encoding binary data
+
+This example uses the default `alphabet` and `omitPadding` options to encode data from a `Uint8Array` into a base64 string.
+
+```js
+const uint8Array = new Uint8Array([29, 233, 101, 161]);
+console.log(uint8Array.toBase64()); // "HelloQ=="
+```
+
+### Encoding data without padding
+
+```js
+const uint8Array = new Uint8Array([29, 233, 101, 161]);
+console.log(uint8Array.toBase64({ omitPadding: true })); // "HelloQ"
+```
+
+### Encoding data with URL-safe alphabet
+
+This example populates a {{domxref("URLSearchParams")}} object with a base64-encoded string using the URL-safe alphabet.
+
+```js
+const uint8Array = new Uint8Array([46, 139, 222, 255, 42, 46]);
+const base64 = uint8Array.toBase64({ alphabet: "base64url" });
+const params = new URLSearchParams();
+params.set("data", base64);
+console.log(params.toString()); // "data=Love_you"
+```
+
+### Implementing stream encoding
+
+This example is adapted from the [original proposal](https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs), showcasing how to implement streaming in userland. It mimics the {{domxref("TextEncoder")}} API with the `stream` option.
+
+```js
+class Base64Encoder {
+  #extra;
+  #extraLength;
+  constructor() {
+    this.#extra = new Uint8Array(3);
+    this.#extraLength = 0;
+  }
+
+  // Partly derived from https://github.com/lucacasonato/base64_streams/blob/main/src/iterator/encoder.ts
+  encode(chunk = Uint8Array.of(), options = {}) {
+    const stream = options.stream ?? false;
+
+    if (this.#extraLength > 0) {
+      const bytesNeeded = 3 - this.#extraLength;
+      const bytesAvailable = Math.min(bytesNeeded, chunk.length);
+      this.#extra.set(chunk.subarray(0, bytesAvailable), this.#extraLength);
+      chunk = chunk.subarray(bytesAvailable);
+      this.#extraLength += bytesAvailable;
+    }
+
+    if (!stream) {
+      // assert: this.#extraLength.length === 0 || this.#extraLength === 3 || chunk.length === 0
+      const prefix = this.#extra.subarray(0, this.#extraLength).toBase64();
+      this.#extraLength = 0;
+      return prefix + chunk.toBase64();
+    }
+
+    let extraReturn = "";
+
+    if (this.#extraLength === 3) {
+      extraReturn = this.#extra.toBase64();
+      this.#extraLength = 0;
+    }
+
+    const remainder = chunk.length % 3;
+    if (remainder > 0) {
+      this.#extra.set(chunk.subarray(chunk.length - remainder));
+      this.#extraLength = remainder;
+      chunk = chunk.subarray(0, chunk.length - remainder);
+    }
+
+    return extraReturn + chunk.toBase64();
+  }
+}
+
+const encoder = new Base64Encoder();
+
+console.log(
+  encoder.encode(Uint8Array.of(72, 101, 108, 108, 111), { stream: true }),
+);
+// "SGVs"
+console.log(
+  encoder.encode(Uint8Array.of(32, 87, 111, 114, 108, 100), { stream: true }),
+);
+// "bG8gV29y"
+console.log(encoder.encode());
+// "bGQ="
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Polyfill of `Uint8Array.toBase64` in `core-js`](https://github.com/zloirock/core-js#uint8array-to--from-base64-and-hex)
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8Array.fromBase64()")}}
+- {{jsxref("Uint8Array.prototype.setFromBase64()")}}
+- {{domxref("Window.btoa()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/tobase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/tobase64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Uint8Array.toBase64
 
 The **`toBase64()`** method of {{jsxref("Uint8Array")}} instances returns a [base64](/en-US/docs/Glossary/Base64)-encoded string based on the data in this `Uint8Array` object.
 
-For the general concepts around base64 strings, see the [base64](/en-US/docs/Glossary/Base64) glossary entry. This method should be preferred over {{domxref("Window.btoa()")}}, especially if you already have a `Uint8Array` holding the object, because you don't need to convert it to a string first.
+This method should be preferred over {{domxref("Window.btoa()")}}, especially if you already have a `Uint8Array` holding the object, because you don't need to convert it to a string first.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/tobase64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/tobase64/index.md
@@ -25,9 +25,9 @@ toBase64(options)
     - `alphabet` {{optional_inline}}
       - : A string specifying the base64 alphabet to use. It can be one of the following:
         - `"base64"` (default)
-          - : Use `+` and `/` as `0x3E` and `0x3F`, respectively.
+          - : Encode input with the standard base64 alphabet, which uses `+` and `/`.
         - `"base64url"`
-          - : Use `-` and `_` as `0x3E` and `0x3F`, respectively.
+          - : Encode input with the URL-safe base64 alphabet, which uses `-` and `_`.
     - `omitPadding` {{optional_inline}}
       - : A boolean specifying whether to omit padding characters (`=`) at the end of the base64 string. The default is `false`.
 
@@ -72,7 +72,7 @@ params.set("data", base64);
 console.log(params.toString()); // "data=Love_you"
 ```
 
-### Implementing stream encoding
+### Stream encoding
 
 This example is adapted from the [original proposal](https://github.com/tc39/proposal-arraybuffer-base64/blob/main/stream.mjs), showcasing how to implement streaming in userland. It mimics the {{domxref("TextEncoder")}} API with the `stream` option.
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/tohex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/tohex/index.md
@@ -1,0 +1,53 @@
+---
+title: Uint8Array.prototype.toHex()
+slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/toHex
+page-type: javascript-instance-method
+browser-compat: javascript.builtins.Uint8Array.toHex
+---
+
+{{JSRef}}
+
+The **`toHex()`** method of {{jsxref("Uint8Array")}} instances returns a hex-encoded string based on the data in this `Uint8Array` object.
+
+This method creates strings from a byte array. To convert individual numbers into hex, use the {{jsxref("Number.prototype.toString()")}} method with `radix` set to `16` instead.
+
+## Syntax
+
+```js-nolint
+toHex()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A hex-encoded string representing the data in the `Uint8Array`.
+
+## Examples
+
+### Encoding binary data
+
+This example encodes data from a `Uint8Array` into a hex string.
+
+```js
+const uint8Array = new Uint8Array([202, 254, 208, 13]);
+console.log(uint8Array.toHex()); // "cafed00d"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Polyfill of `Uint8Array.toHex` in `core-js`](https://github.com/zloirock/core-js#uint8array-to--from-base64-and-hex)
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8Array.fromHex()")}}
+- {{jsxref("Uint8Array.prototype.setFromHex()")}}
+- {{jsxref("Number.prototype.toString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/tohex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/tohex/index.md
@@ -34,6 +34,14 @@ This example encodes data from a `Uint8Array` into a hex string.
 ```js
 const uint8Array = new Uint8Array([202, 254, 208, 13]);
 console.log(uint8Array.toHex()); // "cafed00d"
+
+const data = new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255]);
+for (let i = 0; i < data.length; i += 3) {
+  console.log(data.slice(i, i + 3).toHex());
+}
+// "ff0000"
+// "00ff00"
+// "00ff00"
 ```
 
 ## Specifications


### PR DESCRIPTION
This adds documentation for a new API: https://github.com/tc39/proposal-arraybuffer-base64. Based on https://github.com/tc39/proposal-arraybuffer-base64/issues/51, it is in FF 133 and Safari TP 202.

cc @bakkot