### PR TITLE
added release note for :has-slotted and removed the experimental note

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -862,46 +862,6 @@ The parts that have been implemented include:
   </tbody>
 </table>
 
-### :has-slotted pseudo-class
-
-The {{CSSXRef(":has-slotted")}} [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is used to style elements in {{HTMLElement("template")}} that have content added to a {{HTMLElement("slot")}} element when rendering a [web component](/en-US/docs/Web/API/Web_components) ([Firefox bug 1921747](https://bugzil.la/1921747)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>133</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>133</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>133</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>133</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.has-slotted-selector.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## SVG
 
 None.

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -18,6 +18,8 @@ This article provides information about the changes in Firefox 136 that affect d
 
 ### CSS
 
+- The {{CSSXRef(":has-slotted")}} [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is used to style elements in {{HTMLElement("template")}} that have content added to a {{HTMLElement("slot")}} element when rendering a [web component](/en-US/docs/Web/API/Web_components) ([Firefox bug 1940691](https://bugzil.la/1940691)).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
### Description

- Added Firefox 136 release note for `:has-slotted`
- Removed experimental release note for `:has-slotted`

### Motivation

- Working on [MDN issue #37943](https://github.com/mdn/content/issues/37943)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/38081)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/25853)