### PR TITLE
Resolve duplicated commas in pointerevent constructor

### DIFF
--- a/files/en-us/web/api/pointerevent/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.md
@@ -30,9 +30,9 @@ new PointerEvent(type, options)
     - `pointerId`
       - : A number, defaulting to `0`, that sets the value of the instance's {{domxref("PointerEvent.pointerId")}}.
     - `width`
-      - : A number,, defaulting to `1`, that sets the value of the instance's {{domxref("PointerEvent.width")}}.
+      - : A number, defaulting to `1`, that sets the value of the instance's {{domxref("PointerEvent.width")}}.
     - `height`
-      - : A number,, defaulting to `1`, that sets the value of the instance's {{domxref("PointerEvent.height")}}.
+      - : A number, defaulting to `1`, that sets the value of the instance's {{domxref("PointerEvent.height")}}.
     - `pressure`
       - : A number, defaulting to `0`, that sets the value of the instance's {{domxref("PointerEvent.pressure")}}.
     - `tangentialPressure`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Fix issue where there are duplicated commas in pointerevent constructor page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

N.A.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

N.A.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N.A.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
