### PR TITLE
fix(css): update italic font variation example

### DIFF
--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -272,6 +272,8 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground.
 <div>
   <p class="p1">Italic</p>
   <span>(font-style: italic)</span>
+  <p class=".p1-no-synthesis">Italic</p>
+  <span>(font-style: italic; font-synthesis: none)</span>
 </div>
 <div>
   <p class="p2">Italic</p>
@@ -322,15 +324,18 @@ p {
 ```css live-sample___variable-fonts-italic-example
 /* italic range is 0 or 1 */
 .p1 {
-  /* uncomment following line to prevent synthesized italics */
-  /* font-synthesis: none; */
   font-style: italic;
+}
+
+.p1-no-synthesis {
+  font-style: italic;
+  font-synthesis: none;
 }
 
 /* italic range is 0 or 1 */
 .p2 {
-  font-synthesis: none;
   font-variation-settings: "ital" 1;
+  font-synthesis: none;
 }
 
 /* Adjust with slider & custom property */

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -322,7 +322,7 @@ p {
 ```
 
 ```css live-sample___variable-fonts-italic-example
-/* italic range is 0 or 1 */
+/* font-style: italic, with and without font-synthesis */
 .p1 {
   font-style: italic;
 }

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -322,7 +322,8 @@ p {
 ```css live-sample___variable-fonts-italic-example
 /* italic range is 0 or 1 */
 .p1 {
-  font-synthesis: none;
+  /* uncomment following line to prevent synthesized italics */
+  /* font-synthesis: none; */
   font-style: italic;
 }
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/37159

The `font-syntheis: none` prevents the `p1` paragraph from getting synthesized italics font. The intention was to demo the `font-synthesis` property.

To prevent confusion, by default, we show italics font and keep the synthesis none line commented and ask readers to play with it.