### PR TITLE
New `<meta name=application-title>` meta name available in Chromium (Edge/Chrome 134)

### DIFF
--- a/files/en-us/web/html/element/meta/name/index.md
+++ b/files/en-us/web/html/element/meta/name/index.md
@@ -250,7 +250,7 @@ The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtension
 
 #### Other names
 
-- `application-title`: used by web applications that are installed as standalone apps on supporting desktop operating systems to customize an app's title bar. Although the text content of the {{HTMLElement("title")}} element is usually displayed in browser tabs when the app is running in a browser, the `application-title` metadata name can be used to set a different title for the app when it is running as a standalone installed app.
+- `application-title`: Used to customize an app's title bar for web applications installed as standalone apps on supporting desktop operating systems. While the text content of the {{HTMLElement("title")}} element is usually displayed in browser tabs when the app is running in a browser, the `application-title` metadata name can be used to set a different title for the application when it is running as a standalone installed app.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/meta/name/index.md
+++ b/files/en-us/web/html/element/meta/name/index.md
@@ -217,11 +217,7 @@ The CSS Device Adaptation specification defines the following metadata name:
 
 ### Other metadata names
 
-#### application-title
-
-The `application-title` metadata name is used by web applications that are installed as standalone apps on supporting desktop operating systems to customize an app's title bar. Although the text content of the {{HTMLElement("title")}} element is usually displayed in browser tabs when the app is running in a browser, the `application-title` metadata name can be used to set a different title for the app when it is running as a standalone installed app.
-
-#### WHATWG MetaExtensions
+#### Names defined in the WHATWG MetaExtensions wiki
 
 The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtensions) contains a large set of non-standard metadata names that have not been formally accepted yet; however, some of the names included there are already used quite commonly in practice — including the following:
 
@@ -251,6 +247,10 @@ The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtension
   > - If you want to remove a page, `noindex` will work, but only after the robot visits the page again. Ensure that the `robots.txt` file is not preventing revisits.
   > - Some values are mutually exclusive, like `index` and `noindex`, or `follow` and `nofollow`. In these cases the robot's behavior is undefined and may vary between them.
   > - Some crawler robots, like Google, Yahoo and Bing, support the same values for the HTTP header {{HTTPHeader("X-Robots-Tag")}}; this allows non-HTML documents like images to use these rules.
+
+#### Other names
+
+- `application-title`: used by web applications that are installed as standalone apps on supporting desktop operating systems to customize an app's title bar. Although the text content of the {{HTMLElement("title")}} element is usually displayed in browser tabs when the app is running in a browser, the `application-title` metadata name can be used to set a different title for the app when it is running as a standalone installed app.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/meta/name/index.md
+++ b/files/en-us/web/html/element/meta/name/index.md
@@ -217,6 +217,12 @@ The CSS Device Adaptation specification defines the following metadata name:
 
 ### Other metadata names
 
+#### application-title
+
+The `application-title` metadata name is used by web applications that are installed as standalone apps on supporting desktop operating systems to customize an app's title bar. Although the text content of the {{HTMLElement("title")}} element is usually displayed in browser tabs when the app is running in a browser, the `application-title` metadata name can be used to set a different title for the app when it is running as a standalone installed app.
+
+#### WHATWG MetaExtensions
+
 The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtensions) contains a large set of non-standard metadata names that have not been formally accepted yet; however, some of the names included there are already used quite commonly in practice — including the following:
 
 - `creator`: the name of the creator of the document, such as an organization or institution. If there are more than one, several {{HTMLElement("meta")}} elements should be used.
@@ -245,8 +251,6 @@ The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtension
   > - If you want to remove a page, `noindex` will work, but only after the robot visits the page again. Ensure that the `robots.txt` file is not preventing revisits.
   > - Some values are mutually exclusive, like `index` and `noindex`, or `follow` and `nofollow`. In these cases the robot's behavior is undefined and may vary between them.
   > - Some crawler robots, like Google, Yahoo and Bing, support the same values for the HTTP header {{HTTPHeader("X-Robots-Tag")}}; this allows non-HTML documents like images to use these rules.
-
-<!-- ## Technical summary -->
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Edge just shipped, in Chromium, a new name that can be used with `<meta>` tags. This name is `application-title` and is used to provide text content (via the content attribute) that should be displayed in an installed application's title bar.

Installed application: a web app that's been installed as a standalone app on desktop operating systems that support it. For example, when installing a PWA from Microsoft Edge, on Windows.

This new meta tag makes it easy for developers to control the content that appears in the standalone app window's title bar. Developers can still use the `<title>` element (still works), but using `<meta name="application-title" content="...">` provides an additional mechanism just for when the app is installed, which can help avoid UX issues (learn more from the explainer linked below).

There's no spec yet as this is gated behind having more implementer interest. But the feature has shipped in Chrome and Edge, and other Chromium-based browsers, starting with 134.

### Motivation

This needs documentation, the feature is shipping and developers will start using it for progressive enhancement on browsers/platforms that support this new name.

### Additional details

Explainer: https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/DocumentSubtitle/explainer.md

HTML spec discussion: https://github.com/whatwg/html/issues/8909

### Related PRs

See this BCD PR: https://github.com/mdn/browser-compat-data/pull/25792