### PR TITLE
37515 Firefox Nightly supports Temporal behind pref

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -996,7 +996,7 @@ The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Tempor
     </tr>
     <tr>
       <th>Preference name</th>
-      <td colspan="2">javascript.options.experimental.temporal</td>
+      <td colspan="2"><code>javascript.options.experimental.temporal</code></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -950,7 +950,8 @@ None.
 
 ### Temporal API
 
-The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations. ([Firefox bug 1912511](https://bugzil.la/1912511)). This includes:
+The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations ([Firefox bug 1912511](https://bugzil.la/1912511)).
+This includes:
 
 - A **duration** (difference between two time points): {{jsxref("Temporal.Duration")}}
 - **Points in time**:

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -963,7 +963,7 @@ The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Tempor
         - Year, month: {{jsxref("Temporal.PlainYearMonth")}}
         - Month, day: {{jsxref("Temporal.PlainMonthDay")}}
       - Time (hour, minute, second, millisecond, nanosecond): {{jsxref("Temporal.PlainTime")}}
-- The current time as various class instances, or in a specific format: {{jsxref("Temporal.Now")}}
+- **Now** (current time) as various class instances, or in a specific format: {{jsxref("Temporal.Now")}}
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -950,7 +950,7 @@ None.
 
 ### Temporal API
 
-The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) enables date and time management in various scenarios, including built-in time zone and calendar representation. ([Firefox bug 1912511](https://bugzil.la/1912511)). This includes:
+The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations. ([Firefox bug 1912511](https://bugzil.la/1912511)). This includes:
 
 - A **duration** (difference between two time points): {{jsxref("Temporal.Duration")}}
 - **Points in time**:

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -948,6 +948,56 @@ None.
   </tbody>
 </table>
 
+### Temporal API
+
+The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) enables date and time management in various scenarios, including built-in time zone and calendar representation. ([Firefox bug 1912511](https://bugzil.la/1912511)). This includes:
+
+- The {{jsxref("Temporal.Duration")}} object for working between two points in time.
+- The {{jsxref("Temporal.Instant")}} object for setting a specific point in time.
+- The {{jsxref("Temporal.Now")}} object for getting the current point in time.
+- The {{jsxref("Temporal.PlainDate")}} object represents a specific date.
+- The {{jsxref("Temporal.PlainDateTime")}} object represents a specific date and time.
+- The {{jsxref("Temporal.PlainMonthDay")}} object represents a specific date with out a specific year, such as an anniversary.
+- The {{jsxref("Temporal.PlainTime")}} object represents a specific time.
+- The {{jsxref("Temporal.PlainYearMonth")}} object represents a year and month without a date or time.
+- The {{jsxref("Temporal.ZonedDateTime")}} object represents a date and time with a time zone.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>135</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>—</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>—</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>—</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">javascript.options.experimental.temporal</td>
+    </tr>
+  </tbody>
+</table>
+
 ## APIs
 
 ### Cookie Store API

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -952,15 +952,18 @@ None.
 
 The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) enables date and time management in various scenarios, including built-in time zone and calendar representation. ([Firefox bug 1912511](https://bugzil.la/1912511)). This includes:
 
-- The {{jsxref("Temporal.Duration")}} object for working between two points in time.
-- The {{jsxref("Temporal.Instant")}} object for setting a specific point in time.
-- The {{jsxref("Temporal.Now")}} object for getting the current point in time.
-- The {{jsxref("Temporal.PlainDate")}} object represents a specific date.
-- The {{jsxref("Temporal.PlainDateTime")}} object represents a specific date and time.
-- The {{jsxref("Temporal.PlainMonthDay")}} object represents a specific date with out a specific year, such as an anniversary.
-- The {{jsxref("Temporal.PlainTime")}} object represents a specific time.
-- The {{jsxref("Temporal.PlainYearMonth")}} object represents a year and month without a date or time.
-- The {{jsxref("Temporal.ZonedDateTime")}} object represents a date and time with a time zone.
+- A **duration** (difference between two time points): {{jsxref("Temporal.Duration")}}
+- **Points in time**:
+  - As a unique instant in history:
+    - A timestamp: {{jsxref("Temporal.Instant")}}
+    - A date-time with a time zone: {{jsxref("Temporal.ZonedDateTime")}}
+  - **Time-zone-unaware date/time ("Plain")**:
+    - Date (year, month, day) + time (hour, minute, second, millisecond, nanosecond): {{jsxref("Temporal.PlainDateTime")}}
+      - Date (year, month, day): {{jsxref("Temporal.PlainDate")}}
+        - Year, month: {{jsxref("Temporal.PlainYearMonth")}}
+        - Month, day: {{jsxref("Temporal.PlainMonthDay")}}
+      - Time (hour, minute, second, millisecond, nanosecond): {{jsxref("Temporal.PlainTime")}}
+- The current time as various class instances, or in a specific format: {{jsxref("Temporal.Now")}}
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -80,7 +80,7 @@ This article provides information about the changes in Firefox 135 that affect d
 
 These features are newly shipped in Firefox 135 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
-- **Temporal API** (Nightly release): <code>javascript.options.experimental.temporal</code>. The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) enables date and time management in various scenarios, including built-in time zone and calendar representation. ([Firefox bug 1912511](https://bugzil.la/1912511)).
+- **Temporal API** (Nightly release): <code>javascript.options.experimental.temporal</code>. The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations. ([Firefox bug 1912511](https://bugzil.la/1912511)).
 - **Prioritized Task Scheduling API**: <code>dom.enable_web_task_scheduling</code>.
   The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.
   This has temporarily been disabled in Nightly builds in order to avoid [breakage in-the-wild](https://bugzil.la/1937232).

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -80,6 +80,7 @@ This article provides information about the changes in Firefox 135 that affect d
 
 These features are newly shipped in Firefox 135 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **Temporal API** (Nightly release): <code>javascript.options.experimental.temporal</code>. The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) enables date and time management in various scenarios, including built-in time zone and calendar representation. ([Firefox bug 1912511](https://bugzil.la/1912511)).
 - **Prioritized Task Scheduling API**: <code>dom.enable_web_task_scheduling</code>.
   The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.
   This has temporarily been disabled in Nightly builds in order to avoid [breakage in-the-wild](https://bugzil.la/1937232).


### PR DESCRIPTION
### Description

- Added Experimental release note for Temporal API
- Added Temporel API to FF135 exeprimental features

### Motivation

- Working on [issue #37515](https://github.com/mdn/content/issues/37515)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/25796)
- Linked to 3 Tickets:
  - [Implement the Temporal proposal](https://bugzilla.mozilla.org/show_bug.cgi?id=1519167)
  - [Build temporal in Nightly by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1912757)
  - [Temporal.Duration.toLocaleString not working as expected.](https://bugzilla.mozilla.org/show_bug.cgi?id=1942850) - This is only related to `Temporal.Duration.toLocaleString()`