### PR TITLE
feat(frontmatter): use plain strings if possible

### DIFF
--- a/files/en-us/web/api/accelerometer/y/index.md
+++ b/files/en-us/web/api/accelerometer/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Accelerometer: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/Accelerometer/y
 page-type: web-api-instance-property
 status:

--- a/files/en-us/web/api/csspositionvalue/y/index.md
+++ b/files/en-us/web/api/csspositionvalue/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "CSSPositionValue: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/CSSPositionValue/y
 page-type: web-api-instance-property
 status:

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "CSSRotate: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/CSSRotate/y
 page-type: web-api-instance-property
 browser-compat: api.CSSRotate.y

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "CSSScale: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/CSSScale/y
 page-type: web-api-instance-property
 browser-compat: api.CSSScale.y

--- a/files/en-us/web/api/csstranslate/y/index.md
+++ b/files/en-us/web/api/csstranslate/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "CSSTranslate: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/CSSTranslate/y
 page-type: web-api-instance-property
 browser-compat: api.CSSTranslate.y

--- a/files/en-us/web/api/devicemotioneventacceleration/y/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DeviceMotionEventAcceleration: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/DeviceMotionEventAcceleration/y
 page-type: web-api-instance-property
 browser-compat: api.DeviceMotionEventAcceleration.y

--- a/files/en-us/web/api/dompoint/y/index.md
+++ b/files/en-us/web/api/dompoint/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DOMPoint: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/DOMPoint/y
 page-type: web-api-instance-property
 browser-compat: api.DOMPoint.y

--- a/files/en-us/web/api/dompointreadonly/y/index.md
+++ b/files/en-us/web/api/dompointreadonly/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DOMPointReadOnly: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/DOMPointReadOnly/y
 page-type: web-api-instance-property
 browser-compat: api.DOMPointReadOnly.y

--- a/files/en-us/web/api/domrect/y/index.md
+++ b/files/en-us/web/api/domrect/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DOMRect: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/DOMRect/y
 page-type: web-api-instance-property
 browser-compat: api.DOMRect.y

--- a/files/en-us/web/api/domrectreadonly/y/index.md
+++ b/files/en-us/web/api/domrectreadonly/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DOMRectReadOnly: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/DOMRectReadOnly/y
 page-type: web-api-instance-property
 browser-compat: api.DOMRectReadOnly.y

--- a/files/en-us/web/api/gyroscope/y/index.md
+++ b/files/en-us/web/api/gyroscope/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Gyroscope: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/Gyroscope/y
 page-type: web-api-instance-property
 browser-compat: api.Gyroscope.y

--- a/files/en-us/web/api/htmlimageelement/y/index.md
+++ b/files/en-us/web/api/htmlimageelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "HTMLImageElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/HTMLImageElement/y
 page-type: web-api-instance-property
 browser-compat: api.HTMLImageElement.y

--- a/files/en-us/web/api/magnetometer/y/index.md
+++ b/files/en-us/web/api/magnetometer/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Magnetometer: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/Magnetometer/y
 page-type: web-api-instance-property
 status:

--- a/files/en-us/web/api/mouseevent/y/index.md
+++ b/files/en-us/web/api/mouseevent/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "MouseEvent: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/MouseEvent/y
 page-type: web-api-instance-property
 browser-compat: api.MouseEvent.y

--- a/files/en-us/web/api/svgfeblendelement/y/index.md
+++ b/files/en-us/web/api/svgfeblendelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEBlendElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEBlendElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEBlendElement.y

--- a/files/en-us/web/api/svgfecolormatrixelement/y/index.md
+++ b/files/en-us/web/api/svgfecolormatrixelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEColorMatrixElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEColorMatrixElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEColorMatrixElement.y

--- a/files/en-us/web/api/svgfecomponenttransferelement/y/index.md
+++ b/files/en-us/web/api/svgfecomponenttransferelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEComponentTransferElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEComponentTransferElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEComponentTransferElement.y

--- a/files/en-us/web/api/svgfecompositeelement/y/index.md
+++ b/files/en-us/web/api/svgfecompositeelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFECompositeElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFECompositeElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFECompositeElement.y

--- a/files/en-us/web/api/svgfeconvolvematrixelement/y/index.md
+++ b/files/en-us/web/api/svgfeconvolvematrixelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEConvolveMatrixElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEConvolveMatrixElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEConvolveMatrixElement.y

--- a/files/en-us/web/api/svgfediffuselightingelement/y/index.md
+++ b/files/en-us/web/api/svgfediffuselightingelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEDiffuseLightingElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEDiffuseLightingElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEDiffuseLightingElement.y

--- a/files/en-us/web/api/svgfedisplacementmapelement/y/index.md
+++ b/files/en-us/web/api/svgfedisplacementmapelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEDisplacementMapElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEDisplacementMapElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEDisplacementMapElement.y

--- a/files/en-us/web/api/svgfedropshadowelement/y/index.md
+++ b/files/en-us/web/api/svgfedropshadowelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEDropShadowElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEDropShadowElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEDropShadowElement.y

--- a/files/en-us/web/api/svgfefloodelement/y/index.md
+++ b/files/en-us/web/api/svgfefloodelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEFloodElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEFloodElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEFloodElement.y

--- a/files/en-us/web/api/svgfegaussianblurelement/y/index.md
+++ b/files/en-us/web/api/svgfegaussianblurelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEGaussianBlurElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEGaussianBlurElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEGaussianBlurElement.y

--- a/files/en-us/web/api/svgfeimageelement/y/index.md
+++ b/files/en-us/web/api/svgfeimageelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEImageElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEImageElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEImageElement.y

