### PR TITLE
RTCTransportStats - updates

### DIFF
--- a/files/en-us/web/api/rtctransportstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtctransportstats/bytesreceived/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: bytesReceived property"
+short-title: bytesReceived
+slug: Web/API/RTCTransportStats/bytesReceived
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.bytesReceived
+---
+
+{{APIRef("WebRTC")}}
+
+The **`bytesReceived`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the total number of payload bytes received on this transport.
+
+Only data bytes are counted; overhead such as padding, headers, and so on are not included in this count.
+
+## Value
+
+A positive integer indicating the number of received payload bytes.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/bytessent/index.md
+++ b/files/en-us/web/api/rtctransportstats/bytessent/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: bytesSent property"
+short-title: bytesSent
+slug: Web/API/RTCTransportStats/bytesSent
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.bytesSent
+---
+
+{{APIRef("WebRTC")}}
+
+The **`bytesSent`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the total number of payload bytes sent on this transport.
+
+Only data bytes are counted; overhead such as padding, headers, and so on are not included in this count.
+
+## Value
+
+A positive integer indicating the number of sent payload bytes.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/dtlscipher/index.md
+++ b/files/en-us/web/api/rtctransportstats/dtlscipher/index.md
@@ -1,0 +1,26 @@
+---
+title: "RTCTransportStats: dtlsCipher property"
+short-title: dtlsCipher
+slug: Web/API/RTCTransportStats/dtlsCipher
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.dtlsCipher
+---
+
+{{APIRef("WebRTC")}}
+
+The **`dtlsCipher`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the descriptive name of the cipher suite used for the DTLS transport.
+
+Allowed names are defined in the "Description" column of the [TLS Cipher Suites](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4) section in the _IANA cipher suite registry_.
+For example `"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"`.
+
+## Value
+
+A string indicating the name of the DTLS cipher.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/dtlsrole/index.md
+++ b/files/en-us/web/api/rtctransportstats/dtlsrole/index.md
@@ -1,0 +1,33 @@
+---
+title: "RTCTransportStats: dtlsRole property"
+short-title: dtlsRole
+slug: Web/API/RTCTransportStats/dtlsRole
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.dtlsRole
+---
+
+{{APIRef("WebRTC")}}
+
+The **`dtlsRole`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the role of the associated {{domxref("RTCPeerConnection")}} in the DTLS negotiation.
+
+Specifically, whether it acted like a server and listened for connections, or like a client and initiated the connection, or that negotiation has not yet started.
+
+## Value
+
+A string indicating the DTLS role.
+This will be one of:
+
+- `client`
+  - : The peer will initiate the DTLS handshake.
+- `server`
+  - : The peer waited for the DTLS handshake.
+- `unknown`
+  - : DTLS negotiation has not started.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/dtlsrole/index.md
+++ b/files/en-us/web/api/rtctransportstats/dtlsrole/index.md
@@ -18,7 +18,7 @@ A string indicating the DTLS role.
 This will be one of:
 
 - `client`
-  - : The peer will initiate the DTLS handshake.
+  - : The peer initiated the DTLS handshake.
 - `server`
   - : The peer waited for the DTLS handshake.
 - `unknown`

--- a/files/en-us/web/api/rtctransportstats/dtlsstate/index.md
+++ b/files/en-us/web/api/rtctransportstats/dtlsstate/index.md
@@ -10,20 +10,11 @@ browser-compat: api.RTCStatsReport.type_transport.dtlsState
 
 The **`dtlsState`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the current state of the underlying {{domxref("RTCDtlsTransport")}}.
 
+This has the same value as the corresponding {{domxref("RTCDtlsTransport.state")}} property.
+
 ## Value
 
