### PR TITLE
Remove stray closing brace in `ElementInternals/ariaLabel`

### DIFF
--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaLabel
 ---
 
-{{APIRef("Web Components")}}}
+{{APIRef("Web Components")}}
 
 The **`ariaLabel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current Element.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove extra closing brace on `APIRef`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It renders as a stray closing brace at the top of the page.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N/A
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
