### PR TITLE
Add remark describing special dash encoding requirement

### DIFF
--- a/files/en-us/web/uri/fragment/text_fragments/index.md
+++ b/files/en-us/web/uri/fragment/text_fragments/index.md
@@ -60,7 +60,7 @@ Supporting browsers will scroll to and highlight the first text fragment in the 
 
 ### Usage notes
 
-- Text strings used for the `textStart`, `textEnd`, `prefix-`, and `-suffix` values need to be [percent-encoded](/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
+- Text strings used for the `textStart`, `textEnd`, `prefix-`, and `-suffix` values need to be [percent-encoded](/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent). In addition, [the standard](https://wicg.github.io/scroll-to-text-fragment/#syntax) requires the URL-safe dash character `'-'` to be similarly percent-encoded.
 - Matches are case-insensitive.
 - Individual `textStart`, `textEnd`, `prefix-`, and `-suffix` strings need to reside wholly inside the same [block-level element](/en-US/docs/Glossary/Block-level_content), but complete matches can span across multiple element boundaries.
 - For security reasons, the feature requires links to be opened in a noopener context — you need to add `rel="noopener"` to your {{htmlelement("a")}} elements, and add `noopener` to your {{domxref("window.open()")}} calls when using this feature.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The Usage Notes section of the Text Fragments reference correctly advises that text strings must be percent-encoded and links to docs for `encodeURIComponent` as an example of this. However, `encodeURIComponent` performs replacement only on the special characters described in [Percent-encoding](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding) while the Text Fragment [standard](https://wicg.github.io/scroll-to-text-fragment/#syntax) requires that the dash character `-` (ASCII 45) must also be percent encoded when appearing in the directive section of a text fragment link.

As an example, [a fragment link featuring an unencoded dash character](https://pypi.org/simple/tables/#:~:text=tables-3.2.3.tar.gz) will not be highlighted in (e.g.) Chrome, while [the same fragment link containing an encoded dash](https://pypi.org/simple/tables/#:~:text=tables%2D3.2.3.tar.gz) performs as expected.

This PR adds a brief comment which draws attention to the requirement that the usually URL-safe dash character be percent encoded when appearing in a text fragment link.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

An unqualified reference to "percent encoding" may give readers the impression that this is only necessary for those characters for which `encodeURIComponent` performs a substitution, while the standard also makes this requirement of the URL-safe dash character.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

A separate comment highlighting this additional requirement described above helps to draw attention to this special circumstance and avoid unexpected behaviour resulting from non-standard compliant text fragments.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
