### PR TITLE
chore: fix typos

### DIFF
--- a/files/en-us/learn/css/building_blocks/values_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/values_tasks/index.md
@@ -196,7 +196,7 @@ Try to update the code below to recreate the finished example:
 <details>
 <summary>Click here to show the solution</summary>
 
-Use `background-position` with ther `center` keyword and a percentage:
+Use `background-position` with the `center` keyword and a percentage:
 
 ```css
 .box {

--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -407,7 +407,7 @@ For this tutorial we'll hosting our code on [GitHub](https://github.com/), one o
 
 > [!NOTE]
 > Using SCM tools is good software development practice!
-> Ths instructions provide a basic introduction to git and GitHub.
+> These instructions provide a basic introduction to git and GitHub.
 > To learn more, see [Learning Git](https://docs.github.com/en/get-started/start-your-journey/git-and-github-learning-resources).
 
 ### Key concepts

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.md
@@ -64,7 +64,7 @@ For our sample project, we'll be using a toolchain specifically designed to aid 
 
 ## Checking prerequisites
 
-You should have most of the software already if you've been following along with the previous chapters. Here's what you should have before proceeding to the real setup steps. They only need to be done once and you don't need to repeat these again for future projects.
+You should have most of the pieces of software already if you've been following along with the previous chapters. Here's what you should have before proceeding to the real setup steps. They only need to be done once and you don't need to repeat these again for future projects.
 
 ### Creating a GitHub account
 

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.md
@@ -64,7 +64,7 @@ For our sample project, we'll be using a toolchain specifically designed to aid 
 
 ## Checking prerequisites
 
-You should have most of the softwares already if you've been following along with the previous chapters. Here's what you should have before proceeding to the real setup steps. They only need to be done once and you don't need to repeat these again for future projects.
+You should have most of the software already if you've been following along with the previous chapters. Here's what you should have before proceeding to the real setup steps. They only need to be done once and you don't need to repeat these again for future projects.
 
 ### Creating a GitHub account
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -22,7 +22,7 @@ Experimental features can be enabled or disabled using the [Firefox Configuratio
 
 ### Autocorrection of editable text elements
 
-The HTML [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) attribute (and correspoinding {{domxref("HTMLElement.autocorrect")}} property) allow autocompletion in editable text elements including: most kinds of text {{htmlelement("input")}} elements, {{htmlelement("textarea")}} elements, and elements that have the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set ([Firefox bug 1725806](https://bugzil.la/1725806)).
+The HTML [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) attribute (and corresponding {{domxref("HTMLElement.autocorrect")}} property) allow autocompletion in editable text elements including: most kinds of text {{htmlelement("input")}} elements, {{htmlelement("textarea")}} elements, and elements that have the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set ([Firefox bug 1725806](https://bugzil.la/1725806)).
 
 <table>
   <thead>

--- a/files/en-us/web/css/@font-face/font-weight/index.md
+++ b/files/en-us/web/css/@font-face/font-weight/index.md
@@ -14,7 +14,7 @@ Typically, a developer will want to use fonts from a single font family in a ran
 To declare the font to be used for a range of font weights, declare a space-separated pair of font-weight values as the value for the `font-weight` descriptor. When CSS rules set a font weight by setting the {{cssxref("font-weight")}} property or the {{cssxref("font")}} shorthand property, the appropriate font will then be used.
 
 For example, if the descriptor is `font-weight: 400 600;`, when the property is `font-weight: 450` or `font-weight: 550`, that font will be use for that font-family.
-Whether the font is a static or a [variable font](/en-US/docs/Web/CSS/CSS_fonts/Variable_fonts_guide), the font matching the range will be used. In this case, if the font is a static font, `450` and `550` will apear the same. If the font is a variable font, the latter will be bolder.
+Whether the font is a static or a [variable font](/en-US/docs/Web/CSS/CSS_fonts/Variable_fonts_guide), the font matching the range will be used. In this case, if the font is a static font, `450` and `550` will appear the same. If the font is a variable font, the latter will be bolder.
 
 The descriptor is the same for all fonts, but the range you'll set for a variable font will generally be greater, possibly even `1 1000` to use the same font for all font weight property values.
 

--- a/files/en-us/web/css/flood-color/index.md
+++ b/files/en-us/web/css/flood-color/index.md
@@ -82,7 +82,7 @@ rect {
 }
 ```
 
-We then apply different flood color values to the `<feFlood>` elements using the CSS `flood-color` property. We use a named color and a 3-digit hexidecimal color, but we can use any valid CSS color syntax:
+We then apply different flood color values to the `<feFlood>` elements using the CSS `flood-color` property. We use a named color and a 3-digit hexadecimal color, but we can use any valid CSS color syntax:
 
 ```css
 #flood1 feFlood {

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -71,7 +71,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("stiky-footer-example", "", "400px")}}
+{{EmbedLiveSample("sticky-footer-example", "", "400px")}}
 
 > [!NOTE]
 > In this example and the following one we are using a wrapper set to `min-height: 100%`. You can also achieve this for a full page by setting a {{cssxref("min-height")}} of `100vh` on the {{htmlelement("body")}} and then using it as your grid container.
@@ -142,7 +142,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("stiky-footer-flexbox-example", "", "400px")}}
+{{EmbedLiveSample("sticky-footer-flexbox-example", "", "400px")}}
 
 The flexbox example starts out in the same way, but we use `display:flex` rather than `display:grid` on the `.wrapper`; we also set `flex-direction` to `column`. Then we set our main content to `flex-grow: 1` and the other two elements to `flex-shrink: 0` — this prevents them from shrinking smaller when content fills the main area.
 

--- a/files/en-us/web/css/lighting-color/index.md
+++ b/files/en-us/web/css/lighting-color/index.md
@@ -95,7 +95,7 @@ rect {
 }
 ```
 
-We then apply different lighting color values to the filter's child elements using the CSS `lighting-color` property. We use a named color and a 3-digit hexidecimal color, but we can use any valid CSS color syntax:
+We then apply different lighting color values to the filter's child elements using the CSS `lighting-color` property. We use a named color and a 3-digit hexadecimal color, but we can use any valid CSS color syntax:
 
 ```css
 feDiffuseLighting {


### PR DESCRIPTION
### Description

Used the `typos` cli to find typos in the docs and fixed the non-false positives.

### Motivation

MDN should be free of typos.
