### PR TITLE
Correct pseudo class selector

### DIFF
--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -73,7 +73,7 @@ tabbed-custom-element::part(tab):hover {
   color: white;
 }
 
-tabbed-custom-element::part(tab active) {
+tabbed-custom-element::part(tab):active {
   border-color: blue !important;
 }
 ```


### PR DESCRIPTION
The original code had the psudo class selector inside the parentheses with the part pseudo element value, which is why the styling was not working when the element was active.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The css code needs to use a psueod class selecor however it was typed in the selector as a value to the 'part' psudo element selector. Thus this change moves 'active' to be a psudo class selector following the part's parentheses and value.

### Motivation

I was reading over this resource to learn about the 'part' psudo element selector and was looking at the example and started playing with the code because I thought it wasn't working.

