### PR TITLE
HTML autocorrect - clarify device-specific subsitutions

### DIFF
--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLElement.autocorrect
 
 The **`autocorrect`** property of the {{domxref("HTMLElement")}} interface controls whether or not autocorrection of editable text is enabled for spelling and/or punctuation errors.
 
-The specific autocorrection behaviour, including which words are substituted, depends on the user-agent and the services provided by the underlying device.
+The specific autocorrection behavior, including which words are substituted, depends on the user agent and the services provided by the underlying device.
 For example, on macOS a user agent might rely on [registered replacement text and punctuation](https://support.apple.com/en-vn/guide/mac-help/mh35735/mac).
 Other devices and browsers may use a different approach.
 

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -10,7 +10,11 @@ browser-compat: api.HTMLElement.autocorrect
 
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 
-The **`autocorrect`** property of the {{domxref("HTMLElement")}} interface controls whether or not user text input is automatically corrected for spelling and/or punctuation errors.
+The **`autocorrect`** property of the {{domxref("HTMLElement")}} interface controls whether or not autocorrection of editable text is enabled for spelling and/or punctuation errors.
+
+The specific autocorrection behaviour, including which words are substituted, depends on the user-agent and the services provided by the underlying device.
+For example, on macOS a user agent might rely on [registered replacement text and punctuation](https://support.apple.com/en-vn/guide/mac-help/mh35735/mac).
+Other devices and browsers may use a different approach.
 
 The property reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
 
@@ -88,8 +92,9 @@ if (`autocorrect` in HTMLElement.prototype) {
 
 <!-- cSpell:ignore Carot -->
 
-Activate the button to toggle the autocorrect value. Enter invalid text into the text box, such as "Carot".
-This should be corrected automatically when the feature is enabled.
+Activate the button to toggle the autocorrect value.
+Enter invalid text into the text box, such as "Carot".
+When the autocorrect is enabled, and if the implementation has the appropriate substitute word "carrot", the text should automatically be corrected.
 
 {{EmbedLiveSample("Enable and disable autocorrection", "100%", "200")}}
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -9,7 +9,11 @@ browser-compat: html.global_attributes.autocorrect
 
 {{HTMLSidebar("Global_attributes")}}{{SeeCompatTable}}
 
-The **`autocorrect`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that controls whether editable text is automatically corrected for spelling and/or punctuation errors.
+The **`autocorrect`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that controls whether autocorrection of editable text is enabled for spelling and/or punctuation errors.
+
+The specific autocorrection behaviour, including which words are substituted, depends on the user-agent and the services provided by the underlying device.
+For example, on macOS a user agent might rely on [registered replacement text and punctuation](https://support.apple.com/en-vn/guide/mac-help/mh35735/mac).
+Other devices and browsers may use a different approach.
 
 Autocorrection is relevant to editable text elements:
 
@@ -62,7 +66,8 @@ We include two text `<input>` elements with different values for their `autocorr
 {{EmbedLiveSample("Basic example", "100%", "75")}}
 
 Enter invalid text into the fruit and vegetable text entry boxes above.
-If auto-correction is enabled on your browser, a typo in a vegetable name should be auto-corrected, but not in a fruit name.
+If auto-correction is supported on your browser, and there is an appropriate substitution provided by the underlying device, a typo in a vegetable name input should be auto-corrected.
+Typos should not be corrected in the fruit name field.
 
 ### Enabling and disabling autocorrection
 
@@ -138,10 +143,12 @@ resetButton.addEventListener("click", (e) => {
 
 #### Results
 
-Enter invalid text into the name and biography text entry boxes below.
-If auto-correction is enabled on your browser (see the log below) the text in the "Biography" should be auto-corrected, but not in the "Name" box.
+If auto-correction is supported by your browser, the log area below the "Biography" and "Name" inputs should show that it is enabled for "Biography" inputs but not "Name" inputs.
 
 {{EmbedLiveSample("Enabling and disabling autocorrection", "100%", "250")}}
+
+Enter invalid text into the name and biography text entry boxes.
+If the device has a substitute for the entered word, this will be used to autocorrect text in the "Biography" input (only).
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -11,7 +11,7 @@ browser-compat: html.global_attributes.autocorrect
 
 The **`autocorrect`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that controls whether autocorrection of editable text is enabled for spelling and/or punctuation errors.
 
-The specific autocorrection behaviour, including which words are substituted, depends on the user-agent and the services provided by the underlying device.
+The specific autocorrection behavior, including which words are substituted, depends on the user agent and the services provided by the underlying device.
 For example, on macOS a user agent might rely on [registered replacement text and punctuation](https://support.apple.com/en-vn/guide/mac-help/mh35735/mac).
 Other devices and browsers may use a different approach.
 


### PR DESCRIPTION
FF134 adds support for the HTML [`autocorrect`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocorrect) attribute and [`HTMLElement.autocorrect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/autocorrect) property in https://bugzilla.mozilla.org/show_bug.cgi?id=1725806#c19 

This updates the docs to make it clear that while the mechanism for enabling autocorrection is specified, the underlying implementation depends on the user agent and its integration with native services.
That's a bit of a pain for the example, because I can't get this to work on Windows desktop, presumably because it doesn't have appropriate substitutions. It does work on MacOS. I can't test it on Android because there is no nightly release there on browserstack.

Related docs work can be tracked in https://github.com/mdn/content/issues/36919