### PR TITLE
fix: mismatch between code and return value

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/iterator/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/some/index.md
@@ -52,8 +52,7 @@ const isEven = (x) => x % 2 === 0;
 console.log(fibonacci().some(isEven)); // true
 
 const isNegative = (x) => x < 0;
-const isPositive = (x) => x > 0;
-console.log(fibonacci().take(10).some(isPositive)); // false
+console.log(fibonacci().take(10).some(isNegative)); // false
 console.log(fibonacci().some(isNegative)); // Never completes
 ```
 


### PR DESCRIPTION


### Description

I changed
 `console.log(fibonacci().take(10).some(isPositive)); // false`
to 
`console.log(fibonacci().take(10).some(isNegative)); // false`

and removed this line :
`const isPositive = (x) => x > 0;`



### Related issues and pull requests

Fixes #37110

