### PR TITLE
feat: allow sidebars to be defined in front matter

### DIFF
--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -30,7 +30,7 @@
       },
       "sidebar": {
         "title": "Sidebar navigation",
-        "description": "A sidebar defined as YAML in /files/en-us/sidebars",
+        "description": "Sidebar navigation(s) to show, defined as YAML in /files/en-us/sidebars",
         "type": ["array", "string"],
         "items": {
           "type": "string",

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -31,7 +31,18 @@
       "sidebar": {
         "title": "Sidebar navigation",
         "description": "A sidebar defined as YAML in /files/en-us/sidebars",
-        "type": "array"
+        "type": ["array", "string"],
+        "items": {
+          "type": "string",
+          "enum": [
+            "mediasidebar",
+            "urlsidebar",
+            "xmlsidebar",
+            "xpathsidebar",
+            "xsltsidebar",
+            "exsltsidebar"
+          ]
+        }
       },
       "status": {
         "title": "Status",
@@ -566,10 +577,10 @@
     "title",
     "short-title",
     "slug",
-    "sidebar",
     "page-type",
     "status",
     "browser-compat",
-    "spec-urls"
+    "spec-urls",
+    "sidebar"
   ]
 }

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -13,20 +13,25 @@
         "maxLength": 120
       },
       "short-title": {
-        "title": "Short Title",
+        "title": "Short title",
         "description": "To be used in sidebars",
         "type": "string",
         "maxLength": 60
       },
       "slug": {
-        "title": "slug",
+        "title": "Slug",
         "description": "URL path of the page",
         "type": "string"
       },
       "page-type": {
-        "title": "Page Type",
+        "title": "Page type",
         "description": "Type of the page",
         "type": "string"
+      },
+      "sidebar": {
+        "title": "Sidebar navigation",
+        "description": "A sidebar defined as YAML in /files/en-us/sidebars",
+        "type": "array"
       },
       "status": {
         "title": "Status",
@@ -39,7 +44,7 @@
         }
       },
       "browser-compat": {
-        "title": "Browser Compatibility",
+        "title": "Browser compatibility",
         "description": "Browser compatibility location",
         "type": ["array", "string"]
       },
@@ -561,6 +566,7 @@
     "title",
     "short-title",
     "slug",
+    "sidebar",
     "page-type",
     "status",
     "browser-compat",


### PR DESCRIPTION
### Description

The linter needs to allow us to add sidebars via front matter

### Motivation

`front-matter_utils.js` will silently discard any keys not in the schema's `attribute-order`. Sidebars needs to be there or it's automatically thrown out when running:

```
node scripts/front-matter_linter.js --fix true
```

### Related issues and pull requests

WIP branch here: https://github.com/mdn/content/compare/main...bsmth:content:xpath-move#diff-772e8f6fb5437ca6318bdfca57d8d613ba693284f9225309b24412d980f58445