### PR TITLE
fix(redirects): remove locale param + validate with legacy

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 export default {
   "files/en-us/_redirects.txt": (filenames) => [
-    `yarn content fix-redirects en-US`,
-    `yarn content validate-redirects en-us --strict`,
+    `yarn content fix-redirects`,
+    `yarn content:legacy validate-redirects en-us --strict`,
   ],
   "!*.md": (filenames) => [
     `prettier --ignore-unknown --write ${filenames.join(" ")}`,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `lint-staged` config:

1. Remove the locale parameter from the `fix-redirects` command.
2. Validate redirects with `content:legacy` (yari).

> [!NOTE]
> We want to re-add the locale parameter once rari support it, to avoid modifying the local translated-content checkout as a side-effect of the pre-commit hook.

### Motivation

When modifying the `_redirects.txt`, `lint-staged` is currently always failing.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related:

- https://github.com/mdn/rari/issues/106
- https://github.com/mdn/rari/issues/103