### PR TITLE
Update OffscreenCanvas.getContext() options for Blink

### DIFF
--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -50,12 +50,10 @@ getContext(contextType, contextAttributes)
 
     - `alpha`
       - : Boolean that indicates if the canvas contains an alpha channel. If set to `false`, the browser now knows that the backdrop is always opaque, which can speed up drawing of transparent content and images then.
-    - `willReadFrequently` {{non-standard_inline}} (Firefox only)
+    - `willReadFrequently`
       - : Boolean that indicates whether or not a lot of read-back operations are planned.
         This will force the use of a software (instead of hardware accelerated) 2D canvas and can save memory when calling {{domxref("CanvasRenderingContext2D.getImageData", "getImageData()")}} frequently.
-        This option is only available, if the flag `gfx.canvas.willReadFrequently.enable` is set to `true` (which, by default, is only the case for B2G/Firefox OS).
-    - `storage` {{non-standard_inline}} (Blink only)
-      - : String that indicates which storage is used ("persistent" by default).
+        In Firefox this option is only available if the flag `gfx.canvas.willReadFrequently.enable` is set to `true` (which, by default, is only the case for B2G/Firefox OS).
 
     WebGL context attributes:
 


### PR DESCRIPTION
Note: `willReadFrequently` support was added here: https://crrev.com/c/2309569

### Description

Update OffscreenCanvas.getContext() options for Blink

### Motivation

The options are currently outdated/incorrect.

### Additional details

https://crrev.com/c/2309569 (added support for willReadFrequently`)
https://crsrc.org/c/third_party/blink/renderer/modules/canvas/htmlcanvas/canvas_context_creation_attributes_module.idl (getContext attributes for Blink)

### Related issues and pull requests

None