### PR TITLE
Fix typo in Client-side form validation

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -92,7 +92,7 @@ If the data entered in a form field follows all of the rules specified by the at
 
 When an element is valid, the following things are true:
 
-- The element matches the {{cssxref(":valid")}} CSS pseudo-class, which lets you apply a specific style to valid elements. The control will also match {{cssxref(":user-invalid")}} if the user has interacted with the control, and may match other UI pseudo-classes, such as {{cssxref(":in-range")}}, depending on the input type and attributes.
+- The element matches the {{cssxref(":valid")}} CSS pseudo-class, which lets you apply a specific style to valid elements. The control will also match {{cssxref(":user-valid")}} if the user has interacted with the control, and may match other UI pseudo-classes, such as {{cssxref(":in-range")}}, depending on the input type and attributes.
 - If the user tries to send the data, the browser will submit the form, provided there is nothing else stopping it from doing so (e.g., JavaScript).
 
 When an element is invalid, the following things are true:


### PR DESCRIPTION
I believe the paragraph below should have :user-valid selector, not :user-invalid.  This PR fixes that typo.

> The element matches the [:valid](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid) CSS pseudo-class, which lets you apply a specific style to valid elements. The control will also match [:user-invalid](https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid) if the user has interacted with the control, and may match other UI pseudo-classes, such as [:in-range](https://developer.mozilla.org/en-US/docs/Web/CSS/:in-range), depending on the input type and attributes.