### PR TITLE
Bug-1496075 Missed search_provider object properties docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
@@ -157,12 +157,16 @@ The `chrome_settings_overrides` key is an object that may have the following pro
           <dd>String: Address bar keyword for the search engine.</dd>
           <dt><code>prepopulated_id</code> {{optional_inline}}</dt>
           <dd>The ID of a built-in search engine to use.</dd>
+          <dt><code>search_url_get_params</code> {{optional_inline}}</dt>
+          <dd>String: GET parameters to send to <code>search_url</code>.</dd>
           <dt><code>search_url_post_params</code> {{optional_inline}}</dt>
           <dd>String: POST parameters to send to <code>search_url</code>.</dd>
           <dt><code>suggest_url</code> {{optional_inline}}</dt>
           <dd>
             String: URL used for search suggestions. This must be an HTTPS URL.
           </dd>
+          <dt><code>suggest_url_get_params</code> {{optional_inline}}</dt>
+          <dd>String: GET parameters to send to <code>suggest_url</code>.</dd>
           <dt><code>suggest_url_post_params</code> {{optional_inline}}</dt>
           <dd>String: POST parameters to send to <code>suggest_url</code>.</dd>
         </dl>


### PR DESCRIPTION
### Description

The manifest key [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) `search_provider` object properties `search_url_get_params` and `suggest_url_get_params` were added in [Bug 1496075](https://bugzilla.mozilla.org/show_bug.cgi?id=1496075) Support loading search extensions on startup but omitted from the docs.

### Additional details

See https://hg.mozilla.org/mozilla-central/rev/7efb082cc25d#l3.30

### Related issues and pull requests

BCD changes in https://github.com/mdn/browser-compat-data/pull/25160