### PR TITLE
Add `<string>` to list of allowable @property syntax types.

### DIFF
--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -25,7 +25,7 @@ The `@property` rule represents a custom property registration directly in a sty
 
 - {{cssxref("@property/syntax","syntax")}}
 
-  - : Describes the allowable syntax for the property. May be a `<length>`, `<number>`, `<percentage>`, `<length-percentage>`, `<color>`, `<image>`, `<url>`, `<integer>`, `<angle>`, `<time>`, `<resolution>`, `<transform-function>`, or `<custom-ident>`, or a list of data type and keyword values.
+  - : Describes the allowable syntax for the property. May be a `<length>`, `<number>`, `<percentage>`, `<length-percentage>`, `<string>`, `<color>`, `<image>`, `<url>`, `<integer>`, `<angle>`, `<time>`, `<resolution>`, `<transform-function>`, or `<custom-ident>`, or a list of data type and keyword values.
 
     The `+` (space-separated) and `#` (comma-separated) multipliers indicate that a list of values is expected, for example `<color>#` means a comma-separated list of `<color>` values is the expected syntax.
 


### PR DESCRIPTION
### Description

`<string>` was missing somehow. Now the list is same as in the spec.

### Additional details

https://drafts.css-houdini.org/css-properties-values-api/#supported-names