### PR TITLE
Add "background" word to description

### DIFF
--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -7,7 +7,7 @@ spec-urls: https://drafts.csswg.org/css-backgrounds/
 
 {{CSSRef}}
 
-The **CSS backgrounds and borders** module provides properties for adding borders, rounded corners, and box shadows to elements.
+The **CSS backgrounds and borders** module provides properties for adding backgrounds, borders, rounded corners, and box shadows to elements.
 
 You can add different types of border styles, including borders made of images of any image type, from raster images to CSS gradients. Borders can be square or rounded, and a different radius can be set for each corner. Elements can be rounded whether or not they have a visible border.
 


### PR DESCRIPTION
### Description

The backgrounds and borders module doesn't mention backgrounds in the description. This adds the background to the description.

### Motivation

This PR clarifies what the module affects.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
