### PR TITLE
feat(http): Add X-Permitted-Cross-Domain-Policies page

### DIFF
--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -239,7 +239,8 @@ Range requests are useful for applications like media players that support rando
 - {{HTTPHeader("X-Frame-Options")}} (XFO)
   - : Indicates whether a browser should be allowed to render a page in a {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("embed")}} or {{HTMLElement("object")}}.
 - {{HTTPHeader("X-Permitted-Cross-Domain-Policies")}}
-  - : Specifies if a cross-domain policy file (`crossdomain.xml`) is allowed. The file may define a policy to grant clients, such as Adobe's Flash Player (now obsolete), Adobe Acrobat, Microsoft Silverlight (now obsolete), or Apache Flex, permission to handle data across domains that would otherwise be restricted due to the [Same-Origin Policy](/en-US/docs/Web/Security/Same-origin_policy). See the [Cross-domain Policy File Specification](https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/CrossDomain_PolicyFile_Specification.pdf) for more information.
+  - : A cross-domain policy file may grant clients, such as Adobe Acrobat or Apache Flex (among others), permission to handle data across domains that would otherwise be restricted due to the [Same-Origin Policy](/en-US/docs/Web/Security/Same-origin_policy).
+    The `X-Permitted-Cross-Domain-Policies` header overrides such policy files so that clients still block unwanted requests.
 - {{HTTPHeader("X-Powered-By")}}
   - : May be set by hosting environments or other frameworks and contains information about them while not providing any usefulness to the application or its visitors. Unset this header to avoid exposing potential vulnerabilities.
 - {{HTTPHeader("X-XSS-Protection")}}

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -8,12 +8,12 @@ status:
 
 {{HTTPSidebar}}
 
-The HTTP **`X-Permitted-Cross-Domain-Policies`** {{Glossary("response header")}} specifies if a cross-domain policy file (`crossdomain.xml`) is allowed.
+The HTTP **`X-Permitted-Cross-Domain-Policies`** {{Glossary("response header")}} enables a server to override the meta-policy for a site, controlling whether site resources can be accessed cross-origin by a document running in a web client like Adobe Acrobat or Microsoft Silverlight.
 
-A cross-domain policy file may grant clients, such as Adobe Acrobat or Apache Flex, permission to handle data across domains that would otherwise be restricted due to the [Same-Origin Policy](/en-US/docs/Web/Security/Same-origin_policy).
-The `X-Permitted-Cross-Domain-Policies` header overrides such policy files so that clients still block unwanted requests.
+It can be used in cases where the website needs to declare a cross-domain policy, but cannot write to the root directory of the domain.
 
 Usage of this header is less common since Adobe Flash Player and Microsoft Silverlight have been deprecated.
