### PR TITLE
OpenSearch: Remove leftover mentions of moz:SearchForm

### DIFF
--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 The **[OpenSearch description format](https://github.com/dewitt/opensearch)** can be used to describe the web interface of a search engine. This allows a website to describe a search engine for itself, so that a browser or other client application can use that search engine. OpenSearch is supported by (at least) Firefox, Edge, Safari, and Chrome. (See [Reference Material](#reference_material) for links to other browsers' documentation.)
 
-Firefox also supports additional features not in the OpenSearch standard, such as search suggestions and the `<SearchForm>` element. This article focuses on creating OpenSearch-compatible search plugins that support these additional Firefox features.
+Firefox also supports additional features not in the OpenSearch standard, such as search suggestions. This article focuses on creating OpenSearch-compatible search plugins that support these additional Firefox features.
 
 OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins).
 
@@ -28,7 +28,6 @@ The XML file that describes a search engine follows the basic template below. Se
   <Image width="16" height="16" type="image/x-icon">[https://example.com/favicon.ico]</Image>
   <Url type="text/html" template="[searchURL]"/>
   <Url type="application/x-suggestions+json" template="[suggestionURL]"/>
-  <moz:SearchForm>[https://example.com/search]</moz:SearchForm>
 </OpenSearchDescription>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes leftover mentions of `moz:SearchForm` in OpenSearch.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

PR #30140 removed the explanation of `moz:SearchForm` without removing it from the introduction or the example. Someone commented on the PR suggesting removing it from the example (line 30), but this was missed. This creates confusion for the reader who sees `moz:SearchForm` in the example and tries to find the explanation (like me).

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Related issues and pull requests
Fixes #11607 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
