### PR TITLE
Remove padding from CSS round() function example

### DIFF
--- a/files/en-us/web/css/round/index.md
+++ b/files/en-us/web/css/round/index.md
@@ -113,7 +113,6 @@ div.box {
   width: 100px;
   height: 100px;
   background: lightblue;
-  padding: 5px;
   --rounding-interval: 25px;
 }
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Removed unnecessary padding.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The example works on the premise that each column should have the height shown between parenthesis. However, when using the inspector the each column has a difference of 10px in their height, caused by the padding provided by the original author.

This change is requested in the spirit of making the reader not have to wonder why there is a difference between what is described and what is presented to them. As this example is also shown for the purpose of checking browser support, the change also removes the suspicion of there being an issue with the browser implementation of the spec.

While other changes could have been made to keep the subjectively better aesthetics of having the padding, they would muddy the example.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
> None provided

### Related issues and pull requests
> None provided

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
