### PR TITLE
docs(manifest): Update `start_url` and `scope` pages based on document URL clarifications

### DIFF
--- a/files/en-us/web/manifest/scope/index.md
+++ b/files/en-us/web/manifest/scope/index.md
@@ -31,9 +31,8 @@ When users navigate to pages outside the app's scope, they still experience the 
   - : A string that represents a URL.
     The URL can be absolute or relative.
     If the value is relative, it is resolved against the manifest file's URL.
-    The [`start_url`](/en-US/docs/Web/Manifest/start_url) must be within the defined scope.
 
-    If `scope` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or `start_url` is not within scope), the `start_url` value is used as a fallback, with the filename, query, and fragment removed.
+    If `scope` is not specified in the manifest or the value is invalid (i.e., not a string, not a valid URL, or `start_url` is not within the specified `scope`), the effective scope will be set to the `start_url` value after removing its filename, query, and fragment.
 
 ## Description
 
@@ -94,10 +93,10 @@ This behavior helps users understand whether they're viewing pages within or out
 
 The `scope` is invalid if `start_url` is not a subset of the `scope` URL. For example:
 
-- Valid: `scope` is `/app/` and `start_url` is `/app/home.html`.
-- Invalid: `scope` is `/app/` and `start_url` is `/index.html`.
+- **Valid**: `scope` is `/app/`, and `start_url` is `/app/home.html`.
+- **Invalid**: `scope` is `/app/`, and `start_url` is `/index.html`.
 
-If `scope` is missing or invalid, it defaults to `start_url`, with the filename, query, and fragment removed. For example:
+If `scope` is missing or invalid, it defaults to the `start_url` value after removing its filename, query, and fragment. For example:
 
 - If `start_url` is `https://example.com/app/index.html?user=123#home`, the scope will be `https://example.com/app/`.
 - If `start_url` is `/pages/welcome.html`, the scope will be `/pages/` on the same origin.

--- a/files/en-us/web/manifest/scope/index.md
+++ b/files/en-us/web/manifest/scope/index.md
@@ -96,7 +96,11 @@ The `scope` is invalid if `start_url` is not a subset of the `scope` URL. For ex
 - **Valid**: `scope` is `/app/`, and `start_url` is `/app/home.html`.
 - **Invalid**: `scope` is `/app/`, and `start_url` is `/index.html`.
 
-If `scope` is missing or invalid, it defaults to the `start_url` value after removing its filename, query, and fragment. For example:
+If `scope` is missing or invalid, it defaults to the `start_url` value after removing its filename, query, and fragment.
+Note that if the `start_url` is also undefined (or invalid) it defaults to the page that links to the manifest.
+This ensures that by default the scope will start from the page that triggered installation.
+
+For example:
 
 - If `start_url` is `https://example.com/app/index.html?user=123#home`, the scope will be `https://example.com/app/`.
 - If `start_url` is `/pages/welcome.html`, the scope will be `/pages/` on the same origin.

--- a/files/en-us/web/manifest/scope/index.md
+++ b/files/en-us/web/manifest/scope/index.md
@@ -98,7 +98,7 @@ The `scope` is invalid if `start_url` is not a subset of the `scope` URL. For ex
 
 If `scope` is missing or invalid, it defaults to the `start_url` value after removing its filename, query, and fragment.
 Note that if the `start_url` is also undefined (or invalid) it defaults to the page that links to the manifest.
-This ensures that by default the scope will start from the page that triggered installation.
+This ensures that by default the scope will start from the page that triggered the installation.
 
 For example:
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -30,15 +30,28 @@ The `start_url` manifest member is used to specify the URL that should be opened
 
   - : A string that represents the starting URL of a web app.
     The URL can be absolute or relative.
-    If the value is relative, it is resolved against the manifest URL.
+    If the value is relative, it is resolved against the manifest file's URL.
 
-    The `start_url` must be within the [scope](/en-US/docs/Web/Manifest/scope) of the web app and must be same-origin with the manifest URL.
+    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the page that links to the manifest), the URL of the page that links to the manifest is used.
 
-    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the manifest URL), the URL of the page that links to the manifest is used.
+    If [`scope`](/en-US/docs/Web/Manifest/scope) is not specified in the manifest or `start_url` is not within the specified `scope`, the effective scope will be set to the `start_url` value after removing its filename, query, and fragment.
 
 ## Description
 
 The `start_url` allows you to recommend an appropriate common entry point for all users.
+
+When a user installs a web app, the installation happens from the page they're currently viewing.
+During installation, the browser fetches the manifest file linked from this page.
+While the manifest file can be served from any origin, the installation process is tied to the page where it begins.
+Consider a scenario where:
+
+- The installation page is `https://myapp.example.com/index.html`.
+- The manifest file is hosted at `https://assets.cdn.com/manifest.json`.
+- The `start_url` is `https://myapp.example.com/home`.
+
+The specified `start_url` in this example will be used because it is same-origin with the page from which the app is being installed.
+If the specified `start_url` were on a different origin (for example, `https://differentapp.example.com/home`), browsers would fall back to using the installation page URL as the starting point.
+This ensures that web apps start only on pages within their own origin.
 
 Note, however, that browsers are not required to use the specified URL.
 They may ignore the specified value or provide users with a choice not to use it.

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -34,7 +34,8 @@ The `start_url` manifest member is used to specify the URL that should be opened
 
     If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the page that links to the manifest), the URL of the page that links to the manifest is used.
 
-    If [`scope`](/en-US/docs/Web/Manifest/scope) is not specified in the manifest or `start_url` is not within the specified `scope`, the effective scope will be set to the `start_url` value after removing its filename, query, and fragment.
+    > [!NOTE]
+    > If [`scope`](/en-US/docs/Web/Manifest/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).
 
 ## Description
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -32,7 +32,7 @@ The `start_url` manifest member is used to specify the URL that should be opened
     The URL can be absolute or relative.
     If the value is relative, it is resolved against the manifest file's URL.
 
-    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the page that links to the manifest), the URL of the page that links to the manifest is used.
+    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not {{glossary("origin", "same-origin")}} as the page that links to the manifest), the URL of the page that links to the manifest is used.
 
     > [!NOTE]
     > If [`scope`](/en-US/docs/Web/Manifest/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Following the discussion in https://github.com/w3c/manifest/issues/1147 and confirmation from spec editors, this PR updates:

- `scope` page:
  - Improves the description of `scope` fallback behavior.
  - Removes the statement about the requirement of `start_url` to be within `scope`.

- `start_url` page:
  - Reorders sentences in the "Values" section for better flow.
  - Moves the same-origin information from "Values" to "Description" - it is not a requirement to be met, rather how `start_url` is processed in relation to the installation page. This has been explained in the "Description" section along with an example.

