### PR TITLE
fix(css): Fix `flex: 1` explanation

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -292,7 +292,7 @@ Using `flex: auto` is the same as using `flex: 1 1 auto`; this is similar to `fl
 
 Using `flex: none` will create fully inflexible flex items. It is as if you wrote `flex: 0 0 auto`. The items cannot grow or shrink and will be laid out using flexbox with a `flex-basis` of `auto`.
 
-The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow to fill the available space. In this case, the `flex-shrink` value of `1` is redundant because the item starts with minimum size.
+The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow to fill the available space. In this case, the `flex-shrink` value of `1` is redundant because the items start with minimum size — they're not given any size that could cause them to overflow the flex container.
 
 Try these shorthand values in the live sample below.
 

--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -292,8 +292,7 @@ Using `flex: auto` is the same as using `flex: 1 1 auto`; this is similar to `fl
 
 Using `flex: none` will create fully inflexible flex items. It is as if you wrote `flex: 0 0 auto`. The items cannot grow or shrink and will be laid out using flexbox with a `flex-basis` of `auto`.
 
-The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow
-to fill the available space. In this case, the `flex-shrink` value of `1` is redundant because the item starts with minimum size.
+The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow to fill the available space. In this case, the `flex-shrink` value of `1` is redundant because the item starts with minimum size.
 
 Try these shorthand values in the live sample below.
 

--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -292,7 +292,8 @@ Using `flex: auto` is the same as using `flex: 1 1 auto`; this is similar to `fl
 
 Using `flex: none` will create fully inflexible flex items. It is as if you wrote `flex: 0 0 auto`. The items cannot grow or shrink and will be laid out using flexbox with a `flex-basis` of `auto`.
 
-The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items can grow and shrink from a `flex-basis` of `0`.
+The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow 
+to fill the available space. In this case, the `flex-shrink` value of `1` is redundant because the item starts with minimum size.
 
 Try these shorthand values in the live sample below.
 

--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -292,7 +292,7 @@ Using `flex: auto` is the same as using `flex: 1 1 auto`; this is similar to `fl
 
 Using `flex: none` will create fully inflexible flex items. It is as if you wrote `flex: 0 0 auto`. The items cannot grow or shrink and will be laid out using flexbox with a `flex-basis` of `auto`.
 
-The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow 
+The shorthand you often see in tutorials is `flex: 1` or `flex: 2` and so on. This is the same as writing `flex: 1 1 0` or `flex: 2 1 0` and so on, respectively. The items get minimum size due to `flex-basis: 0` and then proportionally grow
 to fill the available space. In this case, the `flex-shrink` value of `1` is redundant because the item starts with minimum size.
 
 Try these shorthand values in the live sample below.


### PR DESCRIPTION
- address https://github.com/mdn/content/issues/37475#issuecomment-2576474190

The current statement is correct if you directly see the end result. However, as the sentence uses `flex-basis: 0`, we need to be more specific about what actually happens behind the scenes. 