### PR TITLE
Update An Animated Solar System code example

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -61,6 +61,8 @@ This example animates a small model of our solar system.
 const sun = new Image();
 const moon = new Image();
 const earth = new Image();
+const ctx = document.getElementById("canvas").getContext("2d");
+
 function init() {
   sun.src = "canvas_sun.png";
   moon.src = "canvas_moon.png";
@@ -69,8 +71,6 @@ function init() {
 }
 
 function draw() {
-  const ctx = document.getElementById("canvas").getContext("2d");
-
   ctx.globalCompositeOperation = "destination-over";
   ctx.clearRect(0, 0, 300, 300); // clear canvas
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Moved the reference to the canvas and context outside of the draw function.

### Motivation

Noticed that this was a fixed reference across frames and should probably live outside of the draw call.

Reduces garbage collection of the ctx canvas reference, also matches the "Mouse following animation" example below where the ctx is defined outside the hot loop.