### PR TITLE
proc/PID is not available on mac

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -266,11 +266,10 @@ async function readFullAsync(length, buffer = new Uint8Array(65536)) {
 }
 
 async function sendMessage(message) {
-  const header = new Uint32Array([message.length]);
-  const stdout = await fs.open(`/proc/${process.pid}/fd/1`, "w");
+  const header = Buffer.from(new Uint32Array([message.length]).buffer);
+  const stdout = process.stdout;
   await stdout.write(header);
-  await stdout.write(message);
-  await stdout.close();
+  await stdout.write(Buffer.from(message));
 }
 
 while (true) {

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -269,7 +269,7 @@ async function sendMessage(message) {
   const header = Buffer.from(new Uint32Array([message.length]).buffer);
   const stdout = process.stdout;
   await stdout.write(header);
-  await stdout.write(Buffer.from(message));
+  await stdout.write(message);
 }
 
 while (true) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The current host example does not work on MacOS. Mac does not have `/proc/PID/fd/1`

```sh
[Error: ENOENT: no such file or directory, open '/proc/22290/fd/1'] {
errno: -2,
code: 'ENOENT',
syscall: 'open',
path: '/proc/22290/fd/1'
}
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Replaced the example with a working one.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #36513 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
