### PR TITLE
Mark depthCompare and depthWriteEnabled as optional, and add explanation

### DIFF
--- a/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
+++ b/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
@@ -52,7 +52,7 @@ The `depthStencil` object can contain the following properties:
   - : A number representing the maximum depth bias of a fragment. If omitted, `depthBiasClamp` defaults to 0.
 - `depthBiasSlopeScale` {{optional_inline}}
   - : A number representing a depth bias that scales with the fragment's slope. If omitted, `depthBiasSlopeScale` defaults to 0.
-- `depthCompare`
+- `depthCompare` {{optional_inline}}
 
   - : An enumerated value specifying the comparison operation used to test fragment depths against `depthStencilAttachment` depth values. Possible values are:
 
@@ -65,8 +65,14 @@ The `depthStencil` object can contain the following properties:
     - `"greater-equal"`: A provided value passes the comparison test if it is greater than or equal to the sampled value.
     - `"always"`: Comparison tests always pass.
 
-- `depthWriteEnabled`
+    `depthCompare` is not required if the specified `format` does not have a depth component, or if the comparison operation is not used.
+
+- `depthWriteEnabled` {{optional_inline}}
+
   - : A boolean. A value of `true` specifies that the {{domxref("GPURenderPipeline")}} can modify `depthStencilAttachment` depth values after creation. Setting it to `false` means it cannot.
+
+    `depthWriteEnabled` is not required if the specified `format` does not have a depth component.
+
 - `format`
   - : An enumerated value specifying the `depthStencilAttachment` format that the {{domxref("GPURenderPipeline")}} will be compatible with. See the specification's [Texture Formats](https://gpuweb.github.io/gpuweb/#enumdef-gputextureformat) section for all the available `format` values.
 - `stencilBack` {{optional_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In Chrome 120, the `depthCompare` and `depthWriteEnabled` properties of the [`createRenderPipeline`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipeline)/[`createRenderPipelineAsync`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createRenderPipelineAsync) descriptors have been made optional when not needed. See https://developer.chrome.com/blog/new-in-webgpu-120#changes_to_depth-stencil_state.

This PR marks both properties as optional and adds an explanation of when they are not needed.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Project issue: https://github.com/mdn/content/issues/36370

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
