### PR TITLE
Update box model Module to contain the correct properties

### DIFF
--- a/files/en-us/web/css/css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/index.md
@@ -9,7 +9,7 @@ spec-urls:
 
 {{CSSRef}}
 
-The **CSS box model** module defines the `height`, `width`, `margin`, and `padding` properties, which along with [border properties](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders) make up the CSS [box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model).
+The **CSS box model** module defines the `margin` and `padding` properties, which along with the [height](/en-US/docs/Web/CSS/CSS_box_sizing), [width](/en-US/docs/Web/CSS/CSS_box_sizing) and [border properties](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders), make up the CSS [box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model).
 
 Every visible element on a webpage is a box laid out according to the [visual formatting model](/en-US/docs/Web/CSS/Visual_formatting_model). CSS properties define their size, position, and stacking level, with the box model properties (and others) defining the extrinsic size of each box, and the space around them.
 
@@ -17,30 +17,23 @@ Each box has a rectangular content area, inside which any text, images, and othe
 
 ![The components of the CSS box model](boxmodel.png)
 
-The CSS box model module defines physical (or "page relative") properties such as `width` and `margin-top`. Flow-relative properties such as `inline-size` and `margin-block-start` (which relate to text direction) are defined in [Logical Properties and Values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values). The box model module is extended by the [CSS box sizing module](/en-US/docs/Web/CSS/CSS_box_sizing), which introduces the {{glossary("intrinsic size")}} value and enables defining {{glossary("aspect ratio")}}s for elements that are auto-sized in at least one dimension.
+The CSS box model module defines physical (or "page relative") properties such as `margin-top` and `padding-top`. Flow-relative properties such as `margin-block-start` and `margin-inline-start` (which relate to text direction) are defined in [Logical Properties and Values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values). The box model module is extended by the [CSS box sizing module](/en-US/docs/Web/CSS/CSS_box_sizing), which introduces the {{glossary("intrinsic size")}} value and enables defining {{glossary("aspect ratio")}} for elements that are auto-sized in at least one dimension.
 
 ## Reference
 
 ### Properties
 
-- {{cssxref("box-sizing")}}
-- {{cssxref("height")}}
-- {{cssxref("margin")}}
+- {{cssxref("margin")}} shorthand
 - {{cssxref("margin-bottom")}}
 - {{cssxref("margin-left")}}
 - {{cssxref("margin-right")}}
 - {{cssxref("margin-top")}}
 - {{cssxref("margin-trim")}}
-- {{cssxref("max-height")}}
-- {{cssxref("max-width")}}
-- {{cssxref("min-height")}}
-- {{cssxref("min-width")}}
-- {{cssxref("padding")}}
+- {{cssxref("padding")}} shorthand
 - {{cssxref("padding-bottom")}}
 - {{cssxref("padding-left")}}
 - {{cssxref("padding-right")}}
 - {{cssxref("padding-top")}}
-- {{cssxref("width")}}
 
 ### Data types
 
@@ -107,15 +100,18 @@ The CSS box model module defines physical (or "page relative") properties such a
   - {{CSSxRef("border-inline-width")}}
 - [CSS box sizing](/en-US/docs/Web/CSS/CSS_box_sizing) module
   - {{cssxref("aspect-ratio")}}
+  - {{cssxref("box-sizing")}}
   - {{cssxref("contain-intrinsic-block-size")}}
   - {{cssxref("contain-intrinsic-height")}}
   - {{cssxref("contain-intrinsic-inline-size")}}
   - {{cssxref("contain-intrinsic-size")}}
   - {{cssxref("contain-intrinsic-width")}}
+  - {{cssxref("height")}}
   - {{cssxref("max-height")}}
   - {{cssxref("max-width")}}
   - {{cssxref("min-height")}}
   - {{cssxref("min-width")}}
+  - {{cssxref("width")}}
 - [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module
   - {{CSSxRef("overflow")}} shorthand
   - {{CSSxRef("overflow-block")}}


### PR DESCRIPTION
### Description

Removes sizing properties (height, width, etc) which are part of the box sizing Module, not the box model Module.

### Motivation

Corrects the information given to readers to match the W3C specs for the box model Module.

### Additional details

See: https://drafts.csswg.org/css-box/#property-index and https://drafts.csswg.org/css-sizing/#property-index