### PR TITLE
Update Firefox 133 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -65,7 +65,6 @@ This article provides information about the changes in Firefox 133 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-
 #### WebDriver BiDi
 
 - Added support for the `url` argument for the `network.continueRequest` command, allowing requests to be transparently redirected to another URL ([Firefox bug 1898158](https://bugzil.la/1898158)).

--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -65,9 +65,6 @@ This article provides information about the changes in Firefox 133 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-#### General
-
-- Added support for action queues to make sure actions are performed sequentially ([Firefox bug 1915798](https://bugzil.la/1915798)).
 
 #### WebDriver BiDi
 

--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -73,7 +73,7 @@ This article provides information about the changes in Firefox 133 that affect d
 
 - Added support for the `url` argument for the `network.continueRequest` command, allowing requests to be transparently redirected to another URL ([Firefox bug 1898158](https://bugzil.la/1898158)).
 - Updated `browsingContext.print` to throw an `InvalidArgumentError` when used with incorrect dimensions ([Firefox bug 1886382](https://bugzil.la/1886382)).
-- Fixed `script.evaluate` and `script.callFunction` to allow the use `document.open` in sandbox realms ([Firefox bug 1918288](https://bugzil.la/1918288)).
+- Fixed `script.evaluate` and `script.callFunction` to allow the use of `document.open` in sandbox realms ([Firefox bug 1918288](https://bugzil.la/1918288)).
 - Fixed a bug where the `browsingContext.load` event might contain the wrong navigation ID if a same-document navigation occurred during the main navigation ([Firefox bug 1922327](https://bugzil.la/1922327)).
 - Fixed another edge case where commands could fail with an `UnknownError` due to navigation ([Firefox bug 1923899](https://bugzil.la/1923899)).
 

--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -67,9 +67,21 @@ This article provides information about the changes in Firefox 133 that affect d
 
 #### General
 
+- Added support for action queues to make sure actions are performed sequentially ([Firefox bug 1915798](https://bugzil.la/1915798)).
+
 #### WebDriver BiDi
 
+- Added support for the `url` argument for the `network.continueRequest` command, allowing requests to be transparently redirected to another URL ([Firefox bug 1898158](https://bugzil.la/1898158)).
+- Updated `browsingContext.print` to throw an `InvalidArgumentError` when used with incorrect dimensions ([Firefox bug 1886382](https://bugzil.la/1886382)).
+- Fixed `script.evaluate` and `script.callFunction` to allow the use `document.open` in sandbox realms ([Firefox bug 1918288](https://bugzil.la/1918288)).
+- Fixed a bug where the `browsingContext.load` event might contain the wrong navigation ID if a same-document navigation occurred during the main navigation ([Firefox bug 1922327](https://bugzil.la/1922327)).
+- Fixed another edge case where commands could fail with an `UnknownError` due to navigation ([Firefox bug 1923899](https://bugzil.la/1923899)).
+
 #### Marionette
+
+- Updated Marionette to better handle window positioning on Linux with Wayland ([Firefox bug 1857571](https://bugzil.la/1857571)).
+- Fixed a bug that could leave an empty `style` attribute on an element when trying to click or clear it ([Firefox bug 1922709](https://bugzil.la/1922709)).
+- Updated the error message sent for `UnexpectedAlertOpen` errors to include the text of the corresponding alert ([Firefox bug 1924469](https://bugzil.la/1924469)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Release notes update based on the following list of [relnote worthy bugs](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox132&query_format=advanced&o1=equals&f1=cf_status_firefox133&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed).

(excluding contributor bugs which will be mentioned in our fxdx blog post)
