### PR TITLE
HTMLMediaElement: sinkId property: Remove `id-multimedia` and `id-communications`

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/sinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/sinkid/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLMediaElement.sinkId
 
 The **`sinkId`** read-only property of the {{domxref("HTMLMediaElement")}} interface returns a string that is the unique ID of the device to be used for playing audio output.
 
-This ID should be one of the {{domxref("MediaDeviceInfo.deviceId")}} values returned from {{domxref("MediaDevices.enumerateDevices()")}}, `id-multimedia`, or `id-communications`.
+This ID should be one of the {{domxref("MediaDeviceInfo.deviceId")}} values returned from {{domxref("MediaDevices.enumerateDevices()")}}.
 If the user agent default device is being used, it returns an empty string.
 
 ## Value


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove `id-multimedia` and `id-communications`. They were last listed in https://www.w3.org/TR/2016/WD-audio-output-20161014/#predefined-ids, but have been removed since.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

These IDs were removed from the spec.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://www.w3.org/TR/2016/WD-audio-output-20161014/#predefined-ids
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
