### PR TITLE
Fix `NavigateEvent` & `NavigationCurrentEntryChangeEvent` constructor…

### DIFF
--- a/files/en-us/web/api/navigateevent/navigateevent/index.md
+++ b/files/en-us/web/api/navigateevent/navigateevent/index.md
@@ -23,7 +23,7 @@ new NavigateEvent(type, init)
 - `type`
   - : A string representing the type of event.
 - `init`
-  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `canIntercept` {{optional_inline}}
       - : A boolean defining whether the navigation can be intercepted or not (e.g. you can't intercept a cross-origin navigation). Defaults to `false`.
     - `destination`
@@ -35,7 +35,7 @@ new NavigateEvent(type, init)
     - `hashChange` {{optional_inline}}
       - : A boolean defining if the navigation is a fragment navigation (i.e. to a fragment identifier in the same document). Defaults to `false`.
     - `hasUAVisualTransition` {{optional_inline}}
-      - : A boolean defining if the user agent has performed a visual transition for this navigation before dispatching this event.
+      - : A boolean defining whether the user agent has performed a visual transition for this navigation before dispatching this event. Defaults to `false`.
     - `info` {{optional_inline}}
       - : The `info` data value passed by the initiating navigation operation (e.g. {{domxref("Navigation.back()")}}, or {{domxref("Navigation.navigate()")}}).
     - `navigationType` {{optional_inline}}

--- a/files/en-us/web/api/navigateevent/navigateevent/index.md
+++ b/files/en-us/web/api/navigateevent/navigateevent/index.md
@@ -10,8 +10,7 @@ browser-compat: api.NavigateEvent.NavigateEvent
 
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
-The **`NavigateEvent()`** constructor creates a new
-{{domxref("NavigateEvent")}} object instance.
+The **`NavigateEvent()`** constructor creates a new {{domxref("NavigateEvent")}} object instance.
 
 ## Syntax
 
@@ -22,9 +21,9 @@ new NavigateEvent(type, init)
 ### Parameters
 
 - `type`
-  - : A string representing the type of event. In the case of `NavigateEvent` this is always `navigate`.
+  - : A string representing the type of event.
 - `init`
-  - : An object containing the following properties:
+  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `canIntercept` {{optional_inline}}
       - : A boolean defining whether the navigation can be intercepted or not (e.g. you can't intercept a cross-origin navigation). Defaults to `false`.
     - `destination`
@@ -35,6 +34,8 @@ new NavigateEvent(type, init)
       - : The {{domxref("FormData")}} object representing the submitted data in the case of a `POST` form submission. Defaults to `null`.
     - `hashChange` {{optional_inline}}
       - : A boolean defining if the navigation is a fragment navigation (i.e. to a fragment identifier in the same document). Defaults to `false`.
+    - `hasUAVisualTransition` {{optional_inline}}
+      - : A boolean defining if the user agent has performed a visual transition for this navigation before dispatching this event.
     - `info` {{optional_inline}}
       - : The `info` data value passed by the initiating navigation operation (e.g. {{domxref("Navigation.back()")}}, or {{domxref("Navigation.navigate()")}}).
     - `navigationType` {{optional_inline}}
@@ -43,6 +44,10 @@ new NavigateEvent(type, init)
       - : An {{domxref("AbortSignal")}}, which will become aborted if the navigation is cancelled (e.g. by the user pressing the browser's "Stop" button, or another navigation starting and thus cancelling the ongoing one).
     - `userInitiated` {{optional_inline}}
       - : A boolean defining whether the navigation was initiated by the user (e.g. by clicking a link, submitting a form, or pressing the browser's "Back"/"Forward" buttons). Defaults to `false`.
+
+### Return value
+
+A new {{domxref("NavigateEvent")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
@@ -23,7 +23,7 @@ new NavigationCurrentEntryChangeEvent(type, init)
 - `type`
   - : A string representing the type of event.
 - `init`
-  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `from`
       - : A {{domxref("NavigationHistoryEntry")}} object representing the location being navigated to.
     - `navigationType` {{optional_inline}}

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
@@ -21,13 +21,17 @@ new NavigationCurrentEntryChangeEvent(type, init)
 ### Parameters
 
 - `type`
-  - : A string representing the type of event. In the case of `NavigationCurrentEntryChangeEvent` this is always `event`.
+  - : A string representing the type of event.
 - `init`
-  - : An object containing the following properties:
-    - `destination`
+  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+    - `from`
       - : A {{domxref("NavigationHistoryEntry")}} object representing the location being navigated to.
     - `navigationType` {{optional_inline}}
       - : The type of the navigation that resulted in the change. Possible values are `push`, `reload`, `replace`, and `traverse`. Defaults to `null`.
+
+### Return value
+
+A new {{domxref("NavigationCurrentEntryChangeEvent")}} object.
 
 ## Examples
 


### PR DESCRIPTION
… syntax

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

constructor can also passing parameters that in `Event()`; add missing return value section which should have per spec; add missing `hasUAVisualTransition` parameter item, which the `hasUAVisualTransition` property page has added yet

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigateevent-interface
https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationcurrententrychangeevent-interface

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
