### PR TITLE
Improve label examples in `Web/HTML/Global_attributes/enterkeyhint`

### DIFF
--- a/files/en-us/web/html/global_attributes/enterkeyhint/index.md
+++ b/files/en-us/web/html/global_attributes/enterkeyhint/index.md
@@ -44,49 +44,37 @@ The `enterkeyhint` attribute is an [enumerated](/en-US/docs/Glossary/Enumerated)
     <tr>
       <td><code>enterkeyhint="enter"</code></td>
       <td>Typically inserting a new line.</td>
-      <td><kbd>↵</kbd></td>
+      <td><kbd>return</kbd>, <kbd>↵</kbd></td>
     </tr>
     <tr>
       <td><code>enterkeyhint="done"</code></td>
-      <td>
-        Typically meaning there is nothing more to input and the input method
-        editor (IME) will be closed.
-      </td>
-      <td><kbd>Done</kbd></td>
+      <td>Typically meaning there is nothing more to input and the input method editor (IME) will be closed.</td>
+      <td><kbd>done</kbd>, <kbd>✅</kbd></td>
     </tr>
     <tr>
       <td><code>enterkeyhint="go"</code></td>
-      <td>
-        Typically meaning to take the user to the target of the text they typed.
-      </td>
-      <td><kbd>Open</kbd></td>
+      <td>Typically meaning to take the user to the target of the text they typed.</td>
+      <td><kbd>go</kbd>, <kbd>🡢</kbd></td>
     </tr>
     <tr>
       <td><code>enterkeyhint="next"</code></td>
-      <td>
-        Typically taking the user to the next field that will accept text.
-      </td>
-      <td><kbd>Next</kbd></td>
+      <td>Typically taking the user to the next field that will accept text.</td>
+      <td><kbd>next</kbd>, <kbd>⇥</kbd></td>
     </tr>
     <tr>
       <td><code>enterkeyhint="previous"</code></td>
-      <td>
-        Typically taking the user to the previous field that will accept text.
-      </td>
-      <td><kbd>Previous</kbd></td>
+      <td>Typically taking the user to the previous field that will accept text.</td>
+      <td><kbd>return</kbd>, <kbd>⇤</kbd></td>
     </tr>
     <tr>
       <td><code>enterkeyhint="search"</code></td>
-      <td>
-        Typically taking the user to the results of searching for the text they
-        have typed.
-      </td>
-      <td><kbd>Search</kbd></td>
+      <td>Typically taking the user to the results of searching for the text they have typed.</td>
+      <td><kbd>search</kbd>, <kbd>🔍</kbd></td>
     </tr>
     <tr>
       <td><code>enterkeyhint="send"</code></td>
       <td>Typically delivering the text to its target.</td>
-      <td><kbd>Send</kbd></td>
+      <td><kbd>send</kbd></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
### Description

This PR improves label examples in `Web/HTML/Global_attributes/enterkeyhint`: 
* use more realistic text for iOS,
* add relevant icons for Adnroid.

### Related issues and pull requests

Fixes #36941