### PR TITLE
Fix browser-compat key for css `<gradient>` type

### DIFF
--- a/files/en-us/web/css/gradient/index.md
+++ b/files/en-us/web/css/gradient/index.md
@@ -2,7 +2,7 @@
 title: <gradient>
 slug: Web/CSS/gradient
 page-type: css-type
-browser-compat: css.types.image.gradient
+browser-compat: css.types.gradient
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

bcd change occurs at https://github.com/mdn/browser-compat-data/pull/25191, its functions has fixed in https://github.com/mdn/content/pull/37033, this fix the one 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
