### PR TITLE
RTCInboundRtpStreamStats.mid - add

### DIFF
--- a/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
@@ -26,6 +26,9 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
 - {{domxref("RTCInboundRtpStreamStats.lastPacketReceivedTimestamp", "lastPacketReceivedTimestamp")}}
   - : A {{domxref("DOMHighResTimeStamp")}} indicating the time at which the last packet was received for this source.
     The [`timestamp`](#timestamp) property, on the other hand, indicates the time at which the statistics object was generated.
+- {{domxref("RTCInboundRtpStreamStats.mid", "mid")}}
+  - : A string that uniquely identifies the pairing of source and destination of the transceiver's stream.
+    This is the value of the corresponding {{domxref("RTCRtpTransceiver.mid")}} unless that is null, in which case the statistic property is not present.
 - {{domxref("RTCInboundRtpStreamStats.nackCount", "nackCount")}}
   - : An integer value indicating the total number of Negative ACKnowledgement (NACK) packets this receiver has sent.
 - {{domxref("RTCInboundRtpStreamStats.packetsDuplicated", "packetsDuplicated")}}

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/mid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/mid/index.md
@@ -1,0 +1,24 @@
+---
+title: "RTCInboundRtpStreamStats: mid property"
+short-title: mid
+slug: Web/API/RTCInboundRtpStreamStats/mid
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_inbound-rtp.mid
+---
+
+{{APIRef("WebRTC")}}
+
+The **`mid`** property of the {{domxref("RTCInboundRtpStreamStats")}} dictionary is a string that contains the media id negotiated between the local and remote peers.
+This uniquely identifies the pairing of source and destination for the transceiver's stream.
+
+## Value
+
+The value of the corresponding {{domxref("RTCRtpTransceiver.mid")}}, unless that value is null, in which case this statistic property is not present.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
FF135 adds support for RTCInboundRtpStreamStats.mid`.

This adds docs for that property.

Related work for the FF135 release can be tracked in #37513

Note, I separately hope to update the rest of this interface, will circle back in a new PR.