### PR TITLE
Revert "chore(iop): Add redirects for :open and :closed to :popover-open"

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11765,7 +11765,6 @@
 /en-US/docs/Web/CSS/::cue-region	/en-US/docs/Web/API/WebVTT_API
 /en-US/docs/Web/CSS/:@-moz-document	/en-US/docs/Web/CSS/@document
 /en-US/docs/Web/CSS/:any	/en-US/docs/Web/CSS/:is
-/en-US/docs/Web/CSS/:closed	/en-US/docs/Web/CSS/:popover-open
 /en-US/docs/Web/CSS/:dir()	/en-US/docs/Web/CSS/:dir
 /en-US/docs/Web/CSS/:host()	/en-US/docs/Web/CSS/:host_function
 /en-US/docs/Web/CSS/:lang()	/en-US/docs/Web/CSS/:lang
@@ -11778,7 +11777,6 @@
 /en-US/docs/Web/CSS/:nth-last-col	/en-US/docs/Web/CSS/:nth-last-of-type
 /en-US/docs/Web/CSS/:nth-last-of-type()	/en-US/docs/Web/CSS/:nth-last-of-type
 /en-US/docs/Web/CSS/:nth-of-type()	/en-US/docs/Web/CSS/:nth-of-type
-/en-US/docs/Web/CSS/:open	/en-US/docs/Web/CSS/:popover-open
 /en-US/docs/Web/CSS/@-moz-document	/en-US/docs/Web/CSS/@document
 /en-US/docs/Web/CSS/@font-face/font-variant	/en-US/docs/Web/CSS/@font-face
 /en-US/docs/Web/CSS/@media/update-frequency	/en-US/docs/Web/CSS/@media/update


### PR DESCRIPTION
Remove redirects of `:open` and `:closed` to `:popover-open`

This reverts https://github.com/mdn/content/pull/30342

Per bcd (https://github.com/mdn/browser-compat-data/blob/main/css/selectors/open.json and https://github.com/mdn/browser-compat-data/blob/main/css/selectors/closed.json), these are shipped in chrome once but removed later

And per spec (https://drafts.csswg.org/selectors/#selectordef-open and https://html.spec.whatwg.org/multipage/semantics-other.html#selector-open), there's seems to be a new `:open` pseudo class, which is different from the previously one. And per the note, a new `:closed` pseudo class may also be added in the future. SO it is better to remove these redirects for now.

https://github.com/w3c/csswg-drafts/issues/7319 proposal for adding `:open`
https://github.com/w3c/csswg-drafts/issues/11039 a open discussion for whether keeping `:open` and `:closedQ`
https://github.com/w3c/csswg-drafts/pull/11326 removes `:closed` (and add note indicate this may add back in the future)
