### PR TITLE
Remove duplicate list item and fix the alphabetical sort

### DIFF
--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -55,13 +55,12 @@ APIs that require transient activation (list is not exhaustive):
 - {{domxref("RemotePlayback.prompt()")}}
 - {{domxref("Serial.requestPort()")}}
 - {{domxref("USB.requestDevice()")}}
-- {{domxref("Keyboard.lock()")}}
 - {{domxref("Window.getScreenDetails()")}}
 - {{domxref("Window.open()")}}
 - {{domxref("Window.queryLocalFonts()")}}
+- {{domxref("Window.showDirectoryPicker()")}}
 - {{domxref("Window.showOpenFilePicker()")}}
 - {{domxref("Window.showSaveFilePicker()")}}
-- {{domxref("Window.showDirectoryPicker()")}}
 - {{domxref("WindowClient.focus()")}}
 - {{domxref("XRSystem.requestSession()")}}
 


### PR DESCRIPTION
### Description

Removes the duplicate mention of Keyboard.lock()
Moves the mention of Window.showDirectoryPicker() to fix the alphabetical sorting on the list.

### Motivation

Makes the list easier to navigate and fixes its inconsistencies.
