### PR TITLE
chore(sidebars): format

### DIFF
--- a/files/sidebars/accessibilitysidebar.yaml
+++ b/files/sidebars/accessibilitysidebar.yaml
@@ -1,12 +1,14 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
-    title: Accessibility
     link: /Web/Accessibility
-  - details: closed
-    title: Guides
+    title: Accessibility
+  - title: Guides
+    details: closed
     children:
       - /Web/Accessibility/Information_for_Web_authors
-      - "/Web/Accessibility/Accessibility:_What_users_can_to_to_browse_safely"
+      - /Web/Accessibility/Accessibility:_What_users_can_to_to_browse_safely
       - /Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets
       - /Web/Accessibility/Keyboard-navigable_JavaScript_widgets
       - /Web/Accessibility/Mobile_accessibility_checklist
@@ -15,8 +17,8 @@ sidebar:
       - /Web/Accessibility/Accessibility_and_Spacial_Patterns
       - /Web/Accessibility/Understanding_Colors_and_Luminance
       - /Web/Accessibility/Seizure_disorders
-  - details: closed
-    title: Learn
+  - title: Learn
+    details: closed
     children:
       - /Learn/Accessibility/
       - /Learn/Accessibility/What_is_accessibility
@@ -27,15 +29,14 @@ sidebar:
       - /Learn/Accessibility/Mobile
       - /Learn/Accessibility/Accessibility_troubleshooting
   - type: listSubPages
-    details: closed
-    title: WCAG
     path: /en-US/docs/Web/Accessibility/Understanding_WCAG
-
+    title: WCAG
+    details: closed
   - type: section
-    title: ARIA
     link: Web/Accessibility/ARIA
-  - details: closed
-    title: ARIA_guides
+    title: ARIA
+  - title: ARIA_guides
+    details: closed
     children:
       - /Web/Accessibility/ARIA/ARIA_Guides
       - /Web/Accessibility/ARIA/ARIA_Live_Regions
@@ -44,14 +45,13 @@ sidebar:
       - /Web/Accessibility/ARIA/Multipart_labels
       - /Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs
   - type: listSubPages
-    details: closed
-    title: ARIA states and properties
     path: /en-US/docs/Web/Accessibility/ARIA/attributes
-  - type: listSubPages
+    title: ARIA states and properties
     details: closed
-    title: ARIA roles
+  - type: listSubPages
     path: /en-US/docs/Web/Accessibility/ARIA/roles
-
+    title: ARIA roles
+    details: closed
 l10n:
   en-US:
     Accessibility: Accessibility

--- a/files/sidebars/accessibilitysidebar.yaml
+++ b/files/sidebars/accessibilitysidebar.yaml
@@ -29,7 +29,7 @@ sidebar:
       - /Learn/Accessibility/Mobile
       - /Learn/Accessibility/Accessibility_troubleshooting
   - type: listSubPages
-    path: /en-US/docs/Web/Accessibility/Understanding_WCAG
+    path: /Web/Accessibility/Understanding_WCAG
     title: WCAG
     details: closed
   - type: section
@@ -45,11 +45,11 @@ sidebar:
       - /Web/Accessibility/ARIA/Multipart_labels
       - /Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs
   - type: listSubPages
-    path: /en-US/docs/Web/Accessibility/ARIA/attributes
+    path: /Web/Accessibility/ARIA/attributes
     title: ARIA states and properties
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/Accessibility/ARIA/roles
+    path: /Web/Accessibility/ARIA/roles
     title: ARIA roles
     details: closed
 l10n:

--- a/files/sidebars/addonsidebar.yaml
+++ b/files/sidebars/addonsidebar.yaml
@@ -1,8 +1,10 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Mozilla/Add-ons/WebExtensions
-  - details: closed
-    title: WebExtensions#Getting_started
+  - title: WebExtensions#Getting_started
+    details: closed
     children:
       - /Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
       - /Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
@@ -10,8 +12,8 @@ sidebar:
       - /Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
       - /Mozilla/Add-ons/WebExtensions/Examples
       - /Mozilla/Add-ons/WebExtensions/What_next
-  - details: closed
-    title: WebExtensions#Concepts
+  - title: WebExtensions#Concepts
+    details: closed
     children:
       - /Mozilla/Add-ons/WebExtensions/API
       - /Mozilla/Add-ons/WebExtensions/Content_scripts
@@ -23,8 +25,8 @@ sidebar:
       - /Mozilla/Add-ons/WebExtensions/Native_messaging
       - /Mozilla/Add-ons/WebExtensions/Differences_between_API_implementations
       - /Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
-  - details: closed
-    title: WebExtensions#User_Interface
+  - title: WebExtensions#User_Interface
+    details: closed
     children:
       - /Mozilla/Add-ons/WebExtensions/user_interface
       - /Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button
@@ -36,8 +38,8 @@ sidebar:
       - /Mozilla/Add-ons/WebExtensions/user_interface/Notifications
       - /Mozilla/Add-ons/WebExtensions/user_interface/Omnibox
       - /Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
-  - details: closed
-    title: WebExtensions#How_to
+  - title: WebExtensions#How_to
+    details: closed
     children:
       - /Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
       - /Mozilla/Add-ons/WebExtensions/Modify_a_web_page
@@ -55,11 +57,11 @@ sidebar:
   - type: webExtApi
     title: WebExtensions#API
   - type: listSubPages
+    path: /en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json
     title: WebExtensions#manifest.json
     details: closed
-    path: /en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json
-  - details: closed
-    title: extension_workshop
+  - title: extension_workshop
+    details: closed
     children:
       - link: https://extensionworkshop.com/documentation/develop/
         title: extension_workshop_develop
@@ -71,8 +73,8 @@ sidebar:
         title: extension_workshop_enterprise
   - type: section
     link: /Mozilla/Add-ons/Contact_us
-  - details: closed
-    title: Channels
+  - title: Channels
+    details: closed
     children:
       - link: https://blog.mozilla.org/addons
         title: Blog
@@ -80,7 +82,6 @@ sidebar:
         title: Forums
       - link: https://chat.mozilla.org/#/room/%23addons:mozilla.org
         title: Chat
-
 l10n:
   en-US:
     WebExtensions#Getting_started: Getting started

--- a/files/sidebars/addonsidebar.yaml
+++ b/files/sidebars/addonsidebar.yaml
@@ -57,7 +57,7 @@ sidebar:
   - type: webExtApi
     title: WebExtensions#API
   - type: listSubPages
-    path: /en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json
+    path: /Mozilla/Add-ons/WebExtensions/manifest.json
     title: WebExtensions#manifest.json
     details: closed
   - title: extension_workshop

--- a/files/sidebars/addonsidebarmain.yaml
+++ b/files/sidebars/addonsidebarmain.yaml
@@ -1,16 +1,16 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Mozilla/Add-ons/WebExtensions
-    text: WebExtensions
   - type: section
     link: https://extensionworkshop.com/documentation/themes/
     title: Themes
   - type: section
     link: https://discourse.mozilla.org/c/add-ons
     title: Community_and_Support
-
-  - details: closed
-    title: Channels
+  - title: Channels
+    details: closed
     children:
       - link: https://blog.mozilla.org/addons
         title: Blog
@@ -19,9 +19,8 @@ sidebar:
       - link: https://stackoverflow.com/questions/tagged/firefox-addon
         title: Stack_Overflow
       - link: /Mozilla/Add-ons
-        title: Contact_us
         hash: "#contact_us"
-
+        title: Contact_us
 l10n:
   en-US:
     WebExtensions: Browser extensions

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -79,49 +79,49 @@ sidebar:
   - type: section
     link: /Web/CSS/Reference
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Modules
     tags: css-module
     details: closed
   - type: listSubPagesGrouped
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Properties
     tags:
       - css-property
       - css-shorthand-property
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Selectors
     tags: css-selector
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Combinators
     tags: css-combinator
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Pseudo-classes
     tags: css-pseudo-class
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Pseudo-elements
     tags: css-pseudo-element
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: At-rules
     tags: css-at-rule
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Functions
     tags: css-function
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/CSS
+    path: /Web/CSS
     title: Types
     tags: css-type
     details: closed

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -1,3 +1,5 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/CSS
@@ -6,8 +8,8 @@ sidebar:
     link: /Learn/CSS
     title: Tutorials
   - /Learn/Getting_started_with_the_web/CSS_basics
-  - details: closed
-    title: CSS_first_steps
+  - title: CSS_first_steps
+    details: closed
     children:
       - link: /Learn/CSS/First_steps
         title: CSS first steps overview
@@ -17,8 +19,8 @@ sidebar:
       - /Learn/CSS/First_steps/How_CSS_works
       - link: /Learn/CSS/First_steps/styling_a_biography_page
         title: Assessment_Styling_a_biography_page
-  - details: closed
-    title: CSS_building_blocks
+  - title: CSS_building_blocks
+    details: closed
     children:
       - link: /Learn/CSS/Building_blocks
         title: CSS building blocks overview
@@ -45,8 +47,8 @@ sidebar:
         title: Assessment_Creating_fancy_letterheaded_paper
       - link: /Learn/CSS/Building_blocks/A_cool_looking_box
         title: Assessment_A_cool_looking_box
-  - details: closed
-    title: Styling_text
+  - title: Styling_text
+    details: closed
     children:
       - link: /Learn/CSS/Styling_text
         title: Styling_text_overview
@@ -56,8 +58,8 @@ sidebar:
       - /Learn/CSS/Styling_text/Web_fonts
       - link: /Learn/CSS/Styling_text/Typesetting_a_homepage
         title: Assessment_Typesetting_a_community_school_homepage
-  - details: closed
-    title: CSS_layout
+  - title: CSS_layout
+    details: closed
     children:
       - link: /Learn/CSS/CSS_layout
         title: CSS_layout_overview
@@ -125,31 +127,31 @@ sidebar:
     details: closed
   - type: section
     title: Guides
-  - details: closed
-    title: Animations
+  - title: Animations
+    details: closed
     children:
       - /Web/CSS/CSS_Animations/Using_CSS_animations
-  - details: closed
-    title: Backgrounds_and_Borders
+  - title: Backgrounds_and_Borders
+    details: closed
     children:
       - /Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
       - link: /Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images
         title: Resizing_background_images
-  - details: closed
-    title: Box alignment
+  - title: Box alignment
+    details: closed
     children:
       - link: /Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Block_Abspos_Tables
         title: Box_alignment_in_block_layout
       - /Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox
       - /Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Grid_Layout
       - /Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Multi-column_Layout
