### PR TITLE
Fix: modifying the name of a named function expression results in TypeError only in strict mode

### DIFF
--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -91,6 +91,8 @@ If a function expression is named, the [`name`](/en-US/docs/Web/JavaScript/Refer
 Unlike declarations, the name of the function expressions is read-only.
 
 ```js
+"use strict";
+
 function foo() {
   foo = 1;
 }


### PR DESCRIPTION
… strict mode

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the "Named function expression", the name of the function expression is read-only. However, the name of the function is modified inside the function body and does not cause an error in non-strict mode. However, it only causes TypeError in strict mode.

Therefore, the corrective this code needs to put a `"use strict";` statement before any other statements to be correct, as demonstrated here:

```js
"use strict";

function foo() {
  foo = 1;
}
foo();
console.log(foo); // 1
(function foo() {
  foo = 1; // TypeError: Assignment to constant variable.
})();
```

In Google Chrome, the result is as follows: (other browsers are similar)

<img width="1341" alt="image" src="https://github.com/user-attachments/assets/0035ac94-9810-4469-8acc-f426b6f1d211">


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
