### PR TITLE
Fix subtitlesMenu redeclaration in "Adding captions and subtitles to HTML video" tutorial

### DIFF
--- a/files/en-us/web/media/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -156,7 +156,7 @@ All we need to do is to go through the video's `textTracks`, reading their prope
 let subtitlesMenu;
 if (video.textTracks) {
   const df = document.createDocumentFragment();
-  const subtitlesMenu = df.appendChild(document.createElement("ul"));
+  subtitlesMenu = df.appendChild(document.createElement("ul"));
   subtitlesMenu.className = "subtitles-menu";
   subtitlesMenu.appendChild(createMenuItem("subtitles-off", "", "Off"));
   for (let i = 0; i < video.textTracks.length; i++) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
In [the "Building a caption menu" section of the "Adding captions and subtitles to HTML video" tutorial](https://developer.mozilla.org/en-US/docs/Web/Media/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video#building_a_caption_menu), the `subtitlesMenu` variable is accidentally declared twice:
```js
let subtitlesMenu;
if (video.textTracks) {
	const df = document.createDocumentFragment();
	const subtitlesMenu = df.appendChild(document.createElement("ul"));
	/* ... */
}
```
Using this verbatim leads to the following error: `Uncaught ReferenceError: can't access lexical declaration 'subtitlesMenu' before initialization`. Removing the `const` for `subtitlesMenu` turns the statement from an unintended 2nd declaration to the intended initialization of the 1st declaration.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Readers who are going through this tutorial would be confused that using the tutorial code is leading to browser errors. This pull request will prevent confusion for future readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The MDN tutorial is based on code from [a tutorial by iandevlin](https://github.com/iandevlin/iandevlin.github.io/blob/master/mdn/video-player-with-captions/js/video-player.js), which uses the ECMAScript 5 syntax of `var` instead of `let` and `const`:
```js
var subtitlesMenu;
if (video.textTracks) {
	var df = document.createDocumentFragment();
	var subtitlesMenu = df.appendChild(document.createElement('ul'));
	/* ... */
}
```
While using `let` and `const` as above means 2 different `subtitlesMenu` variables are stored, using `var` means only 1 `subtitlesMenu` variable is stored and it is assigned `df.appendChild(document.createElement('ul'))`.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Having done a quick search, it appears there are no related issues or pull requests.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
