### PR TITLE
Fix typo in Baseline definition.

### DIFF
--- a/files/en-us/glossary/baseline/compatibility/index.md
+++ b/files/en-us/glossary/baseline/compatibility/index.md
@@ -18,7 +18,7 @@ Baseline considers support in the following browsers:
 - Mozilla Firefox (Android)
 - Mozilla Firefox (desktop)
 
-Baseline is a summary of browser support. It is not a substitute for accessibility, usability, performance, security, or other testing. Baseline may not tell if you if a feature works with:
+Baseline is a summary of browser support. It is not a substitute for accessibility, usability, performance, security, or other testing. Baseline may not tell you if a feature works with:
 
 - Older devices and browser releases
 - Browsers not covered by the Baseline definition, such as operating system web views


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix a simple typo (there's one "if" too many).

