### PR TITLE
Range `cloneRange()` method modifies a problem with no variables

### DIFF
--- a/files/en-us/web/api/range/clonerange/index.md
+++ b/files/en-us/web/api/range/clonerange/index.md
@@ -32,9 +32,9 @@ A {{domxref("Range")}} object.
 ## Examples
 
 ```js
-range = document.createRange();
+const range = document.createRange();
 range.selectNode(document.getElementsByTagName("div").item(0));
-clone = range.cloneRange();
+const clone = range.cloneRange();
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Range/cloneRange
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/range/clonerange/index.md
* Last commit: https://github.com/mdn/content/commit/c58e8c1dd6ecbcb63894c7dd17fb9495b9511b4e