### PR TITLE
fix(typos): Fix repeated words

### DIFF
--- a/files/en-us/learn_web_development/getting_started/environment_setup/browsing_the_web/index.md
+++ b/files/en-us/learn_web_development/getting_started/environment_setup/browsing_the_web/index.md
@@ -152,7 +152,7 @@ For now, try opening a web browser and loading up a couple of your favorite site
 
 As a web developer, you will spend a lot of time searching for information, from syntax you can't remember to solutions to specific problems. It is therefore a good idea to learn how to effectively search the web.
 
-If you are looking for general information about a specific web technology feature, you should type the name of the feature into the MDN search box. For example, try typing `box model`, `fetch()` or `video element` into the the search box and see what comes up. If you don't find the information you need, try expanding your search — try your search term in a search engine.
+If you are looking for general information about a specific web technology feature, you should type the name of the feature into the MDN search box. For example, try typing `box model`, `fetch()` or `video element` into the search box and see what comes up. If you don't find the information you need, try expanding your search — try your search term in a search engine.
 
 If you are looking for a solution to a specific problem, such as `how to print out the fibonacci sequence with JavaScript` or `how to calculate whether a number is a prime number with JavaScript`, it is a good idea to search on a website such as [StackOverflow](https://stackoverflow.com), which is a community dedicated to answering programming problems. Again, try using a general search engine if a specific site doesn't give you a helpful answer.
 

--- a/files/en-us/mozilla/firefox/releases/130/index.md
+++ b/files/en-us/mozilla/firefox/releases/130/index.md
@@ -18,7 +18,7 @@ This article provides information about the changes in Firefox 130 that affect d
 ### CSS
 
 - The [`hyphens`](/en-US/docs/Web/CSS/hyphens) CSS property is now properly supported for Czech and Slovak languages.
-  Among other things, this ensures that words will will no longer split on syllables ([Firefox bug 1908931](https://bugzil.la/1908931)).
+  Among other things, this ensures that words will no longer split on syllables ([Firefox bug 1908931](https://bugzil.la/1908931)).
 
 ### APIs
 
@@ -60,7 +60,7 @@ These features are newly shipped in Firefox 130 but are disabled by default. To 
 - **Request video frame callback:** `media.rvfc.enabled`.
 
   The {{domxref('HTMLVideoElement/requestVideoFrameCallback','requestVideoFrameCallback()')}} method of the {{domxref('HTMLVideoElement')}} interface registers a callback function that runs when a new video frame is sent to the compositor. This enables developers to perform efficient operations on each video frame, such as video analysis, painting to a canvas, synchronization with external audio sources, and so on. The method returns a callback handle that can be passed to {{domxref('HTMLVideoElement.cancelVideoFrameCallback()')}} in order to cancel the outstanding callback request.
-  Both methods are are enabled by default on the nightly build. ([Firefox bug 1800882](https://bugzil.la/1800882)).
+  Both methods are enabled by default on the nightly build. ([Firefox bug 1800882](https://bugzil.la/1800882)).
 
 - **CSP violation reports using the Reporting API:** `dom.reporting.enabled`.
 

--- a/files/en-us/web/api/htmlelement/beforetoggle_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforetoggle_event/index.md
@@ -18,7 +18,7 @@ Among other things, this event can be used to:
 
 - prevent an element from being shown.
 - add or remove classes or properties from the element or associated elements, for example to control the animation behaviour of a dialog as it is opened and closed.
-- clear the state of the element before before it is opened or after it is hidden, for example to reset a dialog form and return value to an empty state, or hide any nested manual popovers when reopening a popup.
+- clear the state of the element before it is opened or after it is hidden, for example to reset a dialog form and return value to an empty state, or hide any nested manual popovers when reopening a popup.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -78,7 +78,7 @@ This example demonstrates how you can set the focus on a button element.
 
 First we define three buttons.
 Both the middle and right button will set focus on the left-most button.
-The right right-most button will also specify `focusVisible`.
+The right-most button will also specify `focusVisible`.
 
 ```html
 <button id="myButton">Button</button>

--- a/files/en-us/web/api/htmltextareaelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmltextareaelement/selectionstart/index.md
@@ -12,7 +12,7 @@ The **`selectionStart`** property of the {{domxref("HTMLTextAreaElement")}} inte
 
 When nothing is selected, the value of both the `selectionStart` and {{domxref("HTMLTextAreaElement.selectionEnd", "selectionEnd")}} is the position of the cursor (caret) inside the `<textarea>` element.
 
-Setting `selectionStart` to a value greater then the current value of {{domxref("HTMLTextAreaElement.selectionEnd", "selectionEnd")}} updates both the the `selectionStart` and `selectionEnd` properties to that value. If that value is equal to or greater than the {{domxref("HTMLTextAreaElement.textLength", "textLength")}}, both properties are both set to the `textLength` property value.
+Setting `selectionStart` to a value greater then the current value of {{domxref("HTMLTextAreaElement.selectionEnd", "selectionEnd")}} updates both the `selectionStart` and `selectionEnd` properties to that value. If that value is equal to or greater than the {{domxref("HTMLTextAreaElement.textLength", "textLength")}}, both properties are both set to the `textLength` property value.
 
 The property value can be retrieved and set without the `<textarea>` having focus, but the element does need to have focus for the {{cssxref("::selection")}} pseudo-element to match the selected text.
 

--- a/files/en-us/web/api/svgrect/height/index.md
+++ b/files/en-us/web/api/svgrect/height/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SVGRect.height
 
 The **`height`** property of the {{domxref("SVGRect")}} interface is an alias for the {{DOMXref("DOMRect.height")}} property. It describes the vertical size of the element. It reflects the SVG element's {{SVGattr("height")}} attribute and the CSS {{cssxref("height")}} property.
 
-The height is a length; it is the distance from the top of element to the bottom of the element in the the user coordinate system. Its syntax is the same as that for [`<length>`](/en-US/docs/Web/SVG/Content_type#length).
+The height is a length; it is the distance from the top of element to the bottom of the element in the user coordinate system. Its syntax is the same as that for [`<length>`](/en-US/docs/Web/SVG/Content_type#length).
 
 ## Usage context
 

--- a/files/en-us/web/api/svgrect/width/index.md
+++ b/files/en-us/web/api/svgrect/width/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SVGRect.width
 
 The **`width`** property of the {{domxref("SVGRect")}} interface is an alias for the {{DOMXref("DOMRect.width")}} property. It describes the horizontal size of the element. It reflects the SVG element's {{SVGattr("width")}} attribute and the CSS {{cssxref("width")}} property.
 
-The width is a length; it is the distance from the left of element to the right of the element in the the user coordinate system. Its syntax is the same as that for [`<length>`](/en-US/docs/Web/SVG/Content_type#length).
+The width is a length; it is the distance from the left of element to the right of the element in the user coordinate system. Its syntax is the same as that for [`<length>`](/en-US/docs/Web/SVG/Content_type#length).
 
 ## Usage context
 

--- a/files/en-us/web/css/@font-face/font-weight/index.md
+++ b/files/en-us/web/css/@font-face/font-weight/index.md
@@ -161,7 +161,7 @@ The other three declarations use the light, bold, and extra-bold versions of the
 - the bold font is associated with the range 500-700
 - the extra-bold font is associated with the range 700-1000
 
-The CSS [cascade](/en-US/docs/Web/CSS/Cascade) ensures that the three latter declarations override parts of the the range that was set in the `FiraSans-Regular` declaration.
+The CSS [cascade](/en-US/docs/Web/CSS/Cascade) ensures that the three latter declarations override parts of the range that was set in the `FiraSans-Regular` declaration.
 
 ```css
 @font-face {
@@ -234,7 +234,7 @@ We include a variable font, ["League Mono"](https://www.theleagueofmoveabletype.
 
 #### HTML
 
-We include a paragraph with `<output>` initially set to `400`, as that is the the default font-weight for unstyled paragraph text. This paragraph is nestled between two other paragraphs, so you can compare rendered versus declared font weight values.
+We include a paragraph with `<output>` initially set to `400`, as that is the default font-weight for unstyled paragraph text. This paragraph is nestled between two other paragraphs, so you can compare rendered versus declared font weight values.
 
 We include an {{htmlelement("input/range")}} of type `range`, nested in a {{htmlelement("label")}}, setting the `step` to `50`.
 

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -390,7 +390,7 @@ When we specify our grid area using the `grid-area` property we first define bot
 
 We can also count backwards from the block and inline ends of the grid, for English that would be the right-hand column line and final row line. The last lines of the explicit grid can be addressed as `-1`, and you can count back from there – so the second to last line is `-2`.
 
-Do note that negative values are relevant only to the explicit grid. The final line is the final line of the the grid defined by `grid-template-columns` and `grid-template-rows`, and does not take into account any rows or columns added in the _implicit grid_ outside of that.
+Do note that negative values are relevant only to the explicit grid. The final line is the final line of the grid defined by `grid-template-columns` and `grid-template-rows`, and does not take into account any rows or columns added in the _implicit grid_ outside of that.
 
 In this next example, we have flipped the layout we were working with by working from the right and bottom of our grid when placing the items.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -112,7 +112,7 @@ An `<easing-function>` can be one of the following types:
         ![Two graphs of Input progress to Output progress. In the step-start graph, an unfilled circle represents the origin point (0, 0), with a horizontal line extending from (0, 1) to (1, 1). In the step-end graph, a horizontal line extends from the origin to (1, 0), with an unfilled circle at (1,0) and a solid circle at (1, 1).](step.svg)
 
     - {{cssxref("easing-function/steps", "steps()")}}
-      - : Creates a stair-shaped curve using an {{cssxref("&lt;integer&gt;")}} to specify the number of intervals and an optional optional keyword to control the timing of jumps.
+      - : Creates a stair-shaped curve using an {{cssxref("&lt;integer&gt;")}} to specify the number of intervals and an optional keyword to control the timing of jumps.
 
 ## Formal syntax
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -39,7 +39,7 @@ The {{htmlelement("input")}} element types that don't support auto-correction al
 For all other editable elements, setting any other value than those listed above is always treated as `on`.
 The default value for elements that are not nested inside a `<form>` is `on`.
 
-When nested in a `<form>`, the following elements inherit their their default value of `autocorrect` from the form if it has been set: {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}.
+When nested in a `<form>`, the following elements inherit their default value of `autocorrect` from the form if it has been set: {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -298,7 +298,7 @@ Headers used by the [WebSockets API](/en-US/docs/Web/API/WebSockets_API) in the 
   - : Request header containing a key that verifies that the client explicitly intends to open a `WebSocket`.
 - {{HTTPHeader("Sec-WebSocket-Protocol")}}
   - : In requests, this header indicates the sub-protocols supported by the client in preferred order.
-    In responses, it indicates the the sub-protocol selected by the server from the client's preferences.
+    In responses, it indicates the sub-protocol selected by the server from the client's preferences.
 - {{HTTPHeader("Sec-WebSocket-Version")}}
   - : In requests, this header indicates the version of the WebSocket protocol used by the client.
     In responses, it is sent only if the requested protocol version is not supported by the server, and lists the versions that the server supports.

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/index.md
@@ -68,7 +68,7 @@ The IANA time zone database changes from time to time, usually to add new time z
 | `Asia/Ho_Chi_Minh`               | `Asia/Saigon`                   |
 | `Europe/Kyiv`                    | `Europe/Kiev`                   |
 
-Historically, these renames caused problems for programmers because the the Unicode [CLDR database](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-bcp47/bcp47/timezone.json) (a library used by browsers rely on to supply time zone identifiers and data) did not follow IANA's renaming for [stability reasons](https://unicode.org/reports/tr35/#Time_Zone_Identifiers). As a result, some browsers like Chrome and Safari reported CLDR's outdated identifiers, while other browsers like Firefox overrode CLDR's defaults and reported the up-to-date primary identifiers.
+Historically, these renames caused problems for programmers because the Unicode [CLDR database](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-bcp47/bcp47/timezone.json) (a library used by browsers rely on to supply time zone identifiers and data) did not follow IANA's renaming for [stability reasons](https://unicode.org/reports/tr35/#Time_Zone_Identifiers). As a result, some browsers like Chrome and Safari reported CLDR's outdated identifiers, while other browsers like Firefox overrode CLDR's defaults and reported the up-to-date primary identifiers.
 
 With the introduction of Temporal, this behavior is now more standardized:
 


### PR DESCRIPTION
### Description

Fix some duplicate word typos, found using variations of this:

```
\b([a-zA-Z]{3,})\s+\1\b
```

### Related issues and pull requests

Folow-up from:

- [x] https://github.com/mdn/content/pull/38070