### PR TITLE
fix: Remove heading from above summary to ensure valid HTML

### DIFF
--- a/files/en-us/web/html/element/summary/index.md
+++ b/files/en-us/web/html/element/summary/index.md
@@ -157,8 +157,9 @@ The CSS includes the `[open]` [attribute selector](/en-US/docs/Web/CSS/Attribute
 #### HTML
 
 ```html-nolint
+<h1>Quotes from Helen Keller</h1>
+
 <details>
-  <h1>Quotes from Helen Keller</h1>
   <summary>On women's rights</summary>
   <p>
     <q>We have prayed, we have coaxed, we have begged, for the vote, with the


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR moves the `h1` tag outside of the `details` element.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Having the `h1` above the `summary` element was invalid HTML, and since the `h1` seemed to describe both of the `details` elements, it seemed like it would be better placed outside of the `details` element altogether.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
