### PR TITLE
convert to the new dot handling logic on jsxref

### DIFF
--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -206,8 +206,8 @@ If you are new to JavaScript, start with the [guide](/en-US/docs/Web/JavaScript/
 - {{jsxref("Operators/Property_accessors", "Property accessors", "", 1)}}
 - {{jsxref("Operators/Optional_chaining", "?.")}}
 - {{jsxref("Operators/new", "new")}}
-- {{jsxref("Operators/new%2Etarget", "new.target")}}
-- {{jsxref("Operators/import%2Emeta", "import.meta")}}
+- {{jsxref("Operators/new.target", "new.target")}}
+- {{jsxref("Operators/import.meta", "import.meta")}}
 - {{jsxref("Operators/super", "super")}}
 - {{jsxref("Operators/import", "import()")}}
 

--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -52,9 +52,9 @@ Left values are the destination of an assignment.
   - : The optional chaining operator returns `undefined` instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
 - {{jsxref("Operators/new", "new")}}
   - : The `new` operator creates an instance of a constructor.
-- {{jsxref("Operators/new%2Etarget", "new.target")}}
+- {{jsxref("Operators/new.target", "new.target")}}
   - : In constructors, `new.target` refers to the constructor that was invoked by {{jsxref("Operators/new", "new")}}.
-- {{jsxref("Operators/import%2Emeta", "import.meta")}}
+- {{jsxref("Operators/import.meta", "import.meta")}}
   - : An object exposing context-specific metadata to a JavaScript module.
 - {{jsxref("Operators/super", "super")}}
   - : The `super` keyword calls the parent constructor or allows accessing properties of the parent object.


### PR DESCRIPTION
### Description

Use the new jsxref dot handling logic. See see https://github.com/mdn/yari/pull/11869
(MP-1708)

### Motivation

rari/yari parity
