### PR TITLE
Revert "corrected builtin function use"

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -235,10 +235,9 @@ const fsSource = `
     varying highp vec2 vTextureCoord;
 
     uniform sampler2D uSampler;
-    out vec4 fragColor;
 
     void main(void) {
-      fragColor = texture(uSampler, vTextureCoord);
+      gl_FragColor = texture2D(uSampler, vTextureCoord);
     }
   `;
 ```


### PR DESCRIPTION
Reverts mdn/content#30461

Hi. The changes made in the pr are incorrect. The current code does not work; the previous code does work as noted in #32537 

Unless I'm mistaken, shaders use GLSL ES 1.0 by default. You have to specify that your shader uses the 3.0 spec

```glsl
#version 300 es
```

By adding the above line at the top of the shader. See https://webgl2fundamentals.org/webgl/lessons/webgl1-to-webgl2.html

The tutorial is written with webgl 1 and the 1.0 spec and was correct before. The previous code using `texture2d` is fine. The fact that `texture2D` is deprecated in favor of `texture` in the 3.0 spec isn't relevant to the tutorial.

Fixes https://github.com/mdn/content/issues/32537