### PR TITLE
webglrenderingcontext.linewidth: remove 2017 warning

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
@@ -11,16 +11,6 @@ browser-compat: api.WebGLRenderingContext.lineWidth
 The **`WebGLRenderingContext.lineWidth()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) sets the line width of rasterized
 lines.
 
-> [!WARNING]
-> The webgl spec, based on the OpenGL ES 2.0/3.0 specs points out that the minimum and
-> maximum width for a line is implementation defined. The maximum minimum width is
-> allowed to be 1.0. The minimum maximum width is also allowed to be 1.0. Because of
-> these implementation defined limits it is not recommended to use line widths other
-> than 1.0 since there is no guarantee any user's browser will display any other width.
->
-> As of January 2017 most implementations of WebGL only support a minimum of 1 and a
-> maximum of 1 as the technology they are based on has these same limits.
-
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
i was able to get 0.5 in tests.