### PR TITLE
PublicKeyCredential.getClientCapabilities - add

### DIFF
--- a/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
@@ -29,13 +29,13 @@ Values may include:
 
 - `ble`
   - : The authenticator may be used over [BLE (Bluetooth Low Energy)](https://en.wikipedia.org/wiki/Bluetooth_Low_Energy).
-- `hybrid`
+- `"hybrid"`
   - : The authenticator can be used over a combination of (often separate) data transport and proximity mechanisms. This supports, for example, authentication on a desktop computer using a smartphone.
-- `internal`
+- `"internal"`
   - : The authenticator is specifically bound to the client device (cannot be removed).
-- `nfc`
+- `"nfc"`
   - : The authenticator may be used over [NFC (Near Field Communication)](https://en.wikipedia.org/wiki/Near-field_communication).
-- `usb`
+- `"usb"`
   - : The authenticator can be contacted over USB.
 
 ## Examples

--- a/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
@@ -24,13 +24,19 @@ None.
 
 ### Return value
 
-An {{jsxref("Array")}} of strings representing the different transports supported by the authenticator, in lexicographical order. Values may include:
+An {{jsxref("Array")}} of strings representing the different transports supported by the authenticator, in lexicographical order.
+Values may include:
 
-- `"ble"`: The authenticator may be used over [BLE (Bluetooth Low Energy)](https://en.wikipedia.org/wiki/Bluetooth_Low_Energy).
-- `"hybrid"`: The authenticator can be used over a combination of (often separate) data transport and proximity mechanisms. This supports, for example, authentication on a desktop computer using a smartphone.
-- `"internal"`: The authenticator is specifically bound to the client device (cannot be removed).
-- `"nfc"`: The authenticator may be used over [NFC (Near Field Communication)](https://en.wikipedia.org/wiki/Near-field_communication).
-- `"usb"`: The authenticator can be contacted over USB.
+- `ble`
+  - : The authenticator may be used over [BLE (Bluetooth Low Energy)](https://en.wikipedia.org/wiki/Bluetooth_Low_Energy).
+- `hybrid`
+  - : The authenticator can be used over a combination of (often separate) data transport and proximity mechanisms. This supports, for example, authentication on a desktop computer using a smartphone.
+- `internal`
+  - : The authenticator is specifically bound to the client device (cannot be removed).
+- `nfc`
+  - : The authenticator may be used over [NFC (Near Field Communication)](https://en.wikipedia.org/wiki/Near-field_communication).
+- `usb`
+  - : The authenticator can be contacted over USB.
 
 ## Examples
 

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -36,19 +36,19 @@ get(options)
 
       - : A string indicating whether the user will be required to login for every visit to a client app. The value can be one of the following:
 
-        - `conditional`
+        - `"conditional"`
 
           - : Discovered credentials are presented to the user in a non-modal dialog box along with an indication of the origin requesting credentials. In practice, this means autofilling available credentials; see [Sign in with a passkey through form autofill](https://web.dev/articles/passkey-form-autofill) for more details of how this is used; {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}} also provides some useful information.
 
-        - `optional`
+        - `"optional"`
 
           - : If credentials can be handed over for a given operation without user mediation, they will be, enabling automatic reauthentication without user mediation. If user mediation is required, then the user agent will ask the user to authenticate. This value is intended for situations where you have reasonable confidence that a user won't be surprised or confused at seeing a login dialog box — for example on a site that doesn't automatically log users in, when a user has just clicked a "Login/Signup" button.
 
-        - `required`
+        - `"required"`
 
           - : The user will always be asked to authenticate, even if prevent silent access (see {{domxref("CredentialsContainer.preventSilentAccess()")}}) is set to `false`. This value is intended for situations where you want to force user authentication — for example if you want a user to reauthenticate when a sensitive operation is being performed (like confirming a credit card payment), or when switching users.
 
-        - `silent`
+        - `"silent"`
           - : The user will not be asked to authenticate. The user agent will automatically reauthenticate the user and log them in if possible. If consent is required, the promise will fulfill with `null`. This value is intended for situations where you would want to automatically sign a user in upon visiting a web app if possible, but if not, you don't want to present them with a confusing login dialog box. Instead, you'd want to wait for them to explicitly click a "Login/Signup" button.
 
         The default value is `"optional"`.

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -36,13 +36,20 @@ get(options)
 
       - : A string indicating whether the user will be required to login for every visit to a client app. The value can be one of the following:
 
-        - `"conditional"`: Discovered credentials are presented to the user in a non-modal dialog box along with an indication of the origin requesting credentials. In practice, this means autofilling available credentials; see [Sign in with a passkey through form autofill](https://web.dev/articles/passkey-form-autofill) for more details of how this is used; {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}} also provides some useful information.
+        - `conditional`
 
-        - `"optional"`: If credentials can be handed over for a given operation without user mediation, they will be, enabling automatic reauthentication without user mediation. If user mediation is required, then the user agent will ask the user to authenticate. This value is intended for situations where you have reasonable confidence that a user won't be surprised or confused at seeing a login dialog box — for example on a site that doesn't automatically log users in, when a user has just clicked a "Login/Signup" button.
+          - : Discovered credentials are presented to the user in a non-modal dialog box along with an indication of the origin requesting credentials. In practice, this means autofilling available credentials; see [Sign in with a passkey through form autofill](https://web.dev/articles/passkey-form-autofill) for more details of how this is used; {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}} also provides some useful information.
 
-        - `"required"`: The user will always be asked to authenticate, even if prevent silent access (see {{domxref("CredentialsContainer.preventSilentAccess()")}}) is set to `false`. This value is intended for situations where you want to force user authentication — for example if you want a user to reauthenticate when a sensitive operation is being performed (like confirming a credit card payment), or when switching users.
+        - `optional`
 
-        - `"silent"`: The user will not be asked to authenticate. The user agent will automatically reauthenticate the user and log them in if possible. If consent is required, the promise will fulfill with `null`. This value is intended for situations where you would want to automatically sign a user in upon visiting a web app if possible, but if not, you don't want to present them with a confusing login dialog box. Instead, you'd want to wait for them to explicitly click a "Login/Signup" button.
+          - : If credentials can be handed over for a given operation without user mediation, they will be, enabling automatic reauthentication without user mediation. If user mediation is required, then the user agent will ask the user to authenticate. This value is intended for situations where you have reasonable confidence that a user won't be surprised or confused at seeing a login dialog box — for example on a site that doesn't automatically log users in, when a user has just clicked a "Login/Signup" button.
+
+        - `required`
+
+          - : The user will always be asked to authenticate, even if prevent silent access (see {{domxref("CredentialsContainer.preventSilentAccess()")}}) is set to `false`. This value is intended for situations where you want to force user authentication — for example if you want a user to reauthenticate when a sensitive operation is being performed (like confirming a credit card payment), or when switching users.
+
+        - `silent`
+          - : The user will not be asked to authenticate. The user agent will automatically reauthenticate the user and log them in if possible. If consent is required, the promise will fulfill with `null`. This value is intended for situations where you would want to automatically sign a user in upon visiting a web app if possible, but if not, you don't want to present them with a confusing login dialog box. Instead, you'd want to wait for them to explicitly click a "Login/Signup" button.
 
         The default value is `"optional"`.
 

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -1,0 +1,101 @@
+---
+title: "PublicKeyCredential: getClientCapabilities() static method"
+short-title: getClientCapabilities()
+slug: Web/API/PublicKeyCredential/getClientCapabilities_static
+page-type: web-api-static-method
+browser-compat: api.PublicKeyCredential.getClientCapabilities_static
+---
+
+{{APIRef("Web Authentication API")}}{{securecontext_header}}
+
+The **`getClientCapabilities()`** static method of the {{domxref("PublicKeyCredential")}} interface returns a {{jsxref("Promise")}} that resolves with a {{jsxref("Map")}} that can be used to check whether or not particular WebAuthn Client capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported.
+
+If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
+However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
+
+For an extension the assumptions are the same, but note that generally if an extension is implemented the value will be `true`.
+Note however that even if the extension is supported by the client a particular authenticator may not support that extension, so RPs must not assume that this is a guarantee that the authenticator processing steps for that extension will be performed.
+If the key is not present for an extension then a Relying Party (RP) can't assume that client processing steps for that extension will be carried out by this client or that the extension will be forwarded to the authenticator.
+
+A WebAuthn Relying Party can evaluate these to offer appropriate workflows and experiences to users.
+
+## Syntax
+
+```js-nolint
+PublicKeyCredential.getClientCapabilities()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to a {{jsxref("Map")}} of client capability strings and a boolean indicating whether or not the corresponding capability or extension is supported.
+
+The client capability strings are:
+
+- `conditionalCreate`
+  - : The WebAuthn Client is capable of conditional mediation for registration ceremonies.
+- `conditionalGet`
+  - : The WebAuthn Client is capable of conditional mediation for authentication ceremonies.
+    This capability is equivalent to isConditionalMediationAvailable() resolving to true.
+- `hybridTransport`
+  - : The WebAuthn Client supports usage of the hybrid transport.
+- `passkeyPlatformAuthenticator`
+  - : The WebAuthn Client supports usage of a passkey platform authenticator, locally and/or via hybrid transport.
+- `userVerifyingPlatformAuthenticator`
+  - : The WebAuthn Client supports usage of a user-verifying platform authenticator.
+- `relatedOrigins`
+  - : The WebAuthn Client supports Related Origin Requests.
+- `signalAllAcceptedCredentials`
+  - : The WebAuthn Client supports signalAllAcceptedCredentials().
+- `signalCurrentUserDetails`
+  - : The WebAuthn Client supports signalCurrentUserDetails().
+- `signalUnknownCredential`
+  - : The WebAuthn Client supports signalUnknownCredential().
+
+The [web extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) strings are formatted by prefixing the [extension identifier](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#available_extensions) with the prefix `extension:`.
+For example, the key `extension.appid` can be used to check if the [`appid` extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appid) is supported.
+
+### Exceptions
+
+The returned {{jsxref("Promise")}} may be rejected with the following values:
+
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : The Web Authentication API is not allowed in the current browsing context.
+    For example, it might be blocked by a permission policy.
+
+## Examples
+
+<!--
+```js
+PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+  .then((available) => {
+    if (available) {
+      // We can proceed with the creation of a PublicKeyCredential
+      // with this authenticator
+    } else {
+      // Use another kind of authenticator or a classical login/password
+      // workflow
+    }
+  })
+  .catch((err) => {
+    // Something went wrong
+    console.error(err);
+  });
+```
+
+-->
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+<!--
+## See also
+-->

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -28,17 +28,18 @@ A {{jsxref("Promise")}} that resolves to an object where the property names are 
 
 The WebAuthn client capability strings are:
 
-- `conditionalCreate`
+- `"conditionalCreate"`
   - : The client is capable of creating [discoverable credentials](/en-US/docs/Web/API/Web_Authentication_API#discoverable_credentials_and_conditional_mediation).
-- `conditionalGet`
+- `"conditionalGet"`
   - : The client is capable of authenticating using [discoverable credentials](/en-US/docs/Web/API/Web_Authentication_API#discoverable_credentials_and_conditional_mediation).
     This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
-- `hybridTransport`
+- `"hybridTransport"`
   - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
     This means that the client can use authenticators that rely on Bluetooth, NFC or USB.
-- `passkeyPlatformAuthenticator`
+- `"passkeyPlatformAuthenticator"`
   - : The client allows usage of a passkey authenticator that supports multi-factor authentication mechanisms such as a PIN or biometric check.
-     The authenticator can part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
+     The authenticator can be part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
+     The credentials are stored on the authenticator.
      See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
 - `userVerifyingPlatformAuthenticator`
   - : The client has a platform authenticator (part of the same device) that support multi-factor authentication mechanisms, such as a PIN or biometric check.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -38,9 +38,9 @@ The WebAuthn client capability strings are:
     This means that the client can use authenticators that rely on Bluetooth, NFC or USB.
 - `"passkeyPlatformAuthenticator"`
   - : The client allows usage of a passkey authenticator that supports multi-factor authentication mechanisms such as a PIN or biometric check.
-     The authenticator can be part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
-     The credentials are stored on the authenticator.
-     See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
+    The authenticator can be part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
+    The credentials are stored on the authenticator.
+    See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
 - `userVerifyingPlatformAuthenticator`
   - : The client has a platform authenticator (part of the same device) that support multi-factor authentication mechanisms, such as a PIN or biometric check.
     The credentials may be stored on either the RP or the authenticator.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.PublicKeyCredential.getClientCapabilities_static
 
 The **`getClientCapabilities()`** static method of the {{domxref("PublicKeyCredential")}} interface returns a {{jsxref("Promise")}} that resolves with an object that can be used to check whether or not particular WebAuthn client capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported.
 
-A WebAuthn Relying Party can evaluate these to offer appropriate workflows and experiences to users.
+A web application can use the information to appropriately customize the user interface and workflows.
 
 ## Syntax
 
@@ -77,7 +77,7 @@ If the key is not present for an extension then a Relying Party (RP) can't assum
 
 ### Check all capabilities
 
-This example shows how iterate the capabilities and their values.
+This example shows how iterate get the capabilities object and iterates its values.
 
 ```html hidden
 <pre id="log"></pre>
@@ -122,8 +122,6 @@ async function checkClientCapabilities() {
     for (const [key, value] of Object.entries(capabilities)) {
       log(` ${key}: ${value}`);
     }
-
-    // You can further use these capabilities to adjust your WebAuthn flow.
   }
 }
 ```
@@ -143,41 +141,73 @@ if (typeof PublicKeyCredential.getClientCapabilities === "function") {
 
 #### Result
 
-{{EmbedLiveSample("Test", "", "400")}}
+{{EmbedLiveSample("Check all capabilities", "", "370")}}
 
-### Example 2 : A more workflow centric test
+### Test for user verifying platform authenticator
 
-<!--
-OK, so a real example showing a workflow modification.
-```js
-// Check for specific capabilities:
-if (capabilities.relatedOrigins) {
-  log("Related Origins are supported.");
-} else {
-  log("Related Origins are NOT supported.");
+This example checks a single capability `userVerifyingPlatformAuthenticator`, and might then use the result to configure the user interface.
+
+```html hidden
+<pre id="log"></pre>
+<button id="reset" type="button">Reset</button>
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+```
+
+```css hidden
+#log {
+  height: 130px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
 }
 ```
--->
 
-<!--
+#### JavaScript
+
+The code is similar to the previous example, except that we check a particular returned capability, and we use `try...catch` to catch the case where `getClientCapabilities()` is not supported.
+
 ```js
-PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-  .then((available) => {
-    if (available) {
-      // We can proceed with the creation of a PublicKeyCredential
-      // with this authenticator
+checkisUserVerifyingPlatformAuthenticatorAvailable();
+
+async function checkisUserVerifyingPlatformAuthenticatorAvailable() {
+  try {
+    const capabilities = await PublicKeyCredential.getClientCapabilities();
+
+    if (capabilities.userVerifyingPlatformAuthenticator) {
+      log("We can proceed with creation of a PublicKeyCredential (true)");
     } else {
-      // Use another kind of authenticator or a classical login/password
-      // workflow
+      log("userVerifyingPlatformAuthenticator not supported. Do fallback.");
     }
-  })
-  .catch((err) => {
-    // Something went wrong
-    console.error(err);
-  });
+  } catch (error) {
+    if (error instanceof TypeError) {
+      log(
+        "PublicKeyCredential.getClientCapabilities() is not supported on this browser.",
+      );
+    } else {
+      log(`Unexpected error: ${error}`);
+    }
+  }
+}
 ```
 
--->
+#### Result
+
+The log below displays either a string indicating the method is not supported, or one that indicates whether or not the `userVerifyingPlatformAuthenticator` is supported.
+
+{{EmbedLiveSample("Test for user verifying platform authenticator", "", "200")}}
 
 ## Specifications
 
@@ -189,4 +219,4 @@ PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
 
 ## See also
 
-[Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API)
+- [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API)

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -29,30 +29,32 @@ A {{jsxref("Promise")}} that resolves to an object where the property names are 
 The WebAuthn client capability strings are:
 
 - `conditionalCreate`
-  - : The client is capable of conditional mediation when creating/registering credentials.
+  - : The client is capable of creating [discoverable credentials](/en-US/docs/Web/API/Web_Authentication_API#discoverable_credentials_and_conditional_mediation).
 - `conditionalGet`
-  - : The client is capable of conditional mediation when authenticating credentials (using [`mediation=conditional`](/en-US/docs/Web/API/CredentialsContainer/get#conditional) in your [`get()`](/en-US/docs/Web/API/CredentialsContainer/get) call).
-    This means that the client supports workflows where the credentials can be silently fetched/auto-filled on sign in.
+  - : The client is capable of authenticating using [discoverable credentials](/en-US/docs/Web/API/Web_Authentication_API#discoverable_credentials_and_conditional_mediation).
     This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
 - `hybridTransport`
   - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
-    This means the the client can use authenticators that rely on Bluetooth, NFC or USB.
+    This means that the client can use authenticators that rely on Bluetooth, NFC or USB.
 - `passkeyPlatformAuthenticator`
   - : The client allows usage of a passkey authenticator that supports multi-factor authentication mechanisms such as a PIN or biometric check.
      The authenticator can part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
      See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
 - `userVerifyingPlatformAuthenticator`
-  - : The client supports usage of a user-verifying platform authenticator.
-    These require user input for authorization.
+  - : The client has a platform authenticator (part of the same device) that support multi-factor authentication mechanisms, such as a PIN or biometric check.
+     The credentials may be stored on either the RP or the authenticator.
 - `relatedOrigins`
   - : The client supports [Related Origin Requests](https://web.dev/articles/webauthn-related-origin-requests).
     These clients allow a passkey to be used across multiple sites that have the same origin.
 - `signalAllAcceptedCredentials`
   - : The client supports the [`PublicKeyCredential.signalAllAcceptedCredentials()`](/en-US/docs/Web/API/PublicKeyCredential/signalAllAcceptedCredentials_static) static method.
+     If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
 - `signalCurrentUserDetails`
   - : The client supports the [`PublicKeyCredential.signalCurrentUserDetails()`](/en-US/docs/Web/API/PublicKeyCredential/signalCurrentUserDetails_static) static method.
+     If not supported, then RP workflows will need to prompt the user to manuall update user details on the authenticator.  
 - `signalUnknownCredential`
   - : The client supports the [`PublicKeyCredential.signalUnknownCredential()`](/en-US/docs/Web/API/PublicKeyCredential/signalUnknownCredential_static) static method.
+     If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
 
 The [web extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) strings are formatted by prefixing the [extension identifier](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#available_extensions) with the prefix `extension:`.
 For example, the key `extension.appid` can be used to check if the [`appid` extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appid) is supported.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -77,7 +77,7 @@ In this case the user might simply be offered a sign-in button in order to log i
 If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
 However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
 
-For an extension the assumptions are the same, but note that generally if an extension is implemented the value will be `true`.
+For an extension the assumptions are the same.
 Note though, that even if the extension is supported by the client a particular authenticator may not support that extension, so RPs must not assume that this is a guarantee that the authenticator processing steps for that extension will be performed.
 If the key is not present for an extension then a Relying Party (RP) can't assume that client processing steps for that extension will be carried out by this client or that the extension will be forwarded to the authenticator.
 

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -43,19 +43,19 @@ The WebAuthn client capability strings are:
      See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
 - `userVerifyingPlatformAuthenticator`
   - : The client has a platform authenticator (part of the same device) that support multi-factor authentication mechanisms, such as a PIN or biometric check.
-     The credentials may be stored on either the RP or the authenticator.
+    The credentials may be stored on either the RP or the authenticator.
 - `relatedOrigins`
   - : The client supports [Related Origin Requests](https://web.dev/articles/webauthn-related-origin-requests).
     These clients allow a passkey to be used across multiple sites that have the same origin.
 - `signalAllAcceptedCredentials`
   - : The client supports the [`PublicKeyCredential.signalAllAcceptedCredentials()`](/en-US/docs/Web/API/PublicKeyCredential/signalAllAcceptedCredentials_static) static method.
-     If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
+    If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
 - `signalCurrentUserDetails`
   - : The client supports the [`PublicKeyCredential.signalCurrentUserDetails()`](/en-US/docs/Web/API/PublicKeyCredential/signalCurrentUserDetails_static) static method.
-     If not supported, then RP workflows will need to prompt the user to manuall update user details on the authenticator.  
+    If not supported, then RP workflows will need to prompt the user to manuall update user details on the authenticator.
 - `signalUnknownCredential`
   - : The client supports the [`PublicKeyCredential.signalUnknownCredential()`](/en-US/docs/Web/API/PublicKeyCredential/signalUnknownCredential_static) static method.
-     If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
+    If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
 
 The [web extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) strings are formatted by prefixing the [extension identifier](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#available_extensions) with the prefix `extension:`.
 For example, the key `extension.appid` can be used to check if the [`appid` extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appid) is supported.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.PublicKeyCredential.getClientCapabilities_static
 
 The **`getClientCapabilities()`** static method of the {{domxref("PublicKeyCredential")}} interface returns a {{jsxref("Promise")}} that resolves with an object that can be used to check whether or not particular WebAuthn client capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported.
 
-A web application can use the information to appropriately customize the user interface and workflows.
+A relying party (RP) can use this information to appropriately customize its sign-in and sign-up user interfaces and workflows.
 
 ## Syntax
 
@@ -66,30 +66,28 @@ The returned {{jsxref("Promise")}} may be rejected with the following values:
 
 ## Description
 
-The method allows you to check if a given capability or extension is supported, and use the information offer an appropriate user experience.
+`getClientCapabilities()` allows you to check if a given capability or extension is supported, and use the information to offer an appropriate user experience.
 
 For example, support for the `userVerifyingPlatformAuthenticator` capability indicates that biometrics such as a fingerprint sensor are allowed.
 A web application could use this to display a fingerprint icon if the capability is supported, or a password input if it is not.
 If biometric login is required, then it could instead provide notification that the site cannot authenticate using this browser or device.
-Similarly, `conditionalGet` indicates that the client supports conditional mediation when signing in a user, which allows for the browser to silently autofill credentials.
-In this case the user might simply be offered a sign-in button in order to log in to the site.
+Similarly, `conditionalGet` indicates that the client supports conditional mediation when signing in a user, which means the browser can provide autofilled discoverable credentials in a login form (for example an autocompeting text field or a drop-down list), along with a sign-in button.
 
-If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
-However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
+If the value of a given capability is present in the returned object, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
+However, if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
 
 For an extension the assumptions are the same.
 Note though, that even if the extension is supported by the client a particular authenticator may not support that extension, so RPs must not assume that this is a guarantee that the authenticator processing steps for that extension will be performed.
-If the key is not present for an extension then a Relying Party (RP) can't assume that client processing steps for that extension will be carried out by this client or that the extension will be forwarded to the authenticator.
+If the key is not present for an extension, an RP can't assume that the client processing steps for that extension will be carried out by this client, or that the extension will be forwarded to the authenticator.
 
 ## Examples
 
 ### Check all capabilities
 
-This example shows how to get the capabilities object and iterates its values.
+This example shows how to get the capabilities object and iterate its values.
 
 ```html hidden
 <pre id="log"></pre>
-<button id="reset" type="button">Reset</button>
 ```
 
 ```js hidden
@@ -98,12 +96,6 @@ function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
 }
-
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
 ```
 
 ```css hidden
@@ -153,7 +145,7 @@ if (typeof PublicKeyCredential.getClientCapabilities === "function") {
 
 ### Test for user verifying platform authenticator
 
-This example checks a single capability `userVerifyingPlatformAuthenticator`, and might then use the result to configure the user interface.
+This example checks a single capability, `userVerifyingPlatformAuthenticator`. A real application might use the result to configure the user interface.
 
 ```html hidden
 <pre id="log"></pre>

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -32,10 +32,11 @@ The WebAuthn client capability strings are:
   - : The client is capable of conditional mediation when creating/registering credentials.
 - `conditionalGet`
   - : The client is capable of conditional mediation when authenticating credentials (using [`mediation=conditional`](/en-US/docs/Web/API/CredentialsContainer/get#conditional) in your [`get()`](/en-US/docs/Web/API/CredentialsContainer/get) call).
-    This means that the client supports workflows where the credentials can be silently fetched/autofilled on sign in.
+    This means that the client supports workflows where the credentials can be silently fetched/auto-filled on sign in.
     This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
 - `hybridTransport`
   - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
+    This means the the client can use authenticators that rely on Bluetooth, NFC or USB.
 - `passkeyPlatformAuthenticator`
   - : The client supports usage of a passkey platform authenticator, locally and/or via hybrid transport.
     These authenticators enable passwordless multi-factor authentication, providing proof of possession of a credential private key provide and requiring a second authentication mechanism such as a PIN or biometric check.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -65,6 +65,9 @@ The returned {{jsxref("Promise")}} may be rejected with the following values:
 ## Description
 
 The method allows you to check if a given capability or extension is supported, and use the information offer an appropriate user experience.
+For example, support for the `userVerifyingPlatformAuthenticator` capability indicates that biometrics such as a fingerprint sensor are allowed.
+A web application could use this to display a fingerprint icon if the capability is supported, or a password input if it is not.
+If biometric login is required, then it could instead provide notification that the site cannot authenticate using this browser or device.
 
 If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
 However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
@@ -187,9 +190,9 @@ async function checkisUserVerifyingPlatformAuthenticatorAvailable() {
     const capabilities = await PublicKeyCredential.getClientCapabilities();
 
     if (capabilities.userVerifyingPlatformAuthenticator) {
-      log("We can proceed with creation of a PublicKeyCredential (true)");
+      log("Biometric login supported");
     } else {
-      log("userVerifyingPlatformAuthenticator not supported. Do fallback.");
+      log("Biometric login not supported. Do password.");
     }
   } catch (error) {
     if (error instanceof TypeError) {
@@ -203,9 +206,12 @@ async function checkisUserVerifyingPlatformAuthenticatorAvailable() {
 }
 ```
 
+Note that here we log the result of a check.
+In a real application we might update the user interface to show appropriate options for verifying the user.
+
 #### Result
 
-The log below displays either a string indicating the method is not supported, or one that indicates whether or not the `userVerifyingPlatformAuthenticator` is supported.
+The log below displays either a string indicating the method is not supported, or one that indicates whether biometric or password login is supported.
 
 {{EmbedLiveSample("Test for user verifying platform authenticator", "", "200")}}
 

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -130,7 +130,7 @@ Before calling the function we check that it is defined, and log the result.
 
 ```js
 // Call the function to check capabilities.
-if (typeof PublicKeyCredential.getClientCapabilities === "function") {
+if (PublicKeyCredential.getClientCapabilities) {
   checkClientCapabilities();
 } else {
   log(

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -35,30 +35,30 @@ The WebAuthn client capability strings are:
     This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
 - `"hybridTransport"`
   - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
-    This means that the client can use authenticators that rely on Bluetooth, NFC or USB.
+    This means that the client can use authenticators that rely on Bluetooth, NFC, or USB.
 - `"passkeyPlatformAuthenticator"`
   - : The client allows usage of a passkey authenticator that supports multi-factor authentication mechanisms such as a PIN or biometric check.
     The authenticator can be part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
     The credentials are stored on the authenticator.
     See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
 - `userVerifyingPlatformAuthenticator`
-  - : The client has a platform authenticator (part of the same device) that support multi-factor authentication mechanisms, such as a PIN or biometric check.
+  - : The client has a platform authenticator (part of the same device) that supports multi-factor authentication mechanisms, such as a PIN or biometric check.
     The credentials may be stored on either the RP or the authenticator.
 - `relatedOrigins`
   - : The client supports [Related Origin Requests](https://web.dev/articles/webauthn-related-origin-requests).
     These clients allow a passkey to be used across multiple sites that have the same origin.
 - `signalAllAcceptedCredentials`
   - : The client supports the [`PublicKeyCredential.signalAllAcceptedCredentials()`](/en-US/docs/Web/API/PublicKeyCredential/signalAllAcceptedCredentials_static) static method.
-    If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
+    If not supported, RP workflows will need to prompt the user to manually delete credentials on the authenticator.
 - `signalCurrentUserDetails`
   - : The client supports the [`PublicKeyCredential.signalCurrentUserDetails()`](/en-US/docs/Web/API/PublicKeyCredential/signalCurrentUserDetails_static) static method.
-    If not supported, then RP workflows will need to prompt the user to manuall update user details on the authenticator.
+    If not supported, RP workflows will need to prompt the user to manually update user details on the authenticator.
 - `signalUnknownCredential`
   - : The client supports the [`PublicKeyCredential.signalUnknownCredential()`](/en-US/docs/Web/API/PublicKeyCredential/signalUnknownCredential_static) static method.
-    If not supported, then RP workflows will need to prompt the user to manually delete credentials from the authenticator.
+    If not supported, RP workflows will need to prompt the user to manually delete credentials from the authenticator.
 
 The [web extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) strings are formatted by prefixing the [extension identifier](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#available_extensions) with the prefix `extension:`.
-For example, the key `extension.appid` can be used to check if the [`appid` extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appid) is supported.
+For example, the key `extension:appid` can be used to check if the [`appid` extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appid) is supported.
 
 ### Exceptions
 
@@ -75,7 +75,7 @@ The returned {{jsxref("Promise")}} may be rejected with the following values:
 For example, support for the `userVerifyingPlatformAuthenticator` capability indicates that biometrics such as a fingerprint sensor are allowed.
 A web application could use this to display a fingerprint icon if the capability is supported, or a password input if it is not.
 If biometric login is required, then it could instead provide notification that the site cannot authenticate using this browser or device.
-Similarly, `conditionalGet` indicates that the client supports conditional mediation when signing in a user, which means the browser can provide autofilled discoverable credentials in a login form (for example an autocompeting text field or a drop-down list), along with a sign-in button.
+Similarly, `conditionalGet` indicates that the client supports conditional mediation when signing in a user, which means the browser can provide auto-filled discoverable credentials in a login form (for example an autocompleting text field or a drop-down list), along with a sign-in button.
 
 If the value of a given capability is present in the returned object, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
 However, if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -32,6 +32,7 @@ The WebAuthn client capability strings are:
   - : The client is capable of conditional mediation when creating/registering credentials.
 - `conditionalGet`
   - : The client is capable of conditional mediation when authenticating credentials (using [`mediation=conditional`](/en-US/docs/Web/API/CredentialsContainer/get#conditional) in your [`get()`](/en-US/docs/Web/API/CredentialsContainer/get) call).
+    This means that the client supports workflows where the credentials can be silently fetched/autofilled on sign in.
     This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
 - `hybridTransport`
   - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
@@ -65,9 +66,12 @@ The returned {{jsxref("Promise")}} may be rejected with the following values:
 ## Description
 
 The method allows you to check if a given capability or extension is supported, and use the information offer an appropriate user experience.
+
 For example, support for the `userVerifyingPlatformAuthenticator` capability indicates that biometrics such as a fingerprint sensor are allowed.
 A web application could use this to display a fingerprint icon if the capability is supported, or a password input if it is not.
 If biometric login is required, then it could instead provide notification that the site cannot authenticate using this browser or device.
+Similarly, `conditionalGet` indicates that the client supports conditional mediation when signing in a user, which allows for the browser to silently autofill credentials.
+In this case the user might simply be offered a sign-in button in order to log in to the site.
 
 If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
 However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -38,8 +38,9 @@ The WebAuthn client capability strings are:
   - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
     This means the the client can use authenticators that rely on Bluetooth, NFC or USB.
 - `passkeyPlatformAuthenticator`
-  - : The client supports usage of a passkey platform authenticator, locally and/or via hybrid transport.
-    These authenticators enable passwordless multi-factor authentication, providing proof of possession of a credential private key provide and requiring a second authentication mechanism such as a PIN or biometric check.
+  - : The client allows usage of a passkey authenticator that supports multi-factor authentication mechanisms such as a PIN or biometric check.
+     The authenticator can part of the same platform (device) as the client, or connected via a hybrid transport such as Bluetooth or USB.
+     See [Passkeys developer guide for relying parties](https://developers.google.com/identity/passkeys/developer-guides).
 - `userVerifyingPlatformAuthenticator`
   - : The client supports usage of a user-verifying platform authenticator.
     These require user input for authorization.

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -85,7 +85,7 @@ If the key is not present for an extension then a Relying Party (RP) can't assum
 
 ### Check all capabilities
 
-This example shows how iterate get the capabilities object and iterates its values.
+This example shows how to get the capabilities object and iterates its values.
 
 ```html hidden
 <pre id="log"></pre>

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -100,7 +100,7 @@ function log(text) {
 
 ```css hidden
 #log {
-  height: 250px;
+  height: 230px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -141,7 +141,7 @@ if (typeof PublicKeyCredential.getClientCapabilities === "function") {
 
 #### Result
 
-{{EmbedLiveSample("Check all capabilities", "", "370")}}
+{{EmbedLiveSample("Check all capabilities", "", "280")}}
 
 ### Test for user verifying platform authenticator
 
@@ -149,7 +149,6 @@ This example checks a single capability, `userVerifyingPlatformAuthenticator`. A
 
 ```html hidden
 <pre id="log"></pre>
-<button id="reset" type="button">Reset</button>
 ```
 
 ```js hidden
@@ -158,17 +157,11 @@ function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
 }
-
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
 ```
 
 ```css hidden
 #log {
-  height: 130px;
+  height: 40px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -210,7 +203,7 @@ In a real application we might update the user interface to show appropriate opt
 
 The log below displays either a string indicating the method is not supported, or one that indicates whether biometric or password login is supported.
 
-{{EmbedLiveSample("Test for user verifying platform authenticator", "", "200")}}
+{{EmbedLiveSample("Test for user verifying platform authenticator", "", "90")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -8,14 +8,7 @@ browser-compat: api.PublicKeyCredential.getClientCapabilities_static
 
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 
-The **`getClientCapabilities()`** static method of the {{domxref("PublicKeyCredential")}} interface returns a {{jsxref("Promise")}} that resolves with a {{jsxref("Map")}} that can be used to check whether or not particular WebAuthn Client capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported.
-
-If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
-However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
-
-For an extension the assumptions are the same, but note that generally if an extension is implemented the value will be `true`.
-Note however that even if the extension is supported by the client a particular authenticator may not support that extension, so RPs must not assume that this is a guarantee that the authenticator processing steps for that extension will be performed.
-If the key is not present for an extension then a Relying Party (RP) can't assume that client processing steps for that extension will be carried out by this client or that the extension will be forwarded to the authenticator.
+The **`getClientCapabilities()`** static method of the {{domxref("PublicKeyCredential")}} interface returns a {{jsxref("Promise")}} that resolves with an object that can be used to check whether or not particular WebAuthn client capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported.
 
 A WebAuthn Relying Party can evaluate these to offer appropriate workflows and experiences to users.
 
@@ -31,29 +24,32 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a {{jsxref("Map")}} of client capability strings and a boolean indicating whether or not the corresponding capability or extension is supported.
+A {{jsxref("Promise")}} that resolves to an object where the property names are the client capability strings, and the values are boolean values that indicate whether or not the corresponding capability or extension is supported.
 
-The client capability strings are:
+The WebAuthn client capability strings are:
 
 - `conditionalCreate`
-  - : The WebAuthn Client is capable of conditional mediation for registration ceremonies.
+  - : The client is capable of conditional mediation when creating/registering credentials.
 - `conditionalGet`
-  - : The WebAuthn Client is capable of conditional mediation for authentication ceremonies.
-    This capability is equivalent to isConditionalMediationAvailable() resolving to true.
+  - : The client is capable of conditional mediation when authenticating credentials (using [`mediation=conditional`](/en-US/docs/Web/API/CredentialsContainer/get#conditional) in your [`get()`](/en-US/docs/Web/API/CredentialsContainer/get) call).
+    This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
 - `hybridTransport`
-  - : The WebAuthn Client supports usage of the hybrid transport.
+  - : The client supports usage of the [hybrid](/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports#hybrid) transport.
 - `passkeyPlatformAuthenticator`
-  - : The WebAuthn Client supports usage of a passkey platform authenticator, locally and/or via hybrid transport.
+  - : The client supports usage of a passkey platform authenticator, locally and/or via hybrid transport.
+    These authenticators enable passwordless multi-factor authentication, providing proof of possession of a credential private key provide and requiring a second authentication mechanism such as a PIN or biometric check.
 - `userVerifyingPlatformAuthenticator`
-  - : The WebAuthn Client supports usage of a user-verifying platform authenticator.
+  - : The client supports usage of a user-verifying platform authenticator.
+    These require user input for authorization.
 - `relatedOrigins`
-  - : The WebAuthn Client supports Related Origin Requests.
+  - : The client supports [Related Origin Requests](https://web.dev/articles/webauthn-related-origin-requests).
+    These clients allow a passkey to be used across multiple sites that have the same origin.
 - `signalAllAcceptedCredentials`
-  - : The WebAuthn Client supports signalAllAcceptedCredentials().
+  - : The client supports the [`PublicKeyCredential.signalAllAcceptedCredentials()`](/en-US/docs/Web/API/PublicKeyCredential/signalAllAcceptedCredentials_static) static method.
 - `signalCurrentUserDetails`
-  - : The WebAuthn Client supports signalCurrentUserDetails().
+  - : The client supports the [`PublicKeyCredential.signalCurrentUserDetails()`](/en-US/docs/Web/API/PublicKeyCredential/signalCurrentUserDetails_static) static method.
 - `signalUnknownCredential`
-  - : The WebAuthn Client supports signalUnknownCredential().
+  - : The client supports the [`PublicKeyCredential.signalUnknownCredential()`](/en-US/docs/Web/API/PublicKeyCredential/signalUnknownCredential_static) static method.
 
 The [web extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) strings are formatted by prefixing the [extension identifier](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#available_extensions) with the prefix `extension:`.
 For example, the key `extension.appid` can be used to check if the [`appid` extension](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appid) is supported.
@@ -66,7 +62,102 @@ The returned {{jsxref("Promise")}} may be rejected with the following values:
   - : The Web Authentication API is not allowed in the current browsing context.
     For example, it might be blocked by a permission policy.
 
+## Description
+
+The method allows you to check if a given capability or extension is supported, and use the information offer an appropriate user experience.
+
+If the value of a given capability is present in the map, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
+However if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.
+
+For an extension the assumptions are the same, but note that generally if an extension is implemented the value will be `true`.
+Note though, that even if the extension is supported by the client a particular authenticator may not support that extension, so RPs must not assume that this is a guarantee that the authenticator processing steps for that extension will be performed.
+If the key is not present for an extension then a Relying Party (RP) can't assume that client processing steps for that extension will be carried out by this client or that the extension will be forwarded to the authenticator.
+
 ## Examples
+
+### Check all capabilities
+
+This example shows how iterate the capabilities and their values.
+
+```html hidden
+<pre id="log"></pre>
+<button id="reset" type="button">Reset</button>
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+```
+
+```css hidden
+#log {
+  height: 250px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+First we await `getClientCapabilities()` to get an object containing the capabilities.
+We then iterate the object and log the result (logging code not shown):
+
+```js
+async function checkClientCapabilities() {
+  const capabilities = await PublicKeyCredential.getClientCapabilities();
+
+  if (capabilities) {
+    log("Client Capabilities:");
+
+    for (const [key, value] of Object.entries(capabilities)) {
+      log(` ${key}: ${value}`);
+    }
+
+    // You can further use these capabilities to adjust your WebAuthn flow.
+  }
+}
+```
+
+Before calling the function we check that it is defined, and log the result.
+
+```js
+// Call the function to check capabilities.
+if (typeof PublicKeyCredential.getClientCapabilities === "function") {
+  checkClientCapabilities();
+} else {
+  log(
+    "PublicKeyCredential.getClientCapabilities() is not supported on this browser.",
+  );
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Test", "", "400")}}
+
+### Example 2 : A more workflow centric test
+
+<!--
+OK, so a real example showing a workflow modification.
+```js
+// Check for specific capabilities:
+if (capabilities.relatedOrigins) {
+  log("Related Origins are supported.");
+} else {
+  log("Related Origins are NOT supported.");
+}
+```
+-->
 
 <!--
 ```js
@@ -96,6 +187,6 @@ PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
 
 {{Compat}}
 
-<!--
 ## See also
--->
+
+[Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API)

--- a/files/en-us/web/api/publickeycredential/index.md
+++ b/files/en-us/web/api/publickeycredential/index.md
@@ -34,7 +34,7 @@ The **`PublicKeyCredential`** interface provides information about a public key 
 ## Static methods
 
 - {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with a {{jsxref("Map")}} that can be used to check whether or not particular client capabilities are supported.
+  - : Returns a {{jsxref("Promise")}} that resolves with an object that can be used to check whether or not particular WebAuthn capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported
 - {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}}
   - : Returns a {{jsxref("Promise")}} which resolves to `true` if conditional mediation is available.
 - {{domxref("PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable_static", "PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()")}}

--- a/files/en-us/web/api/publickeycredential/index.md
+++ b/files/en-us/web/api/publickeycredential/index.md
@@ -33,6 +33,8 @@ The **`PublicKeyCredential`** interface provides information about a public key 
 
 ## Static methods
 
+- {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}}
+  - : Returns a {{jsxref("Promise")}} that resolves with a {{jsxref("Map")}} that can be used to check whether or not particular client capabilities are supported.
 - {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}}
   - : Returns a {{jsxref("Promise")}} which resolves to `true` if conditional mediation is available.
 - {{domxref("PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable_static", "PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()")}}

--- a/files/en-us/web/api/publickeycredential/index.md
+++ b/files/en-us/web/api/publickeycredential/index.md
@@ -34,7 +34,7 @@ The **`PublicKeyCredential`** interface provides information about a public key 
 ## Static methods
 
 - {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with an object that can be used to check whether or not particular WebAuthn capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported
+  - : Returns a {{jsxref("Promise")}} that resolves with an object that can be used to check whether or not particular WebAuthn capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) are supported.
 - {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}}
   - : Returns a {{jsxref("Promise")}} which resolves to `true` if conditional mediation is available.
 - {{domxref("PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable_static", "PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()")}}

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -124,7 +124,7 @@ The signup and login workflows can be customized based on the capabilities of th
 This can be used, for example, to check:
 
 - Client support for various authenticators such as passkeys or biometric user verification.
-- Whether the client supports methods to keep relying party and authenticator credentials in sync
+- Whether the client [supports methods to keep relying party and authenticator credentials in sync](/en-US/docs/Web/API/Web_Authentication_API#discoverable_credential_synchronization_methods).
 - Whether the client allows a single passkey to be used on different websites with the same origin.
 
 The code below shows how you might use `getClientCapabilities()` to check if the client supports authenticators that offer biometric user verification.

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -119,14 +119,17 @@ A typical authentication flow is as follows:
 
 ### Customizing workflows based on client capabilities
 
-The signup and login workflows can be customized based on the capabilities of the WebAuthn client (browser), which can be obtained using the {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} static method.
+The signup and login workflows can be customized based on the capabilities of the WebAuthn client (browser). The {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} static method can be used to query those capabilities; it returns an object where each key refers to a WebAuthn capability or extension, and each value is a boolean indicating support for that feature.
 
-This method returns an object with properties named for capabilities or WebAuthn extensions, where the corresponding value indicates whether the feature is supported.
-This can be used, for example, to check various kinds of authenticators that the client supports, such as passkeys or biometric user verification, whether the client supports methods to keep relying party and authenticator credentials in sync, or allow a single passkey to be used on different websites with the same origin.
+This can be used, for example, to check:
 
-The code below shows how you might use the method to check if the client supports authenticators that offer biometric user verification.
+- Client support for various authenticators such as passkeys or biometric user verification.
+- Whether the client supports methods to keep relying party and authenticator credentials in sync
+- Whether the client allows a single passkey to be used on different websites with the same origin.
+
+The code below shows how you might use `getClientCapabilities()` to check if the client supports authenticators that offer biometric user verification.
 Note that the actual actions performed depend on your site.
-For sites that _require_ biometric authentication you might replace the login UI with a page indicating that a different browser must be used.
+For sites that _require_ biometric authentication, you might replace the login UI with a message indicating that biometric authentication is needed, and the user should try a different browser or device.
 
 ```js
 async function checkisUserVerifyingPlatformAuthenticatorAvailable() {

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -117,6 +117,27 @@ A typical authentication flow is as follows:
 
 5. Once verified by the server, the authentication flow is considered successful.
 
+### Customizing workflows based on client capabilities
+
+The signup and login workflows can be customized based on the capabilities of the WebAuthn client (browser), which can be obtained using the {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} static method.
+
+This method returns an object with properties named for capabilities or WebAuthn extensions, where the corresponding value indicates whether the feature is supported.
+This can be used, for example, to check various kinds of authenticators that the client supports, such as passkeys or biometric user verification, whether the client supports methods to keep relying party and authenticator credentials in sync, or allow a single passkey to be used on different websites with the same origin.
+
+The code below shows how you might use the method to check if the client supports authenticators that offer biometric user verification.
+
+```js
+async function checkisUserVerifyingPlatformAuthenticatorAvailable() {
+  const capabilities = await PublicKeyCredential.getClientCapabilities();
+  // Check the capability: userVerifyingPlatformAuthenticator
+  if (capabilities.userVerifyingPlatformAuthenticator) {
+    log("Biometric login supported");
+  } else {
+    log("Biometric login not supported. Do password.");
+  }
+}
+```
+
 ## Controlling access to the API
 
 The availability of WebAuthn can be controlled using a [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy), specifying two directives in particular:

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -125,15 +125,17 @@ This method returns an object with properties named for capabilities or WebAuthn
 This can be used, for example, to check various kinds of authenticators that the client supports, such as passkeys or biometric user verification, whether the client supports methods to keep relying party and authenticator credentials in sync, or allow a single passkey to be used on different websites with the same origin.
 
 The code below shows how you might use the method to check if the client supports authenticators that offer biometric user verification.
+Note that the actual actions performed depend on your site.
+For sites that _require_ biometric authentication you might replace the login UI with a page indicating that a different browser must be used.
 
 ```js
 async function checkisUserVerifyingPlatformAuthenticatorAvailable() {
   const capabilities = await PublicKeyCredential.getClientCapabilities();
   // Check the capability: userVerifyingPlatformAuthenticator
   if (capabilities.userVerifyingPlatformAuthenticator) {
-    log("Biometric login supported");
+    // Perform actions if biometric support is possible
   } else {
-    log("Biometric login not supported. Do password.");
+    // Perform actions is biometric support is not possible.
   }
 }
 ```

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -136,9 +136,9 @@ async function checkisUserVerifyingPlatformAuthenticatorAvailable() {
   const capabilities = await PublicKeyCredential.getClientCapabilities();
   // Check the capability: userVerifyingPlatformAuthenticator
   if (capabilities.userVerifyingPlatformAuthenticator) {
-    // Perform actions if biometric support is possible
+    // Perform actions if biometric support is available
   } else {
-    // Perform actions is biometric support is not possible.
+    // Perform actions if biometric support is not available.
   }
 }
 ```


### PR DESCRIPTION
FF135 adds support for `PublicKeyCredential_getClientCapabilities()`. 

This adds API reference.

Perhaps also an update to the guide.

#37557 is a precondition for this

Related docs work can be tracked in #37516
