### PR TITLE
fix(webextensions): bump strict_min_version to 58.0

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -33,7 +33,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
 "browser_specific_settings": {
   "gecko": {
     "id": "addon@example.com",
-    "strict_min_version": "42.0"
+    "strict_min_version": "58.0"
   }
 }
 </pre


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Bumps the `strict_min_version` to 58.0.

### Motivation

Otherwise the AMO validation shows this error message:

> Lowest supported "strict_min_version" is 58.0.

### Additional details

<img width="339" alt="image" src="https://github.com/user-attachments/assets/c0bfbb14-96c7-4c5d-a679-274850989070">

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
