### PR TITLE
Remove the "mixed" aria-checked value from the menuitemradio role docs

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/menuitemradio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menuitemradio_role/index.md
@@ -68,7 +68,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 - [`group`](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) role
   - : Container for a group of `menuitem` elements, including `menuitemradio` elements within a `menu` or `menubar`.
 - [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) (Required)
-  - : Set to `true`, `false`, or `mixed`, it indicates the current "checked" state of the menuitemradio
+  - : Set to `true` or `false`, it indicates the current "checked" state of the menuitemradio
 
 ### Keyboard interactions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

In the [menuitemradio role's documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role#associated_wai-aria_roles_states_and_properties) there's a small issue: the `mixed` value is suggested as a valid value for the `aria-checked` attribute, but that's only valid for the checkbox and menuitemcheckbox role (as also clarified on the same page, a bit above). This PR removes `mixed` from this page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
All sections of the documentation should be correct.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

None

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
