### PR TITLE
macro fix

### DIFF
--- a/files/en-us/web/svg/attribute/alignment-baseline/index.md
+++ b/files/en-us/web/svg/attribute/alignment-baseline/index.md
@@ -48,7 +48,7 @@ You can use this attribute with the following SVG elements:
 - `auto` {{deprecated_inline}}
   - : The value is the dominant-baseline of the script to which the character belongs - i.e., use the dominant-baseline of the parent.
 - `baseline`
-  - : Uses the {{Glossary("dominant baseline")}} choice of the parent. Matches the box's corresponding {{Glossary("baseline/typography", "baseline")}} to that of its parent.
+  - : Uses the {{svgattr("dominant-baseline")}} choice of the parent. Matches the box's corresponding {{Glossary("baseline/typography", "baseline")}} to that of its parent.
 - `before-edge` {{deprecated_inline}}
   - : The alignment-point of the object being aligned is aligned with the "before-edge" baseline of the parent text content element.
 - `text-bottom`


### PR DESCRIPTION
it's an inherited svg or css property value, not a glossary entry