### PR TITLE
FF136 ExprFeat: Error.captureStackTrace() added behind pref

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1002,6 +1002,48 @@ This includes:
   </tbody>
 </table>
 
+### Error.captureStackTrace
+
+The {{jsxref("Error.captureStackTrace()")}} static method installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property.
+Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface.
+([Firefox bug 1886820](https://bugzil.la/1886820)).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>javascript.options.experimental.error_capture_stack_trace</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## APIs
 
 ### Cookie Store API

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -70,6 +70,11 @@ This article provides information about the changes in Firefox 136 that affect d
 
 These features are newly shipped in Firefox 136 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **Error.captureStackTrace()**: <code>javascript.options.experimental.error_capture_stack_trace</code>.
+  The {{jsxref("Error.captureStackTrace()")}} static method installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property.
+  Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface.
+  ([Firefox bug 1886820](https://bugzil.la/1886820)).
+
 ## Older versions
 
 {{Firefox_for_developers}}


### PR DESCRIPTION
FF136 adds support for `Error.captureStackTrace()` behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1886820.

This adds an experimental features and near-identical release note. There is a broken link that will be fixed by #38048

Related docs work can be tracked in #37930