### PR TITLE
Fix live example in HTMLTextAreaElement: setRangeText

### DIFF
--- a/files/en-us/web/api/htmltextareaelement/setrangetext/index.md
+++ b/files/en-us/web/api/htmltextareaelement/setrangetext/index.md
@@ -69,7 +69,7 @@ btn.addEventListener("click", () => {
 });
 
 function changeText() {
-  const textarea = document.getElementById("text-box");
+  const textarea = document.getElementById("ta");
   textarea.focus();
   textarea.setRangeText("ALREADY", 14, 17, "select");
 }


### PR DESCRIPTION
### Description

The getElementById seems to have an outdated ID.

### Motivation

A one line fix for the live example

### Additional details

NA

### Related issues and pull requests

NA
