### PR TITLE
Fix description of MessageEvent.ports

### DIFF
--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -41,7 +41,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
   - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
-  - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
+  - : An array of {{domxref("MessagePort")}} objects containing all {{domxref("MessagePort")}} objects sent with the message, in order.
 
 ## Instance methods
 

--- a/files/en-us/web/api/messageevent/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/messageevent/index.md
@@ -38,9 +38,7 @@ new MessageEvent(type, options)
         or a {{domxref("ServiceWorker")}} object) representing the message emitter.
         This defaults to `null` if not set.
     - `ports` {{optional_inline}}
-      - : An array of {{domxref("MessagePort")}} objects representing
-        the ports associated with the channel the message is being sent through where appropriate
-        (E.g. in channel messaging or when sending a message to a shared worker).
+      - : An array of {{domxref("MessagePort")}} objects containing all {{domxref("MessagePort")}} objects sent with the message, in order.
         This defaults to an empty array (`[]`) if not specified.
 
 ### Return value

--- a/files/en-us/web/api/messageevent/ports/index.md
+++ b/files/en-us/web/api/messageevent/ports/index.md
@@ -10,9 +10,7 @@ browser-compat: api.MessageEvent.ports
 
 The **`ports`** read-only property of the
 {{domxref("MessageEvent")}} interface is an array of {{domxref("MessagePort")}} objects
-representing the ports associated with the channel the message is being sent through
-(where appropriate, e.g. in channel messaging or when sending a message to a shared
-worker).
+containing all {{domxref("MessagePort")}} objects sent with the message, in order.
 
 ## Value
 

--- a/files/en-us/web/api/messageport/message_event/index.md
+++ b/files/en-us/web/api/messageport/message_event/index.md
@@ -41,7 +41,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
   - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
-  - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
+  - : An array containing all {{domxref("MessagePort")}} objects sent with the message, in order.
 
 ## Examples
 

--- a/files/en-us/web/api/messageport/messageerror_event/index.md
+++ b/files/en-us/web/api/messageport/messageerror_event/index.md
@@ -41,7 +41,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.source")}} {{ReadOnlyInline}}
   - : A `MessageEventSource` (which can be a {{glossary("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{ReadOnlyInline}}
-  - : An array of {{domxref("MessagePort")}} objects representing the ports associated with the channel the message is being sent through (where appropriate, e.g. in channel messaging or when sending a message to a shared worker).
+  - : An array containing all {{domxref("MessagePort")}} objects sent with the message, in order.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The description of the MessageEvent.ports property was incorrect. It refers to any ports that were sent with the message, *not* any port the message may have been sent through.

### Additional details
References:
The ports attribute at the bottom here: https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports
Steps 7.5 and 7.6 here: https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
