### PR TITLE
docs: update WebTransport unidirectional stream examples

### DIFF
--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -59,7 +59,7 @@ async function writeData() {
   const stream = await transport.createUnidirectionalStream({
     sendOrder: "596996858",
   });
-  const writer = stream.writable.getWriter();
+  const writer = stream.getWriter();
   const data1 = new Uint8Array([65, 66, 67]);
   const data2 = new Uint8Array([68, 69, 70]);
   writer.write(data1);
@@ -80,7 +80,7 @@ You can also use {{domxref("WritableStreamDefaultWriter.abort()")}} to abruptly 
 // ...
 
 const stream = await transport.createUnidirectionalStream();
-const writer = ws.getWriter();
+const writer = stream.getWriter();
 
 // ...
 


### PR DESCRIPTION
### Description

The WebTransport `createUnidirectionalStream` method returns a promise of a `WebTransportSendStream` (which extends `WritableStream`), not an object with a `.writable` property.

So the developer can call `getWriter` directly on the resolved result of the promise instead of `.writable.getWriter` as with bidirectional streams.

### Motivation

The examples are wrong.

### Additional details

- [WebTransport.createUnidirectionalStream spec](https://www.w3.org/TR/webtransport/#dom-webtransport-createunidirectionalstream)
- [WebTransportSendStream spec](https://www.w3.org/TR/webtransport/#webtransportsendstream)
