### PR TITLE
string.concat() is not useful

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.md
@@ -15,7 +15,6 @@ the string arguments to this string and returns a new string.
 ## Syntax
 
 ```js-nolint
-concat()
 concat(str1)
 concat(str1, str2)
 concat(str1, str2, /* …, */ strN)
@@ -23,8 +22,8 @@ concat(str1, str2, /* …, */ strN)
 
 ### Parameters
 
-- `str1`, …, `strN` {{optional_inline}}
-  - : One or more strings to concatenate to `str`.
+- `str1`, …, `strN`
+  - : One or more strings to concatenate to `str`. Though technically permitted, calling `String.prototype.concat()` with no arguments is a useless operation, because it does not result in observable copying (like {{jsxref("Array.prototype.concat()")}}), since strings are immutable. It should only happen if you are [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) an array of strings as arguments, and that array happens to be empty.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.md
@@ -23,7 +23,7 @@ concat(str1, str2, /* …, */ strN)
 
 ### Parameters
 
-- `str1`, …, `strN`
+- `str1`, …, `strN` {{optional_inline}}
   - : One or more strings to concatenate to `str`.
 
 ### Return value


### PR DESCRIPTION
### Description

Just add the {{optional_inline}}, same as "Web/JavaScript/Reference/Global_Objects/Array/concat". :)