### PR TITLE
Improve grammar

### DIFF
--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -7,7 +7,7 @@ spec-urls: https://drafts.csswg.org/css-grid/
 
 {{CSSRef}}
 
-The **CSS grid layout** module excels at dividing a page into major regions or defining the relationship in terms of size, position, and layer, between parts of a control built from HTML primitives.
+The **CSS grid layout** module excels at dividing a page into major regions or defining the relationship in terms of size, position, and layering between parts of a control built from HTML primitives.
 
 Like tables, grid layout enables an author to align elements into columns and rows. However, many more layouts are either possible or easier with CSS grid than they were with tables. For example, a grid container's child elements could position themselves so they actually overlap and layer, similar to CSS positioned elements.
 


### PR DESCRIPTION
### Description

Previous: 'size, position, and layer, between parts of a control built from HTML primitives.'

Suggested: 'size, position, and layering between parts of a control built from HTML primitives.'

### Motivation

To make it easier for readers to consume the content. Improper grammar use will leave readers confused, and reading the sentence several times.

### Additional details

N/A as of current knowledge

### Related issues and pull requests

N/A as of current knowledge
