### PR TITLE
rari-relatede content fixes

### DIFF
--- a/files/en-us/learn/server-side/django/introduction/index.md
+++ b/files/en-us/learn/server-side/django/introduction/index.md
@@ -220,7 +220,7 @@ The code snippet shows what the HTML template called by the `render()` function 
   {% if youngest_teams %}
     <ul>
       {% for team in youngest_teams %}
-        <li>\{\{ team.team_name \}\}</li>
+        <li>\{{ team.team_name }}</li>
       {% endfor %}
     </ul>
   {% else %}

--- a/files/en-us/learn/server-side/first_steps/web_frameworks/index.md
+++ b/files/en-us/learn/server-side/first_steps/web_frameworks/index.md
@@ -158,7 +158,7 @@ The code snippet below shows how this works. Continuing the "youngest team" exam
     {% if youngest_teams %}
       <ul>
         {% for team in youngest_teams %}
-          <li>\{\{ team.team_name \}\}</li>
+          <li>\{{ team.team_name }}</li>
         {% endfor %}
       </ul>
     {% else %}

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.md
@@ -171,7 +171,7 @@ The vanilla JavaScript approach to building out new DOM elements in repetition w
 ```html
 <ul>
   <li v-for="task in tasks" v-bind:key="task.id">
-    <span>\{{task.name\}}</span>
+    <span>\{{task.name}}</span>
     <button type="button">Delete</button>
   </li>
 </ul>

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -303,7 +303,7 @@ this.color("blue");
 
 {{EmbedLiveSample('Rect_code', '700', '300') }}
 
-{{APIRef("Web_Bluetooth_API")}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 {{WebExtAPIRef("tabs.mutedInfo")}}
 

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -303,13 +303,13 @@ this.color("blue");
 
 {{EmbedLiveSample('Rect_code', '700', '300') }}
 
-{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
+{{APIRef("Web_Bluetooth_API")}}{{SeeCompatTable}}
 
 {{WebExtAPIRef("tabs.mutedInfo")}}
 
 ### Obsolete CSSOM interfaces {{deprecated_inline}}
 
-{{InheritanceDiagram}}
+{{InheritanceDiagram("WheelEvent")}}
 
 {{EmbedGHLiveSample("web-tech-games/index.html", '100%', 820)}}
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -12,7 +12,7 @@ In contrast to the macros listed in [Commonly-used macros](/en-US/docs/MDN/Writi
 
 This macro is used only with particular contexts, such as a specific API reference.
 
-- [`RFC`](https://github.com/mdn/yari/blob/main/kumascript/macros/RFC.ejs) creates a link to the specified RFC, given its number. The syntax is: `\{\{RFC(number)\}\}`. For example, `\{\{RFC(2616)\}\}` becomes {{ RFC(2616) }}.
+- [`RFC`](https://github.com/mdn/yari/blob/main/kumascript/macros/RFC.ejs) creates a link to the specified RFC, given its number. The syntax is: `\{{RFC(number)}}`. For example, `\{{RFC(2616)}}` becomes {{ RFC(2616) }}.
 
 ### Landing page components
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -12,7 +12,7 @@ In contrast to the macros listed in [Commonly-used macros](/en-US/docs/MDN/Writi
 
 This macro is used only with particular contexts, such as a specific API reference.
 
-- [`RFC`](https://github.com/mdn/yari/blob/main/kumascript/macros/RFC.ejs) creates a link to the specified RFC, given its number. The syntax is: `\{{RFC(number)}}`. For example, `\{{RFC(2616)}}` becomes {{ RFC(2616) }}.
+- [`RFC`](https://github.com/mdn/yari/blob/main/kumascript/macros/RFC.ejs) creates a link to the specified RFC, given its number. The syntax is `\{{RFC(number)}}`. For example, `\{{RFC(2616)}}` becomes {{ RFC(2616) }}.
 
 ### Landing page components
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -393,7 +393,7 @@ These are our recommendations for using certain technical terms:
   On MDN, you can optionally specify the HTML element in the [`HTMLElement` macro](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#linking_to_pages_in_references), which will style the element, add the angle brackets "<>", as well as add a link to its reference page.
 
   - **Using backticks**: `<span>`
-  - **Using the macro**: {{HTMLElement("span")}} (source in markdown: \\{{HTMLElement("span")\}})
+  - **Using the macro**: {{HTMLElement("span")}} (source in markdown: `\{{HTMLElement("span")}}`)
 
 - **Parameters vs. arguments**: The preferred term on MDN Web Docs is **parameters**. Please avoid the term "arguments" for consistency whenever possible.
 


### PR DESCRIPTION
### Description

This clears a few rari-related deficiencies that were not surfacing under yari or broken in differrent ways. The Syntax for escaping macros is documented as "escaping the first opening brace", this normalizes a few variants of that.

Also removed a sidebar macro from the kitchensink that is incompatible with the way rari handles sidebars. The macro has kitchensink-special-treatment in yari with no rari equivalent possible.

### Motivation

rari / yari parity
