### PR TITLE
fix(ci/reviewdog): Flag files with CRLF line endings

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -84,6 +84,14 @@ jobs:
 
           files_to_lint="$DIFF_DOCUMENTS"
 
+          echo "crlf line ending check"
+          CRLF_FAILED=true
+          CRLF_LOG=$(git ls-files --eol ${files_to_lint} | grep -E 'w/(mixed|crlf)') || CRLF_FAILED=false
+          echo "CRLF_LOG<<${EOF}" >> $GITHUB_ENV
+          echo "${CRLF_LOG}" >> $GITHUB_ENV
+          echo "${EOF}" >> $GITHUB_ENV
+          echo "CRLF_FAILED=${CRLF_FAILED}" >> $GITHUB_ENV
+
           echo "Running markdownlint --fix"
           MD_LINT_FAILED=false
           MD_LINT_LOG=$(yarn markdownlint-cli2 --fix ${files_to_lint} 2>&1) || MD_LINT_FAILED=true
@@ -114,6 +122,7 @@ jobs:
           fi
 
           # info for troubleshooting
+          echo CRLF_FAILED=${CRLF_FAILED}
           echo MD_LINT_FAILED=${MD_LINT_FAILED}
           echo FM_LINT_FAILED=${FM_LINT_FAILED}
           echo PRETTIER_FAILED=${PRETTIER_FAILED}
@@ -154,16 +163,25 @@ jobs:
             -reporter="github-pr-review"
 
       - name: Fail if any issues pending
-        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true'
+        if: env.FILES_MODIFIED == 'true' || env.CRLF_FAILED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true'
         env:
+          CRLF_FAILED: ${{ env.CRLF_FAILED }}
           MD_LINT_FAILED: ${{ env.MD_LINT_FAILED }}
           FM_LINT_FAILED: ${{ env.FM_LINT_FAILED }}
           PRETTIER_FAILED: ${{ env.PRETTIER_FAILED }}
+          CRLF_LOG: ${{ env.CRLF_LOG }}
           MD_LINT_LOG: ${{ env.MD_LINT_LOG }}
           FM_LINT_LOG: ${{ env.FM_LINT_LOG }}
           PRETTIER_LOG: ${{ env.PRETTIER_LOG }}
         run: |
           echo -e "\nPlease fix all the linting issues mentioned in the following logs and in the PR review comments."
+
+          if [[ ${CRLF_FAILED} == 'true' ]]; then
+            echo -e "\n\n🪵 In the following files make sure all the lines end with only Line Feed (LF) character and not with Carriage Return Line Feed (CRLF) characters:"
+            echo "${CRLF_LOG}"
+            echo "For more information refer https://gist.github.com/LunarLambda/3df0840b336a5e314e4ffdac03cbf619 ."
+            echo "You may use https://app.execeratics.com/LFandCRLFonline/?l=en online tool to convert line endings from CRLF to LF."
+          fi
 
           if [[ ${MD_LINT_FAILED} == 'true' ]]; then
             echo -e "\n\n🪵 Logs from markdownlint:"


### PR DESCRIPTION
- addresses https://github.com/mdn/translated-content/issues/25244

## Summary

When there is a file with CRLF(Windows) line endings pushed in a PR, Prettier converts them to LF. The workflow fails to suggest this change as a review comment, and the workflow doesn't fail either.

## Solution 

The `git diff` command doesn't consider CRLF -> LF as a change. CRLF -> LF change is not there in the diff output. Without the diff reviewdog can not make a PR comment.
As a workaround, we can flag files with CRLF and ask contributors to convert CRLF to LF.

## Testing

Testing has been done in https://github.com/OnkarRuikar/content/pull/44#issuecomment-2564990834 and corresponding workflow run is: https://github.com/OnkarRuikar/content/actions/runs/12534736823/job/34955862300?pr=44#step:12:63

```
🪵 In the following files make sure all the lines end with 'lf' character and not 'crlf' characters:
i/lf    w/crlf  attr/text=auto eol=lf 	files/en-us/web/test/index.md
```

/cc @yin1999 