### PR TITLE
Correct static image reference path in Django tutorial

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/home_page/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/home_page/index.md
@@ -339,7 +339,7 @@ You can add an image into the page in a similar way, for example:
 ```django
 {% load static %}
 <img
-  src="{% static 'catalog/images/local_library_model_uml.png' %}"
+  src="{% static 'images/local_library_model_uml.png' %}"
   alt="UML diagram"
   style="width:555px;height:540px;" />
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct image path for referencing in the Django Tutorial Part 5: Creating our home page

### Motivation

While following along the tutorial, I encounter a error that shows server can not locate the image file. 
The log shows the path in the document is incorrect.

### Additional details

Verified locally, after removing `catalog/` the image can be displayed on the website.
Thanks to @hamishwillee for reviewing the issue, only the documentation need to fix, the path inside [django-locallibrary-tutorial](https://github.com/mdn/django-locallibrary-tutorial/blob/main/catalog/templates/index.html#L15) repository is correct.

### Related issues and pull requests

Fixes #38082

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
