### PR TITLE
added the release note for viewport interactive-widget

### DIFF
--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -12,7 +12,7 @@ This article provides information about the changes in Firefox 133 that affect d
 
 ### HTML
 
-No notable changes
+- The [`viewport <meta>` tag](/en-US/docs/Web/HTML/Viewport_meta_tag) now supports the [`interactive-widgets`](/en-US/docs/Web/HTML/Viewport_meta_tag#the_effect_of_interactive_ui_widgets) attribute, this influences the size of the viewport when common UI widgets, such as virtual keyboards, are added to the screen. ([Firefox bug 1831649](https://bugzil.la/1831649) and [Firefox bug 1920755](https://bugzil.la/1920755)).
 
 ### CSS
 


### PR DESCRIPTION
### Description

- Added firefox release note for `interactive-widget` attribute 

### Motivation

- Working on [issue #35720](https://github.com/mdn/content/issues/35720)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/37000)