--- a/files/en-us/web/api/svgfemergeelement/y/index.md
+++ b/files/en-us/web/api/svgfemergeelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEMergeElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEMergeElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEMergeElement.y

--- a/files/en-us/web/api/svgfemorphologyelement/y/index.md
+++ b/files/en-us/web/api/svgfemorphologyelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEMorphologyElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEMorphologyElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEMorphologyElement.y

--- a/files/en-us/web/api/svgfeoffsetelement/y/index.md
+++ b/files/en-us/web/api/svgfeoffsetelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEOffsetElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEOffsetElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEOffsetElement.y

--- a/files/en-us/web/api/svgfepointlightelement/y/index.md
+++ b/files/en-us/web/api/svgfepointlightelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFEPointLightElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFEPointLightElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFEPointLightElement.y

--- a/files/en-us/web/api/svgfespecularlightingelement/y/index.md
+++ b/files/en-us/web/api/svgfespecularlightingelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFESpecularLightingElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFESpecularLightingElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFESpecularLightingElement.y

--- a/files/en-us/web/api/svgfespotlightelement/y/index.md
+++ b/files/en-us/web/api/svgfespotlightelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFESpotLightElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFESpotLightElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFESpotLightElement.y

--- a/files/en-us/web/api/svgfetileelement/y/index.md
+++ b/files/en-us/web/api/svgfetileelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFETileElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFETileElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFETileElement.y

--- a/files/en-us/web/api/svgfeturbulenceelement/y/index.md
+++ b/files/en-us/web/api/svgfeturbulenceelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFETurbulenceElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFETurbulenceElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFETurbulenceElement.y

--- a/files/en-us/web/api/svgfilterelement/y/index.md
+++ b/files/en-us/web/api/svgfilterelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGFilterElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGFilterElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGFilterElement.y

--- a/files/en-us/web/api/svgforeignobjectelement/y/index.md
+++ b/files/en-us/web/api/svgforeignobjectelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGForeignObjectElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGForeignObjectElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGForeignObjectElement.y

--- a/files/en-us/web/api/svgimageelement/y/index.md
+++ b/files/en-us/web/api/svgimageelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGImageElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGImageElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGImageElement.y

--- a/files/en-us/web/api/svgmaskelement/y/index.md
+++ b/files/en-us/web/api/svgmaskelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGMaskElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGMaskElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGMaskElement.y

--- a/files/en-us/web/api/svgpatternelement/y/index.md
+++ b/files/en-us/web/api/svgpatternelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGPatternElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGPatternElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGPatternElement.y

--- a/files/en-us/web/api/svgrect/y/index.md
+++ b/files/en-us/web/api/svgrect/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGRect: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGRect/y
 page-type: web-api-instance-property
 browser-compat: api.SVGRect.y

--- a/files/en-us/web/api/svgrectelement/y/index.md
+++ b/files/en-us/web/api/svgrectelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGRectElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGRectElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGRectElement.y

--- a/files/en-us/web/api/svgtextpositioningelement/y/index.md
+++ b/files/en-us/web/api/svgtextpositioningelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGTextPositioningElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGTextPositioningElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGTextPositioningElement.y

--- a/files/en-us/web/api/svguseelement/y/index.md
+++ b/files/en-us/web/api/svguseelement/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "SVGUseElement: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/SVGUseElement/y
 page-type: web-api-instance-property
 browser-compat: api.SVGUseElement.y

--- a/files/en-us/web/api/xrviewport/y/index.md
+++ b/files/en-us/web/api/xrviewport/y/index.md
@@ -1,6 +1,6 @@
 ---
 title: "XRViewport: y property"
-short-title: "y"
+short-title: y
 slug: Web/API/XRViewport/y
 page-type: web-api-instance-property
 browser-compat: api.XRViewport.y

--- a/files/en-us/web/css/-moz-float-edge/index.md
+++ b/files/en-us/web/css/-moz-float-edge/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-float-edge"
+title: -moz-float-edge
 slug: Web/CSS/-moz-float-edge
 page-type: css-property
 status:

--- a/files/en-us/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/en-us/web/css/-moz-force-broken-image-icon/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-force-broken-image-icon"
+title: -moz-force-broken-image-icon
 slug: Web/CSS/-moz-force-broken-image-icon
 page-type: css-property
 status:

--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-image-rect"
+title: -moz-image-rect
 slug: Web/CSS/-moz-image-rect
 page-type: css-function
 status:

--- a/files/en-us/web/css/-moz-image-region/index.md
+++ b/files/en-us/web/css/-moz-image-region/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-image-region"
+title: -moz-image-region
 slug: Web/CSS/-moz-image-region
 page-type: css-property
 status:

--- a/files/en-us/web/css/-moz-orient/index.md
+++ b/files/en-us/web/css/-moz-orient/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-orient"
+title: -moz-orient
 slug: Web/CSS/-moz-orient
 page-type: css-property
 status:

--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-user-focus"
+title: -moz-user-focus
 slug: Web/CSS/-moz-user-focus
 page-type: css-property
 status:

--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-user-input"
+title: -moz-user-input
 slug: Web/CSS/-moz-user-input
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-border-before/index.md
+++ b/files/en-us/web/css/-webkit-border-before/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-border-before"
+title: -webkit-border-before
 slug: Web/CSS/-webkit-border-before
 page-type: css-shorthand-property
 status:

--- a/files/en-us/web/css/-webkit-box-reflect/index.md
+++ b/files/en-us/web/css/-webkit-box-reflect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-box-reflect"
+title: -webkit-box-reflect
 slug: Web/CSS/-webkit-box-reflect
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-mask-box-image"
+title: -webkit-mask-box-image
 slug: Web/CSS/-webkit-mask-box-image
 page-type: css-shorthand-property
 status:

