### PR TITLE
Fix syntax & structure format for svg gradient related features

### DIFF
--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -2,9 +2,10 @@
 title: cx
 slug: Web/SVG/Attribute/cx
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/geometry.html#CX
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCXAttribute
+browser-compat:
+  - svg.elements.circle.cx
+  - svg.elements.ellipse.cx
+  - svg.elements.radialGradient.cx
 ---
 
 {{SVGRef}}
@@ -101,7 +102,13 @@ For {{SVGElement('radialGradient')}}, `cx` defines the x-axis coordinate of the 
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{cssxref("length-percentage")}}</td>
+      <td>
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#length"
+            >&#x3C;length></a
+          ></strong
+        >
+      </td>
     </tr>
     <tr>
       <th scope="row">Default value</th>
@@ -175,6 +182,10 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -103,11 +103,7 @@ For {{SVGElement('radialGradient')}}, `cx` defines the x-axis coordinate of the 
     <tr>
       <th scope="row">Value</th>
       <td>
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#length"
-            >&#x3C;length></a
-          ></strong
-        >
+        <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&#x3C;length></a></strong>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -2,9 +2,10 @@
 title: cy
 slug: Web/SVG/Attribute/cy
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/geometry.html#CY
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCYAttribute
+browser-compat:
+  - svg.elements.circle.cy
+  - svg.elements.ellipse.cy
+  - svg.elements.radialGradient.cy
 ---
 
 {{SVGRef}}
@@ -101,7 +102,13 @@ For {{SVGElement('radialGradient')}}, `cy` defines the y-axis coordinate of the 
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{cssxref("length-percentage")}}</td>
+      <td>
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#length"
+            >&#x3C;length></a
+          ></strong
+        >
+      </td>
     </tr>
     <tr>
       <th scope="row">Default value</th>
@@ -175,6 +182,10 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -103,11 +103,7 @@ For {{SVGElement('radialGradient')}}, `cy` defines the y-axis coordinate of the 
     <tr>
       <th scope="row">Value</th>
       <td>
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#length"
-            >&#x3C;length></a
-          ></strong
-        >
+        <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&#x3C;length></a></strong>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/svg/attribute/fr/index.md
+++ b/files/en-us/web/svg/attribute/fr/index.md
@@ -131,7 +131,13 @@ This example has `fr` equal to `5%` and is representing how the attributes `fx` 
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{cssxref("length")}}</td>
+      <td>
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#length"
+            >&#x3C;length></a
+          ></strong
+        >
+      </td>
     </tr>
     <tr>
       <th scope="row">Default value</th>

