### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/http/methods/index.md
+++ b/files/en-us/web/http/methods/index.md
@@ -10,7 +10,7 @@ browser-compat: http.methods
 
 HTTP defines a set of **request methods** to indicate the purpose of the request and what is expected if the request is successful.
 Although they can also be nouns, these request methods are sometimes referred to as _HTTP verbs_.
-Each request method has it's own semantics, but some characteristics are shared across multiple methods, specifically request methods can be {{glossary("Safe/HTTP", "safe")}}, {{glossary("idempotent")}}, or {{glossary("cacheable")}}.
+Each request method has its own semantics, but some characteristics are shared across multiple methods, specifically request methods can be {{glossary("Safe/HTTP", "safe")}}, {{glossary("idempotent")}}, or {{glossary("cacheable")}}.
 
 - {{HTTPMethod("GET")}}
   - : The `GET` method requests a representation of the specified resource.


### PR DESCRIPTION
it's -> its for possessive 3rd person

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

removed one character to change "it's" (it is) to "its" (3rd person singular possessive) in the original "Each request method has it's own semantics..."

### Motivation

It bothered me when trying to learn about the difference between GET and POST requests.

### Additional details

https://www.merriam-webster.com/grammar/when-to-use-its-vs-its

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
