### PR TITLE
Fix grammar mistake

### DIFF
--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -31,7 +31,7 @@ new URL(url, base)
     If not specified, it defaults to `undefined`.
 
     When a `base` is specified, the resolved URL is not simply a concatenation of `url` and `base`.
-    Relative references to the parent and current directory are resolved are relative to the current directory of the `base` URL, which includes path segments up until the last forward-slash, but not any after.
+    Relative references to the parent and current directory are resolved relative to the current directory of the `base` URL, which includes path segments up until the last forward-slash, but not any after.
     Relative references to the root are resolved relative to the base origin.
     For more information see [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix grammar mistake in the [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#base) doc.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I feel like there's an unnecessary `are` in the phrase `"are resolved are relative to..."`. I'd appreciate if someone knows English better than I could help check this.

The paragraph is:

> ...Relative references to the parent and current directory are resolved **are**(here!) relative to the current directory of the base URL, which includes path segments up until the last forward-slash, but not any after.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
