### PR TITLE
Fix formatting

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -606,7 +606,7 @@ Now that it's possible to loan books to a specific user, go and loan out a numbe
 
 Now we'll add a view for getting the list of all books that have been loaned to the current user. We'll use the same generic class-based list view we're familiar with, but this time we'll also import and derive from `LoginRequiredMixin`, so that only a logged in user can call this view. We will also choose to declare a `template_name`, rather than using the default, because we may end up having a few different lists of BookInstance records, with different views and templates.
 
-Add the following to catalog/views.py:
+Add the following to **catalog/views.py**:
 
 ```python
 from django.contrib.auth.mixins import LoginRequiredMixin


### PR DESCRIPTION
Bold text `catalog/views.py` to make it consistent when referring file

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Every referred python file is in bold format except `catalog/views.py` in `On loan view` section. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
to make it consistent

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