--- a/files/en-us/web/css/-webkit-mask-composite/index.md
+++ b/files/en-us/web/css/-webkit-mask-composite/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-mask-composite"
+title: -webkit-mask-composite
 slug: Web/CSS/-webkit-mask-composite
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-mask-position-x"
+title: -webkit-mask-position-x
 slug: Web/CSS/-webkit-mask-position-x
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-mask-position-y"
+title: -webkit-mask-position-y
 slug: Web/CSS/-webkit-mask-position-y
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-x/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-mask-repeat-x"
+title: -webkit-mask-repeat-x
 slug: Web/CSS/-webkit-mask-repeat-x
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-y/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-mask-repeat-y"
+title: -webkit-mask-repeat-y
 slug: Web/CSS/-webkit-mask-repeat-y
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/en-us/web/css/-webkit-tap-highlight-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-tap-highlight-color"
+title: -webkit-tap-highlight-color
 slug: Web/CSS/-webkit-tap-highlight-color
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-text-fill-color/index.md
+++ b/files/en-us/web/css/-webkit-text-fill-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-text-fill-color"
+title: -webkit-text-fill-color
 slug: Web/CSS/-webkit-text-fill-color
 page-type: css-property
 browser-compat: css.properties.-webkit-text-fill-color

--- a/files/en-us/web/css/-webkit-text-security/index.md
+++ b/files/en-us/web/css/-webkit-text-security/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-text-security"
+title: -webkit-text-security
 slug: Web/CSS/-webkit-text-security
 page-type: css-property
 status:

--- a/files/en-us/web/css/-webkit-text-stroke-color/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke-color/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-text-stroke-color"
+title: -webkit-text-stroke-color
 slug: Web/CSS/-webkit-text-stroke-color
 page-type: css-property
 browser-compat: css.properties.-webkit-text-stroke-color

--- a/files/en-us/web/css/-webkit-text-stroke-width/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke-width/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-text-stroke-width"
+title: -webkit-text-stroke-width
 slug: Web/CSS/-webkit-text-stroke-width
 page-type: css-property
 browser-compat: css.properties.-webkit-text-stroke-width

--- a/files/en-us/web/css/-webkit-text-stroke/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-text-stroke"
+title: -webkit-text-stroke
 slug: Web/CSS/-webkit-text-stroke
 page-type: css-shorthand-property
 browser-compat: css.properties.-webkit-text-stroke

--- a/files/en-us/web/css/-webkit-touch-callout/index.md
+++ b/files/en-us/web/css/-webkit-touch-callout/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-touch-callout"
+title: -webkit-touch-callout
 slug: Web/CSS/-webkit-touch-callout
 page-type: css-property
 status:

--- a/files/en-us/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/en-us/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-moz-device-pixel-ratio"
+title: -moz-device-pixel-ratio
 slug: Web/CSS/@media/-moz-device-pixel-ratio
 page-type: css-media-feature
 status:

--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-animation"
+title: -webkit-animation
 slug: Web/CSS/@media/-webkit-animation
 page-type: css-media-feature
 status:

--- a/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-device-pixel-ratio"
+title: -webkit-device-pixel-ratio
 slug: Web/CSS/@media/-webkit-device-pixel-ratio
 page-type: css-media-feature
 browser-compat: css.at-rules.media.-webkit-device-pixel-ratio

--- a/files/en-us/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-2d/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-transform-2d"
+title: -webkit-transform-2d
 slug: Web/CSS/@media/-webkit-transform-2d
 page-type: css-media-feature
 status:

--- a/files/en-us/web/css/@media/-webkit-transform-3d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-3d/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-transform-3d"
+title: -webkit-transform-3d
 slug: Web/CSS/@media/-webkit-transform-3d
 page-type: css-media-feature
 browser-compat: css.at-rules.media.-webkit-transform-3d

--- a/files/en-us/web/css/@media/-webkit-transition/index.md
+++ b/files/en-us/web/css/@media/-webkit-transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-transition"
+title: -webkit-transition
 slug: Web/CSS/@media/-webkit-transition
 page-type: css-media-feature
 status:

--- a/files/en-us/web/css/_colon_-moz-broken/index.md
+++ b/files/en-us/web/css/_colon_-moz-broken/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-broken"
+title: :-moz-broken
 slug: Web/CSS/:-moz-broken
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-drag-over/index.md
+++ b/files/en-us/web/css/_colon_-moz-drag-over/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-drag-over"
+title: :-moz-drag-over
 slug: Web/CSS/:-moz-drag-over
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-first-node/index.md
+++ b/files/en-us/web/css/_colon_-moz-first-node/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-first-node"
+title: :-moz-first-node
 slug: Web/CSS/:-moz-first-node
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-blocked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-handler-blocked"
+title: :-moz-handler-blocked
 slug: Web/CSS/:-moz-handler-blocked
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-crashed/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-handler-crashed"
+title: :-moz-handler-crashed
 slug: Web/CSS/:-moz-handler-crashed
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/en-us/web/css/_colon_-moz-handler-disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-handler-disabled"
+title: :-moz-handler-disabled
 slug: Web/CSS/:-moz-handler-disabled
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-last-node/index.md
+++ b/files/en-us/web/css/_colon_-moz-last-node/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-last-node"
+title: :-moz-last-node
 slug: Web/CSS/:-moz-last-node
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-loading/index.md
+++ b/files/en-us/web/css/_colon_-moz-loading/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-loading"
+title: :-moz-loading
 slug: Web/CSS/:-moz-loading
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-locale-dir_ltr/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir_ltr/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-locale-dir(ltr)"
+title: :-moz-locale-dir(ltr)
 slug: Web/CSS/:-moz-locale-dir_ltr
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-locale-dir_rtl/index.md
+++ b/files/en-us/web/css/_colon_-moz-locale-dir_rtl/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-locale-dir(rtl)"
+title: :-moz-locale-dir(rtl)
 slug: Web/CSS/:-moz-locale-dir_rtl
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-only-whitespace"
+title: :-moz-only-whitespace
 slug: Web/CSS/:-moz-only-whitespace
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/en-us/web/css/_colon_-moz-submit-invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-submit-invalid"
+title: :-moz-submit-invalid
 slug: Web/CSS/:-moz-submit-invalid
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-suppressed/index.md
+++ b/files/en-us/web/css/_colon_-moz-suppressed/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-suppressed"
+title: :-moz-suppressed
 slug: Web/CSS/:-moz-suppressed
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/en-us/web/css/_colon_-moz-user-disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-user-disabled"
+title: :-moz-user-disabled
 slug: Web/CSS/:-moz-user-disabled
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/en-us/web/css/_colon_-moz-window-inactive/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":-moz-window-inactive"
+title: :-moz-window-inactive
 slug: Web/CSS/:-moz-window-inactive
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_active/index.md
+++ b/files/en-us/web/css/_colon_active/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":active"
+title: :active
 slug: Web/CSS/:active
 page-type: css-pseudo-class
 browser-compat: css.selectors.active

