### PR TITLE
en-US/docs/Web/CSS/transform code typo

### DIFF
--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -50,7 +50,7 @@ transform: skewY(1.07rad);
 
 /* Multiple function values */
 transform: translateX(10px) rotate(10deg) translateY(5px);
-transform: perspective(500px) translate(10px, 0, 20px) rotateY(3deg);
+transform: perspective(500px) translate3d(10px, 0, 20px) rotateY(30deg);
 
 /* Global values */
 transform: inherit;


### PR DESCRIPTION

Fixes code typo in:
[https://developer.mozilla.org/en-US/docs/Web/CSS/transform#syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#syntax)

Changes `translate` to `translate3d` but also rotateY from `3deg` to `30deg` which I suspect was the author’s original intent.

From:
```
transform: perspective(500px) translate(10px, 0, 20px) rotateY(3deg);
```
To:
```
transform: perspective(500px) translate3d(10px, 0, 20px) rotateY(30deg);
```

Original, computed style for transform resolves to "none":
![Screenshot from 2024-10-24 15-31-13](https://github.com/user-attachments/assets/d403edf6-71f0-4b33-911d-ad6a48ea833a)

Effect of `translate3d` only:
![Screenshot from 2024-10-24 15-31-29](https://github.com/user-attachments/assets/aa800b04-ac06-4017-a280-cf334d7ae2ff)

Effect of both `translate3d` and `30deg`, the result of this PR:
![Screenshot from 2024-10-24 15-32-03](https://github.com/user-attachments/assets/68829d81-13d9-4d5c-8fa6-0370cbb0ce39)

