### PR TITLE
WebExt: fix broken url

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -25,7 +25,7 @@ The first three properties - `type`, `title`, `message` - are mandatory in {{Web
 - `title`
   - : `string`. The notification's title.
 - `iconUrl` {{optional_inline}}
-  - : `string`. A URL pointing to an icon to display in the notification. The URL can be: a data URL, a blob URL, a http or https URL, or the [relative URL of a file within the extension](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#relative_urls). When using an SVG image, ensure that the image includes height and width attributes, for example, `<svg width="96" height="96"…`. Otherwise, the image may not display.
+  - : `string`. A URL pointing to an icon to display in the notification. The URL can be: a data URL, a blob URL, a http or https URL, or the relative URL of a file within the extension. When using an SVG image, ensure that the image includes height and width attributes, for example, `<svg width="96" height="96"…`. Otherwise, the image may not display.
 - `contextMessage` {{optional_inline}}
   - : `string`. Supplementary content to display.
 - `priority` {{optional_inline}}


### PR DESCRIPTION
never does the target document contains section `relative urls` (ever since the file's checkin): [chrome_incompatibilities/index.md at #4da91ee](https://github.com/mdn/content/blob/4da91eeddbbbb1e364e966acf317739a5ca58b39/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md)