### PR TITLE
HTTP `506` status fix format

### DIFF
--- a/files/en-us/web/http/status/506/index.md
+++ b/files/en-us/web/http/status/506/index.md
@@ -21,10 +21,6 @@ Lack of standardization of how clients automatically choose from responses, and 
 506 Variant Also Negotiates
 ```
 
-## Specifications
-
-{{Specifications}}
-
 ## Examples
 
 ### Resource with variants
@@ -70,6 +66,10 @@ Alternates: {"index.html.en" 1 {type text/html} {language en} {length 48}}, {"an
 </body>
 </html>
 ```
+
+## Specifications
+
+{{Specifications}}
 
 ## See also
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/506
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/http/status/506/index.md
* Last commit: https://github.com/mdn/content/commit/bd4d7bc4176d9f67297e3940ae7163a258f07ef5
