### PR TITLE
Fix overflow detection by using the padding box instead of the border box

### DIFF
--- a/files/en-us/web/api/element/scrollwidth/index.md
+++ b/files/en-us/web/api/element/scrollwidth/index.md
@@ -85,9 +85,9 @@ const div2 = document.getElementById("div2");
 const log1 = document.getElementById("log1");
 const log2 = document.getElementById("log2");
 
-// Check if the scrollWidth is bigger than the offsetWidth or not
+// Check if the scrollWidth is bigger than the clientWidth or not
 function isOverflowing(element) {
-  return element.scrollWidth > element.offsetWidth;
+  return element.scrollWidth > element.clientWidth;
 }
 
 function checkOverflow(element, log) {
@@ -124,5 +124,4 @@ Click the buttons to check if the content is overflowing the containers.
 ## See also
 
 - {{domxref("Element.clientWidth")}}
-- {{domxref("HTMLElement.offsetWidth")}}
 - [Determining the dimensions of elements](/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements)


### PR DESCRIPTION
### Description

Replace `HTMLElement.offsetWidth` with `Element.clientWidth` in the page https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth.

### Motivation

The page starts off by mentioning `Element.clientWidth` but then goes on with `HTMLElement.offsetWidth` for detecting overflowing content. This is inconsistent not only with the start of this page but also with the page https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight, and only `Element.clientWidth` is correct. Indeed, the boundaries of the *visible content* of an element are defined by its padding box (that is excluding scrollbars and borders), not by its border box (that is including scrollbars and borders). So to check when the content is overflowing the padding box we compare the content dimensions (`Element.scrollWidth` and `Element.scrollHeight`) with the padding box dimensions (`Element.clientWidth` and `Element.clientHeight`).

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements