### PR TITLE
Add exception info for `HTMLCanvasElement.transferControlToOffscreen()` and `OffscreenCanvas.transferToImageBitmap()`

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -117,7 +117,7 @@ If the context identifier is not supported, or the canvas has already been set t
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Throws if the canvas has transferred its control to offscreen via calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
+  - : Throws if the canvas has transferred its control to offscreen by calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -117,7 +117,7 @@ If the context identifier is not supported, or the canvas has already been set t
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Throws if the canvas has transferred its control to offscreen via calling `HTMLCanvasElement.transferControlToOffscreen()`.
+  - : Throws if the canvas has transferred its control to offscreen via calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -27,7 +27,7 @@ An {{domxref("OffscreenCanvas")}} object.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Throws if the canvas has been set to a context mode via calling {{domxref("HTMLCanvasElement.getContext()")}} or has transferred its control to offscreen via calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
+  - : Throws if the canvas has been set to a context mode by calling {{domxref("HTMLCanvasElement.getContext()")}} or has transferred its control to offscreen by calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -28,8 +28,8 @@ An {{domxref("OffscreenCanvas")}} object.
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Throws if:
-      - the canvas has been set a context mode by calling {{domxref("HTMLCanvasElement.getContext()")}}
-      - the canvas has transferred its control to offscreen by calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
+    - the canvas has been set a context mode by calling {{domxref("HTMLCanvasElement.getContext()")}}
+    - the canvas has transferred its control to offscreen by calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -27,7 +27,9 @@ An {{domxref("OffscreenCanvas")}} object.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Throws if the canvas has been set to a context mode by calling {{domxref("HTMLCanvasElement.getContext()")}} or has transferred its control to offscreen by calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
+  - : Throws if:
+      - the canvas has been set a context mode by calling {{domxref("HTMLCanvasElement.getContext()")}}
+      - the canvas has transferred its control to offscreen by calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -24,6 +24,11 @@ None.
 
 An {{domxref("OffscreenCanvas")}} object.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Throws if the canvas has been set to a context mode via calling {{domxref("HTMLCanvasElement.getContext()")}} or has transferred its control to offscreen via calling {{domxref("HTMLCanvasElement.transferControlToOffscreen()")}}.
+
 ## Examples
 
 The following example shows how to transfer control to an {{domxref("OffscreenCanvas")}} object on the main thread.

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -32,6 +32,11 @@ If your goal is to pass the `ImageBitmap` to other web APIs which do not consume
 
 If you call `transferToImageBitmap()` and don't intend to pass it to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}}, consider whether you need to call `transferToImageBitmap()` at all. Many web APIs which accept `ImageBitmap` also accept `OffscreenCanvas` as an argument.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Throws if the canvas has transferred to another context scope, for example, to worker; or hasn't set to a context mode via calling {{domxref("OffscreenCanvas.getContext()")}}.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -36,8 +36,8 @@ If you call `transferToImageBitmap()` and don't intend to pass it to {{domxref("
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Throws if:
-      - the canvas has transferred to another context scope, such as a worker
-      - the canvas context mode has not been set by calling {{domxref("OffscreenCanvas.getContext()")}}.
+    - the canvas has transferred to another context scope, such as a worker
+    - the canvas context mode has not been set by calling {{domxref("OffscreenCanvas.getContext()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -35,7 +35,9 @@ If you call `transferToImageBitmap()` and don't intend to pass it to {{domxref("
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Throws if the canvas has transferred to another context scope, for example, to worker; or hasn't set to a context mode via calling {{domxref("OffscreenCanvas.getContext()")}}.
+  - : Throws if:
+      - the canvas has transferred to another context scope, such as a worker
+      - the canvas context mode has not been set by calling {{domxref("OffscreenCanvas.getContext()")}}.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-transfercontroltooffscreen
https://html.spec.whatwg.org/multipage/canvas.html#dom-offscreencanvas-transfertoimagebitmap

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
