### PR TITLE
DOMRect instance properties

### DIFF
--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -18,7 +18,7 @@ new DOMRect(x, y, width, height)
 
 ### Parameters
 
-- {{domxref("DOMRect.x")}}
+- {{domxref("DOMRect.x", "x")}}
   - : The `x` coordinate of the `DOMRect`'s origin.
 - {{domxref("DOMRect.y")}}
   - : The `y` coordinate of the `DOMRect`'s origin.

--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -22,7 +22,7 @@ new DOMRect(x, y, width, height)
   - : The `x` coordinate of the `DOMRect`'s origin.
 - {{domxref("DOMRect.y", "y")}}
   - : The `y` coordinate of the `DOMRect`'s origin.
-- {{domxref("DOMRect.width")}}
+- {{domxref("DOMRect.width", "width")}}
   - : The width of the `DOMRect`.
 - {{domxref("DOMRect.height")}}
   - : The height of the `DOMRect`.

--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -18,13 +18,13 @@ new DOMRect(x, y, width, height)
 
 ### Parameters
 
-- `x`
+- {{domxref("DOMRect.x")}}
   - : The `x` coordinate of the `DOMRect`'s origin.
-- `y`
+- {{domxref("DOMRect.y")}}
   - : The `y` coordinate of the `DOMRect`'s origin.
-- `width`
+- {{domxref("DOMRect.width")}}
   - : The width of the `DOMRect`.
-- `height`
+- {{domxref("DOMRect.height")}}
   - : The height of the `DOMRect`.
 
 ### Return value

--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -24,7 +24,7 @@ new DOMRect(x, y, width, height)
   - : The `y` coordinate of the `DOMRect`'s origin.
 - {{domxref("DOMRect.width", "width")}}
   - : The width of the `DOMRect`.
-- {{domxref("DOMRect.height")}}
+- {{domxref("DOMRect.height", "height")}}
   - : The height of the `DOMRect`.
 
 ### Return value

--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -20,7 +20,7 @@ new DOMRect(x, y, width, height)
 
 - {{domxref("DOMRect.x", "x")}}
   - : The `x` coordinate of the `DOMRect`'s origin.
-- {{domxref("DOMRect.y")}}
+- {{domxref("DOMRect.y", "y")}}
   - : The `y` coordinate of the `DOMRect`'s origin.
 - {{domxref("DOMRect.width")}}
   - : The width of the `DOMRect`.

--- a/files/en-us/web/api/domrect/height/index.md
+++ b/files/en-us/web/api/domrect/height/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMRect.height
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`height`** property of the **`DOMRect`** interface represents the height of the `DOMRect`.
+The **`height`** property of the {{domxref("DOMRect")}} interface represents the height of the rectangle. The value can be negative.
 
 ## Value
 

--- a/files/en-us/web/api/domrect/height/index.md
+++ b/files/en-us/web/api/domrect/height/index.md
@@ -1,0 +1,27 @@
+---
+title: "DOMRect: height property"
+short-title: height
+slug: Web/API/DOMRect/height
+page-type: web-api-instance-property
+browser-compat: api.DOMRect.height
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`height`** property of the **`DOMRect`** interface represents the height of the `DOMRect`.
+
+## Value
+
+A double.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMRectReadOnly")}}

--- a/files/en-us/web/api/domrect/index.md
+++ b/files/en-us/web/api/domrect/index.md
@@ -24,13 +24,13 @@ It inherits from its parent, {{domxref("DOMRectReadOnly")}}.
 
 _`DOMRect` inherits properties from its parent, {{domxref("DOMRectReadOnly")}}. The difference is that they are not read-only anymore._
 
-- {{domxref("DOMRectReadOnly.x")}}
+- {{domxref("DOMRect.x")}}
   - : The x coordinate of the `DOMRect`'s origin (typically the top-left corner of the rectangle).
-- {{domxref("DOMRectReadOnly.y")}}
+- {{domxref("DOMRect.y")}}
   - : The y coordinate of the `DOMRect`'s origin (typically the top-left corner of the rectangle).
-- {{domxref("DOMRectReadOnly.width")}}
+- {{domxref("DOMRect.width")}}
   - : The width of the `DOMRect`.
-- {{domxref("DOMRectReadOnly.height")}}
+- {{domxref("DOMRect.height")}}
   - : The height of the `DOMRect`.
 - {{domxref("DOMRectReadOnly.top")}}
   - : Returns the top coordinate value of the `DOMRect` (has the same value as `y`, or `y + height` if `height` is negative).

--- a/files/en-us/web/api/domrect/width/index.md
+++ b/files/en-us/web/api/domrect/width/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMRect.width
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`width`** property of the **`DOMRect`** interface represents the width of the `DOMRect`.
+The **`width`** property of the {{domxref("DOMRect")}} interface represents the width of the rectangle. The value can be negative.
 
 ## Value
 

--- a/files/en-us/web/api/domrect/width/index.md
+++ b/files/en-us/web/api/domrect/width/index.md
@@ -1,0 +1,27 @@
+---
+title: "DOMRect: width property"
+short-title: width
+slug: Web/API/DOMRect/width
+page-type: web-api-instance-property
+browser-compat: api.DOMRect.width
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`width`** property of the **`DOMRect`** interface represents the width of the `DOMRect`.
+
+## Value
+
+A double.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMRectReadOnly")}}

