### PR TITLE
Fix formal syntax on CSS repeat() page

### DIFF
--- a/files/en-us/web/css/repeat/index.md
+++ b/files/en-us/web/css/repeat/index.md
@@ -120,7 +120,7 @@ There is a fourth form, `<name-repeat>`, which is used to add line names to subg
 
 ## Formal syntax
 
-{{CSSSyntax}}
+{{CSSSyntaxRaw(`<track-repeat> <auto-repeat> <fixed-repeat> <name-repeat>`)}}
 
 ## Examples
 


### PR DESCRIPTION

### Description

Use CSSSyntaxRaw for `repeat()`

### Motivation

Content page can't show "Error: could not find syntax for this item"

### Related issues and pull requests


Fixes https://github.com/mdn/rari/issues/89


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
