### PR TITLE
Fix: Update Syntax for console instance methods

### DIFF
--- a/files/en-us/web/api/console/assert_static/index.md
+++ b/files/en-us/web/api/console/assert_static/index.md
@@ -13,15 +13,15 @@ The **`console.assert()`** static method writes an error message to the console 
 ## Syntax
 
 ```js-nolint
-assert(assertion)
+console.assert(assertion)
 
-assert(assertion, val1)
-assert(assertion, val1, val2)
-assert(assertion, val1, val2, /* …, */ valN)
+console.assert(assertion, val1)
+console.assert(assertion, val1, val2)
+console.assert(assertion, val1, val2, /* …, */ valN)
 
-assert(assertion, msg)
-assert(assertion, msg, subst1)
-assert(assertion, msg, subst1, /* …, */ substN)
+console.assert(assertion, msg)
+console.assert(assertion, msg, subst1)
+console.assert(assertion, msg, subst1, /* …, */ substN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/clear_static/index.md
+++ b/files/en-us/web/api/console/clear_static/index.md
@@ -13,7 +13,7 @@ The **`console.clear()`** static method clears the console if the console allows
 ## Syntax
 
 ```js-nolint
-clear()
+console.clear()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/count_static/index.md
+++ b/files/en-us/web/api/console/count_static/index.md
@@ -13,8 +13,8 @@ The **`console.count()`** static method logs the number of times that this parti
 ## Syntax
 
 ```js-nolint
-count()
-count(label)
+console.count()
+console.count(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -13,8 +13,8 @@ The **`console.countReset()`** static method resets counter used with {{domxref(
 ## Syntax
 
 ```js-nolint
