### PR TITLE
Fix frame-ancestors source list syntax

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -47,17 +47,17 @@ Content-Security-Policy: frame-ancestors <source-expression-list>;
 This directive may have one of the following values:
 
 - `'none'`
-  - : No resources of this type may be loaded. The single quotes are mandatory.
+  - : This resource may not be embedded. The single quotes are mandatory.
 - `<source-expression-list>`
 
-  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions. For this directive, the following source expression values are applicable:
+  - : A space-separated list of _source expression_ values. This resource may be embedded if the embedder matches any of the given source expressions. For this directive, the following source expression values are applicable:
 
     - [`<host-source>`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#host-source)
     - [`<scheme-source>`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#scheme-source)
     - [`'self'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#self)
 
 > [!NOTE]
-> The `frame-ancestors` directive's syntax is similar to a source list of other directives (e.g. {{CSP("child-src")}}), but will not fall back to the `default-src` setting. A policy that declares `default-src 'none'` will still allow the resource to be embedded by anyone.
+> The `frame-ancestors` directive's syntax is similar to the source list syntax accepted by other directives (e.g., {{CSP("child-src")}}), but it does not fall back to the `default-src` setting. A policy that declares `default-src 'none'` still allows the resource to be embedded by anyone.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -39,45 +39,25 @@ Setting this directive to `'none'` is similar to {{HTTPHeader("X-Frame-Options")
 
 ## Syntax
 
-One or more sources can be set for the `frame-ancestors` policy:
-
 ```http
-Content-Security-Policy: frame-ancestors <source>;
-Content-Security-Policy: frame-ancestors <space separated list of sources>;
+Content-Security-Policy: frame-ancestors 'none';
+Content-Security-Policy: frame-ancestors <source-expression-list>;
 ```
 
-### Sources
+This directive may have one of the following values:
 
-\<source> can be one of the following:
+- `'none'`
+  - : No resources of this type may be loaded. The single quotes are mandatory.
+- `<source-expression-list>`
+
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions. For this directive, the following source expression values are applicable:
+
+    - [`<host-source>`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#host-source)
+    - [`<scheme-source>`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#scheme-source)
+    - [`'self'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#self)
 
 > [!NOTE]
-> The `frame-ancestors` directive's syntax is similar to a source list of other directives (e.g. {{CSP("default-src")}}), but doesn't allow `'unsafe-eval'` or `'unsafe-inline'` for example. It will also not fall back to a `default-src` setting. Only the sources listed below are allowed:
-
-- \<host-source>
-
-  - : Internet hosts by name or IP address, as well as an optional {{Glossary("URL")}} scheme and/or port number, separated by spaces. The site's address may include an optional leading wildcard (the asterisk character, `'*'`), and you may use a wildcard (again, `'*'`) as the port number, indicating that all legal ports are valid for the source. Single quotes surrounding the host are not allowed.
-    Examples:
-
-    - `http://*.example.com`: Matches all attempts to load from any subdomain of example.com using the `http:` URL scheme.
-    - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
-    - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
-
-    > [!WARNING]
-    > If no URL scheme is specified for a `host-source` and the iframe is loaded from an `https` URL, the URL for the page loading the iframe must also be `https`, per the [Does URL match expression in origin with redirect count?](https://w3c.github.io/webappsec-csp/#match-url-to-source-expression) section of the CSP spec.
-
-- \<scheme-source>
-
-  - : A scheme such as `http:` or `https:`. The colon is required and scheme should not be quoted. You can also specify data schemes (not recommended).
-
-    - `data:` Allows [`data:` URLs](/en-US/docs/Web/URI/Schemes/data) to be used as a content source. _This is insecure; an attacker can also inject arbitrary `data:` URLs. Use this sparingly and definitely not for scripts._
-    - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Capture_and_Streams_API) to be used as a content source.
-    - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
-    - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
-
-- `'self'`
-  - : Refers to the origin from which the protected document is being served, including the same URL scheme and port number. You must include the single quotes. Some browsers specifically exclude `blob` and `filesystem` from source directives. Sites needing to allow these content types can specify them using the Data attribute.
-- `'none'`
-  - : Refers to the empty set; that is, no URLs match. The single quotes are required.
+> The `frame-ancestors` directive's syntax is similar to a source list of other directives (e.g. {{CSP("child-src")}}), but will not fall back to the `default-src` setting. A policy that declares `default-src 'none'` will still allow the resource to be embedded by anyone.
 
 ## Examples
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/32376.

There are many things undesirable about this section in the current form. I'm copying the template from many other pages, such as `child-src` and `connect-src`, over.