### PR TITLE
added correct explanations to offsets in selection api docs

### DIFF
--- a/files/en-us/web/api/selection/anchoroffset/index.md
+++ b/files/en-us/web/api/selection/anchoroffset/index.md
@@ -10,7 +10,9 @@ browser-compat: api.Selection.anchorOffset
 
 The **`Selection.anchorOffset`** read-only property returns the
 number of characters that the selection's anchor is offset within the
-{{domxref("Selection.anchorNode")}}.
+{{domxref("Selection.anchorNode")}} if said node is of type {{domxref("Text")}}, {{domxref("CDATASection")}} or {{domxref("Comment")}}.
+
+In the case of {{domxref("Selection.anchorNode")}} being another type of node, **`Selection.anchorOffset`** returns the number of {{domxref("Node.childNodes")}} the selection's focus is offset within the {{domxref("Selection.anchorNode")}}.
 
 This number is zero-based. If the selection begins with the first character in the
 {{domxref("Selection.anchorNode")}}, `0` is returned.

--- a/files/en-us/web/api/selection/focusoffset/index.md
+++ b/files/en-us/web/api/selection/focusoffset/index.md
@@ -10,7 +10,9 @@ browser-compat: api.Selection.focusOffset
 
 The **`Selection.focusOffset`** read-only property returns the
 number of characters that the selection's focus is offset within the
-{{domxref("Selection.focusNode")}}.
+{{domxref("Selection.focusNode")}} if said node is of type {{domxref("Text")}}, {{domxref("CDATASection")}} or {{domxref("Comment")}}.
+
+In the case of {{domxref("Selection.focusNode")}} being another type of node, **`Selection.focusOffset`** returns the number of {{domxref("Node.childNodes")}} the selection's focus is offset within the {{domxref("Selection.focusNode")}}.
 
 This number is zero-based. If the selection ends with the first character in the
 {{domxref("Selection.focusNode")}}, `0` is returned.


### PR DESCRIPTION
### Description

The Selection api anchorOffset and focusOffset docs are hugely misleading and data on this matter is very scarce. I clarified what those offset return in the case of a non texty node in anchorNode or focusNode

### Motivation

A custom project I am working on heavily reliant on selection api. The docs on this matter are scarce and there are a lot of caveats not mentioned anywhere or in very obscure parts of programming forums. This specificly came up from testing my project and [this SO issue ](https://stackoverflow.com/a/14753667)  which also mentions fixing MDN docs but i guessed there was a regression from 2013 to today.