### PR TITLE
Use `{{domxref("FileSystemHandle")}}` in `show*Picker`

### DIFF
--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -34,7 +34,7 @@ showDirectoryPicker()
       - : A string that defaults to `"read"` for read-only access or `"readwrite"` for read
         and write access to the directory.
     - `startIn` {{optional_inline}}
-      - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
+      - : A {{domxref("FileSystemHandle")}} or a well known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
 
 ### Return value

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -39,7 +39,7 @@ showOpenFilePicker()
       - : A boolean value that defaults to `false`. When
         set to `true` multiple files may be selected.
     - `startIn` {{Optional_Inline}}
-      - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
+      - : A {{domxref("FileSystemHandle")}} or a well known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `types` {{Optional_Inline}}
 

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -36,7 +36,7 @@ showSaveFilePicker()
         IDs. If the same ID is used for another picker, the picker opens in the same
         directory.
     - `startIn` {{Optional_Inline}}
-      - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
+      - : A {{domxref("FileSystemHandle")}} or a well known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `suggestedName` {{Optional_Inline}}
       - : A {{jsxref('String')}}. The suggested file name.


### PR DESCRIPTION
Adds hyperlinks to the type of the file pickers’ starting folder.