### PR TITLE
Clarify WebSocket connection initialization

### DIFF
--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -58,20 +58,21 @@ The examples below show how you might connect to a `WebSocket`.
 The code below shows how we can connect to a socket using an URL with the `wss` schema:
 
 ```js
-const httpsWebSocket = new WebSocket('wss://websocket.example.org');
-console.log(httpsWebSocket.url); // 'wss://websocket.example.org'
+let wssWebSocket = new WebSocket('wss://websocket.example.org');
+console.log(wssWebSocket.url); // 'wss://websocket.example.org'
 ... // Do something with socket
-httpsWebSocket.close();
+wssWebSocket.close();
 ```
 
 The code for connecting to an HTTPS URL is nearly the same.
 Under the hood the browser resolves this to a "WSS" connection, so the {{domxref("WebSocket.url")}} will have the schema "wss:".
 
 ```js
-let wssWebSocket = new WebSocket('https://websocket.example.org');
-console.log(wssWebSocket.url); // 'wss://websocket.example.org'
+
+const httpsWebSocket = new WebSocket('https://websocket.example.org');
+console.log(httpsWebSocket.url); // 'wss://websocket.example.org'
 ... // Do something with socket
-wssWebSocket.close();
+httpsWebSocket.close();
 ```
 
 We can also resolve relative URLs.

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -58,7 +58,7 @@ The examples below show how you might connect to a `WebSocket`.
 The code below shows how we can connect to a socket using an URL with the `wss` schema:
 
 ```js
-let wssWebSocket = new WebSocket('wss://websocket.example.org');
+const wssWebSocket = new WebSocket('wss://websocket.example.org');
 console.log(wssWebSocket.url); // 'wss://websocket.example.org'
 ... // Do something with socket
 wssWebSocket.close();
@@ -68,7 +68,6 @@ The code for connecting to an HTTPS URL is nearly the same.
 Under the hood the browser resolves this to a "WSS" connection, so the {{domxref("WebSocket.url")}} will have the schema "wss:".
 
 ```js
-
 const httpsWebSocket = new WebSocket('https://websocket.example.org');
 console.log(httpsWebSocket.url); // 'wss://websocket.example.org'
 ... // Do something with socket


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This pull request fixes a documentation issue by clarifying that the code for connecting to an HTTPS URL is nearly the same as connecting to a WSS URL. The WebSocket argument will have the schema "wss:" under the hood.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I'm making these changes to clarify the behavior of WebSocket connections in the documentation. This will help readers understand the difference between connecting to an HTTPS URL and a WSS URL, and how the WebSocket URL argument is affected.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- This pull request resolves the documentation issue in the WebSocket documentation.
- No other pull requests are related to this change.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
