### PR TITLE
Remove long non-supported attributes of `<ms>` MathML element

### DIFF
--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -13,15 +13,6 @@ The **`<ms>`** [MathML](/en-US/docs/Web/MathML) element represents a **string** 
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-Some browsers may also support the following deprecated attributes and will render the content of the `<ms>` element surrounded by the specified opening and closing quotes:
-
-- `lquote`
-
-  - : The opening quote to enclose the content. The default value is `&quot;`.
-
-- `rquote`
-  - : The closing quote to enclose the content. The default value is `&quot;`.
-
 ## Examples
 
 ### Default rendering


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix #36291

the attributes of `<ms>` MathML element has been removed from bcd via https://github.com/mdn/browser-compat-data/pull/25108, which has been non-standard long ago

note that only firefox has implemented this and has been removed the support long ago according to the bcd

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
