### PR TITLE
Fix Request.signal example: catch needs req.signal

### DIFF
--- a/files/en-us/web/api/request/signal/index.md
+++ b/files/en-us/web/api/request/signal/index.md
@@ -30,9 +30,9 @@ req.signal.addEventListener("abort", () => {
 
 // In case of abort, log the AbortSignal reason, if any
 fetch(req).catch(() => {
-  if (signal.aborted) {
-    if (signal.reason) {
-      console.log(`Request aborted with reason: ${signal.reason}`);
+  if (req.signal.aborted) {
+    if (req.signal.reason) {
+      console.log(`Request aborted with reason: ${req.signal.reason}`);
     } else {
       console.log("Request aborted but no reason was given.");
     }


### PR DESCRIPTION
### Description

In the example of the article [Request: signal property](https://developer.mozilla.org/en-US/docs/Web/API/Request/signal) the catch method uses a "signal" variable that doesn't exists.

### Motivation

Example code was failing with "Uncaught (in promise) ReferenceError: signal is not defined"

