### PR TITLE
`requestAnimationFrame()` : Warn about long-lived applications and handle 0

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -50,13 +50,14 @@ requestAnimationFrame(callback)
 ### Return value
 
 A `long` integer value, the request ID, that uniquely identifies the entry
-in the callback list. You may not make any about its value. You can pass this value to
+in the callback list. You should not make any assumptions about its value. You can pass this value to
 {{domxref("window.cancelAnimationFrame()")}} to cancel the refresh callback request.
 
 > [!WARNING]
-> The returned value may seem to always be non-zero, however implementations typically increment an integer that may overflow and end up reaching 0.
-> While unlikely to cause issues for short-lived applications, you may want to use `null` for invalid handles instead of 0.
-> Note that it would take ~500 days to reach for a 60Hz based rendering with 100 calls to `requestAnimationFrame()` per frame.
+> The request ID is typically implemented as a per-window incrementing counter. Therefore, even when it starts counting at 1, it may overflow and end up reaching 0.
+> While unlikely to cause issues for short-lived applications, you should avoid `0` as a sentinel value for invalid request identifier IDs and instead prefer unattainable values such as `null`.
+> This also means that request IDs are not truely unique, and may be reused over time.  
+> Note that it would however take ~500 days to reach cycle back to 0 when rendering at 60Hz based rendering with 100 calls to `requestAnimationFrame()` per frame.
 
 ## Examples
 

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -56,8 +56,8 @@ in the callback list. You should not make any assumptions about its value. You c
 > [!WARNING]
 > The request ID is typically implemented as a per-window incrementing counter. Therefore, even when it starts counting at 1, it may overflow and end up reaching 0.
 > While unlikely to cause issues for short-lived applications, you should avoid `0` as a sentinel value for invalid request identifier IDs and instead prefer unattainable values such as `null`.
-> As of January 2025, browsers such as WebKit and Chrome also don't implement it with an `unsigned long` but with a `signed long`, meaning you can not use negative values either. Firefox will return an error and fail instead of wrapping.
-> This also means that request IDs are not truely unique, and may be reused over time for browsers not implementing the check.
+> The spec doesn't specify the overflowing behavior, so browsers have divergent behaviors. When overflowing, the value would either wrap around to 0, to a negative value, or fail with an error.
+> Unless overflow throws, request IDs are also not truly unique because there are only finitely many 32-bit integers for possibly infinitely many callbacks.
 > Note that it would however take ~500 days to reach the issue when rendering at 60Hz with 100 calls to `requestAnimationFrame()` per frame.
 
 ## Examples

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -50,9 +50,14 @@ requestAnimationFrame(callback)
 ### Return value
 
 A `long` integer value, the request ID, that uniquely identifies the entry
-in the callback list. This is a non-zero value, but you may not make any other
-assumptions about its value. You can pass this value to
+in the callback list. You may not make any about its value. You can pass this value to
 {{domxref("window.cancelAnimationFrame()")}} to cancel the refresh callback request.
+
+> [!WARNING]
+> The returned value may seem to always be non-zero, however implementations typically increment an integer that may overflow and end up reaching 0.
+> While unlikely to cause issues for short-lived applications, you may want to use `null` for invalid handles instead of 0.
+> Note that it would take ~500 days to reach for a 60Hz based rendering with 100 calls to `requestAnimationFrame()` per frame.
+
 
 ## Examples
 

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -57,7 +57,7 @@ in the callback list. You should not make any assumptions about its value. You c
 > The request ID is typically implemented as a per-window incrementing counter. Therefore, even when it starts counting at 1, it may overflow and end up reaching 0.
 > While unlikely to cause issues for short-lived applications, you should avoid `0` as a sentinel value for invalid request identifier IDs and instead prefer unattainable values such as `null`.
 > As of January 2025, browsers such as WebKit and Chrome also don't implement it with an `unsigned long` but with a `signed long`, meaning you can not use negative values either. Firefox will return an error and fail instead of wrapping.
-> This also means that request IDs are not truely unique, and may be reused over time for browsers not implementing the check.  
+> This also means that request IDs are not truely unique, and may be reused over time for browsers not implementing the check.
 > Note that it would however take ~500 days to reach the issue when rendering at 60Hz with 100 calls to `requestAnimationFrame()` per frame.
 
 ## Examples

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -58,7 +58,6 @@ in the callback list. You may not make any about its value. You can pass this va
 > While unlikely to cause issues for short-lived applications, you may want to use `null` for invalid handles instead of 0.
 > Note that it would take ~500 days to reach for a 60Hz based rendering with 100 calls to `requestAnimationFrame()` per frame.
 
-
 ## Examples
 
 In this example, an element is animated for 2 seconds (2000 milliseconds). The element

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -49,15 +49,16 @@ requestAnimationFrame(callback)
 
 ### Return value
 
-A `long` integer value, the request ID, that uniquely identifies the entry
+An `unsigned long` integer value, the request ID, that uniquely identifies the entry
 in the callback list. You should not make any assumptions about its value. You can pass this value to
 {{domxref("window.cancelAnimationFrame()")}} to cancel the refresh callback request.
 
 > [!WARNING]
 > The request ID is typically implemented as a per-window incrementing counter. Therefore, even when it starts counting at 1, it may overflow and end up reaching 0.
 > While unlikely to cause issues for short-lived applications, you should avoid `0` as a sentinel value for invalid request identifier IDs and instead prefer unattainable values such as `null`.
-> This also means that request IDs are not truely unique, and may be reused over time.  
-> Note that it would however take ~500 days to reach cycle back to 0 when rendering at 60Hz based rendering with 100 calls to `requestAnimationFrame()` per frame.
+> As of January 2025, browsers such as WebKit and Chrome also don't implement it with an `unsigned long` but with a `signed long`, meaning you can not use negative values either. Firefox will return an error and fail instead of wrapping.
+> This also means that request IDs are not truely unique, and may be reused over time for browsers not implementing the check.  
+> Note that it would however take ~500 days to reach the issue when rendering at 60Hz with 100 calls to `requestAnimationFrame()` per frame.
 
 ## Examples
 
@@ -165,3 +166,4 @@ function animate() {
 - {{domxref("DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
 - [Animating with JavaScript: from setInterval to requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/) - Blog post
 - [TestUFO: Test your web browser for requestAnimationFrame() Timing Deviations](https://www.testufo.com/#test=animation-time-graph)
+- [Firefox switching to uint32_t for the requestAnimationFrame request ID](https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e)


### PR DESCRIPTION
### Description

Do not say that `requestAnimationFrame` returns non-zero values as this is not true, and warn about it.

### Motivation

For applications that may do a lot of calls to `requestAnimationFrame` (or that are long lived), this could cause reliability issues if users use 0 as an invalid handle.

### Additional details



For webkit:
- https://github.com/WebKit/WebKit/blob/6355462b3a9548b4d9df5a39afc5b4b923b57c95/Source/WebCore/dom/ScriptedAnimationController.h#L66 
- https://github.com/WebKit/WebKit/blob/6355462b3a9548b4d9df5a39afc5b4b923b57c95/Source/WebCore/dom/ScriptedAnimationController.cpp#L108


Exact same issue in Blink (since based on Webkit) 

- https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/frame_request_callback_collection.cc;l=20;drc=27d34700b83f381c62e3a348de2e6dfdc08364b8

Since July 2024, Firefox detects overflow and will give an error: 
https://phabricator.services.mozilla.com/rMOZILLACENTRAL149722297f033d5c3ad126d0c72edcb1cb96d72e
https://searchfox.org/mozilla-central/source/dom/base/RequestCallbackManager.h#43 