+Note however that some security testing tools will still check for the presence of a `X-Permitted-Cross-Domain-Policies: none` header because it can mitigate the risk of an unwanted policy file added to your site by accident or through malicious actions.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -1,0 +1,90 @@
+---
+title: X-Permitted-Cross-Domain-Policies
+slug: Web/HTTP/Headers/X-Permitted-Cross-Domain-Policies
+page-type: http-header
+status:
+  - non-standard
+---
+
+{{HTTPSidebar}}
+
+The HTTP **`X-Permitted-Cross-Domain-Policies`** {{Glossary("response header")}} specifies if a cross-domain policy file (`crossdomain.xml`) is allowed.
+
+A cross-domain policy file may grant clients, such as Adobe Acrobat or Apache Flex, permission to handle data across domains that would otherwise be restricted due to the [Same-Origin Policy](/en-US/docs/Web/Security/Same-origin_policy).
+The `X-Permitted-Cross-Domain-Policies` header overrides such policy files so that clients still block unwanted requests.
+
+Usage of this header is less common since Adobe Flash Player and Microsoft Silverlight have been deprecated.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Response header")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```http
+X-Permitted-Cross-Domain-Policies: <permitted-cross-domain-policies>
+```
+
+## Directives
+
+- `none`
+  - : No policy files are allowed anywhere on the target server, including in a master policy file.
+- `master-only`
+  - : Allows cross-domain access to the master policy file defined on the same domain.
+- `by-content-type` (HTTP/HTTPS only)
+  - : Only policy files served with `Content-Type: text/x-cross-domain-policy` are allowed.
+- `by-ftp-filename` (FTP only)
+  - : Only policy files whose file names are `crossdomain.xml` (URLs ending in `/crossdomain.xml`) are allowed.
+- `all`
+  - : All policy files on this target domain are allowed.
+- `none-this-response`
+  - : Indicates that the current document should not be used as a policy file despite other headers or its content.
+    This value is unique to the HTTP header only.
+
+## Description
+
+Policy files are defined in a `crossdomain.xml` file, typically located at the root of the domain (`http://example.com/crossdomain.xml`) and define policies as so (the least permissive master policy definition):
+
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
+<cross-domain-policy>
+  <site-control permitted-cross-domain-policies="none"/>
+</cross-domain-policy>
+```
+
+Instead of relying on policy files, clients may check for the `X-Permitted-Cross-Domain-Policies` header to detect a meta-policy.
+The purpose of the HTTP header is for cases where people wish to declare a cross-domain policy, but cannot write to the root directory of the domain.
+
+## Examples
+
+### Disallowing cross-domain policy files
+
+If you don't need to load application data in clients such as Adobe Flash Player or Adobe Acrobat (or legacy clients), then the header should be configured as `X-Permitted-Cross-Domain-Policies: none`:
+
+```http
+X-Permitted-Cross-Domain-Policies: none
+```
+
+Some security testing tools will check for the presence of a `X-Permitted-Cross-Domain-Policies: none` header because it can mitigate the risk of an unwanted policy file added to your site by accident or through malicious actions.
+
+## Specifications
+
+Documented in the [Adobe Cross Domain Policy File Specification](https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/CrossDomain_PolicyFile_Specification.pdf).
+
+## See also
+
+- [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
+- [Practical security implementation guides](/en-US/docs/Web/Security/Practical_implementation_guides)
+- [HTTP Observatory](/en-US/observatory/) header testing tool
+- [Cross Domain Configuration](https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html) on adobe.com
+- [X-Permitted-Cross-Domain-Policies](https://github.com/OWASP/www-project-secure-headers/blob/master/tab_headers.md#x-permitted-cross-domain-policies) in OWASP Secure Headers Project

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -8,12 +8,12 @@ status:
 
 {{HTTPSidebar}}
 
-The HTTP **`X-Permitted-Cross-Domain-Policies`** {{Glossary("response header")}} enables a server to override the meta-policy for a site, controlling whether site resources can be accessed cross-origin by a document running in a web client like Adobe Acrobat or Microsoft Silverlight.
+The HTTP **`X-Permitted-Cross-Domain-Policies`** {{Glossary("response header")}} defines a meta-policy that controls whether site resources can be accessed cross-origin by a document running in a web client like Adobe Acrobat or Microsoft Silverlight.
 
 It can be used in cases where the website needs to declare a cross-domain policy, but cannot write to the root directory of the domain.
 
 Usage of this header is less common since Adobe Flash Player and Microsoft Silverlight have been deprecated.
-Note however that some security testing tools will still check for the presence of a `X-Permitted-Cross-Domain-Policies: none` header because it can mitigate the risk of an unwanted policy file added to your site by accident or through malicious actions.
+Some security testing tools will still check for the presence of a `X-Permitted-Cross-Domain-Policies: none` header because it can mitigate the risk of an overly-permissive policy file added to your site by accident or through malicious actions.
 
 <table class="properties">
   <tbody>
@@ -56,8 +56,9 @@ Web clients such as Adobe Acrobat or Apache Flex can load web documents, which m
 Access is restricted to same-site resources by default, due to the [same origin policy](/en-US/docs/Web/Security/Same-origin_policy), but cross-origin sites may choose to make some or all of their resources available to clients cross-origin using special files, referred to as a cross-domain policy files.
 
 A "master" cross-domain policy file may be defined as `crossdomain.xml` file in the root of the domain, for example: `http://example.com/crossdomain.xml`.
-The master file defines the _meta-policy_ for the whole site using the `permitted-cross-domain-policies` attribute of the `site-control` tag.
-The meta-policy controls whether any policies are allowed, and the conditions for the the other "sub" cross-domain policy files to be used. These other policy files might be created in particular directories to specify access over the files in their given directory tree.
+The master file defines the _meta-policy_ for the whole site using the `permitted-cross-domain-policies` attribute of the `<site-control>` tag.
+The meta-policy controls whether any policies are allowed, and the conditions for the other "sub" cross-domain policy files to be used.
+These other policy files might be created in particular directories to specify access over the files in their given directory tree.
 
 For example, this is the least permissive master policy definition, which does not permit any access, and does not allow the use of other "sub" policy files.
 
@@ -69,10 +70,10 @@ For example, this is the least permissive master policy definition, which does n
 </cross-domain-policy>
 ```
 
-The HTTP **`X-Permitted-Cross-Domain-Policies`** header can be used to override the meta-policy defined in the master cross-domain policy file.
+The `X-Permitted-Cross-Domain-Policies` header can specify a meta-policy for the HTTP response it's included in or override a meta-policy defined in the master cross-domain policy file, if present.
 It takes the same values as the file's `permitted-cross-domain-policies` attribute and additionally `none-this-response`.
 
-Most commonly this will be used to prevent any access to site resources, in cases where the developer does not have access to create a master cross-domain policy file in the site root.
+Most commonly, it's used to prevent any access to site resources in cases where the developer does not have access to create a master cross-domain policy file in the site root.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -52,7 +52,14 @@ X-Permitted-Cross-Domain-Policies: <permitted-cross-domain-policy>
 
 ## Description
 
-Policy files are defined in a `crossdomain.xml` file, typically located at the root of the domain (`http://example.com/crossdomain.xml`) and define policies as so (the least permissive master policy definition):
+Web clients such as Adobe Acrobat or Apache Flex can load web documents, which may in turn load resources from the same site or other sites.
+Access is restricted to same-site resources by default, due to the [same origin policy](/en-US/docs/Web/Security/Same-origin_policy), but cross-origin sites may choose to make some or all of their resources available to clients cross-origin using special files, referred to as a cross-domain policy files.
+
+A "master" cross-domain policy file may be defined as `crossdomain.xml` file in the root of the domain, for example: `http://example.com/crossdomain.xml`.
+The master file defines the _meta-policy_ for the whole site using the `permitted-cross-domain-policies` attribute of the  `site-control` tag.
+The meta-policy controls whether any policies are allowed, and the conditions for the the other "sub" cross-domain policy files to be used. These other policy files might be created in particular directories to specify access over the files in their given directory tree.
+
+For example, this is the least permissive master policy definition, which does not permit any access, and does not allow the use of other "sub" policy files.
 
 ```xml
 <?xml version="1.0"?>
@@ -62,8 +69,10 @@ Policy files are defined in a `crossdomain.xml` file, typically located at the r
 </cross-domain-policy>
 ```
 
