### PR TITLE
fix(ci): improve logging in the reviewdog workflow

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -166,17 +166,17 @@ jobs:
           echo -e "\nPlease fix all the linting issues mentioned in the following logs and in the PR review comments."
 
           if [[ ${MD_LINT_FAILED} == 'true' ]]; then
-            echo -e "\n🪵 Logs from markdownlint:"
+            echo -e "\n\n🪵 Logs from markdownlint:"
             echo "${MD_LINT_LOG}"
           fi
 
           if [[ ${FM_LINT_FAILED} == 'true' ]]; then
-            echo -e "\n🪵 Logs from front-matter linter:"
+            echo -e "\n\n🪵 Logs from front-matter linter:"
             echo "${FM_LINT_LOG}"
           fi
 
           if [[ ${PRETTIER_FAILED} == 'true' ]]; then
-            echo -e "\n🪵 Logs from Prettier formatter:"
+            echo -e "\n\n🪵 Logs from Prettier formatter:"
             echo "${PRETTIER_LOG}"
             echo -e "\nYou can use Prettier playground to format the files online: https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBiABABwIYGd7owAWc6CMAlgE6kBmFANqSTSADQgSaXS7KjYqVCAHcACoIR8U2BiOwBPPhwBGVbGADWcGAGVsAWzgAZClDjJas3HFXqtO3TjBmA5shhUArrZA2DFB7evnAAHphwVBRGsLIAKpFQghRw0lYMNhy4bkwAil4Q8JbWvgBWuKG6OXD5hRZI6ZkgAI4F8GLCmNIgeAC05nAAJkPsIJ7YjG4AwhAGBtjIPQwMo9lQrkwAgjCeFCpe7ZGm5sUZvkQwBgwA6kQU8LjOcLpS9xQAbvcKi2C4yiDvHwASSgw1gujAUW4m1BuhgCiYpyamGENmu6kwixRqUi7wsHDMNioMA62Fc8yRvhwVCJi3mVE0g1EUFGKLMMGuFEGxGQAA4AAwcGitahwUnkhYNEocGDYFSc7lEZAAJg4XhscTlaWlIDgBhUQ2Gg2M2HWXjJcAAYhAqPMdm5FtgDhAQABfV1AA \n"
           fi

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -101,6 +101,12 @@ jobs:
           echo "FM_LINT_FAILED=${FM_LINT_FAILED}" >> $GITHUB_ENV
 
           echo "Running Prettier"
+          PRETTIER_FAILED=false
+          PRETTIER_LOG=$(yarn prettier --check ${files_to_lint} 2>&1) || PRETTIER_FAILED=true
+          echo "PRETTIER_LOG<<${EOF}" >> $GITHUB_ENV
+          echo "${PRETTIER_LOG}" >> $GITHUB_ENV
+          echo "${EOF}" >> $GITHUB_ENV
+          echo "PRETTIER_FAILED=${PRETTIER_FAILED}" >> $GITHUB_ENV
           yarn prettier -w ${files_to_lint}
 
           if [[ -n $(git diff) ]]; then
@@ -110,16 +116,17 @@ jobs:
           # info for troubleshooting
           echo MD_LINT_FAILED=${MD_LINT_FAILED}
           echo FM_LINT_FAILED=${FM_LINT_FAILED}
+          echo PRETTIER_FAILED=${PRETTIER_FAILED}
           git diff
 
       - name: Setup reviewdog
