### PR TITLE
Include `beforetoggle` as an event type for `ToggleEvent`

### DIFF
--- a/files/en-us/web/api/toggleevent/toggleevent/index.md
+++ b/files/en-us/web/api/toggleevent/toggleevent/index.md
@@ -19,7 +19,7 @@ new ToggleEvent(type, init)
 ### Parameters
 
 - `type`
-  - : A string representing the type of event. In the case of `ToggleEvent` this is always `toggle`.
+  - : A string representing the type of event. In the case of `ToggleEvent` this is always `toggle` or `beforetoggle`.
 - `init`
   - : An object containing the following properties:
     - `newState`

--- a/files/en-us/web/api/toggleevent/toggleevent/index.md
+++ b/files/en-us/web/api/toggleevent/toggleevent/index.md
@@ -19,7 +19,7 @@ new ToggleEvent(type, init)
 ### Parameters
 
 - `type`
-  - : A string representing the type of event. In the case of `ToggleEvent` this is always `toggle` or `beforetoggle`.
+  - : A string representing the type of event. In the case of `ToggleEvent` this is always `beforetoggle` or `toggle`.
 - `init`
   - : An object containing the following properties:
     - `newState`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

For the `type` parameter on the [the “ToggleEvent: ToggleEvent() constructor” page](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/ToggleEvent), the documentation states:

> A string representing the type of event. In the case of `ToggleEvent` this is always `toggle`.

This isn’t completely true. `beforetoggle` events are also a `ToggleEvent`. This pull request updates the text to include `beforetoggle` as an expected value.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To ensure the documentation is accurate.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

- [`beforetoggle` in HTML Standard](https://html.spec.whatwg.org/multipage/indices.html#event-beforetoggle)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
