### PR TITLE
Add note about parens in matchMedia

### DIFF
--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -24,6 +24,7 @@ matchMedia(mediaQueryString)
 
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
+
 > [!NOTE]
 > Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -26,6 +26,7 @@ matchMedia(mediaQueryString)
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
 Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
+
 ### Return value
 
 A new {{domxref("MediaQueryList")}} object for the media query. Use this object's

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -23,6 +23,7 @@ matchMedia(mediaQueryString)
 ### Parameters
 
 - `mediaQueryString`
+
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
     Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia("(max-width: 600px)")` works, whereas `matchMedia("max-width: 600px")` does not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -25,7 +25,7 @@ matchMedia(mediaQueryString)
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
-Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
+      Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 
 ### Return value
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -26,7 +26,7 @@ matchMedia(mediaQueryString)
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
  
 > [!NOTE]
-> Each `mediaQueryString` condition must be wrapped in parentheses, for example: `matchMedia('(min-width: 600px)')` will work, whereas `matchMedia('min-width: 600px')` will not!
+> Just like in CSS, any [media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 
 ### Return value
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -25,7 +25,7 @@ matchMedia(mediaQueryString)
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
-      Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
+    Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 
 ### Return value
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -25,9 +25,7 @@ matchMedia(mediaQueryString)
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
-> [!NOTE]
-> Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
-
+Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 ### Return value
 
 A new {{domxref("MediaQueryList")}} object for the media query. Use this object's

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -26,7 +26,7 @@ matchMedia(mediaQueryString)
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
  
 > [!NOTE]
-> Just like in CSS, any [media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
+> Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 
 ### Return value
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -25,7 +25,7 @@ matchMedia(mediaQueryString)
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
-    Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
+    Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia("(max-width: 600px)")` works, whereas `matchMedia("max-width: 600px")` does not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 
 ### Return value
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -24,7 +24,6 @@ matchMedia(mediaQueryString)
 
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
- 
 > [!NOTE]
 > Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia('(max-width: 600px)')` will work, whereas `matchMedia('max-width: 600px')` will not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -24,6 +24,9 @@ matchMedia(mediaQueryString)
 
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
+ 
+> [!NOTE]
+> Each `mediaQueryString` condition must be wrapped in parentheses, for example: `matchMedia('(min-width: 600px)')` will work, whereas `matchMedia('min-width: 600px')` will not!
 
 ### Return value
 


### PR DESCRIPTION
### Description

Provides a note about explicit requirements for a `matchMedia` condition to be wrapped in parentheses.

### Motivation

I was bitten by this and didn't find an explicit callout to help developers who might have been in my situation and could not understand why their code wouldn't work.