### PR TITLE
Clarity change: replace "okay" with "not too hard"

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/what_went_wrong/index.md
+++ b/files/en-us/learn_web_development/core/scripting/what_went_wrong/index.md
@@ -34,7 +34,7 @@ When you built up the "Guess the number" game in the previous article, you may h
 
 Generally speaking, when you do something wrong in code, there are two main types of error that you'll come across:
 
-- **Syntax errors**: These are spelling errors in your code that actually cause the program not to run at all, or stop working part way through — you will usually be provided with some error messages too. These are usually okay to fix, as long as you are familiar with the right tools and know what the error messages mean!
+- **Syntax errors**: These are spelling errors in your code that actually cause the program not to run at all, or stop working part way through — you will usually be provided with some error messages too. These are usually not too hard to fix, as long as you are familiar with the right tools and know what the error messages mean!
 - **Logic errors**: These are errors where the syntax is actually correct but the code is not what you intended it to be, meaning that program runs successfully but gives incorrect results. These are often harder to fix than syntax errors, as there usually isn't an error message to direct you to the source of the error.
 
 Okay, so it's not quite _that_ simple — there are some other differentiators as you drill down deeper. But the above classifications will do at this early stage in your career. We'll look at both of these types going forward.


### PR DESCRIPTION
In the original sentence, "These are usually okay to fix, as long as you are familiar with the right tools and know what the error messages mean!", readers might understand 'okay' to mean 'allowable'. The sentence reads like "you probably won't cause a problem if you fix this issue" -- when I think it's actually meant to say "these issues probably aren't too difficult to fix".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
