### PR TITLE
FF135 Relnote: RTC{In|Out}boundRtpStreamStats.mid and outbound rid

### DIFF
--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -49,6 +49,8 @@ This article provides information about the changes in Firefox 135 that affect d
 
 #### Media, WebRTC, and Web Audio
 
+- The {{domxref("RTCOutboundRtpStreamStats.mid", "mid")}} and {{domxref("RTCOutboundRtpStreamStats.rid", "rid")}} properties of the {{domxref("RTCOutboundRtpStreamStats")}} interface, and the{{domxref("RTCOutboundRtpStreamStats.mid", "mid")}} property of the {{domxref("RTCInboundRtpStreamStats")}} interface are now supported. ([Firefox bug 1643001](https://bugzil.la/1643001)).
+
 #### Removals
 
 ### WebAssembly


### PR DESCRIPTION
FF135 implements `RTCOutboundRtpStreamStats.rid`,  `RTCOutboundRtpStreamStats.mid` and `RTCInboundRtpStreamStats.mid`. This adds a  (very simple) release note to that effect. 

Note that the links in the PR are waiting on other PRs to merge.

Related docs work can be tracked in #37513