### PR TITLE
fix(scripts): replace `printf` with `process.stderr.write`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "type": "module",
   "scripts": {
-    "info:deprecated": "node -e \"console.warn('\\n🗑️  This command is deprecated, and will be removed soon.\\n')\"",
-    "info:rari": "node -e \"console.info('\\n🐥 This command is now using rari: https://github.com/mdn/rari\\n🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml\\n')\"",
+    "info:deprecated": "node -e \"process.stderr.write('\\n🗑️  This command is deprecated, and will be removed soon.\\n\\n')\"",
+    "info:rari": "node -e \"process.stderr.write('\\n🐥 This command is now using rari: https://github.com/mdn/rari\\n🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml\\n\\n')\"",
     "postinstall": "node scripts/update-history.js",
     "build": "yarn -s info:rari && env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build rari-build",
     "build:legacy": "yarn -s info:deprecated && env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build yari-build",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "type": "module",
   "scripts": {
-    "info:deprecated": "printf '\\n🗑️  This command is deprecated, and will be removed soon.\\n\\n'",
-    "info:rari": "printf '\\n🐥 This command is now using rari: https://github.com/mdn/rari\\n🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml\\n\\n'",
+    "info:deprecated": "node -e \"console.warn('\\n🗑️  This command is deprecated, and will be removed soon.\\n')\"",
+    "info:rari": "node -e \"console.info('\\n🐥 This command is now using rari: https://github.com/mdn/rari\\n🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml\\n')\"",
     "postinstall": "node scripts/update-history.js",
     "build": "yarn -s info:rari && env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build rari-build",
     "build:legacy": "yarn -s info:deprecated && env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build yari-build",


### PR DESCRIPTION
### Description

Replace `printf` calls in `info:{deprecated,rari}` commands with `process.stderr.write`.

### Motivation

1. `printf` is not available on Windows.
2. The messages ended up in `stdout`, breaking the `content inventory` command.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See: https://github.com/ddbeck/mdn-content-inventory/actions/runs/13004738683/job/36269551871#step:5:22