### PR TITLE
Remove reference to disallowing :not() within :not()

### DIFF
--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -15,7 +15,7 @@ The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected result
 
 ## Syntax
 
-The `:not()` pseudo-class requires a [selector list](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#selector_list), a comma-separated list of one or more selectors, as its argument. The list must not contain another negation selector or a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), but any other simple, compound, and complex selectors are allowed.
+The `:not()` pseudo-class requires a [selector list](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#selector_list), a comma-separated list of one or more selectors, as its argument. The list must not contain a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), but any other simple, compound, and complex selectors are allowed.
 
 ```css-nolint
 :not(<complex-selector-list>) {


### PR DESCRIPTION
### Description

This is no longer the case - The current spec does not mention any restriction like this. web-platform-tests parses a nested `:not()` as a valid selector. 

### Motivation

Accuracy of information

### Additional details

* WPT parsing nested `:not()`: https://github.com/web-platform-tests/wpt/blob/master/css/selectors/parsing/parse-not.html#L17
* Current spec: https://drafts.csswg.org/selectors/#negation)

### Related issues and pull requests

N/A