-  - details: closed
-    title: Box_model
+  - title: Box_model
+    details: closed
     children:
       - /Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
       - /Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
-  - details: closed
-    title: Colors
+  - title: Colors
+    details: closed
     children:
       - link: /Web/CSS/CSS_colors/Applying_color
         title: Applying_color_to_HTML_elements
@@ -160,30 +162,30 @@ sidebar:
         title: Accessibility_Understanding_colors_and_luminance"
       - link: /Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
         title: Color_contrast
-  - details: closed
-    title: Columns
+  - title: Columns
+    details: closed
     children:
       - /Web/CSS/CSS_Multicol_Layout/Basic_concepts
       - /Web/CSS/CSS_Multicol_Layout/Styling_columns
       - /Web/CSS/CSS_Multicol_Layout/Spanning_balancing_columns
       - /Web/CSS/CSS_Multicol_Layout/Handling_overflow_in_multicol_layout
       - /Web/CSS/CSS_Multicol_Layout/Handling_content_breaks_in_multicol_layout
-  - details: closed
-    title: Conditional_rules
+  - title: Conditional_rules
+    details: closed
     children:
       - /Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries
-  - details: closed
-    title: Containment
+  - title: Containment
+    details: closed
     children:
       - /Web/CSS/CSS_Containment/Using_CSS_containment
       - /Web/CSS/CSS_Containment/Container_queries
       - /Web/CSS/CSS_Containment/Container_size_and_style_queries
-  - details: closed
-    title: CSSOM_view
+  - title: CSSOM_view
+    details: closed
     children:
       - /Web/CSS/CSSOM_View/Coordinate_systems
-  - details: closed
-    title: Flexbox
+  - title: Flexbox
+    details: closed
     children:
       - /Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
       - /Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods
@@ -192,21 +194,21 @@ sidebar:
       - /Web/CSS/CSS_Flexible_Box_Layout/Controlling_ratios_of_flex_items_along_the_main_axis
       - /Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items
       - /Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
-  - details: closed
-    title: Flow_layout
+  - title: Flow_layout
+    details: closed
     children:
       - /Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow
       - /Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
       - /Web/CSS/CSS_Flow_Layout/Introduction_to_formatting_contexts
       - /Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes
       - /Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow
-  - details: closed
-    title: Fonts
+  - title: Fonts
+    details: closed
     children:
       - /Web/CSS/CSS_Fonts/OpenType_fonts_guide
       - /Web/CSS/CSS_Fonts/Variable_Fonts_Guide
-  - details: closed
-    title: Grid
+  - title: Grid
+    details: closed
     children:
       - /Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
       - /Web/CSS/CSS_Grid_Layout/Relationship_of_grid_layout_with_other_layout_methods
@@ -221,65 +223,64 @@ sidebar:
       - /Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_grids
       - /Web/CSS/CSS_Grid_Layout/Subgrid
       - /Web/CSS/CSS_Grid_Layout/Masonry_Layout
-  - details: closed
-    title: Images
+  - title: Images
+    details: closed
     children:
       - /Web/CSS/CSS_Images/Using_CSS_gradients
-  - details: closed
-    title: Lists_and_counters
+  - title: Lists_and_counters
+    details: closed
     children:
       - /Web/CSS/CSS_Counter_Styles/Using_CSS_counters
       - /Web/CSS/CSS_Lists/Consistent_list_indentation
-  - details: closed
-    title: Logical_properties
+  - title: Logical_properties
+    details: closed
     children:
-      - >-
-        /Web/CSS/CSS_Logical_Properties_and_Values/Basic_concepts_of_logical_properties_and_values
+      - /Web/CSS/CSS_Logical_Properties_and_Values/Basic_concepts_of_logical_properties_and_values
       - /Web/CSS/CSS_Logical_Properties_and_Values/Floating_and_positioning
       - /Web/CSS/CSS_Logical_Properties_and_Values/Margins_borders_padding
       - /Web/CSS/CSS_Logical_Properties_and_Values/Sizing
-  - details: closed
-    title: Math_functions
+  - title: Math_functions
+    details: closed
     children:
       - /Web/CSS/CSS_Functions/Using_CSS_math_functions
-  - details: closed
-    title: Media_queries
+  - title: Media_queries
+    details: closed
     children:
       - /Web/CSS/CSS_Media_Queries/Using_media_queries
       - /Web/CSS/CSS_Media_Queries/Using_Media_Queries_for_Accessibility
       - /Web/CSS/CSS_Media_Queries/Testing_media_queries
       - /Web/CSS/CSS_Media_Queries/Printing
-  - details: closed
-    title: Nesting
+  - title: Nesting
+    details: closed
     children:
       - /Web/CSS/CSS_Nesting/Using_CSS_nesting
       - /Web/CSS/CSS_Nesting/Nesting_at-rules
       - /Web/CSS/CSS_Nesting/Nesting_and_specificity
-  - details: closed
-    title: Positioning
+  - title: Positioning
+    details: closed
     children:
       - /Web/CSS/CSS_Positioned_Layout/Understanding_z-index
-  - details: closed
-    title: Scroll_snap
+  - title: Scroll_snap
+    details: closed
     children:
       - /Web/CSS/CSS_Scroll_Snap/Basic_concepts
-  - details: closed
-    title: Shapes
+  - title: Shapes
+    details: closed
     children:
       - /Web/CSS/CSS_Shapes/Overview_of_Shapes
       - /Web/CSS/CSS_Shapes/From_box_values
       - /Web/CSS/CSS_Shapes/Basic_Shapes
       - /Web/CSS/CSS_Shapes/Shapes_From_Images
-  - details: closed
-    title: Text
+  - title: Text
+    details: closed
     children:
       - /Web/CSS/CSS_Text/Wrapping_Breaking_Text
-  - details: closed
-    title: Transforms
+  - title: Transforms
+    details: closed
     children:
       - /Web/CSS/CSS_Transforms/Using_CSS_transforms
-  - details: closed
-    title: Transitions
+  - title: Transitions
+    details: closed
     children:
       - /Web/CSS/CSS_Transitions/Using_CSS_transitions
   - type: section

--- a/files/sidebars/firefoxsidebar.yaml
+++ b/files/sidebars/firefoxsidebar.yaml
@@ -1,23 +1,22 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
-  - details: closed
-    title: Firefox_releases
+  - title: Firefox_releases
+    details: closed
     children:
       - link: /Mozilla/Firefox/Releases
         title: Firefox_release_notes_developer
       - link: /Mozilla/Firefox/Experimental_features
         title: Experimental_features_firefox
-
-  - details: closed
-    title: Add-ons
+  - title: Add-ons
+    details: closed
     children:
       - link: /Mozilla/Add-ons/WebExtensions
         title: Browser_extensions
       - link: https://extensionworkshop.com/documentation/themes
         title: Themes
-
   - link: https://firefox-source-docs.mozilla.org/
     title: Firefox_documentation
-
 l10n:
   en-US:
     Firefox_releases: Firefox releases
@@ -29,7 +28,7 @@ l10n:
     Firefox_documentation: Firefox documentation
   es:
     Firefox_releases: Lanzamientos de Firefox
-    Firefox_release_notes_developer: "Notas de lanzamiento de Firefox, para desarrolladores"
+    Firefox_release_notes_developer: Notas de lanzamiento de Firefox, para desarrolladores
     Experimental_features_firefox: Caracteristicas experimentales en Firefox
     Add-ons: Complementos
     Browser_extensions: Extensiones del navegador

--- a/files/sidebars/gamessidebar.yaml
+++ b/files/sidebars/gamessidebar.yaml
@@ -1,3 +1,5 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - title: Introduction
     details: closed
@@ -6,7 +8,6 @@ sidebar:
         title: Introduction
       - link: /Games/Anatomy
         title: Anatomy
-
   - title: APIs_for_game_development
     details: closed
     children:
@@ -42,7 +43,6 @@ sidebar:
         title: Web_Workers
       - link: /Web/API/XMLHttpRequest
         title: XMLHttpRequest
-
   - title: Techniques
     details: closed
     children:
@@ -58,7 +58,6 @@ sidebar:
         title: 2D_collision_detection
       - link: /Games/Techniques/Tilemaps
         title: Tiles_and_tilemaps_overview
-
   - title: 3D_games_on_the_Web
     details: closed
     children:
@@ -80,7 +79,6 @@ sidebar:
         title: 3D_collision_detection
       - link: /Games/Techniques/3D_collision_detection/Bounding_volume_collision_detection_with_THREE.js
         title: Bounding_volume_collision_detection_with_THREE.js
-
   - title: Implementing_game_control_mechanisms
     details: closed
     children:
@@ -94,7 +92,6 @@ sidebar:
         title: Desktop_with_gamepad
       - link: /Games/Techniques/Control_mechanisms/Other
         title: Other
-
   - title: Tutorials
     details: closed
     children:
@@ -106,7 +103,6 @@ sidebar:
         title: 2D_maze_game_with_device_orientation
       - link: https://mozdevs.github.io/html5-games-workshop/en/guides/platformer/start-here/
         title: 2D_platform_game_using_Phaser
-
   - title: Publishing_games
     details: closed
     children:
@@ -118,7 +114,6 @@ sidebar:
         title: Game_promotion
       - link: /Games/Publishing_games/Game_monetization
         title: Game_monetization
-
 l10n:
   en-US:
     Introduction: Introduction

--- a/files/sidebars/glossarysidebar.yaml
+++ b/files/sidebars/glossarysidebar.yaml
@@ -5,4 +5,4 @@ sidebar:
     link: /Glossary
     title: Glossary
   - type: listSubPages
-    path: /en-US/docs/Glossary
+    path: /Glossary

--- a/files/sidebars/glossarysidebar.yaml
+++ b/files/sidebars/glossarysidebar.yaml
@@ -1,3 +1,5 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Glossary

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -1,3 +1,5 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/HTML
@@ -6,9 +8,8 @@ sidebar:
     title: Tutorials
   - link: /Learn/Getting_started_with_the_web/HTML_basics
     title: HTML_basics
-
-  - details: closed
-    title: Introduction_to_HTML
+  - title: Introduction_to_HTML
+    details: closed
     children:
       - link: /Learn/HTML/Introduction_to_HTML
         title: Introduction_to_HTML_overview
@@ -30,9 +31,8 @@ sidebar:
         title: Assessment_Marking_up_a_letter
       - link: /Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
         title: Assessment_Structuring_a_page_of_content
-
-  - details: closed
-    title: Multimedia_and_embedding
+  - title: Multimedia_and_embedding
+    details: closed
     children:
       - link: /Learn/HTML/Multimedia_and_embedding
         title: Multimedia_and_embedding_overview