--- a/files/en-us/web/css/_colon_any-link/index.md
+++ b/files/en-us/web/css/_colon_any-link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":any-link"
+title: :any-link
 slug: Web/CSS/:any-link
 page-type: css-pseudo-class
 browser-compat: css.selectors.any-link

--- a/files/en-us/web/css/_colon_autofill/index.md
+++ b/files/en-us/web/css/_colon_autofill/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":autofill"
+title: :autofill
 slug: Web/CSS/:autofill
 page-type: css-pseudo-class
 browser-compat: css.selectors.autofill

--- a/files/en-us/web/css/_colon_blank/index.md
+++ b/files/en-us/web/css/_colon_blank/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":blank"
+title: :blank
 slug: Web/CSS/:blank
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_buffering/index.md
+++ b/files/en-us/web/css/_colon_buffering/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":buffering"
+title: :buffering
 slug: Web/CSS/:buffering
 page-type: css-pseudo-class
 browser-compat: css.selectors.buffering

--- a/files/en-us/web/css/_colon_checked/index.md
+++ b/files/en-us/web/css/_colon_checked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":checked"
+title: :checked
 slug: Web/CSS/:checked
 page-type: css-pseudo-class
 browser-compat: css.selectors.checked

--- a/files/en-us/web/css/_colon_current/index.md
+++ b/files/en-us/web/css/_colon_current/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":current"
+title: :current
 slug: Web/CSS/:current
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_default/index.md
+++ b/files/en-us/web/css/_colon_default/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":default"
+title: :default
 slug: Web/CSS/:default
 page-type: css-pseudo-class
 browser-compat: css.selectors.default

--- a/files/en-us/web/css/_colon_defined/index.md
+++ b/files/en-us/web/css/_colon_defined/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":defined"
+title: :defined
 slug: Web/CSS/:defined
 page-type: css-pseudo-class
 browser-compat: css.selectors.defined

--- a/files/en-us/web/css/_colon_dir/index.md
+++ b/files/en-us/web/css/_colon_dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":dir()"
+title: :dir()
 slug: Web/CSS/:dir
 page-type: css-pseudo-class
 browser-compat: css.selectors.dir

--- a/files/en-us/web/css/_colon_disabled/index.md
+++ b/files/en-us/web/css/_colon_disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":disabled"
+title: :disabled
 slug: Web/CSS/:disabled
 page-type: css-pseudo-class
 browser-compat: css.selectors.disabled

--- a/files/en-us/web/css/_colon_empty/index.md
+++ b/files/en-us/web/css/_colon_empty/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":empty"
+title: :empty
 slug: Web/CSS/:empty
 page-type: css-pseudo-class
 browser-compat: css.selectors.empty

--- a/files/en-us/web/css/_colon_enabled/index.md
+++ b/files/en-us/web/css/_colon_enabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":enabled"
+title: :enabled
 slug: Web/CSS/:enabled
 page-type: css-pseudo-class
 browser-compat: css.selectors.enabled

--- a/files/en-us/web/css/_colon_first-child/index.md
+++ b/files/en-us/web/css/_colon_first-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":first-child"
+title: :first-child
 slug: Web/CSS/:first-child
 page-type: css-pseudo-class
 browser-compat: css.selectors.first-child

--- a/files/en-us/web/css/_colon_first-of-type/index.md
+++ b/files/en-us/web/css/_colon_first-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":first-of-type"
+title: :first-of-type
 slug: Web/CSS/:first-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.first-of-type

--- a/files/en-us/web/css/_colon_first/index.md
+++ b/files/en-us/web/css/_colon_first/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":first"
+title: :first
 slug: Web/CSS/:first
 page-type: css-pseudo-class
 browser-compat: css.selectors.first

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":focus-visible"
+title: :focus-visible
 slug: Web/CSS/:focus-visible
 page-type: css-pseudo-class
 browser-compat: css.selectors.focus-visible

--- a/files/en-us/web/css/_colon_focus-within/index.md
+++ b/files/en-us/web/css/_colon_focus-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":focus-within"
+title: :focus-within
 slug: Web/CSS/:focus-within
 page-type: css-pseudo-class
 browser-compat: css.selectors.focus-within

--- a/files/en-us/web/css/_colon_focus/index.md
+++ b/files/en-us/web/css/_colon_focus/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":focus"
+title: :focus
 slug: Web/CSS/:focus
 page-type: css-pseudo-class
 browser-compat: css.selectors.focus

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":fullscreen"
+title: :fullscreen
 slug: Web/CSS/:fullscreen
 page-type: css-pseudo-class
 browser-compat: css.selectors.fullscreen

