### PR TITLE
fix(css): remove the unimplemented src()

### DIFF
--- a/files/en-us/web/css/at-rule-functions/index.md
+++ b/files/en-us/web/css/at-rule-functions/index.md
@@ -25,8 +25,6 @@ The {{CSSxRef("@import")}} at-rule is used to import styles from other styleshee
 
 - {{CSSxRef("@import", "@import url()")}}
   - : Imports a stylesheet file from the specified URL.
-- {{CSSxRef("@import", "@import src()")}}
-  - : Imports a stylesheet file from the specified source.
 - {{CSSxRef("@import", "@import supports()")}}
   - : Imports a stylesheet file based on browser support.
 - {{CSSxRef("@import", "@import layer()")}}
@@ -49,8 +47,6 @@ The {{CSSxRef("@namespace")}} at-rule is used to specify XML namespaces to be us
 
 - {{CSSxRef("@namespace", "@namespace url()")}}
   - : Defines XML namespace from the specified URL.
-- {{CSSxRef("@namespace", "@namespace src()")}}
-  - : Defines XML namespace from the specified source.
 
 ## @container functions
 

--- a/files/en-us/web/css/url_value/index.md
+++ b/files/en-us/web/css/url_value/index.md
@@ -12,7 +12,7 @@ The **`<url>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_T
 ## Syntax
 
 ```plain
-<url> = <url()> | <src()>
+<url> = <url()>
 ```
 
 ### Values
@@ -21,8 +21,9 @@ The value is either of the following:
 
 - [`<url()>`](/en-US/docs/Web/CSS/url_function)
   - : The `url()` function accepts only a URL literal string (with or without quotes).
-- `<src()>`
-  - : This function can accept a URL string or a [CSS variable](/en-US/docs/Web/CSS/var).
+
+> [!NOTE]
+> The specification defines an alternative function called `src()` that accepts a URL string or a [CSS variable](/en-US/docs/Web/CSS/var). But no web browser has implemented the function yet.
 
 ## Specifications
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/36831
- related to https://github.com/mdn/browser-compat-data/pull/25081#pullrequestreview-2439709005

Per our policy, we don't document stuff that is not implemented in browsers.