### PR TITLE
More information about formatToParts pages

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -20,7 +20,7 @@ format(date)
 ### Parameters
 
 - `date`
-  - : The date to format.
+  - : The date to format. Omitting it results in formatting the current date (as returned by {{jsxref("Date.now()")}}), which could be slightly confusing, so it is advisable to always explicitly pass a date.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
@@ -7,8 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatRangeToParts
 
 {{JSRef}}
 
-The **`formatRangeToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of locale-specific tokens representing each part of the formatted date
-range produced by this `Intl.DateTimeFormat` object.
+The **`formatRangeToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DatetimeFormat/formatRange", "formatRange()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrangetoparts.html", "taller")}}
 
@@ -18,15 +17,31 @@ range produced by this `Intl.DateTimeFormat` object.
 formatRangeToParts(startDate, endDate)
 ```
 
+### Parameters
+
+- `startDate`
+  - : A {{jsxref("Date")}} object representing the start of the date range.
+- `endDate`
+  - : A {{jsxref("Date")}} object representing the end of the date range.
+
+### Return value
+
+An {{jsxref("Array")}} of objects containing the formatted date range in parts. Each object has three properties, `type`, `value`, and `source`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/DateTimeFormat/formatRange", "formatRange()")}}. The `type` may have the same values as {{jsxref("Intl/DateTimeFormat/formatToParts", "formatToParts()")}}. The `source` can be one of the following:
+
+- `startRange`
+  - : The token is a part of the start date.
+- `endRange`
+  - : The token is a part of the end date.
+- `shared`
+  - : The token is shared between the start and end; for example, if the start and end dates share the same day period, that token may get reused. All literals that are part of the range pattern itself, such as the `" – "` separator, are also marked as `shared`.
+
+If the start and end dates are equivalent at the precision of the output, then the output has the same list of tokens as calling {{jsxref("Intl/DateTimeFormat/formatToParts", "formatToParts()")}} on the start date, with all tokens marked as `source: "shared"`.
+
 ## Examples
 
-### Basic formatRangeToParts usage
+### Using formatRangeToParts()
 
-This method receives two {{jsxref("Date")}}s and returns an {{jsxref("Array")}} of
-objects containing the _locale-specific_ tokens representing each part of the formatted date range.
-
-> [!NOTE]
-> The return values shown in your locale may differ from those listed below.
+The `formatRange()` method outputs localized, opaque strings that cannot be manipulated directly:
 
 ```js
 const date1 = new Date(Date.UTC(1906, 0, 10, 10, 0, 0)); // Wed, 10 Jan 1906 10:00:00 GMT
@@ -38,19 +53,25 @@ const fmt = new Intl.DateTimeFormat("en", {
 });
 
 console.log(fmt.formatRange(date1, date2)); // '10:00 – 11:00 AM'
