### PR TITLE
Standardize punctuation after trailing following

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/dom_scripting/index.md
+++ b/files/en-us/learn_web_development/core/scripting/dom_scripting/index.md
@@ -188,7 +188,7 @@ When you want to remove a node based only on a reference to itself, which is fai
 linkPara.remove();
 ```
 
-This method is not supported in older browsers. They have no method to tell a node to remove itself, so you'd have to do the following.
+This method is not supported in older browsers. They have no method to tell a node to remove itself, so you'd have to do the following:
 
 ```js
 linkPara.parentNode.removeChild(linkPara);

--- a/files/en-us/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
@@ -174,7 +174,7 @@ You can also use keywords:
 
 In the example below, the _balloons.jpg_ image has length units set to size it inside the box. You can see this has distorted the image.
 
-Try the following.
+Try the following:
 
 - Change the length units used to modify the size of the background.
 - Remove the length units and see what happens when you use `background-size: cover` or `background-size: contain`.

--- a/files/en-us/learn_web_development/extensions/server-side/django/models/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/models/index.md
@@ -257,7 +257,7 @@ We can get all records for a model as a `QuerySet`, using `objects.all()`. The `
 all_books = Book.objects.all()
 ```
 
-Django's `filter()` method allows us to filter the returned `QuerySet` to match a specified **text** or **numeric** field against particular criteria. For example, to filter for books that contain "wild" in the title and then count them, we could do the following.
+Django's `filter()` method allows us to filter the returned `QuerySet` to match a specified **text** or **numeric** field against particular criteria. For example, to filter for books that contain "wild" in the title and then count them, we could do the following:
 
 ```python
 wild_books = Book.objects.filter(title__contains='wild')

--- a/files/en-us/related/imsc/styling/index.md
+++ b/files/en-us/related/imsc/styling/index.md
@@ -8,7 +8,7 @@ IMSC offers many options for styling documents, and most of the IMSC styling pro
 
 ## Inline styling
 
-The simplest way of styling content elements like `<p>` or `<span>` is by specifying one or more style attributes, such as `tts:color`, on them. For instance, the following
+The simplest way of styling content elements like `<p>` or `<span>` is by specifying one or more style attributes, such as `tts:color`, on them. For instance, the following:
 
 ```xml
 <p tts:textAlign="center"

--- a/files/en-us/web/api/webxr_device_api/performance/index.md
+++ b/files/en-us/web/api/webxr_device_api/performance/index.md
@@ -32,7 +32,7 @@ When using libraries that perform things such as matrix mathematics, you typical
 
 While an individual vector or matrix doesn't occupy an inordinate amount of memory, the sheer number of vectors and matrices and other structures that are used to build each frame of a 3D scene means the memory management becomes a problem eventually if you keep allocating and de-allocating memory objects.
 
-Consider the following
+Consider the following:
 
 ```js
 function drawScene(gl, view, programInfo, buffers, texture, deltaTime) {

--- a/files/en-us/web/api/workerglobalscope/navigator/index.md
+++ b/files/en-us/web/api/workerglobalscope/navigator/index.md
@@ -16,7 +16,7 @@ A {{domxref("WorkerNavigator")}} object.
 
 ## Examples
 
-If you call the following
+If you call the following:
 
 ```js
 console.log(navigator);

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -87,7 +87,7 @@ In addition to the pre-defined keywords that are part of the specification for a
 
 ### URLs
 
-A {{cssxref("url_value", "&lt;url&gt;")}} type uses functional notation, which accepts a `<string>` that is a URL. This may be an absolute URL or a relative URL. For example, if you wanted to include a background image, you might use either of the following.
+A {{cssxref("url_value", "&lt;url&gt;")}} type uses functional notation, which accepts a `<string>` that is a URL. This may be an absolute URL or a relative URL. For example, if you wanted to include a background image, you might use either of the following:
 
 ```css
 .box {

--- a/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
@@ -32,7 +32,7 @@ hence {{jsxref("JSON.stringify()")}} doesn't try to solve them and fails accordi
 
 ### Circular references
 
-In a circular structure like the following
+In a circular structure like the following:
 
 ```js
 const circularReference = { otherData: 123 };


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Use colon (instead of period or nothing) after a trailing "following" where appropriate.

### Motivation

The overwhelming majority of instances, a colon is used, hence making it uniform is desirable.

### Additional details

N/A

### Related issues and pull requests

N/A
