### PR TITLE
Fix typo in 'align-self' documentation: change 'an intrinsic sizes' to 'an intrinsic size'

### DIFF
--- a/files/en-us/web/css/align-self/index.md
+++ b/files/en-us/web/css/align-self/index.md
@@ -60,7 +60,7 @@ align-self: unset;
     - In absolutely-positioned layouts, the keyword behaves like `start` on _replaced_ absolutely-positioned boxes, and as `stretch` on _all other_ absolutely-positioned boxes.
     - In static position of absolutely-positioned layouts, the keyword behaves as `stretch`.
     - For flex items, the keyword behaves as `stretch`.
-    - For grid items, this keyword leads to a behavior similar to the one of `stretch`, except for boxes with an {{glossary("aspect ratio")}} or an intrinsic sizes where it behaves like `start`.
+    - For grid items, this keyword leads to a behavior similar to the one of `stretch`, except for boxes with an {{glossary("aspect ratio")}} or an intrinsic size where it behaves like `start`.
     - The property doesn't apply to block-level boxes, and to table cells.
 
 - `self-start`


### PR DESCRIPTION
fixed an issue

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed a typo in the 'align-self' CSS documentation: changed "an intrinsic sizes" to "an intrinsic size."

### Motivation
The typo in the documentation may cause confusion for the user ,and fixing it will ensure that the user is happy by providing them with clear and more accurate documentation

### Additional details

None

### Related issues and pull requests

Fixes #37619

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
