### PR TITLE
Fix browser-compat tags for gradient functions

### DIFF
--- a/files/en-us/web/css/gradient/conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/conic-gradient/index.md
@@ -2,7 +2,7 @@
 title: conic-gradient()
 slug: Web/CSS/gradient/conic-gradient
 page-type: css-function
-browser-compat: css.types.image.gradient.conic-gradient
+browser-compat: css.types.gradient.conic-gradient
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/gradient/linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/linear-gradient/index.md
@@ -2,7 +2,7 @@
 title: linear-gradient()
 slug: Web/CSS/gradient/linear-gradient
 page-type: css-function
-browser-compat: css.types.image.gradient.linear-gradient
+browser-compat: css.types.gradient.linear-gradient
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -2,7 +2,7 @@
 title: radial-gradient()
 slug: Web/CSS/gradient/radial-gradient
 page-type: css-function
-browser-compat: css.types.image.gradient.radial-gradient
+browser-compat: css.types.gradient.radial-gradient
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/gradient/repeating-conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient/index.md
@@ -2,7 +2,7 @@
 title: repeating-conic-gradient()
 slug: Web/CSS/gradient/repeating-conic-gradient
 page-type: css-function
-browser-compat: css.types.image.gradient.repeating-conic-gradient
+browser-compat: css.types.gradient.repeating-conic-gradient
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-linear-gradient/index.md
@@ -2,7 +2,7 @@
 title: repeating-linear-gradient()
 slug: Web/CSS/gradient/repeating-linear-gradient
 page-type: css-function
-browser-compat: css.types.image.gradient.repeating-linear-gradient
+browser-compat: css.types.gradient.repeating-linear-gradient
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/gradient/repeating-radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-radial-gradient/index.md
@@ -2,7 +2,7 @@
 title: repeating-radial-gradient()
 slug: Web/CSS/gradient/repeating-radial-gradient
 page-type: css-function
-browser-compat: css.types.image.gradient.repeating-radial-gradient
+browser-compat: css.types.gradient.repeating-radial-gradient
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix browser-compat tags for gradient functions.

### Motivation

Their pages fail to show browser compat tables.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
