### PR TITLE
Pr test new ci

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -7,7 +7,7 @@ name: PR review companion
 
 on:
   workflow_run:
-    workflows: ["PR Test"]
+    workflows: ["PR Test", "PR Test - new CI"]
     types:
       - completed
 

--- a/.github/workflows/pr-test-new-ci.yml
+++ b/.github/workflows/pr-test-new-ci.yml
@@ -4,7 +4,7 @@
 # This way, if the tests passed, you'll be able to review the built
 # pages on a public URL.
 
-name: PR Test
+name: PR Test - new CI
 
 on:
   pull_request:

--- a/.github/workflows/pr-test-new-ci.yml
+++ b/.github/workflows/pr-test-new-ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   tests:
-    if: github.repository == 'mdn/content' && !startsWith(github.event.pull_request.title, '[new-ci]')
+    if: github.repository == 'mdn/content' && startsWith(github.event.pull_request.title, '[new-ci]')
     runs-on: ubuntu-latest
     # Set the permissions to `read-all`, preventing the workflow from
     # any accidental write access to the repository.
@@ -92,12 +92,18 @@ jobs:
           # Playground
           REACT_APP_PLAYGROUND_BASE_HOST: mdnyalp.dev
 
+          # rari
+          LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
+          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
+
         run: |
           # The reason this script isn't in `package.json` is because
           # you don't need that script as a writer. It's only used in CI
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
-          yarn build $GIT_DIFF_CONTENT
+          echo Y|yarn rari update
+          ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $PWD/files#g")
+          yarn rari build --no-basic --json-issues $ARGS
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT


### PR DESCRIPTION
### Description

This is preliminary work to move to rari as default in content. Since CI is hard to test, let's test it live!


### Additional details

This does not affect our regular business (unless folks use `[new-ci]` in the PR title).



