### PR TITLE
Fix typo in "super" keyword reference page

### DIFF
--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -175,7 +175,7 @@ obj2.method2(); // Logs "method 1"
 
 ### Methods that read super.prop do not behave differently when bound to other objects
 
-Accessing `super.x` behaves like `Reflect.get(Object.getPrototypeOf(objectLiteral), "x", this)`, which means the property is always seeked on the object literal/class declaration's prototype, and unbinding and re-binding a method won't change the reference of `super`.
+Accessing `super.x` behaves like `Reflect.get(Object.getPrototypeOf(objectLiteral), "x", this)`, which means the property is always sought on the object literal/class declaration's prototype, and unbinding and re-binding a method won't change the reference of `super`.
 
 ```js
 class Base {


### PR DESCRIPTION
Changed "seeked" to "sought"

