### PR TITLE
docs: update `navigator.credentials.create` sample

### DIFF
--- a/files/en-us/web/api/publickeycredential/parsecreationoptionsfromjson_static/index.md
+++ b/files/en-us/web/api/publickeycredential/parsecreationoptionsfromjson_static/index.md
@@ -86,7 +86,7 @@ const createCredentialOptions =
   );
 
 navigator.credentials
-  .create({ createCredentialOptions })
+  .create({ publicKey: createCredentialOptions })
   .then((newCredentialInfo) => {
     // Handle the new credential information here.
   })


### PR DESCRIPTION
### Description

This change fixes an issue regarding the `CredentialCreationOptions` in the `navigator.credentials.create` sample.

### Motivation

This change will help readers who are attempting to use the `parseCreationOptionsFromJSON` static method.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create#publickey