### PR TITLE
Remove outdated warning and update link of `@page`

### DIFF
--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -154,15 +154,12 @@ Where the `<page-body>` includes:
 
 and `<pseudo-page>` represents these pseudo-classes:
 
-- [`:blank`](https://drafts.csswg.org/css-page/#blank-pseudo)
+- {{Cssxref(":blank")}}
 - {{Cssxref(":first")}}
 - {{Cssxref(":left")}}
 - {{Cssxref(":right")}}
 
 ## Margin at-rules
-
-> [!WARNING]
-> The margin at-rules have not been implemented by any user agent (updated: August 2023).
 
 The margin at-rules are used inside of the `@page` at-rule. They each target a different section of the document printed page, styling the area of the printed page based on the property values set in the style block:
 
@@ -385,13 +382,14 @@ button.addEventListener("click", () => {
 #### Result
 
 Clicking the print button will launch a print dialog with the html sections split into individual pages.
-{{ EmbedLiveSample('Using the size property to change the page orientation', '100%', 520) }}
+
+{{EmbedLiveSample('Using the size property to change the page orientation', '100%', 520)}}
 
 ### @page pseudo-class examples
 
 Please refer to the various [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) of `@page` for examples.
 
-- [`:blank`](https://drafts.csswg.org/css-page/#blank-pseudo)
+- {{Cssxref(":blank")}}
 - {{Cssxref(":first")}}
 - {{Cssxref(":left")}}
 - {{Cssxref(":right")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

these margin at-rules features has implemented in chromium M131, so the warning is no longer necesssary

and `:blank` has its own mdn documentation, so it's better to refer to the mdn docs than the spec

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
