### PR TITLE
fix: add note to `Intl.DisplayNames#of` about Chromium browsers

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
@@ -23,7 +23,7 @@ of(code)
 
   - : The `code` to provide depends on the `type`:
 
-    - If the type is "region", `code` should be either an [two-letter ISO 3166 region code](https://www.iso.org/iso-3166-country-codes.html), or a [three-digit UN M49 geographic region](https://unstats.un.org/unsd/methodology/m49/). It is required to follow the [`unicode_region_subtag`](https://unicode.org/reports/tr35/#unicode_region_subtag) grammar.
+    - If the type is "region", `code` should be either an [two-letter ISO 3166 region code](https://www.iso.org/iso-3166-country-codes.html), or a [three-digit UN M49 geographic region](https://unstats.un.org/unsd/methodology/m49/). It is required to follow the [`unicode_region_subtag`](https://unicode.org/reports/tr35/#unicode_region_subtag) grammar. Additionally, on Chromium browsers, it must be uppercase.
     - If the type is "script", `code` should be an [four-letter ISO 15924 script code](https://unicode.org/iso15924/iso15924-codes.html). It is required to follow the [`unicode_script_subtag`](https://unicode.org/reports/tr35/#unicode_script_subtag) grammar.
     - If the type is "language", `code` should be matched by the [`unicode_language_id`](https://unicode.org/reports/tr35/#Unicode_language_identifier) nonterminal.
     - If the type is "currency", `code` should be a [three-letter ISO 4217 currency code](https://www.iso.org/iso-4217-currency-codes.html). It is required to have exactly three alphabetic characters.

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
@@ -23,7 +23,7 @@ of(code)
 
   - : The `code` to provide depends on the `type`:
 
-    - If the type is "region", `code` should be either an [two-letter ISO 3166 region code](https://www.iso.org/iso-3166-country-codes.html), or a [three-digit UN M49 geographic region](https://unstats.un.org/unsd/methodology/m49/). It is required to follow the [`unicode_region_subtag`](https://unicode.org/reports/tr35/#unicode_region_subtag) grammar. Additionally, on Chromium browsers, it must be uppercase.
+    - If the type is "region", `code` should be either an [two-letter ISO 3166 region code](https://www.iso.org/iso-3166-country-codes.html), or a [three-digit UN M49 geographic region](https://unstats.un.org/unsd/methodology/m49/). It is required to follow the [`unicode_region_subtag`](https://unicode.org/reports/tr35/#unicode_region_subtag) grammar. Use uppercase codes (e.g., `"US"`), because lowercase ones (e.g., `"us"`) may not work reliably everywhere.
     - If the type is "script", `code` should be an [four-letter ISO 15924 script code](https://unicode.org/iso15924/iso15924-codes.html). It is required to follow the [`unicode_script_subtag`](https://unicode.org/reports/tr35/#unicode_script_subtag) grammar.
     - If the type is "language", `code` should be matched by the [`unicode_language_id`](https://unicode.org/reports/tr35/#Unicode_language_identifier) nonterminal.
     - If the type is "currency", `code` should be a [three-letter ISO 4217 currency code](https://www.iso.org/iso-4217-currency-codes.html). It is required to have exactly three alphabetic characters.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
add note to ``Intl.DisplayNames#of`` about Chromium browsers that region codes must be uppercase.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
It is not noted anywhere, and was the cause of 3 hours of headache.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
