### PR TITLE
removed empty space in the example

### DIFF
--- a/files/en-us/web/css/_colon_has-slotted/index.md
+++ b/files/en-us/web/css/_colon_has-slotted/index.md
@@ -58,7 +58,7 @@ This example has two `<slot>` elements, one of which has been assigned some cont
 
 The `<slot>` element that has been assigned content matched the `:has-slotted` pseudo-class and has the `color` value of `rebeccapurple` applied.
 
-{{EmbedLiveSample("simple_example",100,300)}}
+{{EmbedLiveSample("simple_example",100,70)}}
 
 ## Specifications
 


### PR DESCRIPTION
### Description

- removed empty space in the `:has-slotted` example

### Motivation

- Working on [MDN issue #37943](https://github.com/mdn/content/issues/37943)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/25853)
- [Firefox Release Note PR](https://github.com/mdn/content/pull/38083)