### PR TITLE
Clarify returned buffer is not resizable

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.ArrayBuffer.slice
 
 {{JSRef}}
 
-The **`slice()`** method of {{jsxref("ArrayBuffer")}} instances returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `start`, inclusive, up to `end`, exclusive. If either `start` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning.
+The **`slice()`** method of {{jsxref("ArrayBuffer")}} instances returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `start`, inclusive, up to `end`, exclusive. If either `start` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning. The returned `ArrayBuffer` is not [resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable), even if the original was.
 
 {{EmbedInteractiveExample("pages/js/arraybuffer-slice.html")}}
 
@@ -35,7 +35,7 @@ slice(start, end)
 
 ### Return value
 
-A new {{jsxref("ArrayBuffer")}} containing the extracted elements.
+A new {{jsxref("ArrayBuffer")}} containing the extracted elements, which will not be [resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable), even if the original was.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.ArrayBuffer.slice
 
 {{JSRef}}
 
-The **`slice()`** method of {{jsxref("ArrayBuffer")}} instances returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `start`, inclusive, up to `end`, exclusive. If either `start` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning. The returned `ArrayBuffer` is not [resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable), even if the original was.
+The **`slice()`** method of {{jsxref("ArrayBuffer")}} instances returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `start`, inclusive, up to `end`, exclusive. If either `start` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning.
 
 {{EmbedInteractiveExample("pages/js/arraybuffer-slice.html")}}
 
@@ -35,7 +35,7 @@ slice(start, end)
 
 ### Return value
 
-A new {{jsxref("ArrayBuffer")}} containing the extracted elements, which will not be [resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable), even if the original was.
+A new {{jsxref("ArrayBuffer")}} containing the extracted elements. It is not [resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable), even if the original was.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
- Add note to description and return value sections indicating the sliced ArrayBuffer is not resizable, even if the original was.
- Links to resizable ArrayBuffer documentation for reference.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #37986 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
