### PR TITLE
Remove links of legacy self-link properties

### DIFF
--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -75,9 +75,6 @@ The alignment of text and inline-level content is defined in [CSS text module](/
 
 - {{cssxref("alignment-baseline")}}
 - {{cssxref("dominant-baseline")}}
-- {{cssxref("grid-column-gap")}}
-- {{cssxref("grid-gap")}}
-- {{cssxref("grid-row-gap")}}
 - {{cssxref("scroll-snap-align")}}
 - SVG {{SVGAttr("dominant-baseline")}} attribute
 - {{Glossary("Cross axis")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

these properties are legacy alias (redirect to) for `column-gap` `gap` `row-gap`, which are include by this module already

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
