### PR TITLE
fix : wrong method name

### DIFF
--- a/files/en-us/web/api/medialist/deletemedium/index.md
+++ b/files/en-us/web/api/medialist/deletemedium/index.md
@@ -37,7 +37,7 @@ The following removes the media query `print` from the
 
 ```js
 const stylesheet = document.styleSheets[0];
-stylesheet.media.removeMedium("print");
+stylesheet.media.deleteMedium("print");
 ```
 
 ## Specifications


### PR DESCRIPTION

### Description

Change removeMedium() in example to deleteMedium()

### Additional details

[deleteMedium specs](https://drafts.csswg.org/cssom/#dom-medialist-deletemedium)
### Related issues and pull requests
Fixes  #36841




