### PR TITLE
Lcp timing allow origin

### DIFF
--- a/files/en-us/web/api/largestcontentfulpaint/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/index.md
@@ -85,11 +85,11 @@ observer.observe({ type: "largest-contentful-paint", buffered: true });
 
 ### Cross-origin image render time
 
-For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property was originally `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} should be used as a fallback.
+For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property was originally `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} property should be used as a fallback.
 
-Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in threse situations. Check for [browser support](#browser_compatibility).
+Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in these situations. Check for [browser support](#browser_compatibility).
 
-To expose more accurate cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+To expose more accurate cross-origin render-time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
 For example, to allow `https://developer.mozilla.org` to see an accurate `renderTime`, the cross-origin resource should send:
 

--- a/files/en-us/web/api/largestcontentfulpaint/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/index.md
@@ -85,9 +85,13 @@ observer.observe({ type: "largest-contentful-paint", buffered: true });
 
 ### Cross-origin image render time
 
-For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property is `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} is exposed. To expose cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property was originally `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} should be used as a fallback.
 
-For example, to allow `https://developer.mozilla.org` to see `renderTime`, the cross-origin resource should send:
+Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in threse situations. Check for [browser support](#browser_compatibility).
+
+To expose more accurate cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see an accurate `renderTime`, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
@@ -34,11 +34,11 @@ observer.observe({ type: "largest-contentful-paint", buffered: true });
 
 ### Cross-origin image render time
 
-For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property was originally `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} should be used as a fallback.
+For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property was originally `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} property should be used as a fallback.
 
 Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in threse situations. Check for [browser support](#browser_compatibility).
 
-To expose more accurate cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+To expose more accurate cross-origin render-time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
 For example, to allow `https://developer.mozilla.org` to see an accurate `renderTime`, the cross-origin resource should send:
 

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
@@ -34,9 +34,13 @@ observer.observe({ type: "largest-contentful-paint", buffered: true });
 
 ### Cross-origin image render time
 
-For security reasons, the value of the `renderTime` property is `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} is exposed. To expose cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+For security reasons, the value of the {{domxref("LargestContentfulPaint.renderTime", "renderTime")}} property was originally `0` if the resource is a cross-origin request. Instead the {{domxref("LargestContentfulPaint.loadTime", "loadTime")}} should be used as a fallback.
 
-For example, to allow `https://developer.mozilla.org` to see `renderTime`, the cross-origin resource should send:
+Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in threse situations. Check for [browser support](#browser_compatibility).
+
+To expose more accurate cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see an accurate `renderTime`, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.md
@@ -47,9 +47,13 @@ observer.observe({ type: "element", buffered: true });
 
 ### Cross-origin image render time
 
-For security reasons, the value of the `renderTime` property is `0` if the resource is a cross-origin request. To expose cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+For security reasons, the value of the `renderTime` property was originally `0` if the resource is a cross-origin request. Instead the `loadTime` should be used as a fallback.
 
-For example, to allow `https://developer.mozilla.org` to see `renderTime`, the cross-origin resource should send:
+Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in threse situations. Check for [browser support](#browser_compatibility).
+
+To expose more accurate cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+
+For example, to allow `https://developer.mozilla.org` to see and accurate `renderTime`, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.md
@@ -47,13 +47,13 @@ observer.observe({ type: "element", buffered: true });
 
 ### Cross-origin image render time
 
-For security reasons, the value of the `renderTime` property was originally `0` if the resource is a cross-origin request. Instead the `loadTime` should be used as a fallback.
+For security reasons, the value of the `renderTime` property was originally `0` if the resource is a cross-origin request. Instead the `loadTime` property should be used as a fallback.
 
-Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in threse situations. Check for [browser support](#browser_compatibility).
+Browsers [may now expose a slightly coarsened render time](https://github.com/w3c/paint-timing/issues/104) in these situations. Check for [browser support](#browser_compatibility).
 
-To expose more accurate cross-origin render time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
+To expose more accurate cross-origin render-time information, the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header needs to be set.
 
-For example, to allow `https://developer.mozilla.org` to see and accurate `renderTime`, the cross-origin resource should send:
+For example, to allow `https://developer.mozilla.org` to see an accurate `renderTime`, the cross-origin resource should send:
 
 ```http
 Timing-Allow-Origin: https://developer.mozilla.org


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

There have been some recent changes to `renderTime` for LCP and Element Timing and Chrome is changing this for Chrome 133.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

See also:
- https://github.com/w3c/paint-timing/pull/105
- https://chromestatus.com/feature/5128261284397056

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

https://github.com/mdn/browser-compat-data/pull/25735

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
