### PR TITLE
Fix a typo that causes missing content

### DIFF
--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -52,7 +52,7 @@ h1 {
 }
 ```
 
-Alternatively, to avoid overwriting other style rules that target `<h1>` you can use {{cssxref(":where()"}}, which has zero specificity:
+Alternatively, to avoid overwriting other style rules that target `<h1>` you can use {{cssxref(":where()")}}, which has zero specificity:
 
 ```css
 :where(h1) {


### PR DESCRIPTION
This regressed in #37827.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix typo.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Currently, the content ends after "you can use": https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#specifying_a_uniform_font_size_for_h1

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
