### PR TITLE
fix(css): fix macros

### DIFF
--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -318,7 +318,7 @@ The following functions are used as a value in transition and animation properti
 
 - {{cssxref("easing-function#linear_easing_function", "linear()")}}
   - : Easing function that interpolates linearly between its points.
-- {{cssxref("easing-function#cubic_b%C3%A9zier_easing_function", "cubic-bezier()")}}
+- {{cssxref("easing-function#cubic_bezier_easing_function", "cubic-bezier()")}}
   - : Easing function that defines a cubic Bézier curve.
 - {{cssxref("easing-function#steps_easing_function", "steps()")}}
   - : Iteration along a specified number of stops along the transition, displaying each stop for equal lengths of time.

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -64,7 +64,7 @@ Because `<gradient>`s belong to the `<image>` data type, they can only be used w
 
 ### Composition of a radial gradient
 
-![Graph explaining radial gradients: the virtual radiant ray is horizontal starting from the midpoint. The elliptical gradient, and therefore the ending shape, has the same {{glossary("aspect ratio")}} as the box upon which it is declared.](radial_gradient.png)
+![Graph explaining radial gradients: the virtual radiant ray is horizontal starting from the midpoint. The elliptical gradient, and therefore the ending shape, has the same aspect ratio as the box upon which it is declared.](radial_gradient.png)
 
 A radial gradient is defined by a _center point_, an _ending shape_, and two or more _color-stop points_.
 


### PR DESCRIPTION
### Description

- fix a anchor for `#cubic_bezier_easing_function`
- don't have macros in alt text

### Motivation

Preparing for rari.