### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/index.md
@@ -71,7 +71,7 @@ These tutorials are not part of the learning pathway, but they are interesting n
   - : [Scrimba's](https://scrimba.com?via=mdn) _Learn HTML and CSS_ course teaches you HTML and CSS through building and deploying five awesome projects, with fun interactive lessons and challenges taught by knowledgeable teachers.
 - [The basics of semantic HTML](https://v2.scrimba.com/the-frontend-developer-career-path-c0j/~0xid?via=mdn), Scrimba <sup>_MDN Curriculum partner_</sup>
   - : This interactive lesson provides a useful description of HTML, with particular emphasis on why the _semantic_ aspect of it is important.
-- [Learn HTML](https://v2.scrimba.com/the-frontend-developer-career-path-c0j/~0xid?via=mdn), Codecademy
+- [Learn HTML](https://www.codecademy.com/learn/learn-html), Codecademy
   - : Another useful (and free resource) for learning HTML basics.
 
 {{NextMenu("Learn_web_development/Core/Structuring_content/Basic_HTML_syntax", "Learn_web_development/Core")}}


### PR DESCRIPTION
docs: fix incorrect link for Codeacademy course

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

This change provides the right link for Codeacademy Learn HTML course.

<!-- ✍️ Summarize your changes in one or two sentences -->

Switch paid Scrimba course link to free Codeacademy course link.

<!-- ❓ Why are you making these changes and how do they help readers? -->

Keep docs consistent.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

NA

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
