### PR TITLE
FF134 Relnote: AudioParam.value can be set anytime

### DIFF
--- a/files/en-us/mozilla/firefox/releases/134/index.md
+++ b/files/en-us/mozilla/firefox/releases/134/index.md
@@ -44,6 +44,8 @@ This article provides information about the changes in Firefox 134 that affect d
 
 ### APIs
 
+- {{domxref("AudioParam.value")}} now allows the value to be set even during the time that an automated event is scheduled: previously the operation would silently be ignored at those times. ([Firefox bug 1308435](https://bugzil.la/1308435)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF134 brings [`AudioParam.value`](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/value) to spec compliance with removal of this line:

> If `value` is set during a time when there are any automation events scheduled then it will be ignored and no exception will be thrown.

This adds a release note. 

Related docs work can be tracked in #36916