### PR TITLE
Fix: Typo in WebGL example

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -235,10 +235,9 @@ const fsSource = `
     varying highp vec2 vTextureCoord;
 
     uniform sampler2D uSampler;
-    out vec4 fragColor;
 
     void main(void) {
-      fragColor = texture(uSampler, vTextureCoord);
+      gl_FragColor = texture2D(uSampler, vTextureCoord);
     }
   `;
 ```


### PR DESCRIPTION
### Description

Fixes #36477 - Fixed typo in the example code