### PR TITLE
Removed confusing use of accolades behind pseudoselector.

### DIFF
--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -30,11 +30,11 @@ You can use the following pseudo-elements to customize various parts of the scro
 
 - `::-webkit-scrollbar` — the entire scrollbar.
 - `::-webkit-scrollbar-button` — the buttons on the scrollbar (arrows pointing upwards and downwards that scroll one line at a time).
-- `::-webkit-scrollbar:horizontal{}` — the horizontal scrollbar.
+- `::-webkit-scrollbar:horizontal` — the horizontal scrollbar.
 - `::-webkit-scrollbar-thumb` — the draggable scrolling handle.
 - `::-webkit-scrollbar-track` — the track (progress bar) of the scrollbar, where there is a gray bar on top of a white bar.
 - `::-webkit-scrollbar-track-piece` — the part of the track (progress bar) not covered by the handle.
-- `::-webkit-scrollbar:vertical{}` — the vertical scrollbar.
+- `::-webkit-scrollbar:vertical` — the vertical scrollbar.
 - `::-webkit-scrollbar-corner` — the bottom corner of the scrollbar, where both horizontal and vertical scrollbars meet. This is often the bottom-right corner of the browser window.
 - `::-webkit-resizer` — the draggable resizing handle that appears at the bottom corner of some elements.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed accolades behind pseudo selectors, on two occasions, to make the description more uniform. Since the accolades are not part of the selector.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

It appears as if you need the accolades in order to make the selector functional. But you don't, hence why I've removed them:

```diff
-body *::-webkit-scrollbar:horizontal{} {
+body *::-webkit-scrollbar:horizontal {
    height: 10px;
}
```

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

None.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

None.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
