### PR TITLE
Update page: <marquee> element

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -61,7 +61,7 @@ No notable changes.
 
 ##### Removals
 
-- The marquee events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handler attributes](/en-US/docs/Web/HTML/Element/marquee#event_handlers) defined on the [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) ([Firefox bug 1689705](https://bugzil.la/1689705)).
+- The [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handler attributes](/en-US/docs/Web/API/HTMLMarqueeElement#events) ([Firefox bug 1689705](https://bugzil.la/1689705)).
 - The [Theora](/en-US/docs/Web/Media/Formats/Video_codecs#theora) codec was disabled by default, and will be removed in a future release ([Firefox bug 1860492](https://bugzil.la/1860492)).
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)

--- a/files/en-us/web/html/element/marquee/index.md
+++ b/files/en-us/web/html/element/marquee/index.md
@@ -11,7 +11,7 @@ browser-compat: html.elements.marquee
 
 The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes.
 
-The HTML `<marquee>` element is depreciated and strongly discouraged from being used. If you must create the effect of scrolling text or continuous elements, consider using [CSS animations](/en-US/docs/Web/CSS/CSS_animations) to [transform](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms) content instead and include the [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS {{cssxref("@media")}} query to stop the animation based on user preference, improving user experience and accessibility.
+The HTML `<marquee>` element is deprecated and its use is strongly discouraged. If you must create the effect of scrolling text or continuous elements, consider using [CSS animations](/en-US/docs/Web/CSS/CSS_animations) to [transform](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms) content instead and include the [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS {{cssxref("@media")}} query to stop the animation based on user preference, improving user experience and accessibility.
 
 ## Attributes
 

--- a/files/en-us/web/html/element/marquee/index.md
+++ b/files/en-us/web/html/element/marquee/index.md
@@ -11,7 +11,7 @@ browser-compat: html.elements.marquee
 
 The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes.
 
-The HTML `<marquee>` element is deprecated and its use is strongly discouraged. If you must create the effect of scrolling text or continuous elements, consider using [CSS animations](/en-US/docs/Web/CSS/CSS_animations) to [transform](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms) content instead and include the [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS {{cssxref("@media")}} query to stop the animation based on user preference, improving user experience and accessibility.
+The HTML `<marquee>` element is deprecated and its use is strongly discouraged. If you must create the effect of scrolling text or continuous elements, consider using [CSS animations](/en-US/docs/Web/CSS/CSS_animations) with [CSS transforms](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms) instead of `<marquee>` elements to smoothly animate content. Additionally, include the [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS {{cssxref("@media")}} query to stop the animation based on user preference, thereby improving user experience and accessibility.
 
 ## Attributes
 

--- a/files/en-us/web/html/element/marquee/index.md
+++ b/files/en-us/web/html/element/marquee/index.md
@@ -11,6 +11,8 @@ browser-compat: html.elements.marquee
 
 The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes.
 
+The HTML `<marquee>` element is depreciated and strongly discouraged from being used. If you must create the effect of scrolling text or continuous elements, consider using [CSS animations](/en-US/docs/Web/CSS/CSS_animations) to [transform](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms) content instead and include the [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS {{cssxref("@media")}} query to stop the animation based on user preference, improving user experience and accessibility.
+
 ## Attributes
 
 - `behavior` {{Deprecated_Inline}}
@@ -35,22 +37,6 @@ The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scr
   - : Sets the vertical margin in pixels or percentage value.
 - `width` {{Deprecated_Inline}}
   - : Sets the width in pixels or percentage value.
-
-## Event handlers
-
-- `onbounce` {{deprecated_inline}}
-  - : Fires when the marquee has reached the end of its scroll position. It can only fire when the behavior attribute is set to `alternate`.
-- `onfinish` {{deprecated_inline}}
-  - : Fires when the marquee has finished the amount of scrolling that is set by the loop attribute. It can only fire when the loop attribute is set to some number that is greater than 0.
-- `onstart` {{deprecated_inline}}
-  - : Fires when the marquee starts scrolling.
-
-## Methods
-
-- `start()` {{deprecated_inline}}
-  - : Starts scrolling of the marquee.
-- `stop()` {{deprecated_inline}}
-  - : Stops scrolling of the marquee.
 
 ## Examples
 
@@ -94,4 +80,8 @@ The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scr
 
 ## See also
 
+- CSS {{cssxref("transform")}} property
+- CSS {{cssxref("translate")}} property
+- [CSS transforms](/en-US/docs/Web/CSS/CSS_transforms) module
+- [CSS animations](/en-US/docs/Web/CSS/CSS_animations) module
 - {{DOMxRef("HTMLMarqueeElement")}}


### PR DESCRIPTION
Events were in the HTML page. They're in the API page, so removed them from the HTML page. Added the alternative to marquee, better practices, and helpful links.