### PR TITLE
Nonexistent menu items now return an error message

### DIFF
--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 136 that affect d
 
 ## Changes for add-on developers
 
+- {{WebExtAPIRef("menus.update")}} and {{WebExtAPIRef("menus.remove")}} and the aliases {{WebExtAPIRef("contextMenus.update")}} and {{WebExtAPIRef("contextMenus.remove")}} now reject with an error when the menu item doesn't exist, rather than returning `undefined` ([Firefox bug 1688743](https://bugzil.la/1688743)).
+
 ### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -58,7 +58,7 @@ This article provides information about the changes in Firefox 136 that affect d
 
 ## Changes for add-on developers
 
-- {{WebExtAPIRef("menus.update")}} and {{WebExtAPIRef("menus.remove")}} and the aliases {{WebExtAPIRef("contextMenus.update")}} and {{WebExtAPIRef("contextMenus.remove")}} now reject with an error when the menu item doesn't exist, rather than returning `undefined` ([Firefox bug 1688743](https://bugzil.la/1688743)).
+- {{WebExtAPIRef("menus.update")}} and {{WebExtAPIRef("menus.remove")}} and the aliases {{WebExtAPIRef("contextMenus.update")}} and {{WebExtAPIRef("contextMenus.remove")}} now reject with an error when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled. ([Firefox bug 1688743](https://bugzil.la/1688743)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Addresses the dev docs needed requirements of [Bug 1688743](https://bugzilla.mozilla.org/show_bug.cgi?id=1688743) menus.remove doesn't return an error when removing a non-existing menu item.

Adds a release note. Reference documentation already indicates that the relevant APIs should return an error message.

### Related issues and pull requests

Related to BCD note added in TBC
