### PR TITLE
fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -51,7 +51,7 @@ A new {{jsxref("TypedArray")}} instance.
 See {{jsxref("Array.of()")}} for more details. There are some subtle distinctions between {{jsxref("Array.of()")}} and
 `TypedArray.of()`:
 
-- If the `this` value passed to `TypedArray.of()` is not a constructor, `TypedArray.from()` will throw a {{jsxref("TypeError")}}, while `Array.of()` defaults to creating a new {{jsxref("Array")}}.
+- If the `this` value passed to `TypedArray.of()` is not a constructor, `TypedArray.of()` will throw a {{jsxref("TypeError")}}, while `Array.of()` defaults to creating a new {{jsxref("Array")}}.
 - `TypedArray.of()` uses `[[Set]]` while `Array.of()` uses `[[DefineOwnProperty]]`. Hence, when working with {{jsxref("Proxy")}} objects, it calls [`handler.set()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set) to create new elements rather than [`handler.defineProperty()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty).
 
 ## Examples


### PR DESCRIPTION
### Description

It should be `TypedArray.of()` (not `from()`). See Also:

- https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.of

### Related issues and pull requests

Downstream PR: mdn/translated-content#24264
