### PR TITLE
Update <option> CSS styling info

### DIFF
--- a/files/en-us/web/html/element/option/index.md
+++ b/files/en-us/web/html/element/option/index.md
@@ -26,7 +26,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Styling with CSS
 
-Styling the **`<option>`** element is highly limited. Options don't inherit the font set on the parent. In Firefox, only [`color`](/en-US/docs/Web/CSS/color) and [`background-color`](/en-US/docs/Web/CSS/background-color) can be set, however in Chrome and Safari it's not possible to set any properties. You can find more details about styling in [our guide to advanced form styling](/en-US/docs/Learn_web_development/Extensions/Forms/Advanced_form_styling).
+Styling the **`<option>`** element inside a `<select>` dropdown is highly limited. In Firefox, only font-size of the owning `<select>` is respected. Chrome additionally allows [`color`](/en-US/docs/Web/CSS/color), [`background-color`](/en-US/docs/Web/CSS/background-color) [`font-size`](/en-US/docs/Web/CSS/font-size), [`font-family`](/en-US/docs/Web/CSS/font-family), [`font-variant`](/en-US/docs/Web/CSS/font-variant) and [`text-align`](/en-US/docs/Web/CSS/text-align) to be set. You can find more details about styling in [our guide to advanced form styling](/en-US/docs/Learn_web_development/Extensions/Forms/Advanced_form_styling).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updated CSS styling information about the `<option>` element.

### Motivation

Information about `<option>` styling seemed incorrect based on my tests with `Firefox v134.0.2` and `Chrome v132.0.6834.110` on Kubuntu 24.04.

### Additional details

I've not tested every possible attribute so feel free to improve upon this PR.