### PR TITLE
p1, p2, p3, p4 Instance Properties of DOMQuad

### DIFF
--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -17,7 +17,17 @@ A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbit
 ## Instance properties
 
 - p1,p2,p3,p4 {{ReadOnlyInline}}
+
   - : are {{domxref("DOMPoint")}} objects for each of the `DOMQuad` object's four corners.
+
+- {{domxref("DOMQuad.p1")}}
+  - : The `p1` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+- {{domxref("DOMQuad.p2")}}
+  - : The `p2` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+- {{domxref("DOMQuad.p3")}}
+  - : The `p3` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+- {{domxref("DOMQuad.p4")}}
+  - : The `p4` {{domxref("DOMPoint")}} for the new `DOMQuad`.
 
 ## Instance methods
 

--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -17,13 +17,13 @@ A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbit
 ## Instance properties
 
 - {{domxref("DOMQuad.p1")}} {{ReadOnlyInline}}
-  - : The `p1` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+  - : A {{domxref("DOMPoint")}} representing one corner of the `DOMQuad`.
 - {{domxref("DOMQuad.p2")}} {{ReadOnlyInline}}
-  - : The `p2` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+  - : A {{domxref("DOMPoint")}} representing one corner of the `DOMQuad`.
 - {{domxref("DOMQuad.p3")}} {{ReadOnlyInline}}
-  - : The `p3` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+  - : A {{domxref("DOMPoint")}} representing one corner of the `DOMQuad`.
 - {{domxref("DOMQuad.p4")}} {{ReadOnlyInline}}
-  - : The `p4` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+  - : A {{domxref("DOMPoint")}} representing one corner of the `DOMQuad`.
 
 ## Instance methods
 

--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -16,17 +16,13 @@ A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbit
 
 ## Instance properties
 
-- p1,p2,p3,p4 {{ReadOnlyInline}}
-
-  - : are {{domxref("DOMPoint")}} objects for each of the `DOMQuad` object's four corners.
-
-- {{domxref("DOMQuad.p1")}}
+- {{domxref("DOMQuad.p1")}} {{ReadOnlyInline}}
   - : The `p1` {{domxref("DOMPoint")}} for the new `DOMQuad`.
-- {{domxref("DOMQuad.p2")}}
+- {{domxref("DOMQuad.p2")}} {{ReadOnlyInline}}
   - : The `p2` {{domxref("DOMPoint")}} for the new `DOMQuad`.
-- {{domxref("DOMQuad.p3")}}
+- {{domxref("DOMQuad.p3")}} {{ReadOnlyInline}}
   - : The `p3` {{domxref("DOMPoint")}} for the new `DOMQuad`.
-- {{domxref("DOMQuad.p4")}}
+- {{domxref("DOMQuad.p4")}} {{ReadOnlyInline}}
   - : The `p4` {{domxref("DOMPoint")}} for the new `DOMQuad`.
 
 ## Instance methods

--- a/files/en-us/web/api/domquad/p1/index.md
+++ b/files/en-us/web/api/domquad/p1/index.md
@@ -1,0 +1,36 @@
+---
+title: "DOMQuad: p1 property"
+short-title: p1
+slug: Web/API/DOMQuad/p1
+page-type: web-api-instance-property
+browser-compat: api.DOMQuad.p1
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`DOMQuad`** interface's
+**`p1`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+
+## Value
+
+The {{domxref("DOMPoint")}} object includes the following double-precision floating-point values:
+
+- {{domxref("DOMPoint.x")}}: The horizontal coordinate.
+- {{domxref("DOMPoint.y")}}: The vertical coordinate.
+- {{domxref("DOMPoint.z")}}: The depth coordinate.
+- {{domxref("DOMPoint.w")}}: The perspective value. The default value is 1.0.
+
+Each of these values is **unrestricted**, meaning that it is allowed to be infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The other `DOMPoint` properties: {{domxref("DOMQuad.p2", "p2")}},
+  {{domxref("DOMQuad.p3", "p3")}}, and {{domxref("DOMQuad.p4", "p4")}}.

