### PR TITLE
Reference for de-facto interoperable V8 Stack trace API props

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/capturestacktrace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/capturestacktrace/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Error.captureStackTrace
 {{JSRef}}{{Non-standard_Header}}
 
 > [!NOTE]
-> This feature is part of the currently non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, due to compatibility reasons, it is de facto implemented by all major JavaScript engines.
+> This feature is part of the non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, for compatibility reasons, it is de facto implemented by all major JavaScript engines.
 
 The **`Error.captureStackTrace()`** static method installs stack trace information on a provided object as the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) property.
 
@@ -26,7 +26,7 @@ Error.captureStackTrace(object, constructor)
 - `object`
   - : The object on which to add the `stack` property.
 - `constructor` {{optional_inline}}
-  - : The constructor where the `object` was created. When collecting the stack trace, all frames above the topmost call to this function, including that call, are left out of the stack trace.
+  - : A function, typically the constructor where the `object` was created. When collecting the stack trace, all frames above the topmost call to this function, including that call, are left out of the stack trace.
 
 ### Return value
 
@@ -37,6 +37,8 @@ The `object` is modified in-place with an extra own property called `stack` defi
 ## Examples
 
 ### Using Error.captureStackTrace()
+
+The `getStack()` utility function returns the current stack trace at the point it is called, removing itself from the stack. This serves the same debugging purpose as {{domxref("console.trace()")}}, but allows you to output the string elsewhere. Note that it does not construct an `Error` instance for this purpose, but installs `stack` on a plain object, which would be more efficient for our purposes. Normally, you would call `Error.captureStackTrace` on objects intended to be thrown as errors, as shown in the next example.
 
 ```js
 function getStack() {
@@ -79,7 +81,7 @@ console.log(myError.stack);
 //     at <anonymous>:8:17
 ```
 
