### PR TITLE
Remove note about Firefox bug which is resolved and released.

### DIFF
--- a/files/en-us/web/api/htmlimageelement/loading/index.md
+++ b/files/en-us/web/api/htmlimageelement/loading/index.md
@@ -25,9 +25,6 @@ The possible values are:
 
 ## Usage notes
 
-> [!NOTE]
-> In Firefox, the `loading` attribute must be defined before the `src` attribute, otherwise it has no effect ([Firefox bug 1647077](https://bugzil.la/1647077)).
-
 ### JavaScript must be enabled
 
 Loading is only deferred when JavaScript is enabled.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The FF bug this page referenced has been fixed, and released in FF 131 (Oct 2024)
https://bugzilla.mozilla.org/show_bug.cgi?id=1647077#c16 closes the linked bug as a dupe of...
https://bugzilla.mozilla.org/show_bug.cgi?id=1076583#c71 resolves the bug

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Don't warn about bugs that no longer exist.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
