### PR TITLE
change anchor-element parameters to anchor-name, as per spec change

### DIFF
--- a/files/en-us/web/css/anchor-size/index.md
+++ b/files/en-us/web/css/anchor-size/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.anchor-size
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`anchor-size()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables [sizing anchor-positioned elements](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#sizing_elements_based_on_anchor_size) relative to the dimensions of anchor elements. It returns the `<length>` of a specified side of the target anchor element. `anchor()` is only valid when used within the value of anchor-positioned elements' [sizing properties](#properties_that_accept_anchor-size_function_values).
+The **`anchor-size()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables [sizing anchor-positioned elements](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#sizing_elements_based_on_anchor_size) relative to the dimensions of anchor elements. It returns the `<length>` of a specified side of the target anchor element. `anchor-size()` is only valid when used within the value of anchor-positioned elements' [sizing properties](#properties_that_accept_anchor-size_function_values).
 
 For detailed information on anchor features and usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide.
 
@@ -35,19 +35,19 @@ block-size: anchor-size(--myAnchor block, 200px);
 The `anchor-size()` function's syntax is as follows:
 
 ```plain
-anchor-size(<anchor-element> <anchor-size>, <length-percentage>)
+anchor-size(<anchor-name> <anchor-size>, <length-percentage>)
 ```
 
 The parameters are:
 
-- `<anchor-element>` {{optional_inline}}
+- `<anchor-name>` {{optional_inline}}
 
   - : The [`anchor-name`](/en-US/docs/Web/CSS/anchor-name) property value of an anchor element you want to size the element relative to. This is a `<dashed-ident>` value. If omitted, the element's default anchor is used.
 
     > [!NOTE]
-    > Specifying an `<anchor-element>` inside an `anchor-size()` function neither associates nor tethers an element to an anchor; it only sizes the element relative to that anchor.
+    > Specifying an `<anchor-name>` inside an `anchor-size()` function neither associates nor tethers an element to an anchor; it only sizes the element relative to that anchor.
 
-- `<anchor-size>`
+- `<anchor-size>` {{optional_inline}}
 
   - : Specifies the dimension of the anchor element that the positioned element will be sized relative to. Valid values include:
 
@@ -90,7 +90,7 @@ Returns a {{cssxref("length")}} value.
 
 ## Description
 
-The `anchor()` function enables a positioned element's sizing values to be expressed in terms of an anchor element's dimensions; it defines the dimension of a specific anchor element the positioned element is being sized relative to. It is a valid value for [sizing properties](#properties_that_accept_anchor-size_function_values) set on anchor-positioned elements. When used, the function returns the {{cssxref("length")}} dimension of an anchor element, with both the anchor element and the dimension being optional parameters.
+The `anchor-size()` function enables a positioned element's sizing values to be expressed in terms of an anchor element's dimensions; it returns a {{cssxref("length")}} value representing the dimension of a specific anchor element the positioned element is being sized relative to. It is a valid value for [sizing properties](#properties_that_accept_anchor-size_function_values) set on anchor-positioned elements.
 
 The length returned is the vertical or horizontal size of an anchor element or its containing block. The dimension used is defined by the `<anchor-size>` parameter. If that parameter is omitted, the dimension used will match the axis of the sizing property is it set on.
 

--- a/files/en-us/web/css/anchor/index.md
+++ b/files/en-us/web/css/anchor/index.md
@@ -35,17 +35,17 @@ left: calc(anchor(--myAnchor right, 0%) + 10px);
 The `anchor()` function's syntax is as follows:
 
 ```plain
-anchor(<anchor-element> <anchor-side>, <length-percentage>)
+anchor(<anchor-name> <anchor-side>, <length-percentage>)
 ```
 
 The parameters are:
 
-- `<anchor-element>` {{optional_inline}}
+- `<anchor-name>` {{optional_inline}}
 
   - : The [`anchor-name`](/en-US/docs/Web/CSS/anchor-name) property value of an anchor element you want to position the element's side relative to. This is a `<dashed-ident>` value. If omitted, the element's **default anchor**, referenced in its [`position-anchor`](/en-US/docs/Web/CSS/position-anchor) property, or associated with the element via the [`anchor`](/en-US/docs/Web/HTML/Global_attributes/anchor) HTML attribute, is used.
 
     > [!NOTE]
-    > Specifying an `<anchor-element>` inside an `anchor()` function does not associate an element with an anchor; it only positions the element relative to that anchor. The [`position-anchor`](/en-US/docs/Web/CSS/position-anchor) CSS property or the [`anchor`](/en-US/docs/Web/HTML/Global_attributes/anchor) HTML attribute is still needed to create the association.
+    > Specifying an `<anchor-name>` inside an `anchor()` function does not associate an element with an anchor; it only positions the element relative to that anchor. The [`position-anchor`](/en-US/docs/Web/CSS/position-anchor) CSS property or the [`anchor`](/en-US/docs/Web/HTML/Global_attributes/anchor) HTML attribute is still needed to create the association.
 
 - `<anchor-side>`
 
@@ -72,7 +72,7 @@ The parameters are:
     - {{cssxref("percentage")}}
       - : Specifies the distance, as a percentage, from the start of the element's content along the axis of the inset property on which the `anchor()` function is set.
 
-    The CSS anchor positioning module introduces two additional `<anchor-side>` values, `inside` and `outside`, that have not yet been implemented.
+    The CSS anchor positioning module specifies two additional `<anchor-side>` values, `inside` and `outside`, which have not yet been implemented.
 
 - {{cssxref("length-percentage")}} {{optional_inline}}
   - : Specifies a fallback value the function should resolve to if the `anchor()` function would otherwise not be valid.
@@ -87,7 +87,7 @@ The `anchor()` function enables positioning an element relative to the edges of 
 
 It returns a `<length>` value specifying the distance between the anchor-positioned element side specified by the inset value, and the side of the anchor element specified by the chosen `<anchor-side>` value. As it returns a `<length>`, it can be used within [other CSS functions](/en-US/docs/Web/CSS/CSS_Functions) that accept length values, including {{cssxref("calc()")}}, {{cssxref("clamp()")}}, etc.
 
-If no anchor with the name specified by the `<anchor-element>` exists, or if the positioned element does not have an anchor associated with it (i.e. via the {{cssxref("position-anchor")}} property), the first parameter is considered invalid and the fallback `<length-percentage>` value is used if one is available. For example, if `top: anchor(bottom, 50px)` were specified on the positioned element but no anchor was associated with it, the fallback value would be used, so `top` would get a computed value of `50px`.
+If no anchor with the name specified by the `<anchor-name>` exists, or if the positioned element does not have an anchor associated with it (i.e. via the {{cssxref("position-anchor")}} property), the first parameter is considered invalid and the fallback `<length-percentage>` value is used if one is available. For example, if `top: anchor(bottom, 50px)` were specified on the positioned element but no anchor was associated with it, the fallback value would be used, so `top` would get a computed value of `50px`.
 
 For detailed information on anchor features and usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide.
 
@@ -158,7 +158,7 @@ This example positions the positioned element's logical block end edge `10px` fr
 
 ### Positioning an element relative to multiple anchors
 
-You can position an element relative to multiple anchors by specifying different `<anchor-element>` names inside the `anchor()` function of different inset properties on the same element (see [Element positioned relative to multiple anchors](#element_positioned_relative_to_multiple_anchors) below). This can be used to create useful functionality such as drag handles at the corners of a positioned element that can be used to resize it.
+You can position an element relative to multiple anchors by specifying different `<anchor-name>` values inside the `anchor()` function of different inset properties on the same element (see [Element positioned relative to multiple anchors](#element_positioned_relative_to_multiple_anchors) below). This can be used to create useful functionality such as drag handles at the corners of a positioned element that can be used to resize it.
 
 While a positioned element can be positioned relative to more than one anchor element, it is only ever associated with the single anchor defined via its [`position-anchor`](/en-US/docs/Web/CSS/position-anchor) property (or the [`anchor`](/en-US/docs/Web/HTML/Global_attributes/anchor) HTML attribute). This is the anchor the element will scroll with when the page scrolls; it can also be used to control when the element is [conditionally hidden](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding#conditionally_hiding_anchor-positioned_elements).
 
@@ -174,7 +174,7 @@ In this example, the `anchor()` function is used to set the height of an anchor-
 
 #### HTML
 
-We include a {{htmlelement("div")}} element, which we'll set as our anchor, and a {{htmlelement("p")}} that we will position relative to that anchor:
+We include a {{htmlelement("div")}} element, which we'll set as our anchor, and a {{htmlelement("p")}} element that we will position relative to that anchor:
 
 ```html
 <div class="anchor">⚓︎</div>
@@ -428,7 +428,7 @@ body {
 }
 ```
 
-The anchors are each given a different {{cssxref("anchor-name")}} values, a {{cssxref("position")}} value of `absolute`, and different inset values to position the anchors in a rectangle formation.
+The anchors are each given a different {{cssxref("anchor-name")}} value, a {{cssxref("position")}} value of `absolute`, and different inset values to position the anchors in a rectangle formation.
 
 ```css
 .anchor {

--- a/files/en-us/web/css/css_anchor_positioning/using/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/using/index.md
@@ -159,14 +159,14 @@ CSS anchor positioning changes this paradigm, enabling anchor-positioned element
 The function components look like this:
 
 ```plain
-anchor(<anchor-element> <anchor-side>, <fallback>)
+anchor(<anchor-name> <anchor-side>, <fallback>)
 ```
 
-- `<anchor-element>`
+- `<anchor-name>`
 
   - : The [`anchor-name`](/en-US/docs/Web/CSS/anchor-name) property value of the anchor element you want to position the element's side relative to. This is a `<dashed-ident>` value. If omitted, the element's **default anchor** is used. This is the anchor referenced in its [`position-anchor`](/en-US/docs/Web/CSS/position-anchor) property, or associated with the element via the [`anchor`](/en-US/docs/Web/HTML/Global_attributes/anchor) HTML attribute.
     > [!NOTE]
-    > Specifying an `<anchor-element>` positions the element relative to that anchor, but does not provide element association. Only the `position-anchor` property and `anchor` attributes create the association. While you can position an element's sides relative to multiple anchors by specifying [different `<anchor-element>` values](/en-US/docs/Web/CSS/anchor#element_positioned_relative_to_multiple_anchors) inside different `anchor()` functions on the same element, the positioned element is only associated with a single anchor.
+    > Specifying an `<anchor-name>` positions the element relative to that anchor, but does not provide element association. Only the `position-anchor` property and `anchor` attributes create the association. While you can position an element's sides relative to multiple anchors by specifying [different `<anchor-name>` values](/en-US/docs/Web/CSS/anchor#positioning_an_element_relative_to_multiple_anchors) inside different `anchor()` functions on the same element, the positioned element is only associated with a single anchor.
 
 - [`<anchor-side>`](/en-US/docs/Web/CSS/anchor#anchor-side)
 
@@ -573,10 +573,10 @@ Sizing properties that can accept an `anchor-size()` value include:
 `anchor-size()` functions resolve to {{cssxref("length")}} values. Their syntax looks like this:
 
 ```plain
-anchor-size(<anchor-element> <anchor-size>, <length-percentage>)
+anchor-size(<anchor-name> <anchor-size>, <length-percentage>)
 ```
 
-- `<anchor-element>`
+- `<anchor-name>`
   - : The `<dashed-ident>` name set as the value of the [`anchor-name`](/en-US/docs/Web/CSS/anchor-name) property of the anchor element you want to size the element relative to. If omitted, the element's **default anchor**, which is the anchor referenced in the [`position-anchor`](/en-US/docs/Web/CSS/position-anchor) property, is used.
 - [`<anchor-size>`](/en-US/docs/Web/CSS/anchor-size#anchor-size)
   - : Specifies the dimension of the anchor element that the positioned element will be sized relative to. This can be expressed using physical (`width` or `height`) or logical (`inline`, `block`, `self-inline`, or `self-block`) values.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the [CSS anchor positioning spec](https://drafts.csswg.org/css-anchor-position-1/), the `anchor()` and `anchor-size()` functions' `<anchor-element>` parameters have been changed to `<anchor-name>` (see https://github.com/w3c/csswg-drafts/commit/1d18c6a86099b158ddc9adb50e7e75f8990d0207).

This makes sense, as those parameters are `anchor-name` values.

This PR makes the necessary updates to the MDN docs.

See also https://github.com/mdn/data/pull/770. It looks like the `position-anchor` syntax changes were already accounted for in the docs, so this PR just has to worry about the `anchor()` and `anchor-size()` changes.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
