### PR TITLE
Fixed a reference to tasks in App()

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
@@ -428,7 +428,7 @@ Add this just above your `taskList` constant declaration:
 
 ```jsx
 function toggleTaskCompleted(id) {
-  console.log(tasks[0]);
+  console.log(props.tasks[0]);
 }
 ```
 


### PR DESCRIPTION
Changed 'console.log(tasks[0]);' on line 431 to
'console.log(props.tasks[0]);' to fix the unreferenced console error faced while checking/unchecking the Checkbox for the task "Eat". Error was triggered because tasks is passed a prop from main.jsx to App.jsx and line 431 is trying to get index 0 of tasks array directly without using the props parameter.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
