### PR TITLE
Sync CRC2D.save() saved drawing state attributes with the spec

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
@@ -21,24 +21,32 @@ The drawing state that gets saved onto a stack consists of:
 - The current clipping region.
 - The current dash list.
 - The current values of the following attributes:
-  {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}},
-  {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}},
-  {{domxref("CanvasRenderingContext2D.globalAlpha", "globalAlpha")}},
-  {{domxref("CanvasRenderingContext2D.lineWidth", "lineWidth")}},
-  {{domxref("CanvasRenderingContext2D.lineCap", "lineCap")}},
-  {{domxref("CanvasRenderingContext2D.lineJoin", "lineJoin")}},
-  {{domxref("CanvasRenderingContext2D.miterLimit", "miterLimit")}},
-  {{domxref("CanvasRenderingContext2D.lineDashOffset", "lineDashOffset")}},
-  {{domxref("CanvasRenderingContext2D.shadowOffsetX", "shadowOffsetX")}},
-  {{domxref("CanvasRenderingContext2D.shadowOffsetY", "shadowOffsetY")}},
-  {{domxref("CanvasRenderingContext2D.shadowBlur", "shadowBlur")}},
-  {{domxref("CanvasRenderingContext2D.shadowColor", "shadowColor")}},
-  {{domxref("CanvasRenderingContext2D.globalCompositeOperation", "globalCompositeOperation")}},
-  {{domxref("CanvasRenderingContext2D.font", "font")}},
-  {{domxref("CanvasRenderingContext2D.textAlign", "textAlign")}},
-  {{domxref("CanvasRenderingContext2D.textBaseline", "textBaseline")}},
-  {{domxref("CanvasRenderingContext2D.direction", "direction")}},
-  {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}}.
+  - {{domxref("CanvasRenderingContext2D.direction", "direction")}}
+  - {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}}
+  - {{domxref("CanvasRenderingContext2D.filter", "filter")}}
+  - {{domxref("CanvasRenderingContext2D.font", "font")}}
+  - {{domxref("CanvasRenderingContext2D.fontKerning", "fontKerning")}}
+  - {{domxref("CanvasRenderingContext2D.fontStretch", "fontStretch")}}
+  - {{domxref("CanvasRenderingContext2D.fontVariantCaps", "fontVariantCaps")}}
+  - {{domxref("CanvasRenderingContext2D.globalAlpha", "globalAlpha")}}
+  - {{domxref("CanvasRenderingContext2D.globalCompositeOperation", "globalCompositeOperation")}}
+  - {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}}
+  - {{domxref("CanvasRenderingContext2D.imageSmoothingQuality", "imageSmoothingQuality")}}
+  - {{domxref("CanvasRenderingContext2D.letterSpacing", "letterSpacing")}}
+  - {{domxref("CanvasRenderingContext2D.lineCap", "lineCap")}}
+  - {{domxref("CanvasRenderingContext2D.lineDashOffset", "lineDashOffset")}}
+  - {{domxref("CanvasRenderingContext2D.lineJoin", "lineJoin")}}
+  - {{domxref("CanvasRenderingContext2D.lineWidth", "lineWidth")}}
+  - {{domxref("CanvasRenderingContext2D.miterLimit", "miterLimit")}}
+  - {{domxref("CanvasRenderingContext2D.shadowBlur", "shadowBlur")}}
+  - {{domxref("CanvasRenderingContext2D.shadowColor", "shadowColor")}}
+  - {{domxref("CanvasRenderingContext2D.shadowOffsetX", "shadowOffsetX")}}
+  - {{domxref("CanvasRenderingContext2D.shadowOffsetY", "shadowOffsetY")}}
+  - {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}}
+  - {{domxref("CanvasRenderingContext2D.textAlign", "textAlign")}}
+  - {{domxref("CanvasRenderingContext2D.textBaseline", "textBaseline")}}
+  - {{domxref("CanvasRenderingContext2D.textRendering", "textRendering")}}
+  - {{domxref("CanvasRenderingContext2D.wordSpacing", "wordSpacing")}}
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Update the list of saved attributes by the CRC2D.save() method, additionally sort it alphabetically and display it as a nested list.

### Motivation
The list of saved attributes by the CRC2D.save() method was incomplete, unsorted, and difficult to read.

### Additional details
https://html.spec.whatwg.org/multipage/canvas.html#drawing-state

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
