### PR TITLE
Add glossary term 'escaping text'

### DIFF
--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An {{glossary("HTML")}} **character reference** is a formatted pattern of characters that is used to represent another character in the rendered web page.
+An {{glossary("HTML")}} **character reference** is a {{glossary("escaping text", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
 
 Character references are used as replacements for characters that are reserved in HTML, such as the less-than (`<`) and greater-than (`>`) symbols used by the HTML parser to identify element {{Glossary('tag','tags')}}, or `"` or `'` within attributes, which may be enclosed by those characters.
 They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, control characters like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.
@@ -21,7 +21,7 @@ There are three types of character references:
 
 - **Decimal numeric character references**
 
-  - : These references start with `&#`, followed by one or more ASCII digits representing the base-ten integer that corresponds to the character's Unicode code point, and ending with `;`.
+  - : These references start with `&#`, followed by one or more ASCII digits representing the base-ten integer that corresponds to the character's {{glossary("Unicode")}} {{glossary("code point")}}, and ending with `;`.
     For example, the decimal character reference for `<` is `&#60;`, because the Unicode code point for the symbol is `U+0003C`, and `3C` hexadecimal is 60 in decimal.
 
 - **Hexadecimal numeric character reference**
@@ -50,3 +50,11 @@ A very small subset of useful named character references along with their unicod
 | °         | `&deg;`         | U+000B0            |
 
 The full list of HTML named character references [can found in the HTML specification here](https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references).
+
+## See also
+
+- Related glossary terms:
+  - {{glossary("Character")}}
+  - {{glossary("Escaping text")}}
+  - {{glossary("Code point")}}
+  - {{glossary("Unicode")}}

--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An {{glossary("HTML")}} **character reference** is an {{glossary("escaping character", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
+An {{glossary("HTML")}} **character reference** is an {{glossary("escape character", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
 
 Character references are used as replacements for characters that are reserved in HTML, such as the less-than (`<`) and greater-than (`>`) symbols used by the HTML parser to identify element {{Glossary('tag','tags')}}, or `"` or `'` within attributes, which may be enclosed by those characters.
 They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, control characters like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.
@@ -55,6 +55,6 @@ The full list of HTML named character references [can found in the HTML specific
 
 - Related glossary terms:
   - {{glossary("Character")}}
-  - {{glossary("Escaping character")}}
+  - {{glossary("Escape character")}}
   - {{glossary("Code point")}}
   - {{glossary("Unicode")}}

--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An {{glossary("HTML")}} **character reference** is an {{glossary("escaping text", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
+An {{glossary("HTML")}} **character reference** is an {{glossary("escaping character", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
 
 Character references are used as replacements for characters that are reserved in HTML, such as the less-than (`<`) and greater-than (`>`) symbols used by the HTML parser to identify element {{Glossary('tag','tags')}}, or `"` or `'` within attributes, which may be enclosed by those characters.
 They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, control characters like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.
@@ -55,6 +55,6 @@ The full list of HTML named character references [can found in the HTML specific
 
 - Related glossary terms:
   - {{glossary("Character")}}
-  - {{glossary("Escaping text")}}
+  - {{glossary("Escaping character")}}
   - {{glossary("Code point")}}
   - {{glossary("Unicode")}}

--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An {{glossary("HTML")}} **character reference** is a {{glossary("escaping text", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
+An {{glossary("HTML")}} **character reference** is an {{glossary("escaping text", "escape sequence")}} of {{glossary("character", "characters")}} that is used to represent another character in the rendered web page.
 
 Character references are used as replacements for characters that are reserved in HTML, such as the less-than (`<`) and greater-than (`>`) symbols used by the HTML parser to identify element {{Glossary('tag','tags')}}, or `"` or `'` within attributes, which may be enclosed by those characters.
 They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, control characters like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.

--- a/files/en-us/glossary/escape_character/index.md
+++ b/files/en-us/glossary/escape_character/index.md
@@ -6,11 +6,11 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **escape character** is a {{glossary("character")}} that causes one or more characters that follow it to be interpreted differently. This forms an **escape sequence**, which is often used to represent a character that has an alternative meaning when printed literally, such as the quote character in a string literal. Escape sequences can have other usage too, especially in [regular expressions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#escape_sequences).
+An **escape character** is a {{glossary("character")}} that causes one or more characters that follow it to be interpreted differently. This forms an **escape sequence**, which is often used to represent a character that has an alternative meaning when printed literally, such as the quote character in a string literal. Escape sequences can have other usages too, especially in [regular expressions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#escape_sequences).
 
-- In {{glossary("JavaScript")}} [regexes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), [string literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#string_literals), and [identifiers](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
-- In {{glossary("CSS")}} identifiers, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escape characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
-- In {{glossary("HTML")}} text content and attribute values, we can use {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;`.
+- In JavaScript [regexes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), [string literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#string_literals), and [identifiers](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
+- In CSS identifiers, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escape characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
+- In HTML text content and attribute values, we can use {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;`.
 - In {{glossary("URL", "URLs")}}, we can use the percent sign (`%`) to escape characters like `%20`, `%3C`, `%3E`, etc.
 
 ## See also

--- a/files/en-us/glossary/escape_character/index.md
+++ b/files/en-us/glossary/escape_character/index.md
@@ -1,6 +1,6 @@
 ---
-title: Escape Character
-slug: Glossary/Escape_Character
+title: Escape character
+slug: Glossary/Escape_character
 page-type: glossary-definition
 ---
 

--- a/files/en-us/glossary/escape_character/index.md
+++ b/files/en-us/glossary/escape_character/index.md
@@ -1,6 +1,6 @@
 ---
-title: Escaping Character
-slug: Glossary/Escaping_Character
+title: Escape Character
+slug: Glossary/Escape Character
 page-type: glossary-definition
 ---
 
@@ -9,7 +9,7 @@ page-type: glossary-definition
 An **escape character** is a {{glossary("character")}} that causes one or more characters that follow it to be interpreted differently. This forms an **escape sequence**, which is often used to represent a character that has an alternative meaning when printed literally, such as the quote character in a string literal. Escape sequences can have other usage too, especially in [regular expressions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#escape_sequences).
 
 - In {{glossary("JavaScript")}} [regexes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), [string literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#string_literals), and [identifiers](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
-- In {{glossary("CSS")}} identifiers, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escaping characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
+- In {{glossary("CSS")}} identifiers, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escape characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
 - In {{glossary("HTML")}} text content and attribute values, we can use {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;`.
 - In {{glossary("URL", "URLs")}}, we can use the percent sign (`%`) to escape characters like `%20`, `%3C`, `%3E`, etc.
 

--- a/files/en-us/glossary/escape_character/index.md
+++ b/files/en-us/glossary/escape_character/index.md
@@ -1,6 +1,6 @@
 ---
 title: Escape Character
-slug: Glossary/Escape Character
+slug: Glossary/Escape_Character
 page-type: glossary-definition
 ---
 

--- a/files/en-us/glossary/escaping_text/index.md
+++ b/files/en-us/glossary/escaping_text/index.md
@@ -6,9 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **escape character** is a {{glossary("character")}} that invokes an alternative interpretation of the following character in a sequence, signaling that the following character should be interpreted differently.
-
-In many programming languages, an escape character also forms some **escape sequences** that has a special meaning rather than the literal characters, marked by one or more preceding characters and possibly terminating characters.
+An **escape character** is a {{glossary("character")}} that causes one or more characters that follow it to be interpreted differently. This forms an **escape sequence**, which is often used to represent a character that has an alternative meaning when printed literally, such as the quote character in a string literal. Escape sequences can have other usage too, especially in [regular expressions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#escape_sequences).
 
 - In {{glossary("JavaScript")}} [regexes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), [string literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#string_literals), and [identifiers](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
 - In {{glossary("CSS")}} identifiers, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escaping characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.

--- a/files/en-us/glossary/escaping_text/index.md
+++ b/files/en-us/glossary/escaping_text/index.md
@@ -1,0 +1,25 @@
+---
+title: Escaping Text
+slug: Glossary/Escaping_Text
+page-type: glossary-definition
+---
+
+{{GlossarySidebar}}
+
+An **escape character** is a {{glossary("character")}} that invokes an alternative interpretation on the following character in a sequence. The escape character is a character that signals that the following character should be interpreted differently.
+
+In many programming languages, an escape character also forms some **escape sequences** that has a special meaning rather than the literal characters, marked by one or more preceding characters and possibly terminating characters.
+
+- In {{glossary("JavaScript")}}, we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
+- In {{glossary("CSS")}}, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escaping characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
+- In {{glossary("HTML")}}, we can use the {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;` to represent the less-than (`<`) symbol.
+- In {{glossary("URL")}}, we can use the percent sign (`%`) to escape characters like `%20`, `%3C`, `%3E`, etc.
+
+## See also
+
+- [Escape character](https://en.wikipedia.org/wiki/Escape_character) on Wikipedia
+- [Escape sequence](https://en.wikipedia.org/wiki/Escape_sequence) on Wikipedia
+- Related glossary terms:
+  - {{glossary("Character")}}
+  - {{glossary("Character reference")}}
+  - {{glossary("Code point")}}

--- a/files/en-us/glossary/escaping_text/index.md
+++ b/files/en-us/glossary/escaping_text/index.md
@@ -6,20 +6,20 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **escape character** is a {{glossary("character")}} that invokes an alternative interpretation on the following character in a sequence. The escape character is a character that signals that the following character should be interpreted differently.
+An **escape character** is a {{glossary("character")}} that invokes an alternative interpretation of the following character in a sequence, signaling that the following character should be interpreted differently.
 
 In many programming languages, an escape character also forms some **escape sequences** that has a special meaning rather than the literal characters, marked by one or more preceding characters and possibly terminating characters.
 
 - In {{glossary("JavaScript")}}, we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
 - In {{glossary("CSS")}}, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escaping characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
-- In {{glossary("HTML")}}, we can use the {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;` to represent the less-than (`<`) symbol.
-- In {{glossary("URL")}}, we can use the percent sign (`%`) to escape characters like `%20`, `%3C`, `%3E`, etc.
+- In {{glossary("HTML")}}, we can use {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;` to represent the less-than (`<`) symbol.
+- In {{glossary("URL", "URLs")}}, we can use the percent sign (`%`) to escape characters like `%20`, `%3C`, `%3E`, etc.
 
 ## See also
 
-- [Escape character](https://en.wikipedia.org/wiki/Escape_character) on Wikipedia
-- [Escape sequence](https://en.wikipedia.org/wiki/Escape_sequence) on Wikipedia
 - Related glossary terms:
   - {{glossary("Character")}}
   - {{glossary("Character reference")}}
   - {{glossary("Code point")}}
+- [Escape character](https://en.wikipedia.org/wiki/Escape_character) on Wikipedia
+- [Escape sequence](https://en.wikipedia.org/wiki/Escape_sequence) on Wikipedia

--- a/files/en-us/glossary/escaping_text/index.md
+++ b/files/en-us/glossary/escaping_text/index.md
@@ -10,9 +10,9 @@ An **escape character** is a {{glossary("character")}} that invokes an alternati
 
 In many programming languages, an escape character also forms some **escape sequences** that has a special meaning rather than the literal characters, marked by one or more preceding characters and possibly terminating characters.
 
-- In {{glossary("JavaScript")}}, we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
-- In {{glossary("CSS")}}, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escaping characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
-- In {{glossary("HTML")}}, we can use {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;` to represent the less-than (`<`) symbol.
+- In {{glossary("JavaScript")}} [regexes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), [string literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#string_literals), and [identifiers](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), we can use the backslash (`\`) to escape characters like `\'`, `\"`, `\u0026`, etc.
+- In {{glossary("CSS")}} identifiers, we can use the backslash (`\`) to escape characters like `\\`, `\n`, `\26`, etc. See [escaping characters](/en-US/docs/Web/CSS/ident#escaping_characters) for more information.
+- In {{glossary("HTML")}} text content and attribute values, we can use {{glossary("character reference", "character references")}} like `&lt;`, `&#60;`, or `&#x3C;`.
 - In {{glossary("URL", "URLs")}}, we can use the percent sign (`%`) to escape characters like `%20`, `%3C`, `%3E`, etc.
 
 ## See also

--- a/files/en-us/glossary/escaping_text/index.md
+++ b/files/en-us/glossary/escaping_text/index.md
@@ -1,6 +1,6 @@
 ---
-title: Escaping Text
-slug: Glossary/Escaping_Text
+title: Escaping Character
+slug: Glossary/Escaping_Character
 page-type: glossary-definition
 ---
 

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -26,7 +26,7 @@ Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers because th
 
 ### Escaping characters
 
-{{glossary("Escaping character", "Escaping a character")}} means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
+{{glossary("Escape character", "Escaping a character")}} means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
 
 You can also escape any character with a backslash followed by the character's {{glossary("Unicode")}} {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
 

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -26,7 +26,7 @@ Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers because th
 
 ### Escaping characters
 
-{{glossary("Escaping text", "Escaping a character")}} means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
+{{glossary("Escaping character", "Escaping a character")}} means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
 
 You can also escape any character with a backslash followed by the character's {{glossary("Unicode")}} {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
 

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -26,9 +26,9 @@ Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers because th
 
 ### Escaping characters
 
-Escaping a character means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
+{{glossary("Escaping text", "Escaping a character")}} means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
 
-You can also escape any character with a backslash followed by the character's Unicode {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
+You can also escape any character with a backslash followed by the character's {{glossary("Unicode")}} {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
 
 - Place a space or other whitespace character after the Unicode code point.
 - Provide the full six-digit Unicode code point of the character being escaped.


### PR DESCRIPTION
### Description

This may fixes #37206.

The addition mainly talks about the *escape character* and the *escape sequence* with several examples in HTML, CSS, JavaScript and URLs.
