### PR TITLE
autocorrect HTML element typo

### DIFF
--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -127,7 +127,7 @@ if (!("autocorrect" in HTMLElement.prototype)) {
   log("autocorrect not supported");
 } else {
   log(`userNameElement.autocorrect: ${userNameElement.autocorrect}`);
-  log(`userNameElement.autocorrect: ${bioElement.autocorrect}`);
+  log(`bioElement.autocorrect: ${bioElement.autocorrect}`);
 }
 
 resetButton.addEventListener("click", (e) => {


### PR DESCRIPTION
Typo in example code for logged element label - part of #36919