### PR TITLE
fix: typo in "Using the Document Object Model" page

### DIFF
--- a/files/en-us/web/api/document_object_model/using_the_document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/using_the_document_object_model/index.md
@@ -116,7 +116,7 @@ root.appendChild(body);
 
 ## How can I learn more?
 
-Now that you are familiar with the basic concepts of the DOM, you may want to learn about the more about fundamental features of the Document API by reading [how to traverse an HTML table with JavaScript and DOM interfaces](/en-US/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces).
+Now that you are familiar with the basic concepts of the DOM, you may want to learn more about the fundamental features of the Document API by reading [how to traverse an HTML table with JavaScript and DOM interfaces](/en-US/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces).
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed a typo by removing the duplicate "about" in [How can i learn more](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Using_the_Document_Object_Model#how_can_i_learn_more) section in the "Using the Document Object Model" page.
