### PR TITLE
Fix usage info for horiz-origin-y

### DIFF
--- a/files/en-us/web/svg/attribute/horiz-origin-y/index.md
+++ b/files/en-us/web/svg/attribute/horiz-origin-y/index.md
@@ -44,7 +44,7 @@ You can use this attribute with the following SVG elements:
 </table>
 
 - `<number>`
-  - : This value indicates the x-coordinate of the origin of a glyph for horizontally oriented text.
+  - : This value indicates the y-coordinate of the origin of a glyph for horizontally oriented text.
 
 ## Specifications
 


### PR DESCRIPTION
Fix documentation of horiz-origin-y SVG attribute, which seems to have been copy-pasted from horiz-origin-x without changing "x" to "y".

Both links show the following description for <number> which is clearly incorrect.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/horiz-origin-x
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/horiz-origin-y