--- a/files/en-us/web/api/domquad/p1/index.md
+++ b/files/en-us/web/api/domquad/p1/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.p1
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's **`p1`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p1`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. When created from {{domxref("DOMQuad.fromRect()")}}, it is the point (x, y).
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p1/index.md
+++ b/files/en-us/web/api/domquad/p1/index.md
@@ -8,8 +8,7 @@ browser-compat: api.DOMQuad.p1
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's
-**`p1`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p1`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p2/index.md
+++ b/files/en-us/web/api/domquad/p2/index.md
@@ -1,0 +1,36 @@
+---
+title: "DOMQuad: p2 property"
+short-title: p2
+slug: Web/API/DOMQuad/p2
+page-type: web-api-instance-property
+browser-compat: api.DOMQuad.p2
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`DOMQuad`** interface's
+**`p2`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+
+## Value
+
+The {{domxref("DOMPoint")}} object includes the following double-precision floating-point values:
+
+- {{domxref("DOMPoint.x")}}: The horizontal coordinate.
+- {{domxref("DOMPoint.y")}}: The vertical coordinate.
+- {{domxref("DOMPoint.z")}}: The depth coordinate.
+- {{domxref("DOMPoint.w")}}: The perspective value. The default value is 1.0.
+
+Each of these values is **unrestricted**, meaning that it is allowed to be infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The other `DOMPoint` properties: {{domxref("DOMQuad.p1", "p1")}},
+  {{domxref("DOMQuad.p3", "p3")}}, and {{domxref("DOMQuad.p4", "p4")}}.

--- a/files/en-us/web/api/domquad/p2/index.md
+++ b/files/en-us/web/api/domquad/p2/index.md
@@ -8,8 +8,7 @@ browser-compat: api.DOMQuad.p2
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's
-**`p2`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p2`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p2/index.md
+++ b/files/en-us/web/api/domquad/p2/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.p2
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's **`p2`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p2`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. When created from {{domxref("DOMQuad.fromRect()")}}, it is the point (x + width, y).
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p3/index.md
+++ b/files/en-us/web/api/domquad/p3/index.md
@@ -1,0 +1,36 @@
+---
+title: "DOMQuad: p3 property"
+short-title: p3
+slug: Web/API/DOMQuad/p3
+page-type: web-api-instance-property
+browser-compat: api.DOMQuad.p3
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`DOMQuad`** interface's
+**`p3`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+
+## Value
+
+The {{domxref("DOMPoint")}} object includes the following double-precision floating-point values:
+
+- {{domxref("DOMPoint.x")}}: The horizontal coordinate.
+- {{domxref("DOMPoint.y")}}: The vertical coordinate.
+- {{domxref("DOMPoint.z")}}: The depth coordinate.
+- {{domxref("DOMPoint.w")}}: The perspective value. The default value is 1.0.
+
+Each of these values is **unrestricted**, meaning that it is allowed to be infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The other `DOMPoint` properties: {{domxref("DOMQuad.p1", "p1")}},
+  {{domxref("DOMQuad.p2", "p2")}}, and {{domxref("DOMQuad.p4", "p4")}}.

--- a/files/en-us/web/api/domquad/p3/index.md
+++ b/files/en-us/web/api/domquad/p3/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.p3
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's **`p3`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p3`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. When created from {{domxref("DOMQuad.fromRect()")}}, it is the point (x + width, y + height).
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p3/index.md
+++ b/files/en-us/web/api/domquad/p3/index.md
@@ -8,8 +8,7 @@ browser-compat: api.DOMQuad.p3
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's
-**`p3`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p3`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p4/index.md
+++ b/files/en-us/web/api/domquad/p4/index.md
@@ -1,0 +1,36 @@
+---
+title: "DOMQuad: p4 property"
+short-title: p4
+slug: Web/API/DOMQuad/p4
+page-type: web-api-instance-property
+browser-compat: api.DOMQuad.p4
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`DOMQuad`** interface's
+**`p4`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+
+## Value
+
+The {{domxref("DOMPoint")}} object includes the following double-precision floating-point values:
+
+- {{domxref("DOMPoint.x")}}: The horizontal coordinate.
+- {{domxref("DOMPoint.y")}}: The vertical coordinate.
+- {{domxref("DOMPoint.z")}}: The depth coordinate.
+- {{domxref("DOMPoint.w")}}: The perspective value. The default value is 1.0.
+
+Each of these values is **unrestricted**, meaning that it is allowed to be infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The other `DOMPoint` properties: {{domxref("DOMQuad.p1", "p1")}},
+  {{domxref("DOMQuad.p2", "p2")}}, and {{domxref("DOMQuad.p3", "p3")}}.

--- a/files/en-us/web/api/domquad/p4/index.md
+++ b/files/en-us/web/api/domquad/p4/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.p4
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's **`p4`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p4`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. When created from {{domxref("DOMQuad.fromRect()")}}, it is the point (x, y + height).
 
 ## Value
 

--- a/files/en-us/web/api/domquad/p4/index.md
+++ b/files/en-us/web/api/domquad/p4/index.md
@@ -8,8 +8,7 @@ browser-compat: api.DOMQuad.p4
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad`** interface's
-**`p4`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
+The **`DOMQuad`** interface's **`p4`** property holds the {{domxref("DOMPoint")}} object that represents one of the four corners of the `DOMQuad`. This point includes the {{domxref("DOMPoint.x")}} (horizontal), {{domxref("DOMPoint.y")}} (vertical), {{domxref("DOMPoint.z")}} (depth), and {{domxref("DOMPoint.w")}} (perspective) coordinates for a point in space.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR adds the MDN feature pages for the DOMQuad interface as part of a recent project to document missing Widely available pages for interface features.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The p1,p2,p3,p4 DOMPoints that are instance properties of the DOMQuad were missing from the MDN feature pages. This can help readers understand about DOMQuad.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
For more context, see the discussion on missing documentation tracked at https://openwebdocs.github.io/web-docs-backlog/baseline/. Additionally, related projects for adding widely available web features can be found at https://github.com/openwebdocs/project/issues/214.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes https://github.com/mdn/mdn/issues/599