### PR TITLE
Update dead reference for XSL transformations

### DIFF
--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -330,6 +330,6 @@ async function sort() {
 
 - [XSLT](/en-US/docs/Web/XML/XSLT)
 - [Transforming with XSLT](/en-US/docs/Web/API/Document_Object_Model/Transforming_with_XSLT)
-- [What kind of language is XSLT?](https://developer.ibm.com/technologies/web-development/) at [IBM developer](https://developer.ibm.com/)
+- [Chapter 15 of the XML 1.1 Bible: XSL Transformations](https://www.ibiblio.org/xml/books/bible3/chapters/ch15.html)
 - [XSLT Tutorial](https://zvon.org/xxl/XSLTutorial/Books/Book1/index.html) at [zvon.org](https://zvon.org/)
 - [XPath Tutorial](https://zvon.org/xxl/XPathTutorial/General/examples.html) at [zvon.org](https://zvon.org/)


### PR DESCRIPTION
[The old article](https://web.archive.org/web/20120409051950/http://www.ibm.com/developerworks/xml/library/x-xslt/) isn't hosted anywhere on the IBM website anymore, and the author doesn't seem to have published it anywhere else.

I found this new link while searching the [IBM documentation](https://www.ibm.com/docs/en/svdi/7.1.1?topic=parsers-xsl-based-xml-parser) for the old article, and it seems like an appropriate replacement.