### PR TITLE
addEventListener: change "non-capturing" to current and bubbling

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -95,7 +95,7 @@ addEventListener(type, listener, useCapture)
 
     > [!NOTE]
     > For event listeners attached to the event target, the event is in the target phase, rather than the capturing and bubbling phases.
-    > Event listeners in the _capturing_ phase are called before event listeners in any non-capturing phases.
+    > Event listeners in the _capturing_ phase are called before event listeners in the target and bubbling phases.
 
 - `wantsUntrusted` {{optional_inline}} {{non-standard_inline}}
   - : A Firefox (Gecko)-specific parameter. If `true`, the listener receives


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Spell out what actually happens. This seems to be the primary point on the page where order is explained, and it doesn't actually say what happens before what.

### Motivation

Avoid needlessly indirect and complex phrasing.

### Additional details

This page could do with an explicit ordering:
* capturing phase (from document down to target).
* target phase.
* bubbling phase (from target up to document).

Perhaps that can be a future revision.
