### PR TITLE
Update exception description for HTMLDialogElement.show() and .showMo…

### DIFF
--- a/files/en-us/web/api/htmldialogelement/show/index.md
+++ b/files/en-us/web/api/htmldialogelement/show/index.md
@@ -26,6 +26,11 @@ None.
 
 None ({{jsxref("undefined")}}).
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the dialog is already open and modal (i.e. if the dialog has already been opened with {{domxref("HTMLDialogElement.showModal()")}}).
+
 ## Examples
 
 The following example shows a simple button that, when clicked, opens a

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -31,7 +31,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the dialog is already open (i.e. if the `open` attribute is already set on the {{htmlelement("dialog")}} element), or if the dialog is also a [popover](/en-US/docs/Web/API/Popover_API) that is already being shown.
+  - : Thrown if the dialog is already open and non-modal (i.e. if the dialog has already been opened with {{domxref("HTMLDialogElement.show()")}}).
 
 ## Examples
 


### PR DESCRIPTION
### Description

The current exception descriptions for `HTMLDialogElement.showModal()` and `HTMLDialogElement.show()` are outdated. 

### Motivation

This behavior was [updated to only throw errors when switching between modes](https://github.com/whatwg/html/pull/9142).