### PR TITLE
Remove outdated mention of JSONP

### DIFF
--- a/files/en-us/web/security/practical_implementation_guides/csp/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/csp/index.md
@@ -55,9 +55,7 @@ If you are unable to get a strict CSP to work, an allowlist-based CSP is much be
 >
 > - `unsafe-inline`.
 > - `data:` URIs inside `script-src`, `object-src`, or `default-src`.
-> - overly broad sources or form submission targets.
->
-> Similarly, the use of `script-src 'self'` can be unsafe for sites with JSONP endpoints. These sites should use a `script-src` that includes the path to their JavaScript source folder(s).
+> - Overly broad sources or form submission targets.
 
 If you are unable to use the `Content-Security-Policy` header, pages can instead include a [`<meta http-equiv="Content-Security-Policy" content="…">`](/en-US/docs/Web/HTML/Element/meta#http-equiv) element. This should be the first {{htmlelement("meta")}} element that appears inside the document {{htmlelement("head")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As per the conversation at https://github.com/mdn/content/pull/37227#discussion_r1892926036, this PR removes the mention of JSONP. It is outdated, JSONP is not covered at all in the HTTP Observatory test criteria, and it probably hurts more than it helps.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