-Note that even if you don't call `Error.captureStackTrace()` here, some engines are still smart enough to avoid `MyError` in the stack trace if the constructor inherits from `Error`. Calling `Error.captureStackTrace()` is more important for custom errors that do not inherit from `Error` for some reason.
+Note that even if you don't call `Error.captureStackTrace()` here, some engines are still smart enough to avoid `MyError` in the stack trace if the constructor inherits from `Error`. Calling `Error.captureStackTrace()` is more important for custom errors that, for some reason, do not inherit from `Error`.
 
 ```js
 class MyError {

--- a/files/en-us/web/javascript/reference/global_objects/error/capturestacktrace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/capturestacktrace/index.md
@@ -1,0 +1,113 @@
+---
+title: Error.captureStackTrace()
+slug: Web/JavaScript/Reference/Global_Objects/Error/captureStackTrace
+page-type: javascript-static-method
+status:
+  - non-standard
+browser-compat: javascript.builtins.Error.captureStackTrace
+---
+
+{{JSRef}}{{Non-standard_Header}}
+
+> [!NOTE]
+> This feature is part of the currently non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, due to compatibility reasons, it is de facto implemented by all major JavaScript engines.
+
+The **`Error.captureStackTrace()`** static method installs stack trace information on a provided object as the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) property.
+
+## Syntax
+
+```js-nolint
+Error.captureStackTrace(object)
+Error.captureStackTrace(object, constructor)
+```
+
+### Parameters
+
+- `object`
+  - : The object on which to add the `stack` property.
+- `constructor` {{optional_inline}}
+  - : The constructor where the `object` was created. When collecting the stack trace, all frames above the topmost call to this function, including that call, are left out of the stack trace.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+The `object` is modified in-place with an extra own property called `stack` defined, whose string value follows the same format as {{jsxref("Error.prototype.stack")}}. This property is non-enumerable and configurable. In V8, it is a getter-setter pair. In SpiderMonkey and JavaScriptCore, it is a data property that is writable.
+
+## Examples
+
+### Using Error.captureStackTrace()
+
+```js
+function getStack() {
+  const obj = {};
+  if ("captureStackTrace" in Error) {
+    // Avoid getStack itself in the stack trace
+    Error.captureStackTrace(obj, getStack);
+  }
+  return obj.stack;
+}
+
+function foo() {
+  console.log(getStack());
+}
+
+foo();
+// Error
+//     at foo (<anonymous>:8:15)
+//     at <anonymous>:11:1
+```
+
+### Installing stack trace on a custom error object
+
+The main use case for `Error.captureStackTrace()` is to install a stack trace on a custom error object. Typically, you define [custom errors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#custom_error_types) by extending the `Error` class, which automatically makes the `stack` property available via inheritance. However, the problem with the default stack trace is that it includes the constructor call itself, which leaks implementation details. You can avoid this by using `Error.captureStackTrace()`, which allows the stack trace to be installed even for custom errors that do not inherit from `Error`.
+
+```js
+class MyError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    if ("captureStackTrace" in Error) {
+      // Avoid MyError itself in the stack trace
+      Error.captureStackTrace(this, MyError);
+    }
+  }
+}
+
+const myError = new MyError("Something went wrong");
+console.log(myError.stack);
+// Error: Something went wrong
+//     at <anonymous>:8:17
+```
+
+Note that even if you don't call `Error.captureStackTrace()` here, some engines are still smart enough to avoid `MyError` in the stack trace if the constructor inherits from `Error`. Calling `Error.captureStackTrace()` is more important for custom errors that do not inherit from `Error` for some reason.
+
+```js
+class MyError {
+  constructor(message) {
+    this.message = message;
+    if ("captureStackTrace" in Error) {
+      // Avoid MyError itself in the stack trace
+      Error.captureStackTrace(this, MyError);
+    }
+  }
+}
+
+const myError = new MyError("Something went wrong");
+console.log(myError.stack);
+// Error: Something went wrong
+//     at <anonymous>:8:17
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Error.prototype.stack")}}
+- {{jsxref("Error.stackTraceLimit")}}
+- [Stack trace API](https://v8.dev/docs/stack-trace-api) in the V8 docs

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -50,8 +50,8 @@ Besides the generic `Error` constructor, there are other core error constructors
 
 - {{jsxref("Error.captureStackTrace()")}} {{non-standard_inline}}
   - : A non-standard function that creates the {{jsxref("Error/stack", "stack")}} property on the provided object.
-- [`Error.prepareStackTrace()`](https://v8.dev/docs/stack-trace-api#customizing-stack-traces) {{non-standard_inline}} {{optional_inline}}
-  - : A non-standard function that, if provided by user code, is called by the JavaScript engine for thrown exceptions, allowing the user to provide custom formatting for stack traces.
+- `Error.prepareStackTrace()` {{non-standard_inline}} {{optional_inline}}
+  - : A non-standard function that, if provided by user code, is called by the JavaScript engine for thrown exceptions, allowing the user to provide custom formatting for stack traces. See the [V8 Stack Trace API](https://v8.dev/docs/stack-trace-api#customizing-stack-traces) docs.
 
 ## Instance properties
 

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -41,14 +41,17 @@ Besides the generic `Error` constructor, there are other core error constructors
 - {{jsxref("Error/Error", "Error()")}}
   - : Creates a new `Error` object.
 
+## Static properties
+
+- {{jsxref("Error.stackTraceLimit")}} {{non-standard_inline}}
+  - : A non-standard numerical property that limits how many stack frames to include in an error stack trace.
+
 ## Static methods
 
-- `Error.captureStackTrace()` {{non-standard_inline}}
-  - : A non-standard V8 function that creates the {{jsxref("Error/stack", "stack")}} property on an Error instance.
-- `Error.stackTraceLimit` {{non-standard_inline}}
-  - : A non-standard V8 numerical property that limits how many stack frames to include in an error stacktrace.
-- `Error.prepareStackTrace()` {{non-standard_inline}} {{optional_inline}}
-  - : A non-standard V8 function that, if provided by user code, is called by the V8 JavaScript engine for thrown exceptions, allowing the user to provide custom formatting for stacktraces.
+- {{jsxref("Error.captureStackTrace()")}} {{non-standard_inline}}
+  - : A non-standard function that creates the {{jsxref("Error/stack", "stack")}} property on the provided object.
+- [`Error.prepareStackTrace()`](https://v8.dev/docs/stack-trace-api#customizing-stack-traces) {{non-standard_inline}} {{optional_inline}}
+  - : A non-standard function that, if provided by user code, is called by the JavaScript engine for thrown exceptions, allowing the user to provide custom formatting for stack traces.
 
 ## Instance properties
 
@@ -187,7 +190,7 @@ class CustomError extends Error {
     // Pass remaining arguments (including vendor specific ones) to parent constructor
     super(...params);
 
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    // Maintains proper stack trace for where our error was thrown (non-standard)
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, CustomError);
     }
@@ -205,7 +208,7 @@ try {
   console.error(e.name); // CustomError
   console.error(e.foo); // baz
   console.error(e.message); // bazMessage
-  console.error(e.stack); // stacktrace
+  console.error(e.stack); // stack trace
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/error/stack/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/stack/index.md
@@ -66,6 +66,8 @@ Error
     at filename.js:13:1
 ```
 
+V8 provides the non-standard [stack trace API](https://v8.dev/docs/stack-trace-api) for customizing the stack trace, including {{jsxref("Error.captureStackTrace()")}}, {{jsxref("Error.stackTraceLimit")}}, and `Error.prepareStackTrace()`. Other engines support this API to varying extents.
+
 Different engines set this value at different times. Most modern engines set it when the {{jsxref("Error")}} object is created. This means you can get the full call stack information within a function using the following:
 
 ```js
@@ -75,8 +77,6 @@ function foo() {
 ```
 
 Without having to throw an error and then catch it.
-
-In V8, the non-standard `Error.captureStackTrace()`, `Error.stackTraceLimit`, and `Error.prepareStackTrace()` APIs can be used to customize the stack trace. Read the [Stack trace API](https://v8.dev/docs/stack-trace-api) in the V8 docs for more information.
 
 Stack frames can be things other than explicit function calls, too. For example, event listeners, timeout jobs, and promise handlers all begin their own call chain. Source code within {{jsxref("Global_Objects/eval", "eval()")}} and {{jsxref("Function")}} constructor calls also appear in the stack:
 

--- a/files/en-us/web/javascript/reference/global_objects/error/stacktracelimit/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/stacktracelimit/index.md
@@ -10,11 +10,11 @@ browser-compat: javascript.builtins.Error.stackTraceLimit
 {{JSRef}}{{Non-standard_Header}}
 
 > [!NOTE]
-> This feature is part of the currently non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, due to compatibility reasons, it is also implemented by JavaScriptCore.
+> This feature is part of the currently non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, for compatibility reasons, it is also implemented by JavaScriptCore.
 
 The **`Error.stackTraceLimit`** static data property indicates the maximum number of stack frames captured by the stack trace of an error. It can be set by user code to change the engine's behavior.
 
-Generally, _reading_ this property is not very useful, but you can _set_ it to a new value. Setting it to a larger value can be useful for debugging, as it allows you to see more of the call stack. Setting it to a smaller value can be useful for performance, as it can reduce the amount of stack captured.
+Generally, _reading_ this property is not very useful, but you can _set_ it to a new value. Setting it to a larger value can be useful for debugging, as it allows you to see more of the call stack. Setting it to a smaller value can improve performance as it reduces the amount of stack captured.
 
 ## Value
 

--- a/files/en-us/web/javascript/reference/global_objects/error/stacktracelimit/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/stacktracelimit/index.md
@@ -1,0 +1,64 @@
+---
+title: Error.stackTraceLimit
+slug: Web/JavaScript/Reference/Global_Objects/Error/stackTraceLimit
+page-type: javascript-static-data-property
+status:
+  - non-standard
+browser-compat: javascript.builtins.Error.stackTraceLimit
+---
+
+{{JSRef}}{{Non-standard_Header}}
+
+> [!NOTE]
+> This feature is part of the currently non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, due to compatibility reasons, it is also implemented by JavaScriptCore.
+
+The **`Error.stackTraceLimit`** static data property indicates the maximum number of stack frames captured by the stack trace of an error. It can be set by user code to change the engine's behavior.
+
+Generally, _reading_ this property is not very useful, but you can _set_ it to a new value. Setting it to a larger value can be useful for debugging, as it allows you to see more of the call stack. Setting it to a smaller value can be useful for performance, as it can reduce the amount of stack captured.
+
+## Value
+
+An integer representing the maximum number of stack frames captured by the stack trace of an error.
+
+{{js_property_attributes(1, 1, 1)}}
+
+## Description
+
+Because `stackTraceLimit` is a static property of `Error`, you always use it as `Error.stackTraceLimit`, rather than as a property of an `Error` object you created. If you want to customize the stack trace for a single error only, you may need to set the property, create the error, and then reset the property to its original value.
+
+## Examples
+
+### Setting Error.stackTraceLimit
+
+This code is safe to run even in environments that don't support `Error.stackTraceLimit`, because it doesn't read the property, only sets it, and engines that don't support it will ignore the setting.
+
+```js
+Error.stackTraceLimit = 2;
+const a = () => b();
+const b = () => c();
+const c = () => d();
+const d = () => e();
+const e = () => {
+  throw new Error("My error");
+};
+try {
+  a();
+} catch (e) {
+  console.log(e.stack);
+}
+// Only two frames in supporting engines; all frames in others
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Error.prototype.stack")}}
+- {{jsxref("Error.captureStackTrace()")}}
+- [Stack trace API](https://v8.dev/docs/stack-trace-api) in the V8 docs


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/37930.

I'm not documenting `prepareStackTrace` because (a) it's only supported by V8 (b) it's too big and complex and prone to changes.