### PR TITLE
Rename -webkit-line-clamp to line-clamp

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11714,6 +11714,7 @@
 /en-US/docs/Web/CSS/-webkit-font-variant-ligatures	/en-US/docs/Web/CSS/font-variant-ligatures
 /en-US/docs/Web/CSS/-webkit-hyphens	/en-US/docs/Web/CSS/hyphens
 /en-US/docs/Web/CSS/-webkit-justify-content	/en-US/docs/Web/CSS/justify-content
+/en-US/docs/Web/CSS/-webkit-line-clamp	/en-US/docs/Web/CSS/line-clamp
 /en-US/docs/Web/CSS/-webkit-linear-gradient	/en-US/docs/Web/CSS/gradient/linear-gradient
 /en-US/docs/Web/CSS/-webkit-mask	/en-US/docs/Web/CSS/mask
 /en-US/docs/Web/CSS/-webkit-mask-attachment	/en-US/docs/Web/CSS

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -72331,17 +72331,6 @@
       "velvel53"
     ]
   },
-  "Web/CSS/-webkit-line-clamp": {
-    "modified": "2020-10-15T22:18:29.295Z",
-    "contributors": [
-      "ddbeck",
-      "Sheppy",
-      "Siilwyn",
-      "chrisdavidmills",
-      "rsinohara",
-      "Sebastianz"
-    ]
-  },
   "Web/CSS/-webkit-mask-box-image": {
     "modified": "2020-10-15T21:08:28.807Z",
     "contributors": [
@@ -85619,6 +85608,17 @@
       "ishita",
       "mkato",
       "teoli"
+    ]
+  },
+  "Web/CSS/line-clamp": {
+    "modified": "2020-10-15T22:18:29.295Z",
+    "contributors": [
+      "ddbeck",
+      "Sheppy",
+      "Siilwyn",
+      "chrisdavidmills",
+      "rsinohara",
+      "Sebastianz"
     ]
   },
   "Web/CSS/line-height": {

--- a/files/en-us/web/css/line-clamp/index.md
+++ b/files/en-us/web/css/line-clamp/index.md
@@ -1,39 +1,36 @@
 ---
-title: "-webkit-line-clamp"
-slug: Web/CSS/-webkit-line-clamp
+title: line-clamp
+slug: Web/CSS/line-clamp
 page-type: css-property
 browser-compat: css.properties.line-clamp
 ---
 
 {{CSSRef}}
 
-The **`-webkit-line-clamp`** [CSS](/en-US/docs/Web/CSS) property allows limiting of the contents of a {{Glossary("block")}} to the specified number of lines.
+The **`line-clamp`** [CSS](/en-US/docs/Web/CSS) property allows limiting of the contents of a {{Glossary("block")}} to the specified number of lines.
 
-It only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`. Despite them being deprecated, the co-dependency of these three properties is fully specified behavior and will continue to be supported.
+Currently this property is only supported with a vendor-prefix as `-webkit-line-clamp`. And only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`. Despite them being deprecated, the co-dependency of these three properties is fully specified behavior and will continue to be supported.
 
 In most cases you will also want to set {{cssxref("overflow")}} to `hidden`, otherwise the contents won't be clipped but an ellipsis will still be shown after the specified number of lines.
 
 When applied to anchor elements, the truncating can happen in the middle of the text, not necessarily at the end.
 
-> [!NOTE]
-> This property was originally implemented in WebKit and has some issues, such as the dependency on two other legacy properties. It got standardized in [CSS Overflow Module Level 4](https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp) for legacy support. CSS Overflow Module Level 4 also defines a {{cssxref("line-clamp")}} property, which is meant to replace this property and avoid its issues. However, all browsers that support `line-clamp` will also support `-webkit-line-clamp` for compatibility reasons.
-
 ## Syntax
 
 ```css
 /* Keyword value */
--webkit-line-clamp: none;
+line-clamp: none;
 
 /* <integer> values */
--webkit-line-clamp: 3;
--webkit-line-clamp: 10;
+line-clamp: 3;
+line-clamp: 10;
 
 /* Global values */
--webkit-line-clamp: inherit;
--webkit-line-clamp: initial;
--webkit-line-clamp: revert;
--webkit-line-clamp: revert-layer;
--webkit-line-clamp: unset;
+line-clamp: inherit;
+line-clamp: initial;
+line-clamp: revert;
+line-clamp: revert-layer;
+line-clamp: unset;
 ```
 
 ### Values
@@ -92,4 +89,3 @@ p {
 ## See also
 
 - [Line Clampin' (Truncating Multiple Line Text)](https://css-tricks.com/line-clampin/)
-- {{cssxref("line-clamp")}}

--- a/files/en-us/web/css/line-clamp/index.md
+++ b/files/en-us/web/css/line-clamp/index.md
@@ -9,7 +9,8 @@ browser-compat: css.properties.line-clamp
 
 The **`line-clamp`** [CSS](/en-US/docs/Web/CSS) property allows limiting of the contents of a {{Glossary("block")}} to the specified number of lines.
 
-For legacy support with a vendor-prefix as `-webkit-line-clamp`, it only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`. Despite them being deprecated, the co-dependency of these three properties is fully specified behavior and will continue to be supported.
+> [!NOTE]
+> For legacy support, the vendor-prefixed `-webkit-line-clamp` property only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`. Despite these prefixed properties being deprecated, the co-dependency of these three properties is a fully specified behavior and will continue to be supported.
 
 In most cases you will also want to set {{cssxref("overflow")}} to `hidden`, otherwise the contents won't be clipped but an ellipsis will still be shown after the specified number of lines.
 

--- a/files/en-us/web/css/line-clamp/index.md
+++ b/files/en-us/web/css/line-clamp/index.md
@@ -9,7 +9,7 @@ browser-compat: css.properties.line-clamp
 
 The **`line-clamp`** [CSS](/en-US/docs/Web/CSS) property allows limiting of the contents of a {{Glossary("block")}} to the specified number of lines.
 
-Currently this property is only supported with a vendor-prefix as `-webkit-line-clamp`. And only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`. Despite them being deprecated, the co-dependency of these three properties is fully specified behavior and will continue to be supported.
+For legacy support with a vendor-prefix as `-webkit-line-clamp`, it only works in combination with the {{cssxref("display")}} property set to `-webkit-box` or `-webkit-inline-box` and the {{cssxref("box-orient", "-webkit-box-orient")}} property set to `vertical`. Despite them being deprecated, the co-dependency of these three properties is fully specified behavior and will continue to be supported.
 
 In most cases you will also want to set {{cssxref("overflow")}} to `hidden`, otherwise the contents won't be clipped but an ellipsis will still be shown after the specified number of lines.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

this property has got standardized as line-clamp, bcd has renamed already, and mdn web docs should do the same thing

safari has supported the unprefixed version yet

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
https://drafts.csswg.org/css-overflow-4/#propdef-line-clamp
https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
