### PR TITLE
Fix Boolean.prototype.valueOf() no variable

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -38,8 +38,8 @@ This method is usually called internally by JavaScript and not explicitly in cod
 ### Using `valueOf()`
 
 ```js
-x = new Boolean();
-myVar = x.valueOf(); // assigns false to myVar
+const x = new Boolean();
+const myVar = x.valueOf(); // assigns false to myVar
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.md
* Last commit: https://github.com/mdn/content/commit/27180875516cc311342e74b596bfb589b7211e0c