### PR TITLE
RTCIceCandidateStats - updates to match BCD

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9934,11 +9934,8 @@
 /en-US/docs/Web/API/RTCIceCandidateInit/sdpMid	/en-US/docs/Web/API/RTCIceCandidate/sdpMid
 /en-US/docs/Web/API/RTCIceCandidateInit/usernameFragment	/en-US/docs/Web/API/RTCIceCandidate/usernameFragment
 /en-US/docs/Web/API/RTCIceCandidatePairStats/bytesReceieved	/en-US/docs/Web/API/RTCIceCandidatePairStats/bytesReceived
-/en-US/docs/Web/API/RTCIceCandidateStats/deleted	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateStats/ip	/en-US/docs/Web/API/RTCIceCandidateStats/address
 /en-US/docs/Web/API/RTCIceCandidateStats/mozLocalTransport	/en-US/docs/Web/API/RTCIceCandidateStats
-/en-US/docs/Web/API/RTCIceCandidateStats/relayProtocol	/en-US/docs/Web/API/RTCIceCandidateStats
-/en-US/docs/Web/API/RTCIceCandidateStats/url	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateType	/en-US/docs/Web/API/RTCIceCandidate/type
 /en-US/docs/Web/API/RTCIceComponent	/en-US/docs/Web/API/RTCIceCandidate/component
 /en-US/docs/Web/API/RTCIceConnectionState	/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9934,6 +9934,7 @@
 /en-US/docs/Web/API/RTCIceCandidateInit/sdpMid	/en-US/docs/Web/API/RTCIceCandidate/sdpMid
 /en-US/docs/Web/API/RTCIceCandidateInit/usernameFragment	/en-US/docs/Web/API/RTCIceCandidate/usernameFragment
 /en-US/docs/Web/API/RTCIceCandidatePairStats/bytesReceieved	/en-US/docs/Web/API/RTCIceCandidatePairStats/bytesReceived
+/en-US/docs/Web/API/RTCIceCandidateStats/deleted	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateStats/ip	/en-US/docs/Web/API/RTCIceCandidateStats/address
 /en-US/docs/Web/API/RTCIceCandidateStats/mozLocalTransport	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateStats/relayProtocol	/en-US/docs/Web/API/RTCIceCandidateStats

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9935,7 +9935,8 @@
 /en-US/docs/Web/API/RTCIceCandidateInit/usernameFragment	/en-US/docs/Web/API/RTCIceCandidate/usernameFragment
 /en-US/docs/Web/API/RTCIceCandidatePairStats/bytesReceieved	/en-US/docs/Web/API/RTCIceCandidatePairStats/bytesReceived
 /en-US/docs/Web/API/RTCIceCandidateStats/ip	/en-US/docs/Web/API/RTCIceCandidateStats/address
-/en-US/docs/Web/API/RTCIceCandidateStats/mozLocalTransport	/en-US/docs/Web/API/RTCIceCandidateStats/relayProtocol
+/en-US/docs/Web/API/RTCIceCandidateStats/mozLocalTransport	/en-US/docs/Web/API/RTCIceCandidateStats
+/en-US/docs/Web/API/RTCIceCandidateStats/relayProtocol	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateType	/en-US/docs/Web/API/RTCIceCandidate/type
 /en-US/docs/Web/API/RTCIceComponent	/en-US/docs/Web/API/RTCIceCandidate/component
 /en-US/docs/Web/API/RTCIceConnectionState	/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9937,6 +9937,7 @@
 /en-US/docs/Web/API/RTCIceCandidateStats/ip	/en-US/docs/Web/API/RTCIceCandidateStats/address
 /en-US/docs/Web/API/RTCIceCandidateStats/mozLocalTransport	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateStats/relayProtocol	/en-US/docs/Web/API/RTCIceCandidateStats
+/en-US/docs/Web/API/RTCIceCandidateStats/url	/en-US/docs/Web/API/RTCIceCandidateStats
 /en-US/docs/Web/API/RTCIceCandidateType	/en-US/docs/Web/API/RTCIceCandidate/type
 /en-US/docs/Web/API/RTCIceComponent	/en-US/docs/Web/API/RTCIceCandidate/component
 /en-US/docs/Web/API/RTCIceConnectionState	/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -53567,10 +53567,6 @@
     "modified": "2020-10-15T22:13:26.613Z",
     "contributors": ["Sheppy"]
   },
