### PR TITLE
updateText: Remove false information

### DIFF
--- a/files/en-us/web/api/editcontext/updatetext/index.md
+++ b/files/en-us/web/api/editcontext/updatetext/index.md
@@ -34,7 +34,6 @@ updateText(rangeStart, rangeEnd, text)
 ### Exceptions
 
 - If less than three arguments are provided, a `TypeError` {{domxref("DOMException")}} is thrown.
-- if `rangeStart` is greater than `rangeEnd`, a {{domxref("DOMException")}} is thrown.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Remove false information about when to throw exceptions.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Passing `rangeStart` that is greater than `rangeEnd` is explicitly allowed.

[EditContext API](https://w3c.github.io/edit-context/#editcontext-interface)

> Note
> It's permissible that rangeStart &gt; rangeEnd. The substring between the indices should be replaced in the same way as when rangeStart &lt;= rangeEnd.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
