### PR TITLE
TrustedTypes injection - Document.write() and Document.writeln()

### DIFF
--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -12,58 +12,55 @@ browser-compat: api.Document.write
 
 > [!WARNING]
 > Use of the `document.write()` method is strongly discouraged.
+> Avoid using it, and where possible replace it in existing code.
 >
 > As [the HTML spec itself warns](<https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.write()>):
 >
-> > This method has very idiosyncratic behavior. In some cases, this method can affect the state of the [HTML parser](https://html.spec.whatwg.org/multipage/parsing.html#html-parser) while the parser is running, resulting in a DOM that does not correspond to the source of the document (e.g., if the string written is the string `<plaintext>` or `<!--`). In other cases, the call can clear the current page first, as if [`document.open()`](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open) had been called. In yet more cases, the method is simply ignored, or throws an exception. Users agents are [explicitly allowed to avoid executing `script` elements inserted via this method](https://html.spec.whatwg.org/multipage/parsing.html#document-written-scripts-intervention). And to make matters even worse, the exact behavior of this method can in some cases be dependent on network latency, which can lead to failures that are very hard to debug. For all these reasons, use of this method is strongly discouraged.
-> > Therefore, avoid using `document.write()` — and if possible, update any existing code that is still using it.
+> > This method has very idiosyncratic behavior.
+> > In some cases, this method can affect the state of the [HTML parser](https://html.spec.whatwg.org/multipage/parsing.html#html-parser) while the parser is running, resulting in a DOM that does not correspond to the source of the document (e.g., if the string written is the string "`<plaintext>`" or "`<!--`").
+> > In other cases, the call can clear the current page first, as if {{domxref("document.open()")}} had been called.
+> > In yet more cases, the method is simply ignored, or throws an exception. Users agents are [explicitly allowed to avoid executing `script` elements inserted via this method](https://html.spec.whatwg.org/multipage/parsing.html#document-written-scripts-intervention).
+> > And to make matters even worse, the exact behavior of this method can in some cases be dependent on network latency, which can lead to failures that are very hard to debug.
+> > For all these reasons, use of this method is strongly discouraged.
 
-The **`document.write()`** method writes a string of text to a document stream opened by {{domxref("document.open()")}}.
-
-> [!NOTE]
-> Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document automatically calls `document.open()`, [which will clear the document](/en-US/docs/Web/API/Document/open#notes).
+The **`document.write()`** method writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}.
 
 ## Syntax
 
 ```js-nolint
 write(markup)
+write(markup, markup2)
+write(markup, markup2, /* …, */ markupN)
 ```
 
 ### Parameters
 
-- `markup`
-  - : A string containing the text to be written to the document.
+- `markup`, …, `markupN`
+  - : {{domxref("TrustedHTML")}} or string objects containing the text to be written to the document.
+    `TrustedHTML` is recommended for sanitizing any markup that may have been provided as user input.
 
 ### Return value
 
 None ({{jsxref("undefined")}}).
 
-## Examples
+### Exceptions
 
-```html
-<p>Some original document content.</p>
-<button>Replace document content</button>
-```
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : The method was called on an XML document, or called when the parser is currently executing a custom element constructor.
+- `TypeError`
+  - : A string is passed as one of the parameters when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are enforced (using [CSP: require-trusted-types-for](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for)), and no [default policy](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#the_default_policy) has been defined for creating {{domxref("TrustedHTML")}} objects.
 
-```js
-function newContent() {
-  document.open();
-  document.write("<h1>Out with the old, in with the new!</h1>");
-  document.close();
-}
+## Description
 
-document.querySelector("button").addEventListener("click", newContent);
-```
+`document.write()` parses the markup text in the objects passed as parameters into the open document's object model (DOM), in the order that the parameters are specified.
 
-{{EmbedLiveSample("Examples")}}
+The passed objects may be strings or {{domxref("TrustedHTML")}} instances.
+Using the `TrustedHTML` [trusted type](/en-US/docs/Web/API/Trusted_Types_API) is recommended, as this allows the strings to be passed through a transformation function (and potentially sanitized) before they are parsed into the document.
+[The trusted types JavaScript API](/en-US/docs/Web/API/Trusted_Types_API#the_trusted_types_javascript_api) section of _Trusted Types API_ explains policy definition and enforcement in more detail.
 
-## Notes
+Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document (without first calling {{domxref("document.open()")}}) automatically calls {{domxref("document.open()")}}, which will [clear the document](/en-US/docs/Web/API/Document/open#description).
 
-The text you write is parsed into the document's structure model. In the example above, the `h1` element becomes a node in the document.
-
-Writing to a document that has already loaded without calling {{domxref("document.open()")}} will automatically call `document.open()`. After writing, call {{domxref("document.close()")}} to tell the browser to finish loading the page.
-
-If the `document.write()` call is embedded within an inline HTML `<script>` tag, then it will not call `document.open()`. For example:
+The exception is that if the `document.write()` call is embedded within an inline HTML `<script>` tag, then it will not automatically call `document.open()`:
 
 ```html
 <script>
@@ -71,13 +68,99 @@ If the `document.write()` call is embedded within an inline HTML `<script>` tag,
 </script>
 ```
 
-`document.write()` and {{domxref("document.writeln")}} do not work in XHTML documents (you'll get an "Operation is not supported" (`NS_ERROR_DOM_NOT_SUPPORTED_ERR`) error in the error console). This happens when opening a local file with the .xhtml file extension or for any document served with an `application/xhtml+xml` {{Glossary("MIME type")}}. More information is available in the [W3C XHTML FAQ](https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite).
+`document.write()` and {{domxref("document.writeln")}} cannot be used with XML or XHTML, and attempting to do so will throw an `InvalidStateError` exception.
 
 Using `document.write()` in [deferred](/en-US/docs/Web/HTML/Reference/Elements/script#defer) or [asynchronous](/en-US/docs/Web/HTML/Reference/Elements/script#async) scripts will be ignored and you'll get a message like "A call to `document.write()` from an asynchronously-loaded external script was ignored" in the error console.
 
 In Edge only, calling `document.write()` more than once in an {{HTMLElement("iframe")}} causes the error "SCRIPT70: Permission denied".
 
-Starting with version 55, Chrome will not execute `<script>` elements injected via `document.write()` when specific conditions are met. For more information, refer to [Intervening against document.write()](https://developer.chrome.com/blog/removing-document-write/).
+Starting with version 55, Chrome will not execute `<script>` elements injected via `document.write()` when specific conditions are met.
+For more information, refer to [Intervening against document.write()](https://developer.chrome.com/blog/removing-document-write/).
+
+## Examples
+
+### Write strings
+
+When the button is clicked, this example opens the current document, writes two strings, then closes the document.
+This replaces the document in the example frame, including the original HTML for the button and the JavaScript that made the update!
+
+Note that in this example trusted types are not used or enforced.
+We're writing unsanitized strings, which may provide a path for [XSS attacks](/en-US/docs/Web/Security/Attacks/XSS).
+
+#### HTML
+
+```html
+<p>Some original document content.</p>
+<button id="replace" type="button">Replace document content</button>
+```
+
+#### JavaScript
+
+```js
+const replace = document.querySelector("#replace");
+
+replace.addEventListener("click", () => {
+  document.open();
+  document.write("<h1>Out with the old</h1>", "<p>in with the new!</p>");
+  document.close();
+});
+```
+
+#### Results
+
+{{EmbedLiveSample("Write strings")}}
+
+### Writing TrustedHTML
+
+This example is the same as the previous one, except that we use the [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API) to create {{domxref("TrustedHTML")}} instances, and pass those to the `write()` method instead of strings.
+
+#### HTML
+
+```html
+<p>Some original document content.</p>
+<button id="replace" type="button">Replace document content</button>
+```
+
+#### JavaScript
+
+First we use the {{domxref("Window.trustedTypes")}} property to access the global {{domxref("TrustedTypePolicyFactory")}}, and use its {{domxref("TrustedTypePolicyFactory/createPolicy","createPolicy()")}} method to define a policy called `"docPolicy"`.
+
+The new policy defines a transformation function `createHTML()` for creating the {{domxref("TrustedHTML")}} objects that we will pass to the `write()` method.
+This method can do anything it likes with the input string: the trusted types API just requires that you pass the input through a policy transformation function, not that the trusted type does anything in particular.
+
+Commonly you'd use the method to sanitize the input of XSS-unsafe elements and attributes, perhaps using a third party library such as [DOMPurify](https://github.com/cure53/DOMPurify).
+In this case we implement rudimentary "sanitizer" that just replaces `<` symbols with the `&lt;` characters.
+
+```js
+const writeDocumentHTMLPolicy = trustedTypes.createPolicy("docPolicy", {
+  createHTML: (string) => string.replace(/</g, "&lt;"),
+});
+```
+
+We can then use the {{domxref("TrustedTypePolicy.createHTML()")}} method on the returned policy to create {{domxref("TrustedHTML")}} objects from our original input strings.
+These are then passed to the `write()` function when the user clicks the button.
+
+```js
+const oneInput = writeDocumentHTMLPolicy.createHTML(
+  "<h1>Out with the old</h1>",
+);
+const twoInput = writeDocumentHTMLPolicy.createHTML("<p>in with the new!</p>");
+
+const replace = document.querySelector("#replace");
+
+replace.addEventListener("click", () => {
+  document.open();
+  document.write(oneInput, twoInput);
+  document.close();
+});
+```
+
+#### Results
+
+Press the button and note that the HTML is now rendered as plain text.
+In a real application we'd filter just the unsafe HTML elements and inject the desired ones
+
+{{EmbedLiveSample("Writing TrustedHTML")}}
 
 ## Specifications
 
@@ -89,5 +172,8 @@ Starting with version 55, Chrome will not execute `<script>` elements injected v
 
 ## See also
 
+- {{domxref("document.writeln()")}}
 - {{domxref("element.innerHTML")}}
 - {{domxref("document.createElement()")}}
+- [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API)
+- [Cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS)

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -23,6 +23,13 @@ browser-compat: api.Document.write
 > > And to make matters even worse, the exact behavior of this method can in some cases be dependent on network latency, which can lead to failures that are very hard to debug.
 > > For all these reasons, use of this method is strongly discouraged.
 
+> [!WARNING]
+> This API parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+> This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
+
 The **write()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}.
 
 ## Syntax
@@ -131,7 +138,7 @@ replace.addEventListener("click", () => {
   document.write(
     policy.createHTML(oneInput),
     policy.createHTML(twoInput),
-    policy.createHTML(threeInput),
+    policy.createHTML(threeInput)
   );
   document.close();
 });

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -36,8 +36,7 @@ write(markup, markup2, /* …, */ markupN)
 ### Parameters
 
 - `markup`, …, `markupN`
-  - : {{domxref("TrustedHTML")}} or string objects containing the text to be written to the document.
-    `TrustedHTML` is recommended for sanitizing any markup that may have been provided as user input.
+  - : {{domxref("TrustedHTML")}} objects or strings containing the markup to be written to the document.
 
 ### Return value
 
@@ -48,7 +47,7 @@ None ({{jsxref("undefined")}}).
 - `InvalidStateError` {{domxref("DOMException")}}
   - : The method was called on an XML document, or called when the parser is currently executing a custom element constructor.
 - `TypeError`
-  - : A string is passed as one of the parameters when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are enforced (using [CSP: require-trusted-types-for](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for)), and no [default policy](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#the_default_policy) has been defined for creating {{domxref("TrustedHTML")}} objects.
+  - : A string is passed as one of the parameters when [Trusted Types are enforced](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and [no default policy has been defined](https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#creating_a_default_policy) for creating {{domxref("TrustedHTML")}} objects.
 
 ## Description
 
@@ -56,7 +55,7 @@ None ({{jsxref("undefined")}}).
 
 The passed objects may be strings or {{domxref("TrustedHTML")}} instances.
 Using the `TrustedHTML` [trusted type](/en-US/docs/Web/API/Trusted_Types_API) is recommended, as this allows the strings to be passed through a transformation function (and potentially sanitized) before they are parsed into the document.
-[The trusted types JavaScript API](/en-US/docs/Web/API/Trusted_Types_API#the_trusted_types_javascript_api) section of _Trusted Types API_ explains policy definition and enforcement in more detail.
+[The Trusted Types JavaScript API](/en-US/docs/Web/API/Trusted_Types_API#the_trusted_types_javascript_api) section of _Trusted Types API_ explains policy definition and enforcement in more detail.
 
 Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document (without first calling {{domxref("document.open()")}}) automatically calls {{domxref("document.open()")}}, which will [clear the document](/en-US/docs/Web/API/Document/open#description).
 
@@ -128,9 +127,9 @@ This example is the same as the previous one, except that we use the [Trusted Ty
 First we use the {{domxref("Window.trustedTypes")}} property to access the global {{domxref("TrustedTypePolicyFactory")}}, and use its {{domxref("TrustedTypePolicyFactory/createPolicy","createPolicy()")}} method to define a policy called `"docPolicy"`.
 
 The new policy defines a transformation function `createHTML()` for creating the {{domxref("TrustedHTML")}} objects that we will pass to the `write()` method.
-This method can do anything it likes with the input string: the trusted types API just requires that you pass the input through a policy transformation function, not that the trusted type does anything in particular.
+This method can do anything it likes with the input string: the trusted types API just requires that you pass the input through a policy transformation function, not that the transformation function does anything in particular.
 
-Commonly you'd use the method to sanitize the input of XSS-unsafe elements and attributes, perhaps using a third party library such as [DOMPurify](https://github.com/cure53/DOMPurify).
+You'd use the method to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input by removing potentially unsafe features such as {{htmlelement("script")}} tags or event handler attributes. Sanitization is hard to get right, so this process typically uses a reputable third-party library such as [DOMPurify](https://github.com/cure53/DOMPurify).
 In this case we implement rudimentary "sanitizer" that just replaces `<` symbols with the `&lt;` characters.
 
 ```js
@@ -143,24 +142,21 @@ We can then use the {{domxref("TrustedTypePolicy.createHTML()")}} method on the 
 These are then passed to the `write()` function when the user clicks the button.
 
 ```js
-const oneInput = writeDocumentHTMLPolicy.createHTML(
-  "<h1>Out with the old</h1>",
-);
-const twoInput = writeDocumentHTMLPolicy.createHTML("<p>in with the new!</p>");
+const oneInput = "<h1>Out with the old</h1>";
+const twoInput = "<p>in with the new!</p>";
 
 const replace = document.querySelector("#replace");
 
 replace.addEventListener("click", () => {
   document.open();
-  document.write(oneInput, twoInput);
+  document.write(policy.createHTML(oneInput), policy.createHTML(twoInput));
   document.close();
 });
-```
 
 #### Results
 
 Press the button and note that the HTML is now rendered as plain text.
-In a real application we'd filter just the unsafe HTML elements and inject the desired ones
+In a real application we'd filter just the unsafe HTML elements and inject the desired ones.
 
 {{EmbedLiveSample("Writing TrustedHTML")}}
 

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -30,7 +30,7 @@ browser-compat: api.Document.write
 > For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 > This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
-The **write()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}.
+The **`write()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}.
 
 ## Syntax
 
@@ -150,7 +150,7 @@ Press the button and note that the HTML elements that we trust (in this example)
 
 {{EmbedLiveSample("Writing TrustedHTML")}}
 
-### Write strings
+### Writing strings
 
 This is the same as the preceding example, except that trusted types are not used or enforced.
 We're writing unsanitized strings, which may provide a path for [XSS attacks](/en-US/docs/Web/Security/Attacks/XSS).
@@ -187,7 +187,7 @@ replace.addEventListener("click", () => {
 Press the button and note that all the HTML elements are injected.
 This includes the {{htmlelement("script")}} element, which in a real application might have executed harmful code.
 
-{{EmbedLiveSample("Write strings")}}
+{{EmbedLiveSample("Writing strings")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -23,7 +23,7 @@ browser-compat: api.Document.write
 > > And to make matters even worse, the exact behavior of this method can in some cases be dependent on network latency, which can lead to failures that are very hard to debug.
 > > For all these reasons, use of this method is strongly discouraged.
 
-The **`document.write()`** method writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}.
+The **write()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}.
 
 ## Syntax
 
@@ -68,7 +68,9 @@ The exception is that if the `document.write()` call is embedded within an inlin
 </script>
 ```
 
-`document.write()` and {{domxref("document.writeln")}} cannot be used with XML or XHTML, and attempting to do so will throw an `InvalidStateError` exception.
+`document.write()` (and {{domxref("document.writeln")}}) cannot be used with XML or XHTML, and attempting to do so will throw an `InvalidStateError` exception.
+This is the case if opening a local file with a .xhtml file extension or for any document served with an `application/xhtml+xml` MIME type.
+More information is available in the [W3C XHTML FAQ](https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite).
 
 Using `document.write()` in [deferred](/en-US/docs/Web/HTML/Reference/Elements/script#defer) or [asynchronous](/en-US/docs/Web/HTML/Reference/Elements/script#async) scripts will be ignored and you'll get a message like "A call to `document.write()` from an asynchronously-loaded external script was ignored" in the error console.
 

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -82,7 +82,7 @@ For more information, refer to [Intervening against document.write()](https://de
 
 ### Writing TrustedHTML
 
-This example uses the [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API) to sanitize strings of {{htmlelement("script")}} elements before they are written to a document.
+This example uses the [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API) to sanitize HTML strings of {{htmlelement("script")}} elements before they are written to a document.
 
 The example initially displays some default text and a button.
 When the button is clicked, the current document is opened, three strings of HTML are converted to {{domxref("TrustedHTML")}} instances and written into the document, and the document is then closed.

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -60,9 +60,9 @@ None ({{jsxref("undefined")}}).
 
 `document.write()` parses the markup text in the objects passed as parameters into the open document's object model (DOM), in the order that the parameters are specified.
 
-The passed objects may be strings or {{domxref("TrustedHTML")}} instances.
-Using the `TrustedHTML` [trusted type](/en-US/docs/Web/API/Trusted_Types_API) is recommended, as this allows the strings to be passed through a transformation function (and potentially sanitized) before they are parsed into the document.
-[The Trusted Types JavaScript API](/en-US/docs/Web/API/Trusted_Types_API#the_trusted_types_javascript_api) section of _Trusted Types API_ explains policy definition and enforcement in more detail.
+The passed objects may be {{domxref("TrustedHTML")}} instances or strings.
+It is much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+The guarantees that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
 Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document (without first calling {{domxref("document.open()")}}) automatically calls {{domxref("document.open()")}}, which will [clear the document](/en-US/docs/Web/API/Document/open#description).
 
@@ -138,7 +138,7 @@ replace.addEventListener("click", () => {
   document.write(
     policy.createHTML(oneInput),
     policy.createHTML(twoInput),
-    policy.createHTML(threeInput)
+    policy.createHTML(threeInput),
   );
   document.close();
 });

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -10,8 +10,9 @@ browser-compat: api.Document.writeln
 
 The **`writeln()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}, followed by a newline character.
 
-The method is essentially the same as {{domxref("document.write()")}} but adds a newline.
+The method is essentially the same as {{domxref("document.write()")}} but adds a newline (information in the linked topic also applies to this method).
 This newline will only be visible if it is injected inside an element where newlines are displayed.
+There is more information about how it is used and limitations in
 
 ## Syntax
 

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -8,34 +8,75 @@ browser-compat: api.Document.writeln
 
 {{ ApiRef("DOM") }}
 
-Writes a string of text followed by a newline character to a document.
+The **`writeln()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}, followed by a newline character.
+
+The method is essentially the same as {{domxref("document.write()")}} but adds a newline.
+This newline will only be visible if it is injected inside an element where newlines are displayed.
 
 ## Syntax
 
 ```js-nolint
-writeln(line)
+writeln(markup)
+writeln(markup, markup2)
+writeln(markup, markup2, /* …, */ markupN)
 ```
 
 ### Parameters
 
-- `line`
-  - : A string containing a line of text.
+- `markup`, …, `markupN`
+  - : {{domxref("TrustedHTML")}} or string objects containing the text to be written to the document.
+    `TrustedHTML` is recommended for sanitizing any markup that may have been provided as user input.
 
 ### Return value
 
 None ({{jsxref("undefined")}}).
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : The method was called on an XML document, or called when the parser is currently executing a custom element constructor.
+- `TypeError`
+  - : A string is passed as one of the parameters when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are enforced (using [CSP: require-trusted-types-for](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for)), and no [default policy](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#the_default_policy) has been defined for creating {{domxref("TrustedHTML")}} objects.
+
 ## Examples
 
-```js
-document.writeln("<p>enter password:</p>");
+### Write strings
+
+When the button is clicked, this example opens the current document, writes a number of strings, then closes the document.
+This replaces the document in the example frame, including the original HTML for the button and the JavaScript that made the update!
+
+Note that in this example trusted types are not used or enforced.
+We're writing unsanitized strings, which may provide a path for [XSS attacks](/en-US/docs/Web/Security/Attacks/XSS).
+
+#### HTML
+
+```html
+<p>Some original document content.</p>
+<button id="replace" type="button">Replace document content</button>
 ```
 
-## Notes
+#### JavaScript
 
-**document.writeln** is the same as {{domxref("document.write")}} but adds a newline.
+The code below adds opens the document, writes four strings when the button is clicked, and then closes the document when the button is clicked.
 
-> **Note:** **document.writeln** (like **document.write**) does not work in XHTML documents (you'll get a "Operation is not supported" (`NS_ERROR_DOM_NOT_SUPPORTED_ERR`) error on the error console). This is the case if opening a local file with a .xhtml file extension or for any document served with an application/xhtml+xml MIME type. More information is available in the [W3C XHTML FAQ](https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite).
+```js
+const replace = document.querySelector("#replace");
+
+replace.addEventListener("click", () => {
+  document.open();
+  document.writeln("<h1>Out with");
+  document.writeln("the old</h1>", "<pre>in with");
+  document.writeln("the new!</pre>");
+  document.close();
+});
+```
+
+#### Results
+
+Click the button.
+Note that a newline is added after each call to `writeln()`, but this will only be visible inside the {{htmlelement("pre")}} element as its layout preserves whitespace by default.
+
+{{EmbedLiveSample("Write strings")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -26,7 +26,6 @@ writeln(markup, markup2, /* …, */ markupN)
 
 - `markup`, …, `markupN`
   - : {{domxref("TrustedHTML")}} or string objects containing the text to be written to the document.
-    `TrustedHTML` is recommended for sanitizing any markup that may have been provided as user input.
 
 ### Return value
 
@@ -37,7 +36,7 @@ None ({{jsxref("undefined")}}).
 - `InvalidStateError` {{domxref("DOMException")}}
   - : The method was called on an XML document, or called when the parser is currently executing a custom element constructor.
 - `TypeError`
-  - : A string is passed as one of the parameters when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are enforced (using [CSP: require-trusted-types-for](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for)), and no [default policy](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#the_default_policy) has been defined for creating {{domxref("TrustedHTML")}} objects.
+  - : A string is passed as one of the parameters when [Trusted Types are enforced](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and [no default policy has been defined](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#creating_a_default_policy) for creating {{domxref("TrustedHTML")}} objects.
 
 ## Examples
 

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -8,6 +8,13 @@ browser-compat: api.Document.writeln
 
 {{ ApiRef("DOM") }}
 
+> [!WARNING]
+> This API parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+> This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
+
 The **`writeln()`** method of the {{domxref("Document")}} interface writes text in one or more {{domxref("TrustedHTML")}} or string parameters to a document stream opened by {{domxref("document.open()")}}, followed by a newline character.
 
 The method is essentially the same as {{domxref("document.write()")}} but adds a newline (information in the linked topic also applies to this method).


### PR DESCRIPTION
This is update of injection sinks reference docs for TrustedTypes for `Document.write()` and `Document.writeln()`

Note, first pass at this I said far too much about trusted types. The key here is to note that trusted types can be a parameter, and ideally provide a simple example of how they are used alongside the string.

But there is no need to explain trusted types in full gory detail, that's what the trusted API docs are for. This is to highlight the option.

Related docs work in #37518