### PR TITLE
fix: wrong log approximation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ln10/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Math.LN10
 
 {{JSRef}}
 
-The **`Math.LN10`** static data property represents the natural logarithm of 10, approximately 2.302.
+The **`Math.LN10`** static data property represents the natural logarithm of 10, approximately 2.303.
 
 {{EmbedInteractiveExample("pages/js/math-ln10.html", "shorter")}}
 
@@ -15,7 +15,7 @@ The **`Math.LN10`** static data property represents the natural logarithm of 10,
 
 <!-- prettier-ignore-start -->
 <math display="block">
-  <semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙽𝟷𝟶</mi><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mo stretchy="false">(</mo><mn>10</mn><mo stretchy="false">)</mo><mo>≈</mo><mn>2.302</mn></mrow><annotation encoding="TeX">\mathtt{Math.LN10} = \ln(10) \approx 2.302</annotation></semantics>
+  <semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙽𝟷𝟶</mi><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mo stretchy="false">(</mo><mn>10</mn><mo stretchy="false">)</mo><mo>≈</mo><mn>2.303</mn></mrow><annotation encoding="TeX">\mathtt{Math.LN10} = \ln(10) \approx 2.303</annotation></semantics>
 </math>
 <!-- prettier-ignore-end -->
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Math.LOG2E
 
 {{JSRef}}
 
-The **`Math.LOG2E`** static data property represents the base 2 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 1.442.
+The **`Math.LOG2E`** static data property represents the base 2 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 1.443.
 
 {{EmbedInteractiveExample("pages/js/math-log2e.html", "shorter")}}
 
@@ -15,7 +15,7 @@ The **`Math.LOG2E`** static data property represents the base 2 logarithm of [e]
 
 <!-- prettier-ignore-start -->
 <math display="block">
-  <semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙾𝙶𝟸𝙴</mi><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>2</mn></msub><mo stretchy="false">(</mo><mi mathvariant="normal">e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>1.442</mn></mrow><annotation encoding="TeX">\mathtt{Math.LOG2E} = \log_2(\mathrm{e}) \approx 1.442</annotation></semantics>
+  <semantics><mrow><mi>𝙼𝚊𝚝𝚑.𝙻𝙾𝙶𝟸𝙴</mi><mo>=</mo><msub><mo lspace="0em" rspace="0em">log</mo><mn>2</mn></msub><mo stretchy="false">(</mo><mi mathvariant="normal">e</mi><mo stretchy="false">)</mo><mo>≈</mo><mn>1.443</mn></mrow><annotation encoding="TeX">\mathtt{Math.LOG2E} = \log_2(\mathrm{e}) \approx 1.443</annotation></semantics>
 </math>
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
### Description
Changed log approximation for `LOG2E` and `LN10` to `1.443` and `2.303` respectively.
By the way, on the main page of the [Math](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math) object, the values are correct.




### Related issues and pull requests

Fixes #37147