-Instead of relying on policy files, clients may check for the `X-Permitted-Cross-Domain-Policies` header to detect a meta-policy.
-The purpose of the HTTP header is for cases where people wish to declare a cross-domain policy, but cannot write to the root directory of the domain.
+The HTTP **`X-Permitted-Cross-Domain-Policies`** header can be used to override the meta-policy defined in the master cross-domain policy file.
+It takes the same values as the file's `permitted-cross-domain-policies` attribute and additionally `none-this-response`.
+
+Most commonly this will be used to prevent any access to site resources, in cases where the developer does not have access to create a master cross-domain policy file in the site root.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -84,7 +84,6 @@ If you don't need to load application data in clients such as Adobe Flash Player
 X-Permitted-Cross-Domain-Policies: none
 ```
 
-Some security testing tools will check for the presence of a `X-Permitted-Cross-Domain-Policies: none` header because it can mitigate the risk of an unwanted policy file added to your site by accident or through malicious actions.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -56,7 +56,7 @@ Web clients such as Adobe Acrobat or Apache Flex can load web documents, which m
 Access is restricted to same-site resources by default, due to the [same origin policy](/en-US/docs/Web/Security/Same-origin_policy), but cross-origin sites may choose to make some or all of their resources available to clients cross-origin using special files, referred to as a cross-domain policy files.
 
 A "master" cross-domain policy file may be defined as `crossdomain.xml` file in the root of the domain, for example: `http://example.com/crossdomain.xml`.
-The master file defines the _meta-policy_ for the whole site using the `permitted-cross-domain-policies` attribute of the  `site-control` tag.
+The master file defines the _meta-policy_ for the whole site using the `permitted-cross-domain-policies` attribute of the `site-control` tag.
 The meta-policy controls whether any policies are allowed, and the conditions for the the other "sub" cross-domain policy files to be used. These other policy files might be created in particular directories to specify access over the files in their given directory tree.
 
 For example, this is the least permissive master policy definition, which does not permit any access, and does not allow the use of other "sub" policy files.
@@ -83,7 +83,6 @@ If you don't need to load application data in clients such as Adobe Flash Player
 ```http
 X-Permitted-Cross-Domain-Policies: none
 ```
-
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -70,7 +70,7 @@ For example, this is the least permissive master policy definition, which does n
 </cross-domain-policy>
 ```
 
-The `X-Permitted-Cross-Domain-Policies` header can specify a meta-policy for the HTTP response it's included in or override a meta-policy defined in the master cross-domain policy file, if present.
+The `X-Permitted-Cross-Domain-Policies` header can specify a meta-policy for the HTTP response it's included in, or override a meta-policy defined in the master cross-domain policy file, if present.
 It takes the same values as the file's `permitted-cross-domain-policies` attribute and additionally `none-this-response`.
 
 Most commonly, it's used to prevent any access to site resources in cases where the developer does not have access to create a master cross-domain policy file in the site root.

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -31,7 +31,7 @@ Usage of this header is less common since Adobe Flash Player and Microsoft Silve
 ## Syntax
 
 ```http
-X-Permitted-Cross-Domain-Policies: <permitted-cross-domain-policies>
+X-Permitted-Cross-Domain-Policies: <permitted-cross-domain-policy>
 ```
 
 ## Directives


### PR DESCRIPTION
### Description

Adding a page for `X-Permitted-Cross-Domain-Policies`.

### Motivation

This is not so relevant with modern clients, but the header is still referenced by a lot of security tools / guides, so I'm adding some details and context.
Notably OWASP secure headers project still advises to add it to websites:

https://owasp.org/www-project-secure-headers/ci/headers_add.json

### Additional details

Good summary here:

* https://security.stackexchange.com/questions/166024/does-the-x-permitted-cross-domain-policies-header-have-any-benefit-for-my-websit

### Related issues and pull requests

- [x] https://github.com/mdn/content/issues/1458
