### PR TITLE
Fix typo in Browsing the web

### DIFF
--- a/files/en-us/learn_web_development/getting_started/environment_setup/browsing_the_web/index.md
+++ b/files/en-us/learn_web_development/getting_started/environment_setup/browsing_the_web/index.md
@@ -208,7 +208,7 @@ As a result, you need to be careful to check the answers they give you, and not 
 
   - Typing in `"ant fish cheese"` (with the quotes) will only return results that contain that exact phrase.
   - `"ant cheese" -fish` will return results that contain `ant` and/or `cheese` but not `fish`.
-  - `and OR cheese` will only return results with one term or the other, not both. From our testing, this one only seemed to work effectively in Google.
+  - `ant OR cheese` will only return results with one term or the other, not both. From our testing, this one only seemed to work effectively in Google.
   - `intitle:cheese` will only return results that have "cheese" in the main title of the page.
 
   > [!NOTE]


### PR DESCRIPTION
### Description

Fixed typo in [Browsing the web](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Browsing_the_web) article in Learn. 

### Motivation

Just was reading the docs and stumbled on a small typo.

### Additional details

> Typing in a plain search term such as `ant fish cheese` will return results that contain any combination of those words...
> `and OR cheese` will only return results with one term or the other, not both.

`and OR cheese` -> `ant OR cheese`