-        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true'
+        if: ${{ env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' }}
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest
 
       - name: Suggest changes using diff
-        if: env.FILES_MODIFIED == 'true'
+        if: ${{ env.FILES_MODIFIED == 'true' }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -134,7 +141,7 @@ jobs:
             -reporter=github-pr-review < "${TMPFILE}"
 
       - name: Add reviews for markdownlint errors
-        if: env.MD_LINT_FAILED == 'true'
+        if: ${{ env.MD_LINT_FAILED == 'true' }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -147,11 +154,31 @@ jobs:
             -reporter="github-pr-review"
 
       - name: Fail if any issues pending
-        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true'
+        if: ${{ env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true' }}
+        env:
+          MD_LINT_FAILED: ${{ env.MD_LINT_FAILED }}
+          FM_LINT_FAILED: ${{ env.FM_LINT_FAILED }}
+          PRETTIER_FAILED: ${{ env.PRETTIER_FAILED }}
+          MD_LINT_LOG: ${{ env.MD_LINT_LOG }}
+          FM_LINT_LOG: ${{ env.FM_LINT_LOG }}
+          PRETTIER_LOG: ${{ env.PRETTIER_LOG }}
         run: |
-          echo -e "\nLogs from markdownlint:"
-          echo "${MD_LINT_LOG}"
-          echo -e "\nLogs from front-matter linter:"
-          echo "${FM_LINT_LOG}"
-          echo -e "\nPlease fix all the linting issues mentioned in above logs and in the review comments."
+          echo -e "\nPlease fix all the linting issues mentioned in the following logs and in the PR review comments."
+
+          if [[ ${MD_LINT_FAILED} == 'true' ]]; then
+            echo -e "\n🪵 Logs from markdownlint:"
+            echo "${MD_LINT_LOG}"
+          fi
+
+          if [[ ${FM_LINT_FAILED} == 'true' ]]; then
+            echo -e "\n🪵 Logs from front-matter linter:"
+            echo "${FM_LINT_LOG}"
+          fi
+
+          if [[ ${PRETTIER_FAILED} == 'true' ]]; then
+            echo -e "\n🪵 Logs from Prettier formatter:"
+            echo "${PRETTIER_LOG}"
+            echo -e "\nYou can use Prettier playground to format the files online: https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBiABABwIYGd7owAWc6CMAlgE6kBmFANqSTSADQgSaXS7KjYqVCAHcACoIR8U2BiOwBPPhwBGVbGADWcGAGVsAWzgAZClDjJas3HFXqtO3TjBmA5shhUArrZA2DFB7evnAAHphwVBRGsLIAKpFQghRw0lYMNhy4bkwAil4Q8JbWvgBWuKG6OXD5hRZI6ZkgAI4F8GLCmNIgeAC05nAAJkPsIJ7YjG4AwhAGBtjIPQwMo9lQrkwAgjCeFCpe7ZGm5sUZvkQwBgwA6kQU8LjOcLpS9xQAbvcKi2C4yiDvHwASSgw1gujAUW4m1BuhgCiYpyamGENmu6kwixRqUi7wsHDMNioMA62Fc8yRvhwVCJi3mVE0g1EUFGKLMMGuFEGxGQAA4AAwcGitahwUnkhYNEocGDYFSc7lEZAAJg4XhscTlaWlIDgBhUQ2Gg2M2HWXjJcAAYhAqPMdm5FtgDhAQABfV1AA \n"
+          fi
+
           exit 1

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -178,7 +178,7 @@ jobs:
           if [[ ${PRETTIER_FAILED} == 'true' ]]; then
             echo -e "\n\n🪵 Logs from Prettier formatter:"
             echo "${PRETTIER_LOG}"
-            echo -e "\nYou can use Prettier playground to format the files online: https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBiABABwIYGd7owAWc6CMAlgE6kBmFANqSTSADQgSaXS7KjYqVCAHcACoIR8U2BiOwBPPhwBGVbGADWcGAGVsAWzgAZClDjJas3HFXqtO3TjBmA5shhUArrZA2DFB7evnAAHphwVBRGsLIAKpFQghRw0lYMNhy4bkwAil4Q8JbWvgBWuKG6OXD5hRZI6ZkgAI4F8GLCmNIgeAC05nAAJkPsIJ7YjG4AwhAGBtjIPQwMo9lQrkwAgjCeFCpe7ZGm5sUZvkQwBgwA6kQU8LjOcLpS9xQAbvcKi2C4yiDvHwASSgw1gujAUW4m1BuhgCiYpyamGENmu6kwixRqUi7wsHDMNioMA62Fc8yRvhwVCJi3mVE0g1EUFGKLMMGuFEGxGQAA4AAwcGitahwUnkhYNEocGDYFSc7lEZAAJg4XhscTlaWlIDgBhUQ2Gg2M2HWXjJcAAYhAqPMdm5FtgDhAQABfV1AA \n"
+            echo -e "\nYou can use Prettier playground to format the files online (configuration pre-filled): https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBiABABwIYGd7owAWc6CMAlgE6kBmFANqSTSADQgSaXS7KjYqVCAHcACoIR8U2BiOwBPPhwBGVbGADWcGAGVsAWzgAZClDjIYVAK5xV6rTt04wZgOaWbdkLjgGKnrYccAAemHBUFEawsgAqEVCCFHDStLK+HLjuTACK1hDwyGkMGSAAVrghutlweQUWSMWlAI758GLCmNIgeAC05nAAJkPsIFbYjO4AwhAGBtjIPQwMo1lQbkwAgjBWFCrW7RGm5kXp3kQwBgwA6kQU8LgucLpS9xQAbvcKi2C4yiDvWwASSgw1gujAkW4m1BuhgCiYpxK3kwwl813UmEWqJSEXeFg4Zl8VBgHWwbnmSNKOCoxMW8yomkGoigo1RZhg1wog2IyAAHAAGDg0VrUOBkikLRpnDgwbAqLk8ojIABMHGsvli8tSMpAfhUQ2Gg2M2HW1nJcAAYhAqPMdu5FtgDhAQABfV1AA \n"
           fi
 
           exit 1

--- a/.vscode/dictionaries/terms-abbreviations.txt
+++ b/.vscode/dictionaries/terms-abbreviations.txt
@@ -21,6 +21,7 @@ ANMF
 anonymization
 antialiasing
 antitracking
+apideck
 APNG
 appcontent
 arcosh
@@ -529,6 +530,7 @@ quickmenu
 qvalues
 QWERTZ
 randomizer
+rari
 rasterizes
 RDBMS
 RDBMSes
@@ -562,6 +564,7 @@ retarget
 retargeted
 retargeting
 retargetings
+reviewdog
 RFCOMM
 RGTC
 roadmaps
@@ -879,6 +882,7 @@ xrayed
 Xrays
 XRCPU
 XSSI
+yari
 yearless
 Zalgo
 zoomable


### PR DESCRIPTION
- addresses https://github.com/mdn/content/pull/37217#issuecomment-2550488960

## Summary

At the moment, it is [hard to figure out what went wrong](https://github.com/mdn/content/pull/37217#issuecomment-2545037906) when the reviewdog workflow fails to post comments on a PR.

## Solution

When the workflow fails, dump the `prettier—-check` logs. Also, provide the Prettier playground link so driveby GitHub online contributors can format files without setting up a local dev environment.

Note: The PR also adds words used in workflows to the cSpell ignore list.

## Testing

The code has been tested in:
- https://github.com/OnkarRuikar/content/pull/43
- https://github.com/OnkarRuikar/content/actions/runs/12428086076/job/34699041382?pr=43#step:12:52

<details>
<summary>The new logs look like as follows:</summary>

> Please fix all the linting issues mentioned in the following logs and in the PR review comments.
>
> 🪵 Logs from markdownlint:
> yarn run v1.22.22
$ /home/runner/work/content/content/node_modules/.bin/markdownlint-cli2 --fix files/en-us/web/html/element/summary/index.md
markdownlint-cli2 v0.16.0 (markdownlint v0.36.1)
Finding: files/en-us/web/html/element/summary/index.md !node_modules !.git !.github !tests
Linting: 1 file(s)
Summary: 1 error(s)
files/en-us/web/html/element/summary/index.md:30 MD001/heading-increment Heading levels should only increment by one level at a time [Expected: h4; Actual: h5]
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
>
> 🪵 Logs from front-matter linter:
1 0
>
> error: Error: files/en-us/web/html/element/summary/index.md
       Front matter boolean schema is false
       'page-type' property must be equal to one of the allowed values:
       	guide, landing-page, html-attribute, html-attribute-value, html-element
>
>🪵 Logs from Prettier formatter:
yarn run v1.22.22
$ /home/runner/work/content/content/node_modules/.bin/prettier --check files/en-us/web/html/element/summary/index.md
Checking formatting...
[warn] files/en-us/web/html/element/summary/index.md
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
>
>You can use Prettier playground to format the files online: https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBiABABwIYGd7oIwCWATnOgGbEA2FAFnOSADQgSYnS7KjamkIAdwAK-BDxTYaQ7AE8ebAEalsYANZwYAZWwBbOABliUOMkrTccZao1btOMCYDmyGKQCu1kFb3E3nt5wAB6YTMQGsNIAKkxQ-MRwkhY0Vmy4LnQAih4Q8OaW3gBWuMHamXA5eWZIKWkgAI6[58](https://github.com/OnkarRuikar/content/actions/runs/12428086076/job/34699041382?pr=43#step:12:59)CKCmJIgeAC0pnAAJv2sIO7YtC4AwhB6etjInTQ0QxlQznQAgjDuxEoeLUzGpgWp3vQwejQA6vTE8LiOcNoSN8QAbjdyc2C4iiAvXgCSUAGsG0YFIxE4ayB2hgcjoR3qmEEVguqkwcyRSSYLzMbBMVlIMFa2GcMwR3hwpAJcxmpHUfWEUCGSJMMAuxD6MHoyAAHAAGNjkJpkODE0mzWqFNgwbBKdmc7lIABMbA8VmisuSUpAcD0Sn6Az6hmwKw8JLgADEIKQZpsXHNsLsICAAL4uoA 
>
>Error: Process completed with exit code 1.
</details>