### PR TITLE
Update example to use type="time" instead of type="number"

### DIFF
--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -284,7 +284,7 @@ In this example, we create an interface element for choosing time using the nati
 ### CSS
 
 ```css
-input[type="number"] {
+input[type="time"] {
   width: 100px;
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

For the example around modifying a time input, the type should be "time", not "number" in order for the CSS to be applied correctly.

### Motivation

The example doesn't work as described.

### Additional details

N/A

### Related issues and pull requests

N/A