### PR TITLE
Update German sidebars (2025-01)

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -137,7 +137,7 @@ sidebar:
       - /Web/CSS/CSS_colors/Relative_colors
       - /Web/CSS/CSS_colors/Using_color_wisely
       - link: /Web/Accessibility/Understanding_Colors_and_Luminance
-        title: Accessibility_Understanding_colors_and_luminance"
+        title: Accessibility_Understanding_colors_and_luminance
       - link: /Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
         title: Color_contrast
   - title: Columns
@@ -283,37 +283,53 @@ sidebar:
       - /Web/CSS/CSS_Backgrounds_and_Borders/Border-radius_generator
 l10n:
   de:
+    Beginners: Einsteiger-Tutorials
+    Styling_the_content: "Ihre erste Website: Das Styling des Inhalts"
+    CSS_styling_basics: Grundlagen des CSS-Stylings
+    CSS_text_styling: CSS-Textgestaltung
     CSS_layout: CSS-Layout
-    Combinators: Kombinatoren
     Guides: Leitfäden
     Animations: Animationen
+    "Accessibility_Understanding_colors_and_luminance": "Barrierefreiheit: Farbwerte verstehen"
+    Applying_color_to_HTML_elements: Farben auf HTML-Elemente anwenden
+    At-rules: At-Regeln
     Backgrounds_and_Borders: Hintergründe und Rahmen
     Resizing_background_images: Hintergrundbilder skalieren
+    "Box alignment": "Box-Ausrichtung"
     Box_alignment_in_block_layout: Box-Ausrichtung im Block-Layout
     Box_model: Box-Modell
     Colors: Farben
     Color_contrast: "Barrierefreiheit: Farbkontrast"
+    Color_values: "CSS-Farbwerte"
     Columns: Spalten
+    Combinators: Kombinatoren
     Conditional_rules: Bedingte Regeln
     Containment: Containment
     CSSOM_view: CSSOM-Ansicht
     Flexbox: Flexbox
     Flow_layout: Fluss-Layout
     Fonts: Schriftarten
+    Functions: Funktionen
     Grid: Raster
     Images: Bilder
     Lists_and_counters: Listen und Zähler
     Logical_properties: Logische Eigenschaften
     Math_functions: Mathematische Funktionen
     Media_queries: Media-Abfragen
+    Modules: Module
     Nesting: Verschachteln von Stilregeln
     Positioning: Positionierung
+    Pseudo-classes: Pseudo-Klassen
+    Pseudo-elements: Pseudo-Elemente
+    Properties: Eigenschaften
     Scroll_snap: Scroll-Snap
+    Selectors: Selektoren
     Shapes: Formen
     Text: Text
     Transforms: Transformationen
     Transitions: Übergänge
     Tools: Werkzeuge
+    Types: Typen
   en-US:
     Beginners: Beginner's tutorials
     Styling_the_content: "Your first website: Styling the content"

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -78,8 +78,8 @@ sidebar:
 l10n:
   de:
     Beginners: Einsteiger-Tutorials
-    Creating_the_content: "Ihre erste Website: Erstellen der Inhalte"
-    Structuring_content_with_HTML: Strukturierung von Inhalten mit HTML
+    Creating_the_content: "Ihre erste Website: Inhalte erstellen"
+    Structuring_content_with_HTML: Inhalte mit HTML strukturieren
     Reference: Referenzen
     HTML_Elements: HTML-Elemente
     Global_attributes: Globale Attribute

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -77,6 +77,9 @@ sidebar:
     code: true
 l10n:
   de:
+    Beginners: Einsteiger-Tutorials
+    Creating_the_content: "Ihre erste Website: Erstellen der Inhalte"
+    Structuring_content_with_HTML: Strukturierung von Inhalten mit HTML
     Reference: Referenzen
     HTML_Elements: HTML-Elemente
     Global_attributes: Globale Attribute

--- a/files/sidebars/jssidebar.yaml
+++ b/files/sidebars/jssidebar.yaml
@@ -141,8 +141,8 @@ sidebar:
         title: Deprecated_features
 l10n:
   de:
-    Overview: JavaScript-Technologie (Übersicht)
-    Tutorials: Tutorials
+    Overview: Übersicht über JavaScript-Technologien
+    Tutorials: Tutorials und Anleitungen
     Guide: JavaScript-Handbuch
     Guide_Introduction: Einführung
     Guide_Grammar: Grammatik und Typen
@@ -150,23 +150,29 @@ l10n:
     Guide_Loops: Schleifen und Iteration
     Guide_Functions: Funktionen
     Guide_Expressions: Ausdrücke und Operatoren
