### PR TITLE
<body> element: enhance attribute section

### DIFF
--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -16,7 +16,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 ### Event attributes
 
 > [!NOTE]
-> Each event attribute has an equivalent {{domxref("Window")}} interface event. You can listen to these events, linked to from the attribute name, using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) instead of adding the `oneventname` to the `<body>` element.
+> Each of the below event attribute names is linked to its equivalent {{domxref("Window")}} interface event. You can listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) instead of adding the `oneventname` attribute to the `<body>` element.
 
 - [`onafterprint`](/en-US/docs/Web/API/Window/afterprint_event)
   - : Function to call after the user has printed the document.

--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -11,84 +11,95 @@ The **`<body>`** [HTML](/en-US/docs/Web/HTML) element represents the content of 
 
 ## Attributes
 
-This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes), event attributes, and deprecated attributes:
+
+### Event attributes
+
+> [!NOTE]
+> Each event attribute has an equivalent {{domxref("Window")}} interface event. You can listen to these events, linked to from the attribute name, using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) instead of adding the `oneventname` to the `<body>` element.
+
+- [`onafterprint`](/en-US/docs/Web/API/Window/afterprint_event)
+  - : Function to call after the user has printed the document.
+- [`onbeforeprint`](/en-US/docs/Web/API/Window/beforeprint_event)
+  - : Function to call when the user requests printing of the document.
+- [`onbeforeunload`](/en-US/docs/Web/API/Window/beforeunload_event)
+  - : Function to call when the document is about to be unloaded.
+- [`onblur`](/en-US/docs/Web/API/Window/blur_event)
+  - : Function to call when the document loses focus.
+- [`onerror`](/en-US/docs/Web/API/Window/error_event)
+  - : Function to call when the document fails to load properly.
+- [`onfocus`](/en-US/docs/Web/API/Window/focus_event)
+  - : Function to call when the document receives focus.
+- [`onhashchange`](/en-US/docs/Web/API/Window/hashchange_event)
+  - : Function to call when the fragment identifier part (starting with the hash (`'#'`) character) of the document's current address has changed.
+- [`onlanguagechange`](/en-US/docs/Web/API/Window/languagechange_event)
+  - : Function to call when the preferred languages changed.
+- [`onload`](/en-US/docs/Web/API/Window/load_event)
+  - : Function to call when the document has finished loading.
+- [`onmessage`](/en-US/docs/Web/API/Window/message_event)
+  - : Function to call when the document has received a message.
+- [`onmessageerror`](/en-US/docs/Web/API/Window/messageerror_event)
+  - : Function to call when the document has received a message that cannot be deserialized.
+- [`onoffline`](/en-US/docs/Web/API/Window/offline_event)
+  - : Function to call when network communication has failed.
+- [`ononline`](/en-US/docs/Web/API/Window/online_event)
+  - : Function to call when network communication has been restored.
+- [`onpageswap`](/en-US/docs/Web/API/Window/pageswap_event)
+  - : Function to call when you navigate across documents, when the previous document is about to unload.
+- [`onpagehide`](/en-US/docs/Web/API/Window/pagehide_event)
+  - : Function to call when the browser hides the current page in the process of presenting a different page from the session's history.
+- [`onpagereveal`](/en-US/docs/Web/API/Window/pagereveal_event)
+  - : Function to call when a document is first rendered, either when loading a fresh document from the network or activating a document.
+- [`onpageshow`](/en-US/docs/Web/API/Window/pageshow_event)
+  - : Function to call when the browser displays the window's document due to navigation.
+- [`onpopstate`](/en-US/docs/Web/API/Window/popstate_event)
+  - : Function to call when the user has navigated session history.
+- [`onresize`](/en-US/docs/Web/API/Window/resize_event)
+  - : Function to call when the document has been resized.
+- [`onrejectionhandled`](/en-US/docs/Web/API/Window/rejectionhandled_event)
+  - : Function to call when a JavaScript {{jsxref("Promise")}} is handled late.
+- [`onstorage`](/en-US/docs/Web/API/Window/storage_event)
+  - : Function to call when the storage area has changed.
+- [`onunhandledrejection`](/en-US/docs/Web/API/Window/unhandledrejection_event)
+  - : Function to call when a JavaScript {{jsxref("Promise")}} that has no rejection handler is rejected.
+- [`onunload`](/en-US/docs/Web/API/Window/unload_event)
+  - : Function to call when the document is going away.
+
+### Deprecated attributes
+
+> [!WARNING]
+> Do not use these deprecated attributes; opt for the CSS alternatives listed with each deprecated attribute instead.
 
 - `alink` {{deprecated_inline}}
   - : Color of text for hyperlinks when selected.
-    **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} pseudo-class instead.**
+    Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":active")}} and {{cssxref(":focus")}} pseudo-classes instead.
 - `background` {{deprecated_inline}}
   - : URI of an image to use as a background.
