### PR TITLE
Bug-1833415 web_accessible_resources.matches clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -110,7 +110,12 @@ Each object must include a `"resources"` property and either a `"matches"` or `"
       <td>
         Optional. Defaults to <code>[]</code>, meaning that other websites cannot access the resource.
         <p>
-        A list of URL <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a> specifying the pages that can access the resources. Only the origin is used to match URLs. Origins include subdomain matching. Paths must be set to <code>/*</code>.
+        A list of URL <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a> specifying the pages that can access the resources. Only the origin is used to match URLs. However:
+        <ul>
+          <li>In Firefox and Safari, any path can be included.</li>
+          <li>In Chrome, the path must be set to <code>/*</code>.</li>
+        </ul>
+        Origins include subdomain matching.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description

Adds a note about the supported path values in Chrome, Firefox, and Safari for `web_accessible_resources.matches`.

### Related issues and pull requests

Addresses the dev-docs-needed request for [Bug 1833415](https://bugzilla.mozilla.org/show_bug.cgi?id=1833415) web_accessible_resources[].matches should only accept patterns with "/*"