### PR TITLE
Rework console.table() page

### DIFF
--- a/files/en-us/web/api/console/table_static/index.md
+++ b/files/en-us/web/api/console/table_static/index.md
@@ -17,22 +17,24 @@ console.table(data)
 console.table(data, columns)
 ```
 
-This function takes one mandatory argument `data`, which must be an array or an object, and one additional optional parameter `columns`.
-
-It logs `data` as a table. Each element in the array (or enumerable property if `data` is an object) will be a row in the table.
-
-The first column in the table will be labeled `(index)`. If `data` is an array, then its values will be the array indices. If `data` is an object, then its values will be the property names. Note that (in Firefox) `console.table` is limited to displaying 1000 rows (first row is the labeled index).
-
 ### Parameters
 
 - `data`
-  - : The data to display. This must be either an array or an object.
-- `columns`
-  - : An array containing the names of columns to include in the output.
+
+  - : The data to display. This must be either an array or an object. Each item in the array, or property in the object, is represented by a row in the table. The first column in the table is labeled `(index)` and its values are the array indices or the property names.
+
+    If the elements in the array, or properties in the object, are themselves arrays or objects, then their items or properties are enumerated in the row, one per column.
+
+    Note that in Firefox, `console.table()` is limited to displaying 1000 rows, including the heading row.
+
+- `columns` {{optional_inline}}
+  - : An array which can be used to restrict the columns shown in the table. It contains indices, if `data` is a table, or property names, if `data` is an object. The resulting table then includes only columns for items which match the given indices or names.
 
 ### Return value
 
 None ({{jsxref("undefined")}}).
+
+## Examples
 
 ### Collections of primitive types
 
@@ -104,7 +106,7 @@ const maria = new Person("Maria", "Cruz");
 console.table([tyrone, janet, maria]);
 ```
 
-Note that if the array contains objects, then the columns are labeled with the property name.
+If the array contains objects, then the columns are labeled with the property name.
 
 | (index) | firstName | lastName |
 | ------- | --------- | -------- |
@@ -154,10 +156,6 @@ console.table([tyrone, janet, maria], ["firstName"]);
 | 0       | 'Tyrone'  |
 | 1       | 'Janet'   |
 | 2       | 'Maria'   |
-
-### Sorting columns
-
-You can sort the table by a particular column by clicking on that column's label.
 
 ## Specifications
 

--- a/files/en-us/web/api/console/table_static/index.md
+++ b/files/en-us/web/api/console/table_static/index.md
@@ -28,7 +28,7 @@ console.table(data, columns)
     Note that in Firefox, `console.table()` is limited to displaying 1000 rows, including the heading row.
 
 - `columns` {{optional_inline}}
-  - : An array which can be used to restrict the columns shown in the table. It contains indices, if `data` is a table, or property names, if `data` is an object. The resulting table then includes only columns for items which match the given indices or names.
+  - : An array which can be used to restrict the columns shown in the table. It contains indices, if each entry of `data` is an array, or property names, if each entry of `data` is an object. The resulting table then includes only columns for items which match the given indices or names.
 
 ### Return value
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/pull/36479, and just reorganizes the page a bit:
- attach description of the params to the params
- moved examples into `## Examples`