@@ -48,9 +48,8 @@ sidebar:
         title: Responsive_images
       - link: /Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
         title: Assessment_Mozilla_splash_page
-
-  - details: closed
-    title: HTML_tables
+  - title: HTML_tables
+    details: closed
     children:
       - link: /Learn/HTML/Tables
         title: HTML_tables_overview
@@ -60,34 +59,27 @@ sidebar:
         title: HTML_table_advanced_features_and_accessibility
       - link: /Learn/HTML/Tables/Structuring_planet_data
         title: Assessment_Structuring_planet_data
-
   - type: section
     link: /Web/HTML/Reference
     title: Reference
-
   - type: listSubPages
-    details: closed
-    title: HTML_Elements
     path: /en-US/docs/Web/HTML/Element
-
-  - type: listSubPages
+    title: HTML_Elements
     details: closed
-    title: Global_attributes
+  - type: listSubPages
     path: /en-US/docs/Web/HTML/Global_attributes
-
-  - type: listSubPages
+    title: Global_attributes
     details: closed
-    title: Attributes
+  - type: listSubPages
     path: /en-US/docs/Web/HTML/Attributes
-
-  - type: listSubPages
+    title: Attributes
     details: closed
-    title: Input_types
+  - type: listSubPages
     path: /en-US/docs/Web/HTML/Element/input
-
+    title: Input_types
+    details: closed
   - type: section
     title: Guides
-
   - children:
       - link: /Web/HTML/Content_categories
         title: Content_categories
@@ -109,7 +101,6 @@ sidebar:
         title: Viewport_meta_tag
       - link: /Web/HTML/CORS_enabled_image
         title: Allowing_cross-origin_images_and_canvas
-
 l10n:
   en-US:
     Tutorials: Tutorials
@@ -166,21 +157,21 @@ l10n:
     Advanced_text_formatting: Formatage avancé du texte
     Document_and_website_structure: Structure d'un site et d'un document web
     Debugging_HTML: Déboguer du HTML
-    Assessment_Marking_up_a_letter: "Évaluation\_: baliser une lettre"
-    Assessment_Structuring_a_page_of_content: "Évaluation\_: structurer une page de contenu"
+    Assessment_Marking_up_a_letter: "Évaluation : baliser une lettre"
+    Assessment_Structuring_a_page_of_content: "Évaluation : structurer une page de contenu"
     Multimedia_and_embedding: Multimédia et intégration
     Multimedia_and_embedding_overview: Aperçu pour le multimédia et l'intégration
     Images_in_HTML: Images en HTML
     Video_and_audio_content: Contenu audio et vidéo
-    From_object_to_iframe_other_embedding_technologies: "Des objets aux iframes, les autres technologies d'intégration"
+    From_object_to_iframe_other_embedding_technologies: Des objets aux iframes, les autres technologies d'intégration
     Adding_vector_graphics_to_the_web: Ajouter des graphiques vectoriels sur le Web
     Responsive_images: Images responsives
-    Assessment_Mozilla_splash_page: "Évaluation\_: page d'accueil Mozilla"
+    Assessment_Mozilla_splash_page: "Évaluation : page d'accueil Mozilla"
     HTML_tables: Tableaux HTML
     HTML_tables_overview: Aperçu des tableaux HTML
     HTML_table_basics: Bases des tableaux HTML
     HTML_table_advanced_features_and_accessibility: Fonctionnalités avancées et accessibilité des tableaux HTML
-    Assessment_Structuring_planet_data: "Évaluation\_: structurer les données des planètes"
+    Assessment_Structuring_planet_data: "Évaluation : structurer les données des planètes"
     Reference: Références
     HTML_Elements: Éléments HTML
     Global_attributes: Attributs universels
@@ -195,9 +186,7 @@ l10n:
     Microdata: Microdonnées
     microformats: Microformats
     Quirks_Mode_and_Standards_Mode: Mode quirks et mode standard
-    Viewport_meta_tag: >-
-      Utilisation de la balise meta viewport pour contrôler la mise en page sur
-      mobile
+    Viewport_meta_tag: Utilisation de la balise meta viewport pour contrôler la mise en page sur mobile
   ja:
     Tutorials: チュートリアル
     HTML_basics: HTML の基本

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -63,19 +63,19 @@ sidebar:
     link: /Web/HTML/Reference
     title: Reference
   - type: listSubPages
-    path: /en-US/docs/Web/HTML/Element
+    path: /Web/HTML/Element
     title: HTML_Elements
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTML/Global_attributes
+    path: /Web/HTML/Global_attributes
     title: Global_attributes
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTML/Attributes
+    path: /Web/HTML/Attributes
     title: Attributes
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTML/Element/input
+    path: /Web/HTML/Element/input
     title: Input_types
     details: closed
   - type: section

--- a/files/sidebars/httpsidebar.yaml
+++ b/files/sidebars/httpsidebar.yaml
@@ -1,3 +1,5 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/HTTP
@@ -20,8 +22,8 @@ sidebar:
   - /Web/HTTP/Protocol_upgrade_mechanism
   - /Web/HTTP/Proxy_servers_and_tunneling
   - /Web/HTTP/Client_hints
-  - details: closed
-    title: Security
+  - title: Security
+    details: closed
     children:
       - /Web/Security/Practical_implementation_guides
       - link: /en-US/observatory
@@ -33,39 +35,31 @@ sidebar:
       - /Web/HTTP/Headers
   - type: section
     title: Reference
-
   - type: listSubPages
-    details: closed
-    title: Headers
     path: /en-US/docs/Web/HTTP/Headers
-
-  - type: listSubPages
+    title: Headers
     details: closed
-    title: Methods
+  - type: listSubPages
     path: /en-US/docs/Web/HTTP/Methods
-
-  - type: listSubPages
+    title: Methods
     details: closed
-    title: Status
+  - type: listSubPages
     path: /en-US/docs/Web/HTTP/Status
-
-  - type: listSubPages
+    title: Status
     details: closed
-    title: CSPDirectives
+  - type: listSubPages
     path: /en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-
-  - type: listSubPages
+    title: CSPDirectives
     details: closed
-    title: CORS_errors
+  - type: listSubPages
     path: /en-US/docs/Web/HTTP/CORS/Errors
-
-  - type: listSubPages
+    title: CORS_errors
     details: closed
-    title: PermissionsPolicyDirectives
+  - type: listSubPages
     path: /en-US/docs/Web/HTTP/Headers/Permissions-Policy
-
+    title: PermissionsPolicyDirectives
+    details: closed
   - /Web/HTTP/Resources_and_specifications
-
 l10n:
   en-US:
     CORS_errors: CORS errors
@@ -137,4 +131,3 @@ l10n:
     Reference: 参考：
     Security: HTTP 安全
     Status: HTTP 响应状态码
-

--- a/files/sidebars/httpsidebar.yaml
+++ b/files/sidebars/httpsidebar.yaml
@@ -36,27 +36,27 @@ sidebar:
   - type: section
     title: Reference
   - type: listSubPages
-    path: /en-US/docs/Web/HTTP/Headers
+    path: /Web/HTTP/Headers
     title: Headers
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTTP/Methods
+    path: /Web/HTTP/Methods
     title: Methods
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTTP/Status
+    path: /Web/HTTP/Status
     title: Status
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+    path: /Web/HTTP/Headers/Content-Security-Policy
     title: CSPDirectives
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTTP/CORS/Errors
+    path: /Web/HTTP/CORS/Errors
     title: CORS_errors
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/HTTP/Headers/Permissions-Policy
+    path: /Web/HTTP/Headers/Permissions-Policy
     title: PermissionsPolicyDirectives
     details: closed
   - /Web/HTTP/Resources_and_specifications

--- a/files/sidebars/jssidebar.yaml
+++ b/files/sidebars/jssidebar.yaml
@@ -86,37 +86,37 @@ sidebar:
     link: /Web/JavaScript/Reference
     title: Reference
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Global_Objects
+    path: /Web/JavaScript/Reference/Global_Objects
     title: Global_Objects
     details: closed
     includeParent: true
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Operators
+    path: /Web/JavaScript/Reference/Operators
     title: Operators
     details: closed
     includeParent: true
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Statements
+    path: /Web/JavaScript/Reference/Statements
     title: Statements
     details: closed
     includeParent: true
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Functions
+    path: /Web/JavaScript/Reference/Functions
     title: Functions
     details: closed
     includeParent: true
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Classes
+    path: /Web/JavaScript/Reference/Classes
     title: Classes
     details: closed
     includeParent: true
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Regular_expressions
+    path: /Web/JavaScript/Reference/Regular_expressions
     title: Guide_RegExp
     details: closed
     includeParent: true
   - type: listSubPages
-    path: /en-US/docs/Web/JavaScript/Reference/Errors
+    path: /Web/JavaScript/Reference/Errors
     title: Errors
     details: closed
     includeParent: true

--- a/files/sidebars/jssidebar.yaml
+++ b/files/sidebars/jssidebar.yaml
@@ -1,12 +1,13 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/JavaScript
     title: JavaScript
   - type: section
     title: Tutorials
-
-  - details: closed
-    title: Complete_beginners
+  - title: Complete_beginners
+    details: closed
     children:
       - link: /Learn/Getting_started_with_the_web/JavaScript_basics
         title: Basics
@@ -16,9 +17,8 @@ sidebar:
         title: Building_blocks
       - link: /Learn/JavaScript/Objects
         title: Introducing_objects
-
-  - details: closed
-    title: Guide
+  - title: Guide
+    details: closed
     children:
       - link: /Web/JavaScript/Guide/Introduction
         title: Guide_Introduction
@@ -56,9 +56,8 @@ sidebar:
         title: Guide_Meta
       - link: /Web/JavaScript/Guide/Modules
         title: Guide_Modules
-
-  - details: closed
-    title: Intermediate
+  - title: Intermediate
+    details: closed
     children:
       - link: /Learn/Tools_and_testing/Client-side_JavaScript_frameworks
         title: Frameworks
@@ -74,9 +73,8 @@ sidebar:
         title: Enumerability
       - link: /Web/JavaScript/Closures
         title: Closures
-
-  - details: closed
-    title: Advanced
+  - title: Advanced
+    details: closed
     children:
       - link: /Web/JavaScript/Inheritance_and_the_prototype_chain
         title: Inheritance
@@ -84,55 +82,46 @@ sidebar:
         title: Memory_management
       - link: /Web/JavaScript/Event_loop
         title: Event_loop
-
   - type: section
     link: /Web/JavaScript/Reference
     title: Reference
