### PR TITLE
Cookie Store API docs updates - live examples

### DIFF
--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -114,9 +114,7 @@ async function cookieTest() {
 cookieTest();
 ```
 
-When run, the console log should show that both cookie1 and cookie2 are present initially, but cookie1 is not listed after it has been deleted.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
+When run, the console log should initially show that both cookie1 and cookie2 are present, but cookie1 is not listed after it has been deleted.
 
 ### Delete a cookie with options
 
@@ -186,7 +184,7 @@ async function cookieTest() {
   cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  console.log(`Cookies after deleting cookie1: ${cookieNames}`);
+  console.log(`Cookies remaining after deleting cookie1: ${cookieNames}`);
 }
 
 cookieTest();
@@ -196,34 +194,32 @@ When run, the console log should show that both "cookie1" and "cookie2" are pres
 The cookie named "cookie1" is still present because it does not match the cookies specified in the `delete()` call.
 
 > [!NOTE]
-> The deletion silently fails if the cookies to be deleted does not match.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
+> The deletion silently fails if no cookie is matched.
 
 ### Delete cookies created using document.cookies
 
-This example shows how we can use `delete()` to remove a cookie that was created using {{domxref("document.cookie")}}.
+This example shows that we can use `delete()` to remove a cookie that was created using {{domxref("document.cookie")}}.
 
-A potential issue is that cookies created with `document.cookie` have a default path equal to the path of the document they are created in (unlike cookies created with {{domxref("CookieStore.set()")}}, which have a default [`path`](#path) of `/`).
-In order to be able to know the path later when we match the cookie, we can explicitly set the value when creating the cookie.
+Cookies created with {{domxref("CookieStore.set()")}} have a [default path](/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) of `/`, which is also the default [`path`](#path) for cookies to be deleted, while cookies created with `document.cookie` have a default path equal to the path of the document they are created in.
+What this means is that the default `delete()` options will not match a cookie created using `document.cookie` unless it is created from a root page, or explicitly sets the path to the root.
 
 > [!NOTE]
-> On some browsers you could read the path and other properties from {{domxref("CookieStore.get()")}} or {{domxref("CookieStore.getAll()")}}.
-> This does not work on Firefox.
+> If you're using `document.cookie` you should explicitly set the path to a known value, and match that path when deleting the cookie.
 
-The example code below first creates two cookies "doc_cookie1" and "doc_cookie2" using `document.cookie` and logs their names.
-
-The first cookie uses the default path, which will depend on the location of the document that set the cookie, while the second sets the path to `/`.
+The code below uses `document.cookie` to first create a cookie named "doc_cookie1" with the path `/some_path`, simulating the case where `document.cookie` is called from some document that is not the root.
+It then creates "doc_cookie2" with the path set to `/`, and logs both cookies.
 The code then deletes both cookies without specifying a `path` match option, and lists the cookies again.
 
 ```js
 async function cookieTest() {
-  // Create doc_cookie1 with document.cookie default path
-  document.cookie = "doc_cookie1=doc_cookie1_name; SameSite=None; Secure";
+  // Create doc_cookie1 with path /some_path
+  // This simulates setting document.cookie def from a page at /some_path
+  document.cookie =
+    "doc_cookie1=doc_cookie1_name; SameSite=None; Secure; path=/some_path";
+
   // Create doc_cookie2 with path /, the CookieStore.set() default
   document.cookie =
     "doc_cookie2=doc_cookie2_name; SameSite=None; Secure; path=/";
-  // Delete cookie1 specifying just the name
 
   // Log cookie names
   let cookieNames = (await cookieStore.getAll())
@@ -255,11 +251,8 @@ async function cookieTest() {
 cookieTest();
 ```
 
-When run, the console log should show that both "doc_cookie1" and "doc_cookie2" are present initially.
-Afterwards `doc_cookie2` should not be present: it will have been deleted because its path matches the default path used by `delete()`.
-The cookie `doc_cookie1` will be removed if the code is run from a page in the root, but otherwise will not match the path, and hence not be removed.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
+When run, the first log should show that both cookies are present.
+The second log should still include "doc_cookie1" (but not "doc_cookie2"), because `/some_path` did not match the default deletion path (`/`).
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -198,26 +198,22 @@ The cookie named "cookie1" is still present because it does not match the cookie
 
 ### Delete cookies created using document.cookies
 
-This example shows that we can use `delete()` to remove a cookie that was created using {{domxref("document.cookie")}}.
-
-Cookies created with {{domxref("CookieStore.set()")}} have a [default path](/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) of `/`, which is also the default [`path`](#path) for cookies to be deleted, while cookies created with `document.cookie` have a default path equal to the path of the document they are created in.
-What this means is that the default `delete()` options will not match a cookie created using `document.cookie` unless it is created from a root page, or explicitly sets the path to the root.
+Deleting a cookie that was created using {{domxref("document.cookie")}} has the same requirements as deleting a cookie created using {{domxref("CookieStore.set()")}}: the cookie either needs to match the passed `options`, or the `name` and the default options.
 
 > [!NOTE]
-> If you're using `document.cookie` you should explicitly set the path to a known value, and match that path when deleting the cookie.
+> Cookies created with `set()` always have a [default path](/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) of `/`, while cookies created with `document.cookie` have a default path equal to the path of the document they are created in.
+> Therefore when deleting cookies created with `document.cookie`, you can't assume they have the path `/` (unless it was been explicitly set as such), and hence that it will match the default `delete()` options.
 
-The code below uses `document.cookie` to first create a cookie named "doc_cookie1" with the path `/some_path`, simulating the case where `document.cookie` is called from some document that is not the root.
-It then creates "doc_cookie2" with the path set to `/`, and logs both cookies.
+The code below uses `document.cookie` to create cookies named "doc_cookie1" and "doc_cookie2", with the paths `/some_path` and `/` respectively, and then logs both cookies.
 The code then deletes both cookies without specifying a `path` match option, and lists the cookies again.
 
 ```js
 async function cookieTest() {
   // Create doc_cookie1 with path /some_path
-  // This simulates setting document.cookie def from a page at /some_path
   document.cookie =
     "doc_cookie1=doc_cookie1_name; SameSite=None; Secure; path=/some_path";
 
-  // Create doc_cookie2 with path /, the CookieStore.set() default
+  // Create doc_cookie2 with path / (the CookieStore.set() default)
   document.cookie =
     "doc_cookie2=doc_cookie2_name; SameSite=None; Secure; path=/";
 
@@ -227,7 +223,7 @@ async function cookieTest() {
     .join(" ");
   console.log(`Initial cookies: ${cookieNames}`);
 
-  // Delete doc_cookie1 (fails if cookie path is not the root ("/")
+  // Delete doc_cookie1 (should fail)
   try {
     await cookieStore.delete("doc_cookie1");
   } catch (error) {
@@ -252,7 +248,8 @@ cookieTest();
 ```
 
 When run, the first log should show that both cookies are present.
-The second log should still include "doc_cookie1" (but not "doc_cookie2"), because `/some_path` did not match the default deletion path (`/`).
+The second log should not include "doc_cookie2", as it should have matched and been deleted.
+It should include "doc_cookie1" because `/some_path` will not match the default deletion path (`/`).
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -8,7 +8,8 @@ browser-compat: api.CookieStore.delete
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}
 
-The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a cookie with the given `name` or `options` object. The `delete()` method expires the cookie by changing the date to one in the past.
+The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a cookie that matches with the given `name` or `options` object.
+The method expires the cookie by changing its date to one in the past.
 
 ## Syntax
 
@@ -56,6 +57,9 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
 
 In this example, a cookie is deleted by passing its name to the `delete()` method.
 
+This will work if the cookie to be deleted matches the cookie name and the default values of the [`options`](#options) above.
+This will be the case if the cookie was {{domxref("CookieStore/set","set()")}} using the just a name and value, but may not be if the cookie was created with options or using {{domxref("Document.cookie")}}.
+
 ```html hidden
 <button id="showCookies" type="button">Show cookies</button>
 <button id="reset" type="button">Reset</button>
@@ -80,6 +84,10 @@ reload.addEventListener("click", () => {
 
 const logElement = document.querySelector("#log");
 
+function clearLog() {
+  logElement.innerText = "";
+}
+
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
@@ -88,30 +96,47 @@ function log(text) {
 
 #### JavaScript
 
-The code first sets two cookies.
-We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cookie names again.
+The code first defines `setTestCookies()`, which we'll call below to create some test cookies and log their names.
 
 ```js
-async function cookieTest() {
+async function setTestCookies() {
   // Set two cookies
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
 
-  await cookieStore.set({
-    name: "cookie2",
-    value: `cookie2-value`,
-  });
+  try {
+    await cookieStore.set("cookie2", "cookie2-value");
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
 
   // Log cookie names
-  let cookieNames = (await cookieStore.getAll())
+  const cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
   log(`Initial cookies: ${cookieNames}`);
+}
+```
+
+The `cookieTest()` method is called when the **Show cookies** button is clicked.
+This first calls the method to set the test cookies.
+
+We then delete cookie1 that we just created, and then list all cookie names again.
+
+```js
+async function cookieTest() {
+  //Create our test cookies
+  await setTestCookies();
 
   // Delete cookie1
-  await cookieStore.delete("cookie1");
+  try {
+    await cookieStore.delete("cookie1");
+  } catch (error) {
+    log(`Error deleting cookie1: ${error}`);
+  }
 
   // Log cookie names again (to show cookie1 deleted)
   cookieNames = (await cookieStore.getAll())
@@ -125,6 +150,7 @@ async function cookieTest() {
 const showCookies = document.querySelector("#showCookies");
 
 showCookies.addEventListener("click", () => {
+  clearLog();
   cookieTest();
 });
 ```
@@ -134,9 +160,280 @@ Note that some logging and other code is omitted for brevity.
 #### Result
 
 Press **Show cookies** to run the code above.
-This should show that the deleted cookie is present in the first list, and not in the second.
+This should show that both cookie1 and cookie2 are present initially, but cookie1 is not listed after it has been deleted.
 
 {{EmbedLiveSample('Delete a named cookie', 100, 190)}}
+
+### Delete a cookie with options
+
+This example is almost identical to the previous one, except it demonstrates that the options must match those of the cookie to be deleted.
+We define two cookies with the partitioned property set, and show that deletion only work in the case where this option is specified, and hence matches the cookie.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function clearLog() {
+  logElement.innerText = "";
+}
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+#### JavaScript
+
+The code first defines `setTestCookies()`, which we'll call below to create some test cookies and log their names.
+Note that in this case we have set `partitioned` to `true`.
+
+```js
+async function setTestCookies() {
+  // Set two cookies
+  try {
+    await cookieStore.set({
+      name: "cookie1",
+      value: `cookie1-value`,
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
+
+  try {
+    await cookieStore.set({
+      name: "cookie2",
+      value: `cookie2-value`,
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
+
+  // Log cookie names
+  const cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  log(`Initial cookies: ${cookieNames}`);
+}
+```
+
+The `cookieTest()` method is called when the **Show cookies** button is clicked.
+This first calls the method to set the test cookies and list them.
+
+The code then attempts to delete cookie1 using just the name, which should fail because cookie1 is partitioned, and will not match.
+It then attempts to delete cookie2, specifying both the name and `partitioned` options, which should succeed.
+
+> [!NOTE]
+> The deletion silently fails if the cookies to be deleted does not match.
+
+```js
+async function cookieTest() {
+  //Create our test cookies
+  await setTestCookies();
+
+  // Delete cookie1 specifying just the name
+  try {
+    await cookieStore.delete("cookie1");
+  } catch (error) {
+    log(`Error deleting cookie1: ${error}`);
+  }
+
+  // Delete cookie2 specified partitioned as true
+  try {
+    await cookieStore.delete({
+      name: "cookie2",
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error deleting cookie2: ${error}`);
+  }
+
+  // Log cookie names again (to show cookie1 deleted)
+  cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  log(`Cookies after deleting cookie1: ${cookieNames}`);
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  clearLog();
+  cookieTest();
+});
+```
+
+Note that some logging and other code is omitted for brevity.
+
+#### Result
+
+Press **Show cookies** to run the code above.
+This should show that both cookie1 and cookie2 are present initially, but cookie2 is not listed afterwards.
+
+{{EmbedLiveSample('Delete a cookie with options', 100, 190)}}
+
+### Delete cookies created using document.cookies
+
+`delete()` can be used to delete any cookies, including those created using {{domxref("document.cookie")}}.
+
+Note however that unlike cookies created with {{domxref("CookieStore.set()")}}, which have a default [`path`](#path) of `/`, cookies created with `document.cookie` have a default path equal to the path of the document they are created in.
+In order to delete them you have to know this path, which means that you must either set it to a default value such as `/`, or store it.
+
+> [!NOTE]
+> On some browsers you could read the path and other properties from {{domxref("CookieStore.get()")}} or {{domxref("CookieStore.getAll()")}}.
+> This does not work on Firefox.
+
+This example demonstrates how you might set the default path when creating a cookie with {{domxref("document.cookie")}}, so that you can then delete it.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function clearLog() {
+  logElement.innerText = "";
+}
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+#### JavaScript
+
+The code first defines `setTestCookies()`, which we'll call below to create some test cookies and log their names.
+Note that in this case we have set `partitioned` to `true`.
+
+```js
+async function setTestCookies() {
+  // Set two cookies
+  try {
+    await cookieStore.set({
+      name: "cookie1",
+      value: `cookie1-value`,
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
+
+  try {
+    await cookieStore.set({
+      name: "cookie2",
+      value: `cookie2-value`,
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
+}
+```
+
+The `cookieTest()` method is called when the **Show cookies** button is clicked.
+This creates two cookies using `document.cookie`.
+We don't know the path of `doc_cookie1`, but we explicitly set the path of `doc_cookie2` to the default expected by `delete()`.
+
+> [!NOTE]
+> The deletion silently fails if the cookies to be deleted does not match.
+
+```js
+async function cookieTest() {
+  // Create doc_cookie1 with document.cookie default path
+  document.cookie = "doc_cookie1=doc_cookie1_name; SameSite=None; Secure";
+  // Create doc_cookie2 with path /, the CookieStore.set() default
+  document.cookie =
+    "doc_cookie2=doc_cookie2_name; SameSite=None; Secure; path=/";
+  // Delete cookie1 specifying just the name
+
+  // Log cookie names
+  const cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  log(`Initial cookies: ${cookieNames}`);
+
+  // Delete doc_cookie1 (should fail)
+  try {
+    await cookieStore.delete("doc_cookie1");
+  } catch (error) {
+    log(`Error deleting doc_cookie1: ${error}`);
+  }
+
+  // Delete doc_cookie2 (should succeed)
+  try {
+    await cookieStore.delete("doc_cookie2");
+  } catch (error) {
+    log(`Error deleting cookie2: ${error}`);
+  }
+
+  // Log cookie names again (to show cookie1 deleted)
+  cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  log(`Cookies attempting deletion: ${cookieNames}`);
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  clearLog();
+  cookieTest();
+});
+```
+
+Note that some logging and other code is omitted for brevity.
+
+#### Result
+
+Press **Show cookies** to run the code above.
+This should show that both cookie1 and cookie2 are present initially, but cookie2 is not listed afterwards.
+
+{{EmbedLiveSample('Delete cookies created using document.cookies', 100, 190)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -11,6 +11,8 @@ browser-compat: api.CookieStore.delete
 The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a cookie that matches with the given `name` or `options` object.
 The method expires the cookie by changing its date to one in the past.
 
+Note that there is no error if a cookie cannot be matched: the returned promise will fulfill when the matched cookie is deleted or if no cookie is matched.
+
 ## Syntax
 
 ```js-nolint
@@ -42,7 +44,7 @@ Or
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion completes.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when the deletion operation completes or no cookie is matched.
 
 ### Exceptions
 
@@ -52,6 +54,10 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
   - : Thrown if a cookie that matches a given `name` or `options` cannot be deleted.
 
 ## Examples
+
+> [!WARNING]
+> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
+> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
 
 ### Delete a named cookie
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -52,13 +52,98 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
 
 ## Examples
 
-In this example, a cookie is deleted by passing the name to the `delete()` method.
+### Delete a named cookie
+
+In this example, a cookie is deleted by passing its name to the `delete()` method.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+// List cookies
+async function getCookieNames() {
+  let names = "";
+  const cookies = await cookieStore.getAll();
+  if (cookies.length > 0) {
+    cookies.forEach((cookie) => (names += `${cookie.name} `));
+  }
+  return names;
+}
+```
+
+#### JavaScript
+
+The code first sets two cookies (which we then use to demonstrate deletion).
+
+We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cooking names again.
 
 ```js
-const result = await cookieStore.delete("cookie1");
+async function cookieTest() {
+  // Set two cookies
+  await cookieStore.set({
+    name: "cookie1",
+    value: `cookie1-value`,
+  });
 
-console.log(result);
+  await cookieStore.set({
+    name: "cookie2",
+    value: `cookie2-value`,
+  });
+
+  // Log cookie names
+  log(`Initial cookies: ${await getCookieNames()}`);
+
+  // Delete cookie1
+  await cookieStore.delete("cookie1");
+
+  // Log cookie names again (to show cookie1 deleted)
+  log(`Cookies after deleting cookie1: ${await getCookieNames()}`);
+}
 ```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+Note that some logging and other code is omitted for brevity.
+
+#### Result
+
+Press **Show cookies** to run the code above.
+This should show that the deleted cookie is present in the first list, and not in the second.
+
+{{EmbedLiveSample('Delete a named cookie', 100, 190)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CookieStore.delete
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}
 
-The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a cookie that matches with the given `name` or `options` object.
+The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a cookie that matches the given `name` or `options` object.
 The method expires the cookie by changing its date to one in the past.
 
 Note that there is no error if a cookie cannot be matched: the returned promise will fulfill when the matched cookie is deleted or if no cookie is matched.
@@ -169,10 +169,10 @@ async function cookieTest() {
   try {
     await cookieStore.delete("cookie1");
   } catch (error) {
-    log(`Error deleting cookie1: ${error}`);
+    console.log(`Error deleting cookie1: ${error}`);
   }
 
-  // Delete cookie2 specified partitioned as true
+  // Delete cookie2, setting partitioned to true
   try {
     await cookieStore.delete({
       name: "cookie2",
@@ -202,7 +202,7 @@ The code can be tested by copying it into a test harness and running it with a [
 
 ### Delete cookies created using document.cookies
 
-This example shows how we can use `delete()` to remove a cookie created using {{domxref("document.cookie")}}.
+This example shows how we can use `delete()` to remove a cookie that was created using {{domxref("document.cookie")}}.
 
 A potential issue is that cookies created with `document.cookie` have a default path equal to the path of the document they are created in (unlike cookies created with {{domxref("CookieStore.set()")}}, which have a default [`path`](#path) of `/`).
 In order to be able to know the path later when we match the cookie, we can explicitly set the value when creating the cookie.
@@ -213,7 +213,7 @@ In order to be able to know the path later when we match the cookie, we can expl
 
 The example code below first creates two cookies "doc_cookie1" and "doc_cookie2" using `document.cookie` and logs their names.
 
-The first cookie uses the default path, which will depend on where the cookies is deployed, while the second sets the path to `/`.
+The first cookie uses the default path, which will depend on the location of the document that set the cookie, while the second sets the path to `/`.
 The code then deletes both cookies without specifying a `path` match option, and lists the cookies again.
 
 ```js
@@ -226,30 +226,30 @@ async function cookieTest() {
   // Delete cookie1 specifying just the name
 
   // Log cookie names
-  const cookieNames = (await cookieStore.getAll())
+  let cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  log(`Initial cookies: ${cookieNames}`);
+  console.log(`Initial cookies: ${cookieNames}`);
 
-  // Delete doc_cookie1 (should fail)
+  // Delete doc_cookie1 (fails if cookie path is not the root ("/")
   try {
     await cookieStore.delete("doc_cookie1");
   } catch (error) {
-    log(`Error deleting doc_cookie1: ${error}`);
+    console.log(`Error deleting doc_cookie1: ${error}`);
   }
 
   // Delete doc_cookie2 (should succeed)
   try {
     await cookieStore.delete("doc_cookie2");
   } catch (error) {
-    log(`Error deleting cookie2: ${error}`);
+    console.log(`Error deleting cookie2: ${error}`);
   }
 
   // Log cookie names again (to show cookie1 deleted)
   cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  log(`Cookies attempting deletion: ${cookieNames}`);
+  console.log(`Cookies remaining: ${cookieNames}`);
 }
 
 cookieTest();
@@ -257,7 +257,7 @@ cookieTest();
 
 When run, the console log should show that both "doc_cookie1" and "doc_cookie2" are present initially.
 Afterwards `doc_cookie2` should not be present: it will have been deleted because its path matches the default path used by `delete()`.
-The cookie `doc_cookie2` will be removed if the code is run from a page in the root, but otherwise will not match the path, and hence not be removed.
+The cookie `doc_cookie1` will be removed if the code is run from a page in the root, but otherwise will not match the path, and hence not be removed.
 
 The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -108,7 +108,9 @@ async function cookieTest() {
   const cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  console.log(`Cookies after deleting cookie1: ${cookieNames}`);
+  console.log(
+    `Cookies remaining after attempting to delete cookie1: ${cookieNames}`,
+  );
 }
 
 cookieTest();
@@ -184,7 +186,9 @@ async function cookieTest() {
   cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  console.log(`Cookies remaining after deleting cookie1: ${cookieNames}`);
+  console.log(
+    `Cookies remaining after attempted deletions (cookie2 should be deleted): ${cookieNames}`,
+  );
 }
 
 cookieTest();
@@ -211,11 +215,11 @@ The code then deletes both cookies without specifying a `path` match option, and
 async function cookieTest() {
   // Create doc_cookie1 with path /some_path
   document.cookie =
-    "doc_cookie1=doc_cookie1_name; SameSite=None; Secure; path=/some_path";
+    "doc_cookie1=doc_cookie1_name; SameSite=None; Secure; max-age=10; path='/some_path'";
 
   // Create doc_cookie2 with path / (the CookieStore.set() default)
   document.cookie =
-    "doc_cookie2=doc_cookie2_name; SameSite=None; Secure; path=/";
+    "doc_cookie2=doc_cookie2_name; SameSite=None; Secure; max-age=10; path=/";
 
   // Log cookie names
   let cookieNames = (await cookieStore.getAll())
@@ -241,7 +245,9 @@ async function cookieTest() {
   cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  console.log(`Cookies remaining: ${cookieNames}`);
+  console.log(
+    `Cookies remaining after attempted deletions (doc_cookie2 should be deleted): ${cookieNames}`,
+  );
 }
 
 cookieTest();

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -49,7 +49,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the origin can not be {{glossary("Serialization", "serialized")}} to a URL.
 - {{jsxref("TypeError")}}
-  - : Thrown if deleting the cookie represented by the given `name` or `options` fails.
+  - : Thrown if a cookie that matches a given `name` or `options` cannot be deleted.
 
 ## Examples
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -86,18 +86,6 @@ function log(text) {
 }
 ```
 
-```js hidden
-// List cookies
-async function getCookieNames() {
-  let names = "";
-  const cookies = await cookieStore.getAll();
-  if (cookies.length > 0) {
-    cookies.forEach((cookie) => (names += `${cookie.name} `));
-  }
-  return names;
-}
-```
-
 #### JavaScript
 
 The code first sets two cookies.
@@ -117,13 +105,19 @@ async function cookieTest() {
   });
 
   // Log cookie names
-  log(`Initial cookies: ${await getCookieNames()}`);
+  let cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  log(`Initial cookies: ${cookieNames}`);
 
   // Delete cookie1
   await cookieStore.delete("cookie1");
 
   // Log cookie names again (to show cookie1 deleted)
-  log(`Cookies after deleting cookie1: ${await getCookieNames()}`);
+  cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  log(`Cookies after deleting cookie1: ${cookieNames}`);
 }
 ```
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -55,54 +55,16 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when the dele
 
 ## Examples
 
-> [!WARNING]
-> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
-> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+<!-- The examples don't work as live examples in MDN environment (due to unknown errors) -->
 
 ### Delete a named cookie
 
-In this example, a cookie is deleted by passing its name to the `delete()` method.
+This example shows how a cookie can be deleted by passing its name to the `delete()` method.
 
 This will work if the cookie to be deleted matches the cookie name and the default values of the [`options`](#options) above.
 This will be the case if the cookie was {{domxref("CookieStore/set","set()")}} using the just a name and value, but may not be if the cookie was created with options or using {{domxref("Document.cookie")}}.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-#### JavaScript
-
-The code first defines `setTestCookies()`, which we'll call below to create some test cookies and log their names.
+The code first defines `setTestCookies()` which creates some test cookies and logs their names.
 
 ```js
 async function setTestCookies() {
@@ -110,109 +72,58 @@ async function setTestCookies() {
   try {
     await cookieStore.set("cookie1", "cookie1-value");
   } catch (error) {
-    log(`Error setting cookie1: ${error}`);
+    console.log(`Error setting cookie1: ${error}`);
   }
 
   try {
     await cookieStore.set("cookie2", "cookie2-value");
   } catch (error) {
-    log(`Error setting cookie2: ${error}`);
+    console.log(`Error setting cookie2: ${error}`);
   }
 
   // Log cookie names
   const cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  log(`Initial cookies: ${cookieNames}`);
+  console.log(`Initial cookies: ${cookieNames}`);
 }
 ```
 
-The `cookieTest()` method is called when the **Show cookies** button is clicked.
-This first calls the method to set the test cookies.
-
-We then delete cookie1 that we just created, and then list all cookie names again.
+The `cookieTest()` method calls `setTestCookies()`.
+It then deletes "cookie1" that we just created, and lists all cookie names again.
 
 ```js
 async function cookieTest() {
-  //Create our test cookies
+  // Create our test cookies
   await setTestCookies();
 
   // Delete cookie1
   try {
     await cookieStore.delete("cookie1");
   } catch (error) {
-    log(`Error deleting cookie1: ${error}`);
+    console.log(`Error deleting cookie1: ${error}`);
   }
 
   // Log cookie names again (to show cookie1 deleted)
   cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  log(`Cookies after deleting cookie1: ${cookieNames}`);
+  console.log(`Cookies after deleting cookie1: ${cookieNames}`);
 }
+
+cookieTest();
 ```
 
-```js hidden
-const showCookies = document.querySelector("#showCookies");
+When run, the console log should show that both cookie1 and cookie2 are present initially, but cookie1 is not listed after it has been deleted.
 
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
-
-Note that some logging and other code is omitted for brevity.
-
-#### Result
-
-Press **Show cookies** to run the code above.
-This should show that both cookie1 and cookie2 are present initially, but cookie1 is not listed after it has been deleted.
-
-{{EmbedLiveSample('Delete a named cookie', 100, 190)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ### Delete a cookie with options
 
 This example is almost identical to the previous one, except it demonstrates that the options must match those of the cookie to be deleted.
-We define two cookies with the partitioned property set, and show that deletion only work in the case where this option is specified, and hence matches the cookie.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-#### JavaScript
-
-The code first defines `setTestCookies()`, which we'll call below to create some test cookies and log their names.
-Note that in this case we have set `partitioned` to `true`.
+The code first defines `setTestCookies()`.
+This creates two cookies with the `partitioned` property set to `true`, and logs their names.
 
 ```js
 async function setTestCookies() {
@@ -224,7 +135,7 @@ async function setTestCookies() {
       partitioned: true,
     });
   } catch (error) {
-    log(`Error setting cookie1: ${error}`);
+    console.log(`Error setting cookie1: ${error}`);
   }
 
   try {
@@ -234,25 +145,20 @@ async function setTestCookies() {
       partitioned: true,
     });
   } catch (error) {
-    log(`Error setting cookie2: ${error}`);
+    console.log(`Error setting cookie2: ${error}`);
   }
 
   // Log cookie names
   const cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  log(`Initial cookies: ${cookieNames}`);
+  console.log(`Initial cookies: ${cookieNames}`);
 }
 ```
 
-The `cookieTest()` method is called when the **Show cookies** button is clicked.
-This first calls the method to set the test cookies and list them.
-
-The code then attempts to delete cookie1 using just the name, which should fail because cookie1 is partitioned, and will not match.
-It then attempts to delete cookie2, specifying both the name and `partitioned` options, which should succeed.
-
-> [!NOTE]
-> The deletion silently fails if the cookies to be deleted does not match.
+The `cookieTest()` method calls `setTestCookies()`.
+It then attempts to delete the cookies named "cookie1", specifying its name, and "cookie2" specifying its name and `partitioned: true`.
+The method then lists the cookie names again.
 
 ```js
 async function cookieTest() {
@@ -273,118 +179,42 @@ async function cookieTest() {
       partitioned: true,
     });
   } catch (error) {
-    log(`Error deleting cookie2: ${error}`);
+    console.log(`Error deleting cookie2: ${error}`);
   }
 
   // Log cookie names again (to show cookie1 deleted)
   cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
-  log(`Cookies after deleting cookie1: ${cookieNames}`);
+  console.log(`Cookies after deleting cookie1: ${cookieNames}`);
 }
+
+cookieTest();
 ```
 
-```js hidden
-const showCookies = document.querySelector("#showCookies");
+When run, the console log should show that both "cookie1" and "cookie2" are present initially, but "cookie2" is not listed afterwards.
+The cookie named "cookie1" is still present because it does not match the cookies specified in the `delete()` call.
 
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
+> [!NOTE]
+> The deletion silently fails if the cookies to be deleted does not match.
 
-Note that some logging and other code is omitted for brevity.
-
-#### Result
-
-Press **Show cookies** to run the code above.
-This should show that both cookie1 and cookie2 are present initially, but cookie2 is not listed afterwards.
-
-{{EmbedLiveSample('Delete a cookie with options', 100, 190)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ### Delete cookies created using document.cookies
 
-`delete()` can be used to delete any cookies, including those created using {{domxref("document.cookie")}}.
+This example shows how we can use `delete()` to remove a cookie created using {{domxref("document.cookie")}}.
 
-Note however that unlike cookies created with {{domxref("CookieStore.set()")}}, which have a default [`path`](#path) of `/`, cookies created with `document.cookie` have a default path equal to the path of the document they are created in.
-In order to delete them you have to know this path, which means that you must either set it to a default value such as `/`, or store it.
+A potential issue is that cookies created with `document.cookie` have a default path equal to the path of the document they are created in (unlike cookies created with {{domxref("CookieStore.set()")}}, which have a default [`path`](#path) of `/`).
+In order to be able to know the path later when we match the cookie, we can explicitly set the value when creating the cookie.
 
 > [!NOTE]
 > On some browsers you could read the path and other properties from {{domxref("CookieStore.get()")}} or {{domxref("CookieStore.getAll()")}}.
 > This does not work on Firefox.
 
-This example demonstrates how you might set the default path when creating a cookie with {{domxref("document.cookie")}}, so that you can then delete it.
+The example code below first creates two cookies "doc_cookie1" and "doc_cookie2" using `document.cookie` and logs their names.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-#### JavaScript
-
-The code first defines `setTestCookies()`, which we'll call below to create some test cookies and log their names.
-Note that in this case we have set `partitioned` to `true`.
-
-```js
-async function setTestCookies() {
-  // Set two cookies
-  try {
-    await cookieStore.set({
-      name: "cookie1",
-      value: `cookie1-value`,
-      partitioned: true,
-    });
-  } catch (error) {
-    log(`Error setting cookie1: ${error}`);
-  }
-
-  try {
-    await cookieStore.set({
-      name: "cookie2",
-      value: `cookie2-value`,
-      partitioned: true,
-    });
-  } catch (error) {
-    log(`Error setting cookie2: ${error}`);
-  }
-}
-```
-
-The `cookieTest()` method is called when the **Show cookies** button is clicked.
-This creates two cookies using `document.cookie`.
-We don't know the path of `doc_cookie1`, but we explicitly set the path of `doc_cookie2` to the default expected by `delete()`.
-
-> [!NOTE]
-> The deletion silently fails if the cookies to be deleted does not match.
+The first cookie uses the default path, which will depend on where the cookies is deployed, while the second sets the path to `/`.
+The code then deletes both cookies without specifying a `path` match option, and lists the cookies again.
 
 ```js
 async function cookieTest() {
@@ -421,25 +251,15 @@ async function cookieTest() {
     .join(" ");
   log(`Cookies attempting deletion: ${cookieNames}`);
 }
+
+cookieTest();
 ```
 
-```js hidden
-const showCookies = document.querySelector("#showCookies");
+When run, the console log should show that both "doc_cookie1" and "doc_cookie2" are present initially.
+Afterwards `doc_cookie2` should not be present: it will have been deleted because its path matches the default path used by `delete()`.
+The cookie `doc_cookie2` will be removed if the code is run from a page in the root, but otherwise will not match the path, and hence not be removed.
 
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
-
-Note that some logging and other code is omitted for brevity.
-
-#### Result
-
-Press **Show cookies** to run the code above.
-This should show that both cookie1 and cookie2 are present initially, but cookie2 is not listed afterwards.
-
-{{EmbedLiveSample('Delete cookies created using document.cookies', 100, 190)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -105,7 +105,7 @@ async function cookieTest() {
   }
 
   // Log cookie names again (to show cookie1 deleted)
-  cookieNames = (await cookieStore.getAll())
+  const cookieNames = (await cookieStore.getAll())
     .map((cookie) => cookie.name)
     .join(" ");
   console.log(`Cookies after deleting cookie1: ${cookieNames}`);

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -100,9 +100,8 @@ async function getCookieNames() {
 
 #### JavaScript
 
-The code first sets two cookies (which we then use to demonstrate deletion).
-
-We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cooking names again.
+The code first sets two cookies.
+We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cookie names again.
 
 ```js
 async function cookieTest() {

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -66,14 +66,7 @@ The object returned for a match contains the following properties:
 
 - `sameSite`
 
-  - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
-
-    - `"strict"`
-      - : Cookies will only be sent in a first-party context and not be sent with requests initiated by third party websites.
-    - `"lax"`
-      - : Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating within the origin site (i.e. when following a link).
-    - `"none"`
-      - : Cookies will be sent in all contexts.
+  - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values: [`"strict"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#strict), [`"lax"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#lax), or [`"none"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#none).
 
 - `secure`
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -82,8 +82,8 @@ The object returned for a match contains the following properties:
 - {{jsxref("TypeError")}}
   - : Thrown if:
     - The `options` parameter is an empty object.
-    - The `url` option is present and is not equal with the creation URL, if in main thread.
-    - The `url` option is present and its origin is not the same as the origin of the creation URL.
+    - The `url` option is specified but is not equal with the URL of the window that created the cookie (if created by the main thread).
+    - The `url` option is specified but its origin is not equal to the origin of the resource that created the cookie.
     - Querying cookies represented by the given `name` or `options` fails.
 
 ## Examples

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -88,109 +88,42 @@ The object returned for a match contains the following properties:
 
 ## Examples
 
-> [!WARNING]
-> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
-> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+<!-- The examples don't work as live examples in MDN environment (due to unknown errors) -->
 
 ### Getting a cookie by name
 
-In this example we get a particular cookie named `cookie1`, awaiting the returned promise, and logging the resolved object.
+This example shows how to get a particular cookie by name.
 
-```html hidden
-<button id="showCookies" type="button">Show cookie</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 180px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-#### JavaScript
-
-The `cookieTest()` method is called when the **Show cookies** button is clicked.
-It first calls `setTestCookie()` to define a cookie, then waits on `get()` to retrieve information about that same cookie.
-If the returned promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
+The code first creates a cookie named "cookie1" using {{domxref("CookieStore.set()")}}, logging any errors.
+It then waits on `get()` to retrieve information about that same cookie.
+If the returned promise resolves with an object we log the cookie: otherwise we log that no matching cookie was found.
 
 ```js
 async function cookieTest() {
   // Set test cookie
-  await setTestCookie();
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    console.log(`Error setting cookie1: ${error}`);
+  }
 
   // Get cookie, specifying name
   const cookie = await cookieStore.get("cookie1");
 
-  // Log the cookie object keys and values.
   if (cookie) {
-    log("cookie1:");
-    for (const [key, value] of Object.entries(cookie)) {
-      log(` ${key}: ${value}`);
-    }
+    console.log(cookie);
   } else {
-    log("cookie1: Cookie not found");
+    console.log("cookie1: Cookie not found");
   }
 }
+
+cookieTest();
 ```
 
-The code for `setTestCookie()` is shown here just "for your interest".
-Note that some logging and other code is omitted for brevity.
-
-```js
-async function setTestCookie() {
-  // Set two cookies
-  try {
-    await cookieStore.set("cookie1", "cookie1-value");
-  } catch (error) {
-    log(`Error setting cookie1: ${error}`);
-  }
-
-  try {
-    await cookieStore.set("cookie2", "cookie2-value");
-  } catch (error) {
-    log(`Error setting cookie2: ${error}`);
-  }
-}
-```
-
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
-
-#### Result
-
-Press **Show cookie** to set the cookie and then display it.
+When run in a browser this will display information about "cookie1" in the console.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 
-{{EmbedLiveSample('Getting a cookie by name', 100, 260)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CookieStore.get
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}
 
-The **`get()`** method of the {{domxref("CookieStore")}} interface returns a single cookie with the given `name` or `options` object. The method will return the first matching cookie for the passed parameters.
+The **`get()`** method of the {{domxref("CookieStore")}} interface returns a {{jsxref("Promise")}} that resolves to single cookie with the given `name` or `options` object. The method will return the first matching cookie for the passed parameters.
 
 ## Syntax
 
@@ -40,7 +40,9 @@ Or
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with an object representing the first cookie matching the submitted `name` or `options`. This object contains the following properties:
+A {{jsxref("Promise")}} that resolves with an object representing the first cookie matching the submitted `name` or `options`, or `null` if there is no matching cookie.
+
+The object returned for a match contains the following properties:
 
 - `domain`
 
@@ -93,17 +95,86 @@ A {{jsxref("Promise")}} that resolves with an object representing the first cook
 
 ## Examples
 
-In this example, we return a cookie named "cookie1". If the cookie is found the result of the Promise is an object containing the details of a single cookie.
+### Getting a cookie by name
 
-```js
-const cookie = await cookieStore.get("cookie1");
+In this example we get a particular cookie named `cookie1`, awaiting the returned Promise, and logging the resolved object.
 
-if (cookie) {
-  console.log(cookie);
-} else {
-  console.log("Cookie not found");
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 180px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
 }
 ```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+#### JavaScript
+
+The code first sets a cookie (which we then use to demonstrate `get()`).
+
+We then await on `get()`, specifying the name of the cookie.
+If the promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
+
+```js
+async function cookieTest() {
+  // await on setting the cookie
+  await cookieStore.set({
+    name: "cookie1",
+    value: `cookie1-value`,
+  });
+
+  // await on getting the cookie
+  const cookie = await cookieStore.get("cookie1");
+
+  // log the cookie object keys and values.
+  if (cookie) {
+    log("cookie1:");
+    for (const [key, value] of Object.entries(cookie)) {
+      log(` ${key}: ${value}`);
+    }
+  } else {
+    log("cookie1: Cookie not found");
+  }
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+Note that some logging and other code is omitted for brevity.
+
+#### Result
+
+Press **Show cookies** to set the cookie and then display it.
+Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
+
+{{EmbedLiveSample('Setting a cookie with name and value', 100, 250)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -82,8 +82,8 @@ The object returned for a match contains the following properties:
 - {{jsxref("TypeError")}}
   - : Thrown if:
     - The `options` parameter is an empty object.
-    - The `url` option is specified but is not equal with the URL of the window that created the cookie (if created by the main thread).
-    - The `url` option is specified but its origin is not equal to the origin of the resource that created the cookie.
+    - The method is called in the main thread, and the `url` option is specified but does not match the URL of the current window.
+    - The method is called in a worker and the `url` option is specified, but does not match the origin of the worker.
     - Querying cookies represented by the given `name` or `options` fails.
 
 ## Examples

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CookieStore.get
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}
 
-The **`get()`** method of the {{domxref("CookieStore")}} interface returns a {{jsxref("Promise")}} that resolves to single cookie with the given `name` or `options` object. The method will return the first matching cookie for the passed parameters.
+The **`get()`** method of the {{domxref("CookieStore")}} interface returns a {{jsxref("Promise")}} that resolves to a single cookie matching the given `name` or `options` object. The method will return the first cookie that matches.
 
 ## Syntax
 
@@ -131,10 +131,10 @@ function log(text) {
 
 #### JavaScript
 
-The code first sets a cookie (which we then use to demonstrate `get()`).
+The code first sets a cookie.
 
 We then await on `get()`, specifying the name of the cookie.
-If the returned Promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
+If the returned promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
 
 ```js
 async function cookieTest() {

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -94,7 +94,7 @@ The object returned for a match contains the following properties:
 
 This example shows how to get a particular cookie by name.
 
-The code first creates a cookie named "cookie1" using {{domxref("CookieStore.set()")}}, logging any errors.
+The code first creates a cookie named "cookie1" using {{domxref("CookieStore.set()")}}, logging any errors to the console.
 It then waits on `get()` to retrieve information about that same cookie.
 If the returned promise resolves with an object we log the cookie: otherwise we log that no matching cookie was found.
 
@@ -119,11 +119,6 @@ async function cookieTest() {
 
 cookieTest();
 ```
-
-When run in a browser this will display information about "cookie1" in the console.
-Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -90,10 +90,10 @@ The object returned for a match contains the following properties:
 
 ### Getting a cookie by name
 
-In this example we get a particular cookie named `cookie1`, awaiting the returned Promise, and logging the resolved object.
+In this example we get a particular cookie named `cookie1`, awaiting the returned promise, and logging the resolved object.
 
 ```html hidden
-<button id="showCookies" type="button">Show cookies</button>
+<button id="showCookies" type="button">Show cookie</button>
 <button id="reset" type="button">Reset</button>
 <pre id="log"></pre>
 ```
@@ -116,6 +116,10 @@ reload.addEventListener("click", () => {
 
 const logElement = document.querySelector("#log");
 
+function clearLog() {
+  logElement.innerText = "";
+}
+
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
@@ -124,23 +128,19 @@ function log(text) {
 
 #### JavaScript
 
-The code first sets a cookie.
-
-We then await on `get()`, specifying the name of the cookie.
+The `cookieTest()` method is called when the **Show cookies** button is clicked.
+It first calls `setTestCookie()` to define a cookie, then waits on `get()` to retrieve information about that same cookie.
 If the returned promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
 
 ```js
 async function cookieTest() {
-  // await on setting the cookie
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
+  // Set test cookie
+  await setTestCookie();
 
-  // await on getting the cookie
+  // Get cookie, specifying name
   const cookie = await cookieStore.get("cookie1");
 
-  // log the cookie object keys and values.
+  // Log the cookie object keys and values.
   if (cookie) {
     log("cookie1:");
     for (const [key, value] of Object.entries(cookie)) {
@@ -152,22 +152,41 @@ async function cookieTest() {
 }
 ```
 
+The code for `setTestCookie()` is shown here just "for your interest".
+Note that some logging and other code is omitted for brevity.
+
+```js
+async function setTestCookie() {
+  // Set two cookies
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
+
+  try {
+    await cookieStore.set("cookie2", "cookie2-value");
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
+}
+```
+
 ```js hidden
 const showCookies = document.querySelector("#showCookies");
 
 showCookies.addEventListener("click", () => {
+  clearLog();
   cookieTest();
 });
 ```
 
-Note that some logging and other code is omitted for brevity.
-
 #### Result
 
-Press **Show cookies** to set the cookie and then display it.
+Press **Show cookie** to set the cookie and then display it.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 
-{{EmbedLiveSample('Setting a cookie with name and value', 100, 250)}}
+{{EmbedLiveSample('Getting a cookie by name', 100, 260)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -134,7 +134,7 @@ function log(text) {
 The code first sets a cookie (which we then use to demonstrate `get()`).
 
 We then await on `get()`, specifying the name of the cookie.
-If the promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
+If the returned Promise resolves with an object we log the properties of the cookie: otherwise we log that no matching cookie was found.
 
 ```js
 async function cookieTest() {

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -88,6 +88,10 @@ The object returned for a match contains the following properties:
 
 ## Examples
 
+> [!WARNING]
+> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
+> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+
 ### Getting a cookie by name
 
 In this example we get a particular cookie named `cookie1`, awaiting the returned promise, and logging the resolved object.

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -114,7 +114,7 @@ async function setTestCookies() {
 
 The `cookieTest()` method calls `setTestCookies()` and then waits on `getAll()`.
 This returns a {{jsxref("Promise")}} that resolves with all of the cookies for this context as an array of objects, or an empty array if there are no cookies.
-If the returned promise resolves with array containing cookie information we iterate the array and log each cookie.
+If the returned promise resolves with array containing cookie information we iterate the array and log each cookie ("cookie1" and "cookie2").
 
 ```js
 async function cookieTest() {
@@ -133,11 +133,6 @@ async function cookieTest() {
   }
 }
 ```
-
-When run in a browser this will display information about "cookie1" and "cookie2" in the console.
-Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -8,7 +8,8 @@ browser-compat: api.CookieStore.getAll
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}
 
-The **`getAll()`** method of the {{domxref("CookieStore")}} interface returns a list of cookies that match the `name` or `options` passed to it. Passing no parameters will return all cookies for the current context.
+The **`getAll()`** method of the {{domxref("CookieStore")}} interface returns a {{jsxref("Promise")}} that resolves as an array of cookies that match the `name` or `options` passed to it.
+Passing no parameters will return all cookies for the current context.
 
 ## Syntax
 
@@ -92,17 +93,102 @@ Each object contains the following properties:
 
 ## Examples
 
-In this example, we use `getAll()` with no parameters. This returns all of the cookies for this context as an array of objects.
+### Get all cookies for this context
 
-```js
-const cookies = await cookieStore.getAll();
+In this example, we use `getAll()` with no parameters. This returns a {{jsxref("Promise")}} that resolves with all of the cookies for this context as an array of objects, or an empty array if there are no cookies.
 
-if (cookies.length > 0) {
-  console.log(cookies);
-} else {
-  console.log("Cookie not found");
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 300px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
 }
 ```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+function logCookie(name, cookie) {
+  if (cookie) {
+    log(`${name}:`);
+    for (const [key, value] of Object.entries(cookie)) {
+      log(` ${key}: ${value}`);
+    }
+  } else {
+    log(`${name}: Cookie not found`);
+  }
+}
+```
+
+#### JavaScript
+
+The code first sets two cookies (which we then use to demonstrate `getAll()`).
+
+We then await on `getAll()`, without specifying any parameters.
+If the returned Promise resolves with an object we iterate the array, logging the properties of each cookie.
+
+```js
+async function cookieTest() {
+  // Set two cookies
+  await cookieStore.set({
+    name: "cookie1",
+    value: `cookie1-value`,
+  });
+
+  await cookieStore.set({
+    name: "cookie2",
+    value: `cookie2-value`,
+  });
+
+  // Get all cookies
+  const cookies = await cookieStore.getAll();
+
+  // Iterate the cookies, or log that none were found
+  if (cookies.length > 0) {
+    log(`Found cookies: ${cookies.length}:`);
+    cookies.forEach((cookie) => logCookie(cookie.value, cookie));
+  } else {
+    log("Cookies not found");
+  }
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+Note that some logging and other code is omitted for brevity.
+
+#### Result
+
+Press **Show cookies** to add and then get all the cookies.
+Note that some browsers will only display the `name` and `value`, while others will display all the properties of each cookie.
+
+{{EmbedLiveSample('Get all cookies for this context', 100, 350)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -189,7 +189,7 @@ Note that some logging and other code is omitted for brevity.
 Press **Show cookies** to add and then get all the cookies.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of each cookie.
 
-{{EmbedLiveSample('Get all cookies for this context', 100, 350)}}
+{{EmbedLiveSample('Get all cookies for this context', 100, 380)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -87,6 +87,10 @@ Each object contains the following properties:
 
 ## Examples
 
+> [!WARNING]
+> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
+> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+
 ### Get all cookies for this context
 
 In this example, we use `getAll()` with no parameters.

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -87,67 +87,34 @@ Each object contains the following properties:
 
 ## Examples
 
-> [!WARNING]
-> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
-> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+<!-- The examples don't work as live examples in MDN environment (due to unknown errors) -->
 
 ### Get all cookies for this context
 
-In this example, we use `getAll()` with no parameters.
-This returns a {{jsxref("Promise")}} that resolves with all of the cookies for this context as an array of objects, or an empty array if there are no cookies.
+This example shows how to get all cookies in the current context.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
+First we define `setTestCookies()` which creates the test cookies "cookie1" and "cookie2", logging any errors.
 
-```css hidden
-#log {
-  height: 330px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
+```js
+async function setTestCookies() {
+  // Set two cookies
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    console.log(`Error setting cookie1: ${error}`);
+  }
 
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js hidden
-function logCookie(name, cookie) {
-  if (cookie) {
-    log(`${name}:`);
-    for (const [key, value] of Object.entries(cookie)) {
-      log(` ${key}: ${value}`);
-    }
-  } else {
-    log(`${name}: Cookie not found`);
+  try {
+    await cookieStore.set("cookie2", "cookie2-value");
+  } catch (error) {
+    console.log(`Error setting cookie2: ${error}`);
   }
 }
 ```
 
-#### JavaScript
-
-The `cookieTest()` method is called when the **Show cookies** button is clicked.
-It first waits on `setTestCookies()` to set some cookies, then waits on `getAll()` to fetch all cookies defined in the current context.
-If the returned promise resolves with an object we iterate the array, logging the properties of each cookie.
+The `cookieTest()` method calls `setTestCookies()` and then waits on `getAll()`.
+This returns a {{jsxref("Promise")}} that resolves with all of the cookies for this context as an array of objects, or an empty array if there are no cookies.
+If the returned promise resolves with array containing cookie information we iterate the array and log each cookie.
 
 ```js
 async function cookieTest() {
@@ -159,51 +126,18 @@ async function cookieTest() {
 
   // Iterate the cookies, or log that none were found
   if (cookies.length > 0) {
-    log(`Found cookies: ${cookies.length}:`);
-    cookies.forEach((cookie) => logCookie(cookie.value, cookie));
+    console.log(`Found cookies: ${cookies.length}:`);
+    cookies.forEach((cookie) => console.log(cookie));
   } else {
-    log("Cookies not found");
+    console.log("Cookies not found");
   }
 }
 ```
 
-The code for `setTestCookies()` is shown here just "for your interest".
-Note that some logging and other code is omitted for brevity.
+When run in a browser this will display information about "cookie1" and "cookie2" in the console.
+Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 
-```js
-async function setTestCookies() {
-  // Set two cookies
-  try {
-    await cookieStore.set("cookie1", "cookie1-value");
-  } catch (error) {
-    log(`Error setting cookie1: ${error}`);
-  }
-
-  try {
-    await cookieStore.set("cookie1", "cookie1-value");
-  } catch (error) {
-    log(`Error setting cookie2: ${error}`);
-  }
-}
-```
-
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
-
-Note that some logging and other code is omitted for brevity.
-
-#### Result
-
-Press **Show cookies** to add and then get all the cookies.
-Note that some browsers will only display the `name` and `value`, while others will display all the properties of each cookie.
-
-{{EmbedLiveSample('Get all cookies for this context', 100, 410)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -14,6 +14,7 @@ Passing no parameters will return all cookies for the current context.
 ## Syntax
 
 ```js-nolint
+getAll()
 getAll(name)
 getAll(options)
 ```

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -66,14 +66,7 @@ Each object contains the following properties:
 
 - `sameSite`
 
-  - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
-
-    - `"strict"`
-      - : Cookies will only be sent in a first-party context and not be sent with requests initiated by third party websites.
-    - `"lax"`
-      - : Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating within the origin site (i.e. when following a link).
-    - `"none"`
-      - : Cookies will be sent in all contexts.
+  - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values: [`"strict"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#strict), [`"lax"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#lax), or [`"none"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#none).
 
 - `secure`
 
@@ -96,7 +89,8 @@ Each object contains the following properties:
 
 ### Get all cookies for this context
 
-In this example, we use `getAll()` with no parameters. This returns a {{jsxref("Promise")}} that resolves with all of the cookies for this context as an array of objects, or an empty array if there are no cookies.
+In this example, we use `getAll()` with no parameters.
+This returns a {{jsxref("Promise")}} that resolves with all of the cookies for this context as an array of objects, or an empty array if there are no cookies.
 
 ```html hidden
 <button id="showCookies" type="button">Show cookies</button>

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -81,8 +81,8 @@ Each object contains the following properties:
   - : Thrown if the origin does not {{glossary("Serialization", "serialize")}} to a URL.
 - {{jsxref("TypeError")}}
   - : Thrown if:
-    - The `url` option is present and is not equal with the creation URL, if in main thread.
-    - The `url` option is present and its origin is not the same as the origin of the creation URL.
+    - The method is called in the main thread, and the `url` option is specified but does not match the URL of the current window.
+    - The method is called in a worker and the `url` option is specified, but does not match the origin of the worker.
     - Querying cookies represented by the given `name` or `options` fails.
 
 ## Examples

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -146,7 +146,7 @@ function logCookie(name, cookie) {
 The code first sets two cookies (which we then use to demonstrate `getAll()`).
 
 We then await on `getAll()`, without specifying any parameters.
-If the returned Promise resolves with an object we iterate the array, logging the properties of each cookie.
+If the returned promise resolves with an object we iterate the array, logging the properties of each cookie.
 
 ```js
 async function cookieTest() {

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -100,7 +100,7 @@ This returns a {{jsxref("Promise")}} that resolves with all of the cookies for t
 
 ```css hidden
 #log {
-  height: 300px;
+  height: 330px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -115,6 +115,10 @@ reload.addEventListener("click", () => {
 });
 
 const logElement = document.querySelector("#log");
+
+function clearLog() {
+  logElement.innerText = "";
+}
 
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
@@ -137,23 +141,14 @@ function logCookie(name, cookie) {
 
 #### JavaScript
 
-The code first sets two cookies (which we then use to demonstrate `getAll()`).
-
-We then await on `getAll()`, without specifying any parameters.
+The `cookieTest()` method is called when the **Show cookies** button is clicked.
+It first waits on `setTestCookies()` to set some cookies, then waits on `getAll()` to fetch all cookies defined in the current context.
 If the returned promise resolves with an object we iterate the array, logging the properties of each cookie.
 
 ```js
 async function cookieTest() {
-  // Set two cookies
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
-
-  await cookieStore.set({
-    name: "cookie2",
-    value: `cookie2-value`,
-  });
+  // Set our test cookies
+  await setTestCookies();
 
   // Get all cookies
   const cookies = await cookieStore.getAll();
@@ -168,10 +163,31 @@ async function cookieTest() {
 }
 ```
 
+The code for `setTestCookies()` is shown here just "for your interest".
+Note that some logging and other code is omitted for brevity.
+
+```js
+async function setTestCookies() {
+  // Set two cookies
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
+
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
+}
+```
+
 ```js hidden
 const showCookies = document.querySelector("#showCookies");
 
 showCookies.addEventListener("click", () => {
+  clearLog();
   cookieTest();
 });
 ```
@@ -183,7 +199,7 @@ Note that some logging and other code is omitted for brevity.
 Press **Show cookies** to add and then get all the cookies.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of each cookie.
 
-{{EmbedLiveSample('Get all cookies for this context', 100, 380)}}
+{{EmbedLiveSample('Get all cookies for this context', 100, 410)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -59,6 +59,10 @@ reload.addEventListener("click", () => {
 
 const logElement = document.querySelector("#log");
 
+function clearLog() {
+  logElement.innerText = "";
+}
+
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
@@ -81,26 +85,36 @@ function logCookie(name, cookie) {
 #### JavaScript
 
 The example code sets two cookies.
-The first is set with `name` and `value` properties, while the second is set with `name`, `value`, `expires`, and `partitioned` properties.
+The first is set with `name` and `value` properties, while the second is set with `name`, `value`, and `expires` properties.
 
-We then use the {{domxref("CookieStore.get()")}} method to get the cookies, which are then logged.
+We then use the {{domxref("CookieStore.get()")}} method to get each of the cookies, which are then logged.
 
 ```js
 async function cookieTest() {
-  // Set a cookie passing name and value
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
+  clearLog();
 
-  // Set a cookie passing an options object
+  // Set cookie: passing name and value
+  try {
+    await cookieStore.set({
+      name: "cookie1",
+      value: `cookie1-value`,
+    });
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
+
+  // Set cookie: passing options
   const day = 24 * 60 * 60 * 1000;
-  await cookieStore.set({
-    name: "cookie2",
-    value: `cookie2-value`,
-    expires: Date.now() + day,
-    partitioned: true,
-  });
+
+  try {
+    await cookieStore.set({
+      name: "cookie2",
+      value: `cookie2-value`,
+      expires: Date.now() + day,
+    });
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
 
   // Get named cookies and log their properties
   const cookie1 = await cookieStore.get("cookie1");
@@ -131,7 +145,7 @@ Even if the values are not displayed, they are still set.
 
 ### Getting cookies
 
-The following example shows how you can get a particular cookie using {{domxref("CookieStore.get()")}} or all cookies using {{domxref("CookieStore.getAll()")}}.
+This example shows how you can get a particular cookie using {{domxref("CookieStore.get()")}} or all cookies using {{domxref("CookieStore.getAll()")}}.
 
 ```html hidden
 <button id="showCookies" type="button">Show cookies</button>

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -142,6 +142,7 @@ This example shows how to delete a named cookie using the {{domxref("CookieStore
 
 The code first sets two cookies and logs them to the console.
 We then delete one of the cookies, and then list all cookies again.
+The deleted cookie ("cookie1") is present in the first log array, and not in the second.
 
 ```js
 async function cookieTest() {
@@ -170,8 +171,6 @@ async function cookieTest() {
   console.log(await cookieStore.getAll());
 }
 ```
-
-When run in a console we should see the deleted cookie ("cookie1") is present in the first log array, and not in the second.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -31,27 +31,303 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 
 ## Examples
 
-In this example, we set a cookie and write to the console feedback as to whether the operation succeeded or failed.
+### Setting cookies
+
+The following example sets cookie by passing a `name` and `value` and then by setting an options value.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 280px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+function logCookie(name, cookie) {
+  if (cookie) {
+    log(`${name}:`);
+    for (const [key, value] of Object.entries(cookie)) {
+      log(` ${key}: ${value}`);
+    }
+  } else {
+    log(`${name}: Cookie not found`);
+  }
+}
+```
+
+#### JavaScript
+
+The example code sets two cookies, the first using `name` and `value` parameters, and the second using an "options" object with `name`, `value`, `expires`, and `partitioned` properties set.
+
+The {{apiref("CookieStore.get()")}} method is then used to get the cookies, which are then logged.
 
 ```js
-const day = 24 * 60 * 60 * 1000;
-
-cookieStore
-  .set({
+async function cookieTest() {
+  // Set a cookie passing name and value
+  await cookieStore.set({
     name: "cookie1",
-    value: "cookie1-value",
+    value: `cookie1-value`,
+  });
+
+  // Set a cookie passing an options object
+  const day = 24 * 60 * 60 * 1000;
+  await cookieStore.set({
+    name: "cookie2",
+    value: `cookie2-value`,
     expires: Date.now() + day,
-    domain: "example.com",
-  })
-  .then(
-    () => {
-      console.log("It worked!");
-    },
-    (reason) => {
-      console.error("It failed: ", reason);
-    },
-  );
+    partitioned: true,
+  });
+
+  // Get named cookies and log their properties
+  const cookie1 = await cookieStore.get("cookie1");
+  logCookie("cookie1", cookie1);
+
+  const cookie2 = await cookieStore.get("cookie2");
+  logCookie("cookie2", cookie2);
+}
 ```
+
+Note that some logging and other code is omitted for brevity.
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+#### Result
+
+Press **Show cookies** to set the cookies and then display them in the log below
+Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
+Even if the values are not displayed, they are still set.
+
+{{EmbedLiveSample('Setting cookies', 100, 350)}}
+
+### Getting cookies
+
+The following example shows how you can get a particular cookie using {{domxref("CookieStore.get()")}} or all cookies using {{domxref("CookieStore.getAll()")}}.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 550px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+function logCookie(name, cookie) {
+  if (cookie) {
+    log(`${name}:`);
+    for (const [key, value] of Object.entries(cookie)) {
+      log(` ${key}: ${value}`);
+    }
+  } else {
+    log(`${name}: Cookie not found`);
+  }
+}
+```
+
+#### JavaScript
+
+The example code first sets a number of cookies that we'll use for demonstrating the get methods.
+
+First it creates `cookie1` and `cookie2` using the {{domxref("CookieStore.set()")}} method.
+Then it creates a couple of using the older synchronous {{domxref("Document.cookie")}} property (just so we can show that these are also fetched using our get methods)
+
+The code then uses {{domxref("CookieStore.get()")}} to fetch "cookie1" and log its properties and {{domxref("CookieStore.getAll()")}} (without arguments) to fetch all cookies in the current context.
+
+```js
+async function cookieTest() {
+  // Set a cookie passing name and value
+  await cookieStore.set({
+    name: "cookie1",
+    value: `cookie1-value`,
+  });
+
+  // Set a cookie passing an options object
+  const day = 24 * 60 * 60 * 1000;
+  await cookieStore.set({
+    name: "cookie2",
+    value: `cookie2-value`,
+    expires: Date.now() + day,
+    partitioned: true,
+  });
+
+  // Set cookie using document.cookie
+  // (to demonstrate these are are fetched too)
+  document.cookie = "favorite_food=tripe; SameSite=None; Secure";
+
+  // Get named cookie and log properties
+  const cookie1 = await cookieStore.get("cookie1");
+  logCookie("cookie1", cookie1);
+
+  // Get all cookies and log each
+  const cookies = await cookieStore.getAll();
+  if (cookies.length > 0) {
+    log(`\ngetAll(): ${cookies.length}:`);
+    cookies.forEach((cookie) => logCookie(cookie.value, cookie));
+  } else {
+    log("Cookies not found");
+  }
+}
+```
+
+Note that some logging and other code is omitted for brevity.
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+#### Result
+
+Press **Show cookies** to set the cookies and then display them in the log below.
+
+{{EmbedLiveSample('Getting cookies', 100, 640)}}
+
+### Delete a named cookie
+
+In this example, a cookie is deleted by passing its name to the `delete()` method.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+// List cookies
+async function getCookieNames() {
+  let names = "";
+  const cookies = await cookieStore.getAll();
+  if (cookies.length > 0) {
+    cookies.forEach((cookie) => (names += `${cookie.name} `));
+  }
+  return names;
+}
+```
+
+#### JavaScript
+
+The code first sets two cookies (which we then use to demonstrate deletion).
+
+We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cooking names again.
+
+```js
+async function cookieTest() {
+  // Set two cookies
+  await cookieStore.set({
+    name: "cookie1",
+    value: `cookie1-value`,
+  });
+
+  await cookieStore.set({
+    name: "cookie2",
+    value: `cookie2-value`,
+  });
+
+  // Log cookie names
+  log(`Initial cookies: ${await getCookieNames()}`);
+
+  // Delete cookie1
+  await cookieStore.delete("cookie1");
+
+  // Log cookie names again (to show cookie1 deleted)
+  log(`Cookies after deleting cookie1: ${await getCookieNames()}`);
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+Note that some logging and other code is omitted for brevity.
+
+#### Result
+
+Press **Show cookies** to run the code above.
+This should show that the deleted cookie is present in the first list, and not in the second.
+
+{{EmbedLiveSample('Delete a named cookie', 100, 190)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -35,66 +35,15 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 
 ## Examples
 
-> [!WARNING]
-> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
-> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+The examples below can be tested by copying the code into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
+
+<!-- The examples don't work as live examples in MDN environment (due to unknown errors) -->
 
 ### Setting cookies
 
-The following example sets cookies by passing a `name` and `value` and then by setting an `options` value.
+This example shows how to set cookies by passing a `name` and `value`, and by setting an `options` value.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 300px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js hidden
-function logCookie(name, cookie) {
-  if (cookie) {
-    log(`${name}:`);
-    for (const [key, value] of Object.entries(cookie)) {
-      log(` ${key}: ${value}`);
-    }
-  } else {
-    log(`${name}: Cookie not found`);
-  }
-}
-```
-
-#### JavaScript
-
-The example code sets two cookies.
-The first is set with `name` and `value` properties, while the second is set with `name`, `value`, and `expires` properties.
-
+The `cookieTest()` method first sets a cookie with `name` and `value` properties, while the second is set with `name`, `value`, and `expires` properties.
 We then use the {{domxref("CookieStore.get()")}} method to get each of the cookies, which are then logged.
 
 ```js
@@ -103,7 +52,7 @@ async function cookieTest() {
   try {
     await cookieStore.set("cookie1", "cookie1-value");
   } catch (error) {
-    log(`Error setting cookie1: ${error}`);
+    console.log(`Error setting cookie1: ${error}`);
   }
 
   // Set cookie: passing options
@@ -114,6 +63,7 @@ async function cookieTest() {
       name: "cookie2",
       value: "cookie2-value",
       expires: Date.now() + day,
+      partitioned: true,
     });
   } catch (error) {
     log(`Error setting cookie2: ${error}`);
@@ -121,91 +71,27 @@ async function cookieTest() {
 
   // Get named cookies and log their properties
   const cookie1 = await cookieStore.get("cookie1");
-  logCookie("cookie1", cookie1);
+  console.log(cookie1);
 
   const cookie2 = await cookieStore.get("cookie2");
-  logCookie("cookie2", cookie2);
+  console.log(cookie2);
 }
+
+cookieTest();
 ```
 
-Note that some logging and other code is omitted for brevity.
-
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
-
-#### Result
-
-Press **Show cookies** to set the cookies and then display them in the log below
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 Even if the values are not displayed, they are still set.
-
-{{EmbedLiveSample('Setting cookies', 100, 390)}}
 
 ### Getting cookies
 
 This example shows how you can get a particular cookie using {{domxref("CookieStore.get()")}} or all cookies using {{domxref("CookieStore.getAll()")}}.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 600px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js hidden
-function logCookie(name, cookie) {
-  if (cookie) {
-    log(`${name}:`);
-    for (const [key, value] of Object.entries(cookie)) {
-      log(` ${key}: ${value}`);
-    }
-  } else {
-    log(`${name}: Cookie not found`);
-  }
-}
-```
-
-#### JavaScript
-
 The example code first sets three cookies that we'll use for demonstrating the get methods.
-
 First it creates `cookie1` and `cookie2` using the {{domxref("CookieStore.set()")}} method.
 Then it creates a third cookie using the older synchronous {{domxref("Document.cookie")}} property (just so we can show that these are also fetched using the `get()` and `getAll()` methods).
 
-The code then uses {{domxref("CookieStore.get()")}} to fetch "cookie1" and log its properties and {{domxref("CookieStore.getAll()")}} (without arguments) to fetch all cookies in the current context.
+The code then uses {{domxref("CookieStore.get()")}} to fetch "cookie1" and log its properties, and {{domxref("CookieStore.getAll()")}} (without arguments) to fetch all cookies in the current context.
 
 ```js
 async function cookieTest() {
@@ -213,7 +99,7 @@ async function cookieTest() {
   try {
     await cookieStore.set("cookie1", "cookie1-value");
   } catch (error) {
-    log(`Error setting cookie1: ${error}`);
+    console.log(`Error setting cookie1: ${error}`);
   }
 
   // Set a cookie passing an options object
@@ -226,7 +112,7 @@ async function cookieTest() {
       partitioned: true,
     });
   } catch (error) {
-    log(`Error setting cookie2: ${error}`);
+    console.log(`Error setting cookie2: ${error}`);
   }
 
   // Set cookie using document.cookie
@@ -235,119 +121,30 @@ async function cookieTest() {
 
   // Get named cookie and log properties
   const cookie1 = await cookieStore.get("cookie1");
-  logCookie("cookie1", cookie1);
+  console.log(cookie1);
 
   // Get all cookies and log each
   const cookies = await cookieStore.getAll();
   if (cookies.length > 0) {
-    log(`\ngetAll(): ${cookies.length}:`);
-    cookies.forEach((cookie) => logCookie(cookie.value, cookie));
+    console.log(`getAll(): ${cookies.length}:`);
+    cookies.forEach((cookie) => console.log(cookie));
   } else {
-    log("Cookies not found");
+    console.log("Cookies not found");
   }
 }
+
+cookieTest();
 ```
 
-Note that some logging and other code is omitted for brevity.
-
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", () => {
-  clearLog();
-  cookieTest();
-});
-```
-
-#### Result
-
-Press **Show cookies** to set the cookies and then display them in the log below.
-
-One thing to note is that the cookie created using {{domxref("Document.cookie")}} has a different default path than those created using `set()`.
-
-{{EmbedLiveSample('Getting cookies', 100, 670)}}
+The example should log "cookie1" and all three cookies separately.
+One thing to note is that the cookie created using {{domxref("Document.cookie")}} may have a different path than those created using {{domxref("CookieStore.set()","set()")}} (which defaults to `/`).
 
 ### Delete a named cookie
 
-In this example, we delete a cookie by passing its name to the {{domxref("CookieStore.delete()","delete()")}} method.
+This example shows how to delete a named cookie using the {{domxref("CookieStore.delete()","delete()")}} method.
 
-```html hidden
-<button id="showCookies" type="button">Show cookies</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js hidden
-// List cookies
-async function getCookieNames() {
-  let names = "";
-  const cookies = await cookieStore.getAll();
-  if (cookies.length > 0) {
-    cookies.forEach((cookie) => (names += `${cookie.name} `));
-  }
-  return names;
-}
-
-// Delete cookies. Cleans up cookies from other examples.
-async function deleteAllCookies() {
-  const cookieNamesToDelete = (await cookieStore.getAll()).map(
-    (cookie) => cookie.name,
-  );
-
-  for (const name of cookieNamesToDelete) {
-    try {
-      await cookieStore.delete(name);
-      //log(` Deleted cookie: ${name}`);
-    } catch (error) {
-      //log(` Error deleting cookie ${name}:`, error);
-    }
-  }
-
-  //This deletes cookies that don't have default settings.
-  try {
-    await cookieStore.delete({ name: "cookie2", partitioned: true });
-    await cookieStore.delete({
-      name: "favorite_food",
-      path: "/en-US/docs/Web/API/CookieStore",
-    });
-  } catch (error) {
-    //log(` Error deleting cookie ${name}:`, error);
-  }
-}
-```
-
-#### JavaScript
-
-The code first sets two cookies.
-We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cookie names again.
+The code first sets two cookies and logs them to the console.
+We then delete one of the cookies, and then list all cookies again.
 
 ```js
 async function cookieTest() {
@@ -355,44 +152,29 @@ async function cookieTest() {
   try {
     await cookieStore.set("cookie1", "cookie1-value");
   } catch (error) {
-    log(`Error setting cookie1: ${error}`);
+    console.log(`Error setting cookie1: ${error}`);
   }
 
   try {
     await cookieStore.set("cookie2", "cookie2-value");
   } catch (error) {
-    log(`Error setting cookie2: ${error}`);
+    console.log(`Error setting cookie2: ${error}`);
   }
 
-  // Log cookie names
-  log(`Initial cookies: ${await getCookieNames()}`);
+  // Log cookies
+  console.log("Initial cookies");
+  console.log(await cookieStore.getAll());
 
   // Delete cookie1
   await cookieStore.delete("cookie1");
 
-  // Log cookie names again (to show cookie1 deleted)
-  log(`Cookies after deleting cookie1: ${await getCookieNames()}`);
+  // Log cookies again (to show cookie1 deleted)
+  console.log("Cookies after deleting cookie1");
+  console.log(await cookieStore.getAll());
 }
 ```
 
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", async () => {
-  clearLog();
-  await deleteAllCookies();
-  await cookieTest();
-});
-```
-
-Note that some logging and other code is omitted for brevity.
-
-#### Result
-
-Press **Show cookies** to run the code above.
-This should show that the deleted cookie is present in the first list, and not in the second.
-
-{{EmbedLiveSample('Delete a named cookie', 100, 190)}}
+When run in a console we should see the deleted cookie ("cookie1") is present in the first log array, and not in the second.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -80,9 +80,6 @@ async function cookieTest() {
 cookieTest();
 ```
 
-Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
-Even if the values are not displayed, they are still set.
-
 ### Getting cookies
 
 This example shows how you can get a particular cookie using {{domxref("CookieStore.get()")}} or all cookies using {{domxref("CookieStore.getAll()")}}.

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -16,13 +16,17 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 ## Instance methods
 
 - {{domxref("CookieStore.delete()")}}
-  - : The `delete()` method deletes a cookie with the given `name` or `options` object, it returns a {{jsxref("Promise")}} that resolves when the deletion completes.
+  - : The `delete()` method deletes a cookie with the given `name` or `options` object.
+    It returns a {{jsxref("Promise")}} that resolves when the deletion completes or if no cookies is matched.
 - {{domxref("CookieStore.get()")}}
-  - : The `get()` method gets a single cookie with the given `name` or `options` object, it returns a {{jsxref("Promise")}} that resolves with details of a single cookie.
+  - : The `get()` method gets a single cookie with the given `name` or `options` object.
+    It returns a {{jsxref("Promise")}} that resolves with details of a single cookie.
 - {{domxref("CookieStore.getAll()")}}
-  - : The `getAll()` method gets all matching cookies, it returns a {{jsxref("Promise")}} that resolves with a list of cookies.
+  - : The `getAll()` method gets all matching cookies.
+    It returns a {{jsxref("Promise")}} that resolves with a list of cookies.
 - {{domxref("CookieStore.set()")}}
-  - : The `set()` method sets a cookie with the given `name` and `value` or `options` object, it returns a {{jsxref("Promise")}} that resolves when the cookie is set.
+  - : The `set()` method sets a cookie with the given `name` and `value` or `options` object.
+    It returns a {{jsxref("Promise")}} that resolves when the cookie is set.
 
 ## Events
 
@@ -30,6 +34,10 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
   - : The `change` event fires when a change is made to any cookie.
 
 ## Examples
+
+> [!WARNING]
+> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
+> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
 
 ### Setting cookies
 
@@ -338,8 +346,7 @@ async function deleteAllCookies() {
 
 #### JavaScript
 
-The code first sets two cookies (which we then use to demonstrate deletion).
-
+The code first sets two cookies.
 We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cookie names again.
 
 ```js

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -80,7 +80,8 @@ function logCookie(name, cookie) {
 
 #### JavaScript
 
-The example code sets two cookies, the first using `name` and `value` parameters, and the second using an "options" object with `name`, `value`, `expires`, and `partitioned` properties set.
+The example code sets two cookies.
+The first is set with `name` and `value` properties, while the second is set with `name`, `value`, `expires`, and `partitioned` properties.
 
 We then use the {{domxref("CookieStore.get()")}} method to get the cookies, which are then logged.
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -281,6 +281,29 @@ async function getCookieNames() {
   }
   return names;
 }
+
+// Delete cookies
+async function deleteAllCookies() {
+  log("deleteAllCookies: in");
+  const cookieNamesToDelete = (await cookieStore.getAll()).map(
+    (cookie) => cookie.name,
+  );
+
+  log(`len: ${cookieNamesToDelete.length}`);
+  for (const name of cookieNamesToDelete) {
+    try {
+      await cookieStore.delete(name);
+      log(` Deleted cookie: ${name}`);
+    } catch (error) {
+      log(` Error deleting cookie ${name}:`, error);
+    }
+  }
+  const cookieNames2 = (await cookieStore.getAll()).map(
+    (cookie) => cookie.name,
+  );
+
+  log(`deleteAllCookies: out: len: ${cookieNames2.length}`);
+}
 ```
 
 #### JavaScript
@@ -316,8 +339,9 @@ async function cookieTest() {
 ```js hidden
 const showCookies = document.querySelector("#showCookies");
 
-showCookies.addEventListener("click", () => {
-  cookieTest();
+showCookies.addEventListener("click", async () => {
+  await deleteAllCookies();
+  await cookieTest();
 });
 ```
 

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -43,7 +43,7 @@ The following example sets cookies by passing a `name` and `value` and then by s
 
 ```css hidden
 #log {
-  height: 280px;
+  height: 300px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -91,14 +91,9 @@ We then use the {{domxref("CookieStore.get()")}} method to get each of the cooki
 
 ```js
 async function cookieTest() {
-  clearLog();
-
   // Set cookie: passing name and value
   try {
-    await cookieStore.set({
-      name: "cookie1",
-      value: `cookie1-value`,
-    });
+    await cookieStore.set("cookie1", "cookie1-value");
   } catch (error) {
     log(`Error setting cookie1: ${error}`);
   }
@@ -109,7 +104,7 @@ async function cookieTest() {
   try {
     await cookieStore.set({
       name: "cookie2",
-      value: `cookie2-value`,
+      value: "cookie2-value",
       expires: Date.now() + day,
     });
   } catch (error) {
@@ -131,6 +126,7 @@ Note that some logging and other code is omitted for brevity.
 const showCookies = document.querySelector("#showCookies");
 
 showCookies.addEventListener("click", () => {
+  clearLog();
   cookieTest();
 });
 ```
@@ -141,7 +137,7 @@ Press **Show cookies** to set the cookies and then display them in the log below
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 Even if the values are not displayed, they are still set.
 
-{{EmbedLiveSample('Setting cookies', 100, 350)}}
+{{EmbedLiveSample('Setting cookies', 100, 390)}}
 
 ### Getting cookies
 
@@ -155,7 +151,7 @@ This example shows how you can get a particular cookie using {{domxref("CookieSt
 
 ```css hidden
 #log {
-  height: 550px;
+  height: 600px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -170,6 +166,10 @@ reload.addEventListener("click", () => {
 });
 
 const logElement = document.querySelector("#log");
+
+function clearLog() {
+  logElement.innerText = "";
+}
 
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
@@ -202,10 +202,7 @@ The code then uses {{domxref("CookieStore.get()")}} to fetch "cookie1" and log i
 ```js
 async function cookieTest() {
   // Set a cookie passing name and value
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
+  await cookieStore.set("cookie1", "cookie1-value");
 
   // Set a cookie passing an options object
   const day = 24 * 60 * 60 * 1000;
@@ -241,6 +238,7 @@ Note that some logging and other code is omitted for brevity.
 const showCookies = document.querySelector("#showCookies");
 
 showCookies.addEventListener("click", () => {
+  clearLog();
   cookieTest();
 });
 ```
@@ -249,7 +247,9 @@ showCookies.addEventListener("click", () => {
 
 Press **Show cookies** to set the cookies and then display them in the log below.
 
-{{EmbedLiveSample('Getting cookies', 100, 640)}}
+One thing to note is that the cookie created using {{domxref("Document.cookie")}} has a different default path than those created using `set()`.
+
+{{EmbedLiveSample('Getting cookies', 100, 670)}}
 
 ### Delete a named cookie
 
@@ -279,6 +279,10 @@ reload.addEventListener("click", () => {
 
 const logElement = document.querySelector("#log");
 
+function clearLog() {
+  logElement.innerText = "";
+}
+
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
@@ -296,27 +300,31 @@ async function getCookieNames() {
   return names;
 }
 
-// Delete cookies
+// Delete cookies. Cleans up cookies from other examples.
 async function deleteAllCookies() {
-  log("deleteAllCookies: in");
   const cookieNamesToDelete = (await cookieStore.getAll()).map(
     (cookie) => cookie.name,
   );
 
-  log(`len: ${cookieNamesToDelete.length}`);
   for (const name of cookieNamesToDelete) {
     try {
       await cookieStore.delete(name);
-      log(` Deleted cookie: ${name}`);
+      //log(` Deleted cookie: ${name}`);
     } catch (error) {
-      log(` Error deleting cookie ${name}:`, error);
+      //log(` Error deleting cookie ${name}:`, error);
     }
   }
-  const cookieNames2 = (await cookieStore.getAll()).map(
-    (cookie) => cookie.name,
-  );
 
-  log(`deleteAllCookies: out: len: ${cookieNames2.length}`);
+  //This deletes cookies that don't have default settings.
+  try {
+    await cookieStore.delete({ name: "cookie2", partitioned: true });
+    await cookieStore.delete({
+      name: "favorite_food",
+      path: "/en-US/docs/Web/API/CookieStore",
+    });
+  } catch (error) {
+    //log(` Error deleting cookie ${name}:`, error);
+  }
 }
 ```
 
@@ -329,15 +337,17 @@ We then list the names of both cookies (code for getting the cookie names not sh
 ```js
 async function cookieTest() {
   // Set two cookies
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
 
-  await cookieStore.set({
-    name: "cookie2",
-    value: `cookie2-value`,
-  });
+  try {
+    await cookieStore.set("cookie2", "cookie2-value");
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
 
   // Log cookie names
   log(`Initial cookies: ${await getCookieNames()}`);
@@ -354,6 +364,7 @@ async function cookieTest() {
 const showCookies = document.querySelector("#showCookies");
 
 showCookies.addEventListener("click", async () => {
+  clearLog();
   await deleteAllCookies();
   await cookieTest();
 });

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -17,7 +17,7 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 
 - {{domxref("CookieStore.delete()")}}
   - : The `delete()` method deletes a cookie with the given `name` or `options` object.
-    It returns a {{jsxref("Promise")}} that resolves when the deletion completes or if no cookies is matched.
+    It returns a {{jsxref("Promise")}} that resolves when the deletion completes or if no cookies are matched.
 - {{domxref("CookieStore.get()")}}
   - : The `get()` method gets a single cookie with the given `name` or `options` object.
     It returns a {{jsxref("Promise")}} that resolves with details of a single cookie.
@@ -43,7 +43,7 @@ The examples below can be tested by copying the code into a test harness and run
 
 This example shows how to set cookies by passing a `name` and `value`, and by setting an `options` value.
 
-The `cookieTest()` method first sets a cookie with `name` and `value` properties, while the second is set with `name`, `value`, and `expires` properties.
+The `cookieTest()` method sets one cookie with `name` and `value` properties and another with `name`, `value`, and `expires` properties.
 We then use the {{domxref("CookieStore.get()")}} method to get each of the cookies, which are then logged.
 
 ```js

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -159,17 +159,25 @@ async function cookieTest() {
     console.log(`Error setting cookie2: ${error}`);
   }
 
-  // Log cookies
-  console.log("Initial cookies");
-  console.log(await cookieStore.getAll());
+  // Log cookie names
+  let cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  console.log(`Initial cookies: ${cookieNames}`);
 
   // Delete cookie1
   await cookieStore.delete("cookie1");
 
   // Log cookies again (to show cookie1 deleted)
-  console.log("Cookies after deleting cookie1");
-  console.log(await cookieStore.getAll());
+  cookieNames = (await cookieStore.getAll())
+    .map((cookie) => cookie.name)
+    .join(" ");
+  console.log(
+    `Cookies remaining after attempted deletions (cookie1 should be deleted): ${cookieNames}`,
+  );
 }
+
+cookieTest();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -33,7 +33,7 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 
 ### Setting cookies
 
-The following example sets cookie by passing a `name` and `value` and then by setting an options value.
+The following example sets cookies by passing a `name` and `value` and then by setting an `options` value.
 
 ```html hidden
 <button id="showCookies" type="button">Show cookies</button>
@@ -82,7 +82,7 @@ function logCookie(name, cookie) {
 
 The example code sets two cookies, the first using `name` and `value` parameters, and the second using an "options" object with `name`, `value`, `expires`, and `partitioned` properties set.
 
-The {{apiref("CookieStore.get()")}} method is then used to get the cookies, which are then logged.
+We then use the {{domxref("CookieStore.get()")}} method to get the cookies, which are then logged.
 
 ```js
 async function cookieTest() {
@@ -177,10 +177,10 @@ function logCookie(name, cookie) {
 
 #### JavaScript
 
-The example code first sets a number of cookies that we'll use for demonstrating the get methods.
+The example code first sets three cookies that we'll use for demonstrating the get methods.
 
 First it creates `cookie1` and `cookie2` using the {{domxref("CookieStore.set()")}} method.
-Then it creates a couple of using the older synchronous {{domxref("Document.cookie")}} property (just so we can show that these are also fetched using our get methods)
+Then it creates a third cookie using the older synchronous {{domxref("Document.cookie")}} property (just so we can show that these are also fetched using the `get()` and `getAll()` methods).
 
 The code then uses {{domxref("CookieStore.get()")}} to fetch "cookie1" and log its properties and {{domxref("CookieStore.getAll()")}} (without arguments) to fetch all cookies in the current context.
 
@@ -238,7 +238,7 @@ Press **Show cookies** to set the cookies and then display them in the log below
 
 ### Delete a named cookie
 
-In this example, a cookie is deleted by passing its name to the `delete()` method.
+In this example, we delete a cookie by passing its name to the {{domxref("CookieStore.delete()","delete()")}} method.
 
 ```html hidden
 <button id="showCookies" type="button">Show cookies</button>
@@ -286,7 +286,7 @@ async function getCookieNames() {
 
 The code first sets two cookies (which we then use to demonstrate deletion).
 
-We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cooking names again.
+We then list the names of both cookies (code for getting the cookie names not shown), delete one of the cookies, and then list all cookie names again.
 
 ```js
 async function cookieTest() {

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -202,16 +202,24 @@ The code then uses {{domxref("CookieStore.get()")}} to fetch "cookie1" and log i
 ```js
 async function cookieTest() {
   // Set a cookie passing name and value
-  await cookieStore.set("cookie1", "cookie1-value");
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
 
   // Set a cookie passing an options object
   const day = 24 * 60 * 60 * 1000;
-  await cookieStore.set({
-    name: "cookie2",
-    value: `cookie2-value`,
-    expires: Date.now() + day,
-    partitioned: true,
-  });
+  try {
+    await cookieStore.set({
+      name: "cookie2",
+      value: `cookie2-value`,
+      expires: Date.now() + day,
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+  }
 
   // Set cookie using document.cookie
   // (to demonstrate these are are fetched too)

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -69,18 +69,170 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 
 ## Examples
 
-The following example sets a cookie by passing an object with `name`, `value`, `expires`, and `domain`.
+### Setting a cookie with name and value
+
+The following example sets a cookie by passing a `name` and `value` of cookie1 and cookie1-value, respectively.
+This approach can be used when you only want to set a name and value.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 180px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+function logCookie(name, cookie) {
+  if (cookie) {
+    log(`${name}:`);
+    for (const [key, value] of Object.entries(cookie)) {
+      log(` ${key}: ${value}`);
+    }
+  } else {
+    log(`${name}: Cookie not found`);
+  }
+}
+```
+
+#### JavaScript
+
+The example code first awaits for the cookie to be set, then waits to get the value and log it (note the logging and other display code is omitted).
+Note that asynchronous code is called within an `async` function because you can't `await` on a top level function.
 
 ```js
-const day = 24 * 60 * 60 * 1000;
+async function cookieTest() {
+  // await on setting the cookie
+  await cookieStore.set({
+    name: "cookie1",
+    value: `cookie1-value`,
+  });
 
-cookieStore.set({
-  name: "cookie1",
-  value: "cookie1-value",
-  expires: Date.now() + day,
-  domain: "example.com",
+  // await on getting the cookie and then log its values
+  const cookie = await cookieStore.get("cookie1");
+  logCookie("cookie1", cookie);
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
 });
 ```
+
+#### Result
+
+Press **Show cookies** to set the cookie and then display it.
+Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
+
+{{EmbedLiveSample('Setting a cookie with name and value', 100, 250)}}
+
+### Setting a cookie with options
+
+The following example sets a cookie by passing an "options" object with `name`, `value`, `expires`, and `partitioned`.
+
+```html hidden
+<button id="showCookies" type="button">Show cookies</button>
+<button id="reset" type="button">Reset</button>
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 180px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+function logCookie(name, cookie) {
+  if (cookie) {
+    log(`${name}:`);
+    for (const [key, value] of Object.entries(cookie)) {
+      log(` ${key}: ${value}`);
+    }
+  } else {
+    log(`${name}: Cookie not found`);
+  }
+}
+```
+
+#### JavaScript
+
+The example code first awaits for the cookie to be set, then waits to get the value and log it (note the logging and other display code is omitted).
+Note that asynchronous code is called within an `async` function because you can't `await` on a top level function.
+
+```js
+async function cookieTest() {
+  const day = 24 * 60 * 60 * 1000;
+  await cookieStore.set({
+    name: "cookie2",
+    value: `cookie2-value`,
+    expires: Date.now() + day,
+    partitioned: true,
+  });
+
+  const cookie = await cookieStore.get("cookie2");
+  logCookie("cookie2", cookie);
+}
+```
+
+```js hidden
+const showCookies = document.querySelector("#showCookies");
+
+showCookies.addEventListener("click", () => {
+  cookieTest();
+});
+```
+
+#### Result
+
+Press **Show cookies** to set the cookie and then display it.
+Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
+Even if the values are not displayed, they are still set.
+
+{{EmbedLiveSample('Setting a cookie with options', 100, 250)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -47,9 +47,8 @@ Or
     - `value`
       - : A string with the value of the cookie.
 
-> [!WARNING]
-> Note while you can set any of the options and these will be used by browsers internally, but some browsers will only return `name` and `value` from {{domxref("CookieStore.get()")}} and {{domxref("CookieStore.getAll()")}}.
-> What this means is that if you want to use these properties for matching a particular cookie later, for example in {{domxref("CookieStore.delete()")}}, you will need to store the information for later use on those browsers.
+> [!NOTE]
+> While the values can be set here and will be used internally, some browsers will only return `name` and `value` options from {{domxref("CookieStore.get()")}} and {{domxref("CookieStore.getAll()")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -70,8 +70,8 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 This example sets a cookie by passing a `name` and `value` of "cookie1" and "cookie1-value", respectively.
 The other properties of the cookie are set with default values, as defined in the [`options`](#options) parameter.
 
-The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged.
-It then gets the same cookie and displays its properties.
+The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged to the console.
+It then gets and logs the cookie that was just set.
 
 ```js
 async function cookieTest() {
@@ -88,17 +88,12 @@ async function cookieTest() {
 }
 ```
 
-When run in a browser this will display information about "cookie1" in the console.
-Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
-
 ### Setting a cookie with options
 
 This example sets a cookie by passing an `options` object with `name`, `value`, `expires`, and `partitioned`.
 
-The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged.
-The example then gets the new cookie, if it exists, and logs its properties.
+The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged to the console.
+It then gets and logs the cookie that was just set.
 
 ```js
 async function cookieTest() {
@@ -122,12 +117,6 @@ async function cookieTest() {
   console.log(cookie);
 }
 ```
-
-When run in a browser this will display information about "cookie1" in the console.
-Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
-Even if the values are not displayed, they are still set.
-
-The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -47,6 +47,10 @@ Or
     - `value`
       - : A string with the value of the cookie.
 
+> [!WARNING]
+> Note while you can set any of the options and these will be used by browsers internally, but some browsers will only return `name` and `value` from {{domxref("CookieStore.get()")}} and {{domxref("CookieStore.getAll()")}}.
+> What this means is that if you want to use these properties for matching a particular cookie later, for example in {{domxref("CookieStore.delete()")}}, you will need to store the information for later use on those browsers.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting the cookie completes.
@@ -63,10 +67,10 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 ### Setting a cookie with name and value
 
 The following example sets a cookie by passing a `name` and `value` of "cookie1" and "cookie1-value", respectively.
-This approach can be used when you only want to set a name and value.
+The other properties of the cookie are set with default values, as defined in the [`options`](#options) parameter.
 
 ```html hidden
-<button id="showCookies" type="button">Show cookies</button>
+<button id="showCookies" type="button">Show cookie</button>
 <button id="reset" type="button">Reset</button>
 <pre id="log"></pre>
 ```
@@ -89,6 +93,10 @@ reload.addEventListener("click", () => {
 
 const logElement = document.querySelector("#log");
 
+function clearLog() {
+  logElement.innerText = "";
+}
+
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
@@ -97,6 +105,7 @@ function log(text) {
 
 ```js hidden
 function logCookie(name, cookie) {
+  clearLog();
   if (cookie) {
     log(`${name}:`);
     for (const [key, value] of Object.entries(cookie)) {
@@ -110,17 +119,19 @@ function logCookie(name, cookie) {
 
 #### JavaScript
 
-The example code first waits for the cookie to be set, then waits to get the value, then logs the value (note that the logging and other display code is omitted).
+The code first waits for the cookie to be set within a `try...catch` block, as setting a cookie can throw an exception.
+It then gets the same cookie and displays its properties (note that some logging and other display code is omitted).
 
 ```js
 async function cookieTest() {
-  // await on setting the cookie
-  await cookieStore.set({
-    name: "cookie1",
-    value: `cookie1-value`,
-  });
+  // Set cookie: passing name and value
+  try {
+    await cookieStore.set("cookie1", "cookie1-value");
+  } catch (error) {
+    log(`Error setting cookie1: ${error}`);
+  }
 
-  // await on getting the cookie and then log its values
+  // Get the cookie and log its values
   const cookie = await cookieStore.get("cookie1");
   logCookie("cookie1", cookie);
 }
@@ -136,7 +147,7 @@ showCookies.addEventListener("click", () => {
 
 #### Result
 
-Press **Show cookies** to set the cookie and then display it.
+Press **Show cookie** to set the cookie and then display it.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 
 {{EmbedLiveSample('Setting a cookie with name and value', 100, 250)}}
@@ -146,7 +157,7 @@ Note that some browsers will only display the `name` and `value`, while others w
 The following example sets a cookie by passing an `options` object with `name`, `value`, `expires`, and `partitioned`.
 
 ```html hidden
-<button id="showCookies" type="button">Show cookies</button>
+<button id="showCookies" type="button">Show cookie</button>
 <button id="reset" type="button">Reset</button>
 <pre id="log"></pre>
 ```
@@ -172,6 +183,10 @@ const logElement = document.querySelector("#log");
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
+}
+
+function clearLog() {
+  logElement.innerText = "";
 }
 ```
 
@@ -195,24 +210,25 @@ The example then gets the new cookie, if it exists, and logs its properties (not
 
 ```js
 async function cookieTest() {
-  const day = 24 * 60 * 60 * 1000;
+  clearLog();
 
+  const day = 24 * 60 * 60 * 1000;
+  const cookieName = "cookie2";
   try {
-    // Set cookie
+    // Set cookie: passing options
     await cookieStore.set({
-      name: "cookie2",
-      value: `cookie2-value`,
+      name: cookieName,
+      value: `${cookieName}-value`,
       expires: Date.now() + day,
-      partitioned: true,
     });
   } catch (error) {
-    log(`Error setting cookie2: ${error}`);
+    log(`Error setting ${cookieName}: ${error}`);
     console.log(error);
   }
 
   // Log the new cookie
-  const cookie = await cookieStore.get("cookie2");
-  logCookie("cookie2", cookie);
+  const cookie = await cookieStore.get(cookieName);
+  logCookie(cookieName, cookie);
 }
 ```
 
@@ -228,7 +244,7 @@ showCookies.addEventListener("click", () => {
 
 #### Result
 
-Press **Show cookies** to set the cookie and then display it.
+Press **Show cookie** to set the cookie and then display it.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 Even if the values are not displayed, they are still set.
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -63,6 +63,10 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 
 ## Examples
 
+> [!WARNING]
+> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
+> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+
 ### Setting a cookie with name and value
 
 The following example sets a cookie by passing a `name` and `value` of "cookie1" and "cookie1-value", respectively.

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -71,7 +71,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 
 ### Setting a cookie with name and value
 
-The following example sets a cookie by passing a `name` and `value` of cookie1 and cookie1-value, respectively.
+The following example sets a cookie by passing a `name` and `value` of "cookie1" and "cookie1-value", respectively.
 This approach can be used when you only want to set a name and value.
 
 ```html hidden
@@ -119,7 +119,7 @@ function logCookie(name, cookie) {
 
 #### JavaScript
 
-The example code first awaits for the cookie to be set, then waits to get the value and log it (note the logging and other display code is omitted).
+The example code first waits for the cookie to be set, then waits to get the value, then logs the value (note that the logging and other display code is omitted).
 Note that asynchronous code is called within an `async` function because you can't `await` on a top level function.
 
 ```js
@@ -153,7 +153,7 @@ Note that some browsers will only display the `name` and `value`, while others w
 
 ### Setting a cookie with options
 
-The following example sets a cookie by passing an "options" object with `name`, `value`, `expires`, and `partitioned`.
+The following example sets a cookie by passing an `options` object with `name`, `value`, `expires`, and `partitioned`.
 
 ```html hidden
 <button id="showCookies" type="button">Show cookies</button>

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -43,16 +43,7 @@ Or
     - `path` {{Optional_Inline}}
       - : A string containing the path of the cookie. Defaults to `/`.
     - `sameSite` {{Optional_Inline}}
-
-      - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
-
-        - `"strict"`
-          - : Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites. This is the default.
-        - `"lax"`
-          - : Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).
-        - `"none"`
-          - : Cookies will be sent in all contexts.
-
+      - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values: [`"strict"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#strict), [`"lax"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#lax), or [`"none"`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#none).
     - `value`
       - : A string with the value of the cookie.
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -63,67 +63,15 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 
 ## Examples
 
-> [!WARNING]
-> Cookie examples do not run properly within the MDN environment because setting cookies results in an unknown error.
-> The examples can be tested by copying the source code and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or by [building this documentation locally](https://github.com/mdn/content?tab=readme-ov-file#build-the-site).
+<!-- The examples don't work as live examples in MDN environment (due to unknown errors) -->
 
 ### Setting a cookie with name and value
 
-The following example sets a cookie by passing a `name` and `value` of "cookie1" and "cookie1-value", respectively.
+This example sets a cookie by passing a `name` and `value` of "cookie1" and "cookie1-value", respectively.
 The other properties of the cookie are set with default values, as defined in the [`options`](#options) parameter.
 
-```html hidden
-<button id="showCookies" type="button">Show cookie</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 180px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function clearLog() {
-  logElement.innerText = "";
-}
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js hidden
-function logCookie(name, cookie) {
-  clearLog();
-  if (cookie) {
-    log(`${name}:`);
-    for (const [key, value] of Object.entries(cookie)) {
-      log(` ${key}: ${value}`);
-    }
-  } else {
-    log(`${name}: Cookie not found`);
-  }
-}
-```
-
-#### JavaScript
-
-The code first waits for the cookie to be set within a `try...catch` block, as setting a cookie can throw an exception.
-It then gets the same cookie and displays its properties (note that some logging and other display code is omitted).
+The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged.
+It then gets the same cookie and displays its properties.
 
 ```js
 async function cookieTest() {
@@ -131,90 +79,29 @@ async function cookieTest() {
   try {
     await cookieStore.set("cookie1", "cookie1-value");
   } catch (error) {
-    log(`Error setting cookie1: ${error}`);
+    console.log(`Error setting cookie1: ${error}`);
   }
 
   // Get the cookie and log its values
   const cookie = await cookieStore.get("cookie1");
-  logCookie("cookie1", cookie);
+  console.log(cookie);
 }
 ```
 
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", () => {
-  cookieTest();
-});
-```
-
-#### Result
-
-Press **Show cookie** to set the cookie and then display it.
+When run in a browser this will display information about "cookie1" in the console.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 
-{{EmbedLiveSample('Setting a cookie with name and value', 100, 250)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ### Setting a cookie with options
 
-The following example sets a cookie by passing an `options` object with `name`, `value`, `expires`, and `partitioned`.
-
-```html hidden
-<button id="showCookies" type="button">Show cookie</button>
-<button id="reset" type="button">Reset</button>
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 180px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const reload = document.querySelector("#reset");
-
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-
-const logElement = document.querySelector("#log");
-
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-
-function clearLog() {
-  logElement.innerText = "";
-}
-```
-
-```js hidden
-function logCookie(name, cookie) {
-  if (cookie) {
-    log(`${name}:`);
-    for (const [key, value] of Object.entries(cookie)) {
-      log(` ${key}: ${value}`);
-    }
-  } else {
-    log(`${name}: Cookie not found`);
-  }
-}
-```
-
-#### JavaScript
+This example sets a cookie by passing an `options` object with `name`, `value`, `expires`, and `partitioned`.
 
 The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged.
-The example then gets the new cookie, if it exists, and logs its properties (note the logging and other display code is omitted).
+The example then gets the new cookie, if it exists, and logs its properties.
 
 ```js
 async function cookieTest() {
-  clearLog();
-
   const day = 24 * 60 * 60 * 1000;
   const cookieName = "cookie2";
   try {
@@ -223,6 +110,7 @@ async function cookieTest() {
       name: cookieName,
       value: `${cookieName}-value`,
       expires: Date.now() + day,
+      partitioned: true,
     });
   } catch (error) {
     log(`Error setting ${cookieName}: ${error}`);
@@ -231,27 +119,15 @@ async function cookieTest() {
 
   // Log the new cookie
   const cookie = await cookieStore.get(cookieName);
-  logCookie(cookieName, cookie);
+  console.log(cookie);
 }
 ```
 
-Note that some logging and other code is omitted for brevity.
-
-```js hidden
-const showCookies = document.querySelector("#showCookies");
-
-showCookies.addEventListener("click", () => {
-  cookieTest();
-});
-```
-
-#### Result
-
-Press **Show cookie** to set the cookie and then display it.
+When run in a browser this will display information about "cookie1" in the console.
 Note that some browsers will only display the `name` and `value`, while others will display all the properties of the cookie.
 Even if the values are not displayed, they are still set.
 
-{{EmbedLiveSample('Setting a cookie with options', 100, 250)}}
+The code can be tested by copying it into a test harness and running it with a [local server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server), or deploying it to a website site such as GitHub pages.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -190,18 +190,27 @@ function logCookie(name, cookie) {
 
 #### JavaScript
 
-The example code first awaits for the cookie to be set, then waits to get the value and log it (note the logging and other display code is omitted).
+The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged.
+The example then gets the new cookie, if it exists, and logs its properties (note the logging and other display code is omitted).
 
 ```js
 async function cookieTest() {
   const day = 24 * 60 * 60 * 1000;
-  await cookieStore.set({
-    name: "cookie2",
-    value: `cookie2-value`,
-    expires: Date.now() + day,
-    partitioned: true,
-  });
 
+  try {
+    // Set cookie
+    await cookieStore.set({
+      name: "cookie2",
+      value: `cookie2-value`,
+      expires: Date.now() + day,
+      partitioned: true,
+    });
+  } catch (error) {
+    log(`Error setting cookie2: ${error}`);
+    console.log(error);
+  }
+
+  // Log the new cookie
   const cookie = await cookieStore.get("cookie2");
   logCookie("cookie2", cookie);
 }

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -120,7 +120,6 @@ function logCookie(name, cookie) {
 #### JavaScript
 
 The example code first waits for the cookie to be set, then waits to get the value, then logs the value (note that the logging and other display code is omitted).
-Note that asynchronous code is called within an `async` function because you can't `await` on a top level function.
 
 ```js
 async function cookieTest() {

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -201,7 +201,6 @@ function logCookie(name, cookie) {
 #### JavaScript
 
 The example code first awaits for the cookie to be set, then waits to get the value and log it (note the logging and other display code is omitted).
-Note that asynchronous code is called within an `async` function because you can't `await` on a top level function.
 
 ```js
 async function cookieTest() {
@@ -217,6 +216,8 @@ async function cookieTest() {
   logCookie("cookie2", cookie);
 }
 ```
+
+Note that some logging and other code is omitted for brevity.
 
 ```js hidden
 const showCookies = document.querySelector("#showCookies");


### PR DESCRIPTION
FF134 adds support for a (large) subset of the Cookie Store API.

The docs are good, but perhaps a little "thin" on examples. I created some live examples in order to test my understanding: this PR adds them to the docs. 
Note that they are not perfect - it is hard to control the domain etc in live examples, and hence demonstrate some of the API options.

Related docs work can be tracked in #37929
