### PR TITLE
chore(workflows/pr-check): validate redirects with rari + fix only en-US

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Check redirects file(s)
         if: steps.filter.outputs.required_files == 'true'
-        run: yarn content:legacy validate-redirects en-us --strict
+        run: yarn content validate-redirects en-US

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -113,7 +113,7 @@ jobs:
 
       - run: yarn content fix-redirects en-US
 
-      - run: yarn content validate-redirects en-us
+      - run: yarn content validate-redirects en-US
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -113,7 +113,7 @@ jobs:
 
       - run: yarn content fix-redirects en-US
 
-      - run: yarn content validate-redirects en-us --strict
+      - run: yarn content validate-redirects en-us
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -111,6 +111,10 @@ jobs:
 
       - run: yarn content --help
 
+      - run: yarn content fix-redirects en-US
+
+      - run: yarn content validate-redirects en-us --strict
+
   build:
     runs-on: ubuntu-latest
 

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 export default {
   "files/en-us/_redirects.txt": (filenames) => [
-    `yarn content fix-redirects`,
-    `yarn content:legacy validate-redirects en-us --strict`,
+    `yarn content fix-redirects en-US`,
+    `yarn content validate-redirects en-us --strict`,
   ],
   "!*.md": (filenames) => [
     `prettier --ignore-unknown --write ${filenames.join(" ")}`,

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 export default {
   "files/en-us/_redirects.txt": (filenames) => [
     `yarn content fix-redirects en-US`,
-    `yarn content validate-redirects en-us --strict`,
+    `yarn content validate-redirects en-US`,
   ],
   "!*.md": (filenames) => [
     `prettier --ignore-unknown --write ${filenames.join(" ")}`,


### PR DESCRIPTION
Reverts mdn/content#37844 and mdn/content#37822, as support for both has landed in rari: https://github.com/mdn/rari/issues/103