### PR TITLE
FF134 Relnote: ReadableStreamBYOBReader.read() option_min

### DIFF
--- a/files/en-us/mozilla/firefox/releases/134/index.md
+++ b/files/en-us/mozilla/firefox/releases/134/index.md
@@ -45,6 +45,7 @@ This article provides information about the changes in Firefox 134 that affect d
 
 - The [`PushManager.supportedContentEncodings`](/en-US/docs/Web/API/PushManager/supportedContentEncodings_static) static method is now supported for getting the allowed algorithms for encrypting the payload of a [push message](/en-US/docs/Web/API/Push_API). ([Firefox bug 1497430](https://bugzil.la/1497430)).
 - {{domxref("AudioParam.value")}} now allows the value to be set even during the time that an automated event is scheduled: previously the operation would silently be ignored at those times. ([Firefox bug 1308435](https://bugzil.la/1308435)).
+- The {{domxref("ReadableStreamBYOBReader.read()")}} method has a new argument [`options.min`](/en-US/docs/Web/API/ReadableStreamBYOBReader/read#min) that can be used to specify the minimum number of elements to be returned on each call. This might, for example, be used to avoid unnecessary iteration when working with data structures that have a known data size. ([Firefox bug 1864406](https://bugzil.la/1864406)).
 
 #### DOM
 


### PR DESCRIPTION
FF134 Release note added for `ReadableStreamBYOBReader.read()` now takes `options.min` argument.

Related docs work can be tracked in #36921