### PR TITLE
glossary links: to aphabetic baseline

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
@@ -25,7 +25,7 @@ Possible values:
 - `"middle"`
   - : The text baseline is the middle of the em square.
 - `"alphabetic"`
-  - : The text baseline is the normal alphabetic baseline. Default value.
+  - : The text baseline is the normal {{glossary("/Baseline/Typography", "alphabetic baseline")}}. Default value.
 - `"ideographic"`
   - : The text baseline is the ideographic baseline; this is the bottom of the body of the
     characters, if the main body of characters protrudes beneath the alphabetic baseline.

--- a/files/en-us/web/api/textmetrics/index.md
+++ b/files/en-us/web/api/textmetrics/index.md
@@ -32,7 +32,7 @@ The **`TextMetrics`** interface represents the dimensions of a piece of text in 
 - {{domxref("TextMetrics.hangingBaseline")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the hanging baseline of the line box, in CSS pixels.
 - {{domxref("TextMetrics.alphabeticBaseline")}} {{ReadOnlyInline}}
-  - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the alphabetic baseline of the line box, in CSS pixels.
+  - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the {{glossary("/Baseline/Typography", "alphabetic baseline")}} of the line box, in CSS pixels.
 - {{domxref("TextMetrics.ideographicBaseline")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the ideographic baseline of the line box, in CSS pixels.
 

--- a/files/en-us/web/css/text-underline-position/index.md
+++ b/files/en-us/web/css/text-underline-position/index.md
@@ -35,7 +35,7 @@ text-underline-position: unset;
 ### Values
 
 - `auto`
-  - : The {{glossary("user agent")}} uses its own algorithm to place the line at or under the alphabetic baseline.
+  - : The {{glossary("user agent")}} uses its own algorithm to place the line at or under the {{glossary("/Baseline/Typography", "alphabetic baseline")}}.
 - `from-font`
   - : If the font file includes information about a preferred position, use that value. If the font file doesn't include this information, behave as if `auto` was set, with the browser choosing an appropriate position.
 - `under`

--- a/files/en-us/web/svg/attribute/alignment-baseline/index.md
+++ b/files/en-us/web/svg/attribute/alignment-baseline/index.md
@@ -7,7 +7,7 @@ browser-compat: svg.global_attributes.alignment-baseline
 
 {{SVGRef}}
 
-The **`alignment-baseline`** attribute specifies how an object is aligned with respect to its parent. This property specifies which baseline of this element is to be aligned with the corresponding baseline of the parent. For example, this allows alphabetic baselines in Roman text to stay aligned across font size changes. It defaults to the baseline with the same name as the computed value of the `alignment-baseline` property.
+The **`alignment-baseline`** attribute specifies how an object is aligned with respect to its parent. This property specifies which baseline of this element is to be aligned with the corresponding baseline of the parent. For example, this allows {{glossary("/Baseline/Typography", "alphabetic baselines")}} in Roman text to stay aligned across font size changes. It defaults to the baseline with the same name as the computed value of the `alignment-baseline` property.
 
 > [!NOTE]
 > As a presentation attribute, {{cssxref("alignment-baseline")}} can be used as a CSS property.

--- a/files/en-us/web/svg/attribute/alphabetic/index.md
+++ b/files/en-us/web/svg/attribute/alphabetic/index.md
@@ -11,7 +11,7 @@ browser-compat: svg.elements.font-face.alphabetic
 
 The **`alphabetic`** attribute defines the lower baseline of a font. It has the same syntax and semantics as the {{cssxref("@font-face/baseline", "baseline")}} descriptor within an {{cssxref("@font-face")}}.
 
-For horizontally oriented glyph layouts, it indicates the alignment coordinate for glyphs to achieve alphabetic baseline alignment. The value is an offset in the font coordinate system.
+For horizontally oriented glyph layouts, it indicates the alignment coordinate for glyphs to achieve {{glossary("/Baseline/Typography", "alphabetic baseline")}} alignment. The value is an offset in the font coordinate system.
 
 You can use this attribute with the following SVG elements:
 

--- a/files/en-us/web/svg/attribute/v-alphabetic/index.md
+++ b/files/en-us/web/svg/attribute/v-alphabetic/index.md
@@ -9,7 +9,7 @@ browser-compat: svg.elements.font-face.v-alphabetic
 
 {{SVGRef}}{{Deprecated_Header}}
 
-The **`v-alphabetic`** attribute defines indicates the alignment coordinate for {{Glossary("glyph", "glyphs")}} to achieve alphabetic baseline alignment. The value is an offset in the font coordinate system relative to the glyph-specific {{SVGAttr("vert-origin-x")}} attribute.
+The **`v-alphabetic`** attribute defines indicates the alignment coordinate for {{Glossary("glyph", "glyphs")}} to achieve {{glossary("/Baseline/Typography", "alphabetic baseline")}} alignment. The value is an offset in the font coordinate system relative to the glyph-specific {{SVGAttr("vert-origin-x")}} attribute.
 
 You can use this attribute with the following SVG elements:
 


### PR DESCRIPTION
linked the first occurrence of alphabetic baseline to the baseline typography page which defines it.