### PR TITLE
HTMLMediaElement waitingforkey event docs

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/encrypted_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/encrypted_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLMediaElement.encrypted_event
 
 {{APIRef("Encrypted Media Extensions")}}
 
-The `encrypted` event is fired when initialization data is found in the media, indicating that it is encrypted.
+The `encrypted` event is fired when initialization data is found in the media that indicates it is encrypted.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -155,7 +155,7 @@ Listen to these events using {{domxref("EventTarget.addEventListener", "addEvent
 - {{domxref("HTMLMediaElement.emptied_event", 'emptied')}}
   - : Fired when the media has become empty; for example, when the media has already been loaded (or partially loaded), and the {{domxref("HTMLMediaElement.load()")}} method is called to reload it.
 - {{domxref("HTMLMediaElement.encrypted_event", 'encrypted')}}
-  - : Fired when initialization data is found in the media, indicating that it is encrypted.
+  - : Fired when initialization data is found in the media that indicates the media is encrypted.
 - {{domxref("HTMLMediaElement.ended_event", 'ended')}}
   - : Fired when playback stops when end of the media (\<audio> or \<video>) is reached or because no further data is available.
 - {{domxref("HTMLMediaElement.error_event", 'error')}}
@@ -190,6 +190,8 @@ Listen to these events using {{domxref("EventTarget.addEventListener", "addEvent
   - : Fired when the volume has changed.
 - {{domxref("HTMLMediaElement.waiting_event", 'waiting')}}
   - : Fired when playback has stopped because of a temporary lack of data.
+- {{domxref("HTMLMediaElement.waitingforkey_event", 'waitingforkey')}}
+  - : Fired when playback is first blocked while waiting for a key.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlmediaelement/waitingforkey_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/waitingforkey_event/index.md
@@ -1,0 +1,43 @@
+---
+title: "HTMLMediaElement: waitingforkey event"
+short-title: waitingforkey
+slug: Web/API/HTMLMediaElement/waitingforkey_event
+page-type: web-api-event
+browser-compat: api.HTMLMediaElement.waitingforkey_event
+---
+
+{{APIRef("Encrypted Media Extensions")}}
+
+The `waitingforkey` event is fired at a media element when it is first unable to play because it needs a key to decode the following data, and playback is stopped.
+
+If the video frame and/or audio data for the current playback position have been decoded, {{domxref("HTMLMediaElement.readyState", "readyState")}} is set to [`HAVE_CURRENT_DATA`](/en-US/docs/Web/API/HTMLMediaElement/readyState#htmlmediaelement.have_current_data).
+Otherwise, including if the data was previously available but isn't anymore, the `readyState` is set to [`HAVE_METADATA`](/en-US/docs/Web/API/HTMLMediaElement/readyState#htmlmediaelement.have_metadata).
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("waitingforkey", (event) => {});
+
+onwaitingforkey = (event) => {};
+```
+
+## Event type
+
+An {{domxref("Event")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLAudioElement")}}
+- {{domxref("HTMLVideoElement")}}
+- {{HTMLElement("audio")}}
+- {{HTMLElement("video")}}


### PR DESCRIPTION
This adds docs for the [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) event `waitingforkey`, and tidied some grammar for the `encrypted` event.


Related to docs work for FF133 in #36558