### PR TITLE
fix pre-tags' line breaking

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/a_first_splash/index.md
+++ b/files/en-us/learn_web_development/core/scripting/a_first_splash/index.md
@@ -213,8 +213,7 @@ When we are running true/false tests (for example inside conditionals — see [b
       <td><code>===</code></td>
       <td>Strict equality (is it exactly the same?)</td>
       <td>
-        <pre class="brush: js">
-5 === 2 + 4 // false
+        <pre class="brush: js">5 === 2 + 4 // false
 'Chris' === 'Bob' // false
 5 === 2 + 3 // true
 2 === '2' // false; number versus string
@@ -226,8 +225,7 @@ When we are running true/false tests (for example inside conditionals — see [b
       <td><code>!==</code></td>
       <td>Non-equality (is it not the same?)</td>
       <td>
-        <pre class="brush: js">
-5 !== 2 + 4 // true
+        <pre class="brush: js">5 !== 2 + 4 // true
 'Chris' !== 'Bob' // true
 5 !== 2 + 3 // false
 2 !== '2' // true; number versus string
@@ -239,8 +237,7 @@ When we are running true/false tests (for example inside conditionals — see [b
       <td><code>&#x3C;</code></td>
       <td>Less than</td>
       <td>
-        <pre class="brush: js">
-6 &#x3C; 10 // true
+        <pre class="brush: js">6 &#x3C; 10 // true
 20 &#x3C; 10 // false</pre
         >
       </td>
@@ -249,8 +246,7 @@ When we are running true/false tests (for example inside conditionals — see [b
       <td><code>></code></td>
       <td>Greater than</td>
       <td>
-        <pre class="brush: js">
-6 > 10 // false
+        <pre class="brush: js">6 > 10 // false
 20 > 10 // true</pre
         >
       </td>

--- a/files/en-us/learn_web_development/core/text_styling/fundamentals/index.md
+++ b/files/en-us/learn_web_development/core/text_styling/fundamentals/index.md
@@ -210,8 +210,7 @@ The five names are defined as follows:
       </td>
       <td id="serif-example">
         <pre class="brush: html hidden">My big red elephant</pre>
-        <pre class="brush: css hidden">
-body {
+        <pre class="brush: css hidden">body {
   font-family: serif;
 }</pre
         >
@@ -223,8 +222,7 @@ body {
       <td>Fonts that don't have serifs.</td>
       <td id="sans-serif-example">
         <pre class="brush: html hidden">My big red elephant</pre>
-        <pre class="brush: css hidden">
-body {
+        <pre class="brush: css hidden">body {
   font-family: sans-serif;
 }</pre
         >
@@ -239,8 +237,7 @@ body {
       </td>
       <td id="monospace-example">
         <pre class="brush: html hidden">My big red elephant</pre>
-        <pre class="brush: css hidden">
-body {
+        <pre class="brush: css hidden">body {
   font-family: monospace;
 }</pre
         >
@@ -255,8 +252,7 @@ body {
       </td>
       <td id="cursive-example">
         <pre class="brush: html hidden">My big red elephant</pre>
-        <pre class="brush: css hidden">
-body {
+        <pre class="brush: css hidden">body {
   font-family: cursive;
 }</pre
         >
@@ -268,8 +264,7 @@ body {
       <td>Fonts that are intended to be decorative.</td>
       <td id="fantasy-example">
         <pre class="brush: html hidden">My big red elephant</pre>
-        <pre class="brush: css hidden">
-body {
+        <pre class="brush: css hidden">body {
   font-family: fantasy;
 }</pre
         >

--- a/files/en-us/learn_web_development/howto/solve_html_problems/cheatsheet/index.md
+++ b/files/en-us/learn_web_development/howto/solve_html_problems/cheatsheet/index.md
@@ -29,8 +29,7 @@ An "element" is a single part of a webpage. Some elements are large and hold sma
       <td>A link</td>
       <td>{{HTMLElement("a")}}</td>
       <td id="a-example">
-        <pre class="brush: html">
-&#x3C;a href="https://example.org">
+        <pre class="brush: html">&#x3C;a href="https://example.org">
 A link to example.org&#x3C;/a>.</pre
         >
         {{EmbedLiveSample("a-example", 100, 60)}}
@@ -48,8 +47,7 @@ A link to example.org&#x3C;/a>.</pre
       <td>An inline container</td>
       <td>{{HTMLElement("span")}}</td>
       <td id="span-example">
-        <pre class="brush: html">
-Used to group elements: for example,
+        <pre class="brush: html">Used to group elements: for example,
 to &#x3C;span style="color:blue">style
 them&#x3C;/span>.</pre
         >
@@ -68,8 +66,7 @@ them&#x3C;/span>.</pre
       <td>Italic text</td>
       <td>{{HTMLElement("i")}}</td>
       <td id="i-example">
-        <pre class="brush: html">
-Mark a phrase in &#x3C;i>italics&#x3C;/i>.</pre
+        <pre class="brush: html">Mark a phrase in &#x3C;i>italics&#x3C;/i>.</pre
         >
         {{EmbedLiveSample("i-example", 100, 60)}}
       </td>
@@ -118,8 +115,7 @@ Mark a phrase in &#x3C;i>italics&#x3C;/i>.</pre
       <td>Small text</td>
       <td>{{HTMLElement("small")}}</td>
       <td id="small-example">
-        <pre class="brush: html">
-Used to represent the &#x3C;small>small
+        <pre class="brush: html">Used to represent the &#x3C;small>small
 print &#x3C;/small>of a document.</pre
         >
         {{EmbedLiveSample("small-example", 100, 60)}}
@@ -129,8 +125,7 @@ print &#x3C;/small>of a document.</pre
       <td>Address</td>
       <td>{{HTMLElement("address")}}</td>
       <td id="address-example">
-        <pre class="brush: html">
-&#x3C;address>Main street 67&#x3C;/address></pre
+        <pre class="brush: html">&#x3C;address>Main street 67&#x3C;/address></pre
         >
         {{EmbedLiveSample("address-example", 100, 60)}}
       </td>
@@ -139,8 +134,7 @@ print &#x3C;/small>of a document.</pre
       <td>Textual citation</td>
       <td>{{HTMLElement("cite")}}</td>
       <td id="cite-example">
-        <pre class="brush: html">
-For more monsters,
+        <pre class="brush: html">For more monsters,
 see &#x3C;cite>The Monster Book of Monsters&#x3C;/cite>.</pre
         >
         {{EmbedLiveSample("cite-example", 100, 60)}}
@@ -174,8 +168,7 @@ see &#x3C;cite>The Monster Book of Monsters&#x3C;/cite>.</pre
       <td>A possible line break</td>
       <td>{{HTMLElement("wbr")}}</td>
       <td id="wbr-example">
-        <pre class="brush: html">
-&#x3C;div style="width: 200px">
+        <pre class="brush: html">&#x3C;div style="width: 200px">
   Llanfair&#x3C;wbr>pwllgwyngyll&#x3C;wbr>gogerychwyrndrobwllllantysiliogogogoch.
 &#x3C;/div></pre
         >
@@ -186,8 +179,7 @@ see &#x3C;cite>The Monster Book of Monsters&#x3C;/cite>.</pre
       <td>Date</td>
       <td>{{HTMLElement("time")}}</td>
       <td id="time-example">
-        <pre class="brush: html">
-Used to format the date. For example:
+        <pre class="brush: html">Used to format the date. For example:
 &#x3C;time datetime="2020-05-24">
 published on 23-05-2020&#x3C;/time>.</pre
         >
@@ -198,8 +190,7 @@ published on 23-05-2020&#x3C;/time>.</pre
       <td>Code format</td>
       <td>{{HTMLElement("code")}}</td>
       <td id="code-example">
-        <pre class="brush: html">
-This text is in normal format,
+        <pre class="brush: html">This text is in normal format,
 but &#x3C;code>this text is in code
 format&#x3C;/code>.</pre
         >
@@ -210,8 +201,7 @@ format&#x3C;/code>.</pre
       <td>Audio</td>
       <td>{{HTMLElement("audio")}}</td>
       <td id="audio-example">
-        <pre class="brush: html">
-&#x3C;audio controls>
+        <pre class="brush: html">&#x3C;audio controls>
   &#x3C;source src="https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3" type="audio/mpeg">
 &#x3C;/audio>
         </pre>
@@ -222,8 +212,7 @@ format&#x3C;/code>.</pre
       <td>Video</td>
       <td>{{HTMLElement("video")}}</td>
       <td id="video-example">
-        <pre class="brush: html">
-&#x3C;video controls width="250"
+        <pre class="brush: html">&#x3C;video controls width="250"
   src="https://archive.org/download/ElephantsDream/ed_hd.ogv" >
   &#x3C;a href="https://archive.org/download/ElephantsDream/ed_hd.ogv">Download OGV video&#x3C;/a>
 &#x3C;/video></pre
@@ -254,8 +243,7 @@ format&#x3C;/code>.</pre
       <td>A simple paragraph</td>
       <td>{{HTMLElement("p")}}</td>
       <td id="p-example">
-        <pre class="brush: html">
-&#x3C;p>I'm a paragraph&#x3C;/p>
+        <pre class="brush: html">&#x3C;p>I'm a paragraph&#x3C;/p>
 &#x3C;p>I'm another paragraph&#x3C;/p></pre
         >
         {{EmbedLiveSample("p-example", 100, 150)}}
@@ -265,8 +253,7 @@ format&#x3C;/code>.</pre
       <td>An extended quotation</td>
       <td>{{HTMLElement("blockquote")}}</td>
       <td id="blockquote-example">
-        <pre class="brush: html">
-They said:
+        <pre class="brush: html">They said:
 &#x3C;blockquote>The blockquote element indicates
 an extended quotation.&#x3C;/blockquote></pre
         >
@@ -277,8 +264,7 @@ an extended quotation.&#x3C;/blockquote></pre
       <td>Additional information</td>
       <td>{{HTMLElement("details")}}</td>
       <td id="details-example">
-        <pre class="brush: html">
-&#x3C;details>
+        <pre class="brush: html">&#x3C;details>
   &#x3C;summary>HTML Cheat Sheet&#x3C;/summary>
   &#x3C;p>Inline elements&#x3C;/p>
   &#x3C;p>Block elements&#x3C;/p>
@@ -336,8 +322,7 @@ an extended quotation.&#x3C;/blockquote></pre
         {{HTMLElement("Heading_Elements", "&lt;h1&gt;-&lt;h6&gt;")}}
       </td>
       <td id="h1-h6-example">
-        <pre class="brush: html">
-&#x3C;h1> This is Heading 1 &#x3C;/h1>
+        <pre class="brush: html">&#x3C;h1> This is Heading 1 &#x3C;/h1>
 &#x3C;h2> This is Heading 2 &#x3C;/h2>
 &#x3C;h3> This is Heading 3 &#x3C;/h3>
 &#x3C;h4> This is Heading 4 &#x3C;/h4>

--- a/files/en-us/mdn/at_ten/history_of_mdn/index.md
+++ b/files/en-us/mdn/at_ten/history_of_mdn/index.md
@@ -8,8 +8,7 @@ page-type: guide
 
 In this talk from 2015, several contributors of the MDN project look at the past ten years of [developer.mozilla.org](/), and at the decade to come. You will hear the story of different wiki software migrations, how a documentation community was built, and many more highlights of the history of the site. The group then also talks about current challenges and projects the MDN community is working on this year.
 
-<div id="audio"><pre class="brush: html hidden">&#x3C;audio controls="controls">
-  Looks like your browser doesn't have a built-in audio player. Grab the file and play it yourself from here: https://videos.cdn.mozilla.net/uploads/mdn/MDN10/MDN_RoundTable.mp3
+<div id="audio"><pre class="brush: html hidden">&#x3C;audio controls="controls">  Looks like your browser doesn't have a built-in audio player. Grab the file and play it yourself from here: https://videos.cdn.mozilla.net/uploads/mdn/MDN10/MDN_RoundTable.mp3
   &#x3C;source src="https://videos.cdn.mozilla.net/uploads/mdn/MDN10/MDN_RoundTable.mp3" type="audio/mp3">
 &#x3C;/audio>
 </pre><pre class="brush: css hidden">body{margin-top:8px;}

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/action/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.action
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"action": {
+        <pre class="brush: json">"action": {
   "default_icon": {
     "16": "button/geo-16.png",
     "32": "button/geo-32.png"
@@ -146,8 +145,7 @@ The `action` key is an object that may have any of these properties, all optiona
           The name of each property is the icon's height in pixels, and must be
           convertible to an integer. The value is the URL. For example:
         </p>
-        <pre class="brush: json">
-    "default_icon": {
+        <pre class="brush: json">    "default_icon": {
       "16": "path/to/geo-16.png",
       "32": "path/to/geo-32.png"
     }</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.background
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"background": {
+        <pre class="brush: json">"background": {
   "scripts": ["background.js"]
 }</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.browser_action
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"browser_action": {
+        <pre class="brush: json">"browser_action": {
   "default_icon": {
     "16": "button/geo-16.png",
     "32": "button/geo-32.png"
@@ -187,8 +186,7 @@ The `browser_action` key is an object that may have any of the following propert
           The name of each property is the icon's height in pixels, and must be
           convertible to an integer. The value is the URL. For example:
         </p>
-        <pre class="brush: json">
-    "default_icon": {
+        <pre class="brush: json">    "default_icon": {
       "16": "path/to/geo-16.png",
       "32": "path/to/geo-32.png"
     }</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -29,8 +29,7 @@ browser-compat: webextensions.manifest.browser_specific_settings
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json;">
-"browser_specific_settings": {
+        <pre class="brush: json;">"browser_specific_settings": {
   "gecko": {
     "id": "addon@example.com",
     "strict_min_version": "58.0"

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.chrome_url_overrides
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-  "chrome_url_overrides" : {
+        <pre class="brush: json">  "chrome_url_overrides" : {
     "newtab": "my-new-tab.html"
   }</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.commands
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"commands": {
+        <pre class="brush: json">"commands": {
   "toggle-feature": {
     "suggested_key": {
       "default": "Ctrl+Shift+Y",

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.content_scripts
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"content_scripts": [
+        <pre class="brush: json">"content_scripts": [
   {
     "matches": ["*://*.mozilla.org/*"],
     "js": ["borderify.js"]
@@ -163,8 +162,7 @@ Details of all the keys you can include are given in the table below.
           if you include jQuery here followed by another content script, like
           this:
         </p>
-        <pre class="brush: json">
-"js": ["jquery.js", "my-content-script.js"]</pre
+        <pre class="brush: json">"js": ["jquery.js", "my-content-script.js"]</pre
         >
         <p>Then, <code>"my-content-script.js"</code> can use jQuery.</p>
         <p>
@@ -198,8 +196,7 @@ Details of all the keys you can include are given in the table below.
           For example, suppose you have a <code>content_scripts</code> key like
           this:
         </p>
-        <pre class="brush: json">
-  "content_scripts": [
+        <pre class="brush: json">  "content_scripts": [
     {
       "js": ["my-script.js"],
       "matches": ["https://example.org/"],

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -25,11 +25,9 @@ browser-compat: webextensions.manifest.content_security_policy
       <th scope="row">Example</th>
       <td>
         Manifest V2:
-        <pre class="brush: json">
-"content_security_policy": "default-src 'self'"</pre>
+        <pre class="brush: json">"content_security_policy": "default-src 'self'"</pre>
         Manifest V3:
-        <pre class="brush: json">
-"content_security_policy": {
+        <pre class="brush: json">"content_security_policy": {
   "extension_pages": "default-src 'self'"
 }</pre>
       </td>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.declarative_net_request
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"declarative_net_request" : {
+        <pre class="brush: json">"declarative_net_request" : {
   "rule_resources" : [{
     "id": "ruleset",
     "enabled": true,

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.description
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"description": "Replaces pictures with pictures of cats."</pre
+        <pre class="brush: json">"description": "Replaces pictures with pictures of cats."</pre
         >
       </td>
     </tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.developer
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"developer": {
+        <pre class="brush: json">"developer": {
   "name": "Walt Whitman",
   "url": "https://en.wikipedia.org/wiki/Walt_Whitman"
 }</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.dictionaries
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"dictionaries": {
+        <pre class="brush: json">"dictionaries": {
   "en-US": "dictionaries/en-US.dic"
 }</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.homepage_url
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"homepage_url": "https://example.org/my-addon"</pre
+        <pre class="brush: json">"homepage_url": "https://example.org/my-addon"</pre
         >
       </td>
     </tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/host_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/host_permissions/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.host_permissions
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json;">
-"host_permissions": [
+        <pre class="brush: json;">"host_permissions": [
   "*://developer.mozilla.org/*",
   "*://*.example.org/*"
 ]</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.omnibox
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"omnibox": {
+        <pre class="brush: json">"omnibox": {
   "keyword": "mdn"
 }</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_host_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_host_permissions/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.optional_host_permissions
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json;">
-"optional_host_permissions": [
+        <pre class="brush: json;">"optional_host_permissions": [
   "*://developer.mozilla.org/*",
   "*://*.example.org/*"
 ]</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.optional_permissions
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"optional_permissions": [
+        <pre class="brush: json">"optional_permissions": [
   "webRequest"
 ]</pre>
       </td>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.options_ui
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json;">
-"options_ui": {
+        <pre class="brush: json;">"options_ui": {
   "page": "options/options.html"
 }</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.page_action
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"page_action": {
+        <pre class="brush: json">"page_action": {
   "default_icon": {
     "19": "button/geo-19.png",
     "38": "button/geo-38.png"
@@ -107,8 +106,7 @@ The `page_action` key is an object that may have any of three properties, all op
           38×38 pixels), and specify them in an object with properties named
           <code>"19"</code> and <code>"38"</code>, like this:
         </p>
-        <pre class="brush: json">
-    "default_icon": {
+        <pre class="brush: json">    "default_icon": {
       "19": "geo-19.png",
       "38": "geo-38.png"
     }</pre
@@ -219,8 +217,7 @@ The `page_action` key is an object that may have any of three properties, all op
           will override the patterns in <code>show_matches</code>.
         </p>
         <p>For example, consider a value like:</p>
-        <pre class="brush: json">
-"page_action": {
+        <pre class="brush: json">"page_action": {
   "show_matches": ["https://*.mozilla.org/*"],
   "hide_matches": ["https://developer.mozilla.org/*"]
 }</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.permissions
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json;">
-"permissions": [
+        <pre class="brush: json;">"permissions": [
   "webRequest"
 ]</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.protocol_handlers
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"protocol_handlers": [
+        <pre class="brush: json">"protocol_handlers": [
   {
     "protocol": "ircs",
     "name": "IRC Mozilla Extension",

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.sidebar_action
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"sidebar_action": {
+        <pre class="brush: json">"sidebar_action": {
   "default_icon": {
     "16": "button/geo-16.png",
     "32": "button/geo-32.png"
@@ -112,8 +111,7 @@ The `sidebar_action` key is an object that may have any of the properties listed
           The name of each property is the icon's height in pixels, and must be
           convertible to an integer. The value is the URL. For example:
         </p>
-        <pre class="brush: json">
-    "default_icon": {
+        <pre class="brush: json">    "default_icon": {
       "16": "path/to/geo-16.png",
       "32": "path/to/geo-32.png"
     }</pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.storage
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"storage": {
+        <pre class="brush: json">"storage": {
   "managed_schema": "schema.json"
 }</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.theme
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"theme": {
+        <pre class="brush: json">"theme": {
   "images": {
     "theme_frame": "images/sun.jpg"
   },
@@ -243,8 +242,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "tab_background_text": "white",
@@ -269,8 +267,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The color of the background of the pressed toolbar buttons.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -288,8 +285,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The color of the background of the toolbar buttons on hover.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -315,8 +311,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -345,8 +340,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -368,8 +362,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "red",
      "tab_background_text": "white"
@@ -391,8 +384,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "red",
      "frame_inactive": "gray",
@@ -415,8 +407,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The new tab page background color.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "ntp_background": "red"
   }
@@ -432,8 +423,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The new tab page card background color.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "ntp_card_background": "red"
   }
@@ -455,8 +445,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "ntp_text": "red"
   }
@@ -475,8 +464,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -494,8 +482,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The border color of popups.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -525,8 +512,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -551,8 +537,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -577,8 +562,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -597,8 +581,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The background color of the sidebar.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "sidebar": "red",
      "sidebar_highlight": "white",
@@ -617,8 +600,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The border and splitter color of the browser sidebar</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "sidebar_border": "red"
   }
@@ -634,8 +616,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The background color of highlighted rows in built-in sidebars</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "sidebar_highlight": "red",
      "sidebar_highlight_text": "white"
@@ -658,8 +639,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "sidebar_highlight": "pink",
     "sidebar_highlight_text": "red",
@@ -682,8 +662,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "sidebar": "red",
      "sidebar_highlight": "white",
@@ -710,8 +689,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The color of the vertical separator of the background tabs.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -745,8 +723,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "white",
@@ -764,8 +741,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The color of the selected tab line.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -783,8 +759,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The color of the tab loading indicator and the tab loading burst.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
      "frame": "black",
      "tab_background_text": "white",
@@ -806,8 +781,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "images": {
   "theme_frame": "weta.png"
 },
@@ -839,8 +813,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "images": {
   "theme_frame": "weta.png"
 },
@@ -866,8 +839,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>This also sets the background color of the "Find" bar.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "red",
@@ -888,8 +860,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "tab_background_text": "white",
@@ -913,8 +884,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "tab_background_text": "white",
@@ -936,8 +906,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "black",
@@ -958,8 +927,7 @@ All these properties can be specified as either a string containing any valid [C
         <p>The focused border color for fields in the toolbar.</p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "black",
@@ -983,8 +951,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "black",
@@ -1006,8 +973,7 @@ All these properties can be specified as either a string containing any valid [C
         the URL bar (and the search bar, if it's configured to be separate).
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "toolbar_field": "rgb(255 255 255 / 91%)",
     "toolbar_field_text": "rgb(0 100 0)",
@@ -1045,8 +1011,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "toolbar_field": "rgb(255 255 255 / 91%)",
     "toolbar_field_text": "rgb(0 100 0)",
@@ -1084,8 +1049,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "black",
@@ -1119,8 +1083,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "black",
@@ -1149,8 +1112,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "toolbar": "black",
@@ -1180,8 +1142,7 @@ All these properties can be specified as either a string containing any valid [C
         </div>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "tab_background_text": "white",
@@ -1203,8 +1164,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "tab_background_text": "white",
@@ -1226,8 +1186,7 @@ All these properties can be specified as either a string containing any valid [C
         </p>
         <details open>
           <summary>See example</summary>
-          <pre class="brush: json">
-"theme": {
+          <pre class="brush: json">"theme": {
   "colors": {
     "frame": "black",
     "tab_background_text": "white",

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.theme_experiment
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"theme_experiment": {
+        <pre class="brush: json">"theme_experiment": {
   "stylesheet": "style.css",
   "colors": {
     "popup_affordance": "--arrowpanel-dimmed"

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.user_scripts
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-  "user_scripts": {
+        <pre class="brush: json">  "user_scripts": {
     "api_script": "apiscript.js",
   }
 </pre

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -24,8 +24,7 @@ browser-compat: webextensions.manifest.web_accessible_resources
     <tr>
       <th scope="row">Example</th>
       <td>
-        <pre class="brush: json">
-"web_accessible_resources": [
+        <pre class="brush: json">"web_accessible_resources": [
   "images/my-image.png"
 ]</pre
         >

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -51,8 +51,7 @@ Most styles are automatically applied, but some elements require you to add the 
         >
       </td>
       <td>
-        <pre class="brush: html">
-&#x3C;button class="browser-style">Click me&#x3C;/button></pre
+        <pre class="brush: html">&#x3C;button class="browser-style">Click me&#x3C;/button></pre
         >
       </td>
     </tr>
@@ -67,8 +66,7 @@ Most styles are automatically applied, but some elements require you to add the 
         </p>
       </td>
       <td>
-        <pre class="brush: html">
-&#x3C;select class="browser-style" name="select">
+        <pre class="brush: html">&#x3C;select class="browser-style" name="select">
   &#x3C;option value="value1">Value 1&#x3C;/option>
   &#x3C;option value="value2" selected>Value 2&#x3C;/option>
   &#x3C;option value="value3">Value 3&#x3C;/option>
@@ -85,8 +83,7 @@ Most styles are automatically applied, but some elements require you to add the 
         >
       </td>
       <td>
-        <pre class="brush: html">
-&#x3C;textarea class="browser-style">Write here&#x3C;/textarea></pre
+        <pre class="brush: html">&#x3C;textarea class="browser-style">Write here&#x3C;/textarea></pre
         >
       </td>
     </tr>
@@ -98,8 +95,7 @@ Most styles are automatically applied, but some elements require you to add the 
         >
       </td>
       <td>
-        <pre class="brush: html">
-&#x3C;div class="browser-style">
+        <pre class="brush: html">&#x3C;div class="browser-style">
   &#x3C;input type="radio" id="op1" name="choices" value="op1"/>
   &#x3C;label for="op1">Option 1&#x3C;/label>
 
@@ -144,8 +140,7 @@ The [legacy Firefox Style Guide](https://firefoxux.github.io/StyleGuide/#/naviga
     <tr>
       <td>Header</td>
       <td>
-        <pre class="brush: html">
-&#x3C;header class="panel-section panel-section-header">
+        <pre class="brush: html">&#x3C;header class="panel-section panel-section-header">
   &#x3C;div class="icon-section-header">&#x3C;img src="image.svg"/>&#x3C;/div>
   &#x3C;div class="text-section-header">Header&#x3C;/div>
 &#x3C;/header></pre
@@ -155,8 +150,7 @@ The [legacy Firefox Style Guide](https://firefoxux.github.io/StyleGuide/#/naviga
     <tr>
       <td>Footer</td>
       <td>
-        <pre class="brush: html">
-&#x3C;footer class="panel-section panel-section-footer">
+        <pre class="brush: html">&#x3C;footer class="panel-section panel-section-footer">
   &#x3C;button class="panel-section-footer-button">Cancel&#x3C;/button>
   &#x3C;div class="panel-section-footer-separator">&#x3C;/div>
   &#x3C;button class="panel-section-footer-button default">Confirm&#x3C;/button>
@@ -167,8 +161,7 @@ The [legacy Firefox Style Guide](https://firefoxux.github.io/StyleGuide/#/naviga
     <tr>
       <td>Tabs</td>
       <td>
-        <pre class="brush: html">
-&#x3C;div class="panel-section panel-section-tabs">
+        <pre class="brush: html">&#x3C;div class="panel-section panel-section-tabs">
   &#x3C;button class="panel-section-tabs-button selected">Tab&#x3C;/button>
   &#x3C;div class="panel-section-tabs-separator">&#x3C;/div>
   &#x3C;button class="panel-section-tabs-button">Tab&#x3C;/button>
@@ -181,8 +174,7 @@ The [legacy Firefox Style Guide](https://firefoxux.github.io/StyleGuide/#/naviga
     <tr>
       <td>Form</td>
       <td>
-        <pre class="brush: html">
-&#x3C;div class="panel-section panel-section-formElements">
+        <pre class="brush: html">&#x3C;div class="panel-section panel-section-formElements">
   &#x3C;div class="panel-formElements-item">
     &#x3C;label for="name01">Label:&#x3C;/label>
     &#x3C;input type="text" value="Name" id="name01" />
@@ -207,8 +199,7 @@ The [legacy Firefox Style Guide](https://firefoxux.github.io/StyleGuide/#/naviga
     <tr>
       <td>Menu</td>
       <td>
-        <pre class="brush: html">
-&#x3C;div class="panel-section panel-section-list">
+        <pre class="brush: html">&#x3C;div class="panel-section panel-section-list">
   &#x3C;div class="panel-list-item">
     &#x3C;div class="icon">&#x3C;/div>
     &#x3C;div class="text">List Item&#x3C;/div>

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -37,8 +37,7 @@ The available types are as follows:
         A push button with no default behavior displaying the value of the <a href="#value"><code>value</code></a> attribute, empty by default.
       </td>
       <td id="examplebutton">
-        <pre class="brush: html hidden">
-&#x3C;input type="button" name="button" value="Button" /></pre>
+        <pre class="brush: html hidden">&#x3C;input type="button" name="button" value="Button" /></pre>
         {{EmbedLiveSample("examplebutton",200,55)}}
       </td>
     </tr>
@@ -46,8 +45,7 @@ The available types are as follows:
       <td>{{HTMLElement("input/checkbox", "checkbox")}}</td>
       <td>A check box allowing single values to be selected/deselected.</td>
       <td id="examplecheckbox">
-        <pre class="brush: html hidden">
-&#x3C;input type="checkbox" name="checkbox"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="checkbox" name="checkbox"/></pre>
         {{EmbedLiveSample("examplecheckbox",200,55)}}
       </td>
     </tr>
@@ -57,8 +55,7 @@ The available types are as follows:
         A control for specifying a color; opening a color picker when active in supporting browsers.
       </td>
       <td id="examplecolor">
-        <pre class="brush: html hidden">
-&#x3C;input type="color" name="color"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="color" name="color"/></pre>
         {{EmbedLiveSample("examplecolor",200,55)}}
       </td>
     </tr>
@@ -70,8 +67,7 @@ The available types are as follows:
         in supporting browsers.
       </td>
       <td id="exampledate">
-        <pre class="brush: html hidden">
-&#x3C;input type="date" name="date"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="date" name="date"/></pre>
         {{EmbedLiveSample("exampledate",200,55)}}
       </td>
     </tr>
@@ -84,8 +80,7 @@ The available types are as follows:
         picker or numeric wheels for date- and time-components when active in supporting browsers.
       </td>
       <td id="exampledtl">
-        <pre class="brush: html hidden">
-&#x3C;input type="datetime-local" name="datetime-local"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="datetime-local" name="datetime-local"/></pre>
         {{EmbedLiveSample("exampledtl",200,55)}}
       </td>
     </tr>
@@ -97,8 +92,7 @@ The available types are as follows:
         keyboard in supporting browsers and devices with dynamic keyboards.
       </td>
       <td id="exampleemail">
-        <pre class="brush: html hidden">
-&#x3C;input type="email" name="email"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="email" name="email"/></pre>
         {{EmbedLiveSample("exampleemail",200,55)}}
       </td>
     </tr>
@@ -109,8 +103,7 @@ The available types are as follows:
         Use the <a href="#accept"><code>accept</code></a> attribute to define the types of files that the control can select.
       </td>
       <td id="examplefile">
-        <pre class="brush: html hidden">
-&#x3C;input type="file" accept="image/*, text/*" name="file"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="file" accept="image/*, text/*" name="file"/></pre>
         {{EmbedLiveSample("examplefile",'100%',55)}}
       </td>
     </tr>
@@ -121,8 +114,7 @@ The available types are as follows:
         server. There is an example in the next column, but it's hidden!
       </td>
       <td id="examplehidden">
-        <pre class="brush: html hidden">
-&#x3C;input id="userId" name="userId" type="hidden" value="abc123"></pre
+        <pre class="brush: html hidden">&#x3C;input id="userId" name="userId" type="hidden" value="abc123"></pre
         >
         {{EmbedLiveSample("examplehidden",200,55)}}
       </td>
@@ -134,8 +126,7 @@ The available types are as follows:
         The <a href="#alt"><code>alt</code></a> attribute displays if the image <a href="#src"><code>src</code></a> is missing.
       </td>
       <td id="exampleimage">
-        <pre class="brush: html hidden">
-&#x3C;input type="image" name="image" src="" alt="image input"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="image" name="image" src="" alt="image input"/></pre>
         {{EmbedLiveSample("exampleimage",200,55)}}
       </td>
     </tr>
@@ -143,8 +134,7 @@ The available types are as follows:
       <td>{{HTMLElement("input/month", "month")}}</td>
       <td>A control for entering a month and year, with no time zone.</td>
       <td id="examplemonth">
-        <pre class="brush: html hidden">
-&#x3C;input type="month" name="month"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="month" name="month"/></pre>
         {{EmbedLiveSample("examplemonth",200,55)}}
       </td>
     </tr>
@@ -156,8 +146,7 @@ The available types are as follows:
         with dynamic keypads.
       </td>
       <td id="examplenumber">
-        <pre class="brush: html hidden">
-&#x3C;input type="number" name="number"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="number" name="number"/></pre>
         {{EmbedLiveSample("examplenumber",200,55)}}
       </td>
     </tr>
@@ -168,8 +157,7 @@ The available types are as follows:
         Will alert user if site is not secure.
       </td>
       <td id="examplepassword">
-        <pre class="brush: html hidden">
-&#x3C;input type="password" name="password"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="password" name="password"/></pre>
         {{EmbedLiveSample("examplepassword",200,55)}}
       </td>
     </tr>
@@ -179,8 +167,7 @@ The available types are as follows:
         A radio button, allowing a single value to be selected out of multiple choices with the same <a href="#name"><code>name</code></a> value.
       </td>
       <td id="exampleradio">
-        <pre class="brush: html hidden">
-&#x3C;input type="radio" name="radio"/></pre
+        <pre class="brush: html hidden">&#x3C;input type="radio" name="radio"/></pre
         >
         {{EmbedLiveSample("exampleradio",200,55)}}
       </td>
@@ -193,8 +180,7 @@ The available types are as follows:
         Used in conjunction <a href="#min"><code>min</code></a> and <a href="#max"><code>max</code></a> to define the range of acceptable values.
       </td>
       <td id="examplerange">
-        <pre class="brush: html hidden">
-&#x3C;input type="range" name="range" min="0" max="25"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="range" name="range" min="0" max="25"/></pre>
         {{EmbedLiveSample("examplerange",200,55)}}
       </td>
     </tr>
@@ -204,8 +190,7 @@ The available types are as follows:
         A button that resets the contents of the form to default values. Not recommended.
       </td>
       <td id="examplereset">
-        <pre class="brush: html hidden">
-&#x3C;input type="reset" name="reset"/></pre
+        <pre class="brush: html hidden">&#x3C;input type="reset" name="reset"/></pre
         >
         {{EmbedLiveSample("examplereset",200,55)}}
       </td>
@@ -219,8 +204,7 @@ The available types are as follows:
         search icon instead of enter key on some devices with dynamic keypads.
       </td>
       <td id="examplesearch">
-        <pre class="brush: html hidden">
-&#x3C;input type="search" name="search"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="search" name="search"/></pre>
         {{EmbedLiveSample("examplesearch",200,55)}}
       </td>
     </tr>
@@ -228,8 +212,7 @@ The available types are as follows:
       <td>{{HTMLElement("input/submit", "submit")}}</td>
       <td>A button that submits the form.</td>
       <td id="examplesubmit">
-        <pre class="brush: html hidden">
-&#x3C;input type="submit" name="submit"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="submit" name="submit"/></pre>
         {{EmbedLiveSample("examplesubmit",200,55)}}
       </td>
     </tr>
@@ -240,8 +223,7 @@ The available types are as follows:
         in some devices with dynamic keypads.
       </td>
       <td id="exampletel">
-        <pre class="brush: html hidden">
-&#x3C;input type="tel" name="tel"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="tel" name="tel"/></pre>
         {{EmbedLiveSample("exampletel",200,55)}}
       </td>
     </tr>
@@ -252,8 +234,7 @@ The available types are as follows:
         automatically removed from the input value.
       </td>
       <td id="exampletext">
-        <pre class="brush: html hidden">
-&#x3C;input type="text" name="text"/></pre
+        <pre class="brush: html hidden">&#x3C;input type="text" name="text"/></pre
         >
         {{EmbedLiveSample("exampletext",200,55)}}
       </td>
@@ -262,8 +243,7 @@ The available types are as follows:
       <td>{{HTMLElement("input/time", "time")}}</td>
       <td>A control for entering a time value with no time zone.</td>
       <td id="exampletime">
-        <pre class="brush: html hidden">
-&#x3C;input type="time" name="time"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="time" name="time"/></pre>
         {{EmbedLiveSample("exampletime",200,55)}}
       </td>
     </tr>
@@ -275,8 +255,7 @@ The available types are as follows:
         and devices with dynamic keyboards.
       </td>
       <td id="exampleurl">
-        <pre class="brush: html hidden">
-&#x3C;input type="url" name="url"/></pre
+        <pre class="brush: html hidden">&#x3C;input type="url" name="url"/></pre
         >
         {{EmbedLiveSample("exampleurl",200,55)}}
       </td>
@@ -287,8 +266,7 @@ The available types are as follows:
         A control for entering a date consisting of a week-year number and a week number with no time zone.
       </td>
       <td id="exampleweek">
-        <pre class="brush: html hidden">
-&#x3C;input type="week" name="week"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="week" name="week"/></pre>
         {{EmbedLiveSample("exampleweek",200,55)}}
       </td>
     </tr>
@@ -301,8 +279,7 @@ The available types are as follows:
         A control for entering a date and time (hour, minute, second, and fraction of a second) based on UTC time zone.
       </td>
       <td id="exampledatetime">
-        <pre class="brush: html hidden">
-&#x3C;input type="datetime" name="datetime"/></pre>
+        <pre class="brush: html hidden">&#x3C;input type="datetime" name="datetime"/></pre>
         {{EmbedLiveSample("exampledatetime",200,75)}}
       </td>
     </tr>

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -61,8 +61,7 @@ default locations of Firefox are:
             >which(1)</a
           >:
         </p>
-        <pre class="brush: plain">
-% which firefox
+        <pre class="brush: plain">% which firefox
 /usr/bin/firefox
 </pre
         >


### PR DESCRIPTION
### Description

Fixing pre-tags' line breaking by removing `\n` after the tag.

This is done by using the following Regular Expr:

```regex
(\<pre class\=\"brush\: .+?\"\>)\n
```

### Motivation

See mdn/yari#12364:

> formatted code with many lines defined with raw `<pre class="brush: json">` and a blank line following it will have a blank line at the very beginning

### Example

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes

- Markdown:

  <img src="https://github.com/user-attachments/assets/c5901b49-8227-4add-92c3-b56d31ae3a5d" width="240" />

- Actual behavior:

  <img src="https://github.com/user-attachments/assets/e424892a-d3a5-4709-b2af-1774df2edc3f" width="360" />
  <img src="https://github.com/user-attachments/assets/f7cfe261-b9c9-441b-a3eb-7daf84d76791" width="300" />