--- a/files/en-us/web/svg/attribute/fr/index.md
+++ b/files/en-us/web/svg/attribute/fr/index.md
@@ -132,11 +132,7 @@ This example has `fr` equal to `5%` and is representing how the attributes `fx` 
     <tr>
       <th scope="row">Value</th>
       <td>
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#length"
-            >&#x3C;length></a
-          ></strong
-        >
+        <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&#x3C;length></a></strong>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/svg/attribute/fx/index.md
+++ b/files/en-us/web/svg/attribute/fx/index.md
@@ -69,11 +69,7 @@ svg {
     <tr>
       <th scope="row">Value</th>
       <td>
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#length"
-            >&#x3C;length></a
-          ></strong
-        >
+        <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&#x3C;length></a></strong>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/svg/attribute/fx/index.md
+++ b/files/en-us/web/svg/attribute/fx/index.md
@@ -68,7 +68,13 @@ svg {
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{cssxref("length")}}</td>
+      <td>
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#length"
+            >&#x3C;length></a
+          ></strong
+        >
+      </td>
     </tr>
     <tr>
       <th scope="row">Default value</th>

--- a/files/en-us/web/svg/attribute/fy/index.md
+++ b/files/en-us/web/svg/attribute/fy/index.md
@@ -124,11 +124,7 @@ svg {
     <tr>
       <th scope="row">Value</th>
       <td>
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#length"
-            >&#x3C;length></a
-          ></strong
-        >
+        <strong><a href="/en-US/docs/Web/SVG/Content_type#length">&#x3C;length></a></strong>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/svg/attribute/fy/index.md
+++ b/files/en-us/web/svg/attribute/fy/index.md
@@ -123,7 +123,13 @@ svg {
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{cssxref("length")}}</td>
+      <td>
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#length"
+            >&#x3C;length></a
+          ></strong
+        >
+      </td>
     </tr>
     <tr>
       <th scope="row">Default value</th>

--- a/files/en-us/web/svg/attribute/gradienttransform/index.md
+++ b/files/en-us/web/svg/attribute/gradienttransform/index.md
@@ -2,12 +2,14 @@
 title: gradientTransform
 slug: Web/SVG/Attribute/gradientTransform
 page-type: svg-attribute
-browser-compat: svg.elements.linearGradient.gradientTransform
+browser-compat:
+  - svg.elements.linearGradient.gradientTransform
+  - svg.elements.radialGradient.gradientTransform
 ---
 
 {{SVGRef}}
 
-The `gradientTransform` attribute contains the definition of an optional additional transformation from the gradient coordinate system onto the target coordinate system (i.e., userSpaceOnUse or objectBoundingBox). This allows for things such as skewing the gradient. This additional transformation matrix is post-multiplied to (i.e., inserted to the right of) any previously defined transformations, including the implicit transformation necessary to convert from object bounding box units to user space.
+The **`gradientTransform`** attribute contains the definition of an optional additional transformation from the gradient coordinate system onto the target coordinate system (i.e., userSpaceOnUse or objectBoundingBox). This allows for things such as skewing the gradient. This additional transformation matrix is post-multiplied to (i.e., inserted to the right of) any previously defined transformations, including the implicit transformation necessary to convert from object bounding box units to user space.
 
 You can use this attribute with the following SVG elements:
 

--- a/files/en-us/web/svg/attribute/gradientunits/index.md
+++ b/files/en-us/web/svg/attribute/gradientunits/index.md
@@ -2,9 +2,9 @@
 title: gradientUnits
 slug: Web/SVG/Attribute/gradientUnits
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientUnitsAttribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientUnitsAttribute
+browser-compat:
+  - svg.elements.linearGradient.gradientUnits
+  - svg.elements.radialGradient.gradientUnits
 ---
 
 {{SVGRef}}
@@ -78,3 +78,7 @@ For {{SVGElement("radialGradient")}}, `gradientUnits` defines the coordinate sys
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/attribute/href/index.md
+++ b/files/en-us/web/svg/attribute/href/index.md
@@ -2,7 +2,21 @@
 title: href
 slug: Web/SVG/Attribute/href
 page-type: svg-attribute
-browser-compat: svg.global_attributes.href
+browser-compat:
+  - svg.elements.a.href
+  - svg.elements.animate.href
+  - svg.elements.animateMotion.href
+  - svg.elements.animateTransform.href
+  - svg.elements.feImage.href
+  - svg.elements.image.href
+  - svg.elements.linearGradient.href
+  - svg.elements.mpath.href
+  - svg.elements.pattern.href
+  - svg.elements.radialGradient.href
+  - svg.elements.script.href
+  - svg.elements.set.href
+  - svg.elements.textPath.href
+  - svg.elements.use.href
 ---
 
 {{SVGRef}}
@@ -177,7 +191,7 @@ svg {
 
 ### linearGradient
 
-For {{SVGElement("linearGradient")}}, `href` defines URL referring to a template gradient element; to be valid, the reference must be to a different `<linearGradient>` or {{SVGElement("radialGradient")}} element.
+For {{SVGElement("linearGradient")}} or {{SVGElement("radialGradient")}}, `href` defines URL referring to a template gradient element; to be valid, the reference must be to a different `<linearGradient>` or `<radialGradient>` element.
 
 <table class="properties">
   <tbody>
@@ -228,31 +242,6 @@ For {{SVGElement("mpath")}}, `href` defines a URL referring to the {{SVGElement(
 ### pattern
 
 For {{SVGElement("pattern")}}, `href` defines a URL referring to a different `<pattern>` element within the current SVG document. Any attributes which are defined on the referenced element which are not defined on this element are inherited by this element. If this element has no children, and the referenced element does (possibly due to its own `href` attribute), then this element inherits the children from the referenced element. Inheritance can be indirect to an arbitrary level; thus, if the referenced element inherits attributes or children due to its own `href` attribute, then the current element can inherit those attributes or children. On the {{SVGElement("pattern")}} element, the `href` attribute is animatable.
-
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Value</th>
-      <td>
-        <code
-          ><a href="/en-US/docs/Web/SVG/Content_type#url">&#x3C;url></a></code
-        >
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Default value</th>
-      <td><em>None</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Animatable</th>
-      <td>Yes</td>
-    </tr>
-  </tbody>
-</table>
-
-### radialGradient
-
-For {{SVGElement("radialGradient")}}, `href` defines URL referring to a template gradient element; to be valid, the reference must be to a different {{SVGElement("linearGradient")}} or `<radialGradient>` element.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/href/index.md
+++ b/files/en-us/web/svg/attribute/href/index.md
@@ -189,7 +189,7 @@ svg {
 
 {{EmbedLiveSample("image", 200, 250)}}
 
-### linearGradient
+### linearGradient/radialGradient
 
 For {{SVGElement("linearGradient")}} or {{SVGElement("radialGradient")}}, `href` defines URL referring to a template gradient element; to be valid, the reference must be to a different `<linearGradient>` or `<radialGradient>` element.
 

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -2,9 +2,9 @@
 title: r
 slug: Web/SVG/Attribute/r
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/geometry.html#R
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementRAttribute
+browser-compat:
+  - svg.elements.circle.r
+  - svg.elements.radialGradient.r
 ---
 
 {{SVGRef}}
@@ -107,12 +107,6 @@ The gradient will be drawn such that the **100%** gradient stop is mapped to the
             >&#x3C;length></a
           ></strong
         >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
-            >&#x3C;percentage></a
-          ></strong
-        >
       </td>
     </tr>
     <tr>
@@ -129,3 +123,7 @@ The gradient will be drawn such that the **100%** gradient stop is mapped to the
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/attribute/spreadmethod/index.md
+++ b/files/en-us/web/svg/attribute/spreadmethod/index.md
@@ -2,7 +2,9 @@
 title: spreadMethod
 slug: Web/SVG/Attribute/spreadMethod
 page-type: svg-attribute
-browser-compat: svg.elements.linearGradient.spreadMethod
+browser-compat:
+  - svg.elements.linearGradient.spreadMethod
+  - svg.elements.radialGradient.spreadMethod
 ---
 
 {{SVGRef}}
@@ -14,7 +16,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("linearGradient")}}
 - {{SVGElement("radialGradient")}}
 
-## Context notes
+## Usage notes
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -2,9 +2,9 @@
 title: x1
 slug: Web/SVG/Attribute/x1
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementX1Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX1Attribute
+browser-compat:
+  - svg.elements.line.x1
+  - svg.elements.linearGradient.x1
 ---
 
 {{SVGRef}}
@@ -86,18 +86,6 @@ For {{SVGElement('linearGradient')}}, `x1` defines the x coordinate of the start
             >&#x3C;length></a
           ></strong
         >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
-            >&#x3C;percentage></a
-          ></strong
-        >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#number"
-            >&#x3C;number></a
-          ></strong
-        >
       </td>
     </tr>
     <tr>
@@ -170,3 +158,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -2,9 +2,9 @@
 title: x2
 slug: Web/SVG/Attribute/x2
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementX2Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX2Attribute
+browser-compat:
+  - svg.elements.line.x2
+  - svg.elements.linearGradient.x2
 ---
 
 {{SVGRef}}
@@ -86,18 +86,6 @@ For {{SVGElement('linearGradient')}}, `x2` defines the x coordinate of the endin
             >&#x3C;length></a
           ></strong
         >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
-            >&#x3C;percentage></a
-          ></strong
-        >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#number"
-            >&#x3C;number></a
-          ></strong
-        >
       </td>
     </tr>
     <tr>
@@ -170,3 +158,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -2,9 +2,9 @@
 title: y1
 slug: Web/SVG/Attribute/y1
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementY1Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY1Attribute
+browser-compat:
+  - svg.elements.line.y1
+  - svg.elements.linearGradient.y1
 ---
 
 {{SVGRef}}
@@ -86,18 +86,6 @@ For {{SVGElement('linearGradient')}}, `y1` defines the y coordinate of the start
             >&#x3C;length></a
           ></strong
         >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
-            >&#x3C;percentage></a
-          ></strong
-        >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#number"
-            >&#x3C;number></a
-          ></strong
-        >
       </td>
     </tr>
     <tr>
@@ -172,3 +160,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -2,9 +2,9 @@
 title: y2
 slug: Web/SVG/Attribute/y2
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementY2Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY2Attribute
+browser-compat:
+  - svg.elements.line.y2
+  - svg.elements.linearGradient.y2
 ---
 
 {{SVGRef}}
@@ -86,18 +86,6 @@ For {{SVGElement('linearGradient')}}, `y2` defines the y coordinate of the endin
             >&#x3C;length></a
           ></strong
         >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
-            >&#x3C;percentage></a
-          ></strong
-        >
-        |
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Content_type#number"
-            >&#x3C;number></a
-          ></strong
-        >
       </td>
     </tr>
     <tr>
@@ -172,3 +160,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/element/lineargradient/index.md
+++ b/files/en-us/web/svg/element/lineargradient/index.md
@@ -45,7 +45,7 @@ svg {
     _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("gradientTransform")}}
   - : This attribute provides additional [transformation](/en-US/docs/Web/SVG/Attribute/transform) to the gradient coordinate system.
-    _Value type_: **[\<transform-list>](/en-US/docs/Web/SVG/Content_type#transform-list)** ; _Default value_: _identity transform_; _Animatable_: **yes**
+    _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Content_type#transform-list) ; _Default value_: _identity transform_; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : This attribute defines a reference to another `<linearGradient>` element that will be used as a template.
     _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
@@ -54,19 +54,19 @@ svg {
     _Value type_: `pad`|`reflect`|`repeat` ; _Default value_: `pad`; _Animatable_: **yes**
 - {{SVGAttr("x1")}}
   - : This attribute defines the x coordinate of the starting point of the vector gradient along which the linear gradient is drawn.
-    _Value type_: {{cssxref("length-percentage")}} | {{cssxref("number")}}; _Default value_: `0%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**
 - {{SVGAttr("x2")}}
   - : This attribute defines the x coordinate of the ending point of the vector gradient along which the linear gradient is drawn.
-    _Value type_: {{cssxref("length-percentage")}} | {{cssxref("number")}}; _Default value_: `100%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length); _Default value_: `100%`; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : An [\<IRI>](/en-US/docs/Web/SVG/Content_type#iri) reference to another `<linearGradient>` element that will be used as a template.
     _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("y1")}}
   - : This attribute defines the y coordinate of the starting point of the vector gradient along which the linear gradient is drawn.
-    _Value type_: {{cssxref("length-percentage")}} | {{cssxref("number")}}; _Default value_: `0%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**
 - {{SVGAttr("y2")}}
   - : This attribute defines the y coordinate of the ending point of the vector gradient along which the linear gradient is drawn.
-    _Value type_: {{cssxref("length-percentage")}} | {{cssxref("number")}}; _Default value_: `0%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/element/radialgradient/index.md
+++ b/files/en-us/web/svg/element/radialgradient/index.md
@@ -63,7 +63,7 @@ svg {
     _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("gradientTransform")}}
   - : This attribute provides additional [transformation](/en-US/docs/Web/SVG/Attribute/transform) to the gradient coordinate system.
-    _Value type_: **[\<transform-list>](/en-US/docs/Web/SVG/Content_type#transform-list)** ; _Default value_: _identity transform_; _Animatable_: **yes**
+    _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Content_type#transform-list) ; _Default value_: _identity transform_; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : This attribute defines a reference to another `<radialGradient>` element that will be used as a template.
     _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Content_type#url) ; _Default value_: none; _Animatable_: **yes**

--- a/files/jsondata/SVGData.json
+++ b/files/jsondata/SVGData.json
@@ -993,25 +993,24 @@
           "descriptiveElements",
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
+          "&lt;script&gt",
           "&lt;set&gt;",
-          "&lt;stop&gt;"
+          "&lt;stop&gt;",
+          "&lt;style&gt"
         ]
       },
       "attributes": [
         "coreAttributes",
         "presentationAttributes",
         "xLinkAttributes",
-        "'class'",
-        "'style'",
-        "'externalResourcesRequired'",
         "'gradientUnits'",
         "'gradientTransform'",
+        "'href'",
         "'x1'",
         "'y1'",
         "'x2'",
         "'y2'",
-        "'spreadMethod'",
-        "'xlink:href'"
+        "'spreadMethod'"
       ],
       "interfaces": ["SVGLinearGradientElement"]
     },
@@ -1283,26 +1282,26 @@
           "descriptiveElements",
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
+          "&lt;script&gt",
           "&lt;set&gt;",
-          "&lt;stop&gt;"
+          "&lt;stop&gt;",
+          "&lt;style&gt"
         ]
       },
       "attributes": [
         "coreAttributes",
         "presentationAttributes",
         "xLinkAttributes",
-        "'class'",
-        "'style'",
-        "'externalResourcesRequired'",
-        "'gradientUnits'",
-        "'gradientTransform'",
         "'cx'",
         "'cy'",
-        "'r'",
         "'fx'",
         "'fy'",
-        "'spreadMethod'",
-        "'xlink:href'"
+        "'fr'",
+        "'gradientUnits'",
+        "'gradientTransform'",
+        "'href'",
+        "'r'",
+        "'spreadMethod'"
       ],
       "interfaces": ["SVGRadialGradientElement"]
     },

--- a/files/jsondata/SVGData.json
+++ b/files/jsondata/SVGData.json
@@ -993,10 +993,10 @@
           "descriptiveElements",
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
-          "&lt;script&gt",
+          "&lt;script&gt;",
           "&lt;set&gt;",
           "&lt;stop&gt;",
-          "&lt;style&gt"
+          "&lt;style&gt;"
         ]
       },
       "attributes": [
@@ -1282,10 +1282,10 @@
           "descriptiveElements",
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
-          "&lt;script&gt",
+          "&lt;script&gt;",
           "&lt;set&gt;",
           "&lt;stop&gt;",
-          "&lt;style&gt"
+          "&lt;style&gt;"
         ]
       },
       "attributes": [


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

for svg attributes, change *spec-urls* key to *browser-compat* key and add *Browser compatibility* section
fix syntax for `cx` `cy` `r` `x1` `x2` `y1` `y2` attributes
combine linearGradient and radialGradient section for `href` attribute, since the two sections has almost the same content

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://svgwg.org/svg2-draft/pservers.html#LinearGradientElement
https://svgwg.org/svg2-draft/pservers.html#RadialGradientElement

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

see also https://github.com/mdn/browser-compat-data/pull/25150

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