-    Guide_Numbers: Numbers and strings
-    Guide_Dates: Representing dates & times
+    Guide_Numbers: Zahlen und Zeichenketten
+    Guide_Dates: Darstellung von Daten und Uhrzeiten
     Guide_RegExp: Reguläre Ausdrücke
     Guide_Indexed_collections: Indexierte Sammlungen
-    Guide_keyed_collections: Gekennzeichnete Sammlungen
+    Guide_keyed_collections: Schlüsselbasierte Sammlungen
     Guide_Objects: Arbeiten mit Objekten
     Guide_Classes: Verwendung von Klassen
     Guide_Promises: Verwendung von Promises
     Guide_Typed_arrays: Typisierte Arrays in JavaScript
     Guide_Iterators_generators: Iteratoren und Generatoren
-    Guide_Internationalization: Internationalization
+    Guide_Internationalization: Internationalisierung
     Guide_Meta: Metaprogrammierung
     Guide_Modules: JavaScript-Module
+    Beginners: Tutorials für Anfänger
+    Adding_interactivity: "Ihre erste Webseite: Interaktivität hinzufügen"
+    Dynamic_scripting_with_JavaScript: Dynamisches Scripting mit JavaScript
+    JavaScript_frameworks_and_libraries: JavaScript-Frameworks und -Bibliotheken
     Intermediate: Mittelstufe
+    Asynchronous_JavaScript: Asynchrones JavaScript
+    Client-side_web_APIs: Clientseitige Web-APIs
     Language_overview: Sprachübersicht
     Data_structures: JavaScript-Datenstrukturen
-    Equality: Gleichheitsvergleiche und Gleichheit
+    Equality: Gleichheitsvergleiche und Ähnlichkeit
     Closures: Closures
     Advanced: Fortgeschritten
     Inheritance: Vererbung und die Prototypenkette
@@ -184,7 +190,7 @@ l10n:
     Lexical_grammar: Lexikalische Grammatik
     Enumerability: Aufzählbarkeit und Eigentum von Eigenschaften
     Iteration_protocols: Iterationsprotokolle
-    Template_strings: Vorlagenliterale
+    Template_strings: Template-Literale
     Trailing_commas: Abschließende Kommas
     Deprecated_features: Veraltete Funktionen
   en-US:

--- a/files/sidebars/jssidebar.yaml
+++ b/files/sidebars/jssidebar.yaml
@@ -172,7 +172,7 @@ l10n:
     Client-side_web_APIs: Clientseitige Web-APIs
     Language_overview: Sprachübersicht
     Data_structures: JavaScript-Datenstrukturen
-    Equality: Gleichheitsvergleiche und Ähnlichkeit
+    Equality: Gleichheitsvergleiche und Gleichheit
     Closures: Closures
     Advanced: Fortgeschritten
     Inheritance: Vererbung und die Prototypenkette

--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -312,7 +312,7 @@ l10n:
     Django_web_framework_(Python): Django Web-Framework (Python)
     Further_resources: Weitere Ressourcen
     Getting_started_modules: Einstiegsmodule
-    Environment_setup: Einrichtungsumgebung
+    Environment_setup: Umgebung einrichten
     Your_first_website: Ihre erste Website
     Web_standards: Webstandards
     Soft_skills: Soziale Kompetenzen
@@ -327,7 +327,7 @@ l10n:
     Version_control: Versionskontrolle
     Extension_modules: Erweiterungsmodule
     Understanding_client-side_tools: Verständnis für clientseitige Tools
-    Server-side_websites: Serverseitige Websites
+    Server-side_websites: Serverseitige Programmierung
     Server-side_first_steps: Erste Schritte auf der Serverseite
     Express_web_framework_(Node.js): Express Web-Framework (Node.js)
     Web_performance: Web-Performance

--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -311,6 +311,33 @@ l10n:
     Web_forms: Webformulare — Arbeiten mit Benutzerdaten
     Django_web_framework_(Python): Django Web-Framework (Python)
     Further_resources: Weitere Ressourcen
