### PR TITLE
Add missing Formal syntax section for css functions  [s-z]

### DIFF
--- a/files/en-us/web/css/@import/layer_function/index.md
+++ b/files/en-us/web/css/@import/layer_function/index.md
@@ -20,7 +20,7 @@ The `framework.themes.dark` is the layer into which the CSS file would be import
 
 ## Formal syntax
 
-{{CSSSyntax}}
+{{CSSSyntax("layer")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/@import/layer_function/index.md
+++ b/files/en-us/web/css/@import/layer_function/index.md
@@ -20,7 +20,7 @@ The `framework.themes.dark` is the layer into which the CSS file would be import
 
 ## Formal syntax
 
-{{CSSSyntax("layer")}}
+{{CSSSyntax}}
 
 ## Specifications
 

--- a/files/en-us/web/css/animation-timeline/scroll/index.md
+++ b/files/en-us/web/css/animation-timeline/scroll/index.md
@@ -69,7 +69,7 @@ animation-timeline: scroll(x self);
 > [!NOTE]
 > The scroller and axis values can be specified in any order.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/animation-timeline/view/index.md
+++ b/files/en-us/web/css/animation-timeline/view/index.md
@@ -75,7 +75,7 @@ animation-timeline: view(x 200px auto);
 > [!NOTE]
 > The scroller and inset values can be specified in any order.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/basic-shape/xywh/index.md
+++ b/files/en-us/web/css/basic-shape/xywh/index.md
@@ -25,6 +25,10 @@ clip-path: xywh(1px 2% 3px 4em round 0 1% 2px 3em);
 - `round <'border-radius'>`
   - : Specifies the radius of the rounded corners of the rectangle using the same syntax as the CSS [`border-radius`](/en-US/docs/Web/CSS/border-radius) shorthand property. This parameter is optional.
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### Creating offset-path using xywh()

--- a/files/en-us/web/css/filter-function/saturate/index.md
+++ b/files/en-us/web/css/filter-function/saturate/index.md
@@ -24,6 +24,10 @@ saturate(amount)
 - `amount`
   - : The amount of the conversion, specified as a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}. A value under `100%` desaturates the image, while a value over `100%` super-saturates it. A value of `0%` is completely unsaturated, while a value of `100%` leaves the input unchanged. The initial value for {{Glossary("interpolation")}} is `1`.
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### Examples of correct values for saturate()

--- a/files/en-us/web/css/filter-function/sepia/index.md
+++ b/files/en-us/web/css/filter-function/sepia/index.md
@@ -22,6 +22,10 @@ sepia(amount)
 - `amount`
   - : The amount of the conversion, specified as a {{cssxref("&lt;number&gt;")}} or a {{cssxref("&lt;percentage&gt;")}}. A value of `100%` is completely sepia, while a value of `0%` leaves the input unchanged. Values between `0%` and `100%` are linear multipliers on the effect. The initial value for {{Glossary("interpolation")}} is `0`.
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### Examples of correct values for sepia()

--- a/files/en-us/web/css/fit-content_function/index.md
+++ b/files/en-us/web/css/fit-content_function/index.md
@@ -46,7 +46,7 @@ fit-content(40%)
 
 ## Formal syntax
 
-{{CSSSyntax}}
+{{CSSSyntax("fit-content")}}
 
 ## Examples
 

--- a/files/en-us/web/css/sign/index.md
+++ b/files/en-us/web/css/sign/index.md
@@ -36,7 +36,7 @@ A number representing the sign of `A`:
 - If `x` is negative zero, returns `-0`.
 - Otherwise, returns `NaN`.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -40,7 +40,7 @@ The sine of an `angle` will always return a number between `−1` and `1`.
 - If `angle` is `infinity`, `-infinity`, or `NaN`, the result is `NaN`.
 - If `angle` is `0⁻`, the result is `0⁻`.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/sqrt/index.md
+++ b/files/en-us/web/css/sqrt/index.md
@@ -35,7 +35,7 @@ Returns a {{cssxref("&lt;number&gt;")}} which is the square root of `x`.
 - If `x` is `0⁻`, the result is `0⁻`.
 - If `x` is less than `0`, the result is `NaN`.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/symbols/index.md
+++ b/files/en-us/web/css/symbols/index.md
@@ -25,6 +25,10 @@ symbols() = symbols( <symbols-type>? [ <string> | <image> ]+ );
 - `symbolic`: The system cycles through the values, printing them an additional time at each cycle (one time for the first cycle, two times for the second, etc.).
 - `fixed`: The system cycles through the given values once, then falls back to Arabic numerals.
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -41,7 +41,7 @@ The tangent of an `angle` will always return a number between `−∞` and `+∞
 - If `angle` is `0⁻`, the result is `0⁻`.
 - If `angle` is one of the asymptote values (such as `90deg`, `270deg`, etc.), the result is _explicitly undefined_. Authors _must not_ rely on `tan()` returning any particular value for these inputs.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/transform-function/scale/index.md
+++ b/files/en-us/web/css/transform-function/scale/index.md
@@ -82,6 +82,10 @@ scale(sx, sy)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Accessibility
 
 Scaling/zooming animations are problematic for accessibility, as they are a common trigger for certain types of

--- a/files/en-us/web/css/transform-function/scale3d/index.md
+++ b/files/en-us/web/css/transform-function/scale3d/index.md
@@ -67,6 +67,10 @@ scale3d(sx, sy, sz)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### Without changing the origin

--- a/files/en-us/web/css/transform-function/scalex/index.md
+++ b/files/en-us/web/css/transform-function/scalex/index.md
@@ -71,6 +71,10 @@ scaleX(s)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/transform-function/scaley/index.md
+++ b/files/en-us/web/css/transform-function/scaley/index.md
@@ -73,6 +73,10 @@ scaleY(s)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/transform-function/scalez/index.md
+++ b/files/en-us/web/css/transform-function/scalez/index.md
@@ -64,6 +64,10 @@ scaleZ(s)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/transform-function/skew/index.md
+++ b/files/en-us/web/css/transform-function/skew/index.md
@@ -76,6 +76,10 @@ skew(ax, ay)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### Skewing on the x-axis only

--- a/files/en-us/web/css/transform-function/skewx/index.md
+++ b/files/en-us/web/css/transform-function/skewx/index.md
@@ -69,6 +69,10 @@ skewX(a)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/transform-function/skewy/index.md
+++ b/files/en-us/web/css/transform-function/skewy/index.md
@@ -66,6 +66,10 @@ skewY(a)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/transform-function/translate/index.md
+++ b/files/en-us/web/css/transform-function/translate/index.md
@@ -81,11 +81,9 @@ transform: translate(30%, 50%);
   </tbody>
 </table>
 
-### Formal syntax
+## Formal syntax
 
-```plain
-translate({{cssxref("&lt;length-percentage&gt;")}}, {{cssxref("&lt;length-percentage&gt;")}}?)
-```
+{{CSSSyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/transform-function/translate3d/index.md
+++ b/files/en-us/web/css/transform-function/translate3d/index.md
@@ -61,6 +61,10 @@ translate3d(tx, ty, tz)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 ### Using a single axis translation

--- a/files/en-us/web/css/transform-function/translatex/index.md
+++ b/files/en-us/web/css/transform-function/translatex/index.md
@@ -69,11 +69,9 @@ transform: translateX(50%);
   </tbody>
 </table>
 
-### Formal syntax
+## Formal syntax
 
-```plain
-translateX({{cssxref("&lt;length-percentage&gt;")}})
-```
+{{CSSSyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/transform-function/translatey/index.md
+++ b/files/en-us/web/css/transform-function/translatey/index.md
@@ -69,11 +69,9 @@ transform: translateY(50%);
   </tbody>
 </table>
 
-### Formal syntax
+## Formal syntax
 
-```plain
-translateY({{cssxref("&lt;length-percentage&gt;")}})
-```
+{{CSSSyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/transform-function/translatez/index.md
+++ b/files/en-us/web/css/transform-function/translatez/index.md
@@ -60,6 +60,10 @@ translateZ(tz)
   </tbody>
 </table>
 
+## Formal syntax
+
+{{CSSSyntax}}
+
 ## Examples
 
 In this example, two boxes are created. One is positioned normally on the page, without being translated at all. The

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -87,7 +87,7 @@ The **`url()`** function can be included as a value for
 
 ## Formal syntax
 
-{{CSSSyntax}}
+{{CSSSyntax("url")}}
 
 ## Examples
 

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -87,9 +87,7 @@ The **`url()`** function can be included as a value for
 
 ### Formal syntax
 
-```plain
-url( <string> <url-modifier>* )
-```
+{{CSSSyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -85,7 +85,7 @@ The **`url()`** function can be included as a value for
 - `<url-modifier>`
   - : In the future, the `url()` function may support specifying a modifier, an identifier or a functional notation, which alters the meaning of the URL string. This is not supported and not fully defined in the specification.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -43,7 +43,7 @@ The syntax of the fallback, like that of custom properties, allows commas. For e
 
     > **Note:** `var(--a,)` is valid, specifying that if the `--a` custom property is not defined or equals a [CSS-wide keyword](/en-US/docs/Web/CSS/CSS_Values_and_Units#css-wide_values), the `var()` should be replaced with nothing.
 
-### Formal syntax
+## Formal syntax
 
 {{CSSSyntax}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

as https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_function_page_template, all css functions should have a *Formal syntax* section

> [!Note]
> only `url()` can't find a data for {{CSSSyntax}}
> maybe this is because its slug is unusual, and need additional update in https://github.com/mdn/yari/blob/2a1e4e0efa20e06b63289a4238b57782adcb567f/kumascript/src/lib/css-syntax.ts#L19-L23 ?

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
