### PR TITLE
Fix link to `:host()`

### DIFF
--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -239,7 +239,7 @@ H
 
 - {{CSSxRef(":has", ":has()")}} {{Experimental_Inline}}
 - {{CSSxRef(":host")}}
-- {{CSSxRef(":host_function", ":host()")}}
+- {{CSSxRef("host_function", ":host()")}}
 - {{CSSxRef(":host-context", ":host-context()")}} {{Experimental_Inline}}
 - {{CSSxRef(":hover")}}
 

--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -239,7 +239,7 @@ H
 
 - {{CSSxRef(":has", ":has()")}} {{Experimental_Inline}}
 - {{CSSxRef(":host")}}
-- {{CSSxRef("host_function", ":host()")}}
+- {{CSSxRef(":host_function", ":host()")}}
 - {{CSSxRef(":host-context", ":host-context()")}} {{Experimental_Inline}}
 - {{CSSxRef(":hover")}}
 

--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -239,7 +239,7 @@ H
 
 - {{CSSxRef(":has", ":has()")}} {{Experimental_Inline}}
 - {{CSSxRef(":host")}}
-- {{CSSxRef(":host", ":host()")}}
+- {{CSSxRef(":host_function", ":host()")}}
 - {{CSSxRef(":host-context", ":host-context()")}} {{Experimental_Inline}}
 - {{CSSxRef(":hover")}}
 


### PR DESCRIPTION
### Description

In the "H" section of https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#alphabetical_index, we were incorrectly linking `:host()` to the `:host` page instead of the `:host()` page.

### Motivation

We're linking to the wrong page, and this PR fixes it.

### Related issues and pull requests

This PR is very similar to https://github.com/mdn/content/pull/14691/files, but this PR fixes the wrong link in a different part of the site.