### PR TITLE
chore(jsondata): Restore en-US content

### DIFF
--- a/files/jsondata/L10n-JavaScript.json
+++ b/files/jsondata/L10n-JavaScript.json
@@ -1,6 +1,7 @@
 {
   "stdlib": {
-    "en-US": "Globale Objekte",
+    "de": "Globale Objekte",
+    "en-US": "Standard built-in objects",
     "es": "Objetos globales",
     "fr": "Objets standards",
     "ja": "標準組み込みオブジェクト",


### PR DESCRIPTION
This was removed in 65f28e9ade9a0810b74c03edb1fdf9ff2447dabb

This change restores the English text and preserves the German translation

### Description

This change restores some lost en-US text

### Motivation

I was reading the docs randomly and stumbled across this

### Additional details

It looks like this was accidentally introduced as part of a change to add German text to the docs. See [65f28e9ade9a0810b74c03edb1fdf9ff2447dabb](https://github.com/mdn/content/commit/65f28e9ade9a0810b74c03edb1fdf9ff2447dabb#diff-9eb8abe8212aed92552b8936635c4b3fd1254b48fb84697fd0e1cda767377212R3)

And totally understandable mistake, that's a lot of very repetitive code changes!

### Related issues and pull requests

https://github.com/mdn/content/pull/36425
