### PR TITLE
Remove not-css-containemt module features

### DIFF
--- a/files/en-us/web/css/css_cascade/index.md
+++ b/files/en-us/web/css/css_cascade/index.md
@@ -5,6 +5,7 @@ page-type: css-module
 spec-urls:
   - https://drafts.csswg.org/css-cascade/
   - https://drafts.csswg.org/css-cascade-5/
+  - https://drafts.csswg.org/css-cascade-6/
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/css_conditional_rules/index.md
+++ b/files/en-us/web/css/css_conditional_rules/index.md
@@ -24,6 +24,12 @@ There are plans to further extend possible queries by adding the generalized con
 
 ## Reference
 
+### Properties
+
+- {{cssxref("container")}}
+- {{cssxref("container-name")}}
+- {{cssxref("container-type")}}
+
 ### At-rules
 
 - {{cssxref("@media")}}

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -20,9 +20,6 @@ Container queries are similar to dimension [media queries](/en-US/docs/Web/CSS/C
 ### Properties
 
 - {{cssxref("contain")}}
-- {{cssxref("container")}} shorthand
-  - {{cssxref("container-name")}}
-  - {{cssxref("container-type")}}
 - {{cssxref("content-visibility")}}
 
 ### At-rules and descriptors
@@ -87,7 +84,7 @@ Container queries are similar to dimension [media queries](/en-US/docs/Web/CSS/C
   - {{cssxref("@starting-style")}} at-rule
   - {{cssxref("transition-behavior")}} property
 
-- CSS box sizing module
+- [CSS box sizing](/en-US/docs/Web/CSS/CSS_box_sizing) module
 
   - {{CSSxRef("aspect-ratio")}} property
   - {{cssxref("contain-intrinsic-size")}} shorthand property

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -74,6 +74,12 @@ Container queries are similar to dimension [media queries](/en-US/docs/Web/CSS/C
 - [Layout and the containing block](/en-US/docs/Web/CSS/Containing_block)
 - [Block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 
+- [CSS conditional rules](/en-US/docs/Web/CSS/CSS_conditional_rules) module
+
+  - {{CSSxRef("container")}} property
+  - {{CSSxRef("container-name")}} property
+  - {{CSSxRef("container-type")}} property
+
 - [CSS media queries](/en-US/docs/Web/CSS/CSS_media_queries) module
 
   - {{cssxref("@media")}} at-rule
@@ -98,6 +104,7 @@ Container queries are similar to dimension [media queries](/en-US/docs/Web/CSS/C
   - [Using CSS counters](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) guide
 
 - [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) module
+
   - [CSS nesting at-rules](/en-US/docs/Web/CSS/CSS_nesting/Nesting_at-rules) guide
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`container-*` proeprties are of CSS Conditional Rules module, not of CSS Containment module

also add level-6 link for CSS Cascading and Inheritance module, which defines the `@scope` at-rule that is supported in many browsers

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
