### PR TITLE
Add note_taking manifest member

### DIFF
--- a/files/en-us/web/manifest/note_taking/index.md
+++ b/files/en-us/web/manifest/note_taking/index.md
@@ -1,0 +1,48 @@
+---
+title: note_taking
+slug: Web/Manifest/note_taking
+page-type: web-manifest-member
+status:
+  - experimental
+browser-compat: html.manifest.note_taking
+---
+
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
+
+The `note_taking` member identifies a web app as a note-taking app and defines related information, for example a URL pointing to functionality for taking a new note. This enables operating systems to integrate the app's note taking functionality, for example including a "New note" option in the app's context menu, or providing the app as an option for taking a note in other apps.
+
+### Values
+
+An object, which may contain the following values:
+
+- `new_note_url`
+
+  - : A string representing the URL the developer would prefer the user agent to load when the user wants to take a new note via the web app. This value is a hint, and different implementations may choose to ignore it or provide it as a choice in appropriate places. The `new_note_url` is parsed with the app's manifest URL as its base URL and is ignored if not within the [scope](/en-US/docs/Web/Manifest/scope) of the manifest.
+
+## Examples
+
+```json
+{
+  "name": "My Note Taking App",
+  "description": "You can take notes!",
+  "icons": [
+    {
+      "src": "icon/hd_hi",
+      "sizes": "128x128"
+    }
+  ],
+  "start_url": "/index.html",
+  "display": "standalone",
+  "note_taking": {
+    "new_note_url": "/new_note.html"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 95+ supports the [Web Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) [`note_taking`](https://wicg.github.io/manifest-incubations/index.html#note_taking-member) member.

This PR adds a page for this member.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

See https://chromestatus.com/feature/5205972320518144 for the data source.

The BCD is already available.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
