### PR TITLE
Suggest specifying font-size and margin-block on h1

### DIFF
--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -43,13 +43,19 @@ The HTML standard specifies that `<h1>` elements in a `<section>`, `<article>`, 
 To avoid getting smaller `<h1>`, and to avoid the rendering changing when browsers remove the special `<h1>` default styling, use the following style rule:
 
 ```css
-h1 { margin-block: 0.67em; font-size: 2em; }
+h1 {
+  margin-block: 0.67em;
+  font-size: 2em;
+}
 ```
 
 Alternatively, to avoid overwriting other style rules, use {{cssxref(":where()"}} which has zero specificity:
 
 ```css
-:where(h1) { margin-block: 0.67em; font-size: 2em; }
+:where(h1) {
+  margin-block: 0.67em;
+  font-size: 2em;
+}
 ```
 
 ## Accessibility

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -36,6 +36,22 @@ While using multiple `<h1>` elements on one page is allowed by the HTML standard
 
 Prefer using only one `<h1>` per page and [nest headings](#nesting) without skipping levels.
 
+### Specify `font-size` and `margin-block` on `<h1>`
+
+The HTML standard specifies that `<h1>` elements in a `<section>`, `<article>`, `<aside>`, or `<nav>` element should render as an `<h2>` (smaller {{cssxref("font-size")}} and {{cssxref("margin-block")}}), or as an `<h3>` if nested another level, and so on. There is a [proposal](https://github.com/whatwg/html/issues/7867) to remove this special default style, so that `<h1>` always has the same default style (as it was originally).
+
+To avoid getting smaller `<h1>`, and to avoid the rendering changing when browsers remove the special `<h1>` default styling, use the following style rule:
+
+```css
+h1 { margin-block: 0.67em; font-size: 2em; }
+```
+
+Alternatively, to avoid overwriting other style rules, use {{cssxref(":where()"}} which has zero specificity:
+
+```css
+:where(h1) { margin-block: 0.67em; font-size: 2em; }
+```
+
 ## Accessibility
 
 ### Navigation

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -36,7 +36,7 @@ While using multiple `<h1>` elements on one page is allowed by the HTML standard
 
 Prefer using only one `<h1>` per page and [nest headings](#nesting) without skipping levels.
 
-### Specifying a uniform font size  for `<h1>`
+### Specifying a uniform font size for `<h1>`
 
 The [HTML standard](https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings) specifies that `<h1>` elements in a `<section>`, `<article>`, `<aside>`, or `<nav>` element should render as an `<h2>` (smaller {{cssxref("font-size")}} with an adjusted {{cssxref("margin-block")}}), or as an `<h3>` if nested another level, and so on.
 

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -36,9 +36,12 @@ While using multiple `<h1>` elements on one page is allowed by the HTML standard
 
 Prefer using only one `<h1>` per page and [nest headings](#nesting) without skipping levels.
 
-### Specify `font-size` and `margin-block` on `<h1>`
+### Specifying a uniform font size  for `<h1>`
 
-The HTML standard specifies that `<h1>` elements in a `<section>`, `<article>`, `<aside>`, or `<nav>` element should render as an `<h2>` (smaller {{cssxref("font-size")}} and {{cssxref("margin-block")}}), or as an `<h3>` if nested another level, and so on. There is a [proposal](https://github.com/whatwg/html/issues/7867) to remove this special default style, so that `<h1>` always has the same default style (as it was originally).
+The [HTML standard](https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings) specifies that `<h1>` elements in a `<section>`, `<article>`, `<aside>`, or `<nav>` element should render as an `<h2>` (smaller {{cssxref("font-size")}} with an adjusted {{cssxref("margin-block")}}), or as an `<h3>` if nested another level, and so on.
+
+> [!NOTE]
+> There is a [proposal](https://github.com/whatwg/html/issues/7867) to remove this special default style, so that `<h1>` always has the same default style. This proposal is currently [implemented in Firefox Nightly](/en-US/docs/Mozilla/Firefox/Experimental_features#ua_styles_for_h1_nested_in_sectioning_elements).
 
 To ensure consistent `<h1>` rendering, use the following style rule:
 

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -40,7 +40,7 @@ Prefer using only one `<h1>` per page and [nest headings](#nesting) without skip
 
 The HTML standard specifies that `<h1>` elements in a `<section>`, `<article>`, `<aside>`, or `<nav>` element should render as an `<h2>` (smaller {{cssxref("font-size")}} and {{cssxref("margin-block")}}), or as an `<h3>` if nested another level, and so on. There is a [proposal](https://github.com/whatwg/html/issues/7867) to remove this special default style, so that `<h1>` always has the same default style (as it was originally).
 
-To avoid getting smaller `<h1>`, and to avoid the rendering changing when browsers remove the special `<h1>` default styling, use the following style rule:
+To ensure consistent `<h1>` rendering, use the following style rule:
 
 ```css
 h1 {
@@ -49,7 +49,7 @@ h1 {
 }
 ```
 
-Alternatively, to avoid overwriting other style rules, use {{cssxref(":where()"}} which has zero specificity:
+Alternatively, to avoid overwriting other style rules that target `<h1>` you can use {{cssxref(":where()"}}, which has zero specificity:
 
 ```css
 :where(h1) {


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/7867

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Add a new section to help developers avoid the special `h1` in `section` default styling.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

We're trying to remove the special default styling in the spec and in Firefox. Devtools will have a warning, but the warning should have a link to help developers know what to do and why. My plan is to link to this new section.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1937568

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
