### PR TITLE
fix: Add missing "See also" section title and other updates

### DIFF
--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.md
@@ -26,5 +26,3 @@ A boolean value.
 ## Browser compatibility
 
 {{Compat}}
-
-null

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -36,5 +36,3 @@ first {{domxref("BluetoothRemoteGATTDescriptor")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("Web Bluetooth")}}

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -36,5 +36,3 @@ A {{jsxref("Promise")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("Web Bluetooth")}}

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -34,5 +34,3 @@ A {{jsxref("Promise")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("Web Bluetooth")}}

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -34,5 +34,3 @@ A {{jsxref("Promise")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("Web Bluetooth")}}

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -73,4 +73,6 @@ console.log(el.ariaColCount); // 3
 
 {{Compat}}
 
+## See also
+
 - [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -42,4 +42,6 @@ console.log(el.ariaRoleDescription); // "an updated description of this widget"
 
 {{Compat}}
 
+## See also
+
 - [ARIA: application role](/en-US/docs/Web/Accessibility/ARIA/Roles/application_role)

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -72,4 +72,6 @@ console.log(el.ariaRowCount); // 101
 
 {{Compat}}
 
+## See also
+
 - [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -33,4 +33,6 @@ this.internals_.ariaColCount = "3";
 
 {{Compat}}
 
+## See also
+
 - [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -33,4 +33,6 @@ this.internals_.ariaRoleDescription = "My custom widget";
 
 {{Compat}}
 
+## See also
+
 - [ARIA: application role](/en-US/docs/Web/Accessibility/ARIA/Roles/application_role)

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -33,4 +33,6 @@ this.internals_.ariaRowCount = "100";
 
 {{Compat}}
 
+## See also
+
 - [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/headers/foreach/index.md
+++ b/files/en-us/web/api/headers/foreach/index.md
@@ -67,7 +67,7 @@ cookie ==> This is a demo cookie
 
 ## Browser compatibility
 
-{{compat}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/htmlinputelement/files/index.md
+++ b/files/en-us/web/api/htmlinputelement/files/index.md
@@ -52,7 +52,7 @@ for (const file of fileInput.files) {
 
 ## Browser compatibility
 
-{{ Compat }}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -198,8 +198,6 @@ You can find a number of examples at our [webaudio-example repo](https://github.
 
 ## Browser compatibility
 
-### AudioContext
-
 {{Compat}}
 
 ## See also

--- a/files/en-us/web/uri/schemes/data/index.md
+++ b/files/en-us/web/uri/schemes/data/index.md
@@ -111,7 +111,7 @@ lots of text…
 
 ## Browser compatibility
 
-{{compat}}
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Type of changes done via this PR:
- Removed "Web Bluetooth" APIRef sidebar macro. There's already a "Bluetooth API" sidebar that is generating the required options.
- Added "See also" section title to include the reference link.
- Normalized macro name to `{{Compat}}`.