### PR TITLE
Remove obsolete comment about redirecting to data: URIs in webRequest.BlockingResponse

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -32,7 +32,7 @@ Values of this type are objects. They contain the following properties:
 
   - : `string`. This is a URL, and if set, the original request is redirected to that URL. You can only set this property in {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}} or {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}.
 
-    Redirections to non-HTTP schemes such as data: are allowed, but they are not currently supported ([Firefox bug 707624](https://bugzil.la/707624)). Redirects use the same request method as the original request unless initiated from `onHeadersReceived` stage, in which case the redirect uses the GET method.
+    Redirections to non-HTTP schemes such as `data:` are allowed. Redirects use the same request method as the original request unless initiated from `onHeadersReceived` stage, in which case the redirect uses the GET method.
 
     If an extension wants to redirect a public (e.g. HTTPS) URL to an [extension page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages), the extension's manifest.json file must contain a [web_accessible_resources](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) key that lists the URL for the extension page.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The removed note about `data:` URIs not being supported is outdated and no longer relevant. The linked Firefox bug was closed as resolved 2 years ago. I have also manually tested redirecting to a `data:` URL and it does in fact work.

### Motivation

The old comment was incorrect and should be removed.

### Additional details

The closed bug that was referenced: https://bugzil.la/707624

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/35184