### PR TITLE
Add a note about how `delegatesFocus` about focusable element placement

### DIFF
--- a/files/en-us/web/api/shadowroot/delegatesfocus/index.md
+++ b/files/en-us/web/api/shadowroot/delegatesfocus/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ShadowRoot.delegatesFocus
 
 The **`delegatesFocus`** read-only property of the {{domxref("ShadowRoot")}} interface returns `true` if the shadow root delegates focus, and `false` otherwise.
 
-If `true`, when a non-focusable part of the shadow DOM is clicked, or `.focus()` is called on the host element, the first focusable part (inside the host's shadow DOM) is given focus, and the shadow host is given any available `:focus` styling.
+If `true`, when a non-focusable part of the shadow DOM is clicked, or `.focus()` is called on the host element, the first focusable part inside the host's shadow DOM is given focus, and the shadow host is given any available `:focus` styling.
 
 Focus is of particular importance for keyboard users (including those using screen readers). `delegatesFocus` default behavior is to focus the first focusable element — which may be undesirable if that element is not meant to be part of the tabbing order (for example, an element with `tabindex="-1"`), or if a more 'important' focusable element should receive initial focus (for instance, the first text field rather than the 'close' button which precedes it). In such cases, the `autofocus` attribute can be specified on the element which should receive initial focus. Use the `autofocus` attribute with caution as it can introduce accessibility issues, such as bypassing important content which may go unnoticed due to focus being set to an element later in the DOM order.
 

--- a/files/en-us/web/api/shadowroot/delegatesfocus/index.md
+++ b/files/en-us/web/api/shadowroot/delegatesfocus/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ShadowRoot.delegatesFocus
 
 The **`delegatesFocus`** read-only property of the {{domxref("ShadowRoot")}} interface returns `true` if the shadow root delegates focus, and `false` otherwise.
 
-If `true`, when a non-focusable part of the shadow DOM is clicked, or `.focus()` is called on the host element, the first focusable part is given focus, and the shadow host is given any available `:focus` styling.
+If `true`, when a non-focusable part of the shadow DOM is clicked, or `.focus()` is called on the host element, the first focusable part (inside the host's shadow DOM) is given focus, and the shadow host is given any available `:focus` styling.
 
 Focus is of particular importance for keyboard users (including those using screen readers). `delegatesFocus` default behavior is to focus the first focusable element — which may be undesirable if that element is not meant to be part of the tabbing order (for example, an element with `tabindex="-1"`), or if a more 'important' focusable element should receive initial focus (for instance, the first text field rather than the 'close' button which precedes it). In such cases, the `autofocus` attribute can be specified on the element which should receive initial focus. Use the `autofocus` attribute with caution as it can introduce accessibility issues, such as bypassing important content which may go unnoticed due to focus being set to an element later in the DOM order.
 


### PR DESCRIPTION

### Description

I was testing around with `delegatesFocus` and it seems that it will only delegate focus to elements that live inside the shadow dom.

If you have focusable elements in the light dom, they will not get focused.

Example:

https://codepen.io/paramagicdev/pen/ByBjogK?editors=1010

```html
<my-element>
  <template shadowrootmode="open" shadowrootdelegatesfocus="true">
    <slot></slot>
  </template>
  <button>Hello World</button>
</my-element>
```

Call `.focus()` on `<my-element>` *will not* shift focus.

However, if you embedded the "focusable part" inside the shadow dom, delegatesFocus will work as expected.

```html
<my-element>
  <template shadowrootmode="open" shadowrootdelegatesfocus="true">
      <button>Hello World</button>
  </template>
  </my-element>
```


### Motivation

delegatesFocus not working for light dom elements was perplexing me.

### Additional details


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
