### PR TITLE
Reflect that GET, HEAD, and POST are always allowed methods

### DIFF
--- a/files/en-us/web/http/headers/access-control-allow-methods/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.md
@@ -32,7 +32,7 @@ Access-Control-Allow-Methods: *
 ## Directives
 
 - `<method>`
-  - : A comma-separated list of the allowed request methods.
+  - : A comma-separated list of the allowed request methods. `GET`, `HEAD`, and `POST` are always allowed, regardless of whether they are specified in this header, as they are defined as [CORS-safelisted method](https://fetch.spec.whatwg.org/#cors-safelisted-method)s.
 - `*` (wildcard)
   - : All HTTP methods.
     It has this meaning only for requests without credentials (requests without [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information). In requests with credentials, it is
@@ -41,7 +41,7 @@ Access-Control-Allow-Methods: *
 ## Examples
 
 ```http
-Access-Control-Allow-Methods: GET, POST
+Access-Control-Allow-Methods: PUT, DELETE
 Access-Control-Allow-Methods: *
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

 I changed the example to be more meaningful using PUT and DELETE  and added a short description to the <method> directive.

### Motivation

We recently came across the behaviour that even a non-simple POST request is allowed by the browsers, even if POST is not explicitely stated in the A-C-Allow-Methods header. So I looked it up in the specification and found that in fact _all_ GET, HEAD, and POST requests are CORS-safelisted methods (see also fetch-spec https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A2).

A google search revealed that I am not alone in being confused by this. This MDN page added to the confusion, as it shows an example allowing explicitely GET and POST by using this header, which does not make sense, as these HTTP methods are always allowed either way.

### Additional details
Fetch Spec ("If request’s [method](https://fetch.spec.whatwg.org/#concept-request-method) is not in methods, request’s [method](https://fetch.spec.whatwg.org/#concept-request-method) is not a [CORS-safelisted method](https://fetch.spec.whatwg.org/#cors-safelisted-method), ..."
https://fetch.spec.whatwg.org/#ref-for-cors-safelisted-method%E2%91%A2

Confusion on the web:
https://github.com/dotnet/aspnetcore/issues/40616
https://stackoverflow.com/questions/74596745/if-the-post-method-is-not-idempotent-and-is-not-a-safe-method-why-does-the-cors

### Related issues and pull requests


