### PR TITLE
Removed redundant macros in svg element reference

### DIFF
--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -237,5 +237,3 @@ SVG drawings and images are created using a wide array of elements which are ded
 - [SVG attribute reference](/en-US/docs/Web/SVG/Attribute)
 - [SVG Tutorial](/en-US/docs/Web/SVG/Tutorial)
 - [SVG interface reference](/en-US/docs/Web/API/Document_Object_Model#svg_dom)
-
-{{SVGRef}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Element
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/element/index.md
* Last commit: https://github.com/mdn/content/commit/2e5fc06de139c56873a20ec4bc3bf5600ea3cbef