### PR TITLE
Add a section on link `target` attribute

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
@@ -272,7 +272,7 @@ Other tips:
 
 ### Linking to non-HTML resources — leave clear signposts
 
-When linking to a resource that will not be opened in the current page as a "normal navigation", you should add clear wording to the link text about what is going to happen. For example, if you're downloading or streaming a resource, or if the link is going to open a popup or perform some other potentially unexpected effect, this should be stated in the text. This is important for users on low bandwidth connection and want to avoid downloading assets of multiple megabytes. It also helps to set up expectations for screen reader users, who may not be aware of what's happening otherwise.
+When linking to a resource that will not be opened in the current page as a "normal navigation", you should add clear wording to the link text about what is going to happen. For example, if you're downloading or streaming a resource, or if the link is going to open a popup or perform some other potentially unexpected effect, this should be stated in the text. This is important for users on low bandwidth connections, who might want to avoid downloading assets of multiple megabytes. It also helps to set up expectations for screen reader users, who may not be aware of what's happening otherwise.
 
 Let's look at some examples, to see what kind of text can be used here:
 

--- a/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
@@ -278,13 +278,13 @@ Let's look at some examples, to see what kind of text can be used here:
 
 ```html
 <p>
-  <a href="https://www.example.com/large-report.pdf">
+  <a href="/large-report.pdf" download>
     Download the sales report (PDF, 10MB)
   </a>
 </p>
 
 <p>
-  <a href="https://www.example.com/video-stream/">
+  <a href="https://www.example.com/video-stream/" target="_blank">
     Watch the video (stream opens in separate tab, HD quality)
   </a>
 </p>

--- a/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
@@ -319,7 +319,7 @@ Whether or not to open links in a new tab should be a conscious decision, based 
 - Screen reader users may be confused by links that open in a new tab, as they may not realize that the new tab has opened, and they may lose context about their location on the page.
 
 A common approach is to open external links in new tabs and internal links in the same tab.
-Some designers prefer to open all links in the same tab. 
+Some designers prefer to open all links in the same tab.
 If you do open links in new tabs, then it is recommended that you provide cues for these links, such as an icon next to the link text.
 
 ## Active learning: creating a navigation menu

--- a/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
@@ -318,7 +318,9 @@ Whether or not to open links in a new tab should be a conscious decision, based 
 - Even when links are opened in the same tab by default, users can still choose to open them in a new tab, using keyboard shortcuts or context menu options. On the other hand, links that open in a new tab are hard to open in the same tab.
 - Screen reader users may be confused by links that open in a new tab, as they may not realize that the new tab has opened, and they may lose context about their location on the page.
 
-"External links open in new tabs, internal links open in the same tab" is a common principle to stick to. And, if you are not sure, it's always best to open all links in the same tab. You can provide cues for links that open in new tabs, such as an icon next to the link text.
+A common approach is to open external links in new tabs and internal links in the same tab.
+Some designers prefer to open all links in the same tab. 
+If you do open links in new tabs, then it is recommended that you provide cues for these links, such as an icon next to the link text.
 
 ## Active learning: creating a navigation menu
 

--- a/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
@@ -272,7 +272,7 @@ Other tips:
 
 ### Linking to non-HTML resources — leave clear signposts
 
-When linking to a resource that will be downloaded (like a PDF or Word document), streamed (like video or audio), or has another potentially unexpected effect (opens a popup window), you should add clear wording to reduce any confusion. For example, if you're on a low bandwidth connection, click a link, and then a multiple megabyte download starts unexpectedly.
+When linking to a resource that will not be opened in the current page as a "normal navigation", you should add clear wording to the link text about what is going to happen. For example, if you're downloading or streaming a resource, or if the link is going to open a popup or perform some other potentially unexpected effect, this should be stated in the text. This is important for users on low bandwidth connection and want to avoid downloading assets of multiple megabytes. It also helps to set up expectations for screen reader users, who may not be aware of what's happening otherwise.
 
 Let's look at some examples, to see what kind of text can be used here:
 
@@ -302,18 +302,18 @@ When you are linking to a resource that's to be downloaded rather than opened in
 </a>
 ```
 
-### Open links in a new tab: yes or no?
+### When to open links in a new tab
 
