### PR TITLE
Fix example in ARIA: grid role

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -244,7 +244,7 @@ trs.forEach((row) => {
   row.querySelectorAll("td").forEach((el) => {
     el.dataset.row = rowIndex;
     el.dataset.col = colIndex;
-    rowIndex++;
+    colIndex++;
   });
   if (colIndex > maxCol) {
     maxCol = colIndex - 1;


### PR DESCRIPTION
### Description

Replace the incorrect use of `rowIndex` with `colIndex` in the JavaScript example code for initializing the cell datasets.

### Motivation

This error resulted in incorrect `row` and `col` values on the cells, causing the navigation to not work correctly. Pressing PageDown resulted in an endless `do` ... `while` loop that nearly consumed all of my computer's memory over the next few minutes.

### Additional details

It might also be good to add a `default: return;` case to the "keydown" event to avoid `event.preventDefault()` for other keys. I think this JavaScript code could use some more improvements to make it more clear and concise, but I'll leave that to someone that is familiar with MDN's code style guidelines.