### PR TITLE
add: SVGAElement href property

### DIFF
--- a/files/en-us/web/api/svgaelement/href/index.md
+++ b/files/en-us/web/api/svgaelement/href/index.md
@@ -14,7 +14,7 @@ This property enables access to the URI set for a link within an SVG document.
 
 ## Value
 
-An {{domxref("SVGAnimatedString")}} indicating the value of the href attribute. Additionally, for elements defined to support it, it reflects the value of the {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute when the href attribute is not set.
+A {{domxref("SVGAnimatedString")}} indicating the value of the href attribute. Additionally, for elements defined to support it, it reflects the value of the {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute when the href attribute is not set.
 
 ## Examples
 

--- a/files/en-us/web/api/svgaelement/href/index.md
+++ b/files/en-us/web/api/svgaelement/href/index.md
@@ -1,0 +1,44 @@
+---
+title: "SVGAElement: href property"
+short-title: href
+slug: Web/API/SVGAElement/href
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.href
+---
+
+{{APIRef("SVG")}}
+
+The **`SVGAElement.href`** read-only property of the {{domxref("SVGAElement")}} returns an {{domxref("SVGAnimatedString")}} object reflecting the value of the href attribute, and, in certain cases, the {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute. It specifies the target URI associated with the link.
+
+This property enables access to the URI set for a link within an SVG document.
+
+## Value
+
+An {{domxref("SVGAnimatedString")}} indicating the value of the href attribute. Additionally, for elements defined to support it, it reflects the value of the {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute when the href attribute is not set.
+
+## Examples
+
+```js
+// Select an SVG <a> element
+const svgLink = document.querySelector("a");
+
+// Access the href property
+console.log(svgLink.href.baseVal); // Logs the base URI
+console.log(svgLink.href.animVal); // Logs the animated URI if applicable
+
+// Example: Reflecting xlink:href
+const deprecatedLink = document.querySelector("a");
+console.log(deprecatedLink.href.baseVal); // Reflects 'xlink:href' if 'href' is not set
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{ SVGAttr("href") }}

--- a/files/en-us/web/api/svgaelement/href/index.md
+++ b/files/en-us/web/api/svgaelement/href/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.href
 
 {{APIRef("SVG")}}
 
-The **`SVGAElement.href`** read-only property of the {{domxref("SVGAElement")}} returns an {{domxref("SVGAnimatedString")}} object reflecting the value of the href attribute, and, in certain cases, the {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute. It specifies the target URI associated with the link.
+The **`href`** read-only property of the {{domxref("SVGAElement")}} returns an {{domxref("SVGAnimatedString")}} object reflecting the value of the href attribute, and, in certain cases, the {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute. It specifies the target URI associated with the link.
 
 This property enables access to the URI set for a link within an SVG document.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added documentation for the **`SVGAElement.href`** property. This new feature page explains its value, usage, and behavior, including its interaction with the deprecated `xlink:href` attribute.

### Motivation

This update is part of a mission to document all 378 widely available SVG feature pages on MDN Web Docs. The goal is to ensure developers have access to comprehensive and accurate information about SVG, enabling them to use these features effectively in modern web development. [Spreadsheet](https://docs.google.com/spreadsheets/d/1O9tOVsZDF26A8Rag38rAhGWRH5l6VTbDCJIknyKzO_0/edit?gid=276647839#gid=276647839) contains all the pages needed to be documented.

### Additional details

The `href` property is part of the [SVGURIReference mixin](https://www.w3.org/TR/SVG2/struct.html#InterfaceSVGURIReference). 

### Related issues and pull requests

- Relates to [#214 in OpenWebDocs](https://github.com/openwebdocs/project/issues/214), as part of the effort to fill gaps in MDN's SVG documentation.
