### PR TITLE
Tone down X-Frame-Options warning

### DIFF
--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -2,15 +2,11 @@
 title: X-Frame-Options
 slug: Web/HTTP/Headers/X-Frame-Options
 page-type: http-header
-status:
-  - deprecated
 browser-compat: http.headers.X-Frame-Options
 ---
 
-{{HTTPSidebar}}{{deprecated_header}}
-
-> [!WARNING]
-> Instead of this header, use the {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} directive in a {{HTTPHeader("Content-Security-Policy")}} header.
+> [!NOTE]
+> For more comprehensive options than offered by this header, see the {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} directive in a {{HTTPHeader("Content-Security-Policy")}} header.
 
 The HTTP **`X-Frame-Options`** {{Glossary("response header")}} can be used to indicate whether a browser should be allowed to render a page in a {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("embed")}} or {{HTMLElement("object")}}. Sites can use this to avoid [clickjacking](/en-US/docs/Web/Security/Types_of_attacks#clickjacking) attacks, by ensuring that their content is not embedded into other sites.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

X-Frame-Options is not deprecated and it's perfectly fine to use this for simple use cases

See discussion at
https://github.com/mdn/browser-compat-data/pull/25663

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Suggesting this header should not be used is incorrect and risks sites downgrading their security. There are no plans from any browser to deprecate this.

It seems this header being seen as "obsolete" and therefore deprecated was due to a misreading of the spec (see https://github.com/whatwg/html/issues/10936).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Added in #35942 (FYI @wbamberg)

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
