### PR TITLE
Update Firefox 132 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/132/index.md
+++ b/files/en-us/mozilla/firefox/releases/132/index.md
@@ -68,11 +68,13 @@ This article provides information about the changes in Firefox 132 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-#### General
-
 #### WebDriver BiDi
 
-#### Marionette
+- Implemented several improvements to make WebDriver BiDi commands more reliable when used during navigation or with newly created tabs. Previously commands such as `browsingContext.setViewport` were likely to fail due to an `AbortError`, they will now be retried a few times to avoid such issues. ([Firefox bug 1854942](https://bugzil.la/1854942), [Firefox bug 1918287](https://bugzil.la/1918287), [Firefox bug 1918672](https://bugzil.la/1918672), [Firefox bug 1921756](https://bugzil.la/1921756))
+- The `browsingContext.contextCreated` event is now correctly emitted for lazy-loaded frames. Previously the event would only be emitted when the iframe actually started loading its content. ([Firefox bug 1878166](https://bugzil.la/1878166))
+- Network events are now correctly emitted for cached stylesheet requests. ([Firefox bug 1879438](https://bugzil.la/1879438))
+- Network event timings were previously using the wrong unit and were provided in microseconds. They are now correctly set in milliseconds. ([Firefox bug 1916685](https://bugzil.la/1916685))
+- The `requestTime` from network event timings should now be more accurate and really match the time where the request actually started. ([Firefox bug 1922390](https://bugzil.la/1922390))
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Release notes update based on the following list of relnote worthy bugs: https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox131&query_format=advanced&o1=equals&f1=cf_status_firefox132&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=17284146 

(excluding contributor bugs which will be mentioned in our fxdx blog post)