### PR TITLE
On Date.UTC() syntax, parameters are in the singular, but they should be in the plural

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/utc/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/utc/index.md
@@ -17,10 +17,10 @@ The **`Date.UTC()`** static method accepts parameters representing the date and 
 Date.UTC(year)
 Date.UTC(year, monthIndex)
 Date.UTC(year, monthIndex, day)
-Date.UTC(year, monthIndex, day, hour)
-Date.UTC(year, monthIndex, day, hour, minute)
-Date.UTC(year, monthIndex, day, hour, minute, second)
-Date.UTC(year, monthIndex, day, hour, minute, second, millisecond)
+Date.UTC(year, monthIndex, day, hours)
+Date.UTC(year, monthIndex, day, hours, minutes)
+Date.UTC(year, monthIndex, day, hours, minutes, seconds)
+Date.UTC(year, monthIndex, day, hours, minutes, seconds, milliseconds)
 ```
 
 ### Parameters


### PR DESCRIPTION
### Description

The syntax code names the parameters `hour`, `minute`, `second` and `millisecond` in the singular, but they should be in the plural.

### Motivation

The documentation and source code use plural terms, so the syntax code should also use plural terms for consistency.