### PR TITLE
docs: update scrollIntoView() block parameter description in API documentation

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -50,7 +50,7 @@ scrollIntoView(scrollIntoViewOptions)
         - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
         - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
         - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
-        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom 
+        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom
           edge, it will align to the bottom. This minimizes the scrolling distance.
         - Defaults to `start`.
     - `inline` {{optional_inline}}

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -58,8 +58,7 @@ scrollIntoView(scrollIntoViewOptions)
         - `start`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
         - `center`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
         - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
-        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the 
-          right edge, it will align to the right. This minimizes the scrolling distance.
+        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
         - Defaults to `nearest`.
 
 ### Return value

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -54,9 +54,13 @@ scrollIntoView(scrollIntoViewOptions)
           edge, it will align to the bottom. This minimizes the scrolling distance.
         - Defaults to `start`.
     - `inline` {{optional_inline}}
-      - : Defines horizontal alignment.
-        One of `start`, `center`, `end`, or
-        `nearest`. Defaults to `nearest`.
+      - : Defines the horizontal alignment of the element within the scrollable ancestor container. This option is a string and accepts one of the following values:
+        - `start`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
+        - `center`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
+        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the 
+          right edge, it will align to the right. This minimizes the scrolling distance.
+        - Defaults to `nearest`.
 
 ### Return value
 

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -46,9 +46,13 @@ scrollIntoView(scrollIntoViewOptions)
         - `instant`: scrolling should happen instantly in a single jump
         - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
     - `block` {{optional_inline}}
-      - : Defines vertical alignment.
-        One of `start`, `center`, `end`, or
-        `nearest`. Defaults to `start`.
+      - : Defines the vertical alignment of the element within the scrollable ancestor container. This option is a string and accepts one of the following values:
+        - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
+        - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
+        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom 
+          edge, it will align to the bottom. This minimizes the scrolling distance.
+        - Defaults to `start`.
     - `inline` {{optional_inline}}
       - : Defines horizontal alignment.
         One of `start`, `center`, `end`, or


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Updated the documentation for the `block` parameter in `scrollIntoView()` to clarify its possible values (`start`, `center`, `end`, `nearest`) and their effects on vertical alignment. This change improves understanding of the parameter by providing a detailed explanation similar to the existing `behavior` parameter description.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The original documentation lacked specific details on how the `block` parameter values affect element alignment within the scrollable ancestor. By expanding this section, we help developers better understand the use of `block`, especially in cases where precise element positioning is needed.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
For reference, see [MDN scrollIntoView page](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #36679
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
