### PR TITLE
Correct output indication

### DIFF
--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -263,7 +263,7 @@ function sum(a) {
   };
 }
 
-console.log(sum(1)(2)(3)(4)); // 20
+console.log(sum(1)(2)(3)(4)); // 10
 ```
 
 You can also write without anonymous functions:
@@ -287,7 +287,7 @@ const sum2 = sum(1);
 const sum3 = sum2(2);
 const sum4 = sum3(3);
 const result = sum4(4);
-console.log(result); // 20
+console.log(result); // 10
 ```
 
 In the example above, there's a series of nested functions, all of which have access to the outer functions' scope. In this context, we can say that closures have access to _all_ outer scopes.


### PR DESCRIPTION
…the Closure scope chain code example for the answer to the sum of 1 to 4.

In one of the examples, the commenter wrote the answer of a simple addition incorrectly.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed the comment that was written in the first two code examples of the "Closure scope chain" section and wrote the sum of 1 to 4 `// 20` to `// 10`

```javascript
// global scope
const e = 10;
function sum(a) {
  return function (b) {
    return function (c) {
      // outer functions scope
      return function (d) {
        // local scope
        return a + b + c + d + e;
      };
    };
  };
}

console.log(sum(1)(2)(3)(4)); // 20 --===>  this is incorrect but it's very small 😊

```

it's exactly in this [link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#closure_scope_chain)

### Motivation

If the answer is a wrong combination, it may raise the question for readers unfamiliar with the javascript community who have already become professionals in other languages ​​such as C or Fortran, whether the mdn documents are a valid source for learning?
Although this question will be solved later with a little inquiry, but at first glance, it questions the citation of these documents, and in general, we created Open Source so that the main authors of the articles are not involved in these details.


### Related issues and pull requests

I didn't find any Repo or PullRequest on this (very minor thing but I wanted everything to be just right!)