-  "Web/API/RTCIceCandidateStats/deleted": {
-    "modified": "2020-10-15T22:15:50.914Z",
-    "contributors": ["Sheppy"]
-  },
   "Web/API/RTCIceCandidateStats/port": {
     "modified": "2020-10-15T22:15:52.213Z",
     "contributors": ["Sheppy"]

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -53587,10 +53587,6 @@
     "modified": "2020-10-15T22:15:52.263Z",
     "contributors": ["sideshowbarker", "Sheppy"]
   },
-  "Web/API/RTCIceCandidateStats/url": {
-    "modified": "2020-10-15T22:15:52.214Z",
-    "contributors": ["guo-sun", "Sheppy"]
-  },
   "Web/API/RTCIceParameters": {
     "modified": "2020-10-15T22:06:42.205Z",
     "contributors": ["Sheppy"]

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -53583,10 +53583,6 @@
     "modified": "2020-10-15T22:12:42.943Z",
     "contributors": ["Sheppy"]
   },
-  "Web/API/RTCIceCandidateStats/relayProtocol": {
-    "modified": "2020-10-15T22:12:42.881Z",
-    "contributors": ["Sheppy"]
-  },
   "Web/API/RTCIceCandidateStats/transportId": {
     "modified": "2020-10-15T22:15:52.263Z",
     "contributors": ["sideshowbarker", "Sheppy"]

--- a/files/en-us/web/api/rtcicecandidate/foundation/index.md
+++ b/files/en-us/web/api/rtcicecandidate/foundation/index.md
@@ -8,28 +8,27 @@ browser-compat: api.RTCIceCandidate.foundation
 
 {{APIRef("WebRTC")}}
 
-The **{{domxref("RTCIceCandidate")}}**
-interface's read-only **`foundation`** property is a string
-which uniquely identifies the candidate across multiple transports.
+The **`foundation`** read-only property of the {{domxref("RTCIceCandidate")}} interface is a string that allows correlation of candidates from a common network path on multiple {{domxref("RTCIceTransport")}} objects.
 
-The `foundation` can therefore be used to correlate candidates that are present on
-multiple {{domxref("RTCIceTransport")}} objects
+Candidates share the same `foundation` if they:
+
+- have the same type: "host", "relayed", "server reflexive", or "peer reflexive".
+- have "bases" that share the same IP address and transport, but not necessarily the same port.
+  Note that the IP address is that of the network interface from which the ICE agent sent the candidate.
+- They come from a {{Glossary("STUN")}} or TURN server that has the same IP address.
+
+This is used to help optimize ICE performance while prioritizing and correlating candidates that appear on multiple {{domxref("RTCIceTransport")}} objects.
 
 ## Value
 
-A string which uniquely identifies the candidate across all
-`RTCIceTransport`s on which it is available.
+A string which uniquely identifies the candidate across all `RTCIceTransport`s on which it is available.
 
 > [!NOTE]
-> If `port` is `null` — and
-> `port` is supported by the {{Glossary("user agent")}} — passing the
-> candidate to {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}}
-> will fail, throwing an `OperationError` exception.
+> If `port` is `null` — and `port` is supported by the {{Glossary("user agent")}} — passing the candidate to {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}} will fail, throwing an `OperationError` exception.
 
 ## Usage notes
 
