### PR TITLE
Correct PushSubscription code example

### DIFF
--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -78,18 +78,15 @@ fetch("https://example.com/push/", {
 ### Unsubscribing from a push manager
 
 ```js
-navigator.serviceWorker.ready.then((reg) => {
-  reg.pushManager.getSubscription().then((subscription) => {
-    subscription
-      .unsubscribe()
-      .then((successful) => {
-        // You've successfully unsubscribed
-      })
-      .catch((e) => {
-        // Unsubscribing failed
-      });
+navigator.serviceWorker.ready
+  .then((reg) => reg.pushManager.getSubscription())
+  .then((subscription) => subscription.unsubscribe())
+  .then((successful) => {
+    // You've successfully unsubscribed
+  })
+  .catch((e) => {
+    // Unsubscribing failed
   });
-});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -55,7 +55,8 @@ This example shows how you might put the needed information from `PushSubscripti
 
 ```js
 // Get a PushSubscription object
-const pushSubscription = await serviceWorkerRegistration.pushManager.subscribe();
+const pushSubscription =
+  await serviceWorkerRegistration.pushManager.subscribe();
 
 // Create an object containing the information needed by the app server
 const subscriptionObject = {

--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -61,17 +61,17 @@ const pushSubscription = await serviceWorkerRegistration.pushManager.subscribe()
 const subscriptionObject = {
   endpoint: pushSubscription.endpoint,
   keys: {
-    p256dh: pushSubscription.getKey('p256dh'),
-    auth: pushSubscription.getKey('auth'),
+    p256dh: pushSubscription.getKey("p256dh"),
+    auth: pushSubscription.getKey("auth"),
   },
   encoding: PushManager.supportedContentEncodings,
   /* other app-specific data, such as user identity */
 };
 
 // Stringify the object an post to the app server
-fetch(`https://example.com/push/`, {
+fetch("https://example.com/push/", {
   method: "post",
-  body: JSON.stringify(subscriptionObject);
+  body: JSON.stringify(subscriptionObject),
 });
 ```
 

--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -61,8 +61,8 @@ const pushSubscription = await serviceWorkerRegistration.pushManager.subscribe()
 const subscriptionObject = {
   endpoint: pushSubscription.endpoint,
   keys: {
-    p256dh: pushSubscription.getKeys('p256dh'),
-    auth: pushSubscription.getKeys('auth'),
+    p256dh: pushSubscription.getKey('p256dh'),
+    auth: pushSubscription.getKey('auth'),
   },
   encoding: PushManager.supportedContentEncodings,
   /* other app-specific data, such as user identity */


### PR DESCRIPTION
The example used `getKeys`, the correct method name is `getKey`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct PushSubscription code example from `getKeys` to `getKey`

### Motivation

The method name was referenced inaccurately in the code example

### Additional details
https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription/getKey

Sorry, I mistyped the name of the method in the extended commit message. I recommend changing that message when you merge. (I wrote `pushKey` instead of `getKey`)