### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -74,6 +74,7 @@ ctx.fillRect(10, 10, 150, 100);
 
 The Canvas API is extremely powerful, but not always simple to use. The libraries listed below can make the creation of canvas-based projects faster and easier.
 
+- [Canvascript](https://github.com/VBproDev/Canvascript) is an open-source no-code tool that allows to render drawings in the HTML canvas
 - [EaselJS](https://createjs.com/easeljs) is an open-source canvas library that makes creating games, generative art, and other highly graphical experiences easy.
 - [Fabric.js](http://fabricjs.com/) is an open-source canvas library with SVG parsing capabilities.
 - [heatmap.js](https://www.patrick-wied.at/static/heatmapjs/) is an open-source library for creating canvas-based data heat maps.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adding Canvascript in the list of tools in the HTML canvas page of MDN web docs

### Motivation

The purpose of the list of tools section is to navigate readers to relevant resources that can easily help them in their code. Canvascript is an open-source no-code tool that allows developers to easily render their drawings in the HTML canvas without mapping out every single coordinate. It thus allows readers cum users of the canvas to quickly create graphics without this tiresome step.

### Additional details

This is the link to the repo-
https://github.com/VBproDev/Canvascript
