### PR TITLE
CSS grid layout guide refresh: grid lines and template areas

### DIFF
--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -467,7 +467,7 @@ Being able to address the start and end lines of the grid is useful as you can t
 
 ## Gutters or Alleys
 
-CSS grid includes the ability to add gutters between column and row tracks with the {{cssxref("column-gap")}} and {{cssxref("row-gap")}} properties. These specify a gap that acts much like the {{cssxref("column-gap")}} property in multi-column layout.
+CSS grid includes the ability to add gutters between column and row tracks with the {{cssxref("column-gap")}} and {{cssxref("row-gap")}} properties, or {{cssxref("gap")}} shorthand.
 
 Gaps only appear between tracks of the grid, they do not add space to the top and bottom, left or right of the container. We can add gaps to our earlier example by using these properties on the grid container.
 

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -6,17 +6,13 @@ page-type: guide
 
 {{CSSRef}}
 
-In the [article covering the basic concepts of grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout), we started to look at how to position items on a grid using line numbers. In this article, we will fully explore how this fundamental feature of the specification works.
+In the [basic concepts of grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout) guide, we took a brief look at positioning items on a grid using line numbers. In this guide, we will fully explore how this fundamental feature of the specification works.
 
-Starting your exploration of grid with numbered lines is the most logical place to begin because when you use grid layout, you always have numbered lines. The lines are numbered for columns and rows, and are indexed from 1. Note that grid is indexed according to the writing mode of the document. In a left to right language such as English line 1 is on the left-hand side of the grid. If you are working in a right-to-left language such as Arabic then line 1 will be the far right of the grid. We will learn more about the interaction between writing modes and grids in a later guide.
+Starting your exploration of grid with numbered lines is the most logical place to begin because when you use grid layout, you always have numbered lines. The lines are numbered for columns and rows, and are indexed from `1`. Note that grid is indexed according to the writing mode of the document. In a left to right language, such as English, line 1 is on the left-hand side of the grid. If you are working in a right-to-left language, such as Arabic, then line 1 will on the right-hand of the grid. We will learn more about the interaction between writing modes and grids in the [grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes) guide.
 
 ## A basic example
 
-As a very simple example we can take a grid with 3 column tracks and 3 row tracks. This gives us 4 lines in each dimension.
-
-Inside our grid container, we have four child elements. If we do not place these on to the grid in any way they will lay out according to the auto-placement rules, one item in each of the first four cells. If you use the [Firefox grid highlighter](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html) you can see how the grid has defined columns and rows.
-
-![Our grid highlighted in DevTools](highlighted_grid.png)
+As a basic example, we create a grid with 3 column tracks and 3 row tracks. This gives us 4 lines in each dimension.
 
 ```css hidden
 * {
@@ -46,6 +42,8 @@ Inside our grid container, we have four child elements. If we do not place these
 }
 ```
 