--- a/files/en-us/web/css/_colon_future/index.md
+++ b/files/en-us/web/css/_colon_future/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":future"
+title: :future
 slug: Web/CSS/:future
 page-type: css-pseudo-class
 browser-compat: css.selectors.future

--- a/files/en-us/web/css/_colon_has-slotted/index.md
+++ b/files/en-us/web/css/_colon_has-slotted/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":has-slotted"
+title: :has-slotted
 slug: Web/CSS/:has-slotted
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":has()"
+title: :has()
 slug: Web/CSS/:has
 page-type: css-pseudo-class
 browser-compat: css.selectors.has

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":host-context()"
+title: :host-context()
 slug: Web/CSS/:host-context
 page-type: css-pseudo-class
 browser-compat: css.selectors.host-context

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":host"
+title: :host
 slug: Web/CSS/:host
 page-type: css-pseudo-class
 browser-compat: css.selectors.host

--- a/files/en-us/web/css/_colon_host_function/index.md
+++ b/files/en-us/web/css/_colon_host_function/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":host()"
+title: :host()
 slug: Web/CSS/:host_function
 page-type: css-pseudo-class
 browser-compat: css.selectors.hostfunction

--- a/files/en-us/web/css/_colon_hover/index.md
+++ b/files/en-us/web/css/_colon_hover/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":hover"
+title: :hover
 slug: Web/CSS/:hover
 page-type: css-pseudo-class
 browser-compat: css.selectors.hover

--- a/files/en-us/web/css/_colon_in-range/index.md
+++ b/files/en-us/web/css/_colon_in-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":in-range"
+title: :in-range
 slug: Web/CSS/:in-range
 page-type: css-pseudo-class
 browser-compat: css.selectors.in-range

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":indeterminate"
+title: :indeterminate
 slug: Web/CSS/:indeterminate
 page-type: css-pseudo-class
 browser-compat: css.selectors.indeterminate

--- a/files/en-us/web/css/_colon_invalid/index.md
+++ b/files/en-us/web/css/_colon_invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":invalid"
+title: :invalid
 slug: Web/CSS/:invalid
 page-type: css-pseudo-class
 browser-compat: css.selectors.invalid

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":is()"
+title: :is()
 slug: Web/CSS/:is
 page-type: css-pseudo-class
 browser-compat: css.selectors.is

--- a/files/en-us/web/css/_colon_lang/index.md
+++ b/files/en-us/web/css/_colon_lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":lang()"
+title: :lang()
 slug: Web/CSS/:lang
 page-type: css-pseudo-class
 browser-compat: css.selectors.lang

--- a/files/en-us/web/css/_colon_last-child/index.md
+++ b/files/en-us/web/css/_colon_last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":last-child"
+title: :last-child
 slug: Web/CSS/:last-child
 page-type: css-pseudo-class
 browser-compat: css.selectors.last-child

--- a/files/en-us/web/css/_colon_last-of-type/index.md
+++ b/files/en-us/web/css/_colon_last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":last-of-type"
+title: :last-of-type
 slug: Web/CSS/:last-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.last-of-type

--- a/files/en-us/web/css/_colon_left/index.md
+++ b/files/en-us/web/css/_colon_left/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":left"
+title: :left
 slug: Web/CSS/:left
 page-type: css-pseudo-class
 browser-compat: css.selectors.left

--- a/files/en-us/web/css/_colon_link/index.md
+++ b/files/en-us/web/css/_colon_link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":link"
+title: :link
 slug: Web/CSS/:link
 page-type: css-pseudo-class
 browser-compat: css.selectors.link

--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":local-link"
+title: :local-link
 slug: Web/CSS/:local-link
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":modal"
+title: :modal
 slug: Web/CSS/:modal
 page-type: css-pseudo-class
 browser-compat: css.selectors.modal

--- a/files/en-us/web/css/_colon_muted/index.md
+++ b/files/en-us/web/css/_colon_muted/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":muted"
+title: :muted
 slug: Web/CSS/:muted
 page-type: css-pseudo-class
 browser-compat: css.selectors.muted

--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":not()"
+title: :not()
 slug: Web/CSS/:not
 page-type: css-pseudo-class
 browser-compat: css.selectors.not

--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":nth-child()"
+title: :nth-child()
 slug: Web/CSS/:nth-child
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-child

--- a/files/en-us/web/css/_colon_nth-last-child/index.md
+++ b/files/en-us/web/css/_colon_nth-last-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":nth-last-child()"
+title: :nth-last-child()
 slug: Web/CSS/:nth-last-child
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-last-child

--- a/files/en-us/web/css/_colon_nth-last-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-last-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":nth-last-of-type()"
+title: :nth-last-of-type()
 slug: Web/CSS/:nth-last-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-last-of-type

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":nth-of-type()"
+title: :nth-of-type()
 slug: Web/CSS/:nth-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-of-type

--- a/files/en-us/web/css/_colon_only-child/index.md
+++ b/files/en-us/web/css/_colon_only-child/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":only-child"
+title: :only-child
 slug: Web/CSS/:only-child
 page-type: css-pseudo-class
 browser-compat: css.selectors.only-child

--- a/files/en-us/web/css/_colon_only-of-type/index.md
+++ b/files/en-us/web/css/_colon_only-of-type/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":only-of-type"
+title: :only-of-type
 slug: Web/CSS/:only-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.only-of-type

--- a/files/en-us/web/css/_colon_open/index.md
+++ b/files/en-us/web/css/_colon_open/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":open"
+title: :open
 slug: Web/CSS/:open
 page-type: css-pseudo-class
 browser-compat: css.selectors.open

