### PR TITLE
Show nested items in CSSRef + Glossary sidebar

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -97,6 +97,7 @@ sidebar:
     title: Functions
     tags: css-function
     details: closed
+    depth: 2
   - type: listSubPages
     path: /Web/CSS
     title: Types

--- a/files/sidebars/glossarysidebar.yaml
+++ b/files/sidebars/glossarysidebar.yaml
@@ -6,3 +6,5 @@ sidebar:
     title: Glossary
   - type: listSubPages
     path: /Glossary
+    depth: 2
+    nested: true


### PR DESCRIPTION
### Description

Shows nested items in the `CSSRef` and `Glossary` sidebars.

### Motivation

Fixes https://github.com/mdn/rari/issues/73.

### Additional details

Tested locally by running `yarn start:rari`:

<img width="703" alt="image" src="https://github.com/user-attachments/assets/a4191865-ddaf-4837-8ec5-aa1d2e3bd6d6" />

<img width="703" alt="image" src="https://github.com/user-attachments/assets/07b632b6-59c8-4eba-8a12-296e5e2032f2" />

### Related issues and pull requests

See: https://github.com/mdn/rari/pull/78
