### PR TITLE
Update redundant regexp example for identifier name

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -199,7 +199,8 @@ By providing the `d` flag, the indices of each capturing group is returned. This
 const code = `function add(x, y) {
   return x + y;
 }`;
-const functionRegexp = /(function\s+)(?<name>[$_\p{ID_Start}][$\p{ID_Continue}]*)/du;
+const functionRegexp =
+  /(function\s+)(?<name>[$_\p{ID_Start}][$\p{ID_Continue}]*)/du;
 const match = functionRegexp.exec(code);
 const lines = code.split("\n");
 lines.splice(

--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -199,8 +199,7 @@ By providing the `d` flag, the indices of each capturing group is returned. This
 const code = `function add(x, y) {
   return x + y;
 }`;
-const functionRegexp =
-  /(function\s+)(?<name>[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*)/du;
+const functionRegexp = /(function\s+)(?<name>[$_\p{ID_Start}][$\p{ID_Continue}]*)/du;
 const match = functionRegexp.exec(code);
 const lines = code.split("\n");
 lines.splice(

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -164,7 +164,7 @@ In JavaScript, identifiers are commonly made of alphanumeric characters, undersc
 - After the first character, you can use any character in the [ID_Continue](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Continue%7D) category plus U+200C (ZWNJ) and U+200D (ZWJ).
 
 > [!NOTE]
-> If, for some reason, you need to parse some JavaScript source yourself, do not assume all identifiers follow the pattern `/[A-Za-z_$][\w$]*/` (i.e. ASCII-only)! The range of identifiers can be described by the regex `/[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*/u` (excluding unicode escape sequences).
+> If, for some reason, you need to parse some JavaScript source yourself, do not assume all identifiers follow the pattern `/[A-Za-z_$][\w$]*/` (i.e. ASCII-only)! The range of identifiers can be described by the regex `/[$_\p{ID_Start}][$\p{ID_Continue}]*/u` (excluding unicode escape sequences).
 
 In addition, JavaScript allows using [Unicode escape sequences](#unicode_escape_sequences) in the form of `\u0000` or `\u{000000}` in identifiers, which encode the same string value as the actual Unicode characters. For example, `你好` and `\u4f60\u597d` are the same identifiers:
 

--- a/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
@@ -91,8 +91,7 @@ The following example matches any [identifier](/en-US/docs/Web/JavaScript/Refere
 
 ```js
 function isValidIdentifierName(str) {
-  const re =
-    /^(?!(?:break|case|catch)$)[$_\p{ID_Start}][$\p{ID_Continue}]*$/u;
+  const re = /^(?!(?:break|case|catch)$)[$_\p{ID_Start}][$\p{ID_Continue}]*$/u;
   return re.test(str);
 }
 

--- a/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
@@ -87,12 +87,12 @@ A similar effect can be achieved by [capturing](/en-US/docs/Web/JavaScript/Refer
 
 Using lookahead, you can match a string multiple times with different patterns, which allows you to express complex relationships like subtraction (is X but not Y) and intersection (is both X and Y).
 
-The following example matches any [identifier](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) that's not a [reserved word](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) (only showing three reserved words here for brevity; more reserved words can be added to this disjunction). The `[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*` syntax describes exactly the set of identifier strings in the language spec; you can read more about identifiers in [lexical grammar](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) and the `\p` escape in [Unicode character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape).
+The following example matches any [identifier](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) that's not a [reserved word](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) (only showing three reserved words here for brevity; more reserved words can be added to this disjunction). The `[$_\p{ID_Start}][$\p{ID_Continue}]*` syntax describes exactly the set of identifier strings in the language spec; you can read more about identifiers in [lexical grammar](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) and the `\p` escape in [Unicode character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape).
 
 ```js
 function isValidIdentifierName(str) {
   const re =
-    /^(?!(?:break|case|catch)$)[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u;
+    /^(?!(?:break|case|catch)$)[$_\p{ID_Start}][$\p{ID_Continue}]*$/u;
   return re.test(str);
 }
 


### PR DESCRIPTION
### Description

Update redundant regexp example.

### Motivation

According to https://github.com/tc39/ecma262/pull/3074 , `ID_Continue` contains `<ZWJ>(U+200C)` and `<ZWNJ>(U+200D)`.