### PR TITLE
Replace `<iframe>` → `<fencedframe>` in the Accessibility section

### DIFF
--- a/files/en-us/web/html/element/fencedframe/index.md
+++ b/files/en-us/web/html/element/fencedframe/index.md
@@ -78,7 +78,7 @@ People navigating with assistive technology such as a screen reader can use the 
   height="320"></fencedframe>
 ```
 
-Without this title, they have to navigate into the `<iframe>` to determine what its embedded content is. This context shift can be confusing and time-consuming, especially for pages with multiple `<iframe>`s and/or if embeds contain interactive content like video or audio.
+Without this title, they have to navigate into the `<fencedframe>` to determine what its embedded content is. This context shift can be confusing and time-consuming, especially for pages with multiple `<fencedframe>`s and/or if embeds contain interactive content like video or audio.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR fixes the documentation of `<fencedframe>` by removing incorrect references to the `<iframe>` element which should be references to `<fencedframe>` instead.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The documentation of `<fencedframe>` contains leftovers copied from the documentation of `<iframe>` in its *Accessibility* section, which makes it confusing to read.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -→

N/A

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
