### PR TITLE
fix: link to Window.postMessage rather than MessagePost.postMessage

### DIFF
--- a/files/en-us/web/api/messagechannel/port2/index.md
+++ b/files/en-us/web/api/messagechannel/port2/index.md
@@ -23,7 +23,7 @@ port attached to the context at the other end of the channel.
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel.MessageChannel", "MessageChannel()")}} constructor. When the
 IFrame has loaded, we pass `port2` to the IFrame using
-{{domxref("MessagePort.postMessage")}} along with a message. The
+{{domxref("Window.postMessage")}} along with a message. The
 `handleMessage` handler then responds to a message being sent back from the
 IFrame (using {{domxref("MessagePort.message_event", "onmessage")}}), putting it into a paragraph.
 {{domxref("MessageChannel.port1", "port1")}} is listened to, to check when the message arrives.

--- a/files/en-us/web/api/messagechannel/port2/index.md
+++ b/files/en-us/web/api/messagechannel/port2/index.md
@@ -23,7 +23,7 @@ port attached to the context at the other end of the channel.
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel.MessageChannel", "MessageChannel()")}} constructor. When the
 IFrame has loaded, we pass `port2` to the IFrame using
-{{domxref("Window.postMessage")}} along with a message. The
+{{domxref("Window.postMessage()")}} along with a message. The
 `handleMessage` handler then responds to a message being sent back from the
 IFrame (using {{domxref("MessagePort.message_event", "onmessage")}}), putting it into a paragraph.
 {{domxref("MessageChannel.port1", "port1")}} is listened to, to check when the message arrives.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The wrong postMessage method was referenced here. The frame.contentWindow returns a Window, which is a different postMessage and only the Window's postMessage implementation has the correct 3-argument signature as used in the example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
More accurate documentation -confusing to follow that link and not see the actual overload used in the example.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
