### PR TITLE
HTTP `508` status fix format

### DIFF
--- a/files/en-us/web/http/status/508/index.md
+++ b/files/en-us/web/http/status/508/index.md
@@ -18,10 +18,6 @@ It was introduced as a fallback for cases where WebDAV clients do not support {{
 508 Loop Detected
 ```
 
-## Specifications
-
-{{Specifications}}
-
 ## Examples
 
 ### Infinite loop in WebDAV search
@@ -50,6 +46,10 @@ Content-Length: 72
   "Message": "Please check the resources for cyclic references and try again."
 }
 ```
+
+## Specifications
+
+{{Specifications}}
 
 ## See also
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/508
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/status/508/index.md
* Last commit: https://github.com/mdn/content/commit/f584f1b27f9f3b78c95122c560f5135866a87eb0
