### PR TITLE
Add beginRenderPass() depthSlice config option

### DIFF
--- a/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
@@ -75,6 +75,10 @@ Color attachment objects can have the following properties:
 
     If `clearValue` is omitted, it defaults to `{r: 0, g: 0, b: 0, a: 0}`.
 
+- `depthSlice` {{optional_inline}}
+
+  - : A number representing the index of the 3D depth slice that will be output to for this color attachment, in the case of a 3D {{domxref("GPUTextureView")}} `view`. When specified, this allows WebGPU to render directly to slices of 3D textures within render passes.
+
 - `loadOp`
 
   - : An enumerated value indicating the load operation to perform on `view` prior to executing the render pass. Possible values are:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 125 adds support for the [`beginRenderPass()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/beginRenderPass) [`depthSlice`](https://gpuweb.github.io/gpuweb/#dom-gpurenderpasscolorattachment-depthslice) option. This PR adds this option to the config object description.

See https://developer.chrome.com/blog/new-in-webgpu-125#render_to_slice_of_3d_texture for evidence of addition.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

See https://github.com/mdn/content/issues/36345 for project tracking issue.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
