### PR TITLE
fix(css): update opacity example from ::placeholder

### DIFF
--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -129,7 +129,8 @@ input {
 
 {{EmbedLiveSample("default_color", 200, 60)}}
 
-Note that browsers use different default colors for placeholder text. For example, Firefox uses the input element's color with 54% opacity, and Chrome uses `darkgray` color. If you want consistent placeholder text color across the browsers, then set the color explicitly.
+> [!NOTE]
+> Note that browsers use different default colors for placeholder text. For example, Firefox uses the input element's color with 54% opacity, and Chrome uses `darkgray` color. If you want consistent placeholder text color across the browsers, then set the color explicitly.
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -89,6 +89,7 @@ input::placeholder {
   color: red;
   font-size: 1.2em;
   font-style: italic;
+  opacity: 0.5;
 }
 ```
 
@@ -98,30 +99,37 @@ input::placeholder {
 
 ### Opaque text
 
-Some browsers (such as Firefox) set the default {{cssxref("opacity")}} of placeholders to something less than 100%. If you want fully opaque placeholder text, set `opacity` to `1`.
+Some browsers make placeholder text less opaque. If you want fully opaque text, then set the {{CSSXref("color")}} property value explicitly. The [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) value can be used to have the same color as the corresponding input element.
 
 #### HTML
 
 ```html
-<input placeholder="Default opacity" />
-<input placeholder="Full opacity" class="force-opaque" />
+<input placeholder="Color set by browser" />
+<input placeholder="Same color as input" class="explicit-color" />
 ```
 
 #### CSS
 
 ```css
-::placeholder {
+input {
+  font-weight: bold;
   color: green;
 }
 
-.force-opaque::placeholder {
-  opacity: 1;
+.explicit-color::placeholder {
+  /* use the same color as input element to avoid the browser set default color */
+  color: currentColor;
+
+  /* less opaque text */
+  /* color: color-mix(in srgb, currentColor 70%, transparent); */
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("Opaque_text", 200, 60)}}
+{{EmbedLiveSample("default_color", 200, 60)}}
+
+Note that browsers use different default colors for placeholder text. For example, Firefox uses the input element's color with 54% opacity, and Chrome uses `darkgray` color. If you want consistent placeholder text color across the browsers, then set the color explicitly.
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -106,6 +106,7 @@ Some browsers make placeholder text less opaque. If you want fully opaque text, 
 ```html
 <input placeholder="Color set by browser" />
 <input placeholder="Same color as input" class="explicit-color" />
+<input placeholder="Semi-opaque text color" class="opacity-change" />
 ```
 
 #### CSS
@@ -119,9 +120,11 @@ input {
 .explicit-color::placeholder {
   /* use the same color as input element to avoid the browser set default color */
   color: currentColor;
+}
 
+.opacity-change::placeholder {
   /* less opaque text */
-  /* color: color-mix(in srgb, currentColor 70%, transparent); */
+  color: color-mix(in srgb, currentColor 70%, transparent);
 }
 ```
 
@@ -130,7 +133,7 @@ input {
 {{EmbedLiveSample("default_color", 200, 60)}}
 
 > [!NOTE]
-> Note that browsers use different default colors for placeholder text. For example, Firefox uses the input element's color with 54% opacity, and Chrome uses `darkgray` color. If you want consistent placeholder text color across the browsers, then set the color explicitly.
+> Note that browsers use different default colors for placeholder text. For example, Firefox uses the input element's color with 54% opacity, and Chrome uses `darkgray` color. If you want consistent placeholder text color across the browsers, then set the `color` explicitly.
 
 ## Specifications
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/37477

Now, it's about the opacity of the text color and not the element's background, so the `opacity` property shouldn't be used in the example.

Let's explain the opacity of the color and default color separately.
