### PR TITLE
Add information to GPUQueue.submit() to say command buffers must be u…

### DIFF
--- a/files/en-us/web/api/gpuqueue/submit/index.md
+++ b/files/en-us/web/api/gpuqueue/submit/index.md
@@ -22,7 +22,7 @@ submit(commandBuffers)
 ### Parameters
 
 - `commandBuffers`
-  - : An array of {{domxref("GPUCommandBuffer")}} objects containing the commands to be enqueued for processing by the GPU. The referenced `GPUCommandBuffer`s must be unique.
+  - : An array of {{domxref("GPUCommandBuffer")}} objects containing the commands to be enqueued for processing by the GPU. The array must not contain duplicate `GPUCommandBuffer` objects — each one can only be submitted once.
 
 ### Return value
 
@@ -32,7 +32,7 @@ None ({{jsxref("Undefined")}}).
 
 The following criteria must be met when calling **`submit()`**, otherwise a {{domxref("GPUValidationError")}} is generated and the {{domxref("GPUQueue")}} becomes invalid:
 
-- The {{domxref("GPUCommandBuffer")}} objects referenced in the `submit()` call are unique.
+- The array of {{domxref("GPUCommandBuffer")}} objects referenced in the `submit()` call does not contain duplicates.
 - Any {{domxref("GPUBuffer")}}, {{domxref("GPUTexture")}}, and {{domxref("GPUQuerySet")}} objects used in the encoded commands are available for use, i.e. not unavailable (`GPUBuffer`s are unavailable if they are currently {{domxref("GPUBuffer.mapAsync", "mapped", "", "nocode")}}) or destroyed (with the `destroy()` method).
 - Any {{domxref("GPUExternalTexture")}} objects used in the encoded commands are not expired (they expire automatically shortly after being imported via {{domxref("GPUDevice.importExternalTexture", "importExternalTexture()")}}).
 - If a {{domxref("GPUQuerySet")}} object used in an encoded command is of type `"occlusion"` query, it is not already used, except by {{domxref("GPURenderPassEncoder.beginOcclusionQuery()")}}.

--- a/files/en-us/web/api/gpuqueue/submit/index.md
+++ b/files/en-us/web/api/gpuqueue/submit/index.md
@@ -22,7 +22,7 @@ submit(commandBuffers)
 ### Parameters
 
 - `commandBuffers`
-  - : An array of {{domxref("GPUCommandBuffer")}} objects containing the commands to be enqueued for processing by the GPU. The array must not contain duplicate `GPUCommandBuffer` objects — each one can only be submitted once.
+  - : An array of {{domxref("GPUCommandBuffer")}} objects containing the commands to be enqueued for processing by the GPU. The array must not contain duplicate `GPUCommandBuffer` objects — each one can only be submitted once per `submit()` call.
 
 ### Return value
 

--- a/files/en-us/web/api/gpuqueue/submit/index.md
+++ b/files/en-us/web/api/gpuqueue/submit/index.md
@@ -22,7 +22,7 @@ submit(commandBuffers)
 ### Parameters
 
 - `commandBuffers`
-  - : An array of {{domxref("GPUCommandBuffer")}} objects containing the commands to be enqueued for processing by the GPU.
+  - : An array of {{domxref("GPUCommandBuffer")}} objects containing the commands to be enqueued for processing by the GPU. The referenced `GPUCommandBuffer`s must be unique.
 
 ### Return value
 
@@ -32,6 +32,7 @@ None ({{jsxref("Undefined")}}).
 
 The following criteria must be met when calling **`submit()`**, otherwise a {{domxref("GPUValidationError")}} is generated and the {{domxref("GPUQueue")}} becomes invalid:
 
+- The {{domxref("GPUCommandBuffer")}} objects referenced in the `submit()` call are unique.
 - Any {{domxref("GPUBuffer")}}, {{domxref("GPUTexture")}}, and {{domxref("GPUQuerySet")}} objects used in the encoded commands are available for use, i.e. not unavailable (`GPUBuffer`s are unavailable if they are currently {{domxref("GPUBuffer.mapAsync", "mapped", "", "nocode")}}) or destroyed (with the `destroy()` method).
 - Any {{domxref("GPUExternalTexture")}} objects used in the encoded commands are not expired (they expire automatically shortly after being imported via {{domxref("GPUDevice.importExternalTexture", "importExternalTexture()")}}).
 - If a {{domxref("GPUQuerySet")}} object used in an encoded command is of type `"occlusion"` query, it is not already used, except by {{domxref("GPURenderPassEncoder.beginOcclusionQuery()")}}.


### PR DESCRIPTION
…nique

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In Chrome 126, the behavior of the [`GPUQueue.submit()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUQueue/submit) method has been updated to be correct as per spec — the referenced command buffers must be unique.

This PR adds a line to state this in the parameter description, and a validation statement.

See https://developer.chrome.com/blog/new-in-webgpu-126#submitted_command_buffers_must_be_unique for the information source.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

project issue: https://github.com/mdn/content/issues/36344

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
