### PR TITLE
Update syntax for `white-space`

### DIFF
--- a/files/en-us/web/css/text-wrap-mode/index.md
+++ b/files/en-us/web/css/text-wrap-mode/index.md
@@ -7,7 +7,10 @@ browser-compat: css.properties.text-wrap-mode
 
 {{CSSRef}}
 
-The **`text-wrap-mode`** [CSS](/en-US/docs/Web/CSS) property controls whether the text inside an element is wrapped. The different values provide alternate ways of wrapping the content of a block element. It can also be set, and reset, using the {{CSSXRef("text-wrap")}} shorthand.
+The **`text-wrap-mode`** [CSS](/en-US/docs/Web/CSS) property controls whether the text inside an element is wrapped. The different values provide alternate ways of wrapping the content of a block element. It can also be set, and reset, using the {{CSSXRef("text-wrap")}} shorthand or the {{CSSXRef("text-wrap-mode")}} shorthand.
+
+> [!NOTE]
+> The {{CSSxRef("white-space-collapse")}} and `text-wrap-mode` properties can be declared together using the {{CSSxRef("white-space")}} shorthand property.
 
 > [!NOTE]
 > The name of this property is a placeholder, pending the CSSWG finding a better name.
@@ -47,9 +50,6 @@ This property specifies whether lines may wrap at unforced soft wrap opportuniti
 {{CSSSyntax}}
 
 ## Examples
-
-> [!NOTE]
-> Check the browser support for this property.
 
 ### Wrapping content
 

--- a/files/en-us/web/css/text-wrap-mode/index.md
+++ b/files/en-us/web/css/text-wrap-mode/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.text-wrap-mode
 
 {{CSSRef}}
 
-The **`text-wrap-mode`** [CSS](/en-US/docs/Web/CSS) property controls whether the text inside an element is wrapped. The different values provide alternate ways of wrapping the content of a block element. It can also be set, and reset, using the {{CSSXRef("text-wrap")}} shorthand or the {{CSSXRef("text-wrap-mode")}} shorthand.
+The **`text-wrap-mode`** [CSS](/en-US/docs/Web/CSS) property controls whether the text inside an element is wrapped. The different values provide alternate ways of wrapping the content of a block element. It can also be set, and reset, using the {{CSSXRef("text-wrap")}} shorthand or the {{CSSXRef("white-space")}} shorthand.
 
 > [!NOTE]
 > The {{CSSxRef("white-space-collapse")}} and `text-wrap-mode` properties can be declared together using the {{CSSxRef("white-space")}} shorthand property.
@@ -21,15 +21,15 @@ The **`text-wrap-mode`** [CSS](/en-US/docs/Web/CSS) property controls whether th
 
 ```css
 /* Keyword values */
-text-wrap-style: wrap;
-text-wrap-style: nowrap;
+text-wrap-mode: wrap;
+text-wrap-mode: nowrap;
 
 /* Global values */
-text-wrap-style: inherit;
-text-wrap-style: initial;
-text-wrap-style: revert;
-text-wrap-style: revert-layer;
-text-wrap-style: unset;
+text-wrap-mode: inherit;
+text-wrap-mode: initial;
+text-wrap-mode: revert;
+text-wrap-mode: revert-layer;
+text-wrap-mode: unset;
 ```
 
 ## Values

--- a/files/en-us/web/css/text-wrap/index.md
+++ b/files/en-us/web/css/text-wrap/index.md
@@ -12,9 +12,6 @@ The **`text-wrap`** CSS shorthand property controls how text inside an element i
 - Typographic improvements, for example more balanced line lengths across broken headings
 - A way to turn text wrapping off completely.
 
-> [!NOTE]
-> The {{CSSxRef("white-space-collapse")}} and `text-wrap` properties can be declared together using the {{CSSxRef("white-space")}} shorthand property.
-
 {{EmbedInteractiveExample("pages/css/text-wrap.html")}}
 
 ## Constituent properties

--- a/files/en-us/web/css/white-space-collapse/index.md
+++ b/files/en-us/web/css/white-space-collapse/index.md
@@ -10,7 +10,7 @@ browser-compat: css.properties.white-space-collapse
 The **`white-space-collapse`** [CSS](/en-US/docs/Web/CSS) property controls how {{Glossary("whitespace", "white space")}} inside an element is collapsed.
 
 > [!NOTE]
-> The `white-space-collapse` and {{CSSxRef("text-wrap")}} properties can be declared together using the {{CSSxRef("white-space")}} shorthand property.
+> The `white-space-collapse` and {{CSSxRef("text-wrap-mode")}} properties can be declared together using the {{CSSxRef("white-space")}} shorthand property.
 
 ## Syntax
 
