### PR TITLE
Fix nthPrime function example on BigInt

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -292,7 +292,7 @@ function nthPrime(nth) {
   let maybePrime = 2n;
   let prime = 0n;
 
-  while (nth >= 0n) {
+  while (nth > 0n) {
     if (isPrime(maybePrime)) {
       nth--;
       prime = maybePrime;


### PR DESCRIPTION
### Description
The `nthPrime` function on BigInt page is wrong. The function returned n+1th prime number (not nth) because of a little error in conditional comparison.

### Motivation
Maybe it is not much, but I just want to make it better (the example should be logically correct)

### Additional details
The page itself: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#calculating_primes

### Related issues and pull requests
-