+```
 
-fmt.formatRangeToParts(date1, date2);
-// [
-//   { type: 'hour',      value: '10',  source: "startRange" },
-//   { type: 'literal',   value: ':',   source: "startRange" },
-//   { type: 'minute',    value: '00',  source: "startRange" },
-//   { type: 'literal',   value: ' – ', source: "shared"     },
-//   { type: 'hour',      value: '11',  source: "endRange"   },
-//   { type: 'literal',   value: ':',   source: "endRange"   },
-//   { type: 'minute',    value: '00',  source: "endRange"   },
-//   { type: 'literal',   value: ' ',   source: "shared"     },
-//   { type: 'dayPeriod', value: 'AM',  source: "shared"     }
-// ]
+However, in many user interfaces you may want to customize the formatting of this string, or interleave it with other texts. The `formatRangeToParts()` method produces the same information in parts:
+
+```js
+console.log(fmt.formatRangeToParts(date1, date2));
+
+// return value:
+[
+  { type: "hour", value: "10", source: "startRange" },
+  { type: "literal", value: ":", source: "startRange" },
+  { type: "minute", value: "00", source: "startRange" },
+  { type: "literal", value: " – ", source: "shared" },
+  { type: "hour", value: "11", source: "endRange" },
+  { type: "literal", value: ":", source: "endRange" },
+  { type: "minute", value: "00", source: "endRange" },
+  { type: "literal", value: " ", source: "shared" },
+  { type: "dayPeriod", value: "AM", source: "shared" },
+];
 ```
 
 ## Specifications
@@ -63,5 +84,5 @@ fmt.formatRangeToParts(date1, date2);
 
 ## See also
 
-- {{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}}
 - {{jsxref("Intl.DateTimeFormat")}}
+- {{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatToParts
 
 {{JSRef}}
 
-The **`formatToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances allows locale-aware formatting of strings produced by this `Intl.DateTimeFormat` object.
+The **`formatToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DatetimeFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formattoparts.html", "taller")}}
 
@@ -19,66 +19,52 @@ formatToParts(date)
 
 ### Parameters
 
-- `date` {{optional_inline}}
-  - : The date to format.
+- `date`
+  - : The date to format. Omitting it results in formatting the current date (as returned by {{jsxref("Date.now()")}}), which could be slightly confusing, so it is advisable to always explicitly pass a date.
 
 ### Return value
 
-An {{jsxref("Array")}} of objects containing the formatted date in parts.
+An {{jsxref("Array")}} of objects containing the formatted date in parts. Each object has two properties, `type` and `value`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/DateTimeFormat/format", "format()")}}. The `type` may be one of the [date-time components](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#date-time_component_options):
 
-## Description
-
-The `formatToParts()` method is useful for custom formatting of date
-strings. It returns an {{jsxref("Array")}} of objects containing the locale-specific
-tokens from which it possible to build custom strings while preserving the
-locale-specific parts. The structure the `formatToParts()` method returns,
-looks like this:
-
-```js
-[
-  { type: "day", value: "17" },
-  { type: "weekday", value: "Monday" },
-];
-```
-
-Possible types are the following:
-
-- `day`
-  - : The string used for the day, for example `"17"`.
-- `dayPeriod`
-  - : The string used for the day period, for example, `"AM"`,
-    `"PM"`, `"in the morning"`, or `"noon"`
-- `era`
-  - : The string used for the era, for example `"BC"` or `"AD"`.
-- `fractionalSecond`
-  - : The string used for the fractional seconds, for example `"0"` or `"00"` or `"000"`.
-- `hour`
-  - : The string used for the hour, for example `"3"` or `"03"`.
-- `literal`
-  - : The string used for separating date and time values, for example `"/"`,
-    `","`, `"o'clock"`, `"de"`, etc.
-- `minute`
-  - : The string used for the minute, for example `"00"`.
-- `month`
-  - : The string used for the month, for example `"12"`.
-- `relatedYear`
-  - : The string used for the related 4-digit Gregorian year, in the event that the
-    calendar's representation would be a yearName instead of a year, for example `"2019"`.
-- `second`
-  - : The string used for the second, for example `"07"` or `"42"`.
-- `timeZoneName`
-  - : The string used for the name of the time zone, for example `"UTC"`. Default is the timezone of the current environment.
 - `weekday`
-  - : The string used for the weekday, for example `"M"`, `"Monday"`, or `"Montag"`.
+  - : For example `"M"`, `"Monday"`, or `"Montag"`.
+- `era`
+  - : For example `"BC"` or `"AD"`.
 - `year`
-  - : The string used for the year, for example `"2012"` or `"96"`.
+  - : For example `"2012"` or `"96"`.
+- `month`
+  - : For example `"12"` or `"January"`.
+- `day`
+  - : For example `"17"`.
+- `dayPeriod`
+  - : For example `"AM"`, `"PM"`, `"in the morning"`, or `"noon"`.
+- `hour`
+  - : For example `"3"` or `"03"`.
+- `minute`
+  - : For example `"00"`.
+- `second`
+  - : For example `"07"` or `"42"`.
+- `fractionalSecond`
+  - : For example `"0"`, `"00"`, or `"000"`.
+- `timeZoneName`
+  - : For example `"UTC"`, `"CET"`, or `"Central European Time"`.
+
+The `type` may also be one of the following:
+
+- `literal`
+  - : Any string that's a part of the format pattern and not influenced by the `date`; for example `"/"`, `", "`, `"o'clock"`, `"de"`, `" "`, etc.
+- `relatedYear`
+  - : A 4-digit Gregorian year, in the event that the calendar's representation would be a `yearName` instead of a year; for example `"2019"`. See [named years](#named_years) for more details.
 - `yearName`
-  - : The string used for the yearName in relevant contexts, for example `"geng-zi"`
+  - : The name given to the year, usually in calendars without the concept of continuous years; for example `"geng-zi"`.
+- `unknown`
+  - : Reserved for any token that's not recognized as any of the above; should be rarely encountered.
 
 ## Examples
 
-`DateTimeFormat` outputs localized, opaque strings that cannot be
-manipulated directly:
+### Using formatToParts()
+
+The `format()` method outputs localized, opaque strings that cannot be manipulated directly:
 
 ```js
 const date = Date.UTC(2012, 11, 17, 3, 0, 42);
@@ -100,9 +86,7 @@ formatter.format(date);
 // "Monday, 12/17/2012, 3:00:42.000 AM"
 ```
 
-However, in many User Interfaces there is a desire to customize the formatting of this
-string. The `formatToParts` method enables locale-aware formatting of strings
-produced by `DateTimeFormat` formatters by providing you the string in parts:
+However, in many user interfaces you may want to customize the formatting of this string, or interleave it with other texts. The `formatToParts()` method produces the same information in parts:
 
 ```js
 formatter.formatToParts(date);
