### PR TITLE
Add information about non-depth bias for line and point topologies

### DIFF
--- a/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
+++ b/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
@@ -46,6 +46,8 @@ The `depthStencil` object can contain the following properties:
 
 - `depthBias` {{optional_inline}}
   - : A number representing a constant depth bias that is added to each fragment. If omitted, `depthBias` defaults to 0.
+    > [!NOTE]
+    > The `depthBias`, `depthBiasClamp`, and `depthBiasSlopeScale` properties must be set to `0` for line and point topologies, i.e., if [`topology`](#topology) is set to `"line-list"`, `"line-strip"`, or `"point-list"`. If not, a {{domxref("GPUValidationError")}} will be generated and the returned {{domxref("GPURenderPipeline")}} will be invalid.
 - `depthBiasClamp` {{optional_inline}}
   - : A number representing the maximum depth bias of a fragment. If omitted, `depthBiasClamp` defaults to 0.
 - `depthBiasSlopeScale` {{optional_inline}}
@@ -337,6 +339,7 @@ The following criteria must be met when calling **`createRenderPipeline()`**, ot
 
 - For `depthStencil` objects:
   - `format` is a [`depth-or-stencil`](https://gpuweb.github.io/gpuweb/#depth-or-stencil-format) format.
+  - The [`depthBias`](#depthbias), [`depthBiasClamp`](#depthbiasclamp), and [`depthBiasSlopeScale`](#depthbiasslopescale) properties are set to <code>0</code> for line and point topologies, i.e., if [`topology`](#topology) is set to `"line-list"`, `"line-strip"`, or `"point-list"`.
   - If `depthWriteEnabled` is `true` or `depthCompare` is not `"always"`, `format` has a depth component.
   - If `stencilFront` or `stencilBack`'s properties are not at their default values, `format` has a stencil component.
 - For `fragment` objects:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 128 deprecates setting depth bias for lines and points ([Chrome issue](https://issues.chromium.org/issues/352567424), [spec change](https://github.com/gpuweb/gpuweb/pull/4743)).

This PR updates the [`GPUDevice.createRenderPipeline()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipeline) page to:

- include a note in the `depthStencil` object description saying that the `depthBias`, `depthBiasClamp`, and `depthBiasSlopeScale` properties must be set to `0` for line and point topologies.
- echo this same information with a new entry in the Validation section.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

See the [description and data source](https://developer.chrome.com/blog/new-in-webgpu-128#deprecate_setting_depth_bias_for_lines_and_points)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See related MDN project issue: https://github.com/mdn/content/issues/36341

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
