### PR TITLE
Add note about code's default behavior

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.md
@@ -53,6 +53,7 @@ Inside the first `if...else`, you need to nest another `if...else` that puts app
 - Score of 90 to 100 — "What an amazing score! Did you cheat? Are you for real?"
 
 Try updating the live code below to recreate the finished example. After you've entered your code, try changing `machineActive` to `true`, to see if it works.
+Please note that, for the scope of this exercise, the `Your score is __` statement will remain on the screen regardless of the `machineActive`'s value.
 
 {{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/conditionals/conditionals2.html", '100%', 400)}}
 


### PR DESCRIPTION
While working on the exercise, I experienced confusion because the score was displayed despite the `machineValue` being `false`. Instead of changing the code, I suggest adding a note for the reader.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This PR addresses the potential confusion arising a learner's mind. 
The present code displays the "Your score is 75" by default. Even if the `machineValue` is `false`.
Since I wasted a few minutes in solving it as a learner, I suspect more learners would have been affected/will be affected with the same confusion.
<!-- ✍️ Summarize your changes in one or two sentences -->
Added a one-line note about the score being displayed despite machine being off.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This change is for clarity and avoiding cognitive friction in the minds of new learners.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
