### PR TITLE
CSS module: create links for future pages (Safari 18.2)

### DIFF
--- a/files/en-us/web/css/css_inline_layout/index.md
+++ b/files/en-us/web/css/css_inline_layout/index.md
@@ -16,9 +16,12 @@ The **CSS inline layout** module defines the block-axis alignment and sizing of 
 - {{cssxref("dominant-baseline")}}
 - {{cssxref("initial-letter")}}
 - {{cssxref("line-height")}}
+- {{cssxref("text-box-edge")}}
+- {{cssxref("text-box-trim")}}
+- {{cssxref("text-box")}} shorthand
 - {{cssxref("vertical-align")}}
 
-The specification also defines the `alignment-baseline`, `baseline-shift`, `baseline-source`, `initial-letter-align`, `initial-letter-wrap`, `inline-sizing`, `line-fit-edge`, `text-box`, `text-box-edge`, and `text-box-trim` properties, which are not yet supported by any browser.
+The specification also defines the `alignment-baseline`, `baseline-shift`, `baseline-source`, `initial-letter-align`, `initial-letter-wrap`, `inline-sizing`, and `line-fit-edge` properties, which are not yet supported by any browser.
 
 ### Glossary terms
 


### PR DESCRIPTION
Safari 18.2 supports the newly defined CSS inline layout properties. Updating the module landing page to remove "not supported in any browser" as that will no longer be true.

do not merge until 18.2 is released.