### PR TITLE
enhance(sidebars/cssref): group CSS pseudo-classes

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -77,7 +77,7 @@ sidebar:
     tags: css-combinator
     title: Combinators
     details: closed
-  - type: listSubPages
+  - type: listSubPagesGrouped
     path: /Web/CSS
     tags: css-pseudo-class
     title: Pseudo-classes

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -82,7 +82,7 @@ sidebar:
     tags: css-pseudo-class
     title: Pseudo-classes
     details: closed
-  - type: listSubPages
+  - type: listSubPagesGrouped
     path: /Web/CSS
     tags: css-pseudo-element
     title: Pseudo-elements


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Groups the CSS Pseudo-classes in the sidebar, similar to the CSS Properties.

### Motivation

Ensures especially that all the non-standard pseudo-classes are grouped together.

### Additional details

| Before | After |
|--------|--------|
| <img width="283" alt="image" src="https://github.com/user-attachments/assets/d1551e20-5429-46c6-9c69-235dfa2ea005" /> | <img width="283" alt="image" src="https://github.com/user-attachments/assets/a0ffa19b-574b-4930-b61b-a06a3e3102d6" /> | 
| <img width="283" alt="image" src="https://github.com/user-attachments/assets/1b274d32-f68f-46c5-be4b-96f6e50068ab" /> | <img width="283" alt="image" src="https://github.com/user-attachments/assets/829b3a98-bb01-4f23-b6d4-0cb79a746608" /> |
| <img width="283" alt="image" src="https://github.com/user-attachments/assets/b1600df6-8566-4e0b-9c26-558e38cdff09" /> | <img width="283" alt="image" src="https://github.com/user-attachments/assets/9dd31058-ba0d-45fa-9667-34cb5f4111ca" /> |

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/38018.