### PR TITLE
Fix PushSubscription code example to actually post JSON object

### DIFF
--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -71,7 +71,7 @@ const subscriptionObject = {
 // Stringify the object an post to the app server
 fetch(`https://example.com/push/`, {
   method: "post",
-  body: JSON.stringify(pushSubscription);
+  body: JSON.stringify(subscriptionObject);
 });
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example on the `PushSubscription` API creates a neat `subscriptionObject` object, then proceeds to not use it. This PR ensures the neatly constructed object is indeed POSTed to the server in the example.

### Motivation

To make sure the example is correct and aligns with the approach as described above it.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
