### PR TITLE
Fix: Update AudioBuffer parameters to remove deprecated options

### DIFF
--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.md
@@ -36,26 +36,19 @@ new AudioBuffer(options)
         the sample rate of the `context` used in constructing this object. User
         agents are required to support sample rates from 8,000 Hz to 96,000 Hz (but are
         allowed to go farther outside this range).
-    - `channelCount`
-      - : Represents an integer used to determine how many channels are used when [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node.
-        (See {{domxref("AudioNode.channelCount")}} for more information.) Its usage and precise
-        definition depend on the value of `channelCountMode`.
-    - `channelCountMode`
-      - : Represents an enumerated value describing the way channels must be matched between
-        the node's inputs and outputs. (See {{domxref("AudioNode.channelCountMode")}} for more
-        information including default values.)
-    - `channelInterpretation`
-      - : Represents an enumerated value describing the meaning of the channels. This
-        interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
-        The possible values are `"speakers"` or `"discrete"`. (See
-        {{domxref("AudioNode.channelCountMode")}} for more information including default
-        values.)
 
 #### Deprecated parameters
 
+The following parameters were previously part of the `AudioBufferOptions` interface in older versions of the Web Audio API specification. They are no longer in use.
+
+- `channelCount` {{Deprecated_Inline}}
+  - : Used to define the number of channels for up-mixing and down-mixing connections to inputs. See {{domxref("AudioNode.channelCount")}}.
+- `channelCountMode` {{Deprecated_Inline}}
+  - : Described the matching of channels between node inputs and outputs. See {{domxref("AudioNode.channelCountMode")}}.
+- `channelInterpretation` {{Deprecated_Inline}}
+  - : Interpreted the meaning of channels for up-mixing and down-mixing, with possible values `"speakers"` or `"discrete"`. See {{domxref("AudioNode.channelInterpretation")}}.
 - `context` {{Deprecated_Inline}}
-  - : A reference to an {{domxref("AudioContext")}}. This parameter was removed from the
-    spec.
+  - : A reference to an {{domxref("AudioContext")}}. This parameter was removed from the spec.
 
 ### Exceptions
 

--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.md
@@ -37,19 +37,6 @@ new AudioBuffer(options)
         agents are required to support sample rates from 8,000 Hz to 96,000 Hz (but are
         allowed to go farther outside this range).
 
-#### Deprecated parameters
-
-The following parameters were previously part of the `AudioBufferOptions` interface in older versions of the Web Audio API specification. They are no longer in use.
-
-- `channelCount` {{Deprecated_Inline}}
-  - : Used to define the number of channels for up-mixing and down-mixing connections to inputs. See {{domxref("AudioNode.channelCount")}}.
-- `channelCountMode` {{Deprecated_Inline}}
-  - : Described the matching of channels between node inputs and outputs. See {{domxref("AudioNode.channelCountMode")}}.
-- `channelInterpretation` {{Deprecated_Inline}}
-  - : Interpreted the meaning of channels for up-mixing and down-mixing, with possible values `"speakers"` or `"discrete"`. See {{domxref("AudioNode.channelInterpretation")}}.
-- `context` {{Deprecated_Inline}}
-  - : A reference to an {{domxref("AudioContext")}}. This parameter was removed from the spec.
-
 ### Exceptions
 
 - `NotSupportedError` {{domxref("DOMException")}}


### PR DESCRIPTION

### Summary of Changes
- Updated the `AudioBuffer` documentation to remove deprecated parameters (`channelCount`, `channelCountMode`, `channelInterpretation`, `context`).
- Clarified the usage of current parameters.

### Reason for Change
The deprecated parameters were causing confusion, and removing them helps to clarify the expected usage of the `AudioBuffer` constructor.

### Related Issues
- Fixes #36555

### Motivation
The issue was put up by a reader knowledgeable about the topic, so I looked it up and fixed it.

### Additional Details
- Reviewed the latest specifications to ensure accuracy.
- Confirmed that the updated parameters are accurately reflected in the examples.

current AudioBufferOptions: https://webaudio.github.io/web-audio-api/#AudioBufferOptions
current options(AudioBufferOptions) of AudioBuffer constructor in mdn web docs: https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/AudioBuffer#options

### Testing
- I reviewed the relevant documentation and confirmed that the updated parameters are accurately reflected.

### Impact
These changes do not affect any existing functionality but clarify the documentation for future contributors.

### Feedback Request
I’d appreciate any feedback on the clarity of the changes made to the documentation.

