### PR TITLE
fix(docs): non-standard script tags in the attribution reporting api …

### DIFF
--- a/files/en-us/web/api/attribution_reporting_api/registering_sources/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/registering_sources/index.md
@@ -167,7 +167,7 @@ The browser stores the attribution source data when the browser receives the res
 A {{htmlelement("script")}} example might look like so:
 
 ```html
-<script src="advertising-script.js" attributionsrc />
+<script src="advertising-script.js" attributionsrc></script>
 ```
 
 Or via the {{domxref("HTMLScriptElement.attributionSrc")}} property:

--- a/files/en-us/web/api/attribution_reporting_api/registering_triggers/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/registering_triggers/index.md
@@ -138,7 +138,7 @@ In this case, the browser will attempt to match the trigger with a stored attrib
 A {{htmlelement("script")}} example might look like so:
 
 ```html
-<script src="advertising-script.js" attributionsrc />
+<script src="advertising-script.js" attributionsrc></script>
 ```
 
 ```js


### PR DESCRIPTION
### Description

The docs for [registering attribution sources](https://developer.mozilla.org/en-US/docs/Web/API/Attribution_Reporting_API/Registering_sources) and [registering attribution triggers](https://developer.mozilla.org/en-US/docs/Web/API/Attribution_Reporting_API/Registering_triggers) uses a non-standard self-closing script tag in the documentation.

### Motivation

Readers are currently not able to copy-paste the example as is.

### Additional details

In our own docs: https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags
It says that:

> This is especially important to remember for elements such as script or ul that do require a closing tag.
