### PR TITLE
FF135 Relnote: PublicKeyCredential.getClientCapabilities() supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -38,6 +38,9 @@ This article provides information about the changes in Firefox 135 that affect d
 
 ### APIs
 
+- The {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} static method is supported, allowing a web app to check if a browser enables particular [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions).
+  ([Firefox bug 1884466](https://bugzil.la/1884466)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -38,7 +38,7 @@ This article provides information about the changes in Firefox 135 that affect d
 
 ### APIs
 
-- The {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} static method is supported, allowing a web app to check if a browser enables particular [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions).
+- The {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} static method is supported, allowing a web app to check if a browser enables particular [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) capabilities and [extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions) without having to resort to user agent sniffing.
   ([Firefox bug 1884466](https://bugzil.la/1884466)).
 
 #### DOM


### PR DESCRIPTION
FF135 supports the static `PublicKeyCredential.getClientCapabilities()` method in https://bugzilla.mozilla.org/show_bug.cgi?id=1884466

This adds a release note. 

Related info can be tracked in #37516
