### PR TITLE
Update value info for `HTMLMediaElement.srcObject`

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -81,7 +81,7 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
 - {{domxref("HTMLMediaElement.src")}}
   - : A string that reflects the [`src`](/en-US/docs/Web/HTML/Element/video#src) HTML attribute, which contains the URL of a media resource to use.
 - {{domxref("HTMLMediaElement.srcObject")}}
-  - : A {{domxref('MediaStream')}} representing the media to play or that has played in the current `HTMLMediaElement`, or `null` if not assigned.
+  - : An object which serves as the source of the media associated with the {{domxref("HTMLMediaElement")}}, or `null` if not assigned.
 - {{domxref("HTMLMediaElement.textTracks")}} {{ReadOnlyInline}}
   - : Returns a {{domxref('TextTrackList')}} object containing the list of {{domxref("TextTrack")}} objects contained in the element.
 - {{domxref("HTMLMediaElement.videoTracks")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/htmlmediaelement/srcobject/index.md
+++ b/files/en-us/web/api/htmlmediaelement/srcobject/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLMediaElement.srcObject
 
 The **`srcObject`** property of the
 {{domxref("HTMLMediaElement")}} interface sets or returns the object which serves as
-the source of the media associated with the {{domxref("HTMLMediaElement")}}.
+the source of the media associated with the {{domxref("HTMLMediaElement")}}, or `null` if not assigned.
 
 The object can be a {{domxref("MediaStream")}}, a {{domxref("MediaSource")}}, a
 {{domxref("Blob")}}, or a {{domxref("File")}} (which inherits from `Blob`).
@@ -22,7 +22,7 @@ The object can be a {{domxref("MediaStream")}}, a {{domxref("MediaSource")}}, a
 
 A {{domxref('MediaStream')}}, {{domxref('MediaSource')}}, {{domxref('Blob')}}, or
 {{domxref('File')}} object (though see the compatibility table for what is actually
-supported).
+supported), or `null` if not assigned.
 
 ## Usage notes
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the [spec for dom](https://html.spec.whatwg.org/multipage/media.html#dom-media-srcobject) and [spec for media source](https://w3c.github.io/media-source/#htmlmediaelement-extensions-srcobject)

[chromium](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/modules/srcobject/html_media_element_src_object.idl#L8) support for `MediaStream` and `MediaSourceHandle`

[webkit](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/html/HTMLMediaElement.idl#L30-L40) full support for `MediaStream`, `MediaSourceHandle`, `MediaSource` and `Blob`

[gecko](https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/HTMLMediaElement.webidl#L116) only support for `MediaStream`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