+Inside our grid container, we include four child elements.
+
 ```html
 <div class="wrapper">
   <div class="box1">One</div>
@@ -57,9 +55,13 @@ Inside our grid container, we have four child elements. If we do not place these
 
 {{ EmbedLiveSample('A_basic_example', '300', '330') }}
 
+If we do not place these on to the grid in any way they will lay out according to the auto-placement rules, one item in each of the first four cells. You can inspect the grid with your browser developer tools to see how the grid defines columns and rows.
+
+![The example grid highlighted in DevTools](highlighted_grid.png)
+
 ## Positioning items by line number
 
-We can use line-based placement to control where these items sit on the grid. We would like the first item to start on the far left of the grid and span a single column track. It should also start on the first row line, at the top of the grid and span to the fourth row line.
+We can use line-based placement to control where these items sit on the grid. We can use the {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties to make the first item to start on the far left of the grid and span a single column track. With {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}} we make the item start on the first row line, at the top of the grid and span to the fourth row line.
 
 ```css
 .box1 {
@@ -70,9 +72,9 @@ We can use line-based placement to control where these items sit on the grid. We
 }
 ```
 
-As you position some items, other items on the grid will continue to be laid out using the auto-placement rules. We will take a proper look at how these work in a later guide but you can see as you work that grid is laying out un-placed items into empty cells of the grid.
+As you position some items, other items on the grid will continue to be laid out using the auto-placement rules. This behavior is explained in the [Auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) guide. For now, observe how the grid is laying out un-placed items into empty cells of the grid.
 
-Addressing each item individually we can place all four items spanning row and column tracks. Note that we can leave cells empty if we wish. One of the very nice things about grid layout is the ability to have white space in our designs without having to push things around using margins to prevent floats from rising up into the space we have left.
+Addressing each item individually, using the same properties but with different values, we place all four items, spanning row and column tracks.
 
 ```css hidden
 * {
@@ -135,9 +137,11 @@ Addressing each item individually we can place all four items spanning row and c
 
 {{ EmbedLiveSample('Positioning_items_by_line_number', '300', '330') }}
 
+Note that we can leave cells empty if we wish. One of the very nice things about grid layout is the ability to have white space in our designs without any hacks.
+
 ## The `grid-column` and `grid-row` shorthands
 
-We have quite a lot of code here to position each item. It should come as no surprise to know there is a [shorthand](/en-US/docs/Web/CSS/Shorthand_properties). The {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties can be combined into {{cssxref("grid-column")}}, {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}} into {{cssxref("grid-row")}}.
+The previous example had quite a lot of code to position each item. It should come as no surprise to know there is a [shorthand](/en-US/docs/Web/CSS/Shorthand_properties). The {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties can be combined into {{cssxref("grid-column")}}, {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}} into {{cssxref("grid-row")}}. In this example, we replicate the above example using these shorthand properties:
 
 ```css hidden
 * {
@@ -315,12 +319,12 @@ Our shorthand would look like the following code, with no forward slash and seco
 
 ## The `grid-area` property
 
-We can take things a step further and define each area with a single property – {{cssxref("grid-area")}}. The order of the values for grid-area are as follows.
+We can take things a step further and define each area with a single property – {{cssxref("grid-area")}}. The order of the values for `grid-area` is as follows.
 
-- grid-row-start
-- grid-column-start
-- grid-row-end
-- grid-column-end
+– {{cssxref("grid-row-start")}}
+– {{cssxref("grid-column-start")}}
+– {{cssxref("grid-row-end")}}
+– {{cssxref("grid-column-end")}}
 
 ```css hidden
 * {
@@ -371,20 +375,22 @@ We can take things a step further and define each area with a single property �
 
 {{ EmbedLiveSample('The_grid-area_property', '300', '330') }}
 
-This order of values for `grid-area` can seem a little strange, it is the opposite of the direction in which we specify margins and padding as a shorthand for example. It may help to realize that this is due to grid using the flow-relative directions defined in the CSS Writing Modes specification. We will explore how grids work with writing modes in a later article however we have the concept of four flow-relative directions:
+This order of values for `grid-area` can seem a little strange, it is the opposite of the direction in which we specify margins and padding as a shorthand for example. It may help to realize that this is due to grid using the flow-relative directions defined in [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes). We explore how grids work with writing modes in [grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes). For now, consider the concept of four {{glossary("Flow relative values", "flow-relative")}} directions:
 
-- block-start
-- block-end
-- inline-start
-- inline-end
+- `block-start`
+- `block-end`
+- `inline-start`
+- `inline-end`
 
-We are working in English, a left-to-right language. Our block-start is the top row line of the grid container, block-end is the final row line of the container. Our inline-start is the left-hand column line as inline-start is always the point from which text would be written in the current writing mode, inline-end is the final column line of our grid.
+We are working in English, a left-to-right language. Our `block-start` is the top row line of the grid container, `block-end` is the final row line of the container. Our `inline-start` is the left-hand column line as `inline-start` is always the point from which text would be written in the current writing mode, i`nline-end` is the final column line of our grid.
 
-When we specify our grid area using the `grid-area` property we first define both start lines `block-start` and `inline-start`, then both end lines `block-end` and `inline-end`. This seems unusual at first as we are used to the physical properties of top, right, bottom and left but makes more sense if you start to think of websites as being multi-directional in writing mode.
+When we specify our grid area using the `grid-area` property we first define both start lines `block-start` and `inline-start`, then both end lines `block-end` and `inline-end`. This seems unusual at first as we are used to the {{glossary("physical properties")}} of `top`, `right`, `bottom` and `left`, but makes more sense if you start to think of websites as being multi-directional in writing mode.
 
 ## Counting backwards
 
-We can also count backwards from the block and inline end of the grid, for English that would be the right-hand column line and final row line. These lines can be addressed as `-1`, and you can count back from there – so the second last line is `-2`. It is worth noting that the final line is the final line of the _explicit grid_, the grid defined by `grid-template-columns` and `grid-template-rows`, and does not take into account any rows or columns added in the _implicit grid_ outside of that.
+We can also count backwards from the block and inline ends of the grid, for English that would be the right-hand column line and final row line. The last lines of the explicit grid can be addressed as `-1`, and you can count back from there – so the second to last line is `-2`.
+
+Do note that negative values are relevant only to the explicit grid. The final line is the final line of the the grid defined by `grid-template-columns` and `grid-template-rows`, and does not take into account any rows or columns added in the _implicit grid_ outside of that.
 
 In this next example, we have flipped the layout we were working with by working from the right and bottom of our grid when placing the items.
 
@@ -461,12 +467,7 @@ Being able to address the start and end lines of the grid is useful as you can t
 
 ## Gutters or Alleys
 
-The CSS grid specification includes the ability to add gutters between column and row tracks with the {{cssxref("column-gap")}} and {{cssxref("row-gap")}} properties. These specify a gap that acts much like the {{cssxref("column-gap")}} property in multi-column layout.
-
-> [!NOTE]
-> When grid first shipped in browsers the {{cssxref("column-gap")}}, {{cssxref("row-gap")}} and {{cssxref("gap")}} properties were prefixed with the `grid-` prefix as `grid-column-gap`, `grid-row-gap` and `grid-gap` respectively.
->
-> Browsers are updating their rendering engines to remove this prefix, however the prefixed versions will be maintained as aliases, making them safe to use.
+CSS grid includes the ability to add gutters between column and row tracks with the {{cssxref("column-gap")}} and {{cssxref("row-gap")}} properties. These specify a gap that acts much like the {{cssxref("column-gap")}} property in multi-column layout.
 
 Gaps only appear between tracks of the grid, they do not add space to the top and bottom, left or right of the container. We can add gaps to our earlier example by using these properties on the grid container.
 
@@ -543,11 +544,11 @@ The two properties can also be expressed as a shorthand, {{cssxref("gap")}}. If 
 }
 ```
 
-In terms of line-based positioning of items, the gap acts as if the line has gained extra width. Anything starting at that line starts after the gap and you cannot address the gap or place anything into it. If you want gutters that act more like regular tracks you can of course define a track for the purpose instead.
+In terms of line-based positioning of items, the gap acts as if the line has gained extra width. Anything starting at that line starts after the gap and you cannot address the gap or place anything into it. If you want gutters that act more like regular tracks you can define a track for that purpose.
 
 ## Using the `span` keyword
 
-In addition to specifying the start and end lines by number, you can specify a start line and then the number of tracks you would like the area to span.
+In addition to specifying the start and end lines by number, you can specify a start line and then the number of tracks you would like the area to span using the `span` keyword.
 
 ```css hidden
 * {
@@ -622,6 +623,6 @@ In the second example, we specify the end row line we want the item to finish at
 }
 ```
 
-To become familiar with line based positioning in grid try to build a few common layouts by placing items onto grids with varying numbers of columns. Remember that if you do not place all of the items, any leftover items will be placed according to auto-placement rules. This may result in the layout you want, but if something is appearing somewhere unexpected, check that you have set a position for it.
+To become familiar with line based positioning in grid, try to build a few common layouts by placing items onto grids with varying numbers of columns. Remember that if you do not place all of the items, any leftover items will be placed according to auto-placement rules. This may result in the layout you want, but if something is appearing somewhere unexpected, check that you have set a position for it.
 
-Also, remember that items on the grid can overlap each other when you place them explicitly like this. That can create some nice effects, however you can also end up with things overlapping incorrectly if you specify the wrong start or end line. The [Firefox grid highlighter](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html) can be very useful as you learn, especially if your grid is quite complicated.
+Also, remember that items on the grid can overlap each other when you place them explicitly like this. That can create some nice effects, however you can also end up with things overlapping incorrectly if you specify the wrong start or end line. Inspecting grids with your browser developer tools can be very helpful as you learn, especially if your grid is quite complicated.

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -61,7 +61,7 @@ If we do not place these on to the grid in any way they will lay out according t
 
 ## Positioning items by line number
 
-We can use line-based placement to control where these items sit on the grid. We can use the {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties to make the first item to start on the far left of the grid and span a single column track. With {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}} we make the item start on the first row line, at the top of the grid and span to the fourth row line.
+We can use line-based placement to control where these items sit on the grid. We can use the {{cssxref("grid-column-start")}} and {{cssxref("grid-column-end")}} properties to make the first item start on the far left of the grid and span a single column track. With {{cssxref("grid-row-start")}} and {{cssxref("grid-row-end")}}, we make the item start on the first row line at the top of the grid, and span to the fourth row line.
 
 ```css
 .box1 {
@@ -74,7 +74,7 @@ We can use line-based placement to control where these items sit on the grid. We
 
 As you position some items, other items on the grid will continue to be laid out using the auto-placement rules. This behavior is explained in the [Auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) guide. For now, observe how the grid is laying out un-placed items into empty cells of the grid.
 
-Addressing each item individually, using the same properties but with different values, we place all four items, spanning row and column tracks.
+Addressing each item individually using the same properties but with different values, we place all four items, spanning row and column tracks.
 
 ```css hidden
 * {
@@ -375,16 +375,16 @@ We can take things a step further and define each area with a single property â€
 
 {{ EmbedLiveSample('The_grid-area_property', '300', '330') }}
 
-This order of values for `grid-area` can seem a little strange, it is the opposite of the direction in which we specify margins and padding as a shorthand for example. It may help to realize that this is due to grid using the flow-relative directions defined in [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes). We explore how grids work with writing modes in [grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes). For now, consider the concept of four {{glossary("Flow relative values", "flow-relative")}} directions:
+This order of values for `grid-area` can seem a little strange â€” it is the opposite of the direction in which we specify margins and padding as a shorthand, for example. It may help to realize that this is due to CSS grid layout using the flow-relative directions defined in [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes). We explore how grids work with writing modes in [grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes). For now, consider the concept of four {{glossary("Flow relative values", "flow-relative")}} directions:
 
 - `block-start`
 - `block-end`
 - `inline-start`
 - `inline-end`
 
-We are working in English, a left-to-right language. Our `block-start` is the top row line of the grid container, `block-end` is the final row line of the container. Our `inline-start` is the left-hand column line as `inline-start` is always the point from which text would be written in the current writing mode, i`nline-end` is the final column line of our grid.
+We are working in English, a left-to-right language. Our `block-start` is the top row line of the grid container, `block-end` is the final row line of the container. Our `inline-start` is the left-hand column line as `inline-start` is always the point from which text would be written in the current writing mode, while `inline-end` is the final column line of our grid.
 
-When we specify our grid area using the `grid-area` property we first define both start lines `block-start` and `inline-start`, then both end lines `block-end` and `inline-end`. This seems unusual at first as we are used to the {{glossary("physical properties")}} of `top`, `right`, `bottom` and `left`, but makes more sense if you start to think of websites as being multi-directional in writing mode.
+When we specify our grid area using the `grid-area` property we first define both start lines `block-start` and `inline-start`, then both end lines `block-end` and `inline-end`. This seems unusual at first as we are used to the {{glossary("physical properties")}} of `top`, `right`, `bottom`, and `left`, but it makes more sense if you start to think of websites as being multi-directional in different writing modes.
 
 ## Counting backwards
 
@@ -625,4 +625,4 @@ In the second example, we specify the end row line we want the item to finish at
 
 To become familiar with line based positioning in grid, try to build a few common layouts by placing items onto grids with varying numbers of columns. Remember that if you do not place all of the items, any leftover items will be placed according to auto-placement rules. This may result in the layout you want, but if something is appearing somewhere unexpected, check that you have set a position for it.
 
-Also, remember that items on the grid can overlap each other when you place them explicitly like this. That can create some nice effects, however you can also end up with things overlapping incorrectly if you specify the wrong start or end line. Inspecting grids with your browser developer tools can be very helpful as you learn, especially if your grid is quite complicated.
+Also, remember that items on the grid can overlap when you place them explicitly like this. Overlapping items can create some nice effects, however, you can also end up with incorrect overlapping if you specify the wrong start or end line. Inspecting grids with your browser developer tools can be very helpful for identifying such problems as you learn, especially if your grid is quite complicated.

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_named_grid_lines/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_named_grid_lines/index.md
@@ -6,11 +6,13 @@ page-type: guide
 
 {{CSSRef}}
 
-In previous guides, we've looked at placing items by the lines created by defining grid tracks and also how to place items using named template areas. In this guide, we are going to look at how these two things work together when we use named lines. Line naming is incredibly useful, but some of the more baffling looking grid syntax comes from this combination of names and track sizes. Once you work through some examples, it should become clearer and easier to work with.
+In previous guides, we've looked at placing items by the lines created by [defining grid tracks](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement) and also how to place items [using named template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas). In this guide, we look at how these two things work together when we use named lines.
+
+Line naming is incredibly useful, but some of the more baffling looking grid syntax comes from this combination of names and track sizes. Once you work through some examples, it should become clearer and easier to work with.
 
 ## Naming lines when defining a grid
 
-You can assign some or all of the lines in your grid a name when you define your grid with the `grid-template-rows` and `grid-template-columns` properties. To demonstrate I'll use the simple layout created in the guide on line-based placement. This time I'll create the grid using named lines.
+You can assign some or all of the lines in your grid a name when you define your grid with the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} properties. To demonstrate, we'll use the basic layout created in the guide on [line-based placement](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement). This time, we'll create the grid using named lines.
 
 ```css hidden
 * {
@@ -32,7 +34,7 @@ You can assign some or all of the lines in your grid a name when you define your
 }
 ```
 
-When defining the grid, I name my lines inside square brackets. Those names can be anything you like. I have defined a name for the start and end of the container, both for rows and columns. Then defined the center block of the grid as `content-start` and `content-end` again, both for columns and rows although you do not need to name all of the lines on your grid. You might choose to name just some key lines for your layout.
+When defining the grid, we name our lines inside square brackets (`[]`). Those names can be anything you like. We define a name for the start and end of the container, both for rows and columns. In this case, the center block of the grid is named `content-start` and `content-end`, for both columns and rows.
 
 ```css
 .wrapper {
@@ -42,7 +44,9 @@ When defining the grid, I name my lines inside square brackets. Those names can 
 }
 ```
 
-Once the lines have names, we can use the name to place the item rather than the line number.
+We don't need to name all of lines in our grids; you may choose to name just the key lines of your layout.
+
+Once the lines have names, we can use the name we defined, rather than the line number, to place the grid items.
 
 ```css
 .box1 {
@@ -80,7 +84,7 @@ Once the lines have names, we can use the name to place the item rather than the
 
 {{ EmbedLiveSample('Naming_lines_when_defining_a_grid', '500', '330') }}
 
-Everything else about line-based placement still works in the same way and you can mix named lines and line numbers. Naming lines is useful when creating a responsive design where you redefine the grid, rather than then needing to redefine the content position by changing the line number in your media queries, you can ensure that the line is always named the same in your definitions.
+Everything else about line-based placement still works in the same way. In our grid layout, we basically provided each numeric line with an alias name. In our grid items we reference a name rather than a number. Naming lines in this way is useful as, when creating a responsive design, we can update the container's grid properties rather than updating the grid items within each [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).
 
 ### Giving lines multiple names
 
@@ -88,9 +92,9 @@ You may want to give a line more than one name, perhaps it denotes the sidebar-e
 
 ## Implicit grid areas from named lines
 
-When naming the lines, I mentioned that you can name these anything you like. The name is a [custom ident](https://drafts.csswg.org/css-values-4/#custom-idents), an author-defined name. When choosing the name you need to avoid words that might appear in the specification and be confusing - such as `span`. Idents are not quoted.
+When naming the lines, we mentioned that you can name these anything you like. The name is a {{cssxref("custom ident")}}, an author-defined name. When choosing the name you need to avoid words that might appear in the specification and be confusing - such as `span`. Idents are not quoted.
 
-While you can choose any name, if you append `-start` and `-end` to the lines around an area, as I have in the example above, grid will create you a named area of the main name used. Taking the above example, I have `content-start` and `content-end` both for rows and for columns. This means I get a grid area named `content`, and could place something in that area should I wish to.
+While you can choose any name, if you append `-start` and `-end` to the lines around an area, as we have in the example above, grid will create a named area of the main name used. Taking the above example, we have `content-start` and `content-end` both for rows and for columns. This means we get a grid area named `content`, and could place something in that area should we wish to.
 
 ```css hidden
 * {
@@ -112,7 +116,7 @@ While you can choose any name, if you append `-start` and `-end` to the lines ar
 }
 ```
 
-I'm using the same grid definitions as above, however this time I am going to place a single item into the named area `content`.
+We use the same grid definitions as above, placing a single item into the named area `content`.
 
 ```css
 .wrapper {
@@ -133,13 +137,13 @@ I'm using the same grid definitions as above, however this time I am going to pl
 
 {{ EmbedLiveSample('Implicit_grid_areas_from_named_lines', '500', '330') }}
 
-We don't need to define where our areas are with `grid-template-areas` as our named lines have created an area for us.
+We don't need to define where our areas are with {{cssxref("grid-template-areas")}} as our named lines have created an area for us.
 
 ## Implicit grid lines from named areas
 
-We have seen how named lines create a named area, and this also works in reverse. Named template areas create named lines that you can use to place your items. If we take the layout created in the guide to grid template Areas, we can use the lines created by our areas to see how this works.
+We have seen how named lines create a named area, and this also works in reverse. Named template areas create named lines that you can use to place your items. If we take the layout created in the guide to [grid template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas), we can use the lines created by our areas to see how this works.
 
-In this example I have added an extra div with a class of `overlay`. We have named areas created using the `grid-area` property, then a layout created in `grid-template-areas`. The area names are:
+In this example, we have added an extra `<div>` with a class of `overlay`. We have named areas created using the {{cssxref("grid-area")}} property, then a layout created in `grid-template-areas`. The area names are:
 
 - `hd`
 - `ft`
@@ -157,11 +161,11 @@ This gives us column and row lines:
 - `ft-start`
 - `ft-end`
 
-You can see the named lines in the image, note that some lines have two names - for example `sd-end` and `main-start` refer to the same column line.
+You can see the named lines in the image. Mote that some lines have two names - for example `sd-end` and `main-start` refer to the same column line.
 
 ![An image showing the implicit line names created by our grid areas.](5_multiple_lines_from_areas.png)
 
-To position `overlay` using these implicit named lines is the same as positioning an item using lines that we have named.
+Positioning `overlay` using these implicit named lines is the same as positioning an item using named lines.
 
 ```css hidden
 * {
@@ -233,15 +237,15 @@ To position `overlay` using these implicit named lines is the same as positionin
 
 {{ EmbedLiveSample('Implicit_Grid_lines_from_named_areas', '500', '330') }}
 
-Given that we have this ability to position created lines from named areas and areas from named lines, it is worth taking a little bit of time to plan your naming strategy when starting out creating your grid layout. By selecting names that will make sense to you and your team you will help everyone to use the layouts you create more easily.
+Given that we have this ability to position created lines from named areas and areas from named lines, it is worth taking a little bit of time to plan your naming strategy when starting out creating your grid layout. By selecting names that will make sense to you and your team, you will make using the layouts you create more inuitive.
 
 ## Multiple lines with the same name with repeat()
 
-If you want to give all of the lines in your grid a unique name then you will need to write out the track definition long-hand rather than using the repeat syntax, as you need to add the name in square brackets while defining the tracks. If you do use the repeat syntax you will end up with multiple lines that have the same name, however this can be very useful too.
+If you want to give all your grid lines a unique name, you need to define the track definition with long-hand properties rather than using the repeat syntax, as the names need to be added in square brackets when defining tracks. If you do use the repeat syntax, you will get multiple lines that have the same name, which can be useful or confusing, depending on your layout requirements.
 
 ### Twelve-column grid using repeat()
 
-In this next example I am creating a grid with twelve equal width columns. Before defining the 1fr size of the column track I am also defining a line name of `[col-start]`. This means that we will end up with a grid that has 12 column lines all named `col-start` before a `1fr` width column.
+In this example, we create a grid with 12 equal-width columns. Before defining the `1fr` size of the column track, we define a line named `[col-start]`. This means we will have a grid with 12 column lines all named `col-start` before a `1fr` width column.
 
 ```css hidden
 * {
@@ -270,38 +274,42 @@ In this next example I am creating a grid with twelve equal width columns. Befor
 }
 ```
 
-Once you have created the grid you can place items onto it. As we have multiple lines named `col-start` if you place an item to start after line `col-start` grid uses the first line named `col-start`, in our case that will be the far left line. To address another line use the name, plus the number for that line. To place our item from the first line named col-start to the 5th, we can use:
+Once you have created the grid you can place items onto it. As we have multiple lines named `col-start` if you place an item to start after line `col-start`, the first line named `col-start` will be used. In our case, this is the far left line. To address another line, use the name with the number for that line.
+
+To place an item spanning from the first line named `col-start` to the 5th with that name, we can use:
 
 ```css
-.item1 {
+.item1to5 {
   grid-column: col-start / col-start 5;
 }
 ```
 
-You can also use the `span` keyword here. My next item will be placed from the 7th line named `col-start` and span 3 lines.
+You can also use the `span` keyword. This item will span 3 lines starting from the 7th line named `col-start`:
 
 ```css
-.item2 {
+.item7to9 {
   grid-column: col-start 7 / span 3;
 }
 ```
 
 ```html
 <div class="wrapper">
-  <div class="item1">I am placed from col-start line 1 to col-start 5</div>
-  <div class="item2">I am placed from col-start line 7 spanning 3 lines</div>
+  <div class="item1to5">I am placed from col-start line 1 to col-start 5</div>
+  <div class="item7to9">I am placed from col-start line 7 spanning 3 lines</div>
 </div>
 ```
 
-{{ EmbedLiveSample('Twelve-column_grid_using_repeat', '500', '330') }}
+{{ EmbedLiveSample('Twelve-column_grid_using_repeat', '500', '120') }}
 
-If you take a look at this layout in the Firefox grid highlighter you can see how the column lines are shown, and how our items are placed against these lines.
+If you take a look at this layout your browser's developer tools, you will see how the column lines are shown, and how our items are placed against these lines.
 
-![The 12 column grid with items placed. The grid highlighter shows the position of the lines.](5_named_lines1.png)
+![The 12 column grid with items placed. The Firefox grid highlighter shows the position of the lines.](5_named_lines1.png)
 
 ### Defining named lines with a track list
 
-The repeat syntax can also take a track list, it doesn't just need to be a single track size that is being repeated. The code below would create an eight track grid, with a narrower `1fr` width column named `col1-start` followed by a wider `3fr` column named `col2-start`.
+The repeat syntax can also take a track list; it not just single track sizes that can be repeated.
+
+This CSS creates an eight track grid, with a narrower `1fr` width column named `col1-start` followed by a wider `3fr` column named `col2-start`.
 
 ```css
 .wrapper {
@@ -309,7 +317,7 @@ The repeat syntax can also take a track list, it doesn't just need to be a singl
 }
 ```
 
-If your repeating syntax puts two lines next to each other then they will be merged, and create the same result as giving a line multiple names in a non-repeating track definition. The following definition, creates four `1fr` tracks, which each have a start and end line.
+If your repeating syntax puts two lines next to each other then they will be merged and create the same result as giving a line multiple names in a non-repeating track definition. The following definition creates four `1fr` tracks, with each having a start and end line.
 
 ```css
 .wrapper {
@@ -317,7 +325,7 @@ If your repeating syntax puts two lines next to each other then they will be mer
 }
 ```
 
-If we write this definition out without using repeat notation it would look like this.
+If we write this declaration without using repeat notation, it would look like this:
 
 ```css
 .wrapper {
@@ -325,7 +333,7 @@ If we write this definition out without using repeat notation it would look like
 }
 ```
 
-If you have used a track list then you can use the `span` keyword not just to span a number of lines but also to span a number of lines of a certain name.
+Using a track list, we can use the `span` keyword to span a number of lines, including lines of a certain name:
 
 ```css hidden
 * {
@@ -374,13 +382,13 @@ If you have used a track list then you can use the `span` keyword not just to sp
 </div>
 ```
 
-{{ EmbedLiveSample('Defining_named_lines_with_a_track_list', '500', '330') }}
+{{ EmbedLiveSample('Defining_named_lines_with_a_track_list', '500', '230') }}
 
 ### Twelve-column grid framework
 
-Over the last three guides you have discovered that there are a lot of different ways to place items using grid. This can seem a little bit overcomplicated at first, but remember you don't need to use all of them. In practice I find that for straightforward layouts, using named template areas works well, it gives that nice visual representation of what your layout looks like, and it is then easy to move things around on the grid.
+Learning about numeric and named line-based placement and [grid template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas), we now know there are several ways to place items using grid. This may seem overly complex, but you don't need to use all of them. In practice, using named template areas works well for straightforward layouts as this method gives that good visual representation of what your layout looks like, and makes it more intuitive to move things around on the grid. For example, when working with a strict multiple column layout, the named lines demonstration in the last part of this guide works well.
 
-If working with a strict multiple column layout for example the named lines demonstration in the last part of this guide works very well. If you consider grid systems such as those found in frameworks like Foundation or Bootstrap, these are based on a 12 column grid. The framework then imports the code to do all of the calculations to make sure that the columns add up to 100%. With grid layout the only code we need for our grid "framework" is:
+Last decade's grid systems, including Foundation or Bootstrap, were based on a 12 column grid. The frameworks imported code to do the calculations that ensured the columns added up to 100%. Frameworks aren't needed! The only CSS we need for a 12-column grid "framework" is:
 
 ```css
 .wrapper {
@@ -390,7 +398,9 @@ If working with a strict multiple column layout for example the named lines demo
 }
 ```
 
-We can then use that framework to lay out our page. For example, to create a three column layout with a header and footer, I might have the following markup.
+We can then use this "framework" to lay out our page.
+
+For example, to create a three column layout with a header and footer, we might have the following markup.
 
 ```css hidden
 * {
@@ -422,7 +432,7 @@ We can then use that framework to lay out our page. For example, to create a thr
 </div>
 ```
 
-I could then place this on my grid layout framework like this.
+We can place this on our grid layout framework:
 
 ```css
 .main-header,
@@ -446,10 +456,12 @@ I could then place this on my grid layout framework like this.
 }
 ```
 
-{{ EmbedLiveSample('Twelve-column_grid_framework', '500', '330') }}
+{{ EmbedLiveSample('Twelve-column_grid_framework', '500', '220') }}
 
-Once again, the grid highlighter is helpful to show us how the grid we have placed our items on works.
+Once again, the developer tool's grid highlighter is helpful to show us how the grid we have placed our items on works.
 
 ![The layout with the grid highlighted.](5_named_lines2.png)
 
-That's all I need. I don't need to do any calculations, grid automatically removed my 10 pixel gutter track before assigning the space to the `1fr` column tracks. As you start to build out your own layouts, you will find that the syntax becomes more familiar and you choose the ways that work best for you and the type of projects you like to build. Try building some common patterns with these various methods, and you will soon find your most productive way to work. Then, in the next guide we will look at how grid can position items for us - without us needing to use placement properties at all!
+That's all we need. We don't need to do any calculations! Grid automatically removed our 10 pixel gutter track before assigning the space to the `1fr` column tracks.
+
+Up next, we will look at how grid can position items for us - without us needing to use placement properties at all, in the [auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) guide.

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_named_grid_lines/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_named_grid_lines/index.md
@@ -6,9 +6,9 @@ page-type: guide
 
 {{CSSRef}}
 
-In previous guides, we've looked at placing items by the lines created by [defining grid tracks](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement) and also how to place items [using named template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas). In this guide, we look at how these two things work together when we use named lines.
+In previous guides, we've looked at placing items on the lines created by [defining grid tracks](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement) and also how to place items [using named template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas). In this guide, we look at how these two things work together when we use named lines.
 
-Line naming is incredibly useful, but some of the more baffling looking grid syntax comes from this combination of names and track sizes. Once you work through some examples, it should become clearer and easier to work with.
+Line naming is incredibly useful, but some of the more confusing grid syntax comes from this combination of names and track sizes. Once you work through some examples, it should become clearer and easier to work with.
 
 ## Naming lines when defining a grid
 
@@ -34,7 +34,7 @@ You can assign some or all of the lines in your grid a name when you define your
 }
 ```
 
-When defining the grid, we name our lines inside square brackets (`[]`). Those names can be anything you like. We define a name for the start and end of the container, both for rows and columns. In this case, the center block of the grid is named `content-start` and `content-end`, for both columns and rows.
+When defining the grid, we name our lines inside square brackets (`[]`). Those names can be anything you like. We define a name for the start and end of the container, both for rows and columns. In this case, the grid center block's start rows and columns are both named `content-start`, and its end rows and columns are both named `content-end`.
 
 ```css
 .wrapper {
@@ -44,7 +44,7 @@ When defining the grid, we name our lines inside square brackets (`[]`). Those n
 }
 ```
 
-We don't need to name all of lines in our grids; you may choose to name just the key lines of your layout.
+We don't need to name all of the lines in our grids; you may choose to name just the key lines of your layout.
 
 Once the lines have names, we can use the name we defined, rather than the line number, to place the grid items.
 
@@ -84,7 +84,7 @@ Once the lines have names, we can use the name we defined, rather than the line 
 
 {{ EmbedLiveSample('Naming_lines_when_defining_a_grid', '500', '330') }}
 
-Everything else about line-based placement still works in the same way. In our grid layout, we basically provided each numeric line with an alias name. In our grid items we reference a name rather than a number. Naming lines in this way is useful as, when creating a responsive design, we can update the container's grid properties rather than updating the grid items within each [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).
+Everything else about line-based placement still works in the same way. In our grid layout, we provided each numeric line with an alias name. In our grid items, we reference a name rather than a number. Naming lines in this way is useful — when creating a responsive design, we can update the container's grid properties rather than updating the grid items within each [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).
 
 ### Giving lines multiple names
 
@@ -92,7 +92,7 @@ You may want to give a line more than one name, perhaps it denotes the sidebar-e
 
 ## Implicit grid areas from named lines
 
-When naming the lines, we mentioned that you can name these anything you like. The name is a {{cssxref("custom ident")}}, an author-defined name. When choosing the name you need to avoid words that might appear in the specification and be confusing - such as `span`. Idents are not quoted.
+When naming the lines, we mentioned that you can name these anything you like. The name is a {{cssxref("custom-ident")}}, an author-defined name. When choosing the name you need to avoid words that might appear in the specification and be confusing - such as `span`. Idents are not quoted.
 
 While you can choose any name, if you append `-start` and `-end` to the lines around an area, as we have in the example above, grid will create a named area of the main name used. Taking the above example, we have `content-start` and `content-end` both for rows and for columns. This means we get a grid area named `content`, and could place something in that area should we wish to.
 
@@ -161,7 +161,7 @@ This gives us column and row lines:
 - `ft-start`
 - `ft-end`
 
-You can see the named lines in the image. Mote that some lines have two names - for example `sd-end` and `main-start` refer to the same column line.
+You can see the named lines in the image. Note that some lines have two names - for example, `sd-end` and `main-start` refer to the same column line.
 
 ![An image showing the implicit line names created by our grid areas.](5_multiple_lines_from_areas.png)
 
@@ -237,7 +237,7 @@ Positioning `overlay` using these implicit named lines is the same as positionin
 
 {{ EmbedLiveSample('Implicit_Grid_lines_from_named_areas', '500', '330') }}
 
-Given that we have this ability to position created lines from named areas and areas from named lines, it is worth taking a little bit of time to plan your naming strategy when starting out creating your grid layout. By selecting names that will make sense to you and your team, you will make using the layouts you create more inuitive.
+Given that we have this ability to position created lines from named areas and areas from named lines, it is worth taking a little bit of time to plan your naming strategy when starting out creating your grid layout. Selecting names that make sense to you and your team will make your layouts more intuitive.
 
 ## Multiple lines with the same name with repeat()
 
@@ -276,7 +276,7 @@ In this example, we create a grid with 12 equal-width columns. Before defining t
 
 Once you have created the grid you can place items onto it. As we have multiple lines named `col-start` if you place an item to start after line `col-start`, the first line named `col-start` will be used. In our case, this is the far left line. To address another line, use the name with the number for that line.
 
-To place an item spanning from the first line named `col-start` to the 5th with that name, we can use:
+To place an item spanning from the first line named `col-start` to the 5th line with that name, we can use:
 
 ```css
 .item1to5 {
@@ -301,13 +301,13 @@ You can also use the `span` keyword. This item will span 3 lines starting from t
 
 {{ EmbedLiveSample('Twelve-column_grid_using_repeat', '500', '120') }}
 
-If you take a look at this layout your browser's developer tools, you will see how the column lines are shown, and how our items are placed against these lines.
+If you look at this layout in your browser's developer tools, you will see how the column lines are shown, and how our items are placed against these lines.
 
 ![The 12 column grid with items placed. The Firefox grid highlighter shows the position of the lines.](5_named_lines1.png)
 
 ### Defining named lines with a track list
 
-The repeat syntax can also take a track list; it not just single track sizes that can be repeated.
+The `repeat()` syntax can also take a track list; it is not just single track sizes that can be repeated.
 
 This CSS creates an eight track grid, with a narrower `1fr` width column named `col1-start` followed by a wider `3fr` column named `col2-start`.
 
@@ -317,7 +317,7 @@ This CSS creates an eight track grid, with a narrower `1fr` width column named `
 }
 ```
 
-If your repeating syntax puts two lines next to each other then they will be merged and create the same result as giving a line multiple names in a non-repeating track definition. The following definition creates four `1fr` tracks, with each having a start and end line.
+If your repeating syntax puts two lines next to each other then they will be merged and create the same result as giving a line multiple names in a non-repeating track definition. The following definition creates four `1fr` tracks, each with a start and end line.
 
 ```css
 .wrapper {
@@ -325,7 +325,7 @@ If your repeating syntax puts two lines next to each other then they will be mer
 }
 ```
 
-If we write this declaration without using repeat notation, it would look like this:
+If we write this declaration without using repeat notation, it looks like this:
 
 ```css
 .wrapper {
@@ -386,9 +386,9 @@ Using a track list, we can use the `span` keyword to span a number of lines, inc
 
 ### Twelve-column grid framework
 
-Learning about numeric and named line-based placement and [grid template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas), we now know there are several ways to place items using grid. This may seem overly complex, but you don't need to use all of them. In practice, using named template areas works well for straightforward layouts as this method gives that good visual representation of what your layout looks like, and makes it more intuitive to move things around on the grid. For example, when working with a strict multiple column layout, the named lines demonstration in the last part of this guide works well.
+Having learned about numeric and named line-based placement and [grid template areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas), we now know there are several ways to place items using CSS grid layout. This may seem overly complex, but you don't need to use all of them. In practice, using named template areas works well for straightforward layouts as this method gives a good visual representation of what your layout looks like, and makes it more intuitive to move things around on the grid. For example, when working with a strict multiple-column layout, the named lines demonstration in the last part of this guide works well.
 
-Last decade's grid systems, including Foundation or Bootstrap, were based on a 12 column grid. The frameworks imported code to do the calculations that ensured the columns added up to 100%. Frameworks aren't needed! The only CSS we need for a 12-column grid "framework" is:
+Legacy grid systems such as Foundation or Bootstrap are based on a 12-column grid. These frameworks import code to do calculations that ensure the columns add up to 100%. Frameworks aren't needed! The only CSS we need for a 12-column grid "framework" is:
 
 ```css
 .wrapper {
@@ -400,7 +400,7 @@ Last decade's grid systems, including Foundation or Bootstrap, were based on a 1
 
 We can then use this "framework" to lay out our page.
 
-For example, to create a three column layout with a header and footer, we might have the following markup.
+For example, to create a three-column layout with a header and footer, we can use the following markup.
 
 ```css hidden
 * {
@@ -462,6 +462,6 @@ Once again, the developer tool's grid highlighter is helpful to show us how the 
 
 ![The layout with the grid highlighted.](5_named_lines2.png)
 
-That's all we need. We don't need to do any calculations! Grid automatically removed our 10 pixel gutter track before assigning the space to the `1fr` column tracks.
+That's all we need. We don't need to do any calculations! CSS grid layout automatically removed our 10-pixel gutter track before assigning the space to the `1fr` column tracks.
 
-Up next, we will look at how grid can position items for us - without us needing to use placement properties at all, in the [auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) guide.
+Up next, we will look at how CSS grid layout can position items for us without requiring placement properties at all, in the [auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) guide.

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
@@ -483,4 +483,6 @@ You can use this syntax in the exact same way as the {{cssxref("grid-template")}
 
 We will revisit the other functionality offered by this shorthand when we take a look at [auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) and the `grid-auto-flow` property.
 
+## Next steps
+
 If you've been working along the [grid guides](/en-US/docs/Web/CSS/CSS_grid_layout#guides), you should be in a position to create grid layouts using [line-based placement](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement) or [named areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines). Now let's take a look at creating [grid layouts using named grid lines](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines).

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{CSSRef}}
 
-In the [previous guide](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement), we looked at grid lines and how to position items against those lines. When you use CSS grid layout, you always have lines, and this can be a straightforward way to place items on your grid. However, there is an alternate method to use for positioning items on the grid which you can use alone or in combination with line-based placement. This method involves placing our items using named template areas, and we will find out exactly how this method works. You will see very quickly why we sometimes call this the ascii-art method of grid layout!
+In the [grid layout using line-based placement guide](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement), we looked at grid lines and how to position items against those lines. When you use CSS grid layout, you always have lines, and this can be a straightforward way to place items on your grid. However, there is an alternate method to use for positioning items on the grid which you can use alone or in combination with line-based placement. This method involves placing our items using named template areas. You will see very quickly why we sometimes call this the ascii-art method of grid layout!
 
 ## Naming a grid area
 
@@ -22,7 +22,7 @@ What we are doing here when defining all four lines, is defining the area by spe
 
 ![The grid area defined by lines](4_area.png)
 
-We can also define an area by giving it a name and then specify the location of that area in the value of the {{cssxref("grid-template-areas")}} property. You can choose what you would like to name your area. For example, if I wish to create the layout shown below I can identify four main areas.
+We can also define an area by giving it a name and then specify the location of that area in the value of the {{cssxref("grid-template-areas")}} property. You can choose what you would like to name your area. For example, if we wish to create the layout shown below we can identify four main areas.
 
 - a header
 - a footer
@@ -31,7 +31,7 @@ We can also define an area by giving it a name and then specify the location of 
 
 ![An image showing a simple two column layout with header and footer](4_layout.png)
 
-With the {{cssxref("grid-area")}} property I can assign each of these areas a name. This will not yet create any layout, but we now have named areas to use in a layout.
+With the {{cssxref("grid-area")}} property we can assign each of these areas a name. By itself, this does not create any layout. Rather, it provided named areas to use in a layout.
 
 ```css
 .header {
@@ -48,7 +48,7 @@ With the {{cssxref("grid-area")}} property I can assign each of these areas a na
 }
 ```
 
-Having defined these names I then create my layout. This time, instead of placing my items using line numbers specified on the items themselves, I create the whole layout on the grid container.
+Having defined these names we then create the layout. This time, instead of placing items using line numbers specified on the items themselves, we create the whole layout on the grid container. Here we create a 9-column grid, then define the `hd` and `ft` to span all 9 columns, while the `sd` spans three and `main` spans six. Each spans only one row.
 
 ```css
 .wrapper {
@@ -99,7 +99,7 @@ Using this method we do not need to specify anything at all on the individual gr
 
 ## Leaving a grid cell empty
 
-We have completely filled our grid with areas in this example, leaving no white space. However you can leave grid cells empty with this method of layout. To leave a cell empty use the full stop character, `.`. If I want to only display the footer directly under the main content I would need to leave the three cells underneath the sidebar empty.
+We have completely filled our grid with areas in this example, leaving no white space. However you can leave grid cells empty with this method of layout. To leave a cell empty use the full stop character, `.`. If we want to only display the footer directly under the main content we would need to leave the three cells underneath the sidebar empty.
 
 ```css
 .header {
@@ -161,11 +161,11 @@ We have completely filled our grid with areas in this example, leaving no white 
 
 {{ EmbedLiveSample('Leaving_a_grid_cell_empty', '300', '330') }}
 
-In order to make the layout neater I can use multiple `.` characters. As long as there is at least one white space between the full stops it will be counted as one cell. For a complex layout there is a benefit to having the rows and columns neatly aligned. It means that you can actually see, right there in the CSS, what this layout looks like.
+In order to make the layout neater we can use multiple `.` characters. As long as there is at least one white space between the full stops it will be counted as one cell. For a complex layout there is a benefit to having the rows and columns neatly aligned. It means that you can actually see, right there in the CSS, what this layout looks like.
 
 ## Spanning multiple cells
 
-In our example each of the areas spans multiple grid cells and we achieve this by repeating the name of that grid area multiple times with white space between. You can add extra white space in order to keep your columns neatly lined up in the value of `grid-template-areas`. You can see that I have done this in order that the `hd` and `ft` line up with `main`.
+In our example each of the areas spans multiple grid cells and we achieve this by repeating the name of that grid area multiple times with white space between. You can add extra white space in order to keep your columns neatly lined up in the value of `grid-template-areas`. You can see that we have done this in order that the `hd` and `ft` line up with `main`.
 
 The area that you create by chaining the area names must be rectangular, at this point there is no way to create an L-shaped area. The specification does note that a future level might provide this functionality. You can however span rows just as easily as columns. For example we could make our sidebar span down to the end of the footer by replacing the `.` with `sd`.
 
@@ -237,7 +237,7 @@ As our layout is now contained in one part of the CSS, this makes it very easy t
 
 When doing this, define the names for your areas outside of any media queries. That way the content area would always be called `main` no matter where on the grid it is placed.
 
-For our layout above, we might like to have a very simple layout at narrow widths, defining a single column grid and stacking up our items.
+For our layout above, we might like to have a very simple layout at narrow widths, defining a single column grid and stacking our four items into four rows.
 
 ```css hidden
 * {
@@ -287,10 +287,10 @@ For our layout above, we might like to have a very simple layout at narrow width
 }
 ```
 
-We can then redefine that layout inside media queries to go to our two columns layout, and perhaps take it to a three column layout if the available space is even wider. Note that for the wide layout I keep my nine column track grid, I redefine where items are placed using `grid-template-areas`.
+We can then redefine that layout inside [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to go to our two columns layout, and perhaps take it to a three column layout if the available space is even wider. Note that for the wide layout we keep my nine column track grid, we redefine where items are placed using `grid-template-areas`.
 
 ```css
-@media (min-width: 500px) {
+@media (min-width: 30em) {
   .wrapper {
     grid-template-columns: repeat(9, 1fr);
     grid-template-areas:
@@ -299,7 +299,7 @@ We can then redefine that layout inside media queries to go to our two columns l
       "sd sd sd  ft  ft   ft   ft   ft   ft";
   }
 }
-@media (min-width: 700px) {
+@media (min-width: 60em) {
   .wrapper {
     grid-template-areas:
       "hd hd hd   hd   hd   hd   hd   hd hd"
@@ -325,7 +325,7 @@ Many of the grid examples you will find online make the assumption that you will
 
 ### Media object example
 
-As a very simple example we can create a "media object". This is a component with space for an image or other media on one side and content on the other. The image might be displayed on the right or left of the box.
+As a very simple example we can create a "[media object](/en-US/docs/Web/CSS/Layout_cookbook/Media_objects)". This is a component with space for an image or other media on one side and content on the other. The image might be displayed on the right or left of the box.
 
 ![Images showing an example media object design](4_media_objects.png)
 
@@ -370,7 +370,7 @@ We give the image area a grid area name of `img` and the text area `content`, th
 </div>
 ```
 
-{{ EmbedLiveSample('Media_object_example', '300', '200') }}
+{{ EmbedLiveSample('Media_object_example', '300', '105') }}
 
 ### Displaying the image on the other side of the box
 
@@ -418,7 +418,7 @@ We might want to be able to display our box with the image the other way around.
 </div>
 ```
 
-{{ EmbedLiveSample('Displaying_the_image_on_the_other_side_of_the_box', '300', '200') }}
+{{ EmbedLiveSample('Displaying_the_image_on_the_other_side_of_the_box', '300', '105') }}
 
 ## Grid definition shorthands
 
@@ -426,19 +426,19 @@ Having looked at various ways of placing items on our grids and many of the prop
 
 These can quickly become difficult to read for other developers, or even your future self. However they are part of the specification and it is likely you will come across them in examples or in use by other developers, even if you choose not to use them.
 
-Before using any shorthand it is worth remembering that shorthands not only enable the setting of many properties in one go, they also act to **reset things** to their initial values that you do not, or cannot set in the shorthand. Therefore if you use a shorthand, be aware that it may reset things you have applied elsewhere.
+Before using any shorthand it is worth remembering that shorthands not only enable the setting of many properties in one go, they also **reset** everything that you do not, or cannot set in the shorthand to their initial values. Therefore if you use a shorthand, be aware that it may reset things you have applied elsewhere.
 
-The two shorthands for the grid container are the Explicit grid shorthand `grid-template` and the grid definition shorthand `grid`.
+The two shorthands for the grid container are the explicit grid shorthand {{cssxref("grid-template")}} and the grid definition shorthand {{cssxref("grid")}} .
 
 ### `grid-template`
 
-The {{cssxref("grid-template")}} property sets the following properties:
+The {{cssxref("grid-template")}} shorthand property sets the following longhand properties:
 
 - {{cssxref("grid-template-rows")}}
 - {{cssxref("grid-template-columns")}}
 - {{cssxref("grid-template-areas")}}
 
-The property is referred to as the Explicit grid shorthand because it is setting those things that you control when you define an explicit grid, and not those which impact any implicit row or column tracks that might be created.
+The property is referred to as the _explicit grid shorthand_ because it is setting those things that you control when you define an explicit grid, and not those which impact any implicit row or column tracks that might be created.
 
 The following code creates a layout using {{cssxref("grid-template")}} that is the same as the layout created earlier in this guide.
 
@@ -468,7 +468,7 @@ The {{cssxref("grid")}} shorthand goes a step further and also sets properties u
 - {{cssxref("grid-auto-columns")}}
 - {{cssxref("grid-auto-flow")}}
 
-You can use this syntax in the exact same way as the {{cssxref("grid-template")}} shorthand, just be aware than when doing so you will reset the other values set by the property.
+You can use this syntax in the exact same way as the {{cssxref("grid-template")}} shorthand. Just be aware than when doing so you will reset the other values set by the property.
 
 ```css
 .wrapper {
@@ -481,6 +481,6 @@ You can use this syntax in the exact same way as the {{cssxref("grid-template")}
 }
 ```
 
-We will revisit the other functionality offered by this shorthand later in these guides when we take a look at auto placement and the `grid-auto-flow` property.
+We will revisit the other functionality offered by this shorthand when we take a look at [auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) and the `grid-auto-flow` property.
 
-If you have worked through these initial guides you now should be in a position to create grid layouts using line-based placement or named areas. Take some time to build some common layout patterns using grid, while there are lots of new terms to learn, the syntax is relatively straightforward. As you develop examples, you are likely to come up with some questions and use cases for things we haven't covered yet. In the rest of these guides we will be looking at some more of the detail included in the specification – in order that you can begin to create advanced layouts with it.
+If you've been working along the [grid guides](/en-US/docs/Web/CSS/CSS_grid_layout#guides), you should be in a position to create grid layouts using [line-based placement](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement) or [named areas](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines). Now let's take a look at creating [grid layouts using named grid lines](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines).

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
@@ -31,7 +31,7 @@ We can also define an area by giving it a name and then specify the location of 
 
 ![An image showing a simple two column layout with header and footer](4_layout.png)
 
-With the {{cssxref("grid-area")}} property we can assign each of these areas a name. By itself, this does not create any layout. Rather, it provided named areas to use in a layout.
+With the {{cssxref("grid-area")}} property we can assign each of these areas a name. By itself, this does not create any layout. Rather, it provides named areas to use in a layout.
 
 ```css
 .header {
@@ -48,7 +48,7 @@ With the {{cssxref("grid-area")}} property we can assign each of these areas a n
 }
 ```
 
-Having defined these names we then create the layout. This time, instead of placing items using line numbers specified on the items themselves, we create the whole layout on the grid container. Here we create a 9-column grid, then define the `hd` and `ft` to span all 9 columns, while the `sd` spans three and `main` spans six. Each spans only one row.
+Having defined these names, we then create the layout. This time, instead of placing items using line numbers specified on the items themselves, we create the whole layout on the grid container. Here we create a 9-column grid and specify that the `hd` and `ft` areas span all 9 columns, while `sd` spans three and `main` spans six. Each area spans only one row.
 
 ```css
 .wrapper {
@@ -165,7 +165,7 @@ In order to make the layout neater we can use multiple `.` characters. As long a
 
 ## Spanning multiple cells
 
-In our example each of the areas spans multiple grid cells and we achieve this by repeating the name of that grid area multiple times with white space between. You can add extra white space in order to keep your columns neatly lined up in the value of `grid-template-areas`. You can see that we have done this in order that the `hd` and `ft` line up with `main`.
+In our example, each area spans multiple grid cells and we achieve this by repeating the name of that grid area multiple times with white space between. You can add extra white space to keep your columns neatly lined up in the value of `grid-template-areas`. You can see that we have done this so that the `hd` and `ft` areas line up with `main`.
 
 The area that you create by chaining the area names must be rectangular, at this point there is no way to create an L-shaped area. The specification does note that a future level might provide this functionality. You can however span rows just as easily as columns. For example we could make our sidebar span down to the end of the footer by replacing the `.` with `sd`.
 
@@ -287,7 +287,7 @@ For our layout above, we might like to have a very simple layout at narrow width
 }
 ```
 
-We can then redefine that layout inside [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to go to our two columns layout, and perhaps take it to a three column layout if the available space is even wider. Note that for the wide layout we keep my nine column track grid, we redefine where items are placed using `grid-template-areas`.
+We can then redefine that layout inside [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to go to our two columns layout, and perhaps take it to a three column layout if the available space is even wider. Note that for the wide layout, we keep the nine-column track grid, redefining where items are placed using `grid-template-areas`.
 
 ```css
 @media (min-width: 30em) {
@@ -426,7 +426,7 @@ Having looked at various ways of placing items on our grids and many of the prop
 
 These can quickly become difficult to read for other developers, or even your future self. However they are part of the specification and it is likely you will come across them in examples or in use by other developers, even if you choose not to use them.
 
-Before using any shorthand it is worth remembering that shorthands not only enable the setting of many properties in one go, they also **reset** everything that you do not, or cannot set in the shorthand to their initial values. Therefore if you use a shorthand, be aware that it may reset things you have applied elsewhere.
+Before using any shorthand it is worth remembering that shorthands not only enable the setting of many properties in one go, but they also **reset** everything that you do not (or cannot) set in the shorthand to their initial values. Therefore if you use a shorthand, be aware that it may reset things you have applied elsewhere.
 
 The two shorthands for the grid container are the explicit grid shorthand {{cssxref("grid-template")}} and the grid definition shorthand {{cssxref("grid")}} .
 
@@ -438,7 +438,7 @@ The {{cssxref("grid-template")}} shorthand property sets the following longhand 
 - {{cssxref("grid-template-columns")}}
 - {{cssxref("grid-template-areas")}}
 
-The property is referred to as the _explicit grid shorthand_ because it is setting those things that you control when you define an explicit grid, and not those which impact any implicit row or column tracks that might be created.
+The property is referred to as the _explicit grid shorthand_ because it sets values that you control when you define an explicit grid, and not those that impact any implicit row or column tracks that might be created.
 
 The following code creates a layout using {{cssxref("grid-template")}} that is the same as the layout created earlier in this guide.
 


### PR DESCRIPTION
CSS grid layout module sub-PR (https://github.com/mdn/content/pull/37999)

 -   remove "I" language
-    see also links to current writing guideline standards
 -   height of examples
 -   general refresh