### PR TITLE
Clarify usage of return values in iterator protocol

### DIFF
--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -225,6 +225,7 @@ const [b, c, d] = obj;
 // Returning 3
 // Already reached the end (the last call returned `done: true`),
 // so `return` is not called
+console.log([b, c, d]); // [1, 2, undefined]
 
 for (const b of obj) {
   break;

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -225,7 +225,7 @@ const [b, c, d] = obj;
 // Returning 3
 // Already reached the end (the last call returned `done: true`),
 // so `return` is not called
-console.log([b, c, d]); // [1, 2, undefined]
+console.log([b, c, d]); // [1, 2, undefined]; the value associated with `done: true` is not reachable
 
 for (const b of obj) {
   break;


### PR DESCRIPTION
### Description

There's an example with an iterable that returns an iterator that enumerates 1, 2, and returns with `{done: true, value: 3}`, and is evaluated with `const [b, c, d] = obj`.

It takes a careful reading to notice that the third value is used only to ensure that the iterator is exhausted and that the value from the iterator return is not bound to `d`.

### Motivation

Since the example is "Returning 3" in the comment above when `next()` returns `{done:true, value: 3}` a reader may think that `3` is bound to `d` in this case. With this comment, it will be easier to see that the value returned by an exhausted iterator is not used in any normal scenario, including array destructuring.

### Additional details

N/A

### Related issues and pull requests

N/A