### PR TITLE
FF133Relnote: Uint8Array .from/setFrom/toHex() and Base64() methods

### DIFF
--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -22,7 +22,7 @@ This article provides information about the changes in Firefox 133 that affect d
 
 ### JavaScript
 
-- Support for {{jsxref("Uint8Array")}} methods to ease conversions between hex- and {{glossary("base64")}}- encoded strings and byte arrays. ([Firefox bug 1917885](https://bugzil.la/1917885) and [Firefox bug 1862220](https://bugzil.la/1862220)).
+- Support for {{jsxref("Uint8Array")}} methods to ease conversions between {{glossary("base64")}}- and hex-encoded strings and byte arrays. ([Firefox bug 1917885](https://bugzil.la/1917885) and [Firefox bug 1862220](https://bugzil.la/1862220)).
 
   The new methods include:
 

--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -22,6 +22,14 @@ This article provides information about the changes in Firefox 133 that affect d
 
 ### JavaScript
 
+- Support for {{jsxref("Uint8Array")}} methods to ease conversions between hex- and {{glossary("base64")}}- encoded strings and byte arrays. ([Firefox bug 1917885](https://bugzil.la/1917885) and [Firefox bug 1862220](https://bugzil.la/1862220)).
+
+  The new methods include:
+
+  - {{jsxref("Uint8Array.fromBase64()")}} and {{jsxref("Uint8Array.fromHex()")}} static methods for constructing a new `Uint8Array` object from a base64- and hex-encoded string, respectively.
+  - {{jsxref("Uint8Array.prototype.setFromBase64()")}}, and {{jsxref("Uint8Array.prototype.setFromHex()")}} instance methods for populating an existing `Uint8Array` object with bytes from a base64- or hex-encoded string.
+  - {{jsxref("Uint8Array.prototype.toBase64()")}} and {{jsxref("Uint8Array.prototype.toHex()")}} instance methods, which return a base64- and hex- encoded string from the data in a `Uint8Array` object.
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
FF132 adds `Uint8Array` methods for constructing and populating `Uint8Array` byte arrays with strings that are encoded in bas64 or hex, and similarly for creating a base64 or hex-encoded string from a `Uint8Array`.

This adds a release note. The corresponding docs will be added by https://github.com/mdn/content/pull/36387

Related docs can be tracked in #36547

