### PR TITLE
Fixed typo

### DIFF
--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -10,7 +10,7 @@ This article provides a basic guide to using the [Permissions API](/en-US/docs/W
 
 ## The trouble with asking for permission…
 
-Permissions on the Web are a necessary evil, but they are not much fun to deal with as developers.
+Permissions on the Web aren't necessary evil, but they are not much fun to deal with as developers.
 
 Historically, different APIs handle their own permissions inconsistently — for example the [Notifications API](/en-US/docs/Web/API/Notifications_API) had its own methods for checking the permission status and requesting permission, whereas the [Geolocation API](/en-US/docs/Web/API/Geolocation_API) did not.
 


### PR DESCRIPTION
### Description  

Fixed typo; "are a" -> "aren't"  

### Motivation  

Though it is a small change, it can help users who have a screen reader not be confused with the incorrect grammar.  

### Additional details  

https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API#the_trouble_with_asking_for_permission%E2%80%A6