### PR TITLE
Fix minor mistake: you send two directives not two headers

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -73,7 +73,7 @@ The JSON for a single report might look like this:
 ## Usage notes
 
 The `report-to` directive is intended to replace `report-uri`, and browsers that support `report-to` ignore the `report-uri` directive.
-However, until `report-to` is broadly supported you can specify both headers as shown:
+However, until `report-to` is broadly supported you can specify both directives as shown:
 
 ```http
 Content-Security-Policy: …; report-uri https://endpoint.example.com; report-to endpoint_name


### PR DESCRIPTION
### Description

"report-to" and "report-uri" are directives within the CSP Header. Text said: "both headers" which is technically wrong.

### Motivation

doc was technically wrong. Basically a typo

### Additional details

none

### Related issues and pull requests

nothing necessary, really small fix.
