### PR TITLE
Add descriptor requirement to `@font-face`

### DIFF
--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -31,23 +31,23 @@ The **`@font-face`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At
 - {{cssxref("@font-face/font-display", "font-display")}}
   - : Determines how a font face is displayed based on whether and when it is downloaded and ready to use.
 - {{cssxref("@font-face/font-family", "font-family")}}
-  - : Specifies a name that will be used as the font face value for font properties. It is required for the @font-face rule to be valid.
+  - : Specifies a name that will be used as the font face value for font properties. A `font-family` name is required for the `@font-face` rule to be valid.
 - {{cssxref("@font-face/font-stretch", "font-stretch")}}
-  - : A {{cssxref("font-stretch")}} value. Accepts two values to specify a range that is supported by a font-face, for example `font-stretch: 50% 200%;`
+  - : A {{cssxref("font-stretch")}} value. Accepts two values to specify a range that is supported by a font face, for example `font-stretch: 50% 200%;`
 - {{cssxref("@font-face/font-style", "font-style")}}
-  - : A {{cssxref("font-style")}} value. Accepts two values to specify a range that is supported by a font-face, for example `font-style: oblique 20deg 50deg;`
+  - : A {{cssxref("font-style")}} value. Accepts two values to specify a range that is supported by a font face, for example `font-style: oblique 20deg 50deg;`
 - {{cssxref("@font-face/font-weight", "font-weight")}}
-  - : A {{cssxref("font-weight")}} value. Accepts two values to specify a range that is supported by a font-face, for example `font-weight: 100 400;`
+  - : A {{cssxref("font-weight")}} value. Accepts two values to specify a range that is supported by a font face, for example `font-weight: 100 400;`
 - {{cssxref("@font-face/font-feature-settings", "font-feature-settings")}}
   - : Allows control over advanced typographic features in OpenType fonts.
 - {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}
-  - : Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values.
+  - : Allows low-level control over OpenType or TrueType font variations, by specifying the four-letter axis names of the features to vary, along with their variation values.
 - {{cssxref("@font-face/line-gap-override", "line-gap-override")}}
   - : Defines the line gap metric for the font.
 - {{cssxref("@font-face/size-adjust", "size-adjust")}}
   - : Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.
 - {{cssxref("@font-face/src", "src")}}
-  - : Specifies references to font resources including hints about the font format and technology. It is required for the @font-face rule to be valid.
+  - : Specifies references to font resources including hints about the font format and technology. A `src` is required for the `@font-face` rule to be valid.
 - {{cssxref("@font-face/unicode-range", "unicode-range")}}
   - : The range of Unicode code points to be used from the font.
 
@@ -58,9 +58,9 @@ It's common to use both `url()` and `local()` together, so that the user's insta
 If the `local()` function is provided, specifying a font name to look for on the user's device, and if the {{Glossary("user agent")}} finds a match, that local font is used. Otherwise, the font resource specified using the `url()` function is downloaded and used.
 
 Browsers attempt to load resources in their list declaration order, so usually `local()` should be written before `url()`. Both functions are optional, so a rule block containing only one or more `local()` without `url()` is possible.
-If a more specific fonts with `format()` or `tech()` values are desired, these should be listed _before_ versions that don't have these values, as the less-specific variant would otherwise be tried and used first.
+If more specific fonts with `format()` or `tech()` values are desired, these should be listed _before_ versions that don't have these values, as the less specific variant would otherwise be tried and used first.
 
-By allowing authors to provide their own fonts, `@font-face` makes it possible to design content without being limited to the so-called "web-safe" fonts (that is, the fonts which are so common that they're considered to be universally available). The ability to specify the name of a locally-installed font to look for and use makes it possible to customize the font beyond the basics while making it possible to do so without relying on an internet connection.
+By allowing authors to provide their own fonts, `@font-face` makes it possible to design content without being limited to the so-called "web-safe" fonts (that is, the fonts that are so common that they're considered to be universally available). The ability to specify the name of a locally-installed font to look for and use makes it possible to customize the font beyond the basics while making it possible to do so without relying on an internet connection.
 
 > [!NOTE]
 > Fallback strategies for loading fonts on older browsers are described in the [`src` descriptor page](/en-US/docs/Web/CSS/@font-face/src#specifying_fallbacks_for_older_browsers).

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -31,7 +31,7 @@ The **`@font-face`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At
 - {{cssxref("@font-face/font-display", "font-display")}}
   - : Determines how a font face is displayed based on whether and when it is downloaded and ready to use.
 - {{cssxref("@font-face/font-family", "font-family")}}
-  - : Specifies a name that will be used as the font face value for font properties.
+  - : Specifies a name that will be used as the font face value for font properties. It is required for the @font-face rule to be valid.
 - {{cssxref("@font-face/font-stretch", "font-stretch")}}
   - : A {{cssxref("font-stretch")}} value. Accepts two values to specify a range that is supported by a font-face, for example `font-stretch: 50% 200%;`
 - {{cssxref("@font-face/font-style", "font-style")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a missing requirement.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Clarifies the spec:

> [@font-face](https://drafts.csswg.org/css-fonts/#at-font-face-rule) rules require a font-family and src descriptor; if either of these are missing, the @\font-face rule must not be considered when performing the [font matching algorithm](https://drafts.csswg.org/css-fonts/#font-matching-algorithm).
[CSS Fonts Module Level 4](https://drafts.csswg.org/css-fonts/#at-font-face-rule)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The wording follows the same style as the description for the [`@font-face` `src` descriptor](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#descriptors).



### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
