### PR TITLE
Fix typo on 'HTML: Creating the content' page

### DIFF
--- a/files/en-us/learn_web_development/getting_started/your_first_website/creating_the_content/index.md
+++ b/files/en-us/learn_web_development/getting_started/your_first_website/creating_the_content/index.md
@@ -156,7 +156,7 @@ The keywords for alt text are "descriptive text". The alt text you write should 
 Let's get your image displaying now.
 
 1. Inside the `first-website` folder, Create a new folder called `images`, and put the image you chose in the previous example inside this folder.
-2. Inside the `<img>` tag's `alt` attribute value, enter the path to your image. It is inside a folder called `images`, which is inside the same directory as your `index.html` file, therefore the path will be `images/` plus the name of your image. For example, if your image was called `firefox-icon.png`, your `src` attribute would look like this: `src="images/firefox-icon.png"`.
+2. Inside the `<img>` tag's `src` attribute value, enter the path to your image. It is inside a folder called `images`, which is inside the same directory as your `index.html` file, therefore the path will be `images/` plus the name of your image. For example, if your image was called `firefox-icon.png`, your `src` attribute would look like this: `src="images/firefox-icon.png"`.
 3. replace the `alt` attribute value — `My test image` — with some text that better describes your image.
 4. Open your `index.html` file inside a web browser. You should see your image displayed. If not, check your `<img>` element against our code above; make sure it is not missing any of the syntax, such as the quote marks. Make sure the image filename is correct.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This pull request corrects a typo that guides the reader to enter the path of an image as the `alt` attribute on the `<img>` tag, instead of the `src` attribute.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change will help readers avoid confusion about the purpose of the `alt` and `src` attributes on `<img>` tags in HTML, by correcting conflicting information.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
