### PR TITLE
Add gridcell role to td

### DIFF
--- a/files/en-us/web/html/element/td/index.md
+++ b/files/en-us/web/html/element/td/index.md
@@ -320,7 +320,16 @@ While the [visual result](#result_2) is unchanged from the [previous example tab
             >cell</a
           ></code
         >
-        if a descendant of a {{HTMLElement("table")}} element
+        if a descendant of a {{HTMLElement("table")}} element, and <code
+          ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role"
+            >gridcell</a
+          ></code
+        >
+        if a descendant of an element with <code
+          ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role"
+            >grid</a
+          ></code
+        > role
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/td/index.md
+++ b/files/en-us/web/html/element/td/index.md
@@ -320,7 +320,7 @@ While the [visual result](#result_2) is unchanged from the [previous example tab
             >cell</a
           ></code
         >
-        if a descendant of a {{HTMLElement("table")}} element, and <code
+        if a descendant of a {{HTMLElement("table")}} element, or <code
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role"
             >gridcell</a
           ></code


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds a mention of the `gridcell` implicit ARIA role for for `td` elements which are descendants of `role="grid"`.

### Motivation

Gridcell is an ARIA-sub-role which applies to any `cell` elements within a `grid` (and, e.g. the [w3 code sample for grid role](https://www.w3.org/WAI/ARIA/apg/patterns/grid/examples/data-grids/) all just use `td` elements with the explicit role), but MDN currently doesn't mention this on the `td` element descriptor page, which was confusing to me today when researching this. Hoping that adding this will make life a bit easier for future folks looking to implement a `grid` ARIA role. 

### Additional details

The ARIA description of gridcell as a subrole of `cell` applied when a `cell` is in a `grid` [is linked here](https://w3c.github.io/aria/#gridcell).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
