### PR TITLE
FF134 Relnote: Intl.Duration supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/134/index.md
+++ b/files/en-us/mozilla/firefox/releases/134/index.md
@@ -22,6 +22,8 @@ This article provides information about the changes in Firefox 134 that affect d
 
 ### JavaScript
 
+- {{jsxref("Intl.DurationFormat")}} is supported, enabling locale-sensitive formatting of durations. ([Firefox bug 1648139](https://bugzil.la/1648139)).
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
FF134 supports [`Intl.DurationFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat) in https://bugzilla.mozilla.org/show_bug.cgi?id=1648139. 

This PR adds a release note. Docs already exists.

Related docs work can be tracked in #36917