### PR TITLE
Add box alignment module W3C spec

### DIFF
--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -2,6 +2,7 @@
 title: CSS box alignment
 slug: Web/CSS/CSS_box_alignment
 page-type: css-module
+spec-urls: https://drafts.csswg.org/css-align
 ---
 
 {{CSSRef}}
@@ -320,3 +321,7 @@ As the CSS box alignment properties are implemented differently depending on the
 - [Basic concepts of flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
 - [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
 - [Box alignment in CSS grid layouts](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout)
+
+## Specifications
+
+{{Specifications}}

--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -2,7 +2,7 @@
 title: CSS box alignment
 slug: Web/CSS/CSS_box_alignment
 page-type: css-module
-spec-urls: https://drafts.csswg.org/css-align
+spec-urls: https://drafts.csswg.org/css-align/
 ---
 
 {{CSSRef}}
@@ -325,3 +325,9 @@ As the CSS box alignment properties are implemented differently depending on the
 ## Specifications
 
 {{Specifications}}
+
+## See also
+
+- [CSS display](/en-US/docs/Web/CSS/CSS_display) module
+- [CSS flex layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) module
+- [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) module


### PR DESCRIPTION
### Description

Adds missing "Specifications" and "See also" sections to the Box Alignment Module page.

### Motivation

Matches the format of other CSS module pages by providing quick links to the W3C Editor's Draft page for the module in the Specifications section and links to related modules in the "See also" section.
