### PR TITLE
Clarify recommendation to use CSS property

### DIFF
--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -130,8 +130,9 @@ This example contains two MathML formula. The first one is rendered in its own c
         <mn>2</mn>
       </msup>
       <mn>6</mn>
-    </mfrac></math
-  >.
+    </mfrac>
+  </math>
+  .
 </p>
 ```
 

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -17,15 +17,15 @@ The **`<mstyle>`** [MathML](/en-US/docs/Web/MathML) element is used to change th
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
 - `background` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : Use {{cssxref("background-color")}} instead.
+  - : Use CSS property {{cssxref("background-color")}} instead.
 - `color` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : Use {{cssxref("color")}} instead.
+  - : Use CSS property {{cssxref("color")}} instead.
 - `fontsize` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : Use {{cssxref("font-size")}} instead.
+  - : Use CSS property {{cssxref("font-size")}} instead.
 - `fontstyle` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : Use {{cssxref("font-style")}} instead.
+  - : Use CSS property {{cssxref("font-style")}} instead.
 - `fontweight` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : Use {{cssxref("font-weight")}} instead.
+  - : Use CSS property {{cssxref("font-weight")}} instead.
 
 ## Examples
 


### PR DESCRIPTION
### Description

It’s not clear that we’re talking about CSS properties. It looks like the attributes were renamed, or maybe not:

<img width="211" alt="image" src="https://github.com/user-attachments/assets/c7c65123-8931-43bb-abe8-9760613cb462">

And while I’m here, also fixing a broken closing tag.

### Motivation

To make the recommendation to use CSS easier to get.