@@ -128,12 +112,7 @@ formatter.formatToParts(date);
 ];
 ```
 
-Now the information is available separately and it can be formatted and concatenated
-again in a customized way. For example by using {{jsxref("Array.prototype.map()")}},
-[arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
-a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch),
-[template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals),
-and {{jsxref("Array.prototype.join()")}}.
+Now the information is available separately and it can be formatted and concatenated again in a customized way. For example by using {{jsxref("Array.prototype.map()")}}, [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch), [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals), and {{jsxref("Array.prototype.join()")}}, to insert additional markup for certain components.
 
 ```js
 const dateString = formatter
@@ -147,52 +126,20 @@ const dateString = formatter
     }
   })
   .join("");
-```
-
-This will emphasize the day period when using the `formatToParts()` method.
-
-```js
-console.log(formatter.format(date));
-// "Monday, 12/17/2012, 3:00:42.000 AM"
 
 console.log(dateString);
 // "Monday, 12/17/2012, 3:00:42.000 <em>AM</em>"
 ```
 
-### Named Years and Mixed calendars
+### Named years
 
-In some cases, calendars use named years. Chinese and Tibetan calendars, for example,
-use a 60-year [sexagenary cycle](https://en.wikipedia.org/wiki/Sexagenary_cycle) of named years.
-These years are disambiguated by relationship to
-corresponding years on the Gregorian calendar. When this is the case, the result of
-`formatToParts()` will contain an entry for `relatedYear` when a
-year would normally be present, containing the 4-digit Gregorian year, instead of an
-entry for `year`. Setting an entry in the bag for `month` (with a value of `long`) will yield both the and the `yearName` Gregorian
-`relatedYear`:
-
-```js
-const opts = { year: "numeric", month: "long", day: "numeric" };
-const df = new Intl.DateTimeFormat("zh-u-ca-chinese", opts);
-df.formatToParts(Date.UTC(2012, 11, 17, 3, 0, 42));
-
-// return value
-[
-  { type: "relatedYear", value: "2012" },
-  { type: "yearName", value: "壬辰" },
-  { type: "literal", value: "年" },
-  { type: "month", value: "十一月" },
-  { type: "day", value: "5" },
-];
-```
-
-If the `year` option is not set in the bag (to any value), the result will
-include only the `relatedYear`:
+Some calendars use named years; for example, the Chinese and Tibetan calendars use a 60-year [sexagenary cycle](https://en.wikipedia.org/wiki/Sexagenary_cycle) of named years. These calendars do not have a universal way to unambiguously number each year, so years are disambiguated by relationship to corresponding years on the Gregorian calendar. In this case, when the `DateTimeFormat` is configured to output the year component, a token for `relatedYear` is output instead of `year`.
 
 ```js
 const df = new Intl.DateTimeFormat("zh-u-ca-chinese");
 df.formatToParts(Date.UTC(2012, 11, 17, 3, 0, 42));
 
-// return value
+// return value:
 [
   { type: "relatedYear", value: "2012" },
   { type: "literal", value: "年" },
@@ -201,37 +148,24 @@ df.formatToParts(Date.UTC(2012, 11, 17, 3, 0, 42));
 ];
 ```
 
-In cases where the `year` would be output, `.format()` may
-commonly present these side-by-side:
+Sometimes, the combination of date-time component options maps to a format that also includes a `yearName`. There isn't a separate option that controls whether `yearName` is displayed or not. For example, the options below sets `month` to `"long"` and results in a `yearName` token, despite `year` still being `"numeric"`:
 
 ```js
