### PR TITLE
Add information about passing null to unset a bind group

### DIFF
--- a/files/en-us/web/api/gpucomputepassencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/setbindgroup/index.md
@@ -27,7 +27,7 @@ setBindGroup(index, bindGroup, dynamicOffsets, dynamicOffsetsStart,
 - `index`
   - : The index to set the bind group at. This matches the `n` index value of the corresponding [`@group(n)`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-group) attribute in the shader code ({{domxref("GPUShaderModule")}}) used in the related pipeline.
 - `bindGroup`
-  - : The {{domxref("GPUBindGroup")}} to use for subsequent compute commands.
+  - : The {{domxref("GPUBindGroup")}} to use for subsequent compute commands, or `null`, in which case any previously-set bind group in the given slot is unset.
 - `dynamicOffsets` {{optional_inline}}
   - : A value specifying the offset, in bytes, for each entry in `bindGroup` with `hasDynamicOffset: true` set (i.e. in the descriptor of the {{domxref("GPUDevice.createBindGroupLayout()")}} call that created the {{domxref("GPUBindGroupLayout")}} object that the `bindGroup` is based on). This value can be:
     - An array of numbers specifying the different offsets.
@@ -63,6 +63,8 @@ The following criteria must be met when calling **`dispatchWorkgroups()`**, othe
 
 ## Examples
 
+### Set bind group
+
 In our [basic compute demo](https://mdn.github.io/dom-examples/webgpu-compute-demo/), several commands are recorded via a {{domxref("GPUCommandEncoder")}}. Most of these commands originate from the {{domxref("GPUComputePassEncoder")}} created via `beginComputePass()`. The `setBindGroup()` call used here is the simplest form, just specifying index and bind group.
 
 ```js
@@ -97,6 +99,16 @@ commandEncoder.copyBufferToBuffer(
 device.queue.submit([commandEncoder.finish()]);
 
 // ...
+```
+
+### Unset bind group
+
+```js
+// Set bind group in slot 0
+passEncoder.setBindGroup(0, bindGroup);
+
+// Later, unset bind group in slot 0
+passEncoder.setBindGroup(0, null);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
@@ -96,7 +96,7 @@ The above snippet is taken from the WebGPU Samples [Animometer example](https://
 
 ```js
 // Set bind group in slot 0
-passEncoder.setBindGroup(0, bindGroup);
+passEncoder.setBindGroup(0, timeBindGroup);
 
 // Later, unset bind group in slot 0
 passEncoder.setBindGroup(0, null);

--- a/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
@@ -30,7 +30,7 @@ setBindGroup(index, bindGroup, dynamicOffsets, dynamicOffsetsStart,
 - `index`
   - : The index to set the bind group at. This matches the `n` index value of the corresponding [`@group(n)`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-group) attribute in the shader code ({{domxref("GPUShaderModule")}}) used in the related pipeline.
 - `bindGroup`
-  - : The {{domxref("GPUBindGroup")}} to use for subsequent render bundle commands.
+  - : The {{domxref("GPUBindGroup")}} to use for subsequent render bundle commands, or `null`, in which case any previously-set bind group in the given slot is unset.
 - `dynamicOffsets` {{optional_inline}}
   - : A value specifying the offset, in bytes, for each entry in `bindGroup` with `hasDynamicOffset: true` set (i.e. in the descriptor of the {{domxref("GPUDevice.createBindGroupLayout()")}} call that created the {{domxref("GPUBindGroupLayout")}} object that the `bindGroup` is based on). This value can be:
     - An array of numbers specifying the different offsets.
@@ -66,6 +66,8 @@ The following criteria must be met when calling **`setBindGroup()`**, otherwise 
 
 ## Examples
 
+### Set bind group
+
 ```js
 function recordRenderPass(passEncoder) {
   if (settings.dynamicOffsets) {
@@ -89,6 +91,16 @@ function recordRenderPass(passEncoder) {
 ```
 
 The above snippet is taken from the WebGPU Samples [Animometer example](https://webgpu.github.io/webgpu-samples/samples/animometer/).
+
+### Unset bind group
+
+```js
+// Set bind group in slot 0
+passEncoder.setBindGroup(0, bindGroup);
+
+// Later, unset bind group in slot 0
+passEncoder.setBindGroup(0, null);
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
@@ -27,7 +27,7 @@ setBindGroup(index, bindGroup, dynamicOffsets, dynamicOffsetsStart,
 - `index`
   - : The index to set the bind group at. This matches the `n` index value of the corresponding [`@group(n)`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-group) attribute in the shader code ({{domxref("GPUShaderModule")}}) used in the related pipeline.
 - `bindGroup`
-  - : The {{domxref("GPUBindGroup")}} to use for subsequent render commands.
+  - : The {{domxref("GPUBindGroup")}} to use for subsequent render commands, or `null`, in which case any previously-set bind group in the given slot is unset.
 - `dynamicOffsets` {{optional_inline}}
   - : A value specifying the offset, in bytes, for each entry in `bindGroup` with `hasDynamicOffset: true` set (i.e. in the descriptor of the {{domxref("GPUDevice.createBindGroupLayout()")}} call that created the {{domxref("GPUBindGroupLayout")}} object that the `bindGroup` is based on). This value can be:
     - An array of numbers specifying the different offsets.
@@ -63,6 +63,8 @@ The following criteria must be met when calling **`setBindGroup()`**, otherwise 
 
 ## Examples
 
+### Set bind group
+
 In the WebGPU Samples [Textured Cube example](https://webgpu.github.io/webgpu-samples/samples/texturedCube/), `setBindGroup()` is used to bind the `uniformBindGroup` to index position 0. Check out the example for the full context.
 
 ```js
@@ -82,6 +84,16 @@ device.queue.submit([commandEncoder.finish()]);
 
 > [!NOTE]
 > Study the other [WebGPU Samples](https://webgpu.github.io/webgpu-samples/) for more examples of `setBindGroup()` usage.
+
+### Unset bind group
+
+```js
+// Set bind group in slot 0
+passEncoder.setBindGroup(0, bindGroup);
+
+// Later, unset bind group in slot 0
+passEncoder.setBindGroup(0, null);
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
@@ -89,7 +89,7 @@ device.queue.submit([commandEncoder.finish()]);
 
 ```js
 // Set bind group in slot 0
-passEncoder.setBindGroup(0, bindGroup);
+passEncoder.setBindGroup(0, uniformBindGroup);
 
 // Later, unset bind group in slot 0
 passEncoder.setBindGroup(0, null);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In Chrome 117 onwards, you can pass `null` as the second argument when calling https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setBindGroup#bindgroup, https://developer.mozilla.org/en-US/docs/Web/API/GPURenderPassEncoder/setBindGroup#bindgroup, and https://developer.mozilla.org/en-US/docs/Web/API/GPURenderBundleEncoder/setBindGroup#bindgroup to unset a previously-set bind group in the specified slot. 

This PR adds some text to the `bindGroup` argument description to specify this and also adds a small example snippet to each page to show what the unsettling code might look like.

See https://developer.chrome.com/blog/new-in-webgpu-117#unset_bind_group for evidence of this change.

Note that the above link does not mention [GPUComputePassEncoder/setBindGroup](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePassEncoder/setBindGroup#bindgroup), but I tested it and it works there as well.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Project issue: https://github.com/mdn/content/issues/36375

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
