### PR TITLE
docs: add a whitespace for consistent ternary formatting

### DIFF
--- a/files/en-us/web/api/performance_api/long_animation_frame_timing/index.md
+++ b/files/en-us/web/api/performance_api/long_animation_frame_timing/index.md
@@ -116,7 +116,7 @@ The timestamps provided in the {{domxref("PerformanceLongAnimationFrameTiming")}
 | Start time                        | `startTime`                                                              |
 | End time                          | `startTime + duration`                                                   |
 | Work duration                     | `renderStart ? renderStart - startTime : duration`                       |
-| Render duration                   | `renderStart ? (startTime + duration) - renderStart: 0`                  |
+| Render duration                   | `renderStart ? (startTime + duration) - renderStart : 0`                 |
 | Render: Pre-layout duration       | `styleAndLayoutStart ? styleAndLayoutStart - renderStart : 0`            |
 | Render: Style and Layout duration | `styleAndLayoutStart ? (startTime + duration) - styleAndLayoutStart : 0` |
 


### PR DESCRIPTION
### Description

Thanks a lot for the docs! Added a whitespace to ensure consistent "format" of the ternary operator.

### Motivation

When I was reading this doc, my eye staggered a bit when I encountered the colon here, as I did not immediately parse it as ternary operator (like the other examples in the doc).