### PR TITLE
chore: Replace LandingPageListSubpages with SubpagesWithSummaries macro

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/index.md
@@ -11,4 +11,4 @@ This section of MDN Web Docs writing guidelines contains all the step-by-step in
 > [!NOTE]
 > All the way through this section, we assume that you've read the contribution guidelines, are familiar with the `mdn/content` repository, and know how to use git and GitHub.
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/index.md
@@ -9,7 +9,7 @@ page-type: landing-page
 Throughout MDN there are document structures that are used to provide consistent presentation of information in MDN articles.
 This page lists articles describing these structures so that you can modify page content appropriately for the documents you write, edit, or translate.
 
-{{LandingPageListSubPages}}
+{{SubpagesWithSummaries}}
 
 ## See also
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
@@ -12,7 +12,7 @@ MDN provides numerous macros to create always up-to-date links to MDN content. I
 
 MDN provides macros that create a list of links:
 
-- [`\{{LandingPageListSubPages}}`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs)
+- [`\{{SubpagesWithSummaries}}`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs)
 
   - : Inserts a definition list ({{HTMLElement("dl")}}) of the subpages of the current page, with each page's title as the {{HTMLElement("dt")}} term and its first paragraph as the {{HTMLElement("dd")}} term.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -21,7 +21,7 @@ We have an assortment of macros that can be used to automatically generate the c
 #### Lists of subpages
 
 - [`ListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/ListSubpages.ejs) generates an unordered list of links to all the immediate children of the current page; useful for automatically generating tables of contents for sets of documentation.
-- [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) outputs a two-column definition list of all immediate subpages of the current page, with their titles as the {{HTMLElement("dt")}} and their SEO summary as the {{HTMLElement("dd")}}. This makes it easy to automatically generate reasonably attractive landing pages.
+- [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) constructs a definition list of all the immediate children of the current page, with their titles as the {{HTMLElement("dt")}} and their SEO summary as the {{HTMLElement("dd")}}. This makes it easy to automatically generate reasonably attractive landing pages.
 - [`APIListAlpha`](https://github.com/mdn/yari/blob/main/kumascript/macros/APIListAlpha.ejs) builds a list of the current page's subpages, formatted as a list of API terms, divided up by first letter. There are three parameters. The first is 0 if you want to include all top-level subpages or 1 to leave out subpages with "." in their names. The second and third let you add text to display as part of the name in each link. This can be used to add "<" and ">" for element links, or to add "()" at the end of lists of method names.
 
 ### Lists of links

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -21,9 +21,8 @@ We have an assortment of macros that can be used to automatically generate the c
 #### Lists of subpages
 
 - [`ListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/ListSubpages.ejs) generates an unordered list of links to all the immediate children of the current page; useful for automatically generating tables of contents for sets of documentation.
-- [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs) outputs a two-column definition list of all immediate subpages of the current page, with their titles as the {{HTMLElement("dt")}} and their SEO summary as the {{HTMLElement("dd")}}. This makes it easy to automatically generate reasonably attractive landing pages.
+- [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) outputs a two-column definition list of all immediate subpages of the current page, with their titles as the {{HTMLElement("dt")}} and their SEO summary as the {{HTMLElement("dd")}}. This makes it easy to automatically generate reasonably attractive landing pages.
 - [`APIListAlpha`](https://github.com/mdn/yari/blob/main/kumascript/macros/APIListAlpha.ejs) builds a list of the current page's subpages, formatted as a list of API terms, divided up by first letter. There are three parameters. The first is 0 if you want to include all top-level subpages or 1 to leave out subpages with "." in their names. The second and third let you add text to display as part of the name in each link. This can be used to add "<" and ">" for element links, or to add "()" at the end of lists of method names.
-- [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) constructs a definition list of all the immediate children of the current page. There is no other formatting done. You can get a two-column list ready for use as a multi-column landing page using [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs).
 
 ### Lists of links
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -233,7 +233,7 @@ A **landing page** serves as a menu, of sorts, for its subpages, and is therefor
 A landing page layout is typically used for the root page of a tree of pages about a particular topic.
 It opens with a brief summary of the topic, then presents a structured list of links to its subpages, and optionally, additional material that be useful to the reader.
 
-The list of subpages can be generated automatically using the templates [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs), and [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs). However, in more complex cases, the list may need to be created (and maintained!) by hand.
+The list of subpages can be generated automatically using the [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) template. However, in more complex cases, the list may need to be created (and maintained) by hand.
 
 ### Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/index.md
@@ -57,4 +57,4 @@ For example, here is the first code example on this page running in the Toolbox 
 
 See below for a complete list of JavaScript APIs:
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}

--- a/files/en-us/mozilla/firefox/index.md
+++ b/files/en-us/mozilla/firefox/index.md
@@ -57,7 +57,7 @@ Firefox ESR is the long-term support edition of Firefox for desktop for use by o
 
 ## Contents
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}
 
 ## See also
 

--- a/files/en-us/mozilla/index.md
+++ b/files/en-us/mozilla/index.md
@@ -8,4 +8,4 @@ page-type: landing-page
 
 The articles below include content about downloading and building Mozilla code. In addition, you'll find helpful articles about how the code works, how to build add-ons for Mozilla applications and the like.
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -186,7 +186,7 @@ It is possible to process/render an audio graph very quickly in the background â
 
 ## Guides and tutorials
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}
 
 ## Examples
 

--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -14,7 +14,7 @@ There are tools, APIs, and best practices that help us measure and improve web p
 
 ## Key performance guides
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}
 
 ## Beginner's tutorials
 

--- a/files/en-us/web/xml/index.md
+++ b/files/en-us/web/xml/index.md
@@ -8,4 +8,4 @@ page-type: landing-page
 
 The **Extensible Markup Language** is a strict serialization of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model).
 
-{{LandingPageListSubpages}}
+{{SubpagesWithSummaries}}


### PR DESCRIPTION
### Description

The `LandingPageListSubpages` macro is a wrapper for `SubpagesWithSummaries`. It has no additional logic, so we can replace `LandingPageListSubpages` with `SubpagesWithSummaries` directly:

* https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs
* https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs

### Motivation

We can get rid of `LandingPageListSubpages` both in content and in Yari/Rari.

