### PR TITLE
docs(WebGL API): enhance createShader(), compileShader(), and shaderSource() methods

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
@@ -26,6 +26,11 @@ compileShader(shader)
 
 None ({{jsxref("undefined")}}).
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the specified `shader` is not of type `WebGLShader`.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/webglrenderingcontext/createshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createshader/index.md
@@ -27,7 +27,7 @@ createShader(type)
 
 ### Return value
 
-A new ({{domxref("WebGLShader")}}), or `null` if an error occurs creating the ({{domxref("WebGLShader")}}) (such as providing an invalid value for `type`).
+A new {{domxref("WebGLShader")}} instance, or `null` if an error occurs creating the shader (for example, because `type` was an invalid value).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/createshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createshader/index.md
@@ -23,11 +23,11 @@ createShader(type)
 ### Parameters
 
 - `type`
-  - : Either `gl.VERTEX_SHADER` or `gl.FRAGMENT_SHADER`
+  - : Either `gl.VERTEX_SHADER` or `gl.FRAGMENT_SHADER`. The {{domxref("WebGLRenderingContext")}} will set the `gl.INVALID_ENUM` error flag if an unacceptable value has been specified.
 
 ### Return value
 
-A new ({{domxref("WebGLShader")}}).
+A new ({{domxref("WebGLShader")}}), or `null` if an error occurs creating the ({{domxref("WebGLShader")}}) (such as providing an invalid value for `type`).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
@@ -28,6 +28,11 @@ shaderSource(shader, source)
 
 None ({{jsxref("undefined")}}).
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the specified `shader` is not of type `WebGLShader`.
+
 ## Examples
 
 ```js


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The WebGL documentation did not previously indicate the [`createShader()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/createShader) method may return `null` or that both [`compileShader()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compileShader) and [`shaderSource()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/shaderSource) can throw `TypeError` exceptions.

### Motivation

This commit improves clarity and accuracy, ensuring developers are better informed about potential failure cases.

### Additional details

#### Changes

- Added amplifying information to the `type` parameter and details about possible `null` return value to [`createShader()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/createShader) method.
- Added an Exceptions section for [`compileShader()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compileShader) and [`shaderSource()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/shaderSource) methods to document potential `TypeError` exception.

### Related issues and pull requests

n/a