### PR TITLE
docs(javascript engine): add engine names explicitly

### DIFF
--- a/files/en-us/glossary/engine/javascript/index.md
+++ b/files/en-us/glossary/engine/javascript/index.md
@@ -16,7 +16,6 @@ Common JavaScript engines include:
 
 - [V8](https://v8.dev/)
 - [SpiderMonkey](https://spidermonkey.dev/)
-- [WebKit](https://webkit.org/)
 
 ## See also
 

--- a/files/en-us/glossary/engine/javascript/index.md
+++ b/files/en-us/glossary/engine/javascript/index.md
@@ -10,12 +10,13 @@ page-type: glossary-definition
 
 In a browser, the JavaScript engine operates together with the rendering engine via the {{glossary("DOM", "Document Object Model")}} and {{glossary("WebIDL", "Web IDL")}} bindings. Some JavaScript engines also execute {{glossary("WebAssembly")}} code in the same sandbox as regular JavaScript code.
 
+Do not confuse JavaScript engines with {{glossary("engine/rendering", "rendering engines")}}, which are also crucial parts of browsers.
+
 Common JavaScript engines include:
 
 - [V8](https://v8.dev/)
 - [SpiderMonkey](https://spidermonkey.dev/)
 - [WebKit](https://webkit.org/)
-Do not confuse JavaScript engines with {{glossary("engine/rendering", "rendering engines")}}, which are also crucial parts of browsers.
 
 ## See also
 

--- a/files/en-us/glossary/engine/javascript/index.md
+++ b/files/en-us/glossary/engine/javascript/index.md
@@ -15,7 +15,6 @@ Common JavaScript engines include:
 - [V8](https://v8.dev/)
 - [SpiderMonkey](https://spidermonkey.dev/)
 - [WebKit](https://webkit.org/)
-  
 Do not confuse JavaScript engines with {{glossary("engine/rendering", "rendering engines")}}, which are also crucial parts of browsers.
 
 ## See also

--- a/files/en-us/glossary/engine/javascript/index.md
+++ b/files/en-us/glossary/engine/javascript/index.md
@@ -21,7 +21,7 @@ Common JavaScript engines include:
 ## See also
 
 - [JavaScript engine](https://en.wikipedia.org/wiki/JavaScript_engine) on Wikipedia
-- [Browser-Based vs. Non-Browser Engines](/en-US/docs/Web/JavaScript/JavaScript_technologies_overview#javascript_implementations)
+- [JavaScript implementations](/en-US/docs/Web/JavaScript/JavaScript_technologies_overview#javascript_implementations)
 - Related glossary terms:
   - {{glossary("Engine")}}
   - {{glossary("JavaScript")}}

--- a/files/en-us/glossary/engine/javascript/index.md
+++ b/files/en-us/glossary/engine/javascript/index.md
@@ -16,10 +16,12 @@ Common JavaScript engines include:
 
 - [V8](https://v8.dev/)
 - [SpiderMonkey](https://spidermonkey.dev/)
+- [JavaScriptCore](https://developer.apple.com/documentation/javascriptcore)
 
 ## See also
 
 - [JavaScript engine](https://en.wikipedia.org/wiki/JavaScript_engine) on Wikipedia
+- [Browser-Based vs. Non-Browser Engines](/en-US/docs/Web/JavaScript/JavaScript_technologies_overview#javascript_implementations)
 - Related glossary terms:
   - {{glossary("Engine")}}
   - {{glossary("JavaScript")}}

--- a/files/en-us/glossary/engine/javascript/index.md
+++ b/files/en-us/glossary/engine/javascript/index.md
@@ -10,6 +10,12 @@ page-type: glossary-definition
 
 In a browser, the JavaScript engine operates together with the rendering engine via the {{glossary("DOM", "Document Object Model")}} and {{glossary("WebIDL", "Web IDL")}} bindings. Some JavaScript engines also execute {{glossary("WebAssembly")}} code in the same sandbox as regular JavaScript code.
 
+Common JavaScript engines include:
+
+- [V8](https://v8.dev/)
+- [SpiderMonkey](https://spidermonkey.dev/)
+- [WebKit](https://webkit.org/)
+  
 Do not confuse JavaScript engines with {{glossary("engine/rendering", "rendering engines")}}, which are also crucial parts of browsers.
 
 ## See also


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
In the PR, the engine names (with links) were explicitly added to the main document.

### Motivation

It was done to provide a solid starting point for engine studies and offer a quick overview for users interested in high-level information. 