### PR TITLE
Improve MathML examples

### DIFF
--- a/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
+++ b/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
@@ -6,14 +6,19 @@ page-type: guide
 
 {{MathMLRef}}
 
-This page outlines the derivation of the [Quadratic Formula](https://en.wikipedia.org/wiki/Quadratic_formula).
+This page outlines the derivation of the [Quadratic Formula](https://en.wikipedia.org/wiki/Quadratic_formula). Nine equations are organized in the {{MathMLElement("mtable")}} element to align the steps of the derivation by the equal sign. Some steps are annotated with colored text. The derivation is also represented in [LaTeX](https://www.latex-project.org/) format in the {{MathMLElement("annotation")}} element.
 
-We take a quadratic equation in its general form, and solve for x:
+## Derivation
 
-<!-- prettier-ignore-start -->
+We take a quadratic equation in its general form, and solve for x.
+
+{{ EmbedLiveSample("Derivation", "", "400px") }}
+
+```html
 <math display="block">
   <semantics>
     <mtable>
+      <!-- Step one -->
       <mtr>
         <mtd>
           <mrow>
@@ -21,7 +26,8 @@ We take a quadratic equation in its general form, and solve for x:
               <mrow>
                 <mrow>
                   <mi>a</mi>
-                  <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+                  <!-- Invisible times Unicode character -->
+                  <mo>&#x2062;</mo>
                   <msup>
                     <mi>x</mi>
                     <mn>2</mn>
@@ -29,7 +35,8 @@ We take a quadratic equation in its general form, and solve for x:
                 </mrow>
                 <mo>+</mo>
                 <mi>b</mi>
-                <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+                <!-- Invisible times Unicode character -->
+                <mo>&#x2062;</mo>
                 <mi>x</mi>
               </mrow>
               <mo>+</mo>
@@ -44,12 +51,14 @@ We take a quadratic equation in its general form, and solve for x:
           <mn>0</mn>
         </mtd>
       </mtr>
+      <!-- Step two -->
       <mtr>
         <mtd>
           <mrow>
             <mrow>
               <mi>a</mi>
-              <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+              <!-- Invisible times Unicode character -->
+              <mo>&#x2062;</mo>
               <msup>
                 <mi>x</mi>
                 <mn>2</mn>
@@ -57,7 +66,8 @@ We take a quadratic equation in its general form, and solve for x:
             </mrow>
             <mo>+</mo>
             <mi>b</mi>
-            <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+            <!-- Invisible times Unicode character -->
+            <mo>&#x2062;</mo>
             <mi>x</mi>
           </mrow>
         </mtd>
@@ -69,6 +79,7 @@ We take a quadratic equation in its general form, and solve for x:
           <mi>c</mi>
         </mtd>
       </mtr>
+      <!-- Step three -->
       <mtr>
         <mtd>
           <mrow>
@@ -101,10 +112,13 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;">Divide out leading coefficient.</mtext>
+            <mtext style="color: red; font-size: smaller">
+              Divide out leading coefficient.
+            </mtext>
           </mrow>
         </mtd>
       </mtr>
+      <!-- Step four -->
       <mtr>
         <mtd>
           <mrow>
@@ -186,10 +200,13 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;">Complete the square.</mtext>
+            <mtext style="color: red; font-size: smaller">
+              Complete the square.
+            </mtext>
           </mrow>
         </mtd>
       </mtr>
+      <!-- Step five -->
       <mtr>
         <mtd>
           <mrow>
@@ -249,10 +266,13 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;">Discriminant revealed.</mtext>
+            <mtext style="color: red; font-size: smaller">
+              Discriminant revealed.
+            </mtext>
           </mrow>
         </mtd>
       </mtr>
+      <!-- Step six -->
       <mtr>
         <mtd>
           <mrow>
@@ -304,10 +324,11 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;"></mtext>
+            <mtext style="color: red; font-size: smaller"></mtext>
           </mrow>
         </mtd>
       </mtr>
+      <!-- Step seven -->
       <mtr>
         <mtd>
           <mrow>
@@ -356,10 +377,11 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;"></mtext>
+            <mtext style="color: red; font-size: smaller"></mtext>
           </mrow>
         </mtd>
       </mtr>
+      <!-- Step eight -->
       <mtr>
         <mtd>
           <mi>x</mi>
@@ -408,10 +430,13 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;">There's the vertex formula.</mtext>
+            <mtext style="color: red; font-size: smaller">
+              There's the vertex formula.
+            </mtext>
           </mrow>
         </mtd>
       </mtr>
+      <!-- Step nine -->
       <mtr>
         <mtd>
           <mi>x</mi>
@@ -449,12 +474,25 @@ We take a quadratic equation in its general form, and solve for x:
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: 10pt;"></mtext>
+            <mtext style="color: red; font-size: smaller"></mtext>
           </mrow>
         </mtd>
       </mtr>
     </mtable>
-    <annotation encoding="TeX">TODO</annotation>
+    <!-- Representation in TeX format -->
+    <annotation encoding="application/x-tex">
+      \begin{aligned} ax^2 + bx + c &= 0 \\ ax^2 + bx &= -c \\ x^2 +
+      \frac{b}{a}x &= -\frac{c}{a} & \text{\color{red} \small Divide out leading
+      coefficient.} \\ x^2 + \frac{b}{a}x + \left(\frac{b}{2a}\right)^2 &=
+      \frac{-c(4a)}{a(4a)} + \frac{b^2}{4a^2} & \text{\color{red} \small
+      Complete the square.} \\ \left(x + \frac{b}{2a}\right)\left(x +
+      \frac{b}{2a}\right) &= \frac{b^2 - 4ac}{4a^2} & \text{\color{red} \small
+      Discriminant revealed.} \\ \left(x + \frac{b}{2a}\right)^2 &= \frac{b^2 -
+      4ac}{4a^2} \\ x + \frac{b}{2a} &= \sqrt{\frac{b^2 - 4ac}{4a^2}} \\ x &=
+      \frac{-b}{2a} \pm \{C\} \sqrt{\frac{b^2 - 4ac}{4a^2}} & \text{\color{red}
+      \small There's the vertex formula.} \\ x &= \frac{-b \pm \{C\}\sqrt{b^2 -
+      4ac}}{2a} \end{aligned}
+    </annotation>
   </semantics>
 </math>
-<!-- prettier-ignore-end -->
+```

--- a/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
+++ b/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
@@ -14,6 +14,7 @@ We take a quadratic equation in its general form, and solve for x.
 
 {{ EmbedLiveSample("Derivation", "", "400px") }}
 
+<!-- prettier-ignore-start -->
 ```html
 <math display="block">
   <semantics>
@@ -481,18 +482,19 @@ We take a quadratic equation in its general form, and solve for x.
     </mtable>
     <!-- Representation in TeX format -->
     <annotation encoding="application/x-tex">
-      \begin{aligned} ax^2 + bx + c &= 0 \\ ax^2 + bx &= -c \\ x^2 +
-      \frac{b}{a}x &= -\frac{c}{a} & \text{\color{red} \small Divide out leading
-      coefficient.} \\ x^2 + \frac{b}{a}x + \left(\frac{b}{2a}\right)^2 &=
-      \frac{-c(4a)}{a(4a)} + \frac{b^2}{4a^2} & \text{\color{red} \small
-      Complete the square.} \\ \left(x + \frac{b}{2a}\right)\left(x +
-      \frac{b}{2a}\right) &= \frac{b^2 - 4ac}{4a^2} & \text{\color{red} \small
-      Discriminant revealed.} \\ \left(x + \frac{b}{2a}\right)^2 &= \frac{b^2 -
-      4ac}{4a^2} \\ x + \frac{b}{2a} &= \sqrt{\frac{b^2 - 4ac}{4a^2}} \\ x &=
-      \frac{-b}{2a} \pm \{C\} \sqrt{\frac{b^2 - 4ac}{4a^2}} & \text{\color{red}
-      \small There's the vertex formula.} \\ x &= \frac{-b \pm \{C\}\sqrt{b^2 -
-      4ac}}{2a} \end{aligned}
+      \begin{aligned}
+      ax^2 + bx + c &= 0 \\
+      ax^2 + bx &= -c \\
+      x^2 + \frac{b}{a}x &= -\frac{c}{a} & \text{\color{red} \small Divide out leading coefficient.} \\
+      x^2 + \frac{b}{a}x + \left(\frac{b}{2a}\right)^2 &= \frac{-c(4a)}{a(4a)} + \frac{b^2}{4a^2} & \text{\color{red} \small Complete the square.} \\
+      \left(x + \frac{b}{2a}\right)\left(x + \frac{b}{2a}\right) &= \frac{b^2 - 4ac}{4a^2} & \text{\color{red} \small Discriminant revealed.} \\
+      \left(x + \frac{b}{2a}\right)^2 &= \frac{b^2 - 4ac}{4a^2} \\
+      x + \frac{b}{2a} &= \sqrt{\frac{b^2 - 4ac}{4a^2}} \\
+      x &= \frac{-b}{2a} \pm \{C\} \sqrt{\frac{b^2 - 4ac}{4a^2}} & \text{\color{red} \small There's the vertex formula.} \\
+      x &= \frac{-b \pm \{C\}\sqrt{b^2 - 4ac}}{2a}
+      \end{aligned}
     </annotation>
   </semantics>
 </math>
 ```
+<!-- prettier-ignore-end -->

--- a/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
+++ b/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
@@ -113,9 +113,7 @@ We take a quadratic equation in its general form, and solve for x.
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: smaller">
-              Divide out leading coefficient.
-            </mtext>
+            <mtext style="color: red; font-size: smaller">Divide out leading coefficient.</mtext>
           </mrow>
         </mtd>
       </mtr>
@@ -201,9 +199,7 @@ We take a quadratic equation in its general form, and solve for x.
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: smaller">
-              Complete the square.
-            </mtext>
+            <mtext style="color: red; font-size: smaller">Complete the square.</mtext>
           </mrow>
         </mtd>
       </mtr>
@@ -267,9 +263,7 @@ We take a quadratic equation in its general form, and solve for x.
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: smaller">
-              Discriminant revealed.
-            </mtext>
+            <mtext style="color: red; font-size: smaller">Discriminant revealed.</mtext>
           </mrow>
         </mtd>
       </mtr>
@@ -431,9 +425,7 @@ We take a quadratic equation in its general form, and solve for x.
         </mtd>
         <mtd>
           <mrow>
-            <mtext style="color: red; font-size: smaller">
-              There's the vertex formula.
-            </mtext>
+            <mtext style="color: red; font-size: smaller">There's the vertex formula.</mtext>
           </mrow>
         </mtd>
       </mtr>

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -16,6 +16,7 @@ This page outlines the proof of the [Pythagorean theorem](https://en.wikipedia.o
 
 {{ EmbedLiveSample("Proof", "", "100px") }}
 
+<!-- prettier-ignore-start -->
 ```html
 <math display="block">
   <semantics>
@@ -112,9 +113,13 @@ This page outlines the proof of the [Pythagorean theorem](https://en.wikipedia.o
     </mtable>
     <!-- Representation in TeX format -->
     <annotation encoding="application/x-tex">
-      \begin{align*} (a + b)^2 &= c^2 + 4 \cdot \left( \frac{1}{2} ab \right) \\
-      a^2 + 2ab + b^2 &= c^2 + 2ab \\ a^2 + b^2 &= c^2 \end{align*}
+      \begin{aligned}
+      (a + b)^2 &= c^2 + 4 \cdot \left( \frac{1}{2} ab \right) \\
+      a^2 + 2ab + b^2 &= c^2 + 2ab \\
+      a^2 + b^2 &= c^2
+      \end{aligned}
     </annotation>
   </semantics>
 </math>
 ```
+<!-- prettier-ignore-end -->

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -6,14 +6,115 @@ page-type: guide
 
 {{MathMLRef}}
 
-We will now prove the [Pythagorean theorem](https://en.wikipedia.org/wiki/Pythagorean_theorem):
+This page outlines the proof of the [Pythagorean theorem](https://en.wikipedia.org/wiki/Pythagorean_theorem). Three equations are organized in the {{MathMLElement("mtable")}} element to align the steps of the proof by the equal sign. The proof is also represented in [LaTeX](https://www.latex-project.org/) format in the {{MathMLElement("annotation")}} element.
 
-**Statement**: In a right triangle, the square of the hypotenuse is equal to the sum of the squares of the other two sides. Specifically, if <math><mi>a</mi></math> and <math><mi>b</mi></math> are the legs and <math><mi>c</mi></math> is the hypotenuse, then <math><semantics><mrow><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup><mo>=</mo><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="TeX">a^2 + b^2 = c^2</annotation></semantics></math>.
+## Proof
+
+**Statement:** In a right triangle, the square of the hypotenuse is equal to the sum of the squares of the other two sides. Specifically, if <math><mi>a</mi></math> and <math><mi>b</mi></math> are the legs and <math><mi>c</mi></math> is the hypotenuse, then <math><semantics><mrow><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup><mo>=</mo><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="application/x-tex">a^2 + b^2 = c^2</annotation></semantics></math>.
 
 **Proof:** We can prove the theorem algebraically by showing that on [this figure](https://www.cut-the-knot.org/pythagoras/proof31.gif) the area of the big square equals the area of the inner square (hypotenuse squared) plus the area of the four triangles:
 
-<!-- prettier-ignore-start -->
+{{ EmbedLiveSample("Proof", "", "100px") }}
+
+```html
 <math display="block">
-  <semantics><mtable><mtr><mtd><msup><mrow><mo>(</mo><mi>a</mi><mo>+</mo><mi>b</mi><mo>)</mo></mrow><mn>2</mn></msup></mtd><mtd><mo>=</mo></mtd><mtd><msup><mi>c</mi><mn>2</mn></msup><mo>+</mo><mn>4</mn><mo>⋅</mo><mo>(</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><mi>a</mi><mi>b</mi><mo>)</mo></mtd></mtr><mtr><mtd><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><mn>2</mn><mi>a</mi><mi>b</mi><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></mtd><mtd><mo>=</mo></mtd><mtd><msup><mi>c</mi><mn>2</mn></msup><mo>+</mo><mn>2</mn><mi>a</mi><mi>b</mi></mtd></mtr><mtr><mtd><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></mtd><mtd><mo>=</mo></mtd><mtd><msup><mi>c</mi><mn>2</mn></msup></mtd></mtr></mtable><annotation encoding="TeX">\begin{align*} (a + b)^2 &= c^2 + 4 \cdot \left( \frac{1}{2} ab \right) \\ a^2 + 2ab + b^2 &= c^2 + 2ab \\ a^2 + b^2 &= c^2 \end{align*}</annotation></semantics>
+  <semantics>
+    <mtable>
+      <!-- Step one -->
+      <mtr>
+        <mtd>
+          <msup>
+            <mrow>
+              <mo>(</mo>
+              <mi>a</mi>
+              <mo>+</mo>
+              <mi>b</mi>
+              <mo>)</mo>
+            </mrow>
+            <mn>2</mn>
+          </msup>
+        </mtd>
+        <mtd>
+          <mo>=</mo>
+        </mtd>
+        <mtd>
+          <msup>
+            <mi>c</mi>
+            <mn>2</mn>
+          </msup>
+          <mo>+</mo>
+          <mn>4</mn>
+          <mo>⋅</mo>
+          <mo>(</mo>
+          <mfrac>
+            <mn>1</mn>
+            <mn>2</mn>
+          </mfrac>
+          <mi>a</mi>
+          <mi>b</mi>
+          <mo>)</mo>
+        </mtd>
+      </mtr>
+      <!-- Step two -->
+      <mtr>
+        <mtd>
+          <msup>
+            <mi>a</mi>
+            <mn>2</mn>
+          </msup>
+          <mo>+</mo>
+          <mn>2</mn>
+          <mi>a</mi>
+          <mi>b</mi>
+          <mo>+</mo>
+          <msup>
+            <mi>b</mi>
+            <mn>2</mn>
+          </msup>
+        </mtd>
+        <mtd>
+          <mo>=</mo>
+        </mtd>
+        <mtd>
+          <msup>
+            <mi>c</mi>
+            <mn>2</mn>
+          </msup>
+          <mo>+</mo>
+          <mn>2</mn>
+          <mi>a</mi>
+          <mi>b</mi>
+        </mtd>
+      </mtr>
+      <!-- Step three -->
+      <mtr>
+        <mtd>
+          <msup>
+            <mi>a</mi>
+            <mn>2</mn>
+          </msup>
+          <mo>+</mo>
+          <msup>
+            <mi>b</mi>
+            <mn>2</mn>
+          </msup>
+        </mtd>
+        <mtd>
+          <mo>=</mo>
+        </mtd>
+        <mtd>
+          <msup>
+            <mi>c</mi>
+            <mn>2</mn>
+          </msup>
+        </mtd>
+      </mtr>
+    </mtable>
+    <!-- Representation in TeX format -->
+    <annotation encoding="application/x-tex">
+      \begin{align*} (a + b)^2 &= c^2 + 4 \cdot \left( \frac{1}{2} ab \right) \\
+      a^2 + 2ab + b^2 &= c^2 + 2ab \\ a^2 + b^2 &= c^2 \end{align*}
+    </annotation>
+  </semantics>
 </math>
-<!-- prettier-ignore-end -->
+```


### PR DESCRIPTION
### Description

- Adds a short intro explaining the example.
- Uses Playground and shows the code.
- Highlights the steps with comments.
- Uses `font-size: smaller` for inline annotations (it nicely aligns with the `\small` key in TeX).
- Adds TeX annotations.

### Motivation

To make examples more useful and allow playing with them.