### PR TITLE
Correct return value for createDocument

### DIFF
--- a/files/en-us/web/api/domimplementation/createdocument/index.md
+++ b/files/en-us/web/api/domimplementation/createdocument/index.md
@@ -32,7 +32,7 @@ createDocument(namespaceURI, qualifiedName, documentType)
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+The newly-created {{domxref("XMLDocument")}}.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The DOMImplementation.createDocument() returns the document, not undefined.
<!-- ✍️ Summarize your changes in one or two sentences -->
Rewrote "Return value" section to correct this.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
