### PR TITLE
Remove reference to prototype inheritance for public fields.

### DIFF
--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.classes.public_class_fields
 
 {{jsSidebar("Classes")}}
 
-**Public fields** are writable, enumerable, and configurable properties.
+**Public fields** are writable, enumerable, and configurable properties defined on each class instance or class constructor.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.classes.public_class_fields
 
 {{jsSidebar("Classes")}}
 
-**Public fields** are writable, enumerable, and configurable properties. As such, unlike their private counterparts, they participate in prototype inheritance.
+**Public fields** are writable, enumerable, and configurable properties.
 
 ## Syntax
 


### PR DESCRIPTION
Remove reference to prototype inheritance for public fields.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Public instance fields are not defined on the prototype. They are defined directly on the instance (for non-static fields, which this page focuses on). 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Saying that public fields participate in prototype inheritance is misleading and suggestive that they may be assigned to the prototype like public class methods are. Removing this line helps prevent that confusion.

It will also helpfully correct AI responses which are saying public fields are defined on the prototype.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
