### PR TITLE
chore: remove the `Window.updateCommands()` method

### DIFF
--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -257,8 +257,6 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : This method stops window loading.
 - {{domxref("Window.structuredClone()")}}
   - : Creates a [deep clone](/en-US/docs/Glossary/Deep_copy) of a given value using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
-- {{domxref("Window.updateCommands()")}} {{Non-standard_Inline}}
-  - : Updates the state of commands of the current chrome window (UI).
 
 ### Deprecated methods
 


### PR DESCRIPTION
### Description

remove the `Window.updateCommands()` method

### Motivation

Follow #36996, which deleted the document.