--- a/files/en-us/web/css/_colon_optional/index.md
+++ b/files/en-us/web/css/_colon_optional/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":optional"
+title: :optional
 slug: Web/CSS/:optional
 page-type: css-pseudo-class
 browser-compat: css.selectors.optional

--- a/files/en-us/web/css/_colon_out-of-range/index.md
+++ b/files/en-us/web/css/_colon_out-of-range/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":out-of-range"
+title: :out-of-range
 slug: Web/CSS/:out-of-range
 page-type: css-pseudo-class
 browser-compat: css.selectors.out-of-range

--- a/files/en-us/web/css/_colon_past/index.md
+++ b/files/en-us/web/css/_colon_past/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":past"
+title: :past
 slug: Web/CSS/:past
 page-type: css-pseudo-class
 browser-compat: css.selectors.past

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":paused"
+title: :paused
 slug: Web/CSS/:paused
 page-type: css-pseudo-class
 browser-compat: css.selectors.paused

--- a/files/en-us/web/css/_colon_picture-in-picture/index.md
+++ b/files/en-us/web/css/_colon_picture-in-picture/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":picture-in-picture"
+title: :picture-in-picture
 slug: Web/CSS/:picture-in-picture
 page-type: css-pseudo-class
 browser-compat: css.selectors.picture-in-picture

--- a/files/en-us/web/css/_colon_placeholder-shown/index.md
+++ b/files/en-us/web/css/_colon_placeholder-shown/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":placeholder-shown"
+title: :placeholder-shown
 slug: Web/CSS/:placeholder-shown
 page-type: css-pseudo-class
 browser-compat: css.selectors.placeholder-shown

--- a/files/en-us/web/css/_colon_playing/index.md
+++ b/files/en-us/web/css/_colon_playing/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":playing"
+title: :playing
 slug: Web/CSS/:playing
 page-type: css-pseudo-class
 browser-compat: css.selectors.playing

--- a/files/en-us/web/css/_colon_popover-open/index.md
+++ b/files/en-us/web/css/_colon_popover-open/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":popover-open"
+title: :popover-open
 slug: Web/CSS/:popover-open
 page-type: css-pseudo-class
 browser-compat: css.selectors.popover-open

--- a/files/en-us/web/css/_colon_read-only/index.md
+++ b/files/en-us/web/css/_colon_read-only/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":read-only"
+title: :read-only
 slug: Web/CSS/:read-only
 page-type: css-pseudo-class
 browser-compat: css.selectors.read-only

--- a/files/en-us/web/css/_colon_read-write/index.md
+++ b/files/en-us/web/css/_colon_read-write/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":read-write"
+title: :read-write
 slug: Web/CSS/:read-write
 page-type: css-pseudo-class
 browser-compat: css.selectors.read-write

--- a/files/en-us/web/css/_colon_required/index.md
+++ b/files/en-us/web/css/_colon_required/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":required"
+title: :required
 slug: Web/CSS/:required
 page-type: css-pseudo-class
 browser-compat: css.selectors.required

--- a/files/en-us/web/css/_colon_right/index.md
+++ b/files/en-us/web/css/_colon_right/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":right"
+title: :right
 slug: Web/CSS/:right
 page-type: css-pseudo-class
 browser-compat: css.selectors.right

--- a/files/en-us/web/css/_colon_root/index.md
+++ b/files/en-us/web/css/_colon_root/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":root"
+title: :root
 slug: Web/CSS/:root
 page-type: css-pseudo-class
 browser-compat: css.selectors.root

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":scope"
+title: :scope
 slug: Web/CSS/:scope
 page-type: css-pseudo-class
 browser-compat: css.selectors.scope

--- a/files/en-us/web/css/_colon_seeking/index.md
+++ b/files/en-us/web/css/_colon_seeking/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":seeking"
+title: :seeking
 slug: Web/CSS/:seeking
 page-type: css-pseudo-class
 browser-compat: css.selectors.seeking

--- a/files/en-us/web/css/_colon_stalled/index.md
+++ b/files/en-us/web/css/_colon_stalled/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":stalled"
+title: :stalled
 slug: Web/CSS/:stalled
 page-type: css-pseudo-class
 browser-compat: css.selectors.stalled

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":state()"
+title: :state()
 slug: Web/CSS/:state
 page-type: css-pseudo-class
 browser-compat: css.selectors.state

--- a/files/en-us/web/css/_colon_target-within/index.md
+++ b/files/en-us/web/css/_colon_target-within/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":target-within"
+title: :target-within
 slug: Web/CSS/:target-within
 page-type: css-pseudo-class
 status:

--- a/files/en-us/web/css/_colon_target/index.md
+++ b/files/en-us/web/css/_colon_target/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":target"
+title: :target
 slug: Web/CSS/:target
 page-type: css-pseudo-class
 browser-compat: css.selectors.target

--- a/files/en-us/web/css/_colon_user-invalid/index.md
+++ b/files/en-us/web/css/_colon_user-invalid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":user-invalid"
+title: :user-invalid
 slug: Web/CSS/:user-invalid
 page-type: css-pseudo-class
 browser-compat: css.selectors.user-invalid

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":user-valid"
+title: :user-valid
 slug: Web/CSS/:user-valid
 page-type: css-pseudo-class
 browser-compat: css.selectors.user-valid

--- a/files/en-us/web/css/_colon_valid/index.md
+++ b/files/en-us/web/css/_colon_valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":valid"
+title: :valid
 slug: Web/CSS/:valid
 page-type: css-pseudo-class
 browser-compat: css.selectors.valid

--- a/files/en-us/web/css/_colon_visited/index.md
+++ b/files/en-us/web/css/_colon_visited/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":visited"
+title: :visited
 slug: Web/CSS/:visited
 page-type: css-pseudo-class
 browser-compat: css.selectors.visited

