### PR TITLE
Fix inaccurate function name in example code

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/offline_and_background_operation/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/offline_and_background_operation/index.md
@@ -362,7 +362,7 @@ When the PWA no longer needs periodic background updates, (for example, because 
 ```js
 // main.js
 
-async function registerPeriodicSync() {
+async function unregisterPeriodicSync() {
   const swRegistration = await navigator.serviceWorker.ready;
   swRegistration.periodicSync.unregister("update-news");
 }


### PR DESCRIPTION
### Description

Change the function name for unregistering a periodic sync from `registerPeriodicSync` to `unregisterPeriodicSync`.

### Motivation

The function name `registerPeriodicSync` was likely an oversight as the function does the opposite.