-    **Do not use this attribute! Use the CSS {{cssxref("background")}} property on the element instead.**
+    Use the CSS {{cssxref("background-image")}} property instead.
 - `bgcolor` {{deprecated_inline}}
   - : Background color for the document.
-    **Do not use this attribute! Use the CSS {{cssxref("background-color")}} property on the element instead.**
+    Use the CSS {{cssxref("background-color")}} property instead.
 - `bottommargin` {{deprecated_inline}}
   - : The margin of the bottom of the body.
-    **Do not use this attribute! Use the CSS {{cssxref("margin-bottom")}} property on the element instead.**
+    Use the CSS {{cssxref("margin-bottom")}} property (or the logical {{cssxref("margin-block-end")}} property) instead.
 - `leftmargin` {{deprecated_inline}}
   - : The margin of the left of the body.
-    **Do not use this attribute! Use the CSS {{cssxref("margin-left")}} property on the element instead.**
+    Use the CSS {{cssxref("margin-left")}} property (or the logical {{cssxref("margin-inline-start")}} property) instead.
 - `link` {{deprecated_inline}}
   - : Color of text for unvisited hypertext links.
-    **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":link")}} pseudo-class instead.**
-- `onafterprint`
-  - : Function to call after the user has printed the document.
-- `onbeforeprint`
-  - : Function to call when the user requests printing of the document.
-- `onbeforeunload`
-  - : Function to call when the document is about to be unloaded.
-- `onblur`
-  - : Function to call when the document loses focus.
-- `onerror`
-  - : Function to call when the document fails to load properly.
-- `onfocus`
-  - : Function to call when the document receives focus.
-- `onhashchange`
-  - : Function to call when the fragment identifier part (starting with the hash (`'#'`) character) of the document's current address has changed.
-- `onlanguagechange`
-  - : Function to call when the preferred languages changed.
-- `onload`
-  - : Function to call when the document has finished loading.
-- `onmessage`
-  - : Function to call when the document has received a message.
-- `onmessageerror`
-  - : Function to call when the document has received a message that cannot be deserialized.
-- `onoffline`
-  - : Function to call when network communication has failed.
-- `ononline`
-  - : Function to call when network communication has been restored.
-- `onpageswap`
-  - : Function to call when you navigate across documents, when the previous document is about to unload.
-- `onpagehide`
-  - : Function to call when the browser hides the current page in the process of presenting a different page from the session's history.
-- `onpagereveal`
-  - : Function to call when a document is first rendered, either when loading a fresh document from the network or activating a document.
-- `onpageshow`
-  - : Function to call when the browser displays the window's document due to navigation.
-- `onpopstate`
-  - : Function to call when the user has navigated session history.
-- `onresize`
-  - : Function to call when the document has been resized.
-- `onrejectionhandled`
-  - : Function to call when a JavaScript {{jsxref("Promise")}} is handled late.
-- `onstorage`
-  - : Function to call when the storage area has changed.
-- `onunhandledrejection`
-  - : Function to call when a JavaScript {{jsxref("Promise")}} that has no rejection handler is rejected.
-- `onunload`
-  - : Function to call when the document is going away.
+    Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":link")}} pseudo-class instead.
 - `rightmargin` {{deprecated_inline}}
   - : The margin of the right of the body.
-    **Do not use this attribute! Use the CSS {{cssxref("margin-right")}} property on the element instead.**
+    Use the CSS {{cssxref("margin-right")}} property or the logical {{cssxref("margin-inline-end")}} property) instead.
 - `text` {{deprecated_inline}}
   - : Foreground color of text.
-    **Do not use this attribute! Use CSS {{cssxref("color")}} property on the element instead.**
+    Use the CSS {{cssxref("color")}} property instead.
 - `topmargin` {{deprecated_inline}}
   - : The margin of the top of the body.
-    **Do not use this attribute! Use the CSS {{cssxref("margin-top")}} property on the element instead.**
+    Use the CSS {{cssxref("margin-top")}} property (or the logical {{cssxref("margin-block-start")}} property) instead.
 - `vlink` {{deprecated_inline}}
   - : Color of text for visited hypertext links.
-    **Do not use this attribute! Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":visited")}} pseudo-class instead.**
+    Use the CSS {{cssxref("color")}} property in conjunction with the {{cssxref(":visited")}} pseudo-class instead.
 
 ## Examples
 
@@ -195,3 +206,4 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{HTMLElement("html")}}
 - {{HTMLElement("head")}}
+- [Event handling overview](/en-US/docs/Web/Events/Event_handlers)


### PR DESCRIPTION
Separated the attributes into sections: events and deprecated. 
Linked each event to its corresponding page.
Added a note about that.
Added a global warning about deprecated attributes, suggesting the use of CSS instead.
reduced the amount of text and removed the bolding in each individual deprecated attribute
added logical property equivalents to the list of usable attribute.
added :focus to :active
added a link to event handling.