-
   - type: listSubPages
-    details: closed
-    title: Global_Objects
-    includeParent: true
     path: /en-US/docs/Web/JavaScript/Reference/Global_Objects
-
-  - type: listSubPages
+    title: Global_Objects
     details: closed
-    title: Operators
     includeParent: true
+  - type: listSubPages
     path: /en-US/docs/Web/JavaScript/Reference/Operators
-
-  - type: listSubPages
+    title: Operators
     details: closed
-    title: Statements
     includeParent: true
+  - type: listSubPages
     path: /en-US/docs/Web/JavaScript/Reference/Statements
-
-  - type: listSubPages
+    title: Statements
     details: closed
-    title: Functions
     includeParent: true
+  - type: listSubPages
     path: /en-US/docs/Web/JavaScript/Reference/Functions
-
-  - type: listSubPages
+    title: Functions
     details: closed
-    title: Classes
     includeParent: true
+  - type: listSubPages
     path: /en-US/docs/Web/JavaScript/Reference/Classes
-
-  - type: listSubPages
+    title: Classes
     details: closed
-    title: Guide_RegExp
     includeParent: true
+  - type: listSubPages
     path: /en-US/docs/Web/JavaScript/Reference/Regular_expressions
-
-  - type: listSubPages
+    title: Guide_RegExp
     details: closed
-    title: Errors
     includeParent: true
+  - type: listSubPages
     path: /en-US/docs/Web/JavaScript/Reference/Errors
-
-  - details: closed
-    title: More
+    title: Errors
+    details: closed
+    includeParent: true
+  - title: More
+    details: closed
     children:
       - link: /Web/JavaScript/JavaScript_technologies_overview
         title: Overview
@@ -148,7 +137,6 @@ sidebar:
         title: Trailing_commas
       - link: /Web/JavaScript/Reference/Deprecated_and_obsolete_features
         title: Deprecated_features
-
 l10n:
   en-US:
     Overview: JavaScript technologies overview

--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -1,7 +1,9 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
-  - title: Complete_beginners_start_here
+  - type: section
     link: Getting_started_with_the_web
-    type: section
+    title: Complete_beginners_start_here
   - title: Getting_started_with_the_web
     details: closed
     children:
@@ -14,9 +16,9 @@ sidebar:
       - /Learn/Getting_started_with_the_web/JavaScript_basics
       - /Learn/Getting_started_with_the_web/Publishing_your_website
       - /Learn/Getting_started_with_the_web/How_the_Web_works
-  - title: HTML_Structuring_the_web
+  - type: section
     link: HTML
-    type: section
+    title: HTML_Structuring_the_web
   - title: Introduction_to_HTML
     details: closed
     children:
@@ -47,9 +49,9 @@ sidebar:
       - /Learn/HTML/Tables/Basics
       - /Learn/HTML/Tables/Advanced
       - /Learn/HTML/Tables/Structuring_planet_data
-  - title: CSS_Styling_the_web
+  - type: section
     link: CSS
-    type: section
+    title: CSS_Styling_the_web
   - title: CSS_first_steps
     details: closed
     children:
@@ -109,9 +111,9 @@ sidebar:
       - /Learn/CSS/CSS_layout/Legacy_Layout_Methods
       - /Learn/CSS/CSS_layout/Supporting_Older_Browsers
       - /Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension
-  - title: JavaScript_dynamic_client-side_scripting
+  - type: section
     link: JavaScript
-    type: section
+    title: JavaScript_dynamic_client-side_scripting
   - title: JavaScript_first_steps
     details: closed
     children:
@@ -168,9 +170,9 @@ sidebar:
       - /Learn/JavaScript/Client-side_web_APIs/Drawing_graphics
       - /Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs
       - /Learn/JavaScript/Client-side_web_APIs/Client-side_storage
-  - title: Web_forms
+  - type: section
     link: Forms
-    type: section
+    title: Web_forms
   - title: Web_forms_core
     details: closed
     children:
@@ -192,9 +194,9 @@ sidebar:
       - /Learn/Forms/Sending_forms_through_JavaScript
       - /Learn/Forms/Property_compatibility_table_for_form_controls
       - /Learn/Forms/HTML_forms_in_legacy_browsers
-  - title: Accessibility_—_Make_the_web_usable_by_everyone
+  - type: section
     link: Accessibility
-    type: section
+    title: Accessibility_—_Make_the_web_usable_by_everyone
   - title: Accessibility_guides
     details: closed
     children:
@@ -206,9 +208,9 @@ sidebar:
       - /Learn/Accessibility/Multimedia
       - /Learn/Accessibility/Mobile
       - /Learn/Accessibility/Accessibility_troubleshooting
-  - title: Performance
+  - type: section
     link: Performance
-    type: section
+    title: Performance
   - title: Performance_guides
     details: closed
     children:
@@ -223,9 +225,9 @@ sidebar:
       - /Learn/Performance/HTML
       - /Learn/Performance/CSS
       - /Learn/Performance/business_case_for_performance
-  - title: MathML_Writing_mathematics
+  - type: section
     link: MathML
-    type: section
+    title: MathML_Writing_mathematics
   - title: MathML_first_steps
     details: closed
     children:
@@ -236,9 +238,9 @@ sidebar:
       - /Learn/MathML/First_steps/Scripts
       - /Learn/MathML/First_steps/Tables
       - /Learn/MathML/First_steps/Three_famous_mathematical_formulas
-  - title: Games_Developing_for_web
+  - type: section
     link: /Games
-    type: section
+    title: Games_Developing_for_web
   - title: Guides_and_tutorials
     details: closed
     children:
@@ -246,9 +248,9 @@ sidebar:
       - /Games/Techniques
       - /Games/Tutorials
       - /Games/Publishing_games
-  - title: Tools_and_testing
+  - type: section
     link: Tools_and_testing
-    type: section
+    title: Tools_and_testing
   - title: Client-side_web_development_tools
     details: closed
     children:
@@ -330,9 +332,9 @@ sidebar:
       - /Learn/Tools_and_testing/Cross_browser_testing/Feature_detection
       - /Learn/Tools_and_testing/Cross_browser_testing/Automated_testing
       - /Learn/Tools_and_testing/Cross_browser_testing/Your_own_automation_environment
-  - title: Server-side_website_programming
+  - type: section
     link: Server-side
-    type: section
+    title: Server-side_website_programming
   - title: First_steps
     details: closed
     children:
@@ -373,9 +375,9 @@ sidebar:
       - /Learn/Server-side/Express_Nodejs/Displaying_data
       - /Learn/Server-side/Express_Nodejs/forms
       - /Learn/Server-side/Express_Nodejs/deployment
-  - title: Further_resources
+  - type: section
     link: Common_questions
-    type: section
+    title: Further_resources
   - title: Common_questions
     details: closed
     children:
@@ -386,346 +388,345 @@ sidebar:
       - /Learn/Common_questions/Web_mechanics
       - /Learn/Common_questions/Tools_and_setup
       - /Learn/Common_questions/Design_and_accessibility
-
 l10n:
   en-US:
