### PR TITLE
Glossary: remove invalid link

### DIFF
--- a/files/en-us/glossary/time_to_interactive/index.md
+++ b/files/en-us/glossary/time_to_interactive/index.md
@@ -18,4 +18,4 @@ TTI is derived by leveraging information from the [Long Task API](/en-US/docs/We
 
 - [Definition of TTI](https://github.com/WICG/time-to-interactive) from Web Incubator Community Group
 - [Time to Interactive — focusing on human-centric metrics](https://calibreapp.com/blog/time-to-interactive) by Radimir Bitsov
-- [Tracking TTI](https://web.dev/articles/user-centric-performance-metrics#tracking_tti)
+- [Measuring TTI](https://web.dev/articles/tti) with Chrome Lighthouse

--- a/files/en-us/glossary/time_to_interactive/index.md
+++ b/files/en-us/glossary/time_to_interactive/index.md
@@ -18,4 +18,3 @@ TTI is derived by leveraging information from the [Long Task API](/en-US/docs/We
 
 - [Definition of TTI](https://github.com/WICG/time-to-interactive) from Web Incubator Community Group
 - [Time to Interactive — focusing on human-centric metrics](https://calibreapp.com/blog/time-to-interactive) by Radimir Bitsov
-- [Measuring TTI](https://web.dev/articles/tti) with Chrome Lighthouse


### PR DESCRIPTION
removed an invalid link to *user-centric performance* per removal from web.dev, possibly due to Chrome's removal of the metric in Lighthouse 10 ([ref](https://developer.chrome.com/blog/lighthouse-10-0#scoring-changes))