-countReset()
-countReset(label)
+console.countReset()
+console.countReset(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/debug_static/index.md
+++ b/files/en-us/web/api/console/debug_static/index.md
@@ -13,10 +13,10 @@ The **`console.debug()`** static method outputs a message to the console at the 
 ## Syntax
 
 ```js-nolint
-debug(val1)
-debug(val1, /* …, */ valN)
-debug(msg)
-debug(msg, subst1, /* …, */ substN)
+console.debug(val1)
+console.debug(val1, /* …, */ valN)
+console.debug(msg)
+console.debug(msg, subst1, /* …, */ substN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/dir_static/index.md
+++ b/files/en-us/web/api/console/dir_static/index.md
@@ -19,8 +19,8 @@ In runtimes like {{glossary("Node.js", "Node")}} and {{glossary("Deno")}}, where
 ## Syntax
 
 ```js-nolint
-dir(object)
-dir(object, options)
+console.dir(object)
+console.dir(object, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/dirxml_static/index.md
+++ b/files/en-us/web/api/console/dirxml_static/index.md
@@ -13,7 +13,7 @@ The **`console.dirxml()`** static method displays an interactive tree of the des
 ## Syntax
 
 ```js-nolint
-dirxml(object)
+console.dirxml(object)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -13,10 +13,10 @@ The **`console.error()`** static method outputs a message to the console at the 
 ## Syntax
 
 ```js-nolint
-error(val1)
-error(val1, /* …, */ valN)
-error(msg)
-error(msg, subst1, /* …, */ substN)
+console.error(val1)
+console.error(val1, /* …, */ valN)
+console.error(msg)
+console.error(msg, subst1, /* …, */ substN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/group_static/index.md
+++ b/files/en-us/web/api/console/group_static/index.md
@@ -13,8 +13,8 @@ The **`console.group()`** static method creates a new inline group in the [Web c
 ## Syntax
 
 ```js-nolint
-group()
-group(label)
+console.group()
+console.group(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/groupcollapsed_static/index.md
+++ b/files/en-us/web/api/console/groupcollapsed_static/index.md
@@ -17,8 +17,8 @@ See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_th
 ## Syntax
 
 ```js-nolint
-groupCollapsed()
-groupCollapsed(label)
+console.groupCollapsed()
+console.groupCollapsed(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/groupend_static/index.md
+++ b/files/en-us/web/api/console/groupend_static/index.md
@@ -13,7 +13,7 @@ The **`console.groupEnd()`** static method exits the current inline group in the
 ## Syntax
 
 ```js-nolint
-groupEnd()
+console.groupEnd()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -13,10 +13,10 @@ The **`console.info()`** static method outputs a message to the console at the "
 ## Syntax
 
 ```js-nolint
-info(val1)
-info(val1, /* …, */ valN)
-info(msg)
-info(msg, subst1, /* …, */ substN)
+console.info(val1)
+console.info(val1, /* …, */ valN)
+console.info(msg)
+console.info(msg, subst1, /* …, */ substN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/log_static/index.md
+++ b/files/en-us/web/api/console/log_static/index.md
@@ -13,10 +13,10 @@ The **`console.log()`** static method outputs a message to the console.
 ## Syntax
 
 ```js-nolint
-log(val1)
-log(val1, /* …, */ valN)
-log(msg)
-log(msg, subst1, /* …, */ substN)
+console.log(val1)
+console.log(val1, /* …, */ valN)
+console.log(msg)
+console.log(msg, subst1, /* …, */ substN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/profile_static/index.md
+++ b/files/en-us/web/api/console/profile_static/index.md
@@ -19,7 +19,7 @@ To stop recording call {{domxref("console/profileEnd_static", "console.profileEn
 ## Syntax
 
 ```js-nolint
-profile(profileName)
+console.profile(profileName)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/profileend_static/index.md
+++ b/files/en-us/web/api/console/profileend_static/index.md
@@ -21,7 +21,7 @@ You can optionally supply an argument to name the profile. Doing so enables you 
 ## Syntax
 
 ```js-nolint
-profileEnd(profileName)
+console.profileEnd(profileName)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/table_static/index.md
+++ b/files/en-us/web/api/console/table_static/index.md
@@ -10,11 +10,29 @@ browser-compat: api.console.table_static
 
 The **`console.table()`** static method displays tabular data as a table.
 
+## Syntax
+
+```js-nolint
+console.table(data)
+console.table(data, columns)
+```
+
 This function takes one mandatory argument `data`, which must be an array or an object, and one additional optional parameter `columns`.
 
 It logs `data` as a table. Each element in the array (or enumerable property if `data` is an object) will be a row in the table.
 
 The first column in the table will be labeled `(index)`. If `data` is an array, then its values will be the array indices. If `data` is an object, then its values will be the property names. Note that (in Firefox) `console.table` is limited to displaying 1000 rows (first row is the labeled index).
+
+### Parameters
+
+- `data`
+  - : The data to display. This must be either an array or an object.
+- `columns`
+  - : An array containing the names of columns to include in the output.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
 
 ### Collections of primitive types
 
@@ -140,24 +158,6 @@ console.table([tyrone, janet, maria], ["firstName"]);
 ### Sorting columns
 
 You can sort the table by a particular column by clicking on that column's label.
-
-## Syntax
-
-```js-nolint
-table(data)
-table(data, columns)
-```
-
-### Parameters
-
-- `data`
-  - : The data to display. This must be either an array or an object.
-- `columns`
-  - : An array containing the names of columns to include in the output.
-
-### Return value
-
-None ({{jsxref("undefined")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -15,8 +15,8 @@ See [Timers](/en-US/docs/Web/API/console#timers) in the {{domxref("console")}} d
 ## Syntax
 
 ```js-nolint
-time()
-time(label)
+console.time()
+console.time(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -15,8 +15,8 @@ See [Timers](/en-US/docs/Web/API/console#timers) in the documentation for detail
 ## Syntax
 
 ```js-nolint
-timeEnd()
-timeEnd(label)
+console.timeEnd()
+console.timeEnd(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -13,10 +13,10 @@ The **`console.timeLog()`** static method logs the current value of a timer that
 ## Syntax
 
 ```js-nolint
-timeLog()
-timeLog(label)
-timeLog(label, val1)
-timeLog(label, val1, /* …, */ valN)
+console.timeLog()
+console.timeLog(label)
+console.timeLog(label, val1)
+console.timeLog(label, val1, /* …, */ valN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -17,7 +17,7 @@ You can optionally supply an argument to label the timestamp, and this label wil
 ## Syntax
 
 ```js-nolint
-timeStamp(label)
+console.timeStamp(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -18,8 +18,8 @@ See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the {{domxref("c
 ## Syntax
 
 ```js-nolint
-trace()
-trace(object1, /* …, */ objectN)
+console.trace()
+console.trace(object1, /* …, */ objectN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/warn_static/index.md
+++ b/files/en-us/web/api/console/warn_static/index.md
@@ -13,10 +13,10 @@ The **`console.warn()`** static method outputs a warning message to the console 
 ## Syntax
 
 ```js-nolint
-warn(val1)
-warn(val1, /* …, */ valN)
-warn(msg)
-warn(msg, subst1, /* …, */ substN)
+console.warn(val1)
+console.warn(val1, /* …, */ valN)
+console.warn(msg)
+console.warn(msg, subst1, /* …, */ substN)
 ```
 
 ### Parameters


### PR DESCRIPTION
### Description

Fixes #36463 - Updates Syntax for all console instance methods.

Also reorganized the content for `console.table()` which might cause confusion to readers.