--- a/files/en-us/web/css/_colon_volume-locked/index.md
+++ b/files/en-us/web/css/_colon_volume-locked/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":volume-locked"
+title: :volume-locked
 slug: Web/CSS/:volume-locked
 page-type: css-pseudo-class
 browser-compat: css.selectors.volume-locked

--- a/files/en-us/web/css/_colon_where/index.md
+++ b/files/en-us/web/css/_colon_where/index.md
@@ -1,5 +1,5 @@
 ---
-title: ":where()"
+title: :where()
 slug: Web/CSS/:where
 page-type: css-pseudo-class
 browser-compat: css.selectors.where

--- a/files/en-us/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-color-swatch"
+title: ::-moz-color-swatch
 slug: Web/CSS/::-moz-color-swatch
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-focus-inner"
+title: ::-moz-focus-inner
 slug: Web/CSS/::-moz-focus-inner
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-list-bullet/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-list-bullet/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-list-bullet"
+title: ::-moz-list-bullet
 slug: Web/CSS/::-moz-list-bullet
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-list-number/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-list-number/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-list-number"
+title: ::-moz-list-number
 slug: Web/CSS/::-moz-list-number
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-meter-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-meter-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-meter-bar"
+title: ::-moz-meter-bar
 slug: Web/CSS/::-moz-meter-bar
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-progress-bar"
+title: ::-moz-progress-bar
 slug: Web/CSS/::-moz-progress-bar
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-range-progress"
+title: ::-moz-range-progress
 slug: Web/CSS/::-moz-range-progress
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-range-thumb"
+title: ::-moz-range-thumb
 slug: Web/CSS/::-moz-range-thumb
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-moz-range-track"
+title: ::-moz-range-track
 slug: Web/CSS/::-moz-range-track
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-inner-spin-button"
+title: ::-webkit-inner-spin-button
 slug: Web/CSS/::-webkit-inner-spin-button
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-meter-bar"
+title: ::-webkit-meter-bar
 slug: Web/CSS/::-webkit-meter-bar
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-meter-even-less-good-value"
+title: ::-webkit-meter-even-less-good-value
 slug: Web/CSS/::-webkit-meter-even-less-good-value
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-meter-inner-element"
+title: ::-webkit-meter-inner-element
 slug: Web/CSS/::-webkit-meter-inner-element
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-meter-optimum-value"
+title: ::-webkit-meter-optimum-value
 slug: Web/CSS/::-webkit-meter-optimum-value
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-meter-suboptimum-value"
+title: ::-webkit-meter-suboptimum-value
 slug: Web/CSS/::-webkit-meter-suboptimum-value
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-progress-bar"
+title: ::-webkit-progress-bar
 slug: Web/CSS/::-webkit-progress-bar
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-progress-inner-element"
+title: ::-webkit-progress-inner-element
 slug: Web/CSS/::-webkit-progress-inner-element
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-progress-value"
+title: ::-webkit-progress-value
 slug: Web/CSS/::-webkit-progress-value
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-scrollbar"
+title: ::-webkit-scrollbar
 slug: Web/CSS/::-webkit-scrollbar
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-search-cancel-button"
+title: ::-webkit-search-cancel-button
 slug: Web/CSS/::-webkit-search-cancel-button
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-results-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-search-results-button"
+title: ::-webkit-search-results-button
 slug: Web/CSS/::-webkit-search-results-button
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-slider-runnable-track"
+title: ::-webkit-slider-runnable-track
 slug: Web/CSS/::-webkit-slider-runnable-track
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::-webkit-slider-thumb"
+title: ::-webkit-slider-thumb
 slug: Web/CSS/::-webkit-slider-thumb
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_after/index.md
+++ b/files/en-us/web/css/_doublecolon_after/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::after"
+title: ::after
 slug: Web/CSS/::after
 page-type: css-pseudo-element
 browser-compat: css.selectors.after

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::backdrop"
+title: ::backdrop
 slug: Web/CSS/::backdrop
 page-type: css-pseudo-element
 browser-compat: css.selectors.backdrop

--- a/files/en-us/web/css/_doublecolon_before/index.md
+++ b/files/en-us/web/css/_doublecolon_before/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::before"
+title: ::before
 slug: Web/CSS/::before
 page-type: css-pseudo-element
 browser-compat: css.selectors.before

--- a/files/en-us/web/css/_doublecolon_cue/index.md
+++ b/files/en-us/web/css/_doublecolon_cue/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::cue"
+title: ::cue
 slug: Web/CSS/::cue
 page-type: css-pseudo-element
 browser-compat: css.selectors.cue

--- a/files/en-us/web/css/_doublecolon_details-content/index.md
+++ b/files/en-us/web/css/_doublecolon_details-content/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::details-content"
+title: ::details-content
 slug: Web/CSS/::details-content
 page-type: css-pseudo-element
 status:

--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::file-selector-button"
+title: ::file-selector-button
 slug: Web/CSS/::file-selector-button
 page-type: css-pseudo-element
 browser-compat: css.selectors.file-selector-button

--- a/files/en-us/web/css/_doublecolon_first-letter/index.md
+++ b/files/en-us/web/css/_doublecolon_first-letter/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::first-letter"
+title: ::first-letter
 slug: Web/CSS/::first-letter
 page-type: css-pseudo-element
 browser-compat: css.selectors.first-letter

--- a/files/en-us/web/css/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/_doublecolon_first-line/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::first-line"
+title: ::first-line
 slug: Web/CSS/::first-line
 page-type: css-pseudo-element
 browser-compat: css.selectors.first-line

--- a/files/en-us/web/css/_doublecolon_grammar-error/index.md
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::grammar-error"
+title: ::grammar-error
 slug: Web/CSS/::grammar-error
 page-type: css-pseudo-element
 browser-compat: css.selectors.grammar-error

