### PR TITLE
fix(css): the broken image icon will always been displayed

### DIFF
--- a/files/en-us/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/en-us/web/css/-moz-force-broken-image-icon/index.md
@@ -55,7 +55,7 @@ img {
 {{EmbedLiveSample('Examples','125','125')}}
 
 > [!NOTE]
-> Unless the image has a specified height and width the broken image icon will not be displayed but the alt attribute will also be hidden if `-moz-force-broken-image-icon` is set to `1`.
+> Unless the image has a specified height and width the alt attribute will not be displayed if `-moz-force-broken-image-icon` is set to `1`.
 
 ## Notes
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The broken image icon will always been displayed even if the `height` and the `width` properties are not set.

See the test on Firefox 131:

#### With out the sets of `height` and `width` properties

![image](https://github.com/user-attachments/assets/369fe2f4-2bda-4ccc-ad0d-311f5dbdd45c)

#### With the `height` and `width` properties set

![image](https://github.com/user-attachments/assets/fae2d462-f9a3-45d0-acaf-99c767fbb3e8)

I'm not sure from which firefox version this behavior change started. But the link to [Firefox bug 58646](https://bugzil.la/58646) in the "See Also" section shows that the display problem of the "broken image" icon has been fixed for a long time.

### Related issues and pull requests

Downstream PR: mdn/translated-content#24650
