### PR TITLE
FF136 WebRTC AV1, H264 codec support for simulcast

### DIFF
--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -44,6 +44,14 @@ This article provides information about the changes in Firefox 136 that affect d
 
 #### Media, WebRTC, and Web Audio
 
+- WebRTC can now send and receive video encoded using the [AV1 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#av1).
+  When sending, it can be used for both sending multiple simultaneous versions of the same source ("simulcast") and singlecast.
+  ([Firefox bug 1944878](https://bugzil.la/1944878) and [Firefox bug 1944878](https://bugzil.la/1944878)).
+- WebRTC simulcast of screen-shared video with the [H264 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#avc_h.264) is also supported.
+  What this means is that {{domxref("MediaStreamTrack")}} objects for screen and window capture (for example, from {{domxref("MediaDevices.getDisplayMedia()")}}), can now be encoded as multiple simulcast layers when using H264, AV1 or [VP8 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#vp8).
+  Note that he H264 codec is hardware-enabled on Android.
+  ([Firefox bug 1944878](https://bugzil.la/1944878)).
+
 #### Removals
 
 ### WebAssembly

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -50,7 +50,7 @@ This article provides information about the changes in Firefox 136 that affect d
 - WebRTC simulcast of screen-shared video with the [H264 codec](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) is also supported (AV1, H264, and [VP8](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) can now be used for simulcast).
   Note that the H264 codec is hardware-enabled on Android.
   ([Firefox bug 1210175](https://bugzil.la/1210175)).
-- WebRTC support for the [Dependency Descriptor (DD) RTP Header Extension](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#dependency_descriptor_rtp_header_extension), and its use with AV1, VP8, and VP9 codecs.
+- WebRTC support for the [Dependency Descriptor (DD) RTP Header Extension](/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension), and its use with AV1, VP8, and VP9 codecs.
   The DD header extension enables codec-independent forwarding of simulcast streams, including in scenarios where the payload is end-to-end encrypted (E2EE).
   ([Firefox bug 1945261](https://bugzil.la/1945261)).
 

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -44,13 +44,15 @@ This article provides information about the changes in Firefox 136 that affect d
 
 #### Media, WebRTC, and Web Audio
 
-- WebRTC can now send and receive video encoded using the [AV1 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#av1).
+- WebRTC can now send and receive video encoded using the [AV1 codec](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#av1_table).
   When sending, it can be used for both sending multiple simultaneous versions of the same source ("simulcast") and singlecast.
   ([Firefox bug 1944878](https://bugzil.la/1944878) and [Firefox bug 1932065](https://bugzil.la/1932065)).
-- WebRTC simulcast of screen-shared video with the [H264 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#avc_h.264) is also supported.
-  What this means is that {{domxref("MediaStreamTrack")}} objects for screen and window capture (for example, from {{domxref("MediaDevices.getDisplayMedia()")}}), can now be encoded as multiple simulcast layers when using H264 (in addition to AV1 or [VP8 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#vp8)).
+- WebRTC simulcast of screen-shared video with the [H264 codec](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) is also supported (AV1, H264, and [VP8](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) can now be used for simulcast).
   Note that the H264 codec is hardware-enabled on Android.
   ([Firefox bug 1210175](https://bugzil.la/1210175)).
+- WebRTC support for the [Dependency Descriptor (DD) RTP Header Extension](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#dependency_descriptor_rtp_header_extension), and its use with AV1, VP8, and VP9 codecs.
+  The DD header extension enables codec-independent forwarding of simulcast streams, including in scenarios where the payload is end-to-end encrypted (E2EE).
+  ([Firefox bug 1945261](https://bugzil.la/1945261)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -46,11 +46,11 @@ This article provides information about the changes in Firefox 136 that affect d
 
 - WebRTC can now send and receive video encoded using the [AV1 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#av1).
   When sending, it can be used for both sending multiple simultaneous versions of the same source ("simulcast") and singlecast.
-  ([Firefox bug 1944878](https://bugzil.la/1944878) and [Firefox bug 1944878](https://bugzil.la/1944878)).
+  ([Firefox bug 1944878](https://bugzil.la/1944878) and [Firefox bug 1932065](https://bugzil.la/1932065)).
 - WebRTC simulcast of screen-shared video with the [H264 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#avc_h.264) is also supported.
-  What this means is that {{domxref("MediaStreamTrack")}} objects for screen and window capture (for example, from {{domxref("MediaDevices.getDisplayMedia()")}}), can now be encoded as multiple simulcast layers when using H264, AV1 or [VP8 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#vp8).
-  Note that he H264 codec is hardware-enabled on Android.
-  ([Firefox bug 1944878](https://bugzil.la/1944878)).
+  What this means is that {{domxref("MediaStreamTrack")}} objects for screen and window capture (for example, from {{domxref("MediaDevices.getDisplayMedia()")}}), can now be encoded as multiple simulcast layers when using H264 (in addition to AV1 or [VP8 codec](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#vp8)).
+  Note that the H264 codec is hardware-enabled on Android.
+  ([Firefox bug 1210175](https://bugzil.la/1210175)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -45,7 +45,7 @@ This article provides information about the changes in Firefox 136 that affect d
 #### Media, WebRTC, and Web Audio
 
 - WebRTC can now send and receive video encoded using the [AV1 codec](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#av1_table).
-  When sending, it can be used for both sending multiple simultaneous versions of the same source ("simulcast") and singlecast.
+  When sending, it can be used for both sending multiple simultaneous versions of the same source ("[simulcast](/en-US/docs/Web/API/WebRTC_API/Protocols#simulcast)") and singlecast.
   ([Firefox bug 1944878](https://bugzil.la/1944878) and [Firefox bug 1932065](https://bugzil.la/1932065)).
 - WebRTC simulcast of screen-shared video with the [H264 codec](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) is also supported (AV1, H264, and [VP8](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) can now be used for simulcast).
   Note that the H264 codec is hardware-enabled on Android.

--- a/files/en-us/web/api/webrtc_api/protocols/index.md
+++ b/files/en-us/web/api/webrtc_api/protocols/index.md
@@ -80,10 +80,10 @@ In addition, because it is a part of the RTP header rather than the payload, it 
 ### Scalable video coding
 
 [Scalable Video Coding (SVC)](https://www.w3.org/TR/webrtc-svc/) encodes a video source in a single stream, with multiple layers that can be selectively decoded to obtain video with particular resolutions, bitrate, or quality.
-An SMF can forward a subset of the layers in order to send a stream that is appropriate for each recipient's network and device.
+An SFM can forward a subset of the layers in order to send a stream that is appropriate for each recipient's network and device.
 
 Note that the dependencies are much more complicated than needed to for selecting streams to forward when using simulcast (see the [dependency diagrams](https://www.w3.org/TR/webrtc-svc/#dependencydiagrams*) in the SVC specification for a "flavor" of the complexity).
-The SVC stream consists of a base layer that provides a minimum level of quality, and may include a number of enhancement layers that allow varying frame rates ("temporal scalability"), increased resolution ("spatial scalability"), and/or higher quality and bitrate ("quality scalability").
+The SVC stream consists of a base layer that provides a minimum level of quality, and may include a number of enhancement layers that allow varying frame rates ("temporal scalability"), increased resolution ("spatial scalability"), and the same resolution at different bitrates.
 The VP8 codec only supports temporal layers, while VP9 supports both temporal and spatial layers.
 
 VP8 and VP9 codecs can include frame dependency information in the VP8 payload descriptor and VP9 payload descriptor, respectively.

--- a/files/en-us/web/api/webrtc_api/protocols/index.md
+++ b/files/en-us/web/api/webrtc_api/protocols/index.md
@@ -52,3 +52,52 @@ To learn more about SDP, see the following useful resources:
 
 - Specification: {{RFC(8866, "SDP: Session Description Protocol")}}
 - [IANA registry of SDP parameters](https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml)
+
+## Multi-party video conferencing
+
+In WebRTC peer-to-peer networks, peers negotiate appropriate video codecs/stream based on device capabilities and network bandwidth.
+Each sender then sends ("singlecasts") a single stream containing video information to its peer counterpart.
+
+Video conferencing between multiple parties is more complex because the peers may have different capabilities and network conditions: one particular video stream resolution, rate, and quality, may not suit all recipients, and at the same time it is not efficient or scalable for a sender to generate and send multiple streams to many recipients.
+
+The most common approach to address these issues is to use an intermediary server known as a _Selective Forwarding Unit_ (SFU) or _Selective Forwarding Middlebox_ (SFM).
+Senders output video encoded such that the SFM can selectively forward an appropriate video stream for each recipient.
+There are two main technologies used by WebRTC for encoding video in this case: simulcast and scalable video coding.
+
+### Simulcast
+
+_Simulcast_ sends multiple simultaneous versions of the same source with different resolutions and bitrates in separate streams.
+The SFM forwards the most suitable stream to each recipient based on their network conditions and device capabilities.
+
+The SFM relies on the ability to determine frame dependency relationships, such as between a chain of interframes back to the last keyframe, in order to forward packets and switch simulcast layers without a receiver noticing.
+
+VP8 and VP9 codecs can include frame dependency information in the VP8 payload descriptor and VP9 payload descriptor, respectively.
+For the AV1 codec the information is sent in the [Dependency Descriptor (DD) RTP Header Extension](#dependency_descriptor_rtp_header_extension).
+
+Recent browser implementations commonly use the DD header for all codecs, as it is codec-agnostic, which can simply the SFM implementation.
+In addition, because it is a part of the RTP header rather than the payload, it can be used in end-to-end encryption scenarios.
+
+### Scalable video coding
+
+[Scalable Video Coding (SVC)](https://www.w3.org/TR/webrtc-svc/) encodes a video source in a single stream, with multiple layers that can be selectively decoded to obtain video with particular resolutions, bitrate, or quality.
+An SMF can forward a subset of the layers in order to send a stream that is appropriate for each recipient's network and device.
+
+Note that the dependencies are much more complicated than needed to for selecting streams to forward when using simulcast (see the [dependency diagrams](https://www.w3.org/TR/webrtc-svc/#dependencydiagrams*) in the SVC specification for a "flavor" of the complexity).
+The SVC stream consists of a base layer that provides a minimum level of quality, and may include a number of enhancement layers that allow varying frame rates ("temporal scalability"), increased resolution ("spatial scalability"), and/or higher quality and bitrate ("quality scalability").
+The VP8 codec only supports temporal layers, while VP9 supports both temporal and spatial layers.
+
+VP8 and VP9 codecs can include frame dependency information in the VP8 payload descriptor and VP9 payload descriptor, respectively.
+For the AV1 codec the information is sent in the [Dependency Descriptor (DD) RTP Header Extension](#dependency_descriptor_rtp_header_extension).
+
+As for simulcast, recent browser implementations commonly use the DD header for all codecs that support SVC, in order to simply the SFM implementation, and because it supports end-to-end encryption scenarios.
+
+### Dependency Descriptor RTP Header Extension
+
+The [Dependency Descriptor (DD) RTP Header Extension](https://aomediacodec.github.io/av1-rtp-spec/#43-dependency-descriptor-rtp-header-extension), defined in the specification _RTP Payload Format For AV1 (v1.0)_, provides a codec-agnostic, flexible, efficient, and extensible way to describe the relationships between frames in a multi-layered video stream.
+
+These can be used by an SFM to select and forward packets associated with the layers intended for a recipient.
+As the header is a true extension it is not part of the payload, and hence is still available to the SFM in end-to-end encryption (E2EE) scenarios.
+
+### Codecs supported by WebRTC
+
+This information is provided in [Codecs used by WebRTC](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs)

--- a/files/en-us/web/api/webrtc_api/protocols/index.md
+++ b/files/en-us/web/api/webrtc_api/protocols/index.md
@@ -101,6 +101,8 @@ The [Dependency Descriptor (DD) RTP Header Extension](https://aomediacodec.githu
 These can be used by an SFM to select and forward packets associated with the layers intended for a recipient.
 As the header is a true extension it is not part of the payload, and hence is still available to the SFM in end-to-end encryption (E2EE) scenarios.
 
+Chrome and Firefox (136+) support the DD header.
+
 ### Codecs supported by WebRTC
 
 This information is provided in [Codecs used by WebRTC](/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs)

--- a/files/en-us/web/api/webrtc_api/protocols/index.md
+++ b/files/en-us/web/api/webrtc_api/protocols/index.md
@@ -91,6 +91,9 @@ For the AV1 codec the information is sent in the [Dependency Descriptor (DD) RTP
 
 As for simulcast, recent browser implementations commonly use the DD header for all codecs that support SVC, in order to simply the SFM implementation, and because it supports end-to-end encryption scenarios.
 
+Chrome 111 and later supports SVC.
+Firefox does not support SVC at the time of writing (around FF136).
+
 ### Dependency Descriptor RTP Header Extension
 
 The [Dependency Descriptor (DD) RTP Header Extension](https://aomediacodec.github.io/av1-rtp-spec/#43-dependency-descriptor-rtp-header-extension), defined in the specification _RTP Payload Format For AV1 (v1.0)_, provides a codec-agnostic, flexible, efficient, and extensible way to describe the relationships between frames in a multi-layered video stream.

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -42,21 +42,24 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
   </thead>
   <tbody>
     <tr>
-      <th scope="row"><a href="#vp8">VP8</a></th>
+      <th id="vp8_table" scope="row"><a href="#vp8">VP8</a></th>
       <td>—</td>
       <td><p>Chrome, Edge, Firefox, Safari (12.1+)</p>
         <p>
           Firefox 134 supports VP8 for simulcast.
+          Firefox 136+ supports the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP8.
         </p>
       </td>
     </tr>
     <tr>
-      <th scope="row"><a href="#avc_h.264">AVC / H.264</a></th>
+      <th id="h264_table" scope="row"><a href="#avc_h.264">AVC / H.264</a></th>
       <td>Constrained Baseline (CB)</td>
       <td>
         <p>Chrome (52+), Edge, Firefox, Safari</p>
         <p>
           <ul>
+            <li>Firefox 137+ supports the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with H264 on desktop.
+            Firefox on Android does not support the DD header (<a href="https://bugzil.la/1947116">Firefox bug 1947116</a>).</li>
             <li>Firefox 136+ supports H.264 for simulcast.</li>
             <li>Firefox for Android 73+ is hardware supported.</li>
             <li>Firefox for Android versions 68 to 72 do not support H.264 (due to a change in <a href="https://support.mozilla.org/en-US/kb/firefox-android-openh264">Google Play store requirements</a> that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections).</li>
@@ -89,16 +92,21 @@ In addition to the mandatory codecs, some browsers support additional codecs as 
   </thead>
   <tbody>
     <tr>
-      <th scope="row">VP9</th>
+      <th id="vp9_table" scope="row">VP9</th>
       <td>—</td>
-      <td><p>Chrome (48+), Firefox</p></td>
+      <td>
+        <p>Chrome (48+), Firefox</p>
+        <p>Firefox does not support VP9 for simulcast by default (<a href="https://bugzil.la/1633876">Firefox bug 1633876</a>).
+        Firefox 136+ supports the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP9.
+        </p>
+      </td>
     </tr>
     <tr>
-      <th scope="row">AV1</th>
+      <th id="av1_table" scope="row"><a href="#av1">AV1</a></th>
       <td>—</td>
       <td>
         <p>Chrome (113+), Firefox (136+)</p>
-        <p>Firefox 136 supports AV1 for simulcast.</p>
+        <p>Firefox 136 supports AV1 for simulcast and the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a>.</p>
       </td>
     </tr>
   </tbody>
@@ -170,6 +178,17 @@ The payload format used for AVC in WebRTC is described in {{RFC(6184, "RTP Paylo
 ### AV1
 
 AV1 is [described in general](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#av1) in the main [guide to video codecs used on the web](/en-US/docs/Web/Media/Guides/Formats/Video_codecs).
+
+#### Dependency Descriptor RTP Header Extension
+
+WebRTC supports the concept of simulcast: the ability to send multiple versions simultaneous versions of the same source with different resolutions and bitrates.
+A Selective Forwarding Unit (SFU)/Selective Forwarding Middlebox (SFM) can then be used to forward the most suitable version for a particular recipient based on network conditions and device capabilities.
+
+SFUs rely on the ability to determine frame dependency relationships, such as between a chain of interframes back to the last keyframe, in order to forward packets and switch simulcast layers without a receiver noticing.
+VP8, VP9, and other older codecs include frame dependency information in an RTP payload header.
+AV1 instead uses the [Dependency Descriptor (DD) RTP Header Extension](https://aomediacodec.github.io/av1-rtp-spec/#43-dependency-descriptor-rtp-header-extension) defined in the specification _RTP Payload Format For AV1 (v1.0)_, which is a more flexible, efficient, and extensible way to describe the relationships between frames in a multi-layered video stream.
+
+While simulcast using AV1 relies on the DD header, it is also recommended for use with other codecs because it allows for codec-independent forwarding in the SFU, even in end-to-end encryption (E2EE) scenarios where the payload header cannot be parsed by an SFU.
 
 ## Supported audio codecs
 

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -181,14 +181,21 @@ AV1 is [described in general](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#
 
 #### Dependency Descriptor RTP Header Extension
 
-WebRTC supports the concept of simulcast: the ability to send multiple versions simultaneous versions of the same source with different resolutions and bitrates.
+WebRTC supports two main technologies for efficiently sending video for consumption by recipients that are operating with different capabilities and network conditions.
+
+_Simulcast_ sends multiple simultaneous versions of the same source with different resolutions and bitrates in separate streams.
 A Selective Forwarding Unit (SFU)/Selective Forwarding Middlebox (SFM) can then be used to forward the most suitable version for a particular recipient based on network conditions and device capabilities.
 
 SFUs rely on the ability to determine frame dependency relationships, such as between a chain of interframes back to the last keyframe, in order to forward packets and switch simulcast layers without a receiver noticing.
 VP8, VP9, and other older codecs include frame dependency information in an RTP payload header.
 AV1 instead uses the [Dependency Descriptor (DD) RTP Header Extension](https://aomediacodec.github.io/av1-rtp-spec/#43-dependency-descriptor-rtp-header-extension) defined in the specification _RTP Payload Format For AV1 (v1.0)_, which is a more flexible, efficient, and extensible way to describe the relationships between frames in a multi-layered video stream.
-
 While simulcast using AV1 relies on the DD header, it is also recommended for use with other codecs because it allows for codec-independent forwarding in the SFU, even in end-to-end encryption (E2EE) scenarios where the payload header cannot be parsed by an SFU.
+
+[Scalable Video Coding (SVC)](https://www.w3.org/TR/webrtc-svc/) is different in that it encodes a source in a single stream, with multiple layers that can be selectively decoded to obtain video with particular resolutions, bitrate, or quality.
+An SFU/SMF can forward just some layers in order to send a stream that is appropriate for each recipient's network and device.
+
+The DD header provides the efficient mechanism for an SFU (or other system) to determine the dependencies between layers in an SVC encoded stream.
+Note that these dependencies are much more complicated than needed to for selecting streams to forward when using simulcast (see the [dependency diagrams](https://www.w3.org/TR/webrtc-svc/#dependencydiagrams*) in the SVC specification for a "flavor" of the complexity).
 
 ## Supported audio codecs
 

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -100,7 +100,7 @@ In addition to the mandatory codecs, some browsers support additional codecs as 
       <td>—</td>
       <td>
         <p>Chrome (113+), Firefox (136+)</p>
-        <p>Firefox 136 also supports simulcast.</p>
+        <p>Firefox 136 supports AV1 for simulcast.</p>
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -47,7 +47,7 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
       <td><p>Chrome, Edge, Firefox, Safari (12.1+)</p>
         <p>
           Firefox 134 supports VP8 for simulcast.
-          Firefox 136+ supports the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP8.
+          Firefox 136+ supports the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP8.
         </p>
       </td>
     </tr>
@@ -58,7 +58,7 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
         <p>Chrome (52+), Edge, Firefox, Safari</p>
         <p>
           <ul>
-            <li>Firefox 137+ supports the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with H264 on desktop.
+            <li>Firefox 137+ supports the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with H264 on desktop.
             Firefox on Android does not support the DD header (<a href="https://bugzil.la/1947116">Firefox bug 1947116</a>).</li>
             <li>Firefox 136+ supports H.264 for simulcast.</li>
             <li>Firefox for Android 73+ is hardware supported.</li>
@@ -97,7 +97,7 @@ In addition to the mandatory codecs, some browsers support additional codecs as 
       <td>
         <p>Chrome (48+), Firefox</p>
         <p>Firefox does not support VP9 for simulcast by default (<a href="https://bugzil.la/1633876">Firefox bug 1633876</a>).
-        Firefox 136+ supports the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP9.
+        Firefox 136+ supports the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP9.
         </p>
       </td>
     </tr>
@@ -106,7 +106,7 @@ In addition to the mandatory codecs, some browsers support additional codecs as 
       <td>—</td>
       <td>
         <p>Chrome (113+), Firefox (136+)</p>
-        <p>Firefox 136 supports AV1 for simulcast and the <a href="#dependency_descriptor_rtp_header_extension">DD RTP header extension</a>.</p>
+        <p>Firefox 136 supports AV1 for simulcast and the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension">DD RTP header extension</a>.</p>
       </td>
     </tr>
   </tbody>
@@ -183,19 +183,7 @@ AV1 is [described in general](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#
 
 WebRTC supports two main technologies for efficiently sending video for consumption by recipients that are operating with different capabilities and network conditions.
 
-_Simulcast_ sends multiple simultaneous versions of the same source with different resolutions and bitrates in separate streams.
-A Selective Forwarding Unit (SFU)/Selective Forwarding Middlebox (SFM) can then be used to forward the most suitable version for a particular recipient based on network conditions and device capabilities.
-
-SFUs rely on the ability to determine frame dependency relationships, such as between a chain of interframes back to the last keyframe, in order to forward packets and switch simulcast layers without a receiver noticing.
-VP8, VP9, and other older codecs include frame dependency information in an RTP payload header.
-AV1 instead uses the [Dependency Descriptor (DD) RTP Header Extension](https://aomediacodec.github.io/av1-rtp-spec/#43-dependency-descriptor-rtp-header-extension) defined in the specification _RTP Payload Format For AV1 (v1.0)_, which is a more flexible, efficient, and extensible way to describe the relationships between frames in a multi-layered video stream.
-While simulcast using AV1 relies on the DD header, it is also recommended for use with other codecs because it allows for codec-independent forwarding in the SFU, even in end-to-end encryption (E2EE) scenarios where the payload header cannot be parsed by an SFU.
-
-[Scalable Video Coding (SVC)](https://www.w3.org/TR/webrtc-svc/) is different in that it encodes a source in a single stream, with multiple layers that can be selectively decoded to obtain video with particular resolutions, bitrate, or quality.
-An SFU/SMF can forward just some layers in order to send a stream that is appropriate for each recipient's network and device.
-
-The DD header provides the efficient mechanism for an SFU (or other system) to determine the dependencies between layers in an SVC encoded stream.
-Note that these dependencies are much more complicated than needed to for selecting streams to forward when using simulcast (see the [dependency diagrams](https://www.w3.org/TR/webrtc-svc/#dependencydiagrams*) in the SVC specification for a "flavor" of the complexity).
+AV1 uses the [Dependency Descriptor (DD) RTP Header Extension](/en-US/docs/Web/API/WebRTC_API/Protocols/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension) to provide frame dependency information needed to support [multi-party conferencing use cases](/en-US/docs/Web/API/WebRTC_API/Protocols#multi-party_video_conferencing).
 
 ## Supported audio codecs
 

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -56,13 +56,11 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
       <td>
         <p>Chrome (52+), Edge, Firefox, Safari</p>
         <p>
-          Firefox 136+ supports H.264 for simulcast.
-          This includes Firefox for Android, which is hardware supported.
-        </p>
-        <p>
-          Firefox for Android 68 to "some version" before version 136 do not support AVC (H.264) .
-          This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections.
-          See <a href="https://support.mozilla.org/en-US/kb/firefox-android-openh264">this article on SUMO</a> for details.
+          <ul>
+            <li>Firefox 136+ supports H.264 for simulcast.</li>
+            <li>Firefox for Android 73+ is hardware supported.</li>
+            <li>Firefox for Android versions 68 to 72 do not support H.264 (due to a change in <a href="https://support.mozilla.org/en-US/kb/firefox-android-openh264">Google Play store requirements</a> that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections).</li>
+          </ul>
         </p>
       </td>
     </tr>

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -44,7 +44,11 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
     <tr>
       <th scope="row"><a href="#vp8">VP8</a></th>
       <td>—</td>
-      <td>Chrome, Edge, Firefox, Safari (12.1+)</td>
+      <td><p>Chrome, Edge, Firefox, Safari (12.1+)</p>
+        <p>
+          Firefox 134 supports VP8 for simulcast.
+        </p>
+      </td>
     </tr>
     <tr>
       <th scope="row"><a href="#avc_h.264">AVC / H.264</a></th>
@@ -52,15 +56,13 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
       <td>
         <p>Chrome (52+), Edge, Firefox, Safari</p>
         <p>
-          Firefox for Android 68 and later do not support AVC (H.264) anymore.
-          This is due to a change in Google Play store requirements that prevent
-          Firefox from downloading and installing the OpenH264 codec needed to
-          handle H.264 in WebRTC connections. See
-          <a
-            href="https://support.mozilla.org/en-US/kb/firefox-android-openh264"
-            >this article on SUMO</a
-          >
-          for details.
+          Firefox 136+ supports H.264 for simulcast.
+          This includes Firefox for Android, which is hardware supported.
+        </p>
+        <p>
+          Firefox for Android 68 to "some version" before version 136 do not support AVC (H.264) .
+          This is due to a change in Google Play store requirements that prevent Firefox from downloading and installing the OpenH264 codec needed to handle H.264 in WebRTC connections.
+          See <a href="https://support.mozilla.org/en-US/kb/firefox-android-openh264">this article on SUMO</a> for details.
         </p>
       </td>
     </tr>
@@ -91,7 +93,15 @@ In addition to the mandatory codecs, some browsers support additional codecs as 
     <tr>
       <th scope="row">VP9</th>
       <td>—</td>
-      <td>Chrome (48+), Firefox</td>
+      <td><p>Chrome (48+), Firefox</p></td>
+    </tr>
+    <tr>
+      <th scope="row">AV1</th>
+      <td>—</td>
+      <td>
+        <p>Chrome (113+), Firefox (136+)</p>
+        <p>Firefox 136 also supports simulcast.</p>
+      </td>
     </tr>
   </tbody>
 </table>
@@ -158,6 +168,10 @@ Unless signaled otherwise, the pixel aspect ratio is 1:1, indicating that pixels
 #### Other notes
 
 The payload format used for AVC in WebRTC is described in {{RFC(6184, "RTP Payload Format for H.264 Video")}}. AVC implementations for WebRTC are required to support the special "filler payload" and "full frame freeze" SEI messages; these are used to support switching among multiple input streams seamlessly.
+
+### AV1
+
+AV1 is [described in general](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#av1) in the main [guide to video codecs used on the web](/en-US/docs/Web/Media/Guides/Formats/Video_codecs).
 
 ## Supported audio codecs
 

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -46,7 +46,7 @@ Below are the video codecs which are _required_ in any fully WebRTC-compliant br
       <td>—</td>
       <td><p>Chrome, Edge, Firefox, Safari (12.1+)</p>
         <p>
-          Firefox 134 supports VP8 for simulcast.
+          Firefox 134 supports VP8 for <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#simulcast">simulcast</a>.
           Firefox 136+ supports the <a href="/en-US/docs/Web/API/WebRTC_API/Protocols#dependency_descriptor_rtp_header_extension">DD RTP header extension</a> with VP8.
         </p>
       </td>


### PR DESCRIPTION
FF136 supports 
- AV1 for WebRTC singlecast/simulcast when sending, and also supports AV1 for receiving: https://bugzilla.mozilla.org/show_bug.cgi?id=1944878 ,  https://bugzilla.mozilla.org/show_bug.cgi?id=1932065
- H264 simulcast for sending https://bugzilla.mozilla.org/show_bug.cgi?id=1210175
- New DD header in some scenarios (explained in issue)

This adds
- [x] release note.
- [x] Update to codec docs 

Related docs work #37945
