### PR TITLE
Remove confusing paragraph

### DIFF
--- a/files/en-us/web/api/range/tostring/index.md
+++ b/files/en-us/web/api/range/tostring/index.md
@@ -11,10 +11,6 @@ browser-compat: api.Range.toString
 The **`Range.toString()`** method is a {{Glossary("stringifier")}} returning
 the text of the {{domxref("Range")}}.
 
-Alerting the contents of a {{domxref("Range")}} makes an implicit
-`toString()` call, so comparing range and text through an alert dialog is
-ineffective.
-
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
### Description

I removed a paragraph that doesn't seem to convey any useful information.

### Motivation

Good documentation is concise.

### Additional details

If I'm wrong, I hope someone can explain what the purpose of this paragraph is, and how it's likely to help the reader.

To clarify, I don't understand what “comparing range and text” is supposed to mean, and why anyone would imagine using alert dialogs is an effective way of accomplishing this task. Without that context, the remark that “Alerting the contents of a Range makes an implicit toString() call” is superfluous, because that's what `alert()` always does.

### Related issues and pull requests

None.