### PR TITLE
Fix mismatch in 422 Unprocessable Content/Entity wording

### DIFF
--- a/files/en-us/web/http/status/422/index.md
+++ b/files/en-us/web/http/status/422/index.md
@@ -7,7 +7,7 @@ spec-urls: https://httpwg.org/specs/rfc9110.html#status.422
 
 {{HTTPSidebar}}
 
-The HTTP **`422 Unprocessable Content`** [client error response](/en-US/docs/Web/HTTP/Status#client_error_responses) status code indicates that the server understood the content type of the request entity, and the syntax of the request entity was correct, but it was unable to process the contained instructions.
+The HTTP **`422 Unprocessable Content`** [client error response](/en-US/docs/Web/HTTP/Status#client_error_responses) status code indicates that the server understood the content type of the request content, and the syntax of the request content was correct, but it was unable to process the contained instructions.
 
 Clients that receive a `422` response should expect that repeating the request without modification will fail with the same error.
 
@@ -40,10 +40,10 @@ Content-Length: 165
 ```
 
 In this implementation, the server expects strictly {{rfc("4648")}}-compliant Base64 encoded content (using [strict encoding methods](https://ruby-doc.org/3.3.2/stdlibs/base64/Base64.html#method-i-strict_encode64)).
-A `422` Unprocessable Entity response is returned and the `message` field provides context about the validation error:
+A `422` Unprocessable Content response is returned and the `message` field provides context about the validation error:
 
 ```http
-HTTP/1.1 422 Unprocessable Entity
+HTTP/1.1 422 Unprocessable Content
 Date: Fri, 28 Jun 2024 12:00:00 GMT
 Content-Type: application/json; charset=utf-8
 Content-Length: 187


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

[The 422 Unprocessable Content page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) was still using the "entity" word, which is now replaced by "content" in the RFC.

### Motivation

Avoids any miscomprehension.