### PR TITLE
added the FF release note for CSS Nested Declaration rule

### DIFF
--- a/files/en-us/mozilla/firefox/releases/132/index.md
+++ b/files/en-us/mozilla/firefox/releases/132/index.md
@@ -17,6 +17,7 @@ No notable changes
 ### CSS
 
 - The {{CSSXRef("text-emphasis-position")}} property now supports the `auto` value to bring it inline with {{CSSXRef("text-underline-position")}} ([Firefox bug 1919658](https://bugzil.la/1919658)).
+- CSS now supports the [Nested declaration rule](/en-US/docs/Web/API/CSSNestedDeclarations#nested_declarations_rule), which means that nested CSS is now parsed in the correct order ([Firefox bug 1918408](https://bugzil.la/1918408)).
 
 #### Removals
 
@@ -42,6 +43,7 @@ No notable changes
 - The {{domxref('WebGLRenderingContext.drawingBufferColorSpace', 'drawingBufferColorSpace')}} and {{domxref('WebGLRenderingContext.unpackColorSpace','unpackColorSpace')}} properties of the {{domxref('WebGLRenderingContext')}} and {{domxref('WebGL2RenderingContext')}} interfaces are now supported. These specify the color space of the WebGL drawing buffer, and the color space to convert to when importing textures, respectively. ([Firefox bug 1885491](https://bugzil.la/1885491), [Firefox bug 1885446](https://bugzil.la/1885446)).
 - The {{domxref("Notification.silent")}} property is now supported, which controls whether system notifications should be silent. When `silent: true` is specified in the {{domxref("Notification.Notification", "Notification()")}} constructor, the resulting system notification is issued without accompanying sounds or vibrations, regardless of device settings ([Firefox bug 1809028](https://bugzil.la/1809028)).
 - The `fetchpriority` attribute of the {{htmlelement("link")}}, {{htmlelement("script")}}, and {{htmlelement("img")}} elements, the `fetchPriority` property of the {{domxref("HTMLLinkElement")}}, {{domxref("HTMLScriptElement")}}, and {{domxref("HTMLImageElement")}} interfaces, the [`options.priority`](/en-US/docs/Web/API/RequestInit#priority) parameter passed to the [`Request()` constructor](/en-US/docs/Web/API/Request/Request), and the `fetchpriority` directive in the HTTP {{httpheader("Link")}} header, are now supported. These allow developers to provide a hint about the relative priority for fetching a particular resource compared to other resources of the same type, and can be used alongside other ways of setting the priority, such as preloading. ([Firefox bug 1854077](https://bugzil.la/1854077)).
+- The {{domxref("CSSNestedDeclarations")}} interface and associated {{domxref("CSSNestedDeclarations.style")}} property are now supported ([Firefox bug 1918408](https://bugzil.la/1918408)).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
### Description

- Added release notes for:
  - CSS Neseted Declaration Rule
  - CSSNestedDeclarations & CSSNestedDeclarations.style APIs

### Motivation

- Working on [issue #36115](https://github.com/mdn/content/issues/36115)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/36430)
- [BCD PR Firefox](https://github.com/mdn/browser-compat-data/pull/24658)
- [BCD PR Chrome](https://github.com/mdn/browser-compat-data/pull/24663)
- [Yari PR](https://github.com/mdn/yari/pull/11999)