### PR TITLE
Replace 'the DOM load event' with 'the window load event' Issue #37047

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.webNavigation.onCompleted
 
 {{AddonSidebar}}
 
-Fired when a document, including the resources it refers to, is completely loaded and initialized. This is equivalent to the DOM [`load`](/en-US/docs/Web/API/Window/load_event) event.
+Fired when a document, including the resources it refers to, is completely loaded and initialized. This is equivalent to the window [`load`](/en-US/docs/Web/API/Window/load_event) event.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->Replaced 'the DOM load event' with 'the window load event' as it sounded similar to DOMContentLoaded event.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->This change will help new readers to have more clarity regarding onCompleted Navigation

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Chrome docs:
https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onCompleted

Fired when a document, including the resources it refers to, is completely loaded and initialized.

Also this is super useful to know:

Event order
For a navigation that is successfully completed, events are fired in the following order:
onBeforeNavigate -> onCommitted -> [onDOMContentLoaded] -> onCompleted



### Related issues and pull requests

Fixes #37047
