### PR TITLE
fix: label text of font-weight range input

### DIFF
--- a/files/en-us/web/css/@font-face/font-weight/index.md
+++ b/files/en-us/web/css/@font-face/font-weight/index.md
@@ -243,7 +243,7 @@ We include an {{htmlelement("input/range")}} of type `range`, nested in a {{html
 <p id="example">LeagueMono, font-weight: <output>400</output> (example)</p>
 <p>LeagueMono, font-weight: 700 (comparison)</p>
 <label
-  >Change the font size:
+  >Change the font weight:
   <input type="range" min="50" max="1000" step="50" value="400" />
 </label>
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Changed label text from “font size” to “font weight” to accurately reflect what the input enables the user to adjust.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Correct error in interactive example

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
