### PR TITLE
Fix example in SVG scale attribute page

### DIFF
--- a/files/en-us/web/svg/attribute/scale/index.md
+++ b/files/en-us/web/svg/attribute/scale/index.md
@@ -43,7 +43,11 @@ svg {
   </filter>
 
   <circle cx="100" cy="100" r="80" style="filter: url(#displacementFilter);" />
-  <circle cx="100" cy="100" r="80" style="filter: url(#displacementFilter2);
+  <circle
+    cx="100"
+    cy="100"
+    r="80"
+    style="filter: url(#displacementFilter2);
   transform: translateX(240px);" />
 </svg>
 ```

--- a/files/en-us/web/svg/attribute/scale/index.md
+++ b/files/en-us/web/svg/attribute/scale/index.md
@@ -42,9 +42,9 @@ svg {
     <feDisplacementMap in2="turbulence" in="SourceGraphic" scale="50" />
   </filter>
 
-  <circle cx="100" cy="100" r="80" style="filter: url(#displacementFilter);""/>
+  <circle cx="100" cy="100" r="80" style="filter: url(#displacementFilter);" />
   <circle cx="100" cy="100" r="80" style="filter: url(#displacementFilter2);
-  transform: translateX(240px);""/>
+  transform: translateX(240px);" />
 </svg>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove the extra double quote character at the end of 2 style attributes.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

N/A

### Additional details

N/A

### Related issues and pull requests

N/A
