### PR TITLE
Fix invalid markup in index.md

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -74,11 +74,8 @@ When the value to be announced, either the actual value or the value as a percen
 The first rule of ARIA use is "if you can use a native feature with the semantics and behavior you require already built in, instead of repurposing an element and **adding** an ARIA role, state or property to make it accessible, then do so."
 
 ```html
-<label for="temperature">
-  Oven Temperature
-</label>
-<input type="range" id="temperature"
-  value="205" min="70" max="250" step="5"/>
+<label for="temperature">Oven Temperature</label>
+<input type="range" id="temperature" value="205" min="70" max="250" step="5"/>
 ```
 
 If we employ native HTML semantics with {{HTMLElement('input')}} we get styles and semantics for free.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -75,7 +75,7 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
 
 ```html
 <label for="temperature">Oven Temperature</label>
-<input type="range" id="temperature" value="205" min="70" max="250" step="5"/>
+<input type="range" id="temperature" value="205" min="70" max="250" step="5" />
 ```
 
 If we employ native HTML semantics with {{HTMLElement('input')}} we get styles and semantics for free.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -76,10 +76,9 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
 ```html
 <label for="temperature">
   Oven Temperature
-</p>
+</label>
 <input type="range" id="temperature"
   value="205" min="70" max="250" step="5"/>
-</meter>
 ```
 
 If we employ native HTML semantics with {{HTMLElement('input')}} we get styles and semantics for free.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
There was an orphan `</meter>` & `</p>` when there should have been a closing `</label>`

### Motivation
Better clarity to the example markup given.