### PR TITLE
fix(workflows): unwrap if conditions

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -39,14 +39,14 @@ jobs:
           echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
 
       - name: Checkout HEAD
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
 
       - name: Get changed content from HEAD
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
@@ -62,21 +62,21 @@ jobs:
           git commit -m "Code from PR head"
 
       - name: Setup Node.js environment
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint and format markdown files
-        if: ${{ env.DIFF_DOCUMENTS }}
+        if: env.DIFF_DOCUMENTS
         run: |
           # Generate random delimiter
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -120,13 +120,13 @@ jobs:
           git diff
 
       - name: Setup reviewdog
-        if: ${{ env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' }}
+        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true'
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest
 
       - name: Suggest changes using diff
-        if: ${{ env.FILES_MODIFIED == 'true' }}
+        if: env.FILES_MODIFIED == 'true'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -141,7 +141,7 @@ jobs:
             -reporter=github-pr-review < "${TMPFILE}"
 
       - name: Add reviews for markdownlint errors
-        if: ${{ env.MD_LINT_FAILED == 'true' }}
+        if: env.MD_LINT_FAILED == 'true'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -154,7 +154,7 @@ jobs:
             -reporter="github-pr-review"
 
       - name: Fail if any issues pending
-        if: ${{ env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true' }}
+        if: env.FILES_MODIFIED == 'true' || env.MD_LINT_FAILED == 'true' || env.FM_LINT_FAILED == 'true'
         env:
           MD_LINT_FAILED: ${{ env.MD_LINT_FAILED }}
           FM_LINT_FAILED: ${{ env.FM_LINT_FAILED }}

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: "Download artifact"
         uses: actions/download-artifact@v4
@@ -26,18 +26,18 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Check for artifacts
-        if: ${{ hashFiles('build/') != '' }}
+        if: hashFiles('build/') != ''
         run: |
           echo "HAS_ARTIFACT=true" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         with:
           repository: mdn/yari
           path: yari
 
       - name: Install Python
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         id: setup-python
         uses: actions/setup-python@v5
         with:
@@ -45,7 +45,7 @@ jobs:
 
       # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
       - name: Load cached ~/.local
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         uses: actions/cache@v4
         with:
           path: ~/.local
@@ -54,14 +54,14 @@ jobs:
           key: dotlocal-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-0
 
       - name: Install Python poetry
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         uses: snok/install-poetry@v1.4
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Load cached venv
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
@@ -71,19 +71,19 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ steps.setup-python.outputs.python-version }}-0
 
       - name: Install poetry dependencies
-        if: ${{ env.HAS_ARTIFACT && steps.cached-poetry-dependencies.outputs.cache-hit != 'true' }}
+        if: env.HAS_ARTIFACT && steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           cd yari/deployer
           poetry install --no-interaction --no-root
 
       - name: Install Deployer
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         run: |
           cd yari/deployer
           poetry install --no-interaction
 
       - name: Deploy and analyze built content
-        if: ${{ env.HAS_ARTIFACT }}
+        if: env.HAS_ARTIFACT
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
 

--- a/.github/workflows/pr-test-new-ci.yml
+++ b/.github/workflows/pr-test-new-ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build changed content
         id: build-content
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         env:
           CONTENT_ROOT: ${{ github.workspace }}/files
 
@@ -119,7 +119,7 @@ jobs:
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
       - name: Merge static assets with built documents
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         run: |
           # Exclude the .map files, as they're used for debugging JS and CSS.
           rsync -a --exclude "*.map" node_modules/@mdn/yari/client/build/ $BUILD_OUT_ROOT
@@ -127,13 +127,13 @@ jobs:
           du -sh $BUILD_OUT_ROOT
 
       - uses: actions/upload-artifact@v4
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         with:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
 
       - name: Check changed files
-        if: ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_FILES
         run: |
           echo $GIT_DIFF_FILES
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -48,14 +48,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js environment
-        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages
-        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_CONTENT || env.GIT_DIFF_FILES
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build changed content
         id: build-content
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         env:
           CONTENT_ROOT: ${{ github.workspace }}/files
 
@@ -112,7 +112,7 @@ jobs:
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
       - name: Merge static assets with built documents
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         run: |
           # Exclude the .map files, as they're used for debugging JS and CSS.
           rsync -a --exclude "*.map" node_modules/@mdn/yari/client/build/ $BUILD_OUT_ROOT
@@ -120,13 +120,13 @@ jobs:
           du -sh $BUILD_OUT_ROOT
 
       - uses: actions/upload-artifact@v4
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: env.GIT_DIFF_CONTENT
         with:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
 
       - name: Check changed files
-        if: ${{ env.GIT_DIFF_FILES }}
+        if: env.GIT_DIFF_FILES
         run: |
           echo $GIT_DIFF_FILES
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Unwraps several `if` conditions in workflows.

### Motivation

CodeQL reports these, as the `${{ ... }}` is unnecessary and seem to cause conditions to be evaluated to true inadvertently in some cases.

### Additional details

See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#about-expressions

> You need to use specific syntax to tell GitHub to evaluate an expression rather than treat it as a string.
>
> `${{ <expression> }}`
>
> The exception to this rule is when you are using expressions in an `if` clause, where, optionally, you can usually omit `${{` and `}}`. For more information about `if` conditionals, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif).

### Related issues and pull requests

Noticed in https://github.com/mdn/content/pull/37766.