-This has the same values as the corresponding {{domxref("RTCDtlsTransport.state")}} property:
-
-- `new`
-  - : The initial state when DTLS has not started negotiating yet.
-- `connecting`
-  - : DTLS is in the process of negotiating a secure connection and verifying the remote fingerprint.
-- `connected`
-  - : DTLS has completed negotiation of a secure connection and verified the remote fingerprint.
-- `closed`
-  - : The transport has been closed intentionally as the result of receipt of a `close_notify` alert, or calling {{DOMxRef("RTCPeerConnection.close()")}}.
-- `failed`
-  - : The transport has failed as the result of an error (such as receipt of an error alert or failure to validate the remote fingerprint).
+A string that will be one of the following values: `new`, `connecting`, `connected`, `closed`, `failed`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/dtlsstate/index.md
+++ b/files/en-us/web/api/rtctransportstats/dtlsstate/index.md
@@ -1,0 +1,34 @@
+---
+title: "RTCTransportStats: dtlsState property"
+short-title: dtlsState
+slug: Web/API/RTCTransportStats/dtlsState
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.dtlsState
+---
+
+{{APIRef("WebRTC")}}
+
+The **`dtlsState`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the current state of the underlying {{domxref("RTCDtlsTransport")}}.
+
+## Value
+
+This has the same values as the corresponding {{domxref("RTCDtlsTransport.state")}} property:
+
+- `new`
+  - : The initial state when DTLS has not started negotiating yet.
+- `connecting`
+  - : DTLS is in the process of negotiating a secure connection and verifying the remote fingerprint.
+- `connected`
+  - : DTLS has completed negotiation of a secure connection and verified the remote fingerprint.
+- `closed`
+  - : The transport has been closed intentionally as the result of receipt of a `close_notify` alert, or calling {{DOMxRef("RTCPeerConnection.close()")}}.
+- `failed`
+  - : The transport has failed as the result of an error (such as receipt of an error alert or failure to validate the remote fingerprint).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/icelocalusernamefragment/index.md
+++ b/files/en-us/web/api/rtctransportstats/icelocalusernamefragment/index.md
@@ -10,14 +10,16 @@ browser-compat: api.RTCStatsReport.type_transport.iceLocalUsernameFragment
 
 The **`iceLocalUsernameFragment`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the local username fragment ("ufrag" or "ice-ufrag") that uniquely identifies the ICE interaction session managed by this transport.
 
-## Value
-
-A string containing the username fragment that uniquely identifies the ongoing ICE session on the transport.
-The same fragment is used to identify the session for any communication with the STUN server.
-The string may be up to 256 characters long, and has no default value.
+The same username fragment is used to identify the session for any communication with the STUN server.
 
 This has the same values as the corresponding local {{domxref("RTCIceCandidate.usernameFragment")}} property.
 It will change if the connection is renegotiated, for example on ICE restart, or if {{domxref("RTCPeerConnection.setLocalDescription()")}} is called.
