### PR TITLE
Adds units to time offsets mentions

### DIFF
--- a/files/en-us/web/api/timeranges/end/index.md
+++ b/files/en-us/web/api/timeranges/end/index.md
@@ -8,7 +8,7 @@ browser-compat: api.TimeRanges.end
 
 {{APIRef("DOM")}}
 
-The **`end()`** method of the {{domxref("TimeRanges")}} interface returns the time offset at which a specified time range ends.
+The **`end()`** method of the {{domxref("TimeRanges")}} interface returns the time offset (in seconds) at which a specified time range ends.
 
 ## Syntax
 

--- a/files/en-us/web/api/timeranges/start/index.md
+++ b/files/en-us/web/api/timeranges/start/index.md
@@ -8,7 +8,7 @@ browser-compat: api.TimeRanges.start
 
 {{APIRef("DOM")}}
 
-The **`start()`** method of the {{domxref("TimeRanges")}} interface returns the time offset at which a specified time range begins.
+The **`start()`** method of the {{domxref("TimeRanges")}} interface returns the time offset (in seconds) at which a specified time range begins.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
There is missing info about what time units are used for returned values of TimeRange methods, so I had to go find out in specification, better to mention it in docs I suppose

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
they don't need to go to specification to find out units

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
specification: https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-end-dev

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