-const df = new Intl.DateTimeFormat("zh-u-ca-chinese", { year: "numeric" });
-df.format(Date.UTC(2012, 11, 17, 3, 0, 42)); // 2012壬辰年
+const opts = { year: "numeric", month: "long", day: "numeric" };
+const df = new Intl.DateTimeFormat("zh-u-ca-chinese", opts);
+df.formatToParts(Date.UTC(2012, 11, 17, 3, 0, 42));
+
+// return value:
+[
+  { type: "relatedYear", value: "2012" },
+  { type: "yearName", value: "壬辰" },
+  { type: "literal", value: "年" },
+  { type: "month", value: "十一月" },
+  { type: "day", value: "4" },
+];
 ```
 
-This also makes it possible to mix locale and calendar in both `format`:
-
-```js
-const df = new Intl.DateTimeFormat("en-u-ca-chinese", { year: "numeric" });
-const date = Date.UTC(2012, 11, 17, 3, 0, 42);
-df.format(date); // 2012(ren-chen)
-```
-
-And `formatToParts`:
-
-```js
-const opts = { month: "numeric", day: "numeric", year: "numeric" };
-const df = new Intl.DateTimeFormat("en-u-ca-chinese", opts);
-const date = Date.UTC(2012, 11, 17, 3);
-df.formatToParts(date);
-// [
-//   { type: 'month', value: '11' },
-//   { type: 'literal', value: '/' },
-//   { type: 'day', value: '4' },
-//   { type: 'literal', value: '/' },
-//   { type: 'relatedYear', value: '2012' }
-// ]
-```
+Because `format()` just concatenates all the `value` strings together, you will see the Gregorian year and the year name together in the output in this case.
 
 ## Specifications
 
@@ -245,6 +179,3 @@ df.formatToParts(date);
 
 - {{jsxref("Intl.DateTimeFormat")}}
 - {{jsxref("Intl/DateTimeFormat/format", "Intl.DateTimeFormat.prototype.format()")}}
-- {{jsxref("Date.prototype.toLocaleString()")}}
-- {{jsxref("Date.prototype.toLocaleDateString()")}}
-- {{jsxref("Date.prototype.toLocaleTimeString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -167,21 +167,21 @@ These years are disambiguated by relationship to
 corresponding years on the Gregorian calendar. When this is the case, the result of
 `formatToParts()` will contain an entry for `relatedYear` when a
 year would normally be present, containing the 4-digit Gregorian year, instead of an
-entry for `year`. Setting an entry in the bag for `year` (with any
-value) will yield both the and the `yearName` Gregorian
+entry for `year`. Setting an entry in the bag for `month` (with a value of `long`) will yield both the and the `yearName` Gregorian
 `relatedYear`:
 
 ```js
