### PR TITLE
Notes regarding sidePanel API compatibility

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -12,7 +12,7 @@ Gets and sets properties of an extension's sidebar.
 A [sidebar](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars) is a pane displayed at the left or right of a web page. The browser provides a UI that enables the user to see the available sidebars and select one to display. An extension defines sidebars using the [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest.json key. The extension can then get and set the sidebar's properties using this API.
 
 > [!NOTE]
-> Chrome provides support for sidebars through the [`sidePanel` API](https://help.opera.com/en/extensions/sidebar-action-api). This API is not compatible with `sidebarAction`.
+> Chrome provides support for sidebars through the [`sidePanel` API](https://developer.chrome.com/docs/extensions/reference/api/sidePanel). This API is not compatible with `sidebarAction`.
 
 The `sidebarAction` API is based on Opera's [sidebarAction API](https://help.opera.com/en/extensions/sidebar-action-api/) and closely modeled on the {{WebExtAPIRef("browserAction")}} API. However, Firefox has not implemented `setBadgeText()`, `getBadgeText()`, `setBadgeBackgroundColor()`, `getBadgeBackgroundColor()`, `onFocus`, and `onBlur`.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -9,11 +9,12 @@ browser-compat: webextensions.api.sidebarAction
 
 Gets and sets properties of an extension's sidebar.
 
-A [sidebar](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars) is a pane that is displayed at the left-hand or right-hand side of the browser window, next to the web page. The browser provides a UI that enables the user to see the currently available sidebars and to select a sidebar to display. Using the [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest.json key, an extension can define its own sidebar. Using the `sidebarAction` API described here, an extension can get and set the sidebar's properties.
+A [sidebar](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars) is a pane displayed at the left or right of a web page. The browser provides a UI that enables the user to see the available sidebars and select one to display. An extension defines sidebars using the [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest.json key. The extension can then get and set the sidebar's properties using this API.
 
-The `sidebarAction` API is closely modeled on the {{WebExtAPIRef("browserAction")}} API.
+> [!NOTE]
+> Chrome provides support for sidebars through the [`sidePanel` API](https://help.opera.com/en/extensions/sidebar-action-api). This API is not compatible with `sidebarAction`.
 
-The sidebarAction API is based on Opera's [sidebarAction API](https://help.opera.com/en/extensions/sidebar-action-api/). However, note that the following are not yet supported: `setBadgeText()`, `getBadgeText()`, `setBadgeBackgroundColor()`, `getBadgeBackgroundColor()`, `onFocus`, `onBlur`.
+The `sidebarAction` API is based on Opera's [sidebarAction API](https://help.opera.com/en/extensions/sidebar-action-api/) and closely modeled on the {{WebExtAPIRef("browserAction")}} API. However, Firefox has not implemented `setBadgeText()`, `getBadgeText()`, `setBadgeBackgroundColor()`, `getBadgeBackgroundColor()`, `onFocus`, and `onBlur`.
 
 ## Types
 
@@ -29,7 +30,7 @@ The sidebarAction API is based on Opera's [sidebarAction API](https://help.opera
 - {{WebExtAPIRef("sidebarAction.getTitle()")}}
   - : Gets the sidebar's title.
 - {{WebExtAPIRef("sidebarAction.isOpen()")}}
-  - : Checks whether the sidebar is open or not.
+  - : Checks whether the sidebar is open.
 - {{WebExtAPIRef("sidebarAction.open()")}}
   - : Opens the sidebar.
 - {{WebExtAPIRef("sidebarAction.setIcon()")}}
@@ -37,47 +38,15 @@ The sidebarAction API is based on Opera's [sidebarAction API](https://help.opera
 - {{WebExtAPIRef("sidebarAction.setPanel()")}}
   - : Sets the sidebar's panel.
 - {{WebExtAPIRef("sidebarAction.setTitle()")}}
-  - : Sets the sidebar's title. This will be displayed in any UI provided by the browser to list sidebars, such as a menu.
+  - : Sets the sidebar's title. This title is displayed in any UI the browser provides to list sidebars, such as a menu.
 - {{WebExtAPIRef("sidebarAction.toggle()")}}
   - : Toggles the visibility of the sidebar.
+
+## Examples
+
+- [annotate-page](https://github.com/mdn/webextensions-examples/tree/main/annotate-page)
+  {{WebExtExamples}}
 
 ## Browser compatibility
 
 {{Compat}}
-
-## Example add-ons
-
-- [annotate-page](https://github.com/mdn/webextensions-examples/tree/main/annotate-page)
-
-> [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
-
-<!--
-// Copyright 2015 The Chromium Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//    * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//    * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--->

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -120,7 +120,7 @@ Firefox and Chrome include a Proxy API. However, the design of these two APIs is
 Firefox and Chrome provide incompatible APIs for working with a [sidebar](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars).
 
 - **In Firefox (and Opera)**: a sidebar is specified with the [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest key and manipulated with the {{WebExtAPIRef("sidebarAction")}} API.
-- **In Chrome**: an initial sidebar can be specified with the `side_panel` manifest key. The [`sidePanel` API](https://help.opera.com/en/extensions/sidebar-action-api) then enables panels to be manipulated.
+- **In Chrome**: an initial sidebar can be specified with the `side_panel` manifest key. The [`sidePanel` API](https://developer.chrome.com/docs/extensions/reference/api/sidePanel) then enables panels to be manipulated.
 
 #### Tabs API
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -115,6 +115,13 @@ Firefox and Chrome include a Proxy API. However, the design of these two APIs is
 - **In Chrome**: Proxy settings are defined in a [`proxy.ProxyConfig`](https://developer.chrome.com/docs/extensions/reference/api/proxy#type-ProxyConfig) object. Depending on Chrome's proxy settings, the settings may contain [`proxy.ProxyRules`](https://developer.chrome.com/docs/extensions/reference/api/proxy#type-ProxyRules) or a [`proxy.PacScript`](https://developer.chrome.com/docs/extensions/reference/api/proxy#type-PacScript). Proxies are set using the [proxy.settings](https://developer.chrome.com/docs/extensions/reference/api/proxy#property-settings) property.
   See [chrome.proxy](https://developer.chrome.com/docs/extensions/reference/api/proxy) for more information on the API.
 
+#### Sidebar API
+
+Firefox and Chrome provide incompatible APIs for working with a [sidebar](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars).
+
+- **In Firefox (and Opera)**: a sidebar is specified with the [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest key and manipulated with the {{WebExtAPIRef("sidebarAction")}} API.
+- **In Chrome**: an initial sidebar can be specified with the `side_panel` manifest key. The [`sidePanel` API](https://help.opera.com/en/extensions/sidebar-action-api) then enables panels to be manipulated.
+
 #### Tabs API
 
 When using `tabs.executeScript()` or `tabs.insertCSS()`:


### PR DESCRIPTION
### Description

Chrome 114 introduced a API for managing side panels, [chrome.sidePanel](https://developer.chrome.com/docs/extensions/reference/api/sidePanel#type-PanelOptions). This API is incompatible with the sidebarAction. This PR adds notes about this situation to the sidebarAction documentation and Chrome incompatibilities page.

### Motivation

To inform readers that these API are incompatible.


### Related issues and pull requests

Relates to https://github.com/mdn/browser-compat-data/issues/24444