### PR TITLE
Add another cause for unexpected token error

### DIFF
--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
@@ -92,19 +92,23 @@ function round(n, upperBound, lowerBound) {
 
 ### A structure error further up confused the meaning
 
-Sometimes as a member of a class not a method but a property was declared. This might happen with JavaScript frameworks with unfamliar structures:
+Sometimes, the error is caused by some structure issues not directly next to the error location, so you need to look around for potential errors. For example, you intended to declare a method of a class, but you declared it as a propety instead:
 
-```js-noling example-bad
-mounted: {
-  document.getElementById('app').classList.add('loaded');
+```js-nolint example-bad
+class MyComponent {
+  mounted: {
+    document.getElementById("app").classList.add("loaded");
+  }
 }
 ```
 
-The dot after document is unexpedted as in an object body `{}` a property name is followed by a `:`. The problem is solved by declaring `mounted` as function
+The `.` after `document` is unexpected, because JavaScript is parsing the `{}` as an object literal instead of a function body, so it expects a `:`. The problem is solved by declaring `mounted` as function.
 
 ```js-nolint example-good
-mounted() {
-  document.getElementById('app').classList.add('loaded');
+class MyComponent {
+  mounted() {
+    document.getElementById("app").classList.add("loaded");
+  }
 }
 ```
 

--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
@@ -90,6 +90,24 @@ function round(n, upperBound, lowerBound) {
 }
 ```
 
+### A structure error further up confused the meaning
+
+Sometimes as a member of a class not a method but a property was declared. This might happen with JavaScript frameworks with unfamliar structures:
+
+```js-noling example-bad
+mounted: {
+  document.getElementById('app').classList.add('loaded');
+}
+```
+
+The dot after document is unexpedted as in an object body `{}` a property name is followed by a `:`. The problem is solved by declaring `mounted` as function
+
+```js-nolint example-good
+mounted() {
+  document.getElementById('app').classList.add('loaded');
+}
+```
+
 ## See also
 
 - {{jsxref("SyntaxError")}}

--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
@@ -92,10 +92,10 @@ function round(n, upperBound, lowerBound) {
 
 ### A structure error further up confused the meaning
 
-Sometimes, the error is caused by some structure issues not directly next to the error location, so you need to look around for potential errors. For example, you intended to declare a method of a class, but you declared it as a propety instead:
+Sometimes, the error is caused by some structure issues not directly next to the error location, so you need to look around for potential errors. For example, you intended to declare a method of an object, but you declared it as a propety instead:
 
 ```js-nolint example-bad
-class MyComponent {
+const MyComponent = {
   mounted: {
     document.getElementById("app").classList.add("loaded");
   }
@@ -105,7 +105,7 @@ class MyComponent {
 The `.` after `document` is unexpected, because JavaScript is parsing the `{}` as an object literal instead of a function body, so it expects a `:`. The problem is solved by declaring `mounted` as function.
 
 ```js-nolint example-good
-class MyComponent {
+const MyComponent = {
   mounted() {
     document.getElementById("app").classList.add("loaded");
   }


### PR DESCRIPTION
Confusing error if a method name is not followed by `()` but by `:`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

using `:` instead of `()` in a class definition

### Motivation

A non obvious typo higher up causes a confusing un expected  `. `

### Additional details

none

### Related issues and pull requests