-Links by default open in the same tab as the page they are on, which allows the user to navigate back to the previous page using the browser's back button. However, many sites (including MDN) choose to open certain links, especially external links, in a new tab. This is done using the [`target`](/en-US/docs/Web/HTML/Element/a#target) attribute.
+Links by default open in the same tab as the page they are on, which allows the user to navigate back to the previous page using the browser's back button. However, many sites (including MDN) choose to open certain links, especially external links, in a new tab. This is done by setting the [`target`](/en-US/docs/Web/HTML/Element/a#target) attribute to `"_blank"`.
 
 ```html
 Firefox is developed by the
 <a href="https://www.mozilla.org/en-US/" target="_blank">Mozilla Foundation</a>.
 ```
 
-It should be a conscious user experience decision of whether to open links in a new tab or not. Here are some things to consider:
+Whether or not to open links in a new tab should be a conscious decision, based on user experience design considerations. Here are some things to think about:
 
-- Opening links in a new tab presents the two documents simultaneously, which is useful for a "parallel" navigation experience, where the linked page may be an aside that the user is not expected to spend a prolonged period of time on. On the other hand, links that open in the same tab are more like a continuation of the current page.
+- Opening links in a new tab presents the two documents simultaneously, which is useful for a "parallel" navigation experience. On the other hand, links that open in the same tab are more like a continuation of the current page.
 - Opening links in a new tab can be disorienting for users who are accustomed to using the back button.
 - Even when links are opened in the same tab by default, users can still choose to open them in a new tab, using keyboard shortcuts or context menu options. On the other hand, links that open in a new tab are hard to open in the same tab.
 - Screen reader users may be confused by links that open in a new tab, as they may not realize that the new tab has opened, and they may lose context about their location on the page.

--- a/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/creating_links/index.md
@@ -272,11 +272,7 @@ Other tips:
 
 ### Linking to non-HTML resources — leave clear signposts
 
-When linking to a resource that will be downloaded (like a PDF or Word document), streamed (like video or audio), or has another potentially unexpected effect (opens a popup window), you should add clear wording to reduce any confusion.
-
-For example:
-
-- If you're on a low bandwidth connection, click a link, and then a multiple megabyte download starts unexpectedly.
+When linking to a resource that will be downloaded (like a PDF or Word document), streamed (like video or audio), or has another potentially unexpected effect (opens a popup window), you should add clear wording to reduce any confusion. For example, if you're on a low bandwidth connection, click a link, and then a multiple megabyte download starts unexpectedly.
 
 Let's look at some examples, to see what kind of text can be used here:
 
@@ -288,7 +284,7 @@ Let's look at some examples, to see what kind of text can be used here:
 </p>
 
 <p>
-  <a href="https://www.example.com/video-stream/" target="_blank">
+  <a href="https://www.example.com/video-stream/">
     Watch the video (stream opens in separate tab, HD quality)
   </a>
 </p>
@@ -305,6 +301,24 @@ When you are linking to a resource that's to be downloaded rather than opened in
   Download Latest Firefox for Windows (64-bit) (English, US)
 </a>
 ```
+
+### Open links in a new tab: yes or no?
+
+Links by default open in the same tab as the page they are on, which allows the user to navigate back to the previous page using the browser's back button. However, many sites (including MDN) choose to open certain links, especially external links, in a new tab. This is done using the [`target`](/en-US/docs/Web/HTML/Element/a#target) attribute.
+
+```html
+Firefox is developed by the
+<a href="https://www.mozilla.org/en-US/" target="_blank">Mozilla Foundation</a>.
+```
+
+It should be a conscious user experience decision of whether to open links in a new tab or not. Here are some things to consider:
+
+- Opening links in a new tab presents the two documents simultaneously, which is useful for a "parallel" navigation experience, where the linked page may be an aside that the user is not expected to spend a prolonged period of time on. On the other hand, links that open in the same tab are more like a continuation of the current page.
+- Opening links in a new tab can be disorienting for users who are accustomed to using the back button.
+- Even when links are opened in the same tab by default, users can still choose to open them in a new tab, using keyboard shortcuts or context menu options. On the other hand, links that open in a new tab are hard to open in the same tab.
+- Screen reader users may be confused by links that open in a new tab, as they may not realize that the new tab has opened, and they may lose context about their location on the page.
+
+"External links open in new tabs, internal links open in the same tab" is a common principle to stick to. And, if you are not sure, it's always best to open all links in the same tab. You can provide cues for links that open in new tabs, such as an icon next to the link text.
 
 ## Active learning: creating a navigation menu
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/35983.

Instead of just linking to `target`, I decided that it is important enough with enough nuances to deserve its own section.