### PR TITLE
Correct info about AbortSignal usage in addEventListener

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -79,7 +79,7 @@ addEventListener(type, listener, useCapture)
         If this option is not specified it defaults to `false` – except that in browsers other than Safari, it defaults to `true` for {{domxref("Element/wheel_event", "wheel")}}, {{domxref("Element/mousewheel_event", "mousewheel")}}, {{domxref("Element/touchstart_event", "touchstart")}} and {{domxref("Element/touchmove_event", "touchmove")}} events. See [Using passive listeners](#using_passive_listeners) to learn more.
 
     - `signal` {{optional_inline}}
-      - : An {{domxref("AbortSignal")}}. The listener will be removed when the given `AbortSignal` object's {{domxref("AbortController/abort()", "abort()")}} method is called. If not specified, no `AbortSignal` is associated with the listener.
+      - : An {{domxref("AbortSignal")}}. The listener will be removed when the {{domxref("AbortController/abort()", "abort()")}} method of the {{domxref("AbortController")}} which owns the `AbortSignal` is called. If not specified, no `AbortSignal` is associated with the listener.
 
 - `useCapture` {{optional_inline}}
 


### PR DESCRIPTION
### Description

Correct info about AbortSignal usage in addEventListener.

### Motivation

The sentence previously confusingly/misleadingly claimed that AbortSignals had abort() methods when it is their "parent"(?) AbortControllers which have the abort() method in question which must be called.

### Additional details

I tried to mimic the phrasing used on the [removeEventListener page](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener)
