### PR TITLE
Ff134 AudioParam.value - tidy

### DIFF
--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -8,29 +8,22 @@ browser-compat: api.AudioParam.value
 
 {{APIRef("Web Audio API")}}
 
-The [Web Audio API's](/en-US/docs/Web/API/Web_Audio_API)
-{{domxref("AudioParam")}} interface property **`value`** gets
-or sets the value of this {{domxref("AudioParam")}} at the current time. Initially, the value is set to {{domxref("AudioParam.defaultValue")}}.
+The [Web Audio API's](/en-US/docs/Web/API/Web_Audio_API) {{domxref("AudioParam")}} interface property **`value`** gets or sets the value of this {{domxref("AudioParam")}} at the current time.
+Initially, the value is set to {{domxref("AudioParam.defaultValue")}}.
 
-Setting `value` has the same effect as
-calling {{domxref("AudioParam.setValueAtTime")}} with the time returned by the
-`AudioContext`'s {{domxref("BaseAudioContext/currentTime", "currentTime")}}
-property.
+Setting `value` has the same effect as calling {{domxref("AudioParam.setValueAtTime")}} with the time returned by the `AudioContext`'s {{domxref("BaseAudioContext/currentTime", "currentTime")}} property.
 
 ## Value
 
-A floating-point {{jsxref("Number")}} indicating the parameter's value as of the
-current time. This value will be between the values specified by the
-{{domxref("AudioParam.minValue", "minValue")}} and {{domxref("AudioParam.maxValue", "maxValue")}} properties.
+A floating-point {{jsxref("Number")}} indicating the parameter's value as of the current time.
+This value will be between the values specified by the {{domxref("AudioParam.minValue", "minValue")}} and {{domxref("AudioParam.maxValue", "maxValue")}} properties.
 
 ## Usage notes
 
 ### Value precision and variation
 
-The data type used internally to store `value` is a single-precision
-(32-bit) floating point number, while JavaScript uses 64-bit double-precision floating
-point numbers. As a result, the value you read from the `value` property may
-not always exactly equal what you set it to.
+The data type used internally to store `value` is a single-precision (32-bit) floating point number, while JavaScript uses 64-bit double-precision floating point numbers.
+As a result, the value you read from the `value` property may not always exactly equal what you set it to.
 
 Consider this example:
 
@@ -41,11 +34,8 @@ source.playbackRate.value = rate;
 console.log(source.playbackRate.value === rate);
 ```
 
-The log output will be `false`, because the playback rate parameter,
-`rate`, was converted to the 32-bit floating-point number closest to 5.3,
-which yields 5.300000190734863. One solution is to use the {{jsxref("Math.fround()")}}
-method, which returns the single-precision value equivalent to the 64-bit JavaScript
-value specified—when setting `value`, like this:
+The log output will be `false`, because the playback rate parameter, `rate`, was converted to the 32-bit floating-point number closest to 5.3, which yields 5.300000190734863.
+One solution is to use the {{jsxref("Math.fround()")}} method, which returns the single-precision value equivalent to the 64-bit JavaScript value specified—when setting `value`, like this:
 
 ```js
 const source = new AudioBufferSourceNode(/* … */);
@@ -58,37 +48,21 @@ In this case, the log output will be `true`.
 
 ### Value of a property which is changing over time
 
-The `value` of an `AudioParam` can either be fixed or can vary
-over time. This is reflected by the `value` getter, which returns the value
-of the parameter as of the audio rendering engine's most recent **render
-quantum**, or moment at which audio buffers are processed and updated. In
-addition to processing audio buffers, each render quantum updates the `value`
-of each `AudioParam` as needed given the current time and any established
-time-based parameter value changes.
+The `value` of an `AudioParam` can either be fixed or can vary over time.
+This is reflected by the `value` getter, which returns the value of the parameter as of the audio rendering engine's most recent **render quantum**, or moment at which audio buffers are processed and updated.
+In addition to processing audio buffers, each render quantum updates the `value` of each `AudioParam` as needed given the current time and any established time-based parameter value changes.
 
-Upon first creating the parameter, its value is set to its default value, given by
-{{domxref("AudioParam.defaultValue")}}. This is the parameter's value at a time of 0.0
-seconds, and will remain the parameter's value until the first render quantum in which
-the value is altered.
+Upon first creating the parameter, its value is set to its default value, given by {{domxref("AudioParam.defaultValue")}}.
+This is the parameter's value at a time of 0.0 seconds, and will remain the parameter's value until the first render quantum in which the value is altered.
 
-During each render quantum, the browser does the following things related to managing
-the value of a parameter:
+During each render quantum, the browser does the following things related to managing the value of a parameter:
 
-- If the `value` setter has been used, the parameter's value is changed to
-  the value given.
-- If the current time equals or exceeds the time specified by a previous call to
-  {{domxref("AudioParam.setValueAtTime", "setValueAtTime()")}}, the `value`
-  is changed to the value passed into `setValueAtTime()`.
-- If any graduated or ramped value changing methods have been called and the current
-  time is within the time range over which the graduated change should occur, the value
-  is updated based on the appropriate algorithm. These ramped or graduated
-  value-changing methods include
-  {{domxref("AudioParam.linearRampToValueAtTime", "linearRampToValueAtTime()")}},
-  {{domxref("AudioParam.setTargetAtTime", "setTargetAtTime()")}}, and
-  {{domxref("AudioParam.setValueCurveAtTime", "setValueCurveAtTime()")}}.
+- If the `value` setter has been used, the parameter's value is changed to the value given.
+- If the current time equals or exceeds the time specified by a previous call to {{domxref("AudioParam.setValueAtTime", "setValueAtTime()")}}, the `value` is changed to the value passed into `setValueAtTime()`.
+- If any graduated or ramped value changing methods have been called and the current time is within the time range over which the graduated change should occur, the value is updated based on the appropriate algorithm.
+  These ramped or graduated value-changing methods include {{domxref("AudioParam.linearRampToValueAtTime", "linearRampToValueAtTime()")}}, {{domxref("AudioParam.setTargetAtTime", "setTargetAtTime()")}}, and {{domxref("AudioParam.setValueCurveAtTime", "setValueCurveAtTime()")}}.
 
-Thus, the `value` of a parameter is maintained to accurately reflect the
-state of the parameter over time.
+Thus, the `value` of a parameter is maintained to accurately reflect the state of the parameter over time.
 
 ## Examples
 
@@ -110,10 +84,9 @@ gainNode.gain.setValueAtTime(0.4, audioCtx.currentTime);
 
 {{Compat}}
 
-When changing the gain value of a {{domxref("GainNode")}}, Google Chrome prior to
-version 64 (January 2018) would perform a smooth interpolation to prevent dezippering.
-Starting with version 64, the value is changed instantly to bring it in line with the
-Web Audio spec. See [Chrome Platform Status](https://chromestatus.com/feature/5287995770929152) for details.
+When changing the gain value of a {{domxref("GainNode")}}, Google Chrome prior to version 64 (January 2018) would perform a smooth interpolation to prevent dezippering.
+Starting with version 64, the value is changed instantly to bring it in line with the Web Audio spec.
+See [Chrome Platform Status](https://chromestatus.com/feature/5287995770929152) for details.
 
 ## See also
 

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -8,7 +8,7 @@ browser-compat: api.AudioParam.value
 
 {{APIRef("Web Audio API")}}
 
-The [Web Audio API's](/en-US/docs/Web/API/Web_Audio_API) {{domxref("AudioParam")}} interface property **`value`** gets or sets the value of this {{domxref("AudioParam")}} at the current time.
+The **`value`** property of the {{domxref("AudioParam")}} interface gets or sets the value of this `AudioParam` at the current time.
 Initially, the value is set to {{domxref("AudioParam.defaultValue")}}.
 
 Setting `value` has the same effect as calling {{domxref("AudioParam.setValueAtTime")}} with the time returned by the `AudioContext`'s {{domxref("BaseAudioContext/currentTime", "currentTime")}} property.
@@ -18,7 +18,7 @@ Setting `value` has the same effect as calling {{domxref("AudioParam.setValueAtT
 A floating-point {{jsxref("Number")}} indicating the parameter's value as of the current time.
 This value will be between the values specified by the {{domxref("AudioParam.minValue", "minValue")}} and {{domxref("AudioParam.maxValue", "maxValue")}} properties.
 
-## Usage notes
+## Description
 
 ### Value precision and variation
 
@@ -83,10 +83,6 @@ gainNode.gain.setValueAtTime(0.4, audioCtx.currentTime);
 ## Browser compatibility
 
 {{Compat}}
-
-When changing the gain value of a {{domxref("GainNode")}}, Google Chrome prior to version 64 (January 2018) would perform a smooth interpolation to prevent dezippering.
-Starting with version 64, the value is changed instantly to bring it in line with the Web Audio spec.
-See [Chrome Platform Status](https://chromestatus.com/feature/5287995770929152) for details.
 
 ## See also
 


### PR DESCRIPTION
FF134 brings [`AudioParam.value`](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/value) to spec compliance (with a very old change).

This is just a tidy of the document (which was AFAIK broadly correct)
- Fix the initial description to match the template
- Remove/move compat information to browser compat data.

The first commit is pure layout change, so all you need to review is the second https://github.com/mdn/content/pull/36977/commits/9cf293f458cc6dd68fb2cc6df3c1aab9a09e082f


Related docs work can be tracked in #36916