### PR TITLE
Add :: before cues

### DIFF
--- a/files/en-us/web/api/webvtt_api/web_video_text_tracks_format/index.md
+++ b/files/en-us/web/api/webvtt_api/web_video_text_tracks_format/index.md
@@ -474,7 +474,7 @@ For example, the following `STYLE` block would match all cue text and color it y
 
 ```plain
 STYLE
-cue {
+::cue {
   color: yellow;
 }
 ```
@@ -487,16 +487,16 @@ For example, the following block would match cue payload text marked up with `la
 
 ```plain
 STYLE
-cue(c),
-cue(i),
-cue(b),
-cue(u),
-cue(ruby),
-cue(rt),
-cue(v) {
+::cue(c),
+::cue(i),
+::cue(b),
+::cue(u),
+::cue(ruby),
+::cue(rt),
+::cue(v) {
   color: red;
 }
-cue(lang) {
+::cue(lang) {
   color: yellow;
 }
 ```


### PR DESCRIPTION
Some examples missed the :: prefix before the cue CSS selectors, and that does not work for video cues. Added them.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added missing double colons before **cue**s indicating that they're pseudo-element selectors
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The missing double colons were misleading, possibly making it harder for the reader to understand and try these rules.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
