### PR TITLE
Remove link to dead site

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/index.md
@@ -34,7 +34,6 @@ Using the `<canvas>` element is not very difficult, but you do need a basic unde
 ## See also
 
 - [Canvas topic page](/en-US/docs/Web/API/Canvas_API)
-- [HTML5CanvasTutorials](https://www.html5canvastutorials.com/)
 
 ## A note to contributors
 


### PR DESCRIPTION
This site turned into link spam around 2021

https://web.archive.org/web/20200308012418/https://www.html5canvastutorials.com/

https://web.archive.org/web/20210301214618/http://www.html5canvastutorials.com/