### PR TITLE
An attribute must have a value

### DIFF
--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -10,7 +10,6 @@ A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} 
 
 If the attribute is present, it can have one of the following values:
 
-- no value at all, e.g. `attribute`
 - the empty string, e.g. `attribute=""`
 - attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} that represents `true` or `false` values. If an HTML tag contains a boolean attribute --- no matter the value of that attribute --- the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
+A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} that represents `true` or `false` values. If an HTML tag contains a boolean attribute — no matter the value of that attribute — the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
 
 If the attribute is present, it can have one of the following forms:
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
+A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} that represents `true` or `false` values. If an HTML tag contains a boolean attribute --- no matter the value of that attribute --- the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
 
 If the attribute is present, it can have one of the following values:
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -11,8 +11,8 @@ A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} 
 If the attribute is present, it can have one of the following forms:
 
 - the attribute name alone, e.g., `attribute`, meaning it has an implicit empty string value
-- the attribute has a value of the empty string, e.g., `attribute=""`
-- the attribute has a value of attribute's name itself, with no leading or trailing whitespace, e.g., `attribute="attribute"`
+- the attribute with a value of the empty string, e.g., `attribute=""`
+- the attribute with a value of the attribute's name itself, with no leading or trailing whitespace, e.g., `attribute="attribute"`
 
 > [!NOTE]
 > The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -8,10 +8,11 @@ page-type: glossary-definition
 
 A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} that represents `true` or `false` values. If an HTML tag contains a boolean attribute --- no matter the value of that attribute --- the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
 
-If the attribute is present, it can have one of the following values:
+If the attribute is present, it can have one of the following forms:
 
-- the empty string, e.g. `attribute=""`
-- attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
+- the attribute name alone, e.g., `attribute`, meaning it has an implicit empty string value
+- the attribute has a value of the empty string, e.g. `attribute=""`
+- the attribute has a value of attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 
 > [!NOTE]
 > The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -11,8 +11,8 @@ A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} 
 If the attribute is present, it can have one of the following forms:
 
 - the attribute name alone, e.g., `attribute`, meaning it has an implicit empty string value
-- the attribute has a value of the empty string, e.g. `attribute=""`
-- the attribute has a value of attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
+- the attribute has a value of the empty string, e.g., `attribute=""`
+- the attribute has a value of attribute's name itself, with no leading or trailing whitespace, e.g., `attribute="attribute"`
 
 > [!NOTE]
 > The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -11,8 +11,8 @@ A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} 
 If the attribute is present, it can have one of the following forms:
 
 - the attribute name alone; e.g., `attribute`, meaning its implicit value is the empty string
-- the attribute with a value of the empty string, e.g., `attribute=""`
-- the attribute with a value of the attribute's name itself, with no leading or trailing whitespace, e.g., `attribute="attribute"`
+- the attribute with a value of the empty string; e.g., `attribute=""`
+- the attribute with a value of the attribute's name itself, with no leading or trailing whitespace; e.g., `attribute="attribute"`
 
 > [!NOTE]
 > The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -10,7 +10,7 @@ A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} 
 
 If the attribute is present, it can have one of the following forms:
 
-- the attribute name alone, e.g., `attribute`, meaning it has an implicit empty string value
+- the attribute name alone; e.g., `attribute`, meaning its implicit value is the empty string
 - the attribute with a value of the empty string, e.g., `attribute=""`
 - the attribute with a value of the attribute's name itself, with no leading or trailing whitespace, e.g., `attribute="attribute"`
 


### PR DESCRIPTION
HTML attributes by definition are name-value pairs and can't have no value. See [this article](https://8hob.io/posts/set-attribute-without-value-in-js/#an-attribute-always-has-a-value) for a quick explanation.

Relevant HTML standard: https://html.spec.whatwg.org/multipage/syntax.html#attributes-2

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
