### PR TITLE
refactor(workflows): extract pr-test-legacy

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -7,7 +7,7 @@ name: PR review companion
 
 on:
   workflow_run:
-    workflows: ["PR Test"]
+    workflows: ["PR Test", "PR Test Legacy"]
     types:
       - completed
 

--- a/.github/workflows/pr-test-legacy.yml
+++ b/.github/workflows/pr-test-legacy.yml
@@ -4,7 +4,7 @@
 # This way, if the tests passed, you'll be able to review the built
 # pages on a public URL.
 
-name: PR Test
+name: PR Test Legacy
 
 on:
   pull_request:
@@ -92,19 +92,12 @@ jobs:
           # Playground
           REACT_APP_PLAYGROUND_BASE_HOST: mdnyalp.dev
 
-          # rari
-          LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
-          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
-
         run: |
           # The reason this script isn't in `package.json` is because
           # you don't need that script as a writer. It's only used in CI
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
-          echo Y|yarn rari update
-          ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $PWD/files#g")
-          yarn rari build --no-basic --json-issues --data-issues $ARGS
-          yarn yari-render-html
+          yarn build $GIT_DIFF_CONTENT
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT


### PR DESCRIPTION
### Description

Extract new `pr-test-legacy` workflow.

### Motivation

Variables are not passed to workflows that are triggered
by a pull request from a fork, so mdn/content#37766 did
not work as intended, and rari is always used for tests.
    
To mitigate this, we extract a new legacy test workflow,
that we can disable, or re-enable in case of rari issues.

### Additional details

Part of [MP-1851](https://mozilla-hub.atlassian.net/browse/MP-1851).

### Related issues and pull requests

Follow-up of https://github.com/mdn/content/pull/37766.
