### PR TITLE
FF135 Relnote: json.parse() with source

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -948,46 +948,6 @@ None.
   </tbody>
 </table>
 
-### JSON.parse with source
-
-The [`JSON.parse` source text access proposal](https://github.com/tc39/proposal-json-parse-with-source) extends [`JSON.parse`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) behavior to provide features to mitigate issues around loss of precision when converting values such as large floats and date values between JavaScript values and JSON text. ([Firefox bug 1913085](https://bugzil.la/1913085), [Firefox bug 1925334](https://bugzil.la/1925334)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>132</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>132</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>132</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>132</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>javascript.options.experimental.json_parse_with_source</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## APIs
 
 ### Cookie Store API

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -22,6 +22,11 @@ This article provides information about the changes in Firefox 135 that affect d
 
 ### JavaScript
 
+- The [JSON parse with source proposal](https://github.com/tc39/proposal-json-parse-with-source) is now supported, which aims to provide features to mitigate issues around loss of precision when converting values such as large floats and date values between JavaScript values and JSON text ([Firefox bug 1934622](https://bugzil.la/1934622)). Specifically, the following features are now available:
+  - The `JSON.parse()` [`reviver` parameter `context` argument](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter): Provides access to the original JSON source text that was parsed.
+  - [`JSON.isRawJSON()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/isRawJSON): Tests whether a value is an object returned by `JSON.rawJSON()`.
+  - [`JSON.rawJSON()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/rawJSON): Creates a "raw JSON" object containing a piece of JSON text, which can then be included in an object to preserve the specified value when that object is stringified.
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
FF135 re-enables support for the [JSON.parse source text access proposal](https://github.com/tc39/proposal-json-parse-with-source) in https://bugzilla.mozilla.org/show_bug.cgi?id=1934622

This was previously added/removed in FF132. This reverts that change by removing the experimental feature and adding the (same) release note.

Related docs work can be tracked in #37514