### PR TITLE
Fix typo referencing `Map` instead of `Object`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
@@ -39,7 +39,7 @@ A [`null`-prototype object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/
 
 ## Description
 
-`Object.groupBy()` calls a provided `callbackFn` function once for each element in an iterable. The callback function should return a string or symbol (values that are neither type are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion)) indicating the group of the associated element. The values returned by `callbackFn` are used as keys for the object returned by `Map.groupBy()`. Each key has an associated array containing all the elements for which the callback returned the same value.
+`Object.groupBy()` calls a provided `callbackFn` function once for each element in an iterable. The callback function should return a string or symbol (values that are neither type are [coerced to strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion)) indicating the group of the associated element. The values returned by `callbackFn` are used as keys for the object returned by `Object.groupBy()`. Each key has an associated array containing all the elements for which the callback returned the same value.
 
 The elements in the returned object and the original iterable are the same (not {{Glossary("deep copy", "deep copies")}}). Changing the internal structure of the elements will be reflected in both the original iterable and the returned object.
 


### PR DESCRIPTION
This is just a typo fix — the text in this location should pretty clearly be referencing `Object.groupBy` instead of the related `Map.groupBy` function.