### PR TITLE
feat: add start:rari to test rari

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:yml": "prettier -c \"**/*.yml\"",
     "prepare": "husky || true",
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build yari-server",
+    "start:rari": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build rari-server",
     "up-to-date-check": "node scripts/up-to-date-check.js",
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "test:front-matter-linter": "yarn jest tests"


### PR DESCRIPTION
### Description

This adds support for `yarn start:rari` a drop in replacement for `yarn start` but using the new build system: [rari](https://github.com/mdn/rari).

The main difference is that rari uses the [new sidebars](https://github.com/mdn/content/tree/main/files/sidebars) and l10n for macros from [L10n-Template.json](https://github.com/mdn/content/blob/main/files/jsondata/L10n-Template.json).

Flaws are partially support and feedback is very much welcome.

### Motivation

Get feedback from writers before we switch to rari.
