### PR TITLE
WebExt: fix typo

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -32,7 +32,7 @@ let uninstalling = browser.management.uninstall(
 <!---->
 
 - If `id` is the calling add-on's ID, `showConfirmDialog` defaults to `false`.
-- If `id` is an ID of a different add-on, the `showConfirmDialog` option is ignored and the confirmation dialog is always shown.
+- If `id` is the ID of a different add-on, the `showConfirmDialog` option is ignored and the confirmation dialog is always shown.
 
 ### Return value
 
@@ -44,7 +44,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ## Examples
 
-Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the callback, we check whether the user canceled the uninstallation, or if the operation succeeded.
+Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the callback, we check whether the user canceled the uninstallation or if the operation succeeded.
 
 ```js
 let id = "addon-id";

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -54,13 +54,13 @@ const uninstall = () => {
         console.log(`Canceled: ${error}`);
     }
 
-    function onUninstalled() {
-        console.log("Uninstalled");
-    }
+  function onUninstalled() {
+    console.log("Uninstalled");
+  }
 
-    let uninstalling = chrome.management.uninstall(id);
-    uninstalling.then(onUninstalled, onCanceled);
-}
+  let uninstalling = chrome.management.uninstall(id);
+  uninstalling.then(onUninstalled, onCanceled);
+};
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -44,19 +44,23 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ## Examples
 
-Uninstall the add-on whose ID is "my-addon-id", asking the user to confirm. In the callback, check whether the user canceled uninstallation.
-
-Note that we haven't passed a fulfillment handler because if uninstallation succeeds, the add-on is no longer around to handle it.
+Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the callback, we check whether the user cancelled uninstallation, or if the uninstallation succeeded.
 
 ```js
-let id = "my-addon-id";
+let id = "addon-id";
 
-function onCanceled(error) {
-  console.log(`Uninstall canceled: ${error}`);
+const uninstall = () => {
+    function onCanceled(error) {
+        console.log(`Cancelled: ${error}`);
+    }
+
+    function onUninstalled() {
+        console.log("Uninstalled");
+    }
+
+    let uninstalling = chrome.management.uninstall(id);
+    uninstalling.then(onUninstalled, onCanceled);
 }
-
-let uninstalling = browser.management.uninstall(id);
-uninstalling.then(null, onCanceled);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -36,7 +36,7 @@ let uninstalling = browser.management.uninstall(
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be rejected with an error message if the user canceled uninstall.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be rejected with an error message if the user canceled the uninstallation.
 
 ## Browser compatibility
 
@@ -44,14 +44,14 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ## Examples
 
-Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the callback, we check whether the user cancelled uninstallation, or if the uninstallation succeeded.
+Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the callback, we check whether the user canceled the uninstallation, or if the operation succeeded.
 
 ```js
 let id = "addon-id";
 
 const uninstall = () => {
     function onCanceled(error) {
-        console.log(`Cancelled: ${error}`);
+        console.log(`Canceled: ${error}`);
     }
 
     function onUninstalled() {

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -50,9 +50,9 @@ Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the 
 let id = "addon-id";
 
 const uninstall = () => {
-    function onCanceled(error) {
-        console.log(`Canceled: ${error}`);
-    }
+  function onCanceled(error) {
+    console.log(`Canceled: ${error}`);
+  }
 
   function onUninstalled() {
     console.log("Uninstalled");

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -32,7 +32,7 @@ let uninstalling = browser.management.uninstall(
 <!---->
 
 - If `id` is the calling add-on's ID, `showConfirmDialog` defaults to `false`.
-- If `id` is a the ID of a different add-on, the `showConfirmDialog` option is ignored and the confirmation dialog is always shown.
+- If `id` is an ID of a different add-on, the `showConfirmDialog` option is ignored and the confirmation dialog is always shown.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -49,18 +49,16 @@ Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the 
 ```js
 let id = "addon-id";
 
-const uninstall = () => {
-  function onCanceled(error) {
-    console.log(`Canceled: ${error}`);
-  }
+function onCanceled(error) {
+  console.log(`Canceled: ${error}`);
+}
 
-  function onUninstalled() {
-    console.log("Uninstalled");
-  }
+function onUninstalled() {
+  console.log("Uninstalled");
+}
 
-  let uninstalling = chrome.management.uninstall(id);
-  uninstalling.then(onUninstalled, onCanceled);
-};
+let uninstalling = browser.management.uninstall(id);
+uninstalling.then(onUninstalled, onCanceled);
 ```
 
 {{WebExtExamples}}


### PR DESCRIPTION
1. fixed a typo `a the ID of a different add-on`;
2. under `## Examples` line 2 (L49 of file), sentence written `Note that we haven't passed a fulfillment handler because if uninstallation succeeds, the add-on is no longer around to handle it.`; *but that's not factually correct if we are uninstalling different add-on(s) than the one that's calling the method, than shouldn't the add-on is still here to handle it?

    per tested, fulfillment handler are called when the add-on/extension is uninstalled.

    ```js
    let id = "addon-id";

    const uninstall = () => {
        function onCanceled(error) {
            console.log(`Cancelled: ${error}`);
        }

        function onUninstalled() {
            console.log("Uninstalled");
        }

        let uninstalling = chrome.management.uninstall(id);
        uninstalling.then(onUninstalled, onCanceled);
    }
    ```

---

FYI: content was here ever since it's checkin into git.