### PR TITLE
FF133Relnote: ImageDecoder, ImageTrackList, ImageTrack supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -38,6 +38,8 @@ This article provides information about the changes in Firefox 133 that affect d
 
 ### APIs
 
+- The {{domxref("ImageDecoder")}}, {{domxref("ImageTrackList")}}, and {{domxref("ImageTrack")}} interfaces of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) are now supported, enabling the decoding images from the main and worker threads. ([Firefox bug 1923755](https://bugzil.la/1923755)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF133 supports [`ImageDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/ImageDecoder), [`ImageTrackList`](https://developer.mozilla.org/en-US/docs/Web/API/ImageTrackList), [`ImageTrack`](https://developer.mozilla.org/en-US/docs/Web/API/ImageTrack) in https://bugzilla.mozilla.org/show_bug.cgi?id=1923755

This add release note.

Related docs work can be tracked in #36534.