### PR TITLE
fix(workflows/pr-check_redirects): validate with `content:legacy`

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Check redirects file(s)
         if: steps.filter.outputs.required_files == 'true'
-        run: yarn content validate-redirects en-us --strict
+        run: yarn content:legacy validate-redirects en-us --strict


### PR DESCRIPTION
### Description

Validate redirects with `content:legacy` for now.

### Motivation

The subcommand is not yet implemented in rari.

### Additional details

Reported by @bsmth via Discord.

### Related issues and pull requests

See: https://github.com/mdn/rari/issues/103