-Consider this {{Glossary("SDP")}} attribute line (a-line) which describes an ICE
-candidate:
+Consider this {{Glossary("SDP")}} attribute line (a-line) which describes an ICE candidate:
 
 ```plain
 a=candidate:4234997325 1 udp 2043278322 192.0.2.172 44323 typ host
@@ -39,8 +38,7 @@ The field `"4234997325"` is the foundation.
 
 ## Examples
 
-This code snippet uses the `foundation` of two candidates to determine if
-they're actually the same candidate.
+This code snippet uses the `foundation` of two candidates to determine if they're actually the same candidate.
 
 ```js
 if (candidate1.foundation === candidate2.foundation) {

--- a/files/en-us/web/api/rtcicecandidatestats/address/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/address/index.md
@@ -8,36 +8,23 @@ browser-compat: api.RTCStatsReport.type_local-candidate.address
 
 {{APIRef("WebRTC")}}
 
-The **`address`** property of the
-{{domxref("RTCIceCandidateStats")}} dictionary indicates the address of the
-{{Glossary("ICE")}} candidate. While it's preferred that the address be specified as
-an IPv4 or IPv6 numeric address, a fully-qualified domain name can be used as
-well.
+The **`address`** property of the {{domxref("RTCIceCandidateStats")}} dictionary indicates the address of the {{Glossary("ICE")}} candidate.
+While it's preferred that the address be specified as an IPv4 or IPv6 numeric address, a fully-qualified domain name can be used as well.
 
-When a domain name is specified, the first IP address selected for that
-address is used, even if the domain name maps to multiple IP addresses.
+When a domain name is specified, the first IP address selected for that address is used, even if the domain name maps to multiple IP addresses.
 
 ## Value
 
-Either an IPv4 or IPv6 address or a fully-qualified domain name, which corresponds to
-the candidate.
+Either an IPv4 or IPv6 address or a fully-qualified domain name, which corresponds to the candidate.
 
-- If the value of `address` is comprised entirely of digits from 0-9 with
-  periods as separators, the value is interpreted as an IPv4 address.
-- If the value is entirely comprised of hexadecimal digits and colon (":")
-  characters, it is interpreted as an IPv6 address.
-- Otherwise, the `address` is presumed to be a fully-qualified domain name,
-  which is resolved first using an AAAA record (assuming IPv6 is available), then using
-  an A record (if no result is found or the device only supports IPv4). If multiple IP
-  addresses are returned in response to the query, the {{Glossary("user agent")}}
-  selects one, which is then used for the duration of ICE processing.
+- If the value of `address` is comprised entirely of digits from 0-9 with periods as separators, the value is interpreted as an IPv4 address.
+- If the value is entirely comprised of hexadecimal digits and colon (":") characters, it is interpreted as an IPv6 address.
+- Otherwise, the `address` is presumed to be a fully-qualified domain name, which is resolved first using an AAAA record (assuming IPv6 is available), then using an A record (if no result is found or the device only supports IPv4).
+  If multiple IP addresses are returned in response to the query, the {{Glossary("user agent")}} selects one, which is then used for the duration of ICE processing.
 
 ## Usage notes
 
-The `address` property was previously known as `ip`, and only
-permitted IPv4 and IPv6 addresses to be used. The addition of support for
-fully-qualified domain names to be used for the address brought about the renaming of
-the property.
+The `address` property was previously known as `ip`, and only permitted IPv4 and IPv6 addresses to be used. The addition of support for fully-qualified domain names to be used for the address brought about the renaming of the property.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.md
@@ -8,11 +8,9 @@ browser-compat: api.RTCStatsReport.type_local-candidate.candidateType
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCIceCandidateStats")}} interface's
-**`candidateType`** property is a string that indicates the
-type of {{Glossary("ICE")}} candidate the object represents.
+The **`candidateType`** property of the {{domxref("RTCIceCandidateStats")}} dictionary is a string that indicates the type of {{Glossary("ICE")}} candidate the object represents.
 
-## Value
+### Value
 
 A string whose value is one of the strings found in [`RTCIceCandidate.type`](/en-US/docs/Web/API/RTCIceCandidate/type#value).
 

--- a/files/en-us/web/api/rtcicecandidatestats/foundation/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/foundation/index.md
@@ -1,0 +1,27 @@
+---
+title: "RTCIceCandidateStats: foundation property"
+short-title: foundation
+slug: Web/API/RTCIceCandidateStats/foundation
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_local-candidate.foundation
+---
+
+{{APIRef("WebRTC")}}
+
+The **`foundation`** property of the {{domxref("RTCIceCandidateStats")}} interface is a string that uniquely identifies the candidate across multiple transports.
+
+It is the same for two candidates that are of the same type, are using the same transport protocol, originate from the same IP address, use ports that fall within the same range, and come from the same STUN server.
+
+For more information see {{domxref("RTCIceCandidate.foundation")}}.
+
+### Value
+
+A string representing the {{domxref("RTCIceCandidate.foundation", "foundation")}} of the corresponding {{domxref("RTCIceCandidate")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcicecandidatestats/foundation/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/foundation/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCStatsReport.type_local-candidate.foundation
 
 {{APIRef("WebRTC")}}
 
-The **`foundation`** property of the {{domxref("RTCIceCandidateStats")}} interface is a string that uniquely identifies the candidate across multiple transports.
+The **`foundation`** property of the {{domxref("RTCIceCandidateStats")}} interface is a string that allows correlation of candidates from a common network path on multiple {{domxref("RTCIceTransport")}} objects.
 
 It is the same for two candidates that are of the same type, are using the same transport protocol, originate from the same IP address, use ports that fall within the same range, and come from the same STUN server.
 

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -15,16 +15,18 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
 
 - {{domxref("RTCIceCandidateStats.address", "address")}} {{optional_inline}}
   - : A string containing the address of the candidate. This value may be an IPv4 address, an IPv6 address, or a fully-qualified domain name. This property was previously named `ip` and only accepted IP addresses.
+    Corresponds to {{domxref("RTCIceCandidate.address")}}.
 - {{domxref("RTCIceCandidateStats.candidateType", "candidateType")}}
   - : A string matching one of the values in [`RTCIceCandidate.type`](/en-US/docs/Web/API/RTCIceCandidate/type#value), indicating what kind of candidate the object provides statistics for.
-- {{domxref("RTCIceCandidateStats.deleted", "deleted")}} {{optional_inline}}
-  - : A Boolean value indicating whether or not the candidate has been released or deleted; the default value is `false`. For local candidates, its value is `true` if the candidate has been deleted or released. For host candidates, `true` means that any network resources (usually a network socket) associated with the candidate have already been released. For {{Glossary("TURN")}} candidates, the TURN allocation is no longer active for deleted candidates. This property is not present for remote candidates.
 - {{domxref("RTCIceCandidateStats.port", "port")}} {{optional_inline}}
   - : The network port number used by the candidate.
+    Corresponds to {{domxref("RTCIceCandidate.port")}}.
 - {{domxref("RTCIceCandidateStats.priority", "priority")}} {{optional_inline}}
-  - : The candidate's priority, corresponding to {{domxref("RTCIceCandidate.priority")}}.
+  - : The candidate's priority.
+    Corresponds to {{domxref("RTCIceCandidate.priority")}}.
 - {{domxref("RTCIceCandidateStats.protocol", "protocol")}} {{optional_inline}}
   - : A string specifying the protocol (`tcp` or `udp`) used to transmit data on the `port`.
+    Corresponds to {{domxref("RTCIceCandidate.protocol")}}.
 - {{domxref("RTCIceCandidateStats.transportId", "transportId")}}
   - : A string uniquely identifying the transport object that was inspected in order to obtain the {{domxref("RTCTransportStats")}} associated with the candidate corresponding to these statistics.
 

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -18,6 +18,9 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
     Corresponds to {{domxref("RTCIceCandidate.address")}}.
 - {{domxref("RTCIceCandidateStats.candidateType", "candidateType")}}
   - : A string matching one of the values in [`RTCIceCandidate.type`](/en-US/docs/Web/API/RTCIceCandidate/type#value), indicating what kind of candidate the object provides statistics for.
+- {{domxref("RTCIceCandidateStats.foundation", "foundation")}} {{optional_inline}}
+  - : A string that uniquely identifies the candidate across multiple transports.
+    Corresponds to {{domxref("RTCIceCandidate.foundation")}}.
 - {{domxref("RTCIceCandidateStats.port", "port")}} {{optional_inline}}
   - : The network port number used by the candidate.
     Corresponds to {{domxref("RTCIceCandidate.port")}}.
@@ -29,6 +32,9 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
     Corresponds to {{domxref("RTCIceCandidate.protocol")}}.
 - {{domxref("RTCIceCandidateStats.transportId", "transportId")}}
   - : A string uniquely identifying the transport object that was inspected in order to obtain the {{domxref("RTCTransportStats")}} associated with the candidate corresponding to these statistics.
+- {{domxref("RTCIceCandidateStats.usernameFragment", "usernameFragment")}} {{optional_inline}}
+  - : A string containing the ICE username fragment ("ice-ufrag").
+    Corresponds to {{domxref("RTCIceCandidate.usernameFragment")}}.
 
 ### Common instance properties
 
@@ -45,7 +51,19 @@ The following properties are common to all WebRTC statistics objects.
 
 ## Examples
 
-TBD
+Given a variable `myPeerConnection`, which is an instance of {{domxref("RTCPeerConnection")}}, the code below uses `await` to wait for the statistics report, and then iterates it using `RTCStatsReport.forEach()`.
+It then filters the dictionaries for just those reports that have the type of `local-candidate` and logs the result.
+
+```js
+const stats = await myPeerConnection.getStats();
+
+stats.forEach((report) => {
+  if (report.type === "local-candidate") {
+    // Log the ICE candidate information
+    console.log(report);
+  }
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -25,9 +25,6 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
   - : The candidate's priority, corresponding to {{domxref("RTCIceCandidate.priority")}}.
 - {{domxref("RTCIceCandidateStats.protocol", "protocol")}} {{optional_inline}}
   - : A string specifying the protocol (`tcp` or `udp`) used to transmit data on the `port`.
-- {{domxref("RTCIceCandidateStats.relayProtocol", "relayProtocol")}} {{optional_inline}}
-  - : A string identifying the protocol used by the endpoint for communicating with the {{Glossary("TURN")}} server; valid values are `tcp`, `udp`, and `tls`.
-    Only present for local candidates.
 - {{domxref("RTCIceCandidateStats.transportId", "transportId")}}
   - : A string uniquely identifying the transport object that was inspected in order to obtain the {{domxref("RTCTransportStats")}} associated with the candidate corresponding to these statistics.
 - {{domxref("RTCIceCandidateStats.url", "url")}} {{optional_inline}}

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -27,9 +27,6 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
   - : A string specifying the protocol (`tcp` or `udp`) used to transmit data on the `port`.
 - {{domxref("RTCIceCandidateStats.transportId", "transportId")}}
   - : A string uniquely identifying the transport object that was inspected in order to obtain the {{domxref("RTCTransportStats")}} associated with the candidate corresponding to these statistics.
-- {{domxref("RTCIceCandidateStats.url", "url")}} {{optional_inline}}
-  - : For local candidates, the `url` property is the {{Glossary("URL")}} of the {{Glossary("ICE")}} server from which the candidate was received.
-    This URL matches the one included in the {{domxref("RTCPeerConnectionIceEvent")}} object representing the {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} event that delivered the candidate to the local peer.
 
 ### Common instance properties
 

--- a/files/en-us/web/api/rtcicecandidatestats/port/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/port/index.md
@@ -8,13 +8,12 @@ browser-compat: api.RTCStatsReport.type_local-candidate.port
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCIceCandidateStats")}} dictionary's **`port`**
-property specifies the network port used by the candidate.
+The **`port`** property of the {{domxref("RTCIceCandidateStats")}} dictionary specifies the network port used by the candidate.
 
 ## Value
 
-An integer value indicating the network port used by the {{domxref("RTCIceCandidate")}}
-described by the `RTCIceCandidateStats` object.
+An integer value indicating the network port used by the {{domxref("RTCIceCandidate")}} described by this `RTCIceCandidateStats` object.
+Corresponds to {{domxref("RTCIceCandidate.port")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatestats/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/priority/index.md
@@ -8,35 +8,28 @@ browser-compat: api.RTCStatsReport.type_local-candidate.priority
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCIceCandidateStats")}} dictionary's
-**`priority`** property is a positive integer value
-indicating the priority (or desirability) of the described candidate.
+The **`priority`** property of the {{domxref("RTCIceCandidateStats")}} dictionary is a positive integer value indicating the priority (or desirability) of the described candidate.
 
-During {{Glossary("ICE")}} negotiation while setting up a WebRTC peer connection, the
-priority values reported to the remote peer by a {{Glossary("user agent")}} are used
-to determine which candidates are considered "more desirable". The higher the value,
-the more desirable the candidate is.
+### Value
 
-## Value
+A positive integer indicating the priority of the {{domxref("RTCIceCandidate")}} described by the `RTCIceCandidateStats` object.
+The value may be anywhere from 1 to 2,147,483,647.
 
-A positive integer indicating the priority of the {{domxref("RTCIceCandidate")}}
-described by the `RTCIceCandidateStats` object. The value may be anywhere
-from 1 to 2,147,483,647.
+## Description
 
-## Determining priority
+During {{Glossary("ICE")}} negotiation while setting up a WebRTC peer connection, the priority values reported to the remote peer by a {{Glossary("user agent")}} are used to determine which candidates are considered "more desirable".
+The higher the value, the more desirable the candidate is.
 
-The ICE specification describes how user agents and other software using WebRTC should
-calculate the priority. The priority of a candidate is calculated using the following
-variables as inputs:
+### Determining priority
 
-- The preferability of the candidate type (local, server reflexive, peer reflexive,
-  or relayed)
+The ICE specification describes how user agents and other software using WebRTC should calculate the priority.
+The priority of a candidate is calculated using the following variables as inputs:
+
+- The preferability of the candidate type (local, server reflexive, peer reflexive, or relayed)
 - The preferability of the candidate's specific IP address (for multihomed agents)
 - The candidate's component ID (1 for RTP, 2 for RTCP)
 
-The candidate's priority is computed using the formula (_p<sub>type</sub>_ is
-the priority of the candidate's type and _p<sub>local</sub>_ is the priority of
-the IP address):
+The candidate's priority is computed using the formula (_p<sub>type</sub>_ is the priority of the candidate's type and _p<sub>local</sub>_ is the priority of the IP address):
 
 <!-- prettier-ignore-start -->
 <math display="block">
@@ -44,9 +37,7 @@ the IP address):
 </math>
 <!-- prettier-ignore-end -->
 
-This is equivalent to mapping the priorities of the candidate type, the local IP, and
-the component ID into various bit ranges within the 32-bit `priority`
-value.
+This is equivalent to mapping the priorities of the candidate type, the local IP, and the component ID into various bit ranges within the 32-bit `priority` value.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
@@ -8,18 +8,18 @@ browser-compat: api.RTCStatsReport.type_local-candidate.protocol
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCIceCandidateStats")}} dictionary's
-**`protocol`** property specifies the protocol the specified
-candidate would use for communication with the remote peer.
+The **`protocol`** property of the {{domxref("RTCIceCandidateStats")}} dictionary indicates the protocol the specified candidate would use for communication with the remote peer.
 
 ## Value
 
-The value is one of the following string:
+The value is one of the following strings:
 
 - `tcp`
-  - : The candidate, if selected, would use {{Glossary("TCP")}} as the transport protocol for its data. The {{domxref("RTCIceCandidate.tcpType", "tcpType")}} property provides additional information about the kind of TCP candidate represented by the object.
+  - : The candidate, if selected, would use {{Glossary("TCP")}} as the transport protocol for its data.
+    The {{domxref("RTCIceCandidate.tcpType", "tcpType")}} property provides additional information about the kind of TCP candidate represented by the object.
 - `udp`
-  - : The candidate will use the {{Glossary("UDP")}} transport protocol for its data. This is the preferred protocol for media interactions because of its better performance profile.
+  - : The candidate will use the {{Glossary("UDP")}} transport protocol for its data.
+    This is the preferred protocol for media interactions because of its better performance profile.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
@@ -8,17 +8,13 @@ browser-compat: api.RTCStatsReport.type_local-candidate.transportId
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCIceCandidateStats")}} dictionary's
-**`transportId`** property is a string that uniquely
-identifies the transport that produced the {{domxref("RTCTransportStats")}} from which
-information about this candidate was taken.
+The **`transportId`** property of the {{domxref("RTCIceCandidateStats")}} dictionary is a string that uniquely identifies the transport that produced the {{domxref("RTCTransportStats")}} from which information about this candidate was taken.
+
+This can be used, for example, to compare candidates that use the same transport.
 
 ## Value
 
-A string whose value uniquely identifies the transport from which any
-transport-related information accumulated in the {{domxref("RTCIceCandidateStats")}} was
-taken. This can be used to compare candidates that would use the same transport, for
-example.
+A string whose value uniquely identifies the transport from which any transport-related information accumulated in the {{domxref("RTCIceCandidateStats")}} was taken.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatestats/usernamefragment/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/usernamefragment/index.md
@@ -1,0 +1,27 @@
+---
+title: "RTCIceCandidateStats: usernameFragment property"
+short-title: usernameFragment
+slug: Web/API/RTCIceCandidateStats/usernameFragment
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_local-candidate.usernameFragment
+---
+
+{{APIRef("WebRTC")}}
+
+The **`usernameFragment`** property of the {{domxref("RTCIceCandidateStats")}} interface is a string that represents the {{Glossary("ICE")}} username fragment ("ice-ufrag").
+
+The fragment uniquely identifies a single ICE interaction session, and can be used to identify communications that are part of the same session even across ICE restarts.
+
+For more information see {{domxref("RTCIceCandidate.usernameFragment")}}.
+
+### Value
+
+A string representing the {{domxref("RTCIceCandidate.usernameFragment", "usernameFragment")}} of the corresponding {{domxref("RTCIceCandidate")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
This updates `RTCIceCandidateStats` to match BCD as part of https://github.com/mdn/mdn/issues/384

This removes the properties `relayProtocol`, `url`, and `deleted` which are not BCD and adds `foundation` and `usernameFragment` which are. The docs are "thin", mostly linking to the corresponding `RTCIceCandidate` docs that they reflect. 

In addition, some of the other properties were modified to bring them in line with current templates.