### PR TITLE
small fix on code fence language casing

### DIFF
--- a/files/en-us/learn/server-side/django/deployment/index.md
+++ b/files/en-us/learn/server-side/django/deployment/index.md
@@ -634,7 +634,7 @@ Save these settings and commit them to your GitHub repo.
 You will then need to update the version of your project on PythonAnywhere.
 Assuming you're using your Bash prompt in the folder `<user_name>.pythonanywhere.com`, and you have pushed the changes to the main branch, then you could import them in the Bash prompt using the command:
 
-```Bash
+```bash
 git pull origin main
 ```
 


### PR DESCRIPTION
### Description

language names in code fencing should be lower case, `Bash` vs `bash`

### Motivation

rari/yari parity