### PR TITLE
toJSON() instance method page for DOMRectReadOnly

### DIFF
--- a/files/en-us/web/api/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/index.md
@@ -38,6 +38,11 @@ The **`DOMRectReadOnly`** interface specifies the standard properties (also used
 - {{domxref("DOMRectReadOnly/fromRect_static", "DOMRectReadOnly.fromRect()")}}
   - : Creates a new `DOMRectReadOnly` object with a given location and dimensions.
 
+## Instance methods
+
+- {{domxref("DOMRectReadOnly.toJSON()")}}
+  - : Returns a JSON representation of the `DOMRectReadOnly` object.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/domrectreadonly/tojson/index.md
+++ b/files/en-us/web/api/domrectreadonly/tojson/index.md
@@ -8,9 +8,7 @@ browser-compat: api.DOMRectReadOnly.toJSON
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The {{domxref("DOMRectReadOnly")}} method
-`toJSON()` returns a
-{{Glossary("JSON")}} representation of the `DOMRectReadOnly` object.
+The {{domxref("DOMRectReadOnly")}} method `toJSON()` returns a {{Glossary("JSON")}} representation of the `DOMRectReadOnly` object.
 
 ## Syntax
 
@@ -24,8 +22,7 @@ None.
 
 ### Return value
 
-A new object whose properties are set to the values in the
-`DOMRectReadOnly` on which the method was called.
+A new object whose properties are set to the values in the `DOMRectReadOnly` on which the method was called.
 
 ## Examples
 

--- a/files/en-us/web/api/domrectreadonly/tojson/index.md
+++ b/files/en-us/web/api/domrectreadonly/tojson/index.md
@@ -1,0 +1,48 @@
+---
+title: "DOMRectReadOnly: toJSON() method"
+short-title: toJSON()
+slug: Web/API/DOMRectReadOnly/toJSON
+page-type: web-api-instance-method
+browser-compat: api.DOMRectReadOnly.toJSON
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The {{domxref("DOMRectReadOnly")}} method
+`toJSON()` returns a
+{{Glossary("JSON")}} representation of the `DOMRectReadOnly` object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A new object whose properties are set to the values in the
+`DOMRectReadOnly` on which the method was called.
+
+## Examples
+
+This example creates a {{domxref("DOMRectReadOnly")}} that represents a rectangle at position `(10, 20)` with a width of `100` and a height of `50`. It then calls `toJSON()` to obtain a JSON representation of the rectangle.
+
+```js
+const rect = new DOMRectReadOnly(10, 20, 100, 50);
+
+const rectJSON = rect.toJSON();
+console.log(rectJSON);
+// Output: { x: 10, y: 20, width: 100, height: 50, top: 20, right: 110, bottom: 70, left: 10 }
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR adds the `toJSON()` instance method of `DOMRectReadOnly` feature page to MDN web docs. It is one of the [Missing Widely Available Pages](https://github.com/openwebdocs/project/issues/214)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I want to contribute to MDN for the love of open source. This particular PR will help readers understand the `DOMReactReadOnly` with suitable examples.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://openwebdocs.github.io/web-docs-backlog/baseline/
https://drafts.fxtf.org/geometry/#dom-domrectreadonly-tojson

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