-const opts = { year: "numeric", month: "numeric", day: "numeric" };
+const opts = { year: "numeric", month: "long", day: "numeric" };
 const df = new Intl.DateTimeFormat("zh-u-ca-chinese", opts);
 df.formatToParts(Date.UTC(2012, 11, 17, 3, 0, 42));
 
 // return value
 [
   { type: "relatedYear", value: "2012" },
+  { type: "yearName", value: "壬辰" },
   { type: "literal", value: "年" },
   { type: "month", value: "十一月" },
-  { type: "day", value: "4" },
+  { type: "day", value: "5" },
 ];
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/durationformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/durationformat/index.md
@@ -41,7 +41,7 @@ new Intl.DurationFormat(locales, options)
     - `numberingSystem`
       - : The numbering system to use for number formatting, such as `"arab"`, `"hans"`, `"mathsans"`, and so on. For a list of supported numbering system types, see [`Intl.Locale.prototype.getNumberingSystems()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems#supported_numbering_system_types). This option can also be set through the `nu` Unicode extension key; if both are provided, this `options` property takes precedence.
     - `style`
-      - : The style of the formatted duration. Possible values are:
+      - : The style of the formatted duration. This value is used as the default for all other unit options, and also corresponds to the `style` option of {{jsxref("Intl/ListFormat/ListFormat", "Intl.ListFormat()")}} when concatenating the list of duration units. Possible values are:
         - `"long"`
           - : E.g., 1 hour and 50 minutes
         - `"short"` (default)

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.DurationFormat.formatToParts
 
 {{JSRef}}
 
-The **`formatToParts()`** method of {{jsxref("Intl.DurationFormat")}} instances allows locale-aware formatting of strings produced by {{jsxref("Intl.DurationFormat")}} formatters.
+The **`formatToParts()`** method of {{jsxref("Intl.DurationFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DurationFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 ## Syntax
 
@@ -22,23 +22,7 @@ formatToParts(duration)
 
 ### Return value
 
-An {{jsxref("Array")}} of objects containing the formatted duration in parts.
-
-## Description
-
-The `formatToParts()` method is useful for custom formatting of duration objects. It returns an {{jsxref("Array")}} of objects containing the locale-specific tokens from which it possible to build custom strings while preserving the locale-specific parts. The structure the `formatToParts()` method returns, looks like this:
-
-```js
-[
-  { type: "integer", value: "7", unit: "hour" },
-  { type: "literal", value: " ", unit: "hour" },
-  { type: "unit", value: "hr", unit: "hour" },
-  { type: "literal", value: ", " },
-  { type: "integer", value: "8", unit: "minute" },
-  { type: "literal", value: " ", unit: "minute" },
-  { type: "unit", value: "min", unit: "minute" },
-];
-```
+An {{jsxref("Array")}} of objects containing the formatted duration in parts. Each object has two or three properties, `type`, `value`, and optionally `unit`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/DurationFormat/format", "format()")}}. The parts can be thought of as directly obtained from calling {{jsxref("Intl/NumberFormat/formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}} with the numeric value and their respective units. All tokens that are produced by the `NumberFormat` have an additional `unit` property, which is the singular form of the input `unit`; this is for programmatic usage and is not localized. The localized unit is output as a separate `unit` token as part of the `NumberFormat` result. The parts from each duration unit are concatenated together in the same fashion as calling {{jsxref("Intl/ListFormat/formatToParts", "Intl.ListFormat.prototype.formatToParts()")}} with `{ type: "unit" }`, so additional literal tokens are inserted.
 
 ## Examples
 
@@ -77,7 +61,7 @@ new Intl.DurationFormat("en", { style: "long" }).formatToParts(duration);
   { type: "integer", value: "456", unit: "microsecond" },
   { type: "literal", value: " ", unit: "microsecond" },
   { type: "unit", value: "microseconds", unit: "microsecond" },
-  { type: "literal", value: " and " },
+  { type: "literal", value: ", " },
   { type: "integer", value: "789", unit: "nanosecond" },
   { type: "literal", value: " ", unit: "nanosecond" },
   { type: "unit", value: "nanoseconds", unit: "nanosecond" },
@@ -95,5 +79,4 @@ new Intl.DurationFormat("en", { style: "long" }).formatToParts(duration);
 ## See also
 
 - {{jsxref("Intl.DurationFormat")}}
-- {{jsxref("Intl.supportedValuesOf()")}}
-- {{jsxref("Intl")}}
+- {{jsxref("Intl/DurationFormat/format", "Intl.DurationFormat.prototype.format()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.md
@@ -15,14 +15,13 @@ language-specific representation of the list.
 ## Syntax
 
 ```js-nolint
-format()
 format(list)
 ```
 
 ### Parameters
 
 - `list`
-  - : An iterable object, such as an Array.
+  - : An iterable object, such as an Array, containing strings. Omitting it results in formatting the empty array, which could be slightly confusing, so it is advisable to always explicitly pass a list.
 
 ### Return value
 
@@ -30,14 +29,6 @@ A language-specific formatted string representing the elements of the list.
 
 > [!NOTE]
 > Most of the time, the formatting returned by `format()` is consistent. However, the output may vary between implementations, even within the same locale — output variations are by design and allowed by the specification. It may also not be what you expect. For example, the string may use non-breaking spaces or be surrounded by bidirectional control characters. You should not compare the results of `format()` to hardcoded constants.
-
-## Description
-
-The **`format()`** method returns a string that has been
-formatted based on parameters provided in the `Intl.ListFormat` object. The
-`locales` and `options` parameters customize the behavior of
-`format()` and let applications specify the language conventions that
-should be used to format the list.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
@@ -7,9 +7,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.formatToParts
 
 {{JSRef}}
 
-The **`formatToParts()`** method of {{jsxref("Intl.ListFormat")}} instances
-returns an {{jsxref("Array")}} of objects representing the different components that
-can be used to format a list of values in a locale-aware fashion.
+The **`formatToParts()`** method of {{jsxref("Intl.ListFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/ListFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{EmbedInteractiveExample("pages/js/intl-listformat-prototype-formattoparts.html", "taller")}}
 
@@ -22,31 +20,20 @@ formatToParts(list)
 ### Parameters
 
 - `list`
-  - : An iterable object, such as an {{jsxref("Array")}}, to be formatted according to a locale.
+  - : An iterable object, such as an Array, containing strings. Omitting it results in formatting the empty array, which could be slightly confusing, so it is advisable to always explicitly pass a list.
 
 ### Return value
 
-An {{jsxref("Array")}} of components which contains the formatted parts from the list.
+An {{jsxref("Array")}} of objects containing the formatted list in parts. Each object has two properties, `type` and `value`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/ListFormat/format", "format()")}}. The `type` may be one of the following:
 
-## Description
-
-Whereas {{jsxref("Intl/ListFormat/format", "Intl.ListFormat.prototype.format()")}} returns a string being the formatted version
-of the list (according to the given locale and style options),
-`formatToParts()` returns an array of the different components of the
-formatted string.
-
-Each element of the resulting array has two properties: `type` and
-`value`. The `type` property may be either
-`"element"`, which refers to a value from the list, or
-`"literal"` which refers to a linguistic construct. The `value`
-property gives the content, as a string, of the token.
-
-The locale and style options used for formatting are given when constructing the
-{{jsxref("Intl.ListFormat")}} instance.
+- `literal`
+  - : Any string that's a part of the format pattern; for example `", "`, `", and"`, etc.
+- `element`
+  - : An element of the list, exactly as provided.
 
 ## Examples
 
-### Using formatToParts
+### Using formatToParts()
 
 ```js
 const fruits = ["Apple", "Orange", "Pineapple"];
@@ -77,6 +64,3 @@ console.table(myListFormat.formatToParts(fruits));
 
 - {{jsxref("Intl.ListFormat")}}
 - {{jsxref("Intl/ListFormat/format", "Intl.ListFormat.prototype.format()")}}
-- {{jsxref("Intl/RelativeTimeFormat/formatToParts", "Intl.RelativeTimeFormat.prototype.formatToParts()")}}
-- {{jsxref("Intl/NumberFormat/formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}}
-- {{jsxref("Intl/DateTimeFormat/formatToParts", "Intl.DateTimeFormat.prototype.formatToParts()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrangetoparts/index.md
@@ -24,55 +24,16 @@ formatRangeToParts(startRange, endRange)
 
 ### Return value
 
-An {{jsxref("Array")}} of objects containing the formatted range of numbers in parts.
-
-The structure of the returned looks like this:
-
-```js
-[
-  { type: "integer", value: "3", source: "startRange" },
-  { type: "literal", value: "-", source: "shared" },
-  { type: "integer", value: "5", source: "endRange" },
-  { type: "literal", value: " ", source: "shared" },
-  { type: "currency", value: "€", source: "shared" },
-];
-```
-
-Possible values for the `type` property include:
-
-- `currency`
-  - : The currency string, such as the symbols "$" and "€" or the name "Dollar", "Euro", depending on how `currencyDisplay` is specified.
-- `decimal`
-  - : The decimal separator string (".").
-- `fraction`
-  - : The fraction number.
-- `group`
-  - : The group separator string (",").
-- `infinity`
-  - : The {{jsxref("Infinity")}} string ("∞").
-- `integer`
-  - : The integer number.
-- `literal`
-  - : Any literal strings or whitespace in the formatted number.
-- `minusSign`
-  - : The minus sign string ("-").
-- `nan`
-  - : The {{jsxref("NaN")}} string ("NaN").
-- `plusSign`
-  - : The plus sign string ("+").
-- `percentSign`
-  - : The percent sign string ("%").
-- `unit`
-  - : The unit string, such as the "l" or "litres", depending on how `unitDisplay` is specified.
-
-Possible values for the `source` property include:
+An {{jsxref("Array")}} of objects containing the formatted range in parts. Each object has three properties, `type`, `value`, and `source`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/NumberFormat/formatRange", "formatRange()")}}. The `type` may have the same values as {{jsxref("Intl/NumberFormat/formatToParts", "formatToParts()")}}. The `source` can be one of the following:
 
 - `startRange`
-  - : The object is the start part of the range.
+  - : The token is a part of the start number.
 - `endRange`
-  - : The object is the end part of the range.
+  - : The token is a part of the end number.
 - `shared`
-  - : The object is a "shared" part of the range, such as a separator or currency.
+  - : The token is shared between the start and end; for example, the currency symbol. All literals that are part of the range pattern itself, such as the `"–"` separator, are also marked as `shared`.
+
+If the start and end numbers are equivalent, then the output has the same list of tokens as calling {{jsxref("Intl/NumberFormat/formatToParts", "formatToParts()")}} on the start number, with all tokens marked as `source: "shared"`.
 
 ### Exceptions
 
@@ -83,9 +44,9 @@ Possible values for the `source` property include:
 
 ## Examples
 
-### Comparing formatRange and formatRangeToParts
+### Using formatRangeToParts()
 
-`NumberFormat` outputs localized, opaque strings that cannot be manipulated directly:
+The `formatRange()` method outputs localized, opaque strings that cannot be manipulated directly:
 
 ```js
 const startRange = 3500;
@@ -100,8 +61,7 @@ console.log(formatter.formatRange(startRange, endRange));
 // "3.500,00–9.500,00 €"
 ```
 
-However, for many user interfaces there is a need to customize the formatting of this string.
-The `formatRangeToParts` method enables locale-aware formatting of strings produced by `NumberFormat` formatters by providing you the string in parts:
+However, in many user interfaces you may want to customize the formatting of this string, or interleave it with other texts. The `formatRangeToParts()` method produces the same information in parts:
 
 ```js
 console.log(formatter.formatRangeToParts(startRange, endRange));
@@ -136,4 +96,3 @@ console.log(formatter.formatRangeToParts(startRange, endRange));
 
 - {{jsxref("Intl.NumberFormat")}}
 - {{jsxref("Intl/NumberFormat/format", "Intl.NumberFormat.prototype.format()")}}
-- {{jsxref("Intl/DateTimeFormat/formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.formatToParts
 
 {{JSRef}}
 
-The **`formatToParts()`** method of {{jsxref("Intl.NumberFormat")}} instances allows locale-aware formatting of strings produced by this `Intl.NumberFormat` object.
+The **`formatToParts()`** method of {{jsxref("Intl.NumberFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/NumberFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-formattoparts.html")}}
 
@@ -24,67 +24,48 @@ formatToParts(number)
 
 ### Return value
 
-An {{jsxref("Array")}} of objects containing the formatted number in parts.
+An {{jsxref("Array")}} of objects containing the formatted number in parts. Each object has two properties, `type` and `value`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/NumberFormat/format", "format()")}}. The `type` may be one of the following:
 
-## Description
-
-The `formatToParts()` method is useful for custom formatting of number
-strings. It returns an {{jsxref("Array")}} of objects containing the locale-specific
-tokens from which it possible to build custom strings while preserving the
-locale-specific parts. The structure the `formatToParts()` method returns,
-looks like this:
-
-```js
-[
-  { type: "integer", value: "3" },
-  { type: "group", value: "." },
-  { type: "integer", value: "500" },
-];
-```
-
-Possible types are the following:
-
-- `compact`
-  - : The exponent in `"long"` or `"short"` form, depending on how `compactDisplay` (which defaults to `short`) is specified when `notation` is set to `compact`.
-- `currency`
-  - : The currency string, such as the symbols "$" and "€" or the name "Dollar", "Euro", depending on how `currencyDisplay` is specified.
-- `decimal`
-  - : The decimal separator string (".").
-- `exponentInteger`
-  - : The exponent integer value, when `notation` is set to `scientific` or `engineering`.
-- `exponentMinusSign`
-  - : The exponent minus sign string ("-").
-- `exponentSeparator`
-  - : The exponent separator, when `notation` is set to `scientific` or `engineering`.
-- `fraction`
-  - : The fraction number.
-- `group`
-  - : The group separator string (",").
-- `infinity`
-  - : The {{jsxref("Infinity")}} string ("∞").
-- `integer`
-  - : The integer number.
 - `literal`
-  - : Any literal strings or whitespace in the formatted number.
-- `minusSign`
-  - : The minus sign string ("-").
+  - : Any string that's a part of the format pattern; for example `" "`. Note that common tokens like the decimal separator or the plus/minus signs have their own token types.
+- `integer`
+  - : The integral part of the number, or a segment of it if using grouping (controlled by `options.useGrouping`).
+- `group`
+  - : The group separator string, such as `","`. Only present when using grouping (controlled by `options.useGrouping`).
+- `decimal`
+  - : The decimal separator string, such as `"."`. Only present when `fraction` is present.
+- `fraction`
+  - : The fractional part of the number.
+- `compact`
+  - : The compact exponent, such as `"M"` or `"thousands"`. Only present when `options.notation` is `"compact"`. The form (`"short"` or `"long"`) can be controlled via `options.compactDisplay`.
+- `exponentSeparator`
+  - : The exponent separator, such as `"E"`. Only present when `options.notation` is `"scientific"` or `"engineering"`.
+- `exponentMinusSign`
+  - : The exponent minus sign string, such as `"-"`. Only present when `options.notation` is `"scientific"` or `"engineering"` and the exponent is negative.
+- `exponentInteger`
+  - : The exponent's integer value. Only present when `options.notation` is `"scientific"` or `"engineering"`.
 - `nan`
-  - : The {{jsxref("NaN")}} string ("NaN").
+  - : A string representing {{jsxref("NaN")}}, such as `"NaN"`. This is the sole token representing the number itself when the number is `NaN`.
+- `infinity`
+  - : A string representing {{jsxref("Infinity")}} or `-Infinity`, such as `"∞"`. This is the sole token representing the number itself when the number is `Infinity` or `-Infinity`.
 - `plusSign`
-  - : The plus sign string ("+").
+  - : The plus sign, such as `"+"`.
+- `minusSign`
+  - : The minus sign, such as `"-"`.
 - `percentSign`
-  - : The percent sign string ("%").
+  - : The percent sign, such as `"%"`. Only present when `options.style` is `"percent"`.
 - `unit`
-  - : The unit string, such as the "l" or "litres", depending on how `unitDisplay` is specified.
+  - : The unit string, such as `"l"` or `"litres"`. Only present when `options.style` is `"unit"`. The form (`"short"`, `"narrow"`, or `"long"`) can be controlled via `options.unitDisplay`.
+- `currency`
+  - : The currency string, such as `"$"`, `"€"`, `"Dollar"`, or `"Euro"`. Only present when `options.style` is `"currency"`. The form (`"code"`, `"symbol"`, `"narrowSymbol"`, or `"name"`) can be controlled via `options.currencyDisplay`.
 - `unknown`
-  - : The string for `unknown` type results.
+  - : Reserved for any token that's not recognized as one of the above; should be rarely encountered.
 
 ## Examples
 
-### Comparing format and formatToParts
+### Using formatToParts()
 
-`NumberFormat` outputs localized, opaque strings that cannot be manipulated
-directly:
+The `format()` method outputs localized, opaque strings that cannot be manipulated directly:
 
 ```js
 const number = 3500;
@@ -98,10 +79,7 @@ formatter.format(number);
 // "3.500,00 €"
 ```
 
-However, in many User Interfaces there is a desire to customize the formatting of this
-string. The `formatToParts` method enables locale-aware formatting of
-strings produced by `NumberFormat` formatters by providing you the string
-in parts:
+However, in many user interfaces you may want to customize the formatting of this string, or interleave it with other texts. The `formatToParts()` method produces the same information in parts:
 
 ```js
 formatter.formatToParts(number);
@@ -118,11 +96,7 @@ formatter.formatToParts(number);
 ];
 ```
 
-Now the information is available separately and it can be formatted and concatenated
-again in a customized way. For example by using {{jsxref("Array.prototype.map()")}},
-[arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions),
-a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch),
-[template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals), and {{jsxref("Array.prototype.reduce()")}}.
+Now the information is available separately and it can be formatted and concatenated again in a customized way. For example by using {{jsxref("Array.prototype.map()")}}, [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch), [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals), and {{jsxref("Array.prototype.join()")}}, to insert additional markup for certain components.
 
 ```js
 const numberString = formatter
@@ -135,12 +109,8 @@ const numberString = formatter
         return value;
     }
   })
-  .reduce((string, part) => string + part);
-```
+  .join("");
 
-This will make the currency bold, when using the `formatToParts()` method.
-
-```js
 console.log(numberString);
 // "3.500,00 <strong>€</strong>"
 ```
@@ -157,4 +127,3 @@ console.log(numberString);
 
 - {{jsxref("Intl.NumberFormat")}}
 - {{jsxref("Intl/NumberFormat/format", "Intl.NumberFormat.prototype.format()")}}
-- {{jsxref("Intl/DateTimeFormat/formatToParts", "Intl.DateTimeFormat.prototype.formatToParts()")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.formatToParts
 
 {{JSRef}}
 
-The **`formatToParts()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.
+The **`formatToParts()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/RelativeTimeFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-formattoparts.html")}}
 
@@ -26,15 +26,13 @@ formatToParts(value, unit)
 
 ### Return value
 
-An {{jsxref("Array")}} of objects containing the formatted relative time in parts.
+An {{jsxref("Array")}} of objects containing the formatted relative time in parts. Each object has two or three properties, `type`, `value`, and optionally `unit`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/RelativeTimeFormat/format", "format()")}}. The parts can be thought of as directly obtained from calling {{jsxref("Intl/NumberFormat/formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}} with the numeric value, passing only the `numberingSystem` option, and then adding additional `type: "literal"` tokens, such as `"in "`, `" days ago"`, etc. All tokens that are produced by the `NumberFormat` have an additional `unit` property, which is the singular form of the input `unit`; this is for programmatic usage and is not localized. The localized unit is output as a part of a literal token.
 
-## Description
-
-The `Intl.RelativeTimeFormat.prototype.formatToParts` method is a version of the format method which it returns an array of objects which represent "parts" of the object, separating the formatted number into its constituent parts and separating it from other surrounding text. These objects have two properties: type a `NumberFormat` formatToParts type, and value, which is the String which is the component of the output. If a "part" came from `NumberFormat`, it will have a unit property which indicates the unit being formatted; literals which are part of the larger frame will not have this property.
+When `options.numeric` is `"auto"`, and there's a special string for the value, the returned array is a single literal token.
 
 ## Examples
 
-### Using formatToParts
+### Using formatToParts()
 
 ```js
 const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
@@ -62,3 +60,4 @@ rtf.formatToParts(100, "day");
 ## See also
 
 - {{jsxref("Intl.RelativeTimeFormat")}}
+- {{jsxref("Intl/RelativeTimeFormat/format", "Intl.RelativeTimeFormat.prototype.format()")}}


### PR DESCRIPTION
### Description
This pull request corrects a JavaScript mistake in the [Named Years and Mixed Calendars](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts#named_years_and_mixed_calendars) section of MDN Web Docs. Specifically, it updates the code examples to properly handle formatting options for the Chinese calendar using Intl.DateTimeFormat.

### Motivation
The current example contains an error that may lead to confusion or incorrect usage when developers work with named years and mixed calendar formats. Correcting this example ensures clarity and accuracy for MDN readers, helping them better understand the behavior of Intl.DateTimeFormat.

### Related issues and pull requests
Fixes : #37609 