### PR TITLE
column-fill: put `balance-all` back into the content

### DIFF
--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -35,6 +35,8 @@ The `column-fill` property is specified as one of the keyword values listed belo
 - `balance`
   - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.
 
+The specification defines a `balance-all` value, in which content is equally divided between columns in fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media). This value is not yet supported in any browser.
+
 ## Formal definition
 
 {{cssinfo}}


### PR DESCRIPTION
the value was removed in #34561 but is still in web-ref, so it is in the formal syntax section. Putting the value in the values section but not within the DL
