### PR TITLE
Add information on unrestricted_pointer_parameters extension

### DIFF
--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -20,7 +20,11 @@ The `WGSLLanguageFeatures` object is accessed via the {{domxref("GPU.wgslLanguag
 
 ## Available features
 
-The available WGSL language extensions can vary across implementations and physical devices and may also change over time; we have therefore not listed them here. For a complete list, refer to [WGSL language extensions](https://gpuweb.github.io/gpuweb/wgsl/#language-extension) in the WGSL specification.
+The following WGSL language extensions are defined at [WGSL language extensions](https://gpuweb.github.io/gpuweb/wgsl/#language-extension) in the WGSL specification. Bear in mind that the exact set of features available will vary across implementations and physical devices, and may change over time.
+
+| Feature name                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a name="unrestricted_pointer_parameters">`unrestricted_pointer_parameters`</a> | <p>Loosens restrictions on pointers being passed to WGSL functions. When available, the following are allowed:</p><ul><li>Parameter pointers to storage, uniform, and workgroup address spaces being passed to user-declared functions.</li><li>Pointers to structure members and array elements being passed to user-declared functions.</li></ul><p>See [Pointers As Function Parameters](https://google.github.io/tour-of-wgsl/types/pointers/passing_pointers/) for more details.</p> |
 
 ## Instance properties
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 123 supports the `unrestricted_pointer_parameters` language extension (see [`WGSLLanguageFeatures`](https://developer.mozilla.org/en-US/docs/Web/API/WGSLLanguageFeatures)), which loosens restrictions on pointers being passed to WGSL functions as follows:

- Parameter pointers to storage, uniform, and workgroup address spaces being passed to user-declared functions.
- Pointers to structure members and array elements being passed to user-declared functions.

This PR adds an entry to the "Available features" table on the `WGSLLanguageFeatures` ref page for this feature. I'm copying the same structure as I used in https://github.com/mdn/content/pull/36880, and will deal with merging them as they start to get published.

See https://developer.chrome.com/blog/new-in-webgpu-123#unrestricted_pointer_parameters_in_wgsl for the data source.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Project issue: https://github.com/mdn/content/issues/36350

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
