### PR TITLE
Add note about not supported `text-wrap-style.avoid-orphans`

### DIFF
--- a/files/en-us/web/css/text-wrap-style/index.md
+++ b/files/en-us/web/css/text-wrap-style/index.md
@@ -41,6 +41,9 @@ When wrapping is allowed (see {{CSSXRef("text-wrap-mode")}}), the `text-wrap-sty
 - `stable`
   - : Text is wrapped such that when the user is editing the content, the lines that come before the lines they are editing remain static rather than the whole block of text re-wrapping.
 
+> [!NOTE]
+> The [CSS text](/en-US/docs/Web/CSS/CSS_text) module defines a `avoid-orphans` value for the `text-wrap-style` property to avoid excessively short last lines and expect user agent to consider more than one line when making break decisions, however, this is not supported in any browsers.
+
 ## Description
 
 When the content is allowed to wrap, which it does by default, then there are a number of choices that can effect the way the content is wrapped.

--- a/files/en-us/web/css/text-wrap-style/index.md
+++ b/files/en-us/web/css/text-wrap-style/index.md
@@ -42,7 +42,7 @@ When wrapping is allowed (see {{CSSXRef("text-wrap-mode")}}), the `text-wrap-sty
   - : Text is wrapped such that when the user is editing the content, the lines that come before the lines they are editing remain static rather than the whole block of text re-wrapping.
 
 > [!NOTE]
-> The [CSS text](/en-US/docs/Web/CSS/CSS_text) module defines a `avoid-orphans` value for the `text-wrap-style` property to avoid excessively short last lines and expect user agent to consider more than one line when making break decisions, however, this is not supported in any browsers.
+> The [CSS text](/en-US/docs/Web/CSS/CSS_text) module defines an `avoid-orphans` value for the `text-wrap-style` property to avoid excessively short last lines and expect the user agent to consider more than one line when making break decisions. This value is not yet supported in any browser.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the `avoid-orphans` value is in spec but not supported by any browsers yet

see spec at https://drafts.csswg.org/css-text-4/#propdef-text-wrap-style

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

see also https://github.com/skyclouds2001/mdn-tools/blob/master/docs/not-fully-supported-feature.md

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
