### PR TITLE
Add New Guide: Compiling Haskell to WebAssembly

### DIFF
--- a/files/en-us/webassembly/haskell_to_wasm/index.md
+++ b/files/en-us/webassembly/haskell_to_wasm/index.md
@@ -6,8 +6,6 @@ page-type: guide
 
 {{WebAssemblySidebar}}
 
-# Compiling Haskell to WebAssembly: A Step-by-Step Guide
-
 ## Introduction
 
 This guide demonstrates how to compile Haskell code into [WebAssembly](/en-US/docs/WebAssembly) (Wasm). You'll learn how to convert a single Haskell source file to WebAssembly and integrate it into a web application. Additionally, we'll cover compiling a Haskell Cabal project for WebAssembly, including handling data types like strings.

--- a/files/en-us/webassembly/haskell_to_wasm/index.md
+++ b/files/en-us/webassembly/haskell_to_wasm/index.md
@@ -1,0 +1,246 @@
+---
+title: Compiling from Haskell to WebAssembly
+slug: WebAssembly/Haskell_to_Wasm
+page-type: guide
+---
+
+{{WebAssemblySidebar}}
+
+# Compiling Haskell to WebAssembly: A Step-by-Step Guide
+
+## Introduction
+
+This guide demonstrates how to compile Haskell code into [WebAssembly](/en-US/docs/WebAssembly) (Wasm). You'll learn how to convert a single Haskell source file to WebAssembly and integrate it into a web application. Additionally, we'll cover compiling a Haskell Cabal project for WebAssembly, including handling data types like strings.
+
+For detailed technical documentation, refer to the [GHC WebAssembly user guide](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/wasm.html).
+
+## Environment Setup
+
+### Installing the Custom GHC for WebAssembly
+
+To compile Haskell to WebAssembly, you need a custom GHC version that supports the `wasm32-wasi` target. Detailed installation instructions can be found in the [GHC WebAssembly meta repository](https://gitlab.haskell.org/ghc/ghc-wasm-meta). Here’s a quick setup guide:
+
+1. **(Optional): Choose a GHC flavor.**  
+   This determines the specific GHC version. For stability, we'll use GHC 9.8.3:
+   
+   ```bash
+   export FLAVOUR=9.8
+   ```
+
+2. **Run the installation script:**
+
+   ```bash
+   curl https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/raw/master/bootstrap.sh | sh
+   ```
+
+3. **Update your environment:**
+
+   ```bash
+   source /home/username/.ghc-wasm/env
+   ```
+
+4. **Verify the installation:**
+
+   ```bash
+   wasm32-wasi-ghc --version
+   wasm32-wasi-cabal --version
+   ```
+
+
+## Compiling a Simple Haskell File to WebAssembly
+
+### Writing the Haskell Code
+
+Let’s start with a simple Haskell function that takes an integer and adds 10:
+
+```haskell
+-- Test.hs
+addTen :: Int -> Int
+addTen n = n + 10
+
+main :: IO ()
+main = mempty
+```
+
+However, JavaScript and Haskell use different number types. To bridge this gap, we’ll use C FFI. Here’s the updated code:
+
+```haskell
+-- Test.hs
+foreign export ccall addTen :: Int -> IO Int
+
+addTen :: Int -> IO Int
+addTen n = return $ n + 10
+
+main :: IO ()
+main = mempty
+```
+
+### Compiling the Code
+
+Compile your Haskell file to WebAssembly:
+
+```bash
+wasm32-wasi-ghc Test.hs -optl-Wl,--export=hs_init,--export=addTen
+```
+
+- `--export=hs_init` initializes the Haskell runtime.
+- `--export=addTen` exposes the `addTen` function for external calls.
+
+If successful, this will generate a `Test.wasm` file.
+
+## Running WebAssembly in a Browser
+
+### Creating an HTML File
+
+Now that you have a WebAssembly module, let’s run it in the browser. Create an `index.html` file:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Haskell + WASM</title>
+</head>
+<body>
+    <h1>Haskell + WebAssembly</h1>
+</body>
+<script type="module">
+    import { WASI } from 'https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.3.0/+esm';
+
+    const wasi = new WASI([], [], []);
+    const wasm = await WebAssembly.compileStreaming(fetch("Test.wasm"));
+
+    const inst = await WebAssembly.instantiate(wasm, {
+        "wasi_snapshot_preview1": wasi.wasiImport,
+    });
+
+    wasi.initialize(inst);
+    inst.exports.hs_init(0, 0);
+    console.log(inst.exports.addTen(23)); // Outputs: 33
+</script>
+</html>
+```
+
+This script initializes the Haskell runtime and calls the `addTen` function.
+
+## Compiling a Cabal Project to WebAssembly
+
+Next up, we will build a Haskell cabal project and will use strings instead of integer. as it is slightly more complicated to marshall Javascript strings.
+
+### Creating a New Cabal Project
+
+Let’s extend this by creating a Cabal project that handles strings:
+
+```bash
+mkdir haskell_wasm
+cd haskell_wasm
+cabal init
+```
+Note: You need to initialize project with normal `cabal` tool that you can install from [GHCup](https://www.haskell.org/ghcup/).
+
+### Writing the Haskell Code
+
+Here’s a simple function to greet a user:
+
+```haskell
+-- app/Main.hs
+module Main where
+
+import Foreign.C.String (CString, peekCString, newCString)
+import Foreign.Marshal.Alloc (callocBytes, free)
+import Foreign.Ptr (Ptr)
+
+foreign export ccall "hs_sayHello" sayHello :: CString -> IO CString
+foreign export ccall "callocBuffer" callocBuffer :: Int -> IO (Ptr a)
+foreign export ccall "freeBuffer" freeBuffer :: Ptr a -> IO ()
+
+sayHello :: CString -> IO CString
+sayHello cstr = do
+    inputStr <- peekCString cstr
+    newCString $ "Hello, " <> inputStr
+
+callocBuffer :: Int -> IO (Ptr a)
+callocBuffer = callocBytes
+
+freeBuffer :: Ptr a -> IO ()
+freeBuffer = free
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"
+```
+
+### Updating the Cabal File
+
+Add the following `ghc-options` in your Cabal configuration to export the necessary functions:
+
+```cabal
+executable haskell-wasm
+    main-is:          Main.hs
+    build-depends:    base ^>=4.19.1.0
+    hs-source-dirs:   app
+    default-language: Haskell2010
+    ghc-options: -optl-mexec-model=reactor -optl-Wl,--export=hs_init,--export=hs_sayHello,--export=freeBuffer,--export=callocBuffer
+```
+
+### Building and Running
+
+Build the project:
+
+```bash
+wasm32-wasi-cabal build
+```
+
+Copy the generated `.wasm` file into your project directory:
+
+```bash
+$ cp dist-newstyle/build/wasm32-wasi/ghc-9.8.3.20241108/haskell-wasm-0.1.0.0/x/haskell-wasm/opt/build/haskell-wasm/haskell-wasm.wasm .
+```
+
+Update your `index.html` to use the `hs_sayHello` function:
+
+```html
+<script type="module">
+    import { WASI } from 'https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.3.0/+esm';
+
+    const wasi = new WASI([], [], []);
+    const wasm = await WebAssembly.compileStreaming(fetch("haskell-wasm.wasm"));
+
+    const inst = await WebAssembly.instantiate(wasm, {
+        "wasi_snapshot_preview1": wasi.wasiImport,
+    });
+
+    function callWithString(func, str) {
+        const encoder = new TextEncoder();
+        const decoder = new TextDecoder("utf8");
+
+        const encoded = encoder.encode(str + '\0'); // Null-terminated string
+        const ptr = inst.exports.callocBuffer(encoded.length);
+        new Uint8Array(inst.exports.memory.buffer, ptr, encoded.length).set(encoded);
+
+        const resultPtr = func(ptr);
+        const resultBytes = new Uint8Array(inst.exports.memory.buffer, resultPtr);
+        const length = resultBytes.findIndex(b => b === 0);
+        const result = decoder.decode(new Uint8Array(inst.exports.memory.buffer, resultPtr, l));
+
+        inst.exports.freeBuffer(ptr);
+        inst.exports.freeBuffer(resultPtr);
+
+        return result;
+    }
+
+    wasi.initialize(inst);
+    inst.exports.hs_init(0, 0);
+    console.log(callWithString(inst.exports.hs_sayHello, "John")); // Outputs: Hello, John
+</script>
+```
+
+## Conclusion
+
+Congratulations! You’ve successfully compiled Haskell to WebAssembly and integrated it into a web app. This guide covered the basics, but there’s much more to explore, including advanced data types and optimizations.
+
+
+## Useful Links
+
+- [GHC WebAssembly Meta Repository](https://gitlab.haskell.org/ghc/ghc-wasm-meta)
+- [Ormolu live](https://github.com/tweag/ormolu/tree/master/ormolu-live)
+- [Sql2er](https://github.com/tusharad/sql2er)

--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -42,6 +42,8 @@ And what's even better is that it is being developed as a web standard via the [
   - : A core use-case for WebAssembly is to take the existing ecosystem of C libraries and allow developers to use them on the web.
 - [Compiling from Rust to WebAssembly](/en-US/docs/WebAssembly/Rust_to_Wasm)
   - : If you've written some Rust code, you can compile it into WebAssembly! This tutorial takes you through all you need to know to compile a Rust project to Wasm and use it in an existing web app.
+- [Compiling from Haskell to WebAssembly](/en-US/docs/WebAssembly/Haskell_to_Wasm)
+  - : This guide demonstrates how to compile Haskell code into WebAssembly! You'll learn how to convert a single Haskell source file to WebAssembly and integrate it into a web application. we'll also cover compiling a Haskell Cabal project for WebAssembly.
 - [Loading and running WebAssembly code](/en-US/docs/WebAssembly/Loading_and_running)
   - : After you have a Wasm module, this article covers how to fetch, compile and instantiate it, combining the [WebAssembly JavaScript](/en-US/docs/WebAssembly/JavaScript_interface) API with the [Fetch](/en-US/docs/Web/API/Fetch_API) or [XHR](/en-US/docs/Web/API/XMLHttpRequest) APIs.
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -12,6 +12,8 @@ sidebar:
         title: Compiling_to_wasm
       - link: /WebAssembly/Rust_to_wasm
         title: Compiling_rust_to_wasm
+      - link: /WebAssembly/Haskell_to_wasm
+        title: Compiling_haskell_to_wasm
       - link: /WebAssembly/Using_the_JavaScript_API
         title: JavaScript_API
       - link: /WebAssembly/Understanding_the_text_format
@@ -56,6 +58,7 @@ l10n:
     WebAssembly_concepts: WebAssembly concepts
     Compiling_to_wasm: Compiling from C/C++ to WebAssembly
     Compiling_rust_to_wasm: Compiling from Rust to WebAssembly
+    Compiling_haskell_to_wasm: Compiling from Haskell to WebAssembly
     JavaScript_API: Using the WebAssembly JavaScript API
     Text_format: Understanding WebAssembly text format
     Text_format_to_wasm: Converting WebAssembly text format to wasm


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This PR introduces a new guide titled Compiling Haskell to WebAssembly under the WebAssembly section. The guide provides step-by-step instructions on how to set up the environment, compile Haskell code into WebAssembly, and integrate it into a web application. Additionally, it covers compiling a Haskell Cabal project for WebAssembly and handling data types such as strings.

### Motivation

This guide aims to broaden the range of languages covered in the WebAssembly section on MDN, providing valuable resources for Haskell developers interested in WebAssembly.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- [GHC WebAssembly user guide](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/wasm.html)
- [GHC WebAssembly Meta Repository](https://gitlab.haskell.org/ghc/ghc-wasm-meta)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

## Question for Reviewers:
Before proceeding further, I'd like to confirm whether new content of this nature is allowed in the MDN documentation. If there are any specific guidelines or prerequisites for contributing new topics, please let me know, and I'll adjust accordingly.

Looking forward to your feedback!