### PR TITLE
Fix: Removed unused variable

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -481,7 +481,6 @@ async function* makeTextFileLineIterator(fileURL) {
 
   const newline = /\r?\n/gm;
   let startIndex = 0;
-  let result;
 
   while (true) {
     const result = newline.exec(chunk);


### PR DESCRIPTION
### Description

Fixes #36427 - Removed unused `result` variable