@@ -138,5 +138,5 @@ h2 {
 
 ## See also
 
-- Shorthand for `white-space-collapse` and {{CSSxRef("text-wrap")}}: The {{CSSxRef("white-space")}} property.
+- Shorthand for `white-space-collapse` and {{CSSxRef("text-wrap-mode")}}: The {{CSSxRef("white-space")}} property.
 - [CSS text module](/en-US/docs/Web/CSS/CSS_text)

--- a/files/en-us/web/css/white-space/index.md
+++ b/files/en-us/web/css/white-space/index.md
@@ -43,7 +43,7 @@ white-space: unset;
 
 ### Values
 
-`white-space` property values can be specified as a single keyword chosen from the list of values below, or two values representing shorthand for the {{CSSxRef("white-space-collapse")}} and {{cssxref("text-wrap-mode")}} properties.
+The `white-space` property values can be specified as a single keyword chosen from the list of values below, or two values representing shorthand for the {{CSSxRef("white-space-collapse")}} and {{cssxref("text-wrap-mode")}} properties.
 
 - `normal`
   - : Sequences of white space are [collapsed](#collapsing_of_white_space). Newline characters in the source are handled the same as other white spaces. Lines are broken as necessary to fill line boxes.

--- a/files/en-us/web/css/white-space/index.md
+++ b/files/en-us/web/css/white-space/index.md
@@ -29,7 +29,8 @@ white-space: pre-wrap;
 white-space: pre-line;
 
 /* white-space-collapse and text-wrap-mode shorthand values */
-white-space: collapse balance;
+white-space: wrap;
+white-space: collapse;
 white-space: preserve nowrap;
 
 /* Global values */

--- a/files/en-us/web/css/white-space/index.md
+++ b/files/en-us/web/css/white-space/index.md
@@ -30,7 +30,7 @@ white-space: pre-wrap;
 white-space: pre-line;
 white-space: break-spaces;
 
-/* white-space-collapse and text-wrap shorthand values */
+/* white-space-collapse and text-wrap-mode shorthand values */
 white-space: collapse balance;
 white-space: preserve nowrap;
 
@@ -44,7 +44,7 @@ white-space: unset;
 
 ### Values
 
-`white-space` property values can be specified as a single keyword chosen from the list of values below, or two values representing shorthand for the {{CSSxRef("white-space-collapse")}} and {{cssxref("text-wrap")}} properties.
+`white-space` property values can be specified as a single keyword chosen from the list of values below, or two values representing shorthand for the {{CSSxRef("white-space-collapse")}} and {{cssxref("text-wrap-mode")}} properties.
 
 - `normal`
   - : Sequences of white space are [collapsed](#collapsing_of_white_space). Newline characters in the source are handled the same as other white spaces. Lines are broken as necessary to fill line boxes.

--- a/files/en-us/web/css/white-space/index.md
+++ b/files/en-us/web/css/white-space/index.md
@@ -24,11 +24,9 @@ The property specifies two things:
 ```css
 /* Single keyword values */
 white-space: normal;
-white-space: nowrap;
 white-space: pre;
 white-space: pre-wrap;
 white-space: pre-line;
-white-space: break-spaces;
 
 /* white-space-collapse and text-wrap-mode shorthand values */
 white-space: collapse balance;
@@ -48,21 +46,12 @@ white-space: unset;
 
 - `normal`
   - : Sequences of white space are [collapsed](#collapsing_of_white_space). Newline characters in the source are handled the same as other white spaces. Lines are broken as necessary to fill line boxes.
-- `nowrap`
-  - : [Collapses](#collapsing_of_white_space) white space as the `normal` value does, but suppresses line breaks (text wrapping) within the source.
 - `pre`
   - : Sequences of white space are preserved. Lines are only broken at newline characters in the source and at {{HTMLElement("br")}} elements.
 - `pre-wrap`
   - : Sequences of white space are preserved. Lines are broken at newline characters, at {{HTMLElement("br")}}, and as necessary to fill line boxes.
 - `pre-line`
   - : Sequences of white space are [collapsed](#collapsing_of_white_space). Lines are broken at newline characters, at {{HTMLElement("br")}}, and as necessary to fill line boxes.
-- `break-spaces`
-
-  - : The behavior is identical to that of `pre-wrap`, except that:
-
-    - Any sequence of preserved white space always takes up space, including at the end of the line.
-    - A line-breaking opportunity exists after every preserved white space character, including between white space characters.
-    - Such preserved spaces take up space and do not hang, thus affecting the box's intrinsic sizes ({{cssxref("min-content")}} size and {{cssxref("max-content")}} size).
 
 The following table summarizes the behavior of the various `white-space` keyword values:
 
@@ -83,14 +72,6 @@ The following table summarizes the behavior of the various `white-space` keyword
       <td>Collapse</td>
       <td>Collapse</td>
       <td>Wrap</td>
-      <td>Remove</td>
-      <td>Hang</td>
-    </tr>
-    <tr>
-      <th><code>nowrap</code></th>
-      <td>Collapse</td>
-      <td>Collapse</td>
-      <td>No wrap</td>
       <td>Remove</td>
       <td>Hang</td>
     </tr>
@@ -117,14 +98,6 @@ The following table summarizes the behavior of the various `white-space` keyword
       <td>Wrap</td>
       <td>Remove</td>
       <td>Hang</td>
-    </tr>
-    <tr>
-      <th><code>break-spaces</code></th>
-      <td>Preserve</td>
-      <td>Preserve</td>
-      <td>Wrap</td>
-      <td>Wrap</td>
-      <td>Wrap</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the spec has updated the syntax for `white-space` property, it is no longer a shorthand property for `text-wrap` property, but a shorthand property for `text-wrap-mode` property
this happens in https://github.com/w3c/csswg-drafts/commit/3a1eb8567eee76769d64154f0deba892abdf4360, as `text-wrap` property also become a shorthand property for `text-wrap-mode` property and `text-wrap-style` property, see also https://github.com/w3c/csswg-drafts/issues/9102

`nowrap` value and `break-spaces` value has been removed from spec, since they've defined in the `white-space-collapse` and `text-wrap-mode` longhand properties
this happens in https://github.com/w3c/csswg-drafts/commit/dfb236be29cf05f540f499525cd0682eaa2940e7 (https://github.com/w3c/csswg-drafts/issues/9227) and https://github.com/w3c/csswg-drafts/commit/4717dbcb83634fb108e36bd5846dd5942cd539a0

also fix the typo in syntax section in `text-wrap-mode` 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://drafts.csswg.org/css-text-4/#propdef-white-space for spec

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

https://github.com/mdn/browser-compat-data/pull/25572 for bcd change
https://github.com/mdn/data/pull/878 for data change
https://github.com/mdn/interactive-examples/pull/2884 for interactive example change

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
