### PR TITLE
Fix: removed unnecessary webgl.css link

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -23,7 +23,6 @@ This project uses the [glMatrix](https://glmatrix.net/) library to perform its m
   <head>
     <meta charset="utf-8" />
     <title>WebGL Demo</title>
-    <link rel="stylesheet" href="./webgl.css" type="text/css" />
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"
       integrity="sha512-zhHQR0/H5SEBL3Wn6yYSaTTZej12z0hVZKOv3TwCUXT1z5qeqGcXJLLrbERYRScEDDpYIJhPC1fk31gqR783iQ=="


### PR DESCRIPTION

### Description
Fixed issue with removing an unnecessary link dealing with the tutorial adding_2d_content_to_a_webgl_context by removing it.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I made this PR to work on an easier first issue as the label says. I found it and thought I might as well see what its like to go through the process of contributing to a project that is Open source. I fixed the issue mentioned in the original issue link below.

### Additional details


### Related issues and pull requests

Issue link: https://github.com/mdn/content/issues/37097
Relates to: issue 37097

