### PR TITLE
Fixed incorrect attribute for <img> element

### DIFF
--- a/files/en-us/learn_web_development/getting_started/your_first_website/creating_the_content/index.md
+++ b/files/en-us/learn_web_development/getting_started/your_first_website/creating_the_content/index.md
@@ -156,7 +156,7 @@ The keywords for alt text are "descriptive text". The alt text you write should 
 Let's get your image displaying now.
 
 1. Inside the `first-website` folder, Create a new folder called `images`, and put the image you chose in the previous example inside this folder.
-2. Inside the `<img>` tag's `alt` attribute value, enter the path to your image. It is inside a folder called `images`, which is inside the same directory as your `index.html` file, therefore the path will be `images/` plus the name of your image. For example, if your image was called `firefox-icon.png`, your `src` attribute would look like this: `src="images/firefox-icon.png"`.
+2. Inside the `<img>` tag's `src` attribute value, enter the path to your image. It is inside a folder called `images`, which is inside the same directory as your `index.html` file, therefore the path will be `images/` plus the name of your image. For example, if your image was called `firefox-icon.png`, your `src` attribute would look like this: `src="images/firefox-icon.png"`.
 3. replace the `alt` attribute value — `My test image` — with some text that better describes your image.
 4. Open your `index.html` file inside a web browser. You should see your image displayed. If not, check your `<img>` element against our code above; make sure it is not missing any of the syntax, such as the quote marks. Make sure the image filename is correct.
 


### PR DESCRIPTION
### Description
In the context of altering the `<img>` tag to use the filepath of an image file, the text referenced the `alt` attribute and it should be the `src` attribute.


### Motivation
Beginning developers may not understand the typo because the alt tag is valid also, just not to modify the image's source.

### Additional details
n/a

### Related issues and pull requests
n/a