### PR TITLE
Fix incorrect mime type in the <object> example

### DIFF
--- a/files/en-us/web/html/element/object/index.md
+++ b/files/en-us/web/html/element/object/index.md
@@ -52,7 +52,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ```html
 <object
-  type="video/mp4"
+  type="video/webm"
   data="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
   width="600"
   height="140">


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixing the the incorrect MIME type in the video example of [object](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object)

### Motivation

To avoid the confusion and tell the browser the correct file type

### Related issues and pull requests

Fixes #36710

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
