### PR TITLE
docs: Remove reference to houdini.how site

### DIFF
--- a/files/en-us/web/css/css_houdini/index.md
+++ b/files/en-us/web/css/css_houdini/index.md
@@ -42,8 +42,6 @@ Using {{cssxref("@property")}} however, we can declare the custom property with 
 
 A feature of Houdini is the {{domxref("Worklet")}}. A worklet is a module, written in JavaScript, that extends CSS using one of the Houdini APIs. You can see an example worklet on the {{domxref("PaintWorkletGlobalScope.registerPaint()")}} page. Once a worklet has been registered you can use it in CSS just like any other value. This means that even if you are not a JavaScript developer, you can access Houdini APIs by using worklets other people have created.
 
-The [Houdini.how](https://houdini.how/) website has a number of worklets that you can try on your own site.
-
 ## Reference
 
 ### CSS at-rule and descriptors


### PR DESCRIPTION
### Description

Removes a link to https://houdini.how as unfortunately Google has allowed the domain to lapse in the last couple of weeks and the repo associated with it has [been archived](https://github.com/GoogleChromeLabs/houdini.how) nearly a year ago. It seems unlikely to get back up.

### Motivation

It's a dead link.

### Additional details

Depending on the going practice here, The Internet Archive / Wayback Machine does have a number of snapshots that could be linked to instead.

### Related issues and pull requests

N/A
