### PR TITLE
Fix singular form in 'Web/JavaScript/Reference/Global_Objects/Intl/PluralRules' example 

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.md
@@ -25,8 +25,8 @@ This allows construction of sentences that make sense in English for each case, 
 Creating appropriate sentences for each form depends on the language, and even in English may not be as simple as just adding "s" to a noun to make the plural form.
 Using the example above, we see that the form may affect:
 
-- **Nouns**: 1 dogs/2 dogs (but not "fish" or "sheep", which have the same singular and plural form).
-- **Verbs**: 1 dog _is_ happy, 2 dogs _are_ happy
+- **Nouns**: 1 dog, 2 dogs (but not "fish" or "sheep", which have the same singular and plural form).
+- **Verbs**: 1 dog _is_ happy, 2 dogs _are_ happy.
 - **Pronouns** (and other referents): Do you want to play with _it_ / _them_.
 
 Other languages have more forms, and choosing appropriate sentences can be even more complex.


### PR DESCRIPTION
### Description

This PR fixes singular form in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules example.

### Related issues and pull requests

Fixes #36944