### PR TITLE
feat(web/api/sse): add transmit to the tool section

### DIFF
--- a/files/en-us/web/api/server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/index.md
@@ -34,6 +34,7 @@ To learn how to use server-sent events, see our article [Using server-sent event
 ### Tools
 
 - [Mercure: a real-time communication protocol (publish-subscribe) built on top of SSE](https://mercure.rocks/)
+- [Transmit: a native opinionated Server-Sent-Event (SSE) module built for AdonisJS](https://docs.adonisjs.com/guides/digging-deeper/transmit)
 - [EventSource polyfill for Node.js](https://github.com/EventSource/eventsource)
 - Remy Sharp's [EventSource polyfill](https://github.com/remy/polyfills/blob/master/EventSource.js)
 - Yaffle's [EventSource polyfill](https://github.com/Yaffle/EventSource)


### PR DESCRIPTION
### Description

I've add Transmit to the tool section of the Server Side Event page.

### Motivation

There is not a lot of backend framework that provide a module to use SSE. Maybe it can be interesting to add Transmit to know that the reader is not obligate to start using SSE from scratch because there is some module that can facilitate his life

### Additional details

Docs:

https://docs.adonisjs.com/guides/digging-deeper/transmit

Source code:

https://github.com/boringnode/transmit
https://github.com/adonisjs/transmit
https://github.com/adonisjs/transmit-client

