### PR TITLE
FF136 data: url max size 512Mb

### DIFF
--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -38,6 +38,8 @@ This article provides information about the changes in Firefox 136 that affect d
 
 ### APIs
 
+- The maximum size of [Data URLs](/en-US/docs/Web/URI/Schemes/data) has been increased from 32MB to 512MB, matching the limit for Chromium browsers ([Firefox bug 1911300](https://bugzil.la/1911300)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/web/uri/schemes/data/index.md
+++ b/files/en-us/web/uri/schemes/data/index.md
@@ -99,7 +99,7 @@ lots of text…
 - Length limitations
   - : Browsers are not required to support any particular maximum length of data.
     Chromium and Firefox limit `data` URLs to 512MB, and Safari (WebKit) limits them to 2048MB.
-    Note that Firefox 97 increased the limit from 256KB to 32MB, and Firefox 136 increased it to 512MB.
+    Note that Firefox 97 increased the limit from 256KB to 32MB, and [Firefox 136 increased it to 512MB](/en-US/docs/Mozilla/Firefox/Releases/136).
 - Lack of error handling
   - : Invalid parameters in media, or typos when specifying `'base64'`, are ignored, but no error is provided.
 - No support for query strings, etc.

--- a/files/en-us/web/uri/schemes/data/index.md
+++ b/files/en-us/web/uri/schemes/data/index.md
@@ -99,7 +99,7 @@ lots of text…
 - Length limitations
   - : Browsers are not required to support any particular maximum length of data.
     Chromium and Firefox limit `data` URLs to 512MB, and Safari (WebKit) limits them to 2048MB.
-    Note that Firefox 97 increased the limit from 256MB to 32MB, and Firefox 136 increased it to 512MB.
+    Note that Firefox 97 increased the limit from 256KB to 32MB, and Firefox 136 increased it to 512MB.
 - Lack of error handling
   - : Invalid parameters in media, or typos when specifying `'base64'`, are ignored, but no error is provided.
 - No support for query strings, etc.

--- a/files/en-us/web/uri/schemes/data/index.md
+++ b/files/en-us/web/uri/schemes/data/index.md
@@ -97,7 +97,9 @@ lots of text…
 - Formatting in HTML
   - : A `data` URL provides a file within a file, which can potentially be very wide relative to the width of the enclosing document. As a URL, the `data` should be formattable with whitespace (linefeed, tab, or spaces), but there are practical issues that arise [when using base64 encoding](https://bugzil.la/73026#c12).
 - Length limitations
-  - : Browsers are not required to support any particular maximum length of data. For example, the Opera 11 browser limited URLs to 65535 characters long which limits `data` URLs to 65529 characters (65529 characters being the length of the encoded data, not the source, if you use the plain `data:`, without specifying a MIME type). Firefox version 97 and newer supports `data` URLs of up to 32MB (before 97 the limit was close to 256MB). Chromium objects to URLs over 512MB, and WebKit (Safari) to URLs over 2048MB.
+  - : Browsers are not required to support any particular maximum length of data.
+    Chromium and Firefox limit `data` URLs to 512MB, and Safari (WebKit) limits them to 2048MB.
+    Note that Firefox 97 increased the limit from 256MB to 32MB, and Firefox 136 increased it to 512MB.
 - Lack of error handling
   - : Invalid parameters in media, or typos when specifying `'base64'`, are ignored, but no error is provided.
 - No support for query strings, etc.


### PR DESCRIPTION
This updates the data URL page with new max size for FF data URLs. Also a release note, as this is of potential interest to developers.

This fell out of https://bugzilla.mozilla.org/show_bug.cgi?id=1911300

Note, this has no BCD, and I have marked the corresponding issue as dev-doc-complete