### PR TITLE
Correct clickjacking description

### DIFF
--- a/files/en-us/web/security/practical_implementation_guides/clickjacking/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/clickjacking/index.md
@@ -10,11 +10,15 @@ The [Content Security Policy](/en-US/docs/Web/HTTP/CSP) [`frame-ancestors`](/en-
 
 ## Problem
 
-[Clickjacking](/en-US/docs/Web/Security/Attacks/Clickjacking) is an attack whereby malicious sites trick users into clicking links or UI elements by making them appear like a trusted site the user is familiar with. This is usually done by embedding part or all of the trusted site into the malicious site via an `<iframe>`. A button, link, or other UI feature is then positioned on top of that content to make the user think they are interacting with their trusted site, when in fact they are interacting with the malicious site.
+In a clickjacking attack, an attacker tricks a user into interacting with a trusted site in a way that they didn't intend.
+
+Typically, the attacker creates a decoy site which embeds the user's trusted site inside an {{htmlelement("iframe")}} element. The attacker's site hides the `<iframe>`, and aligns some decoy elements so they appear in the same place as elements in the trusted site that perform sensitive actions. When the user tries to interact with the decoy elements, they are inadvertently interacting with the trusted site instead, and may be tricked into performing actions with the trusted site which they did not intend.
+
+See [Clickjacking](/en-US/docs/Web/Security/Attacks/Clickjacking) for more details.
 
 ## Solution
 
-Use the HTTP headers as required:
+The main solution to clickjacking is to prevent the trusted site from being embedded in an `<iframe>`. There are two headers which can be used for this:
 
 - `Content-Security-Policy: frame-ancestors` is preferred as it provides more granular control over site embedding. It is however not supported in IE11 and earlier, pre-Chromium versions of Edge, Safari 9.1 (desktop), and Safari 9.2 (iOS).
 - `X-Frame-Options` is less granular, but it is supported in the older browser set listed above.
@@ -63,5 +67,6 @@ X-Frame-Options: DENY
 
 ## See also
 
+- [Clickjacking](/en-US/docs/Web/Security/Attacks/Clickjacking)
 - [Clickjacking Defense Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html) on `owasp.org`
 - [Clickjacking Attacks and How to Prevent Them](https://auth0.com/blog/preventing-clickjacking-attacks/) on `auth0.com` (2020)


### PR DESCRIPTION
The description in https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Clickjacking says that in a clickjacking attack the user interacts with the attacker's site, thinking that they are interacting with the target site:

> [Clickjacking](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Clickjacking) is an attack whereby malicious sites trick users into clicking links or UI elements by making them appear like a trusted site the user is familiar with. This is usually done by embedding part or all of the trusted site into the malicious site via an <iframe>. A button, link, or other UI feature is then positioned on top of that content to make the user think they are interacting with their trusted site, when in fact they are interacting with the malicious site.

I think this is backwards: in a clickjacking attack the user thinks they are interacting with the decoy site, doing something innocuous, but are actually interacting with the target site doing something consequential. See for instance https://auth0.com/blog/preventing-clickjacking-attacks/:

> The goal of a clickjacking attack is to trick unsuspecting website visitors into performing actions on another website (the target website). For example, a user may be attracted by a website that promises them an exceptional prize. When the user clicks a button to accept the prize, their click is instead used to purchase an item on an e-commerce website. Typically this attack is performed by hiding the target website's UI and arranging the visible UI so that the user isn't aware of clicking the target website. Due to this UI arrangement, this kind of attack is also known as UI redressing or UI redress attack.

or https://owasp.org/www-community/attacks/Clickjacking:

> For example, imagine an attacker who builds a web site that has a button on it that says “click here for a free iPod”. However, on top of that web page, the attacker has loaded an iframe with your mail account, and lined up exactly the “delete all messages” button directly on top of the “free iPod” button. The victim tries to click on the “free iPod” button but instead actually clicked on the invisible “delete all messages” button. In essence, the attacker has “hijacked” the user’s click, hence the name “Clickjacking”.