### PR TITLE
fix(css): descriptions on logical padding pages

### DIFF
--- a/files/en-us/web/css/padding-block-end/index.md
+++ b/files/en-us/web/css/padding-block-end/index.md
@@ -38,9 +38,9 @@ padding-block-end: unset;
 
 ## Description
 
-The `padding-block-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like {{cssxref("padding-bottom")}}, `padding-top`, {{cssxref("padding-left")}}, or {{cssxref("padding-right")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The `padding-block-end` property takes the same values as physical padding properties such as {{cssxref("padding-top")}}. However, it can be equivalent to {{cssxref("padding-bottom")}}, `padding-top`, {{cssxref("padding-left")}}, or {{cssxref("padding-right")}} depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
-It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
+It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other padding values of the element.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-block-end/index.md
+++ b/files/en-us/web/css/padding-block-end/index.md
@@ -38,7 +38,7 @@ padding-block-end: unset;
 
 ## Description
 
-The `padding-block-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
+The `padding-block-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like {{cssxref("padding-bottom")}}, `padding-top`, {{cssxref("padding-left")}}, or {{cssxref("padding-right")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-block-start/index.md
+++ b/files/en-us/web/css/padding-block-start/index.md
@@ -38,9 +38,9 @@ padding-block-start: unset;
 
 ## Description
 
-The `padding-block-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like `padding-top`, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}, or {{cssxref("padding-right")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The `padding-block-start` property takes the same values as physical padding properties such as {{cssxref("padding-top")}}. However, it can be equivalent to `padding-top`, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}, or {{cssxref("padding-right")}} depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
-It relates to {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
+It relates to {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other padding values of the element.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-block-start/index.md
+++ b/files/en-us/web/css/padding-block-start/index.md
@@ -38,7 +38,7 @@ padding-block-start: unset;
 
 ## Description
 
-The `padding-block-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
+The `padding-block-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like `padding-top`, {{cssxref("padding-bottom")}}, {{cssxref("padding-left")}}, or {{cssxref("padding-right")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 It relates to {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-block/index.md
+++ b/files/en-us/web/css/padding-block/index.md
@@ -45,7 +45,7 @@ The `padding-block` property takes the same values as the {{cssxref("padding-lef
 
 ## Description
 
-These values corresponds to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}}, or {{cssxref("padding-right")}} and {{cssxref("padding-left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The padding values specified by `padding-block` can be equivalent to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}} properties or the {{cssxref("padding-right")}} and {{cssxref("padding-left")}} properties, depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-block/index.md
+++ b/files/en-us/web/css/padding-block/index.md
@@ -45,7 +45,7 @@ The `padding-block` property takes the same values as the {{cssxref("padding-lef
 
 ## Description
 
-These values corresponds to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}}, or {{cssxref("padding-right")}}, and {{cssxref("padding-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+These values corresponds to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}}, or {{cssxref("padding-right")}} and {{cssxref("padding-left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline-end/index.md
+++ b/files/en-us/web/css/padding-inline-end/index.md
@@ -38,7 +38,7 @@ padding-inline-end: unset;
 
 ## Description
 
-The `padding-inline-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, the physical property it maps to depends on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}. Therefore, it could map to {{cssxref("padding-bottom")}}, {{cssxref("padding-right")}}, or {{cssxref("padding-left")}}.
+The `padding-inline-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like {{cssxref("padding-right")}}, {{cssxref("padding-left")}}, `padding-top`, or {{cssxref("padding-bottom")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-start")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-inline-end/index.md
+++ b/files/en-us/web/css/padding-inline-end/index.md
@@ -38,9 +38,9 @@ padding-inline-end: unset;
 
 ## Description
 
-The `padding-inline-end` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like {{cssxref("padding-right")}}, {{cssxref("padding-left")}}, `padding-top`, or {{cssxref("padding-bottom")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The `padding-inline-end` property takes the same values as physical padding properties such as {{cssxref("padding-top")}}. However, it can be equivalent to {{cssxref("padding-right")}}, {{cssxref("padding-left")}}, `padding-top`, or {{cssxref("padding-bottom")}} depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
-It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-start")}}, which define the other paddings of the element.
+It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-start")}}, which define the other padding values of the element.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline-start/index.md
+++ b/files/en-us/web/css/padding-inline-start/index.md
@@ -38,7 +38,7 @@ padding-inline-start: unset;
 
 ## Description
 
-In English, a left-to-right top-to-bottom language, the `padding-inline-start` property for this paragraph of text corresponds to the {{cssxref("padding-top")}} property. However, whether this logical property corresponds to the `padding-top`, {{cssxref("padding-right")}}, or {{cssxref("padding-bottom")}}, or {{cssxref("padding-left")}} depends on the element's {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The `padding-inline-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like {{cssxref("padding-left")}}, {{cssxref("padding-right")}}, `padding-top`, or {{cssxref("padding-bottom")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
 

--- a/files/en-us/web/css/padding-inline-start/index.md
+++ b/files/en-us/web/css/padding-inline-start/index.md
@@ -38,9 +38,9 @@ padding-inline-start: unset;
 
 ## Description
 
-The `padding-inline-start` property is defined in the specification as taking the same values as the {{cssxref("padding-top")}} property. However, visually it appears like {{cssxref("padding-left")}}, {{cssxref("padding-right")}}, `padding-top`, or {{cssxref("padding-bottom")}} property depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The `padding-inline-start` property takes the same values as physical properties such as {{cssxref("padding-top")}}. However, it can be equivalent to {{cssxref("padding-left")}}, {{cssxref("padding-right")}}, `padding-top`, or {{cssxref("padding-bottom")}} depending on the values set for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
-It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other paddings of the element.
+It relates to {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, and {{cssxref("padding-inline-end")}}, which define the other padding values of the element.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline/index.md
+++ b/files/en-us/web/css/padding-inline/index.md
@@ -48,7 +48,7 @@ The `padding-inline` property may be specified with one or two values. If one va
 
 ## Description
 
-Values for this property correspond to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}}, or {{cssxref("padding-right")}}, and {{cssxref("padding-left")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+Values for this property correspond to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}}, or {{cssxref("padding-right")}} and {{cssxref("padding-left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/padding-inline/index.md
+++ b/files/en-us/web/css/padding-inline/index.md
@@ -48,7 +48,7 @@ The `padding-inline` property may be specified with one or two values. If one va
 
 ## Description
 
-Values for this property correspond to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}}, or {{cssxref("padding-right")}} and {{cssxref("padding-left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+The padding values specified by `padding-inline` can be equivalent to the {{cssxref("padding-top")}} and {{cssxref("padding-bottom")}} properties or the {{cssxref("padding-right")}} and {{cssxref("padding-left")}} properties, depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
 
 ## Formal definition
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/37082

It would be better to have the same statements on all the pages. We need to be explicit about the value and visual appearance parts.