### PR TITLE
http caching: clarification

### DIFF
--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -273,7 +273,7 @@ But if the server determines the requested resource should now have a different 
 
 ### Force Revalidation
 
-If you do not want a response to be reused, but instead want to always fetch the latest content from the server, you can use the `no-cache` directive to force validation.
+If you do not want a response to be reused, but instead want to always validate the latest content with the server, you can use the `no-cache` directive to force validation.
 
 By adding `Cache-Control: no-cache` to the response along with `Last-Modified` and `ETag` — as shown below — the client will receive a `200 OK` response if the requested resource has been updated, or will otherwise receive a `304 Not Modified` response if the requested resource has not been updated.
 


### PR DESCRIPTION
"Cache-Control: no-cache", does not necessarily fetch the latest content from a server, but checks if the content is still valid. This modification will clarify the sentence and avoid potential confusion. 

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Clarification of "Cache-Control: no-cache" behavior.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I am new to HTTP implementation details, and this sentence made me think that this header-value pair fetches a resource on each request. After some research, I realized that it's a conditional request, used to validate if a resource was modified, and fetches the resource only in case of its modification. Given this behavior, I consider the word "fetch" to be confusing in this context.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Cache-Control: no-cache header description:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#request_directives

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
