### PR TITLE
remove superflous and wrong selectors

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
@@ -125,10 +125,6 @@ form {
   border-radius: 1em;
 }
 
-p + p {
-  margin-top: 1em;
-}
-
 label span {
   display: inline-block;
   text-align: right;
@@ -148,9 +144,8 @@ input[type="radio"] {
   border: none;
 }
 
-input:focus,
-textarea:focus {
-  border-color: #000;
+input:focus {
+  background-color: yellow;
 }
 
 button {

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
@@ -125,7 +125,7 @@ form {
   border-radius: 1em;
 }
 
-div + div {
+p + p {
   margin-top: 1em;
 }
 
@@ -135,7 +135,7 @@ label span {
 }
 
 input,
-textarea {
+fieldset {
   font: 1em sans-serif;
   width: 250px;
   box-sizing: border-box;
@@ -151,18 +151,6 @@ input[type="radio"] {
 input:focus,
 textarea:focus {
   border-color: #000;
-}
-
-textarea {
-  vertical-align: top;
-  height: 5em;
-  resize: vertical;
-}
-
-fieldset {
-  width: 250px;
-  box-sizing: border-box;
-  border: 1px solid #999;
 }
 
 button {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

* textarea selector was used multiple times, even though there is no <textarea> in the HTML.

div + div selector was changed to p + p, as all input and label elements are nested inside p elements, and not divs in the example.

### Motivation

The extra selectors confused me as I was trying to copy the styling, and I thought there was something I had missed.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
