### PR TITLE
Clarify `appearance: none;` behavior

### DIFF
--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -44,8 +44,8 @@ Some examples are provided, but the list is not exhaustive.
 
 - `none`
 
-  - : Hides certain features of widgets, such as arrow displayed in select element, indicating that list can be expanded.
-
+  - : If the element is a widget (native form control) it will be forced to use a standardized primitive appearance instead of a platform native appearance (ex: operating system specific). Non-widget elements, including replaced elements like img and video, are unaffected.
+    
 - `auto`
 
   - : Acts as `none` on elements with no special styling.

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -44,7 +44,7 @@ Some examples are provided, but the list is not exhaustive.
 
 - `none`
 
-  - : If the element is a widget (native form control) it will be forced to use a standardized primitive appearance instead of a platform native appearance (ex: operating system specific). Non-widget elements, including replaced elements like img and video, are unaffected.
+  - : If the element is a widget (native form control), it will be forced to use a standardized primitive appearance instead of a platform-native or operating system specific appearance, supporting the usual rules of CSS.  This value has no effect on non-widget elements, including replaced elements like {{htmlelement("img")}} and {{htmlelement("video")}}.
 
 - `auto`
 

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -44,7 +44,7 @@ Some examples are provided, but the list is not exhaustive.
 
 - `none`
 
-  - : If the element is a widget (native form control), it will be forced to use a standardized primitive appearance instead of a platform-native or operating system specific appearance, supporting the usual rules of CSS.  This value has no effect on non-widget elements, including replaced elements like {{htmlelement("img")}} and {{htmlelement("video")}}.
+  - : If the element is a widget (native form control), it will be forced to use a standardized primitive appearance instead of a platform-native or operating system specific appearance, supporting the usual rules of CSS. This value has no effect on non-widget elements, including replaced elements like {{htmlelement("img")}} and {{htmlelement("video")}}.
 
 - `auto`
 

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -45,7 +45,6 @@ Some examples are provided, but the list is not exhaustive.
 - `none`
 
   - : If the element is a widget (native form control) it will be forced to use a standardized primitive appearance instead of a platform native appearance (ex: operating system specific). Non-widget elements, including replaced elements like img and video, are unaffected.
-    
 - `auto`
 
   - : Acts as `none` on elements with no special styling.

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -45,6 +45,7 @@ Some examples are provided, but the list is not exhaustive.
 - `none`
 
   - : If the element is a widget (native form control) it will be forced to use a standardized primitive appearance instead of a platform native appearance (ex: operating system specific). Non-widget elements, including replaced elements like img and video, are unaffected.
+
 - `auto`
 
   - : Acts as `none` on elements with no special styling.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarify the standardized behavior of `appearance: none;` 

### Motivation

Some people misinterpret the original wording as behavior similar to `display: none;` or `visibility: hidden;` when in reality it is more like a css-reset. 

Here is some supporting evidence of old defintion causing confusion

![Screenshot_2024-11-20-22-25-29-40](https://github.com/user-attachments/assets/99d0e634-597b-4589-8fb7-f80b1f572230)




### Additional details

[Quote from the spec](https://www.w3.org/TR/css-ui-4/#valdef-appearance-none)

> The element is rendered following the usual rules of CSS. Replaced elements other than widgets are not affected by this and remain replaced elements. Widgets must not have their native appearance, and instead must have their primitive appearance. See § 7.2.2 Effects of appearance on Decorative Aspects of Elements and § 7.2.3 Effects of appearance on Semantic Aspects of Elements for details.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->