### PR TITLE
removed outdated note (SVG)

### DIFF
--- a/files/en-us/web/svg/element/fecomposite/index.md
+++ b/files/en-us/web/svg/element/fecomposite/index.md
@@ -138,8 +138,6 @@ This element implements the {{domxref("SVGFECompositeElement")}} interface.
 
 This example defines filters for each of the supported operations (`over`, `atop`, `lighter`, etc.), which composite an input `SourceGraphic` with an image of the MDN logo. The filters are each applied to a circle element, which is then used as the `SourceGraphic`.
 
-> **Note:** `BackgroundImage` cannot be used as a compositing source on modern browsers, so we can't define a filter that composites using whatever pixels happen to be under the filter as one of the sources. The approach taken here is a [workaround because we can't use `BackgroundImage`](/en-US/docs/Web/SVG/Attribute/in#workaround_for_backgroundimage).
-
 ### SVG
 
 ```html


### PR DESCRIPTION
according to the bcd table, backgroundImage has been supported since 2018