### PR TITLE
ACCEPT-ENCODING - encodings sender understands not recipient

### DIFF
--- a/files/en-us/web/http/headers/accept-encoding/index.md
+++ b/files/en-us/web/http/headers/accept-encoding/index.md
@@ -7,7 +7,7 @@ browser-compat: http.headers.Accept-Encoding
 
 {{HTTPSidebar}}
 
-The HTTP **`Accept-Encoding`** {{glossary("request header", "request")}} and {{glossary("response header")}} indicates the content encoding (usually a compression algorithm) that the recipient can understand.
+The HTTP **`Accept-Encoding`** {{glossary("request header", "request")}} and {{glossary("response header")}} indicates the content encoding (usually a compression algorithm) that the sender can understand.
 In requests, the server uses [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation) to select one of the encoding proposals from the client and informs the client of that choice with the {{HTTPHeader("Content-Encoding")}} response header.
 In responses, it provides information about which content encodings the server can understand in messages to the requested resource, so that the encoding can be used in subsequent requests to the resource. For example, this might be sent in the response to a `PUT` request to a resource that used an unsupported encoding.
 


### PR DESCRIPTION
Fixes a typo - the ACCEPT-ENCODING indicates the sender's preference for a particular type of content (recipient is ambiguous here, since the recipient is the person that has to return that content)

Comes out of comment by @bsmth here https://github.com/mdn/content/pull/36657#discussion_r1846072798