### PR TITLE
Update `browser-compat` key for svg `stop-color` attribute

### DIFF
--- a/files/en-us/web/svg/attribute/stop-color/index.md
+++ b/files/en-us/web/svg/attribute/stop-color/index.md
@@ -2,7 +2,7 @@
 title: stop-color
 slug: Web/SVG/Attribute/stop-color
 page-type: svg-attribute
-browser-compat: svg.global_attributes.stop-color
+browser-compat: svg.elements.stop.stop-color
 ---
 
 {{SVGRef}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`stop-color` is not a global attribute, it can only use on SVG `<stop>` elements

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/mdn/browser-compat-data/pull/25130
Depends on https://github.com/mdn/browser-compat-data/pull/25131 (but it's fine to merge this first)
Relates to https://github.com/mdn/data/pull/782

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
