### PR TITLE
feat(ci): Enable GHA scanning

### DIFF
--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,36 @@
+name: "CodeQL checks"
+
+on:
+  schedule:
+    - cron: "0 10 * * MON"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    if: github.repository == 'mdn/content'
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      # Don't cancel in-progress jobs if a matrix job fails
+      # We only have one matrix item (actions) for now
+      # fail-fast: false
+      matrix:
+        # Currently, we're only scanning GHA
+        language: ["actions"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### Description

Adds GHA code scanning via CodeQL. Disabling on push to `main`, on workflow dispatch and weekly cron instead.

### Motivation

Some actionable insights into security issues with actions.

### Additional details

Tested here: https://github.com/bsmth/workflow-demo/blob/main/.github/workflows/codeql.yml

* https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/
* https://github.blog/changelog/2024-12-17-find-and-fix-actions-workflows-vulnerabilities-with-codeql-public-preview/

