### PR TITLE
fix: remove the duplicated sidebar macro

### DIFF
--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -237,5 +237,3 @@ SVG drawings and images are created using a wide array of elements which are ded
 - [SVG attribute reference](/en-US/docs/Web/SVG/Attribute)
 - [SVG Tutorial](/en-US/docs/Web/SVG/Tutorial)
 - [SVG interface reference](/en-US/docs/Web/API/Document_Object_Model#svg_dom)
-
-{{SVGRef}}


### PR DESCRIPTION
### Description

The sidebar macro has been added in line 8, the one at the end of the file is duplicated.
