### PR TITLE
CSS `direction` property docs should mention that it affects grid cell layout

### DIFF
--- a/files/en-us/web/css/direction/index.md
+++ b/files/en-us/web/css/direction/index.md
@@ -10,17 +10,17 @@ browser-compat: css.properties.direction
 > [!WARNING]
 > Where possible, authors are encouraged to avoid using the `direction` CSS property and use the HTML [`dir`](/en-US/docs/Web/HTML/Global_attributes/dir) global attribute instead.
 
-The **`direction`** [CSS](/en-US/docs/Web/CSS) property sets the direction of text, table columns, and horizontal overflow. Use `rtl` for languages written from right to left (like Hebrew or Arabic), and `ltr` for those written from left to right (like English and most other languages).
+The **`direction`** [CSS](/en-US/docs/Web/CSS) property sets the direction of text, table and grid columns, and horizontal overflow. Use `rtl` for languages written from right to left (like Hebrew or Arabic), and `ltr` for those written from left to right (like English and most other languages).
 
 {{EmbedInteractiveExample("pages/css/direction.html")}}
 
 Note that text direction is usually defined within a document (e.g., with [HTML's `dir` attribute](/en-US/docs/Web/HTML/Global_attributes/dir)) rather than through direct use of the `direction` property.
 
-The property sets the base text direction of block-level elements and the direction of embeddings created by the {{Cssxref("unicode-bidi")}} property. It also sets the default alignment of text, block-level elements, and the direction that cells flow within a table row.
+The property sets the base text direction of block-level elements and the direction of embeddings created by the {{Cssxref("unicode-bidi")}} property. It also sets the default alignment of text, block-level elements, and the direction that cells flow within a table or grid row.
 
 Unlike the `dir` attribute in HTML, the `direction` property is not inherited from table columns into table cells, since CSS inheritance follows the document tree, and table cells are inside of rows but not inside of columns.
 
-The `direction` and {{cssxref("unicode-bidi")}} properties are the two only properties which are not affected by the {{cssxref("all")}} shorthand property.
+The `direction` and {{cssxref("unicode-bidi")}} properties are the only two properties which are not affected by the {{cssxref("all")}} shorthand property.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

I was reading through [CSS grid docs](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement) and began to consider how directionality would affect cell layout.  (And also _visual interpretation_ of grid lines -- grid line 1 would be on right instead of left if `rtl` -- but because the numbering remains consistent with source order this probably doesn't need to be documented.)

I saw that CSS `direction` docs mention effect on table cell layout but neglect to mention grid cell layout as well.  This is simple to fix and syncs `direction` documentation to mention effect upon a relatively newer spec.

### Additional details

You can readily verify this behavior by loading [this example](https://developer.mozilla.org/en-US/play?id=EghBKLe%2FM5B5PtD%2F0KUn3HEhlDS3wjQL2sg%2BITdSg0%2FWwfdwuSypwh8%2Fv2e2FHoF38hChtlOPBZ7%2FhF7) and changing the `ltr` class on the `wrapper` `<div>` to `rtl`.  The second line's cell will run between column lines 2 and 4 (1-indexed) visibly differently in the two cases, according to the affected line numbering.  And the first line's cells will automatically run in accordance with the applied direction.