### PR TITLE
fix(scripts/front-matter_linter): exclude conflicting/orphaned

### DIFF
--- a/scripts/front-matter_linter.js
+++ b/scripts/front-matter_linter.js
@@ -24,11 +24,14 @@ async function resolveDirectory(file) {
       .withErrors()
       .withFullPaths()
       .filter((filePath) => filePath.endsWith("index.md"))
+      .exclude((dirName) => dirName === "conflicting" || dirName === "orphaned")
       .crawl(file);
     return api.withPromise();
   } else if (
     stats.isFile() &&
     file.endsWith("index.md") &&
+    !file.includes("/conflicting/") &&
+    !file.includes("/orphaned/") &&
     !file.includes("tests/front-matter_test_files")
   ) {
     return [file];


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Excludes conflicting and orphaned files from the front-matter linter.

### Motivation

This was the reason why the checks in https://github.com/mdn/translated-content/pull/20368 were failing. (An orphaned file included wrongly-formatted frontmatter – see [this fix](https://github.com/mdn/translated-content/pull/20368/commits/f8cec763c47404d843f738e5d53737e46534eb01) – that would be corrected from prettier, but orphaned files are in the prettierignore.)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
