### PR TITLE
Add info about ::-webkit-details-marker in Safari

### DIFF
--- a/files/en-us/web/html/element/details/index.md
+++ b/files/en-us/web/html/element/details/index.md
@@ -198,6 +198,8 @@ The disclosure triangle itself can be customized, although this is not as broadl
 
 The {{HTMLElement("summary")}} element supports the {{cssxref("list-style")}} shorthand property and its longhand properties, such as {{cssxref("list-style-type")}}, to change the disclosure triangle to whatever you choose (usually with {{cssxref("list-style-image")}}). For example, we can remove the disclosure widget icon by setting `list-style: none`.
 
+Note: Safari doesn't support `list-style: none` for customizing the disclosure widget. You must instead use `::-webkit-details-marker` to target the marker and `display: none` to hide it.
+
 #### CSS
 
 ```css

--- a/files/en-us/web/html/element/details/index.md
+++ b/files/en-us/web/html/element/details/index.md
@@ -198,7 +198,7 @@ The disclosure triangle itself can be customized, although this is not as broadl
 
 The {{HTMLElement("summary")}} element supports the {{cssxref("list-style")}} shorthand property and its longhand properties, such as {{cssxref("list-style-type")}}, to change the disclosure triangle to whatever you choose (usually with {{cssxref("list-style-image")}}). For example, we can remove the disclosure widget icon by setting `list-style: none`.
 
-Note: Safari doesn't support `list-style: none` for customizing the disclosure widget. You must instead use `::-webkit-details-marker` to target the marker and `display: none` to hide it.
+**Note:** Safari doesn't support `list-style: none` for customizing the disclosure widget. You must instead use `::-webkit-details-marker` to target the marker and `display: none` to hide it.
 
 #### CSS
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In Safari, `list-style: none` doesn't work to hide the `<summary>` marker. Instead you must use `::-webkit-details-marker` to target the Shadow DOM and hide it with `display: none`.

### Motivation

I needed to learn how to do this for my personal website, and it was hard to find a clear answer online. In particular, MDN seems to be the best resource for things like this, and it felt missing from this site.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=157323

### Related issues and pull requests

There's a PR to change this behavior in Safari, but it will at least be useful to have this documentation for supporting historical versions of the browser.

WebKit GitHub: https://github.com/WebKit/WebKit/pull/34778

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
