### PR TITLE
Add descriptor requirement to `@font-palette-values`

### DIFF
--- a/files/en-us/web/css/@font-palette-values/index.md
+++ b/files/en-us/web/css/@font-palette-values/index.md
@@ -25,7 +25,7 @@ The [&lt;dashed-ident&gt;](/en-US/docs/Web/CSS/dashed-ident) is a user defined i
 ### Descriptors
 
 - {{cssxref("@font-palette-values/base-palette", "base-palette")}}
-  - : Specifies the name or index of the base-palette, created by the font-maker, to use.
+  - : Specifies the name or index of the base-palette, created by the font-maker, to use. It is required for the @font-palette-values rule to be valid.
 - {{cssxref("@font-palette-values/font-family", "font-family")}}
   - : Specifies the name of the font family that this palette can be applied to.
 - {{cssxref("@font-palette-values/override-colors", "override-colors")}}

--- a/files/en-us/web/css/@font-palette-values/index.md
+++ b/files/en-us/web/css/@font-palette-values/index.md
@@ -25,9 +25,9 @@ The [&lt;dashed-ident&gt;](/en-US/docs/Web/CSS/dashed-ident) is a user defined i
 ### Descriptors
 
 - {{cssxref("@font-palette-values/base-palette", "base-palette")}}
-  - : Specifies the name or index of the base-palette, created by the font-maker, to use. It is required for the @font-palette-values rule to be valid.
+  - : Specifies the name or index of the base-palette, created by the font-maker, to use.
 - {{cssxref("@font-palette-values/font-family", "font-family")}}
-  - : Specifies the name of the font family that this palette can be applied to.
+  - : Specifies the name of the font family that this palette can be applied to. It is required for the @font-palette-values rule to be valid.
 - {{cssxref("@font-palette-values/override-colors", "override-colors")}}
   - : Specifies the colors in the base palette to override.
 

--- a/files/en-us/web/css/@font-palette-values/index.md
+++ b/files/en-us/web/css/@font-palette-values/index.md
@@ -27,7 +27,7 @@ The [&lt;dashed-ident&gt;](/en-US/docs/Web/CSS/dashed-ident) is a user defined i
 - {{cssxref("@font-palette-values/base-palette", "base-palette")}}
   - : Specifies the name or index of the base-palette, created by the font-maker, to use.
 - {{cssxref("@font-palette-values/font-family", "font-family")}}
-  - : Specifies the name of the font family that this palette can be applied to. It is required for the @font-palette-values rule to be valid.
+  - : Specifies the name of the font family that this palette can be applied to. A `font-family` name is required for the `@font-palette-values` rule to be valid.
 - {{cssxref("@font-palette-values/override-colors", "override-colors")}}
   - : Specifies the colors in the base palette to override.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a missing requirement.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Clarifies the spec:

> @font-palette-values rules require a font-family descriptor; if it is missing, the @font-palette-values rule is invalid and must be ignored entirely.
[CSS Fonts Module Level 4](https://drafts.csswg.org/css-fonts/#at-ruledef-font-palette-values)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The wording follows the same style as the description for the [`@font-face` `src` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#descriptors).



### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
