### PR TITLE
Fix wording about infinite iterators for iterator helper methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/iterator/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/every/index.md
@@ -32,7 +32,7 @@ every(callbackFn)
 
 `every()` iterates the iterator and invokes the `callbackFn` function once for each element. It returns `false` immediately if the callback function returns a falsy value. Otherwise, it iterates until the end of the iterator and returns `true`. If `every()` returns `false`, the underlying iterator is closed by calling its `return()` method.
 
-The main advantage of iterator helpers over array methods is their ability to work with infinite iterators. With infinite iterators, `every()` returns `false` as soon as the first falsy value is found. If the `callbackFn` always returns a truthy value, the method never returns.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. With infinite iterators, `every()` returns `false` as soon as the first falsy value is found. If the `callbackFn` always returns a truthy value, the method never returns.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/every/index.md
@@ -32,7 +32,7 @@ every(callbackFn)
 
 `every()` iterates the iterator and invokes the `callbackFn` function once for each element. It returns `false` immediately if the callback function returns a falsy value. Otherwise, it iterates until the end of the iterator and returns `true`. If `every()` returns `false`, the underlying iterator is closed by calling its `return()` method.
 
-The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. With infinite iterators, `every()` returns `false` as soon as the first falsy value is found. If the `callbackFn` always returns a truthy value, the method never returns.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This avoids unnecessary computation and also allows them to be used with infinite iterators. With infinite iterators, `every()` returns `false` as soon as the first falsy value is found. If the `callbackFn` always returns a truthy value, the method never returns.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/filter/index.md
@@ -30,7 +30,7 @@ A new [iterator helper](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iter
 
 ## Description
 
-The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This avoids unnecessary computation and also allows them to be used with infinite iterators.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/filter/index.md
@@ -30,7 +30,7 @@ A new [iterator helper](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iter
 
 ## Description
 
-The main advantage of iterator helpers over array methods is their ability to work with infinite iterators. With infinite iterators, `filter()` allows you to iterate over only those elements that satisfy a given condition.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/find/index.md
@@ -32,7 +32,7 @@ The first element produced by the iterator that satisfies the provided testing f
 
 `find()` iterates the iterator and invokes the `callbackFn` function once for each element. It returns the element immediately if the callback function returns a truthy value. Otherwise, it iterates until the end of the iterator and returns `undefined`. If `find()` returns an element, the underlying iterator is closed by calling its `return()` method.
 
-The main advantage of iterator helpers over array methods is their ability to work with infinite iterators. With infinite iterators, `find()` returns the first satisfying element as soon as it is found. If the `callbackFn` always returns a falsy value, the method never returns.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. With infinite iterators, `find()` returns the first satisfying element as soon as it is found. If the `callbackFn` always returns a falsy value, the method never returns.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/find/index.md
@@ -32,7 +32,7 @@ The first element produced by the iterator that satisfies the provided testing f
 
 `find()` iterates the iterator and invokes the `callbackFn` function once for each element. It returns the element immediately if the callback function returns a truthy value. Otherwise, it iterates until the end of the iterator and returns `undefined`. If `find()` returns an element, the underlying iterator is closed by calling its `return()` method.
 
-The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. With infinite iterators, `find()` returns the first satisfying element as soon as it is found. If the `callbackFn` always returns a falsy value, the method never returns.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This avoids unnecessary computation and also allows them to be used with infinite iterators. With infinite iterators, `find()` returns the first satisfying element as soon as it is found. If the `callbackFn` always returns a falsy value, the method never returns.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/foreach/index.md
@@ -30,7 +30,7 @@ forEach(callbackFn)
 
 ## Description
 
-`forEach()` iterates the iterator and invokes the `callbackFn` function once for each element. Unlike most other iterator helper methods, it does not work well with infinite iterators, because it is not lazy.
+`forEach()` iterates the iterator and invokes the `callbackFn` function once for each element. Unlike most other iterator helper methods, it does not work with infinite iterators, because it is not lazy.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/map/index.md
@@ -30,7 +30,7 @@ A new [iterator helper](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iter
 
 ## Description
 
-The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. The `map()` method allows you to create a new iterator that, when iterated, produces transformed elements.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This avoids unnecessary computation and also allows them to be used with infinite iterators. The `map()` method allows you to create a new iterator that, when iterated, produces transformed elements.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/map/index.md
@@ -30,7 +30,7 @@ A new [iterator helper](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iter
 
 ## Description
 
-The main advantage of iterator helpers over array methods is their ability to work with infinite iterators. With infinite iterators, `map()` allows you to create a new iterator that, when iterated, produces transformed elements.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. The `map()` method allows you to create a new iterator that, when iterated, produces transformed elements.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/some/index.md
@@ -32,7 +32,7 @@ some(callbackFn)
 
 `some()` iterates the iterator and invokes the `callbackFn` function once for each element. It returns `true` immediately if the callback function returns a truthy value. Otherwise, it iterates until the end of the iterator and returns `false`. If `some()` returns `true`, the underlying iterator is closed by calling its `return()` method.
 
-The main advantage of iterator helpers over array methods is their ability to work with infinite iterators. With infinite iterators, `some()` returns `true` as soon as the first truthy value is found. If the `callbackFn` always returns a falsy value, the method never returns.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. With infinite iterators, `some()` returns `true` as soon as the first truthy value is found. If the `callbackFn` always returns a falsy value, the method never returns.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/iterator/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/some/index.md
@@ -32,7 +32,7 @@ some(callbackFn)
 
 `some()` iterates the iterator and invokes the `callbackFn` function once for each element. It returns `true` immediately if the callback function returns a truthy value. Otherwise, it iterates until the end of the iterator and returns `false`. If `some()` returns `true`, the underlying iterator is closed by calling its `return()` method.
 
-The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This can improve performance and also allows them to be used with infinite iterators. With infinite iterators, `some()` returns `true` as soon as the first truthy value is found. If the `callbackFn` always returns a falsy value, the method never returns.
+The main advantage of iterator helpers over array methods is that they are lazy, meaning that they only produce the next value when requested. This avoids unnecessary computation and also allows them to be used with infinite iterators. With infinite iterators, `some()` returns `true` as soon as the first truthy value is found. If the `callbackFn` always returns a falsy value, the method never returns.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Fix wording to clarify that the key advantage is laziness (which also provides performance advantages in many scenarios that _don't_ involve infinite iterators).

Suggestions for how to improve the wording further are welcome!

### Motivation

Current wording "The _main advantage_  ... is their ability to work with infinite iterators" is debatable (I'd argue it's plain wrong, but I guess that's subjective).

### Additional details

N/A

### Related issues and pull requests

N/A