### PR TITLE
FF135 Certificate Transparency

### DIFF
--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -34,7 +34,8 @@ This article provides information about the changes in Firefox 135 that affect d
 
 ### Security
 
-- [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) is a standard for ensuring that certificates are publicly disclosed before web browsers will trust them. Firefox now supports this feature on desktop versions (but not Android), affecting servers that use certificates issued by a certificate authority in Mozilla's Root CA Program.
+- [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) is a standard for ensuring that certificates are publicly disclosed before web browsers will trust them. Firefox now supports this feature on desktop versions (but not Android.
+  This affects servers that use certificates issued by a certificate authority in Mozilla's Root CA Program.
   ([Firefox bug 1938242](https://bugzil.la/1938242)).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -35,7 +35,7 @@ This article provides information about the changes in Firefox 135 that affect d
 ### Security
 
 - [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) is a standard for ensuring that certificates are publicly disclosed before web browsers will trust them. Firefox now supports this feature on desktop versions (but not Android.
-  This affects servers that use certificates issued by a certificate authority in Mozilla's Root CA Program.
+  This only affects servers that use certificates issued by a certificate authority in Mozilla's Root CA Program.
   ([Firefox bug 1938242](https://bugzil.la/1938242)).
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -34,7 +34,7 @@ This article provides information about the changes in Firefox 135 that affect d
 
 ### Security
 
-- [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) is a standard for ensuring that certificates are publicly disclosed before web browsers will trust them. Firefox now supports this feature on desktop versions (but not Android.
+- [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) is a standard for ensuring that certificates are publicly disclosed before web browsers will trust them. Firefox now supports this feature on desktop versions (but not Android).
   This only affects servers that use certificates issued by a certificate authority in Mozilla's Root CA Program.
   ([Firefox bug 1938242](https://bugzil.la/1938242)).
 

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -34,6 +34,9 @@ This article provides information about the changes in Firefox 135 that affect d
 
 ### Security
 
+- [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) is a standard for ensuring that certificates are publicly disclosed before web browsers will trust them. Firefox now supports this feature on desktop versions (but not Android), affecting servers that use certificates issued by a certificate authority in Mozilla's Root CA Program.
+  ([Firefox bug 1938242](https://bugzil.la/1938242)).
+
 #### Removals
 
 ### APIs

--- a/files/en-us/web/security/certificate_transparency/index.md
+++ b/files/en-us/web/security/certificate_transparency/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
 
-**Certificate Transparency** is an open framework designed to protect against and monitor for certificate mis-issuances. It's defined in [RFC 9162](https://www.rfc-editor.org/rfc/rfc9162). With certificate transparency, newly-issued certificates are 'logged' to publicly-run, often independent _CT logs_ — which maintain an append-only, cryptographically-assured record of issued TLS certificates.
+**Certificate Transparency** is an open framework designed to protect against and monitor for certificate mis-issuances. With certificate transparency, newly-issued certificates are 'logged' to publicly-run, often independent _CT logs_ — which maintain an append-only, cryptographically-assured record of issued TLS certificates.
 
 In this way, certificate authorities (CAs) can be subject to much greater public scrutiny and oversight. Potentially malicious certificates, such as those that violate the CA/B Forum _Baseline Requirements_, can be detected and revoked much more quickly. Browser vendors and root store maintainers are also empowered to make more informed decisions regarding problematic CAs that they may decide to distrust.
 
@@ -39,4 +39,15 @@ Chrome had previously required CT inclusion for _Extended Validation_ (EV) and S
 
 Apple [requires](https://support.apple.com/en-gb/103214) a varying number of SCTs in order for Safari and other servers to trust server certificates.
 
-Firefox desktop from version 135 requires CT log inclusion for all certificates issued by certificate authorities in Mozilla's Root CA Program. Firefox for Android does not currently require CT log inclusion.
+Firefox desktop from version 135 requires CT log inclusion for all certificates issued by certificate authorities in Mozilla's Root CA Program.
+Firefox for Android does not currently require CT log inclusion.
+
+## Specifications
+
+Browser implementations are based on the obsoleted specification {{rfc("6962","Certificate Transparency")}} (January 2025).
+The current specification is {{rfc("9162","Certificate Transparency Version 2.0")}}.
+
+## See also
+
+- [Apple's Certificate Transparency log program](https://support.apple.com/en-us/103703)
+- [Chrome's Certificate Transparency Log Policy](https://googlechrome.github.io/CertificateTransparency/log_policy.html)


### PR DESCRIPTION
FF135 provides support [Certificate Transparency](https://developer.mozilla.org/en-US/docs/Web/Security/Certificate_Transparency). This adds a release note and minor updates to the CT doc.

Fixes #35570

Related docs work can be tracked in #37811