### PR TITLE
Add information about FireFox override setting for disablePictureInPicture

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -10,6 +10,8 @@ browser-compat: api.HTMLVideoElement.disablePictureInPicture
 
 The {{domxref("HTMLVideoElement")}} **`disablePictureInPicture`** property reflects the HTML attribute indicating whether the picture-in-picture feature is disabled for the current element.
 
+This value only represents a request from the website to the user agent. User configuration may change the eventual behavior—for example, Firefox users can change the `media.videocontrols.picture-in-picture.respect-disablePictureInPicture` setting to ignore the request to disable PiP.
+
 ## Value
 
 A boolean value that is `true` if the picture-in-picture feature is disabled for this element. This means that the user agent should not suggest that feature to users, or request it automatically.
@@ -21,7 +23,3 @@ A boolean value that is `true` if the picture-in-picture feature is disabled for
 ## Browser compatibility
 
 {{Compat}}
-
-## Overrides
-
-FireFox users can decide to ignore the request to disable PiP by changing the `media.videocontrols.picture-in-picture.respect-disablePictureInPicture` setting.

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -21,3 +21,7 @@ A boolean value that is `true` if the picture-in-picture feature is disabled for
 ## Browser compatibility
 
 {{Compat}}
+
+## Overrides
+
+FireFox users can decide to ignore the request to disable PiP by changing the `media.videocontrols.picture-in-picture.respect-disablePictureInPicture` setting.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added information about a FireFox-specific setting users can set to override this setting.

### Motivation

Might be useful for other people to know; both consumers & devs to keep into mind that this is an option.

### Additional details

- none

### Related issues and pull requests

- none