--- a/files/en-us/web/api/domrect/x/index.md
+++ b/files/en-us/web/api/domrect/x/index.md
@@ -1,0 +1,27 @@
+---
+title: "DOMRect: x property"
+short-title: x
+slug: Web/API/DOMRect/x
+page-type: web-api-instance-property
+browser-compat: api.DOMRect.x
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`x`** property of the **`DOMRect`** interface represents the x coordinate of the `DOMRect`'s origin.
+
+## Value
+
+A double.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMRectReadOnly")}}

--- a/files/en-us/web/api/domrect/x/index.md
+++ b/files/en-us/web/api/domrect/x/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMRect.x
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`x`** property of the {{domxref("DOMRect")}} interface represents the x-coordinate of the rectangle, which is the horizontal distance between the viewport’s left edge and the rectangle’s origin.
+The **`x`** property of the {{domxref("DOMRect")}} interface represents the x-coordinate of the rectangle, which is the horizontal distance between the viewport's left edge and the rectangle's origin.
 
 When the rectangle's width is non-negative, the rectangle’s horizontal origin is the viewport's left edge. If the width is negative, the rectangle's horizontal origin is the viewport's right edge.
 

--- a/files/en-us/web/api/domrect/x/index.md
+++ b/files/en-us/web/api/domrect/x/index.md
@@ -10,7 +10,7 @@ browser-compat: api.DOMRect.x
 
 The **`x`** property of the {{domxref("DOMRect")}} interface represents the x-coordinate of the rectangle, which is the horizontal distance between the viewport's left edge and the rectangle's origin.
 
-When the rectangle's width is non-negative, the rectangle’s horizontal origin is the viewport's left edge. If the width is negative, the rectangle's horizontal origin is the viewport's right edge.
+When the rectangle's width is non-negative, the rectangle's horizontal origin is the viewport's left edge. If the width is negative, the rectangle's horizontal origin is the viewport's right edge.
 
 ## Value
 

--- a/files/en-us/web/api/domrect/x/index.md
+++ b/files/en-us/web/api/domrect/x/index.md
@@ -8,7 +8,9 @@ browser-compat: api.DOMRect.x
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`x`** property of the **`DOMRect`** interface represents the x coordinate of the `DOMRect`'s origin.
+The **`x`** property of the {{domxref("DOMRect")}} interface represents the x-coordinate of the rectangle, which is the horizontal distance between the viewport’s left edge and the rectangle’s origin.
+
+When the rectangle's width is non-negative, the rectangle’s horizontal origin is the viewport's left edge. If the width is negative, the rectangle's horizontal origin is the viewport's right edge.
 
 ## Value
 

--- a/files/en-us/web/api/domrect/y/index.md
+++ b/files/en-us/web/api/domrect/y/index.md
@@ -10,7 +10,7 @@ browser-compat: api.DOMRect.y
 
 The **`y`** property of the {{domxref("DOMRect")}} interface represents the y-coordinate of the rectangle, which is the vertical distance between the viewport's top edge and the rectangle's origin.
 
-When the rectangle's height is non-negative, the rectangle’s vertical origin is the viewport's top edge. If the height has a negative height, the rectangle's vertical origin is the viewport's bottom edge.
+When the rectangle's height is non-negative, the rectangle's vertical origin is the viewport's top edge. If the height has a negative height, the rectangle's vertical origin is the viewport's bottom edge.
 
 ## Value
 

--- a/files/en-us/web/api/domrect/y/index.md
+++ b/files/en-us/web/api/domrect/y/index.md
@@ -1,0 +1,27 @@
+---
+title: "DOMRect: y property"
+short-title: "y"
+slug: Web/API/DOMRect/y
+page-type: web-api-instance-property
+browser-compat: api.DOMRect.y
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`y`** property of the **`DOMRect`** interface represents the y coordinate of the `DOMRect`'s origin.
+
+## Value
+
+A double.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMRectReadOnly")}}

--- a/files/en-us/web/api/domrect/y/index.md
+++ b/files/en-us/web/api/domrect/y/index.md
@@ -8,7 +8,9 @@ browser-compat: api.DOMRect.y
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`y`** property of the **`DOMRect`** interface represents the y coordinate of the `DOMRect`'s origin.
+The **`y`** property of the {{domxref("DOMRect")}} interface represents the y-coordinate of the rectangle, which is the vertical distance between the viewport’s top edge and the rectangle’s origin.
+
+When the rectangle's height is non-negative, the rectangle’s vertical origin is the viewport's top edge. If the height has a negative height, the rectangle's vertical origin is the viewport's bottom edge.
 
 ## Value
 

--- a/files/en-us/web/api/domrect/y/index.md
+++ b/files/en-us/web/api/domrect/y/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMRect.y
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`y`** property of the {{domxref("DOMRect")}} interface represents the y-coordinate of the rectangle, which is the vertical distance between the viewport’s top edge and the rectangle’s origin.
+The **`y`** property of the {{domxref("DOMRect")}} interface represents the y-coordinate of the rectangle, which is the vertical distance between the viewport's top edge and the rectangle's origin.
 
 When the rectangle's height is non-negative, the rectangle’s vertical origin is the viewport's top edge. If the height has a negative height, the rectangle's vertical origin is the viewport's bottom edge.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added `DOMRect`: `x`, `y`, `height`, `width` instance properties to MDN Feature pages. This is a part of [Missing Widely Available MDN feature pages](https://github.com/openwebdocs/project/issues/214)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
My motivation is a mix of my talk with @estelle , my love for open source and desire to make the docs up to date with the forever growing HTML web apis.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://drafts.fxtf.org/geometry/#DOMRect
https://openwebdocs.github.io/web-docs-backlog/baseline/

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
