### PR TITLE
Add GPUAdapter.info and update requestAdapterInfo() deprecation info

### DIFF
--- a/files/en-us/web/api/gpuadapter/index.md
+++ b/files/en-us/web/api/gpuadapter/index.md
@@ -21,13 +21,15 @@ A `GPUAdapter` object is requested using the {{domxref("GPU.requestAdapter()")}}
   - : A {{domxref("GPUSupportedFeatures")}} object that describes additional functionality supported by the adapter.
 - {{domxref("GPUAdapter.isFallbackAdapter", "isFallbackAdapter")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A boolean value. Returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not.
+- {{domxref("GPUAdapter.info", "info")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+  - : A {{domxref("GPUAdapterInfo")}} object containing identifying information about the adapter.
 - {{domxref("GPUAdapter.limits", "limits")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A {{domxref("GPUSupportedLimits")}} object that describes the limits supported by the adapter.
 
 ## Instance methods
 
 - {{domxref("GPUAdapter.requestAdapterInfo", "requestAdapterInfo()")}} {{Experimental_Inline}} {{deprecated_inline}} {{non-standard_inline}}
-  - : Returns a {{jsxref("Promise")}} that fulfills with a {{domxref("GPUAdapterInfo")}} object containing identifying information about an adapter.
+  - : Returns a {{jsxref("Promise")}} that fulfills with a {{domxref("GPUAdapterInfo")}} object containing identifying information about the adapter.
 - {{domxref("GPUAdapter.requestDevice", "requestDevice()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that fulfills with a {{domxref("GPUDevice")}} object, which is the primary interface for communicating with the GPU.
 

--- a/files/en-us/web/api/gpuadapter/info/index.md
+++ b/files/en-us/web/api/gpuadapter/info/index.md
@@ -1,0 +1,45 @@
+---
+title: "GPUAdapter: info property"
+short-title: info
+slug: Web/API/GPUAdapter/info
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.GPUAdapter.info
+---
+
+{{APIRef("WebGPU API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+The **`info`** read-only property of the
+{{domxref("GPUAdapter")}} interface returns a {{domxref("GPUAdapterInfo")}} object containing identifying information about the adapter.
+
+The intention behind this property is to allow developers to request specific details about the user's GPU so that they can preemptively apply workarounds for GPU-specific bugs, or provide different codepaths to better suit different GPU architectures. Providing such information does present a security risk — it could be used for fingerprinting — therefore the information shared is to be kept at a minimum, and different browser vendors are likely to share different information types and granularities.
+
+## Value
+
+A {{domxref("GPUAdapterInfo")}} object instance.
+
+## Examples
+
+```js
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
+}
+
+const adapterInfo = adapter.info;
+console.log(adapterInfo.vendor);
+console.log(adapterInfo.architecture);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The [WebGPU API](/en-US/docs/Web/API/WebGPU_API)

--- a/files/en-us/web/api/gpuadapter/requestadapterinfo/index.md
+++ b/files/en-us/web/api/gpuadapter/requestadapterinfo/index.md
@@ -14,10 +14,7 @@ browser-compat: api.GPUAdapter.requestAdapterInfo
 The **`requestAdapterInfo()`** method of the
 {{domxref("GPUAdapter")}} interface returns a {{jsxref("Promise")}} that fulfills with a {{domxref("GPUAdapterInfo")}} object containing identifying information about an adapter.
 
-The intention behind this method is to allow developers to request specific details about the user's GPU so that they can preemptively apply workarounds for GPU-specific bugs, or provide different codepaths to better suit different GPU architectures. Providing such information does present a security risk — it could be used for fingerprinting — therefore the information shared is to be kept at a minimum, and different browser vendors are likely to share different information types and granularities.
-
-> [!NOTE]
-> The specification includes an `unmaskHints` parameter for `requestAdapterInfo()`, which is intended to mitigate the security risk mentioned above. Once it is supported, developers will be able to specify the values they really need to know, and users will be given a permission prompt asking them if they are OK to share this information when the method is invoked. Browser vendors are likely to share more useful information if it is guarded by a permissions prompt, as it makes the method a less viable target for fingerprinting.
+`requestAdapterInfo()` has been removed from the WebGPU specification. Use {{domxref("GPUAdapter.info")}} to access adapter information instead.
 
 ## Syntax
 
@@ -56,7 +53,7 @@ async function init() {
 
 ## Specifications
 
-{{Specifications}}
+No longer part of the [WebGPU specification](https://gpuweb.github.io/gpuweb/).
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/gpuadapterinfo/architecture/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/architecture/index.md
@@ -20,21 +20,13 @@ A string.
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-  if (!adapter) {
-    throw Error("Couldn't request WebGPU adapter.");
-  }
-
-  const adapterInfo = await adapter.requestAdapterInfo();
-  console.log(adapterInfo.architecture);
-
-  // ...
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
 }
+
+const adapterInfo = adapter.info;
+console.log(adapterInfo.architecture);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpuadapterinfo/description/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/description/index.md
@@ -20,21 +20,13 @@ A string.
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-  if (!adapter) {
-    throw Error("Couldn't request WebGPU adapter.");
-  }
-
-  const adapterInfo = await adapter.requestAdapterInfo();
-  console.log(adapterInfo.description);
-
-  // ...
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
 }
+
+const adapterInfo = adapter.info;
+console.log(adapterInfo.description);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpuadapterinfo/device/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/device/index.md
@@ -20,21 +20,13 @@ A string.
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-  if (!adapter) {
-    throw Error("Couldn't request WebGPU adapter.");
-  }
-
-  const adapterInfo = await adapter.requestAdapterInfo();
-  console.log(adapterInfo.device);
-
-  // ...
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
 }
+
+const adapterInfo = adapter.info;
+console.log(adapterInfo.device);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpuadapterinfo/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GPUAdapterInfo
 
 The **`GPUAdapterInfo`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} contains identifying information about a {{domxref("GPUAdapter")}}.
 
-A `GPUAdapterInfo` object instance is requested using the {{domxref("GPUAdapter.requestAdapterInfo()")}} method.
+A `GPUAdapterInfo` object instance is retrieved using the {{domxref("GPUAdapter.info")}} property.
 
 {{InheritanceDiagram}}
 
@@ -29,22 +29,14 @@ A `GPUAdapterInfo` object instance is requested using the {{domxref("GPUAdapter.
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-  if (!adapter) {
-    throw Error("Couldn't request WebGPU adapter.");
-  }
-
-  const adapterInfo = await adapter.requestAdapterInfo();
-  console.log(adapterInfo.architecture);
-  console.log(adapterInfo.vendor);
-
-  // ...
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
 }
+
+const adapterInfo = adapter.info;
+console.log(adapterInfo.vendor);
+console.log(adapterInfo.architecture);
 ```
 
 ## Specifications
@@ -57,4 +49,5 @@ async function init() {
 
 ## See also
 
+- {{domxref("GPUAdapter.info")}}
 - The [WebGPU API](/en-US/docs/Web/API/WebGPU_API)

--- a/files/en-us/web/api/gpuadapterinfo/vendor/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/vendor/index.md
@@ -20,21 +20,13 @@ A string.
 ## Examples
 
 ```js
-async function init() {
-  if (!navigator.gpu) {
-    throw Error("WebGPU not supported.");
-  }
-
-  const adapter = await navigator.gpu.requestAdapter();
-  if (!adapter) {
-    throw Error("Couldn't request WebGPU adapter.");
-  }
-
-  const adapterInfo = await adapter.requestAdapterInfo();
-  console.log(adapterInfo.vendor);
-
-  // ...
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
 }
+
+const adapterInfo = adapter.info;
+console.log(adapterInfo.vendor);
 ```
 
 ## Specifications

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -39,7 +39,6 @@ APIs that require transient activation (list is not exhaustive):
 - {{domxref("Element.requestFullScreen()")}}
 - {{domxref("Element.requestPointerLock()")}}
 - {{domxref("EyeDropper.open()")}}
-- {{domxref("GPUAdapter.requestAdapterInfo()")}}
 - {{domxref("HID.requestDevice()")}}
 - {{domxref("HTMLInputElement.showPicker()")}}
 - {{domxref("HTMLSelectElement.showPicker()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR updates content to account for two recent WebGPU changes:

- GPUAdapter.info was added. I've added a reference page for this new property. This was added in Chrome 127.
- GPUAdapter.requestAdapterInfo(), which used to provide the same functionality, was removed. The reference page already marked it as deprecated and non-standard, but I've updated it to clarify that it is not part of the standard anymore, and you should use the `info` property instead. This was removed in Chrome 131.

I tested the above two features using the code snippets in the relevant pages (the former to ensure it works, and the latter for non-existence).

I also went through the rest of MDN and removed instances of `requestAdapterInfo()`, replacing it with `info` where appropriate.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See related MDN project issue: https://github.com/mdn/content/issues/36342

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
