### PR TITLE
Add browser-specific WebGPU limits

### DIFF
--- a/files/en-us/web/api/gpusupportedlimits/index.md
+++ b/files/en-us/web/api/gpusupportedlimits/index.md
@@ -23,39 +23,40 @@ Given that different browsers will handle this differently and the tier values m
 
 The following limits are represented by properties in a `GPUSupportedLimits` object. See the [Limits](https://gpuweb.github.io/gpuweb/#limits) section of the specification for detailed descriptions of what the limits relate to.
 
-| Limit name                                  | Default value            |
-| ------------------------------------------- | ------------------------ |
-| `maxTextureDimension1D`                     | 8192                     |
-| `maxTextureDimension2D`                     | 8192                     |
-| `maxTextureDimension3D`                     | 2048                     |
-| `maxTextureArrayLayers`                     | 256                      |
-| `maxBindGroups`                             | 4                        |
-| `maxBindingsPerBindGroup`                   | 640                      |
-| `maxDynamicUniformBuffersPerPipelineLayout` | 8                        |
-| `maxDynamicStorageBuffersPerPipelineLayout` | 4                        |
-| `maxSampledTexturesPerShaderStage`          | 16                       |
-| `maxSamplersPerShaderStage`                 | 16                       |
-| `maxStorageBuffersPerShaderStage`           | 8                        |
-| `maxStorageTexturesPerShaderStage`          | 4                        |
-| `maxUniformBuffersPerShaderStage`           | 12                       |
-| `maxUniformBufferBindingSize`               | 65536 bytes              |
-| `maxStorageBufferBindingSize`               | 134217728 bytes (128 MB) |
-| `minUniformBufferOffsetAlignment`           | 256 bytes                |
-| `minStorageBufferOffsetAlignment`           | 256 bytes                |
-| `maxVertexBuffers`                          | 8                        |
-| `maxBufferSize`                             | 268435456 bytes (256 MB) |
-| `maxVertexAttributes`                       | 16                       |
-| `maxVertexBufferArrayStride`                | 2048 bytes               |
-| `maxInterStageShaderComponents`             | 60                       |
-| `maxInterStageShaderVariables`              | 16                       |
-| `maxColorAttachments`                       | 8                        |
-| `maxColorAttachmentBytesPerSample`          | 32                       |
-| `maxComputeWorkgroupStorageSize`            | 16384 bytes              |
-| `maxComputeInvocationsPerWorkgroup`         | 256                      |
-| `maxComputeWorkgroupSizeX`                  | 256                      |
-| `maxComputeWorkgroupSizeY`                  | 256                      |
-| `maxComputeWorkgroupSizeZ`                  | 64                       |
-| `maxComputeWorkgroupsPerDimension`          | 65535                    |
+| Limit name                                  | Default value            | Maximum value (if differs from the Default) |
+| ------------------------------------------- | ------------------------ | ------------------------------------------- |
+| `maxTextureDimension1D`                     | 8192                     |                                             |
+| `maxTextureDimension2D`                     | 8192                     |                                             |
+| `maxTextureDimension3D`                     | 2048                     |                                             |
+| `maxTextureArrayLayers`                     | 256                      | Chromium: 2048                              |
+| `maxBindGroups`                             | 4                        |                                             |
+| `maxBindGroupsPlusVertexBuffers`            | 24                       |                                             |
+| `maxBindingsPerBindGroup`                   | 640                      |                                             |
+| `maxDynamicUniformBuffersPerPipelineLayout` | 8                        |                                             |
+| `maxDynamicStorageBuffersPerPipelineLayout` | 4                        |                                             |
+| `maxSampledTexturesPerShaderStage`          | 16                       |                                             |
+| `maxSamplersPerShaderStage`                 | 16                       |                                             |
+| `maxStorageBuffersPerShaderStage`           | 8                        | Chromium: 10                                |
+| `maxStorageTexturesPerShaderStage`          | 4                        |                                             |
+| `maxUniformBuffersPerShaderStage`           | 12                       |                                             |
+| `maxUniformBufferBindingSize`               | 65536 bytes              |                                             |
+| `maxStorageBufferBindingSize`               | 134217728 bytes (128 MB) |                                             |
+| `minUniformBufferOffsetAlignment`           | 256 bytes                |                                             |
+| `minStorageBufferOffsetAlignment`           | 256 bytes                |                                             |
+| `maxVertexBuffers`                          | 8                        |                                             |
+| `maxBufferSize`                             | 268435456 bytes (256 MB) |                                             |
+| `maxVertexAttributes`                       | 16                       | Chromium: 30                                |
+| `maxVertexBufferArrayStride`                | 2048 bytes               |                                             |
+| `maxInterStageShaderComponents`             | 60                       | Chromium: 112                               |
+| `maxInterStageShaderVariables`              | 16                       | Chromium: 28                                |
+| `maxColorAttachments`                       | 8                        |                                             |
+| `maxColorAttachmentBytesPerSample`          | 32                       | Chromium: 64                                |
+| `maxComputeWorkgroupStorageSize`            | 16384 bytes              |                                             |
+| `maxComputeInvocationsPerWorkgroup`         | 256                      |                                             |
+| `maxComputeWorkgroupSizeX`                  | 256                      |                                             |
+| `maxComputeWorkgroupSizeY`                  | 256                      |                                             |
+| `maxComputeWorkgroupSizeZ`                  | 64                       |                                             |
+| `maxComputeWorkgroupsPerDimension`          | 65535                    |                                             |
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Generally, the maximum values of WebGPU limits (see [`GPUSupportedLimits`](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedLimits)) are the same as the default limits defined in the spec. However, some implementations have different maximum limits.

This PR adds an extra column to the limits table on the above linked page to specify those limits where they differ from the specced default.

See the following issues for the source of these changes:

- https://github.com/mdn/content/issues/36343
- https://github.com/mdn/content/issues/36352
- https://github.com/mdn/content/issues/36361
  - This implementation issue comment contains the actual new limit numbers: https://issues.chromium.org/issues/42240429#comment17

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