+    Getting_started_modules: Einstiegsmodule
+    Environment_setup: Einrichtungsumgebung
+    Your_first_website: Ihre erste Website
+    Web_standards: Webstandards
+    Soft_skills: Soziale Kompetenzen
+    Core_modules: Kernmodule
+    Structuring_content_with_HTML: Inhalte mit HTML strukturieren
+    CSS_styling_basics: Grundlagen des CSS-Stylings
+    CSS_text_styling: CSS-Textgestaltung
+    Dynamic_scripting_with_JavaScript: Dynamisches Scripting mit JavaScript
+    JavaScript_frameworks_and_libraries: JavaScript-Frameworks und -Bibliotheken
+    Accessibility: Barrierefreiheit
+    Design_for_developers: Design für Entwickler:innen
+    Version_control: Versionskontrolle
+    Extension_modules: Erweiterungsmodule
+    Understanding_client-side_tools: Verständnis für clientseitige Tools
+    Server-side_websites: Serverseitige Websites
+    Server-side_first_steps: Erste Schritte auf der Serverseite
+    Express_web_framework_(Node.js): Express Web-Framework (Node.js)
+    Web_performance: Web-Performance
+    Testing: Tests
+    Transform_and_animate_CSS: CSS transformieren und animieren
+    Security_and_privacy: Sicherheit und Datenschutz
+    How_to_solve_common_problems: Häufige Probleme lösen
+    About: Über
+    Resources_for_educators: Ressourcen für Lehrkräfte
+    Changelog: Änderungsprotokoll
   en-US:
     Getting_started_modules: Getting started modules
     Environment_setup: Environment setup

--- a/files/sidebars/mathmlref.yaml
+++ b/files/sidebars/mathmlref.yaml
@@ -45,6 +45,7 @@ l10n:
     Global attributes: Globale Attribute
     Guides: Anleitungen
     Examples: Beispiele
+    Beginners: Einsteiger-Tutorials
   en-US:
     Reference: Reference
     Elements: Elements

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -57,15 +57,15 @@ l10n:
     WebAssembly_home_page: WebAssembly-Startseite
     Tutorials: Anleitungen
     WebAssembly_concepts: WebAssembly-Konzepte
-    Compiling_to_wasm: Kompilieren von C/C++ zu WebAssembly
-    Compiling_rust_to_wasm: Kompilieren von Rust zu WebAssembly
-    JavaScript_API: Verwenden der WebAssembly-JavaScript-API
-    Text_format: Verständnis des WebAssembly-Textformats
-    Text_format_to_wasm: Umwandeln des WebAssembly-Textformats in wasm
-    Loading_and_running: Laden und Ausführen von WebAssembly-Code
+    Compiling_to_wasm: C/C++ zu WebAssembly kompilieren
+    Compiling_rust_to_wasm: Rust zu WebAssembly kompilieren
+    JavaScript_API: WebAssembly-JavaScript-API verwenden
+    Text_format: WebAssembly-Textformat verstehen
+    Text_format_to_wasm: WebAssembly-Textformat in wasm umwandeln
+    Loading_and_running: WebAssembly-Code laden und ausführen
     Exported_functions: Exportierte WebAssembly-Funktionen
-    JavaScript_builtins: JavaScript-Eingebauten
-    Imported_string_constants: Importierte globale Zeichenkettenkonstanten
+    JavaScript_builtins: JavaScript-Standardobjekte
+    Imported_string_constants: Importierte globale String-Konstanten
     JavaScript_interface: JavaScript-Schnittstelle
   en-US:
     WebAssembly_home_page: WebAssembly home page

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -57,13 +57,15 @@ l10n:
     WebAssembly_home_page: WebAssembly-Startseite
     Tutorials: Anleitungen
     WebAssembly_concepts: WebAssembly-Konzepte
-    Compiling_to_wasm: C/C++ zu WebAssembly kompilieren
-    Compiling_rust_to_wasm: Rust zu WebAssembly kompilieren
-    JavaScript_API: WebAssembly JavaScript API verwenden
-    Text_format: WebAssembly-Textformats verstehen
-    Text_format_to_wasm: Umwandlung des WebAssembly-Textformats in wasm
-    Loading_and_running: WebAssembly-Code laden und ausführen
+    Compiling_to_wasm: Kompilieren von C/C++ zu WebAssembly
+    Compiling_rust_to_wasm: Kompilieren von Rust zu WebAssembly
+    JavaScript_API: Verwenden der WebAssembly-JavaScript-API
+    Text_format: Verständnis des WebAssembly-Textformats
+    Text_format_to_wasm: Umwandeln des WebAssembly-Textformats in wasm
+    Loading_and_running: Laden und Ausführen von WebAssembly-Code
     Exported_functions: Exportierte WebAssembly-Funktionen
+    JavaScript_builtins: JavaScript-Eingebauten
+    Imported_string_constants: Importierte globale Zeichenkettenkonstanten
     JavaScript_interface: JavaScript-Schnittstelle
   en-US:
     WebAssembly_home_page: WebAssembly home page


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the German sidebar titles.

### Motivation

The sidebar was displaying several titles in English.

### Additional details

Note that some entries are missing in the `l10n.en-US` object, but this PR doesn't attempt to fix that.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