-    Complete_beginners_start_here: "Complete beginners start here!"
-    Getting_started_with_the_web: "Getting started with the web"
-    HTML_Structuring_the_web: "HTML — Structuring the web"
-    Introduction_to_HTML: "Introduction to HTML"
-    Multimedia_and_embedding: "Multimedia and embedding"
-    HTML_tables: "HTML tables"
-    CSS_Styling_the_web: "CSS — Styling the web"
-    CSS_first_steps: "CSS first steps"
-    CSS_building_blocks: "CSS building blocks"
-    Styling_text: "Styling text"
-    CSS_layout: "CSS layout"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — Dynamic client-side scripting"
-    JavaScript_first_steps: "JavaScript first steps"
-    JavaScript_building_blocks: "JavaScript building blocks"
-    Introducing_JavaScript_objects: "Introducing JavaScript objects"
-    Asynchronous_JavaScript: "Asynchronous JavaScript"
-    Client-side_web_APIs: "Client-side web APIs"
-    Web_forms: "Web forms — Working with user data"
-    Web_forms_core: "Web form building blocks"
-    Web_forms_advanced: "Advanced web form techniques"
-    Accessibility_—_Make_the_web_usable_by_everyone: "Accessibility — Make the web usable by everyone"
-    Accessibility_guides: "Accessibility guides"
-    Accessibility_assessment: "Accessibility assessment"
-    Performance: "Performance — Making websites fast and responsive"
-    Performance_guides: "Performance guides"
-    MathML_Writing_mathematics: "MathML — Writing mathematics with MathML"
-    MathML_first_steps: "MathML first steps"
-    Games_Developing_for_web: "Games — Developing games for the web"
-    Guides_and_tutorials: "Guides and tutorials"
-    Tools_and_testing: "Tools and testing"
-    Cross_browser_testing: "Cross browser testing"
-    Git_and_GitHub: "Git and GitHub"
-    Client-side_web_development_tools: "Client-side web development tools"
-    Introduction_to_client-side_frameworks: "Introduction to client-side frameworks"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "Server-side website programming"
-    First_steps: "First steps"
-    Django_web_framework_(Python): "Django web framework (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Express Web Framework (Node.js/JavaScript)"
-    Further_resources: "Further resources"
-    Common_questions: "Common questions"
+    Complete_beginners_start_here: Complete beginners start here!
+    Getting_started_with_the_web: Getting started with the web
+    HTML_Structuring_the_web: HTML — Structuring the web
+    Introduction_to_HTML: Introduction to HTML
+    Multimedia_and_embedding: Multimedia and embedding
+    HTML_tables: HTML tables
+    CSS_Styling_the_web: CSS — Styling the web
+    CSS_first_steps: CSS first steps
+    CSS_building_blocks: CSS building blocks
+    Styling_text: Styling text
+    CSS_layout: CSS layout
+    JavaScript_dynamic_client-side_scripting: JavaScript — Dynamic client-side scripting
+    JavaScript_first_steps: JavaScript first steps
+    JavaScript_building_blocks: JavaScript building blocks
+    Introducing_JavaScript_objects: Introducing JavaScript objects
+    Asynchronous_JavaScript: Asynchronous JavaScript
+    Client-side_web_APIs: Client-side web APIs
+    Web_forms: Web forms — Working with user data
+    Web_forms_core: Web form building blocks
+    Web_forms_advanced: Advanced web form techniques
+    Accessibility_—_Make_the_web_usable_by_everyone: Accessibility — Make the web usable by everyone
+    Accessibility_guides: Accessibility guides
+    Accessibility_assessment: Accessibility assessment
+    Performance: Performance — Making websites fast and responsive
+    Performance_guides: Performance guides
+    MathML_Writing_mathematics: MathML — Writing mathematics with MathML
+    MathML_first_steps: MathML first steps
+    Games_Developing_for_web: Games — Developing games for the web
+    Guides_and_tutorials: Guides and tutorials
+    Tools_and_testing: Tools and testing
+    Cross_browser_testing: Cross browser testing
+    Git_and_GitHub: Git and GitHub
+    Client-side_web_development_tools: Client-side web development tools
+    Introduction_to_client-side_frameworks: Introduction to client-side frameworks
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: Server-side website programming
+    First_steps: First steps
+    Django_web_framework_(Python): Django web framework (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Express Web Framework (Node.js/JavaScript)
+    Further_resources: Further resources
+    Common_questions: Common questions
   pt-BR:
-    Complete_beginners_start_here: "Completos iniciantes, comecem por aqui!"
-    Getting_started_with_the_web: "Iniciando na Internet"
-    HTML_Structuring_the_web: "HTML — Estruturando a Web"
-    Introduction_to_HTML: "Introdução ao HTML"
-    Multimedia_and_embedding: "Multimídia e incorporação"
-    HTML_tables: "Tabelas HTML"
-    CSS_Styling_the_web: "CSS — Estilizando a Web"
-    CSS_first_steps: "CSS - primeiros passos"
-    CSS_building_blocks: "CSS building blocks"
-    Styling_text: "Estilização de textos"
-    CSS_layout: "Esquemas CSS"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — Uma linguagem de script dinâmica para aplicações cliente"
-    JavaScript_first_steps: "Primeiros passos com JavaScript"
-    JavaScript_building_blocks: "Programando em JavaScript"
-    Introducing_JavaScript_objects: "Introdução Objetos em JavaScript"
-    Asynchronous_JavaScript: "Asynchronous JavaScript"
-    Client-side_web_APIs: "APIs Web na aplicação Cliente"
-    Web_forms: "Web forms — Working with user data"
-    Web_forms_core: "Web form building blocks"
-    Web_forms_advanced: "Advanced web form techniques"
-    Accessibility_—_Make_the_web_usable_by_everyone: "Acessibilidade — Faça a Internet usável por qualquer pessoa"
-    Accessibility_guides: "Guias de acessibilidade"
-    Accessibility_assessment: "Avaliando a acessibilidade"
-    Tools_and_testing: "Ferramentas e teste"
-    Cross_browser_testing: "Testes entre navegadores"
-    Git_and_GitHub: "Git and GitHub"
-    Client-side_web_development_tools: "Client-side web development tools"
-    Introduction_to_client-side_frameworks: "Introduction to client-side frameworks"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Server-side_website_programming: "Programação de servidores de Aplicação"
-    First_steps: "Primeiros passos"
-    Django_web_framework_(Python): "Framework Web Django (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Framework Web Express (Node.js/JavaScript)"
-    Further_resources: "Mais recursos"
-    Common_questions: "Questões gerais"
+    Complete_beginners_start_here: Completos iniciantes, comecem por aqui!
+    Getting_started_with_the_web: Iniciando na Internet
+    HTML_Structuring_the_web: HTML — Estruturando a Web
+    Introduction_to_HTML: Introdução ao HTML
+    Multimedia_and_embedding: Multimídia e incorporação
+    HTML_tables: Tabelas HTML
+    CSS_Styling_the_web: CSS — Estilizando a Web
+    CSS_first_steps: CSS - primeiros passos
+    CSS_building_blocks: CSS building blocks
+    Styling_text: Estilização de textos
+    CSS_layout: Esquemas CSS
+    JavaScript_dynamic_client-side_scripting: JavaScript — Uma linguagem de script dinâmica para aplicações cliente
+    JavaScript_first_steps: Primeiros passos com JavaScript
+    JavaScript_building_blocks: Programando em JavaScript
+    Introducing_JavaScript_objects: Introdução Objetos em JavaScript
+    Asynchronous_JavaScript: Asynchronous JavaScript
+    Client-side_web_APIs: APIs Web na aplicação Cliente
+    Web_forms: Web forms — Working with user data
+    Web_forms_core: Web form building blocks
+    Web_forms_advanced: Advanced web form techniques
+    Accessibility_—_Make_the_web_usable_by_everyone: Acessibilidade — Faça a Internet usável por qualquer pessoa
+    Accessibility_guides: Guias de acessibilidade
+    Accessibility_assessment: Avaliando a acessibilidade
+    Tools_and_testing: Ferramentas e teste
+    Cross_browser_testing: Testes entre navegadores
+    Git_and_GitHub: Git and GitHub
+    Client-side_web_development_tools: Client-side web development tools
+    Introduction_to_client-side_frameworks: Introduction to client-side frameworks
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Server-side_website_programming: Programação de servidores de Aplicação
+    First_steps: Primeiros passos
+    Django_web_framework_(Python): Framework Web Django (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Framework Web Express (Node.js/JavaScript)
+    Further_resources: Mais recursos
+    Common_questions: Questões gerais
   ru:
-    Complete_beginners_start_here: "Новички начинают здесь!"
-    Getting_started_with_the_web: "Начало работы с Вебом"
-    HTML_Structuring_the_web: "HTML — структура Веба"
-    Introduction_to_HTML: "Введение в HTML"
-    Multimedia_and_embedding: "Мультимедиа и встраивание"
-    HTML_tables: "HTML таблицы"
-    CSS_Styling_the_web: "CSS — стилизирование Веба"
-    CSS_first_steps: "Введение в CSS"
-    CSS_building_blocks: "Устройство CSS"
-    Styling_text: "Стилизирование текста"
-    CSS_layout: "CSS макет"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — динамический клиентский скриптинг"
-    JavaScript_first_steps: "Первые шаги в JavaScript"
-    JavaScript_building_blocks: "Блоки в JavaScript"
-    Introducing_JavaScript_objects: "Введение в объекты JavaScript"
-    Asynchronous_JavaScript: "Асинхронный JavaScript"
-    Client-side_web_APIs: "Клиентский веб API"
-    Web_forms: "HTML-формы — работа с пользовательскими данными"
-    Web_forms_core: "Руководство по HTML-формам"
-    Web_forms_advanced: "Advanced web form techniques"
-    Accessibility_—_Make_the_web_usable_by_everyone: "Доступность — сделайте веб удобным для всех"
-    Accessibility_guides: "Руководства по обеспечению доступности"
+    Complete_beginners_start_here: Новички начинают здесь!
+    Getting_started_with_the_web: Начало работы с Вебом
+    HTML_Structuring_the_web: HTML — структура Веба
+    Introduction_to_HTML: Введение в HTML
+    Multimedia_and_embedding: Мультимедиа и встраивание
+    HTML_tables: HTML таблицы
+    CSS_Styling_the_web: CSS — стилизирование Веба
+    CSS_first_steps: Введение в CSS
+    CSS_building_blocks: Устройство CSS
+    Styling_text: Стилизирование текста
+    CSS_layout: CSS макет
+    JavaScript_dynamic_client-side_scripting: JavaScript — динамический клиентский скриптинг
+    JavaScript_first_steps: Первые шаги в JavaScript
+    JavaScript_building_blocks: Блоки в JavaScript
+    Introducing_JavaScript_objects: Введение в объекты JavaScript
+    Asynchronous_JavaScript: Асинхронный JavaScript
+    Client-side_web_APIs: Клиентский веб API
+    Web_forms: HTML-формы — работа с пользовательскими данными
+    Web_forms_core: Руководство по HTML-формам
+    Web_forms_advanced: Advanced web form techniques
+    Accessibility_—_Make_the_web_usable_by_everyone: Доступность — сделайте веб удобным для всех
+    Accessibility_guides: Руководства по обеспечению доступности
     Accessibility_assessment: "Задание: Доступность"
-    Tools_and_testing: "Инструменты и тестирование"
-    Cross_browser_testing: "Кроссбраузерное тестирование"
-    Git_and_GitHub: "Git и GitHub"
-    Client-side_web_development_tools: "Client-side web development tools"
-    Introduction_to_client-side_frameworks: "Introduction to client-side frameworks"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "Программирование серверной части сайта"
-    First_steps: "Первые шаги"
-    Django_web_framework_(Python): "Веб-фреймворк Django (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Веб-фреймворк Express (Node.js/JavaScript)"
-    Further_resources: "Дальнейшее чтение"
-    Common_questions: "Общие вопросы"
+    Tools_and_testing: Инструменты и тестирование
+    Cross_browser_testing: Кроссбраузерное тестирование
+    Git_and_GitHub: Git и GitHub
+    Client-side_web_development_tools: Client-side web development tools
+    Introduction_to_client-side_frameworks: Introduction to client-side frameworks
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: Программирование серверной части сайта
+    First_steps: Первые шаги
+    Django_web_framework_(Python): Веб-фреймворк Django (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Веб-фреймворк Express (Node.js/JavaScript)
+    Further_resources: Дальнейшее чтение
+    Common_questions: Общие вопросы
   zh-CN:
-    Complete_beginners_start_here: "新手请从这开始！"
-    Getting_started_with_the_web: "Web 入门"
-    HTML_Structuring_the_web: "HTML——构建 Web"
-    Introduction_to_HTML: "HTML 介绍"
-    Multimedia_and_embedding: "多媒体与嵌入"
-    HTML_tables: "HTML 表格"
-    CSS_Styling_the_web: "CSS——设计 Web"
-    CSS_first_steps: "CSS 第一步"
-    CSS_building_blocks: "CSS 基础"
-    Styling_text: "样式化文本"
-    CSS_layout: "CSS 排版"
-    JavaScript_dynamic_client-side_scripting: "JavaScript——用户端动态脚本"
-    JavaScript_first_steps: "JavaScript 第一步"
-    JavaScript_building_blocks: "JavaScript 基础"
-    Introducing_JavaScript_objects: "JavaScript 对象介绍"
-    Asynchronous_JavaScript: "异步 JavaScript"
-    Client-side_web_APIs: "客户端 Web API"
-    Web_forms: "Web 表单——与用户数据打交道"
-    Web_forms_core: "Web 表单核心"
-    Web_forms_advanced: "Web 表单进阶"
-    Accessibility_—_Make_the_web_usable_by_everyone: "无障碍——使每个人都能使用 Web"
-    Accessibility_guides: "无障碍指南"
-    Accessibility_assessment: "无障碍测评"
-    Performance: "性能——使网站快速响应"
-    Performance_guides: "性能指南"
-    MathML_Writing_mathematics: "MathML——使用 MathML 语言撰写数学表达式"
-    MathML_first_steps: "MathML 第一步"
-    Games_Developing_for_web: "游戏——开发 Web 游戏"
-    Guides_and_tutorials: "指南和基础教程"
-    Tools_and_testing: "工具与测试"
-    Cross_browser_testing: "跨浏览器测试"
-    Git_and_GitHub: "Git 和 GitHub"
-    Client-side_web_development_tools: "客户端 web 开发工具"
-    Introduction_to_client-side_frameworks: "客户端框架介绍"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "服务端网页编程"
-    First_steps: "第一步"
-    Django_web_framework_(Python): "Django Web 框架（Python）"
-    Express_Web_Framework_(Node.js_JavaScript): "Express Web 框架（Node.js/JavaScript）"
-    Further_resources: "更多资源"
-    Common_questions: "常见问题"
+    Complete_beginners_start_here: 新手请从这开始！
+    Getting_started_with_the_web: Web 入门
+    HTML_Structuring_the_web: HTML——构建 Web
+    Introduction_to_HTML: HTML 介绍
+    Multimedia_and_embedding: 多媒体与嵌入
+    HTML_tables: HTML 表格
+    CSS_Styling_the_web: CSS——设计 Web
+    CSS_first_steps: CSS 第一步
+    CSS_building_blocks: CSS 基础
+    Styling_text: 样式化文本
+    CSS_layout: CSS 排版
+    JavaScript_dynamic_client-side_scripting: JavaScript——用户端动态脚本
+    JavaScript_first_steps: JavaScript 第一步
+    JavaScript_building_blocks: JavaScript 基础
+    Introducing_JavaScript_objects: JavaScript 对象介绍
+    Asynchronous_JavaScript: 异步 JavaScript
+    Client-side_web_APIs: 客户端 Web API
+    Web_forms: Web 表单——与用户数据打交道
+    Web_forms_core: Web 表单核心
+    Web_forms_advanced: Web 表单进阶
+    Accessibility_—_Make_the_web_usable_by_everyone: 无障碍——使每个人都能使用 Web
+    Accessibility_guides: 无障碍指南
+    Accessibility_assessment: 无障碍测评
+    Performance: 性能——使网站快速响应
+    Performance_guides: 性能指南
+    MathML_Writing_mathematics: MathML——使用 MathML 语言撰写数学表达式
+    MathML_first_steps: MathML 第一步
+    Games_Developing_for_web: 游戏——开发 Web 游戏
+    Guides_and_tutorials: 指南和基础教程
+    Tools_and_testing: 工具与测试
+    Cross_browser_testing: 跨浏览器测试
+    Git_and_GitHub: Git 和 GitHub
+    Client-side_web_development_tools: 客户端 web 开发工具
+    Introduction_to_client-side_frameworks: 客户端框架介绍
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: 服务端网页编程
+    First_steps: 第一步
+    Django_web_framework_(Python): Django Web 框架（Python）
+    Express_Web_Framework_(Node.js_JavaScript): Express Web 框架（Node.js/JavaScript）
+    Further_resources: 更多资源
+    Common_questions: 常见问题
   zh-TW:
-    Complete_beginners_start_here: "全新手請從這開始！"
-    Getting_started_with_the_web: "Web 入門"
-    HTML_Structuring_the_web: "HTML — 架構 Web"
-    Introduction_to_HTML: "HTML 介紹"
-    Multimedia_and_embedding: "多媒體與嵌入"
-    HTML_tables: "HTML 表格"
-    CSS_Styling_the_web: "CSS — 設計 Web 的風格"
-    CSS_first_steps: "初探 CSS"
-    CSS_building_blocks: "CSS 組件"
-    Styling_text: "樣式化文字"
-    CSS_layout: "CSS 版面配置"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — 動態的用戶端指令"
-    JavaScript_first_steps: "JavaScript 第一步"
-    JavaScript_building_blocks: "JavaScript 基礎要件"
-    Introducing_JavaScript_objects: "JavaScript 物件介紹"
-    Asynchronous_JavaScript: "非同步的 JavaScript"
-    Client-side_web_APIs: "客戶端 web APIs"
-    Web_forms: "網頁表單-與使用者資料合作"
-    Web_forms_core: "核心的表單學習途徑"
-    Web_forms_advanced: "深入網頁表單"
-    Accessibility_—_Make_the_web_usable_by_everyone: "無障礙網頁 — 每個人都可以使用的網頁"
-    Accessibility_guides: "無障礙網頁指南"
-    Accessibility_assessment: "無障礙網頁評估"
-    Tools_and_testing: "工具與測試"
-    Cross_browser_testing: "跨瀏覽器測試"
-    Git_and_GitHub: "Git and GitHub"
-    Client-side_web_development_tools: "Client-side web development tools"
-    Introduction_to_client-side_frameworks: "介紹前端框架"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "伺服端網站程式設計"
-    First_steps: "第一步"
-    Django_web_framework_(Python): "Django 網站框架 (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Express 網站框架 (Node.js/JavaScript)"
-    Further_resources: "更多資源"
-    Common_questions: "常見問題"
+    Complete_beginners_start_here: 全新手請從這開始！
+    Getting_started_with_the_web: Web 入門
+    HTML_Structuring_the_web: HTML — 架構 Web
+    Introduction_to_HTML: HTML 介紹
+    Multimedia_and_embedding: 多媒體與嵌入
+    HTML_tables: HTML 表格
+    CSS_Styling_the_web: CSS — 設計 Web 的風格
+    CSS_first_steps: 初探 CSS
+    CSS_building_blocks: CSS 組件
+    Styling_text: 樣式化文字
+    CSS_layout: CSS 版面配置
+    JavaScript_dynamic_client-side_scripting: JavaScript — 動態的用戶端指令
+    JavaScript_first_steps: JavaScript 第一步
+    JavaScript_building_blocks: JavaScript 基礎要件
+    Introducing_JavaScript_objects: JavaScript 物件介紹
+    Asynchronous_JavaScript: 非同步的 JavaScript
+    Client-side_web_APIs: 客戶端 web APIs
+    Web_forms: 網頁表單-與使用者資料合作
+    Web_forms_core: 核心的表單學習途徑
+    Web_forms_advanced: 深入網頁表單
+    Accessibility_—_Make_the_web_usable_by_everyone: 無障礙網頁 — 每個人都可以使用的網頁
+    Accessibility_guides: 無障礙網頁指南
+    Accessibility_assessment: 無障礙網頁評估
+    Tools_and_testing: 工具與測試
+    Cross_browser_testing: 跨瀏覽器測試
+    Git_and_GitHub: Git and GitHub
+    Client-side_web_development_tools: Client-side web development tools
+    Introduction_to_client-side_frameworks: 介紹前端框架
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: 伺服端網站程式設計
+    First_steps: 第一步
+    Django_web_framework_(Python): Django 網站框架 (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Express 網站框架 (Node.js/JavaScript)
+    Further_resources: 更多資源
+    Common_questions: 常見問題
   fr:
-    Complete_beginners_start_here: "Vous débutez\xa0? Commencez ici\xa0!"
-    Getting_started_with_the_web: "Démarrer avec le Web"
-    HTML_Structuring_the_web: "HTML — Structurer le Web"
-    Introduction_to_HTML: "Introduction à HTML"
-    Multimedia_and_embedding: "Multimédia et contenu embarqué"
-    HTML_tables: "Tableaux HTML"
-    CSS_Styling_the_web: "CSS — Mettre en forme le Web"
-    CSS_first_steps: "Premiers pas en CSS"
-    CSS_building_blocks: "Blocs de construction CSS"
-    Styling_text: "Mise en forme du texte"
-    CSS_layout: "Disposition en CSS"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — Scripts et dynamisme côté client"
-    JavaScript_first_steps: "Premiers pas en JavaScript"
-    JavaScript_building_blocks: "Blocs de construction JavaScript"
-    Introducing_JavaScript_objects: "Introduction aux objets JavaScript"
-    Asynchronous_JavaScript: "JavaScript asynchrone"
-    Client-side_web_APIs: "Les API web côté client"
-    Web_forms: "Formulaires web — Travailler avec les données des utilisateur·rice·s"
-    Web_forms_core: "Parcours sur les fondamentaux des formulaires web"
-    Web_forms_advanced: "Fonctionnalités avancées des formulaires"
-    Accessibility_—_Make_the_web_usable_by_everyone: "Accessibilité — Rendre le Web utilisable par toutes et tous"
-    Accessibility_guides: "Guides sur l'accessibilité"
-    Accessibility_assessment: "Évaluation de l'accessibilité"
-    MathML_Writing_mathematics: "MathML — Écrire des formules mathématiques sur le Web"
-    MathML_first_steps: "Premiers pas en MathML"
-    Tools_and_testing: "Outils et tests"
-    Cross_browser_testing: "Tests entre les différents navigateurs"
-    Git_and_GitHub: "Git et GitHub"
-    Client-side_web_development_tools: "Outils pour le développement web côté client"
-    Introduction_to_client-side_frameworks: "Introduction aux frameworks côté client"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "Programmation web côté serveur"
-    First_steps: "Premiers pas"
-    Django_web_framework_(Python): "Django (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Express (Node.js/JavaScript)"
-    Further_resources: "Ressources complémentaires"
-    Common_questions: "Questions fréquentes"
+    Complete_beginners_start_here: Vous débutez ? Commencez ici !
+    Getting_started_with_the_web: Démarrer avec le Web
+    HTML_Structuring_the_web: HTML — Structurer le Web
+    Introduction_to_HTML: Introduction à HTML
+    Multimedia_and_embedding: Multimédia et contenu embarqué
+    HTML_tables: Tableaux HTML
+    CSS_Styling_the_web: CSS — Mettre en forme le Web
+    CSS_first_steps: Premiers pas en CSS
+    CSS_building_blocks: Blocs de construction CSS
+    Styling_text: Mise en forme du texte
+    CSS_layout: Disposition en CSS
+    JavaScript_dynamic_client-side_scripting: JavaScript — Scripts et dynamisme côté client
+    JavaScript_first_steps: Premiers pas en JavaScript
+    JavaScript_building_blocks: Blocs de construction JavaScript
+    Introducing_JavaScript_objects: Introduction aux objets JavaScript
+    Asynchronous_JavaScript: JavaScript asynchrone
+    Client-side_web_APIs: Les API web côté client
+    Web_forms: Formulaires web — Travailler avec les données des utilisateur·rice·s
+    Web_forms_core: Parcours sur les fondamentaux des formulaires web
+    Web_forms_advanced: Fonctionnalités avancées des formulaires
+    Accessibility_—_Make_the_web_usable_by_everyone: Accessibilité — Rendre le Web utilisable par toutes et tous
+    Accessibility_guides: Guides sur l'accessibilité
+    Accessibility_assessment: Évaluation de l'accessibilité
+    MathML_Writing_mathematics: MathML — Écrire des formules mathématiques sur le Web
+    MathML_first_steps: Premiers pas en MathML
+    Tools_and_testing: Outils et tests
+    Cross_browser_testing: Tests entre les différents navigateurs
+    Git_and_GitHub: Git et GitHub
+    Client-side_web_development_tools: Outils pour le développement web côté client
+    Introduction_to_client-side_frameworks: Introduction aux frameworks côté client
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: Programmation web côté serveur
+    First_steps: Premiers pas
+    Django_web_framework_(Python): Django (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Express (Node.js/JavaScript)
+    Further_resources: Ressources complémentaires
+    Common_questions: Questions fréquentes
   ja:
-    Complete_beginners_start_here: "完全な初心者はこちらから!"
-    Getting_started_with_the_web: "ウェブ入門"
-    HTML_Structuring_the_web: "HTML — ウェブの構造化"
-    Introduction_to_HTML: "HTML概論"
-    Multimedia_and_embedding: "マルチメディアと埋め込み"
-    HTML_tables: "HTML 表"
-    CSS_Styling_the_web: "CSS — ウェブのスタイル設定"
-    CSS_first_steps: "CSS の第一歩"
-    CSS_building_blocks: "CSS の構成要素"
-    Styling_text: "テキストの装飾"
-    CSS_layout: "CSS レイアウト"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — 動的クライアントサイドスクリプト"
-    JavaScript_first_steps: "JavaScript の第一歩"
-    JavaScript_building_blocks: "JavaScript の構成要素"
-    Introducing_JavaScript_objects: "JavaScript オブジェクトの紹介"
-    Asynchronous_JavaScript: "非同期 JavaScript"
-    Client-side_web_APIs: "クライアントサイド Web API"
-    Web_forms: "ウェブフォーム — ユーザーデータの操作"
-    Web_forms_core: "ウェブフォームの構成要素"
-    Web_forms_advanced: "高度なウェブフォームテクニック"
-    Accessibility_—_Make_the_web_usable_by_everyone: "アクセシビリティ — 誰もウェブを利用できるようにする"
-    Accessibility_guides: "アクセシビリティガイド"
-    Accessibility_assessment: "Accessibility assessment"
-    Performance: "パフォーマンス — ウェブサイトを高速かつ応答性の高いものにする"
-    Performance_guides: "パフォーマンスガイド"
-    MathML_Writing_mathematics: "MathML — MathML を使用して数学を記述する"
-    MathML_first_steps: "MathML の最初のステップ"
-    Games_Developing_for_web: "ゲーム — ウェブ用ゲームの開発"
-    Guides_and_tutorials: "ガイドとチュートリアル"
-    Tools_and_testing: "ツールとテスト"
-    Cross_browser_testing: "ブラウザー横断テスト"
-    Git_and_GitHub: "Git と GitHub"
-    Client-side_web_development_tools: "クライアントサイドウェブ開発ツール"
-    Introduction_to_client-side_frameworks: "クライアントサイドフレームワークの概要"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "サーバーサイドウェブサイトプログラミング"
-    First_steps: "サーバーサイドのウェブサイトプログラミングの第一歩"
-    Django_web_framework_(Python): "Django ウェブフレームワーク (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Express ウェブフレームワーク (Node.js/JavaScript)"
-    Further_resources: "その他のリソース"
-    Common_questions: "よくある質問"
+    Complete_beginners_start_here: 完全な初心者はこちらから!
+    Getting_started_with_the_web: ウェブ入門
+    HTML_Structuring_the_web: HTML — ウェブの構造化
+    Introduction_to_HTML: HTML概論
+    Multimedia_and_embedding: マルチメディアと埋め込み
+    HTML_tables: HTML 表
+    CSS_Styling_the_web: CSS — ウェブのスタイル設定
+    CSS_first_steps: CSS の第一歩
+    CSS_building_blocks: CSS の構成要素
+    Styling_text: テキストの装飾
+    CSS_layout: CSS レイアウト
+    JavaScript_dynamic_client-side_scripting: JavaScript — 動的クライアントサイドスクリプト
+    JavaScript_first_steps: JavaScript の第一歩
+    JavaScript_building_blocks: JavaScript の構成要素
+    Introducing_JavaScript_objects: JavaScript オブジェクトの紹介
+    Asynchronous_JavaScript: 非同期 JavaScript
+    Client-side_web_APIs: クライアントサイド Web API
+    Web_forms: ウェブフォーム — ユーザーデータの操作
+    Web_forms_core: ウェブフォームの構成要素
+    Web_forms_advanced: 高度なウェブフォームテクニック
+    Accessibility_—_Make_the_web_usable_by_everyone: アクセシビリティ — 誰もウェブを利用できるようにする
+    Accessibility_guides: アクセシビリティガイド
+    Accessibility_assessment: Accessibility assessment
+    Performance: パフォーマンス — ウェブサイトを高速かつ応答性の高いものにする
+    Performance_guides: パフォーマンスガイド
+    MathML_Writing_mathematics: MathML — MathML を使用して数学を記述する
+    MathML_first_steps: MathML の最初のステップ
+    Games_Developing_for_web: ゲーム — ウェブ用ゲームの開発
+    Guides_and_tutorials: ガイドとチュートリアル
+    Tools_and_testing: ツールとテスト
+    Cross_browser_testing: ブラウザー横断テスト
+    Git_and_GitHub: Git と GitHub
+    Client-side_web_development_tools: クライアントサイドウェブ開発ツール
+    Introduction_to_client-side_frameworks: クライアントサイドフレームワークの概要
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: サーバーサイドウェブサイトプログラミング
+    First_steps: サーバーサイドのウェブサイトプログラミングの第一歩
+    Django_web_framework_(Python): Django ウェブフレームワーク (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Express ウェブフレームワーク (Node.js/JavaScript)
+    Further_resources: その他のリソース
+    Common_questions: よくある質問
   ko:
-    Complete_beginners_start_here: "입문자들은 여기서부터 시작하세요!"
-    Getting_started_with_the_web: "Web과 함께 시작하기"
-    HTML_Structuring_the_web: "HTML — 웹 구성"
-    Introduction_to_HTML: "HTML 입문서"
-    Multimedia_and_embedding: "멀티미디어와 임베딩"
-    HTML_tables: "HTML 테이블"
-    CSS_Styling_the_web: "CSS — 웹 꾸미기"
-    CSS_first_steps: "CSS 첫 번째 단계"
-    CSS_building_blocks: "CSS 구성요소"
-    Styling_text: "텍스트 꾸미기"
-    CSS_layout: "CSS 레이아웃"
-    JavaScript_dynamic_client-side_scripting: "JavaScript — 동적 클라이언트 사이드 스크립트 언어"
-    JavaScript_first_steps: "JavaScript 첫걸음"
-    JavaScript_building_blocks: "JavaScript 구성요소"
-    Introducing_JavaScript_objects: "JavaScript 객체"
-    Asynchronous_JavaScript: "JavaScript의 비동기성"
-    Client-side_web_APIs: "클라이언트 사이드 웹 API"
-    Web_forms: "웹 Form — 사용자 데이터 사용하기"
-    Web_forms_core: "웹 form 핵심"
-    Web_forms_advanced: "고급 form"
-    Accessibility_—_Make_the_web_usable_by_everyone: "접근성 - 모두를 위한 웹 만들기"
-    Accessibility_guides: "접근성 안내서"
+    Complete_beginners_start_here: 입문자들은 여기서부터 시작하세요!
+    Getting_started_with_the_web: Web과 함께 시작하기
+    HTML_Structuring_the_web: HTML — 웹 구성
+    Introduction_to_HTML: HTML 입문서
+    Multimedia_and_embedding: 멀티미디어와 임베딩
+    HTML_tables: HTML 테이블
+    CSS_Styling_the_web: CSS — 웹 꾸미기
+    CSS_first_steps: CSS 첫 번째 단계
+    CSS_building_blocks: CSS 구성요소
+    Styling_text: 텍스트 꾸미기
+    CSS_layout: CSS 레이아웃
+    JavaScript_dynamic_client-side_scripting: JavaScript — 동적 클라이언트 사이드 스크립트 언어
+    JavaScript_first_steps: JavaScript 첫걸음
+    JavaScript_building_blocks: JavaScript 구성요소
+    Introducing_JavaScript_objects: JavaScript 객체
+    Asynchronous_JavaScript: JavaScript의 비동기성
+    Client-side_web_APIs: 클라이언트 사이드 웹 API
+    Web_forms: 웹 Form — 사용자 데이터 사용하기
+    Web_forms_core: 웹 form 핵심
+    Web_forms_advanced: 고급 form
+    Accessibility_—_Make_the_web_usable_by_everyone: 접근성 - 모두를 위한 웹 만들기
+    Accessibility_guides: 접근성 안내서
     Accessibility_assessment: "과제: 접근성 평가"
-    MathML_Writing_mathematics: "MathML — MathML을 이용해 수학 쓰기"
-    MathML_first_steps: "MathML 첫 걸음"
-    Tools_and_testing: "도구과 테스트"
-    Cross_browser_testing: "크로스 브라우저 테스팅"
-    Git_and_GitHub: "Git과 GitHub"
-    Client-side_web_development_tools: "클라이언트 사이드 웹 개발 도구"
-    Introduction_to_client-side_frameworks: "클라이언트 사이드 프레임워크 소개"
-    React: "React"
-    Ember: "Ember"
-    Vue: "Vue"
-    Svelte: "Svelte"
-    Angular: "Angular"
-    Server-side_website_programming: "서버 사이드 웹사이트 프로그래밍"
-    First_steps: "첫 걸음"
-    Django_web_framework_(Python): "Django 웹 프레임워크 (Python)"
-    Express_Web_Framework_(Node.js_JavaScript): "Express 웹 프레임워크 (Node.js/JavaScript)"
-    Further_resources: "추가 자료"
-    Common_questions: "자주 묻는 질문"
+    MathML_Writing_mathematics: MathML — MathML을 이용해 수학 쓰기
+    MathML_first_steps: MathML 첫 걸음
+    Tools_and_testing: 도구과 테스트
+    Cross_browser_testing: 크로스 브라우저 테스팅
+    Git_and_GitHub: Git과 GitHub
+    Client-side_web_development_tools: 클라이언트 사이드 웹 개발 도구
+    Introduction_to_client-side_frameworks: 클라이언트 사이드 프레임워크 소개
+    React: React
+    Ember: Ember
+    Vue: Vue
+    Svelte: Svelte
+    Angular: Angular
+    Server-side_website_programming: 서버 사이드 웹사이트 프로그래밍
+    First_steps: 첫 걸음
+    Django_web_framework_(Python): Django 웹 프레임워크 (Python)
+    Express_Web_Framework_(Node.js_JavaScript): Express 웹 프레임워크 (Node.js/JavaScript)
+    Further_resources: 추가 자료
+    Common_questions: 자주 묻는 질문

--- a/files/sidebars/mathmlref.yaml
+++ b/files/sidebars/mathmlref.yaml
@@ -12,11 +12,11 @@ sidebar:
   - type: section
     title: Reference
   - type: listSubPages
-    path: /en-US/docs/Web/MathML/Element
+    path: /Web/MathML/Element
     title: Elements
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/MathML/Global_attributes
+    path: /Web/MathML/Global_attributes
     title: Global attributes
     details: closed
   - /Web/MathML/Attribute

--- a/files/sidebars/mathmlref.yaml
+++ b/files/sidebars/mathmlref.yaml
@@ -1,32 +1,30 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/MathML
-
   - type: section
     title: Guides
   - children:
       - link: /Web/MathML/Authoring
       - link: /Web/MathML/Fonts
       - link: /Web/MathML/Values
-
   - type: section
     title: Reference
   - type: listSubPages
+    path: /en-US/docs/Web/MathML/Element
     title: Elements
     details: closed
-    path: /en-US/docs/Web/MathML/Element
   - type: listSubPages
+    path: /en-US/docs/Web/MathML/Global_attributes
     title: Global attributes
     details: closed
-    path: /en-US/docs/Web/MathML/Global_attributes
   - /Web/MathML/Attribute
-
   - type: section
     title: Examples
   - children:
       - link: /Web/MathML/Examples/Deriving_the_Quadratic_Formula
       - link: /Web/MathML/Examples/MathML_Pythagorean_Theorem
-
 l10n:
   en-US:
     Reference: Reference

--- a/files/sidebars/mdnsidebar.yaml
+++ b/files/sidebars/mdnsidebar.yaml
@@ -1,13 +1,14 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /MDN
-
-  - details: closed
-    title: community_guidelines
+  - title: community_guidelines
+    details: closed
     children:
       - /MDN/Community
-      - details: closed
-        title: contributing_to_mdn_web_docs
+      - title: contributing_to_mdn_web_docs
+        details: closed
         children:
           - /MDN/Community/Contributing
           - /MDN/Community/Contributing/Getting_started
@@ -21,15 +22,14 @@ sidebar:
       - /MDN/Community/Issues
       - /MDN/Community/Pull_requests
       - /MDN/Community/Roles_teams
-
-  - details: closed
-    title: writing_guide
+  - title: writing_guide
+    details: closed
     children:
       - /MDN/Writing_guidelines
       - /MDN/Writing_guidelines/What_we_write
       - /MDN/Writing_guidelines/Writing_style_guide
-      - details: closed
-        title: how_to_guides
+      - title: how_to_guides
+        details: closed
         children:
           - /MDN/Writing_guidelines/Howto
           - /MDN/Writing_guidelines/Howto/Images_media
@@ -42,8 +42,8 @@ sidebar:
           - /MDN/Writing_guidelines/Howto/Write_an_api_reference
           - /MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary
           - /MDN/Writing_guidelines/Howto/Markdown_in_MDN
-      - details: closed
-        title: page_structures
+      - title: page_structures
+        details: closed
         children:
           - /MDN/Writing_guidelines/Page_structures
           - /MDN/Writing_guidelines/Page_structures/Banners_and_notices
@@ -58,21 +58,17 @@ sidebar:
           - /MDN/Writing_guidelines/Page_structures/Feature_status
       - /MDN/Writing_guidelines/Attrib_copyright_license
       - /MDN/Writing_guidelines/Experimental_deprecated_obsolete
-
-  - details: closed
-    title: advisory_board
+  - title: advisory_board
+    details: closed
     children:
       - /MDN/MDN_Product_Advisory_Board
       - /MDN/MDN_Product_Advisory_Board/Membership
-
-  - details: closed
-    title: history
+  - title: history
+    details: closed
     children:
       - /MDN/At_ten
       - /MDN/At_ten/History_of_MDN
-
   - /MDN/Changelog
-
 l10n:
   en-US:
     history: History

--- a/files/sidebars/pwasidebar.yaml
+++ b/files/sidebars/pwasidebar.yaml
@@ -1,7 +1,8 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/Progressive_web_apps
-
   - type: section
     link: /Web/Progressive_web_apps/Guides
   - /Web/Progressive_web_apps/Guides/What_is_a_progressive_web_app
@@ -10,7 +11,6 @@ sidebar:
   - /Web/Progressive_web_apps/Guides/Offline_and_background_operation
   - /Web/Progressive_web_apps/Guides/Caching
   - /Web/Progressive_web_apps/Guides/Best_practices
-
   - type: section
     link: /Web/Progressive_web_apps/Tutorials
   - link: /Web/Progressive_web_apps/Tutorials/CycleTracker
@@ -31,7 +31,6 @@ sidebar:
       - /Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs
       - /Web/Progressive_web_apps/Tutorials/js13kGames/Re-engageable_Notifications_Push
       - /Web/Progressive_web_apps/Tutorials/js13kGames/Loading
-
   - type: section
     link: /Web/Progressive_web_apps/How_to
   - /Web/Progressive_web_apps/How_to/Trigger_install_prompt
@@ -42,6 +41,5 @@ sidebar:
   - /Web/Progressive_web_apps/How_to/Expose_common_actions_as_shortcuts
   - /Web/Progressive_web_apps/How_to/Share_data_between_apps
   - /Web/Progressive_web_apps/How_to/Associate_files_with_your_PWA
-
   - type: section
     link: /Web/Progressive_web_apps/Reference

--- a/files/sidebars/svgref.yaml
+++ b/files/sidebars/svgref.yaml
@@ -1,10 +1,12 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/SVG
   - type: section
     title: Tutorials
-  - details: closed
-    title: Introducing SVG from scratch
+  - title: Introducing SVG from scratch
+    details: closed
     children:
       - /Web/SVG/Tutorial/Introduction
       - /Web/SVG/Tutorial/Getting_Started
@@ -26,13 +28,13 @@ sidebar:
   - type: section
     title: Reference
   - type: listSubPages
+    path: /en-US/docs/Web/SVG/Element
     title: Elements
     details: closed
-    path: /en-US/docs/Web/SVG/Element
   - type: listSubPages
+    path: /en-US/docs/Web/SVG/Attribute
     title: Attributes
     details: closed
-    path: /en-US/docs/Web/SVG/Attribute
   - type: section
     title: Guides
   - children:
@@ -41,7 +43,6 @@ sidebar:
       - /Web/SVG/Namespaces_Crash_Course
       - /Web/SVG/SVG_animation_with_SMIL
       - /Web/SVG/SVG_as_an_Image
-
 l10n:
   en-US:
     Tutorials: Tutorials

--- a/files/sidebars/svgref.yaml
+++ b/files/sidebars/svgref.yaml
@@ -28,11 +28,11 @@ sidebar:
   - type: section
     title: Reference
   - type: listSubPages
-    path: /en-US/docs/Web/SVG/Element
+    path: /Web/SVG/Element
     title: Elements
     details: closed
   - type: listSubPages
-    path: /en-US/docs/Web/SVG/Attribute
+    path: /Web/SVG/Attribute
     title: Attributes
     details: closed
   - type: section

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -1,8 +1,9 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /WebAssembly
     title: WebAssembly_home_page
-
   - title: Tutorials
     details: open
     children:
@@ -22,7 +23,6 @@ sidebar:
         title: Loading_and_running
       - link: /WebAssembly/Exported_functions
         title: Exported_functions
-
   - title: JavaScript_interface
     details: open
     children:
@@ -48,7 +48,6 @@ sidebar:
         code: true
       - link: /WebAssembly/JavaScript_interface/RuntimeError
         code: true
-
 l10n:
   en-US:
     WebAssembly_home_page: WebAssembly home page

--- a/files/sidebars/xsltsidebar.yaml
+++ b/files/sidebars/xsltsidebar.yaml
@@ -4,18 +4,18 @@ sidebar:
   - type: section
     link: /Web/XSLT
   - type: listSubPages
-    path: /en-US/docs/Web/XSLT/Transforming_XML_with_XSLT
+    path: /Web/XSLT/Transforming_XML_with_XSLT
   - type: section
     link: /Web/XSLT/Element
   - type: listSubPages
-    path: /en-US/docs/Web/XSLT/Element
+    path: /Web/XSLT/Element
   - type: section
     link: /Web/EXSLT
   - type: listSubPages
-    path: /en-US/docs/Web/EXSLT
+    path: /Web/EXSLT
   - type: section
     link: /Web/XPath/Functions
   - type: listSubPages
-    path: /en-US/docs/Web/XPath/Functions
+    path: /Web/XPath/Functions
   - type: section
     link: /Web/XPath/Axes

--- a/files/sidebars/xsltsidebar.yaml
+++ b/files/sidebars/xsltsidebar.yaml
@@ -1,23 +1,21 @@
+# Do not add comments to this file. They will be lost.
+
 sidebar:
   - type: section
     link: /Web/XSLT
   - type: listSubPages
     path: /en-US/docs/Web/XSLT/Transforming_XML_with_XSLT
-
   - type: section
     link: /Web/XSLT/Element
   - type: listSubPages
     path: /en-US/docs/Web/XSLT/Element
-
   - type: section
     link: /Web/EXSLT
   - type: listSubPages
     path: /en-US/docs/Web/EXSLT
-
   - type: section
     link: /Web/XPath/Functions
   - type: listSubPages
     path: /en-US/docs/Web/XPath/Functions
-
   - type: section
     link: /Web/XPath/Axes


### PR DESCRIPTION
### Description

ran `rari content fmt-sidebars` and `rari content sync-sidebars`

### Motivation

To support automated updates on `content move` we need to serialize the sidebars. To do that we should keep them in a standard format and not allow comments.

We also make the `/en-US/docs` for the `path` property in `listSubPages` and `listSubPagesGrouped` implicit.