+
+## Value
+
+A string containing the username fragment that uniquely identifies the ongoing ICE session on the transport.
+
+The string may be up to 256 characters long, and has no default value.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/icelocalusernamefragment/index.md
+++ b/files/en-us/web/api/rtctransportstats/icelocalusernamefragment/index.md
@@ -13,7 +13,7 @@ The **`iceLocalUsernameFragment`** property of the {{domxref("RTCTransportStats"
 ## Value
 
 A string containing the username fragment that uniquely identifies the ongoing ICE session on the transport.
-The same fragment is used to identify the section for any communication with the STUN server.
+The same fragment is used to identify the session for any communication with the STUN server.
 The string may be up to 256 characters long, and has no default value.
 
 This has the same values as the corresponding local {{domxref("RTCIceCandidate.usernameFragment")}} property.

--- a/files/en-us/web/api/rtctransportstats/icelocalusernamefragment/index.md
+++ b/files/en-us/web/api/rtctransportstats/icelocalusernamefragment/index.md
@@ -1,0 +1,28 @@
+---
+title: "RTCTransportStats: iceLocalUsernameFragment property"
+short-title: iceLocalUsernameFragment
+slug: Web/API/RTCTransportStats/iceLocalUsernameFragment
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.iceLocalUsernameFragment
+---
+
+{{APIRef("WebRTC")}}
+
+The **`iceLocalUsernameFragment`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the local username fragment ("ufrag" or "ice-ufrag") that uniquely identifies the ICE interaction session managed by this transport.
+
+## Value
+
+A string containing the username fragment that uniquely identifies the ongoing ICE session on the transport.
+The same fragment is used to identify the section for any communication with the STUN server.
+The string may be up to 256 characters long, and has no default value.
+
+This has the same values as the corresponding local {{domxref("RTCIceCandidate.usernameFragment")}} property.
+It will change if the connection is renegotiated, for example on ICE restart, or if {{domxref("RTCPeerConnection.setLocalDescription()")}} is called.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/icerole/index.md
+++ b/files/en-us/web/api/rtctransportstats/icerole/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: iceRole property"
+short-title: iceRole
+slug: Web/API/RTCTransportStats/iceRole
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.iceRole
+---
+
+{{APIRef("WebRTC")}}
+
+The **`iceRole`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the ICE role that the transport is fulfilling: that of the controlling agent, or the agent that is being controlled.
+
+This has the same value as the {{domxref("RTCIceTransport.role")}} property of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.
+
+## Value
+
+A string that will be one of the following values: `controlled`, `controlling`, or `unknown`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/icestate/index.md
+++ b/files/en-us/web/api/rtctransportstats/icestate/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: iceState property"
+short-title: iceState
+slug: Web/API/RTCTransportStats/iceState
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.iceState
+---
+
+{{APIRef("WebRTC")}}
+
+The **`iceState`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the current ICE state of the underlying {{domxref("RTCIceTransport")}}.
+
+This has the same value as the corresponding {{domxref("RTCIceTransport.state")}} property.
+
+## Value
+
+A string that will be one of the following values: `new`, `checking`, `connected`, `completed`, `disconnected`, `failed`, or `closed`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -32,13 +32,12 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
     This is one of: `new`, `connecting`, `connected`, `closed`, `failed`.
 - {{domxref("RTCTransportStats.iceLocalUsernameFragment", "iceLocalUsernameFragment")}} {{optional_inline}} {{experimental_inline}}
   - : A string indicating the local username fragment that uniquely identifies the ICE interaction session managed by this transport.
-    This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.
 - {{domxref("RTCTransportStats.iceRole", "iceRole")}} {{optional_inline}} {{experimental_inline}}
-  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.
-    This is one of: [`controlled`](/en-US/docs/Web/API/RTCIceTransport/role#controlled), [`controlling`](/en-US/docs/Web/API/RTCIceTransport/role#controlling), and [`unknown`](/en-US/docs/Web/API/RTCIceTransport/role#unknown).
+  - : A string indicating the ICE [`role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCIceTransport")}}.
+    This is one of: `controlled`, `controlling`, or `unknown`.
 - {{domxref("RTCTransportStats.iceState", "iceState")}} {{optional_inline}} {{experimental_inline}}
   - : A string indicating the current {{domxref("RTCIceTransport.state","state")}} of the underlying {{domxref("RTCIceTransport")}}.
-    This is one of: [`new`](/en-US/docs/Web/API/RTCIceTransport/state#new), [`checking`](/en-US/docs/Web/API/RTCIceTransport/state#checking), [`connected`](/en-US/docs/Web/API/RTCIceTransport/state#connected), [`completed`](/en-US/docs/Web/API/RTCIceTransport/state#completed), [`disconnected`](/en-US/docs/Web/API/RTCIceTransport/state#disconnected), [`failed`](/en-US/docs/Web/API/RTCIceTransport/state#failed), and [`closed`](/en-US/docs/Web/API/RTCIceTransport/state#closed).
+    This is one of: `new`, `checking`, `connected`, `completed`, `disconnected`, `failed`, or `closed`.
 - {{domxref("RTCTransportStats.localCertificateId", "localCertificateId")}} {{optional_inline}}
   - : A string containing the id of the local certificate used by this transport.
     Only present for DTLS transports, and after DTLS has been negotiated.

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -31,7 +31,7 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
   - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}.
     This is one of: `new`, `connecting`, `connected`, `closed`, `failed`.
 - {{domxref("RTCTransportStats.iceLocalUsernameFragment", "iceLocalUsernameFragment")}} {{optional_inline}} {{experimental_inline}}
-  - : A string indicating the local username fragment used in message validation procedures for this transport.
+  - : A string indicating the local username fragment that uniquely identifies the ICE interaction session managed by this transport.
     This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.
 - {{domxref("RTCTransportStats.iceRole", "iceRole")}} {{optional_inline}} {{experimental_inline}}
   - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -54,30 +54,10 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
 - {{domxref("RTCTransportStats.selectedCandidatePairId", "selectedCandidatePairId")}} {{optional_inline}}
   - : A string containing the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
 - {{domxref("RTCTransportStats.srtpCipher", "srtpCipher")}} {{optional_inline}}
-
-  - : A string indicating the descriptive name of the protection profile used for the [Secure Real-time Transport Protocol (SRTP)](/en-US/docs/Glossary/RTP) transport, as defined in the "Profile" column of the [IANA DTLS-SRTP protection profile registry](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml#srtp-protection-1) and [RFC5764](https://www.rfc-editor.org/rfc/rfc5764.html#section-4.1.2).
-
-    For example `"AES_CM_128_HMAC_SHA1_80"` specifies the following profile, where `maximum_lifetime` is the maximum number of packets that can be protected by a single set of keys.
-
-    ```plain
-    SRTP_AES128_CM_HMAC_SHA1_80
-     cipher: AES_128_CM
-     cipher_key_length: 128
-     cipher_salt_length: 112
-     maximum_lifetime: 2^31
-     auth_function: HMAC-SHA1
-     auth_key_length: 160
-     auth_tag_length: 80
-    ```
-
+  - : A string indicating the descriptive name of the protection profile used for the [Secure Real-time Transport Protocol (SRTP)](/en-US/docs/Glossary/RTP) transport.
 - {{domxref("RTCTransportStats.tlsVersion", "tlsVersion")}} {{optional_inline}}
-
   - : A string containing the negotiated TLS version.
     This is present for DTLS transports, and only exists after DTLS has been negotiated.
-
-    The value comes from the DTLS handshake `ServerHello.version`, and is represented as four upper case hexadecimal digits, where the digits represent the two bytes of the version.
-    Note however that the bytes might not map directly to version numbers.
-    For example, DTLS represents version 1.2 as `'FEFD'` which numerically is `{254, 253}`.
 
 ### Common instance properties
 

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -18,66 +18,44 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
 
 ## Instance properties
 
-- `bytesReceived` {{optional_inline}}
+- {{domxref("RTCTransportStats.bytesReceived", "bytesReceived")}} {{optional_inline}}
   - : The total number of payload bytes received on this transport (bytes received, not including headers, padding or ICE connectivity checks).
-- `bytesSent` {{optional_inline}}
+- {{domxref("RTCTransportStats.bytesSent", "bytesSent")}} {{optional_inline}}
   - : The total number of payload bytes sent on this transport (bytes sent, not including headers, padding or ICE connectivity checks).
-- `dtlsCipher` {{optional_inline}}
-  - : A string indicating the name of the cipher suite used for the DTLS transport, as defined in the "Description" column of the [TLS Cipher Suites](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4) section in the _IANA cipher suite registry_.
-    For example `"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"`.
-- `dtlsRole` {{optional_inline}} {{experimental_inline}}
-  - : The DTLS role of the associated {{domxref("RTCPeerConnection")}}.
-    This is one of:
-    - `client`
-    - `server`
-    - `unknown` (before the DTLS negotiation starts).
-
-- `dtlsState`
+- {{domxref("RTCTransportStats.dtlsCipher", "dtlsCipher")}} {{optional_inline}}
+  - : A string indicating the name of the cipher suite used for the DTLS transport, such as `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`.
+- {{domxref("RTCTransportStats.dtlsRole", "dtlsRole")}} {{optional_inline}} {{experimental_inline}}
+  - : A string indicating the DTLS role of the associated {{domxref("RTCPeerConnection")}}.
+    This is one of: `client`, `server`, `unknown` (before the DTLS negotiation starts).
+- {{domxref("RTCTransportStats.dtlsState", "dtlsState")}}
   - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}.
-    This is one of:
-    - [`new`](/en-US/docs/Web/API/RTCDtlsTransport/state#new)
-    - [`connecting`](/en-US/docs/Web/API/RTCDtlsTransport/state#connecting)
-    - [`connected`](/en-US/docs/Web/API/RTCDtlsTransport/state#connected)
-    - [`closed`](/en-US/docs/Web/API/RTCDtlsTransport/state#closed)
-    - [`failed`](/en-US/docs/Web/API/RTCDtlsTransport/state#failed)
-
-- `iceLocalUsernameFragment` {{optional_inline}} {{experimental_inline}}
+    This is one of: `new`, `connecting`, `connected`, `closed`, `failed`.
+- {{domxref("RTCTransportStats.iceLocalUsernameFragment", "iceLocalUsernameFragment")}} {{optional_inline}} {{experimental_inline}}
   - : A string indicating the local username fragment used in message validation procedures for this transport.
     This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.
-- `iceRole` {{optional_inline}} {{experimental_inline}}
+- {{domxref("RTCTransportStats.iceRole", "iceRole")}} {{optional_inline}} {{experimental_inline}}
   - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.
-    This is one of:
-    - [`controlled`](/en-US/docs/Web/API/RTCIceTransport/role#controlled)
-    - [`controlling`](/en-US/docs/Web/API/RTCIceTransport/role#controlling)
-    - [`unknown`](/en-US/docs/Web/API/RTCIceTransport/role#unknown)
-
-- `iceState` {{optional_inline}} {{experimental_inline}}
+    This is one of: [`controlled`](/en-US/docs/Web/API/RTCIceTransport/role#controlled), [`controlling`](/en-US/docs/Web/API/RTCIceTransport/role#controlling), and [`unknown`](/en-US/docs/Web/API/RTCIceTransport/role#unknown).
+- {{domxref("RTCTransportStats.iceState", "iceState")}} {{optional_inline}} {{experimental_inline}}
   - : A string indicating the current {{domxref("RTCIceTransport.state","state")}} of the underlying {{domxref("RTCIceTransport")}}.
-    This is one of:
-    - [`new`](/en-US/docs/Web/API/RTCIceTransport/state#new)
-    - [`checking`](/en-US/docs/Web/API/RTCIceTransport/state#checking)
-    - [`connected`](/en-US/docs/Web/API/RTCIceTransport/state#connected)
-    - [`completed`](/en-US/docs/Web/API/RTCIceTransport/state#completed)
-    - [`disconnected`](/en-US/docs/Web/API/RTCIceTransport/state#disconnected)
-    - [`failed`](/en-US/docs/Web/API/RTCIceTransport/state#failed)
-    - [`closed`](/en-US/docs/Web/API/RTCIceTransport/state#closed)
-
-- `selectedCandidatePairId` {{optional_inline}}
-  - : A string containing the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
-- `localCertificateId` {{optional_inline}}
+    This is one of: [`new`](/en-US/docs/Web/API/RTCIceTransport/state#new), [`checking`](/en-US/docs/Web/API/RTCIceTransport/state#checking), [`connected`](/en-US/docs/Web/API/RTCIceTransport/state#connected), [`completed`](/en-US/docs/Web/API/RTCIceTransport/state#completed), [`disconnected`](/en-US/docs/Web/API/RTCIceTransport/state#disconnected), [`failed`](/en-US/docs/Web/API/RTCIceTransport/state#failed), and [`closed`](/en-US/docs/Web/API/RTCIceTransport/state#closed).
+- {{domxref("RTCTransportStats.localCertificateId", "localCertificateId")}} {{optional_inline}}
   - : A string containing the id of the local certificate used by this transport.
     Only present for DTLS transports, and after DTLS has been negotiated.
-- `packetsSent` {{optional_inline}} {{experimental_inline}}
-  - : The total number of packets sent over this transport.
-- `packetsReceived` {{optional_inline}} {{experimental_inline}}
+- {{domxref("RTCTransportStats.packetsReceived", "packetsReceived")}} {{optional_inline}} {{experimental_inline}}
   - : The total number of packets received on this transport.
-- `remoteCertificateId` {{optional_inline}}
+- {{domxref("RTCTransportStats.packetsSent", "packetsSent")}} {{optional_inline}} {{experimental_inline}}
+  - : The total number of packets sent over this transport.
+- {{domxref("RTCTransportStats.remoteCertificateId", "remoteCertificateId")}} {{optional_inline}}
   - : A string containing the id or the remote certificate used by this transport.
     Only present for DTLS transports, and after DTLS has been negotiated.
-- `selectedCandidatePairChanges` {{optional_inline}}
+- {{domxref("RTCTransportStats.selectedCandidatePairChanges", "selectedCandidatePairChanges")}} {{optional_inline}}
   - : The number of times that the selected candidate pair of this transport has changed.
     The value is initially zero and increases whenever a candidate pair selected or lost.
-- `srtpCipher` {{optional_inline}}
+- {{domxref("RTCTransportStats.selectedCandidatePairId", "selectedCandidatePairId")}} {{optional_inline}}
+  - : A string containing the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
+- {{domxref("RTCTransportStats.srtpCipher", "srtpCipher")}} {{optional_inline}}
+
   - : A string indicating the descriptive name of the protection profile used for the [Secure Real-time Transport Protocol (SRTP)](/en-US/docs/Glossary/RTP) transport, as defined in the "Profile" column of the [IANA DTLS-SRTP protection profile registry](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml#srtp-protection-1) and [RFC5764](https://www.rfc-editor.org/rfc/rfc5764.html#section-4.1.2).
 
     For example `"AES_CM_128_HMAC_SHA1_80"` specifies the following profile, where `maximum_lifetime` is the maximum number of packets that can be protected by a single set of keys.
@@ -93,7 +71,8 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
      auth_tag_length: 80
     ```
 
-- `tlsVersion` {{optional_inline}}
+- {{domxref("RTCTransportStats.tlsVersion", "tlsVersion")}} {{optional_inline}}
+
   - : A string containing the negotiated TLS version.
     This is present for DTLS transports, and only exists after DTLS has been negotiated.
 

--- a/files/en-us/web/api/rtctransportstats/localcertificateid/index.md
+++ b/files/en-us/web/api/rtctransportstats/localcertificateid/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: localCertificateId property"
+short-title: localCertificateId
+slug: Web/API/RTCTransportStats/localCertificateId
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.localCertificateId
+---
+
+{{APIRef("WebRTC")}}
+
+The **`localCertificateId`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the id of the local certificate used by this {{domxref("RTCIceTransport")}}.
+
+It is only present for DTLS transports, and after DTLS has been negotiated.
+
+## Value
+
+A string that containing the id of the local certificate used by this transport.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/packetsreceived/index.md
+++ b/files/en-us/web/api/rtctransportstats/packetsreceived/index.md
@@ -1,0 +1,23 @@
+---
+title: "RTCTransportStats: packetsReceived property"
+short-title: packetsReceived
+slug: Web/API/RTCTransportStats/packetsReceived
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.packetsReceived
+---
+
+{{APIRef("WebRTC")}}
+
+The **`packetsReceived`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the total number of packets received on this transport.
+
+## Value
+
+A positive integer indicating the number of packets received on the transport.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/packetssent/index.md
+++ b/files/en-us/web/api/rtctransportstats/packetssent/index.md
@@ -1,0 +1,23 @@
+---
+title: "RTCTransportStats: packetsSent property"
+short-title: packetsSent
+slug: Web/API/RTCTransportStats/packetsSent
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.packetsSent
+---
+
+{{APIRef("WebRTC")}}
+
+The **`packetsSent`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the total number of packets sent over this transport.
+
+## Value
+
+A positive integer indicating the number of packets sent on the transport.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/remotecertificateid/index.md
+++ b/files/en-us/web/api/rtctransportstats/remotecertificateid/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: remoteCertificateId property"
+short-title: remoteCertificateId
+slug: Web/API/RTCTransportStats/remoteCertificateId
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.remoteCertificateId
+---
+
+{{APIRef("WebRTC")}}
+
+The **`remoteCertificateId`** property of the {{domxref("RTCTransportStats")}} dictionary is a string that indicates the id of the remote certificate used by this {{domxref("RTCIceTransport")}}.
+
+It is only present for DTLS transports, and after DTLS has been negotiated.
+
+## Value
+
+A string that containing the id of the remote certificate used by this transport.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/selectedcandidatepairchanges/index.md
+++ b/files/en-us/web/api/rtctransportstats/selectedcandidatepairchanges/index.md
@@ -1,0 +1,23 @@
+---
+title: "RTCTransportStats: selectedCandidatePairChanges property"
+short-title: selectedCandidatePairChanges
+slug: Web/API/RTCTransportStats/selectedCandidatePairChanges
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.selectedCandidatePairChanges
+---
+
+{{APIRef("WebRTC")}}
+
+The **`selectedCandidatePairChanges`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the total number of times that the selected candidate pair of this transport has changed.
+
+## Value
+
+A positive integer that is initially zero and increases whenever a candidate pair selected or lost.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/selectedcandidatepairchanges/index.md
+++ b/files/en-us/web/api/rtctransportstats/selectedcandidatepairchanges/index.md
@@ -12,7 +12,7 @@ The **`selectedCandidatePairChanges`** property of the {{domxref("RTCTransportSt
 
 ## Value
 
-A positive integer that is initially zero and increases whenever a candidate pair selected or lost.
+A positive integer that is initially zero and increases whenever a candidate pair is selected or lost.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/selectedcandidatepairid/index.md
+++ b/files/en-us/web/api/rtctransportstats/selectedcandidatepairid/index.md
@@ -1,0 +1,23 @@
+---
+title: "RTCTransportStats: selectedCandidatePairId property"
+short-title: selectedCandidatePairId
+slug: Web/API/RTCTransportStats/selectedCandidatePairId
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.selectedCandidatePairId
+---
+
+{{APIRef("WebRTC")}}
+
+The **`selectedCandidatePairId`** property of the {{domxref("RTCTransportStats")}} dictionary represents the unique identifier for the candidate pair stats associated with this transport.
+
+## Value
+
+A string that contains the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/srtpcipher/index.md
+++ b/files/en-us/web/api/rtctransportstats/srtpcipher/index.md
@@ -1,0 +1,42 @@
+---
+title: "RTCTransportStats: srtpCipher property"
+short-title: srtpCipher
+slug: Web/API/RTCTransportStats/srtpCipher
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.srtpCipher
+---
+
+{{APIRef("WebRTC")}}
+
+The **`srtpCipher`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the descriptive name of the protection profile used for the [Secure Real-time Transport Protocol (SRTP)](/en-US/docs/Glossary/RTP) transport.
+
+## Value
+
+A string that indicates the descriptive name of the SRTP protection profile.
+
+Values are defined in the "Profile" column of the [IANA DTLS-SRTP protection profile registry](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml#srtp-protection-1) and {{rfc("5764","", "4.1.2")}}.
+
+## Examples
+
+### SRTP_AES128_CM_HMAC_SHA1_80
+
+`"SRTP_AES128_CM_HMAC_SHA1_80"` is the descriptive name of the following profile, where `maximum_lifetime` is the maximum number of packets that can be protected by a single set of keys.
+
+```plain
+SRTP_AES128_CM_HMAC_SHA1_80
+cipher: AES_128_CM
+cipher_key_length: 128
+cipher_salt_length: 112
+maximum_lifetime: 2^31
+auth_function: HMAC-SHA1
+auth_key_length: 160
+auth_tag_length: 80
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/tlsversion/index.md
+++ b/files/en-us/web/api/rtctransportstats/tlsversion/index.md
@@ -1,0 +1,29 @@
+---
+title: "RTCTransportStats: tlsVersion property"
+short-title: tlsVersion
+slug: Web/API/RTCTransportStats/tlsVersion
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.tlsVersion
+---
+
+{{APIRef("WebRTC")}}
+
+The **`tlsVersion`** property of the {{domxref("RTCTransportStats")}} dictionary indicates the negotiated TLS version of an underlying DTLS transport.
+
+It is only present for DTLS transports, and only exists after DTLS has been negotiated.
+
+The value comes from the DTLS handshake `ServerHello.version`, and is represented as four upper case hexadecimal digits, where the digits represent the two bytes of the version.
+Note however that the bytes might not map directly to version numbers.
+For example, DTLS represents version 1.2 as `'FEFD'` which numerically is `{254, 253}`.
+
+## Value
+
+A string that indicates the negotiated DTS transport.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
This updates `RTCTransportStats` to match BCD as part of https://github.com/mdn/mdn/issues/384

The main reason for this was consistency - most of the other stats/API docs document properties individually. This one had everything in the top level stats docs.
In many cases this adds nothing extra over the original. Though in some cases it does allow the top level to be simpler, making it easier to scan.
