### PR TITLE
fix typo in RFC link

### DIFF
--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -45,7 +45,7 @@ Content-Disposition: attachment; filename*=UTF-8''file%20name.jpg
 
 The quotes around the filename are optional, but are necessary if you use special characters in the filename, such as spaces.
 
-The parameters `filename` and `filename*` differ only in that `filename*` uses the encoding defined in [RFC 5987, section 3.2](hhttps://www.rfc-editor.org/rfc/rfc5987.html#section-3.2).
+The parameters `filename` and `filename*` differ only in that `filename*` uses the encoding defined in [RFC 5987, section 3.2](https://www.rfc-editor.org/rfc/rfc5987.html#section-3.2).
 When both `filename` and `filename*` are present in a single header field value, `filename*` is preferred over `filename` when both are understood. It's recommended to include both for maximum compatibility, and you can convert `filename*` to `filename` by substituting non-ASCII characters with ASCII equivalents (such as converting `é` to `e`).
 You may want to avoid percent escape sequences in `filename`, because they are handled inconsistently across browsers. (Firefox and Chrome decode them, while Safari does not.)
 

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -45,7 +45,7 @@ Content-Disposition: attachment; filename*=UTF-8''file%20name.jpg
 
 The quotes around the filename are optional, but are necessary if you use special characters in the filename, such as spaces.
 
-The parameters `filename` and `filename*` differ only in that `filename*` uses the encoding defined in [RFC 5987, section 3.2](https://www.rfc-editor.org/rfc/rfc5987.html#section-3.2).
+The parameters `filename` and `filename*` differ only in that `filename*` uses the encoding defined in {{rfc("5987", "", "3.2")}}.
 When both `filename` and `filename*` are present in a single header field value, `filename*` is preferred over `filename` when both are understood. It's recommended to include both for maximum compatibility, and you can convert `filename*` to `filename` by substituting non-ASCII characters with ASCII equivalents (such as converting `é` to `e`).
 You may want to avoid percent escape sequences in `filename`, because they are handled inconsistently across browsers. (Firefox and Chrome decode them, while Safari does not.)
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
There was a typo ("hhttps" instead of "https") in a link.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The link now works, bringing readers to to the correct page.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None.

### Related issues and pull requests

None.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