--- a/files/en-us/web/css/_doublecolon_highlight/index.md
+++ b/files/en-us/web/css/_doublecolon_highlight/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::highlight()"
+title: ::highlight()
 slug: Web/CSS/::highlight
 page-type: css-pseudo-element
 browser-compat: css.selectors.highlight

--- a/files/en-us/web/css/_doublecolon_marker/index.md
+++ b/files/en-us/web/css/_doublecolon_marker/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::marker"
+title: ::marker
 slug: Web/CSS/::marker
 page-type: css-pseudo-element
 browser-compat: css.selectors.marker

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::part()"
+title: ::part()
 slug: Web/CSS/::part
 page-type: css-pseudo-element
 browser-compat: css.selectors.part

--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::placeholder"
+title: ::placeholder
 slug: Web/CSS/::placeholder
 page-type: css-pseudo-element
 browser-compat: css.selectors.placeholder

--- a/files/en-us/web/css/_doublecolon_selection/index.md
+++ b/files/en-us/web/css/_doublecolon_selection/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::selection"
+title: ::selection
 slug: Web/CSS/::selection
 page-type: css-pseudo-element
 browser-compat: css.selectors.selection

--- a/files/en-us/web/css/_doublecolon_slotted/index.md
+++ b/files/en-us/web/css/_doublecolon_slotted/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::slotted()"
+title: ::slotted()
 slug: Web/CSS/::slotted
 page-type: css-pseudo-element
 browser-compat: css.selectors.slotted

--- a/files/en-us/web/css/_doublecolon_spelling-error/index.md
+++ b/files/en-us/web/css/_doublecolon_spelling-error/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::spelling-error"
+title: ::spelling-error
 slug: Web/CSS/::spelling-error
 page-type: css-pseudo-element
 browser-compat: css.selectors.spelling-error

--- a/files/en-us/web/css/_doublecolon_target-text/index.md
+++ b/files/en-us/web/css/_doublecolon_target-text/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::target-text"
+title: ::target-text
 slug: Web/CSS/::target-text
 page-type: css-pseudo-element
 browser-compat: css.selectors.target-text

--- a/files/en-us/web/css/_doublecolon_view-transition-group/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-group/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::view-transition-group"
+title: ::view-transition-group
 slug: Web/CSS/::view-transition-group
 page-type: css-pseudo-element
 browser-compat: css.selectors.view-transition-group

--- a/files/en-us/web/css/_doublecolon_view-transition-image-pair/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-image-pair/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::view-transition-image-pair"
+title: ::view-transition-image-pair
 slug: Web/CSS/::view-transition-image-pair
 page-type: css-pseudo-element
 browser-compat: css.selectors.view-transition-image-pair

--- a/files/en-us/web/css/_doublecolon_view-transition-new/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-new/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::view-transition-new"
+title: ::view-transition-new
 slug: Web/CSS/::view-transition-new
 page-type: css-pseudo-element
 browser-compat: css.selectors.view-transition-new

--- a/files/en-us/web/css/_doublecolon_view-transition-old/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-old/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::view-transition-old"
+title: ::view-transition-old
 slug: Web/CSS/::view-transition-old
 page-type: css-pseudo-element
 browser-compat: css.selectors.view-transition-old

--- a/files/en-us/web/css/_doublecolon_view-transition/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition/index.md
@@ -1,5 +1,5 @@
 ---
-title: "::view-transition"
+title: ::view-transition
 slug: Web/CSS/::view-transition
 page-type: css-pseudo-element
 browser-compat: css.selectors.view-transition

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -1,5 +1,5 @@
 ---
-title: "-webkit-prefixed CSS extensions"
+title: -webkit-prefixed CSS extensions
 slug: Web/CSS/WebKit_Extensions
 page-type: landing-page
 status:

--- a/files/en-us/web/css/y/index.md
+++ b/files/en-us/web/css/y/index.md
@@ -1,5 +1,5 @@
 ---
-title: "y"
+title: y
 slug: Web/CSS/y
 page-type: css-property
 browser-compat: css.properties.y

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -1,5 +1,5 @@
 ---
-title: "y"
+title: y
 slug: Web/SVG/Attribute/y
 page-type: svg-attribute
 spec-urls:

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "fdir": "^6.4.3",
     "gray-matter": "^4.0.3",
     "husky": "9.1.7",
-    "js-yaml": "^4.1.0",
     "lint-staged": "15.4.3",
     "markdownlint-cli2": "0.17.2",
     "markdownlint-rule-search-replace": "1.2.0",
-    "prettier": "3.4.2"
+    "prettier": "3.4.2",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/scripts/front-matter_utils.js
+++ b/scripts/front-matter_utils.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import YAML from "js-yaml";
+import YAML from "yaml";
 import * as prettier from "prettier";
 import AJV from "ajv";
 import grayMatter from "gray-matter";
@@ -80,10 +80,8 @@ export async function checkFrontMatter(filePath, options) {
       }
     }
 
-    let yml = YAML.dump(fmOrdered, {
-      skipInvalid: true,
+    let yml = YAML.stringify(fmOrdered, null, {
       lineWidth: options.config.lineWidth,
-      quotingType: '"',
     });
     yml = yml.replace(/[\s\n]+$/g, "");
     yml = await prettier.format(yml, { parser: "yaml" });


### PR DESCRIPTION
### Description

We quote fm strings like `:has()` but they don't need to be quoted.
This happens because `js-yaml` adds quote when serializing yaml.
See https://github.com/nodeca/js-yaml/issues/679

This PR moves to the `yaml` package to mitigate this.

### Motivation

This came up with https://github.com/mdn/translated-content/pull/25717#discussion_r1942129345