### PR TITLE
Change children to Element.children with link to article in sibling's

### DIFF
--- a/files/en-us/web/api/element/nextelementsibling/index.md
+++ b/files/en-us/web/api/element/nextelementsibling/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Element.nextElementSibling
 
 The **`Element.nextElementSibling`** read-only
 property returns the element immediately following the specified one in its parent's
-children list, or `null` if the specified element is the last one in the list.
+{{domxref("Element.children")}} list, or `null` if the specified element is the last one in the list.
 
 ## Value
 

--- a/files/en-us/web/api/element/nextelementsibling/index.md
+++ b/files/en-us/web/api/element/nextelementsibling/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Element.nextElementSibling
 
 The **`Element.nextElementSibling`** read-only
 property returns the element immediately following the specified one in its parent's
-{{domxref("Element.children")}} list, or `null` if the specified element is the last one in the list.
+{{domxref("Element.children", "children")}} list, or `null` if the specified element is the last one in the list.
 
 ## Value
 

--- a/files/en-us/web/api/element/previouselementsibling/index.md
+++ b/files/en-us/web/api/element/previouselementsibling/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Element.previousElementSibling
 
 The **`Element.previousElementSibling`**
 read-only property returns the {{domxref("Element")}} immediately prior to the specified
-one in its parent's {{domxref("Element.children")}} list, or `null` if the specified element is the first one in the list.
+one in its parent's {{domxref("Element.children", "children")}} list, or `null` if the specified element is the first one in the list.
 
 ## Value
 

--- a/files/en-us/web/api/element/previouselementsibling/index.md
+++ b/files/en-us/web/api/element/previouselementsibling/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Element.previousElementSibling
 
 The **`Element.previousElementSibling`**
 read-only property returns the {{domxref("Element")}} immediately prior to the specified
-one in its parent's children list, or `null` if the specified element is the first one in the list.
+one in its parent's {{domxref("Element.children")}} list, or `null` if the specified element is the first one in the list.
 
 ## Value
 


### PR DESCRIPTION
### Description

Change `childred` to `Element.children` for easy navigation to docs i need

Also because in `Node.previousSibling` we have link to `childNodes` 

### Motivation

For easy navigation and sync with node's docs

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Node/previousSibling

https://developer.mozilla.org/en-US/docs/Web/API/Element/previousElementSibling
