### PR TITLE
Clarify optionality of `self` for `crypto` instance methods depending on context

### DIFF
--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -55,7 +55,9 @@ the Unix `/dev/urandom` device, or other source of random or pseudorandom data.
 
 ```js
 const array = new Uint32Array(10);
-self.crypto.getRandomValues(array);
+// Also available as window.crypto.getRandomValues(array)
+// or self.crypto.getRandomValues(array) depending on context
+crypto.getRandomValues(array);
 
 console.log("Your lucky numbers:");
 for (const num of array) {

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -27,9 +27,9 @@ A string containing a randomly generated, 36 character long v4 UUID.
 ## Examples
 
 ```js
-/* Assuming that self.crypto.randomUUID() is available */
-
-let uuid = self.crypto.randomUUID();
+// Also available as window.crypto.randomUUID()
+// or self.crypto.randomUUID() depending on context
+const uuid = crypto.randomUUID();
 console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 ```
 


### PR DESCRIPTION
### Description

Like other globally available objects, showcase an example that accesses the `crypto` object directly. Its availability via `window.crypto` and `self.crypto` can be mentioned in a comment as they're not strictly necessary in all contexts.

### Motivation

The existing pages for [`Crypto: randomUUID()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) and [`Crypto: getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) have code examples that only show their use via `self.crypto`.

In several educational communities, I've seen people confused by this when they use methods like `randomUUID()` in websites because they've never come across `self` before and do not realise in window contexts at least, `self` isn't necessary. `crypto` is available globally but can also be accessed via `window.crypto` or `self.crypto` etc.

I think it would be clearer to more people if the examples showcased accessing `crypto` directly but had comments clarifying that the `crypto` object is also available on the `window` and `self` objects.

This would also be a little more consistent with how `window` methods like `alert()` and `prompt()` have some of their code examples.

### Additional details

N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
