### PR TITLE
Remove VTTCue.line link

### DIFF
--- a/files/en-us/web/api/vttcue/index.md
+++ b/files/en-us/web/api/vttcue/index.md
@@ -32,7 +32,7 @@ _This interface also inherits properties from {{domxref("TextTrackCue")}}._
 - {{domxref("VTTCue.line")}}
   - : Represents the line positioning of the cue. This can be the string `auto` or a number whose interpretation depends on the value of {{domxref("VTTCue.snapToLines")}}.
 - {{domxref("VTTCue.lineAlign")}}
-  - : An enum representing the alignment of the text in the VTT cue.
+  - : An enum representing the alignment of the VTT cue.
 - {{domxref("VTTCue.position")}}
   - : Represents the indentation of the cue within the line.
     This can be the string `auto`, a number representing the percentage of the {{domxref("VTTCue.region")}}, or the video size if {{domxref("VTTCue.region")}} is `null`.

--- a/files/en-us/web/api/vttcue/index.md
+++ b/files/en-us/web/api/vttcue/index.md
@@ -32,7 +32,7 @@ _This interface also inherits properties from {{domxref("TextTrackCue")}}._
 - {{domxref("VTTCue.line")}}
   - : Represents the line positioning of the cue. This can be the string `auto` or a number whose interpretation depends on the value of {{domxref("VTTCue.snapToLines")}}.
 - {{domxref("VTTCue.lineAlign")}}
-  - : An enum representing the alignment of the {{domxref("VTTCue.line")}}.
+  - : An enum representing the alignment of the text in the VTT cue.
 - {{domxref("VTTCue.position")}}
   - : Represents the indentation of the cue within the line.
     This can be the string `auto`, a number representing the percentage of the {{domxref("VTTCue.region")}}, or the video size if {{domxref("VTTCue.region")}} is `null`.

--- a/files/en-us/web/api/webvtt_api/web_video_text_tracks_format/index.md
+++ b/files/en-us/web/api/webvtt_api/web_video_text_tracks_format/index.md
@@ -474,7 +474,7 @@ For example, the following `STYLE` block would match all cue text and color it y
 
 ```plain
 STYLE
-cue {
+::cue {
   color: yellow;
 }
 ```
@@ -487,16 +487,16 @@ For example, the following block would match cue payload text marked up with `la
 
 ```plain
 STYLE
-cue(c),
-cue(i),
-cue(b),
-cue(u),
-cue(ruby),
-cue(rt),
-cue(v) {
+::cue(c),
+::cue(i),
+::cue(b),
+::cue(u),
+::cue(ruby),
+::cue(rt),
+::cue(v) {
   color: red;
 }
-cue(lang) {
+::cue(lang) {
   color: yellow;
 }
 ```


### PR DESCRIPTION
Removed VTTCue.line link

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I removed the link to the VTTCue.line and cleared up the description of lineAlign
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The link to VTTCue.line was confusing as the lineAlign is not dependent on line, it is an other positioning attribute.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

A future extension of the description could be a link to the Cue settings / align
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
