### PR TITLE
Update getPermission() to handle "top-level-storage-access" correctly

### DIFF
--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -145,7 +145,7 @@ async function getPermission(permission) {
     if (permission === "top-level-storage-access") {
       result = await navigator.permissions.query({
         name: permission,
-        requestedOrigin: window.location.origin
+        requestedOrigin: window.location.origin,
       });
     } else {
       result = await navigator.permissions.query({ name: permission });

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -141,7 +141,15 @@ async function processPermissions() {
 // Query a single permission in a try...catch block and return result
 async function getPermission(permission) {
   try {
-    const result = await navigator.permissions.query({ name: permission });
+    let result;
+    if (permission === "top-level-storage-access") {
+      result = await navigator.permissions.query({
+        name: permission,
+        requestedOrigin: window.location.origin
+      });
+    } else {
+      result = await navigator.permissions.query({ name: permission });
+    }
     return `${permission}: ${result.state}`;
   } catch (error) {
     return `${permission} (not supported)`;


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Querying for `top-level-storage-access` [requires](https://developer.mozilla.org/en-US/docs/Web/API/Document/requestStorageAccessFor) the caller to pass a `requestedOrigin` value in addition to a `name`. This updates the implementation of the `getPermission()` to pass the `origin` of the window to the `query` call so that the required parameters are passed to the `permissions.query` call.

### Motivation

This addresses an error in the current implementation of the example query code.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

mdn [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/requestStorageAccessFor) for requestStorageAccessFor provides the additional context for the required parameters for `Permissions.query`.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
