### PR TITLE
WebExt: remove msedge compat data license and improve content

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
@@ -8,7 +8,7 @@ browser-compat: webextensions.api.omnibox.onDeleteSuggestion
 {{AddonSidebar}}
 
 Fired whenever the user deletes a suggestion.
-A suggestion can be deleted when the property `deletable` of {{WebExtAPIRef("omnibox.SuggestResult","SuggestResult")}} is set to true.
+A suggestion can be deleted when the property `deletable` of a {{WebExtAPIRef("omnibox.SuggestResult","SuggestResult")}} is set to true.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
@@ -8,7 +8,7 @@ browser-compat: webextensions.api.omnibox.onDeleteSuggestion
 {{AddonSidebar}}
 
 Fired whenever the user deletes a suggestion.
-A suggestion can be deleted when {{WebExtAPIRef("omnibox.SuggestResult","SuggestResult")}}`.deletable` is set to true.
+A suggestion can be deleted when the property `deletable` of {{WebExtAPIRef("omnibox.SuggestResult","SuggestResult")}} is set to true.
 
 ## Syntax
 
@@ -54,5 +54,3 @@ browser.omnibox.onDeleteSuggestion.addListener(logDeletedSuggestion);
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.
->
-> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
@@ -52,6 +52,3 @@ gettingInfo.then(gotBrowserInfo);
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
@@ -57,6 +57,3 @@ visit(window);
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.

--- a/files/en-us/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
@@ -8,9 +8,6 @@ page-type: guide
 
 {{WebExtAllCompatTables}}
 
-> [!NOTE]
-> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
-
 ## See also
 
 - [Browser compatibility for manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json)


### PR DESCRIPTION
### Description

1. removed msedge compat data licesnes information (per #22639)
2. improve the description:

```diff
- A suggestion can be deleted when {{WebExtAPIRef("omnibox.SuggestResult","SuggestResult")}}`.deletable` is set to true.
+ A suggestion can be deleted when the property `deletable` of {{WebExtAPIRef("omnibox.SuggestResult","SuggestResult")}} is set to true.
```

