### PR TITLE
fix: add missing .vue extension in import path

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_methods_events_models/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_methods_events_models/index.md
@@ -78,7 +78,7 @@ We now have an app that displays a list of to-do items. However, we can't update
 4. Let's load this component into our app. Go back to `App.vue` and add the following `import` statement just below the previous one, inside your `<script>` element:
 
    ```js
-   import ToDoForm from "./components/ToDoForm";
+   import ToDoForm from "./components/ToDoForm.vue";
    ```
 
 5. You also need to register the new component in your `App` component — update the `components` property of the component object so that it looks like this:


### PR DESCRIPTION
### Description

Fix: Added missing `.vue` extension in import path.

### Motivation

This change corrects an import path that lacked the `.vue` extension, ensuring that the module is resolved correctly. This update improves code readability and reduces potential runtime errors.

### Additional details

No external resources were impacted by this change.

### Related issues and pull requests

N/A
