### PR TITLE
Updating arguments.callee() as deprecated

### DIFF
--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -249,7 +249,7 @@ console.log(getScore()); // "Chamakh scored 5"
 A function can refer to and call itself. There are three ways for a function to refer to itself:
 
 1. The function's name
-2. [`arguments.callee`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)
+2. [`arguments.callee`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee) (This feature is deprecated)
 3. An in-scope variable that refers to the function
 
 For example, consider the following function definition:
@@ -263,7 +263,7 @@ const foo = function bar() {
 Within the function body, the following are all equivalent:
 
 1. `bar()`
-2. `arguments.callee()`
+2. `arguments.callee()` (not recommended)
 3. `foo()`
 
 A function that calls itself is called a _recursive function_. In some ways, recursion is analogous to a loop. Both execute the same code multiple times, and both require a condition (to avoid an infinite loop, or rather, infinite recursion in this case).


### PR DESCRIPTION
…precated

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Just mentioned that `arguments.callee()` was now deprecated
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I would have taken it for granted, and being new to JS, I would probably try using it, this avoids using a deprecated feature.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
