### PR TITLE
Note re exception from storage.managed.get

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -13,9 +13,9 @@ A {{WebExtAPIRef("storage.StorageArea")}} object that represents the `managed` s
 
 The procedure for provisioning managed storage varies between browsers. For Chrome instructions, see the ["Manifest for storage areas"](https://developer.chrome.com/docs/extensions/reference/manifest/storage) article.
 
-For Firefox, you need to create a JSON manifest file in a specific format and location. For the details of manifest syntax and location, see [Native manifests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests).
+For Firefox, you need to create a [JSON manifest (native manifest) file in a specific format and location](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or use the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty).
 
-Here's an example manifest:
+Here's an example native manifest:
 
 ```json
 {

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -35,7 +35,7 @@ If the operation fails, the promise is rejected with an error message.
 If managed storage is not set, `undefined` is returned.
 
 > [!WARNING]
-> In Firefox, if an extension's managed storage has not been configured with a native manifest or using the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)).
+> In Firefox, if an extension's managed storage has not been configured with a [native manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or using the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)).
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -28,22 +28,14 @@ Where `<storageType>` is one of the storage types — {{WebExtAPIRef("storage.sy
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `results` object, containing every object in `keys` that was found in the storage area. If `keys` is an object, keys that are not found in the storage area will have their values given by the `keys` object.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `results` object, containing every object in `keys` found in the storage area. If `keys` is an object, keys that are not found in the storage area have their values given by the `keys` object.
 
-If the operation failed, the promise is rejected with an error message.
+If the operation fails, the promise is rejected with an error message.
 
-If managed storage is not set, `undefined` will be returned.
+If managed storage is not set, `undefined` is returned.
 
 > [!WARNING]
-> When used within a content script in Firefox versions prior to 52, the Promise returned by `browser.storage.local.get()` is fulfilled with an Array containing one Object. The Object in the Array contains the `keys` found in the storage area, as described above.
->
-> The Promise is correctly fulfilled with an Object when used in the background context (background scripts, popups, options pages, etc.).
->
-> When this API is used as `chrome.storage.local.get()`, it correctly passes an Object to the callback function.
-
-## Browser compatibility
-
-{{Compat}}
+> In Firefox, if the managed storage manifest is missing, an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)). `storage.managed_schema` provides a fallback managed storage manifest definition on other browsers.
 
 ## Examples
 
@@ -144,6 +136,10 @@ let gettingItem = new Promise((resolve) =>
 );
 gettingItem.then(onGot); // -> Object { kitten: Object }
 ```
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -28,14 +28,14 @@ Where `<storageType>` is one of the storage types — {{WebExtAPIRef("storage.sy
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `results` object, containing every object in `keys` found in the storage area. If `keys` is an object, keys that are not found in the storage area have their values given by the `keys` object.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `results` object, containing a key-value pair for every key in `keys` found in the storage area. When `keys` is an object, any key that isn't found in storage takes the default value from the `keys` object.
 
 If the operation fails, the promise is rejected with an error message.
 
 If managed storage is not set, `undefined` is returned.
 
 > [!WARNING]
-> In Firefox, if the managed storage manifest is missing, an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)). `storage.managed_schema` provides a fallback managed storage manifest definition on other browsers.
+> In Firefox, if an extension's managed storage has not been configured with a native manifest or using the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Adds a note about the exception from storage.managed.get when the manage storage manifest isn't present.

### Motivation

Documents a known issue with Firefox

### Additional details

Originally noted as a documentation need in feedback on https://github.com/mdn/webextensions-examples/pull/554
