### PR TITLE
CSS grid guide refresh: masonry and subgrid

### DIFF
--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
@@ -114,7 +114,7 @@ It is also possible to create a masonry layout with items loading into rows.
 }
 ```
 
-{{EmbedLiveSample("inline-axis", "", "350px")}}
+{{EmbedLiveSample("inline-axis", "", "450px")}}
 
 ## Controlling the grid axis
 
@@ -168,7 +168,7 @@ In this example two of the items span two tracks, and the masonry items work aro
 }
 ```
 
-{{EmbedLiveSample("spanners", "", "220px")}}
+{{EmbedLiveSample("spanners", "", "270px")}}
 
 This example includes an item which has positioning for columns. Items with definite placement are placed before the masonry layout happens.
 
@@ -225,7 +225,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("positioned", "", "260px")}}
+{{EmbedLiveSample("positioned", "", "290px")}}
 
 ## Fallbacks for masonry layout
 
@@ -238,4 +238,4 @@ In browsers [that do not support masonry](#browser_compatibility), regular grid 
 ## See also
 
 - {{cssxref("grid-auto-flow")}} for controlling grid auto-placement
-- [Native CSS masonry layout in CSS grid](https://www.smashingmagazine.com/native-css-masonry-layout-css-grid/)
+- [Native CSS masonry layout in CSS grid](https://www.smashingmagazine.com/native-css-masonry-layout-css-grid/) via Smashing Magazine (2020)

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.md
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.md
@@ -23,7 +23,7 @@ For example, if you use `grid-template-columns: subgrid` and the nested grid spa
 
 In the example below, the grid layout has nine `1fr` column tracks and four rows that are a minimum of `100px` tall.
 
-The `.item` is placed between column lines 2 to 7 and rows 2 to 4. This grid item is itself a grid (`display: grid`) that is a subgrid created by giving it column tracks that are a subgrid (`grid-template-columns: subgrid`) and normally defined rows. The subgrid has five-column tracks as it spans five column tracks.
+The `.item` is placed between column lines 2 to 7 and rows 2 to 4. This grid item is itself specified as a grid using `display: grid` and then defined as a subgrid by giving it column tracks that are a subgrid (`grid-template-columns: subgrid`) and normally defined rows. The subgrid has five-column tracks as it spans five column tracks.
 
 Because the `.item` is a subgrid, even though the `.subitem` is not a direct child of the outer `.grid`, it can be placed on that outer grid, with its columns aligned with the outer grid's columns. The rows are not a subgrid, so behave as a nested grid normally does. The grid area on the parent expands to be large enough for this nested grid.
 

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.md
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.md
@@ -535,7 +535,7 @@ Lines specified on the subgrid are added to any lines specified on the parent, s
 
 ## Using subgrids
 
-Other than needing to take care of items that do not fit in a subgrid, a subgrid acts very similarly to any nested grid; the only difference is that the track sizing of the subgrid is set on the parent grid. As with any nested grid, however, the size of the content in the subgrid can change the track sizing, assuming a track sizing method is used that allows content to affect the size. In such a case, auto-sized row tracks will grow to fit content in the main grid and content in the subgrid.
+A subgrid acts very similarly to any nested grid; the only difference is that the track sizing of the subgrid is set on the parent grid. As with any nested grid, however, the size of the content in the subgrid can change the track sizing, assuming a track sizing method is used that allows content to affect the size. In such a case, auto-sized row tracks will grow to fit content in the main grid and content in the subgrid.
 
 As the subgrid value acts in much the same way as a regular nested grid, it is easy to switch between the two. For example, if you realize that you need an implicit grid for rows, you would need to remove the `subgrid` value of `grid-template-rows` and perhaps give a value for `grid-auto-rows` to control the implicit track sizing.
 

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.md
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.md
@@ -7,25 +7,25 @@ browser-compat: css.properties.grid-template-columns.subgrid
 
 {{CSSRef}}
 
-Level 2 of the CSS grid layout specification includes a `subgrid` value for {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}}. This guide details what subgrid does and gives some use cases and design patterns that the feature solves.
+The [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) module includes a `subgrid` value for {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}}. This guide details what subgrid does and gives some use cases and design patterns that the feature solves.
 
 ## Introduction to subgrid
 
-When you add `display: grid` to a grid container, only the direct children become grid items and can then be placed on the grid you created. The children of these items display in normal flow.
+When you add [`display: grid`](/en-US/docs/Web/CSS/display) to a grid container, only the direct children become grid items, which can then be placed on the grid you created. The children of these items display in normal flow.
 
 You can "nest" grids by making a grid item a grid container. These grids, however, are independent of the parent grid and of each other, meaning that they do not take their track sizing from the parent grid. This makes it difficult to line nested grid items up with the main grid.
 
-If you set the value `subgrid` on `grid-template-columns`, `grid-template-rows` or both, instead of creating a new track listing the nested grid uses the tracks defined on the parent.
+If you set the value `subgrid` on `grid-template-columns`, `grid-template-rows` or both, instead of creating a new track listing, the nested grid uses the tracks defined on the parent.
 
-For example, if you use `grid-template-columns: subgrid` and the nested grid spans three column tracks of the parent, the nested grid will have three column tracks of the same size as the parent grid. Gaps are inherited but can also be overridden with a different {{cssxref("gap")}} value. Line names can be passed from the parent into the subgrid, and the subgrid can also declare its own line names.
+For example, if you use `grid-template-columns: subgrid` and the nested grid spans three column tracks of the parent, the nested grid will have three column tracks of the same size as the parent grid. While [gaps](/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#gutters) are inherited, they can be overridden with a different {{cssxref("gap")}} value. [Line names](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines) can be passed from the parent into the subgrid, and the subgrid can also declare its own line names.
 
 ## Subgrid for columns
 
-In the example below, I have a grid layout with nine `1fr` column tracks and four rows that are a minimum of 100px tall.
+In the example below, the grid layout has nine `1fr` column tracks and four rows that are a minimum of `100px` tall.
 
-I place `.item` from column lines 2 to 7 and rows 2 to 4. I then make this grid item into a grid, giving it column tracks that are a subgrid and defining rows as normal. As the item spans five column tracks, this means that the subgrid has five-column tracks. I can then place `.subitem` on this grid.
+The `.item` is placed between column lines 2 to 7 and rows 2 to 4. This grid item is itself a grid (`display: grid`) that is a subgrid created by giving it column tracks that are a subgrid (`grid-template-columns: subgrid`) and normally defined rows. The subgrid has five-column tracks as it spans five column tracks.
 
-The rows in this example are not a subgrid, and so behave as a nested grid does normally. The grid area on the parent expands to be large enough for this nested grid.
+Because the `.item` is a subgrid, even though the `.subitem` is not a direct child of the outer `.grid`, it can be placed on that outer grid, with its columns aligned with the outer grid's columns. The rows are not a subgrid, so behave as a nested grid normally does. The grid area on the parent expands to be large enough for this nested grid.
 
 ```html live-sample___columns
 <div class="grid">
@@ -79,15 +79,15 @@ The rows in this example are not a subgrid, and so behave as a nested grid does 
 }
 ```
 
-{{EmbedLiveSample("columns", "", "450px")}}
-
 Note that line numbering restarts inside the subgrid — column line 1, when inside the subgrid, is the first line of the subgrid. The subgridded element doesn't inherit the line numbers of the parent grid. This means that you can safely lay out a component that may be placed in different positions on the main grid, knowing that the line numbers on the component will always be the same.
+
+{{EmbedLiveSample("columns", "", "450px")}}
 
 ## Subgrid for rows
 
-The next example is the same setup; however, we are using `subgrid` as the value of `grid-template-rows` and defining explicit column tracks. So, the column tracks behave as a regular nested grid, but the rows are tied to the two tracks that the child spans.
+This example uses the same HTML as above, but here the `subgrid` is applied as the value of `grid-template-rows` instead, with explicitly defined column tracks. In this case, the column tracks behave as a regular nested grid, but the rows are tied to the two tracks that the `.item` spans.
 
-```html live-sample___rows
+```html live-sample___rows hidden
 <div class="grid">
   <div class="item">
     <div class="subitem"></div>
@@ -143,9 +143,9 @@ The next example is the same setup; however, we are using `subgrid` as the value
 
 ## A subgrid in both dimensions
 
-You can define both rows and columns as a subgrid, as in the example below. This means that your subgrid is tied in both dimensions to the number of tracks on the parent.
+In this example, both rows and columns are defined as a subgrid, tying the subgrid to the parent grid's tracks in both dimensions.
 
-```html live-sample___both
+```html live-sample___both hidden
 <div class="grid">
   <div class="item">
     <div class="subitem"></div>
@@ -203,7 +203,7 @@ You can define both rows and columns as a subgrid, as in the example below. This
 
 If you need to autoplace items and do not know how many items you will have, take care when creating a subgrid, as it will prevent additional rows from being created to hold those items.
 
-Take a look at the next example — it uses the same parent and child grid as in the example above. However, I have twelve items inside the subgrid trying to autoplace into ten grid cells. As the subgrid is on both dimensions, there is nowhere for the extra two items to go, so they go into the last track of the grid, as defined in the specification.
+Take a look at the next example — it uses the same parent and child grid as in the example above. There are twelve items inside the subgrid trying to autoplace themselves into ten grid cells. As the subgrid is on both dimensions, there is nowhere for the extra two items to go, so they go into the last track of the grid. This is the behavior defined in the specification.
 
 ```html live-sample___no-implicit
 <div class="grid">
@@ -269,7 +269,7 @@ body {
 
 {{EmbedLiveSample("no-implicit", "", "440px")}}
 
-If we remove the `grid-template-rows` value, we enable regular creation of implicit tracks and although these won't line up with the tracks of the parent, as many as are required will be created.
+By removing the `grid-template-rows` value, the regular creation of implicit tracks is enabled, creating as many rows as required. These won't line up with the tracks of the parent.
 
 ```html live-sample___implicit
 <div class="grid">
@@ -337,9 +337,9 @@ body {
 
 ## The gap properties and subgrid
 
-If you have a {{cssxref("gap")}}, {{cssxref("column-gap")}}, or {{cssxref("row-gap")}} specified on the parent, this will be passed into the subgrid, so it will have the same spacing between tracks as the parent. In some situations, however, you may wish the subgrid tracks to have a different gap or no gap. This can be achieved by using the `gap-*` properties on the grid container of the subgrid.
+Any {{cssxref("gap")}}, {{cssxref("column-gap")}}, or {{cssxref("row-gap")}} values specified on the parent are passed into the subgrid, creating the same spacing between tracks as the parent. This default behavior can be overridden by applying `gap-*` properties on the subgrid container.
 
-You can see this in the example below. The parent grid has a gap of 20px for rows and columns. The subgrid has `row-gap` set to `0`.
+In this example, the parent grid has a gap of `20px` for rows and columns and the subgrid has `row-gap` set to `0`.
 
 ```html live-sample___gap
 <div class="grid">
@@ -404,13 +404,13 @@ You can see this in the example below. The parent grid has a gap of 20px for row
 
 {{EmbedLiveSample("gap", "", "500px")}}
 
-If you inspect this in the Firefox grid inspector, you can see how the line of the grid is in the correct place down the center of the gap, so when we set the gap to 0, it acts in a similar way to applying a negative margin to an element, giving the space from the gap back to the item.
+If you inspect this in your developer tools grid inspector, you will note that the subgrid line is at the center of the gap. Setting the gap to `0` acts in a similar way to applying a negative margin to an element, giving the space from the gap back to the item.
 
-![The smaller item displays in the gap as row-gap is set to 0 on the subgrid.](gap.png)
+![The smaller item displays in the gap as row-gap is set to 0 on the subgrid, as seen in the firefox developer tools grid inspector.](gap.png)
 
 ## Named grid lines
 
-When using CSS grid, you can name lines on your grid and then position items based on those names rather than the line number. The line names on the parent grid are passed into the subgrid, and you can place items using them. In the example below, I named lines on the parent `col-start` and `col-end` and then used those to place the subitem.
+When using CSS grid, you can [name lines on your grid](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines) and then position items based on those names rather than the line number. The line names on the parent grid are passed into the subgrid, and you can place items using them. In the example below, the named lines of the parent `col-start` and `col-end` are used to place the subitem.
 
 ```html live-sample___line-names
 <div class="grid">
@@ -467,9 +467,9 @@ When using CSS grid, you can name lines on your grid and then position items bas
 
 {{EmbedLiveSample("line-names", "", "500px")}}
 
-You can also specify line names on the subgrid. This is achieved by adding a list of line names enclosed in square brackets after the `subgrid` keyword. If you have four lines in your subgrid, to name them all, you could use the syntax `grid-template-columns: subgrid [line1] [line2] [line3] [line4]`
+You can also specify line names on the subgrid. This is achieved by adding a list of line names enclosed in square brackets after the `subgrid` keyword. For example, if you have four lines in your subgrid, to name them all, you could use the syntax `grid-template-columns: subgrid [line1] [line2] [line3] [line4]`
 
-Lines specified on the subgrid are added to any lines specified on the parent, so you can use either or both. To demonstrate this, I have positioned one item in the example below using the parent lines and one using the subgrid lines.
+Lines specified on the subgrid are added to any lines specified on the parent, so you can use either or both. In this example, one item is placed below using the parent lines and one using the subgrid lines.
 
 ```html live-sample___adding-line-names
 <div class="grid">
@@ -535,7 +535,7 @@ Lines specified on the subgrid are added to any lines specified on the parent, s
 
 ## Using subgrids
 
-Other than needing to take care of items that do not fit in your subgrid, a subgrid acts very similarly to any nested grid; the only difference is that the track sizing of the subgrid is set on the parent grid. As with any nested grid, however, the size of the content in the subgrid can change the track sizing, assuming a track sizing method is used that allows content to affect the size. In such a case, auto-sized row tracks, for example, will grow to fit content in the main grid and content in the subgrid.
+Other than needing to take care of items that do not fit in a subgrid, a subgrid acts very similarly to any nested grid; the only difference is that the track sizing of the subgrid is set on the parent grid. As with any nested grid, however, the size of the content in the subgrid can change the track sizing, assuming a track sizing method is used that allows content to affect the size. In such a case, auto-sized row tracks will grow to fit content in the main grid and content in the subgrid.
 
 As the subgrid value acts in much the same way as a regular nested grid, it is easy to switch between the two. For example, if you realize that you need an implicit grid for rows, you would need to remove the `subgrid` value of `grid-template-rows` and perhaps give a value for `grid-auto-rows` to control the implicit track sizing.
 
@@ -549,5 +549,6 @@ As the subgrid value acts in much the same way as a regular nested grid, it is e
 
 ## See also
 
-- Videos: [Laying out forms using subgrid](https://www.youtube.com/watch?v=gmQlK3kRft4) and [Don't wait to use subgrid for better card layouts](https://www.youtube.com/watch?v=lLnFtK1LNu4)
-- [Hello subgrid!](https://noti.st/rachelandrew/i6gUcF/hello-subgrid) A presentation from CSSConf.eu
+- [Video: Laying out forms using subgrid](https://www.youtube.com/watch?v=gmQlK3kRft4) (2019)
+- [Video: Don't wait to use subgrid for better card layouts](https://www.youtube.com/watch?v=lLnFtK1LNu4) (2019)
+- [Video: Hello subgrid!](https://www.youtube.com/watch?v=vxOj7CaWiPU) presentation from CSSConf.eu (2019)


### PR DESCRIPTION
CSS grid layout module sub-PR (https://github.com/mdn/content/pull/37999)
* remove "I" language
* see also links to current writing guideline standards
* height of examples
* general refresh