### PR TITLE
Update index.md | release >= 109 supports top & left parameters for windows.create

### DIFF
--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -73,7 +73,7 @@ No notable changes.
 - The property `secretKeyLength` has been added to {{WebExtAPIRef("webRequest.SecurityInfo")}}. This property provides the length in bits of the secret key in the security properties of a web request ([Firefox bug 1778473](https://bugzil.la/1778473)).
 - With the introduction of the [extensions button](https://support.mozilla.org/en-US/kb/extensions-button), the default value of `default_area` in the [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) and [`browser_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) manifest keys has changed from `"navbar"` to `"menupanel"` ([Firefox bug 1799947](https://bugzil.la/1799947)).
 - Support for {{WebExtAPIRef("omnibox.onDeleteSuggestion")}} and the `deletable` property in {{WebExtAPIRef("omnibox.SuggestResult")}}, enabling extensions to react to a user deleting an address bar search result ([Firefox bug 1799947](https://bugzil.la/1799947)).
-- Support for the <code>top</code> and <code>left</code> parameters to determine positioning of  `panel` or `popup` window  using  {{WebExtAPIRef("windows.create()")}} ([Firefox bug 1271047](https://bugzil.la/1271047)).
+- Support for the <code>top</code> and <code>left</code> parameters to determine positioning of `panel` or `popup` window using {{WebExtAPIRef("windows.create()")}} ([Firefox bug 1271047](https://bugzil.la/1271047)).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -73,6 +73,7 @@ No notable changes.
 - The property `secretKeyLength` has been added to {{WebExtAPIRef("webRequest.SecurityInfo")}}. This property provides the length in bits of the secret key in the security properties of a web request ([Firefox bug 1778473](https://bugzil.la/1778473)).
 - With the introduction of the [extensions button](https://support.mozilla.org/en-US/kb/extensions-button), the default value of `default_area` in the [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) and [`browser_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) manifest keys has changed from `"navbar"` to `"menupanel"` ([Firefox bug 1799947](https://bugzil.la/1799947)).
 - Support for {{WebExtAPIRef("omnibox.onDeleteSuggestion")}} and the `deletable` property in {{WebExtAPIRef("omnibox.SuggestResult")}}, enabling extensions to react to a user deleting an address bar search result ([Firefox bug 1799947](https://bugzil.la/1799947)).
+- Support for the <code>top</code> and <code>left</code> parameters to determine positioning of  `panel` or `popup` window  using  {{WebExtAPIRef("windows.create()")}} ([Firefox bug 1271047](https://bugzil.la/1271047)).
 
 ## Older versions
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

✍️ Summarize your changes in one or two sentences 

Release >= 109 supports top & left parameters for windows.create - (https://github.com/mdn/content/pull/36554)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context

https://bugzilla.mozilla.org/show_bug.cgi?id=1271047
FIX - https://phabricator.services.mozilla.com/D73419?id=649918

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
👉 Highlight related pull requests using "Relates to (https://github.com/mdn/content/pull/36554)"
<!-- ❗ If another pull request should be merged first, use "**Depends on:** " -->

