### PR TITLE
Link to specific referenced subsection instead of containing article

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -234,7 +234,7 @@ false.true = ""; // TypeError
 
 #### Duplicate property names
 
-Duplicate property names used to be considered a {{jsxref("SyntaxError")}} in strict mode. With the introduction of [computed property names](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer), making duplication possible at runtime, this restriction was removed in ES2015.
+Duplicate property names used to be considered a {{jsxref("SyntaxError")}} in strict mode. With the introduction of [computed property names](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names), making duplication possible at runtime, this restriction was removed in ES2015.
 
 ```js
 "use strict";


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
A link referencing "Computed property names" could link to the specific subsection for the topic instead of the "Object initializer" article which contains it.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I was reading the [Strict mode > Duplicate property names](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#duplicate_property_names) section, followed the link to computed property names, and landed at the [Object initializer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) page. I had to spend some time on the article before I realized there was a specific [Computed property names](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names) subsection that I was looking for. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
The [Strict mode > Duplicate property names](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#duplicate_property_names) section references computed property names, but does not directly link to the subsection. By linking directly to the subsection, readers can more quickly access the referenced material.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
None that I am aware of.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
