### PR TITLE
fix wrong macros in HTMLCanvasElement `height` property

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/height/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/height/index.md
@@ -49,10 +49,10 @@ console.log(canvas.height); // 300
 ## See also
 
 - {{domxref("HTMLCanvasElement")}}: Interface used to define the `HTMLCanvasElement.height` property
-- {{domxref("HTMLCanvasElement.width")}}: Other property used to control the size of the canvas
-- {{domxref("HTMLEmbedElement.width")}}
-- {{domxref("HTMLIFrameElement.width")}}
-- {{domxref("HTMLImageElement.width")}}
-- {{domxref("HTMLObjectElement.width")}}
-- {{domxref("HTMLSourceElement.width")}}
-- {{domxref("HTMLVideoElement.width")}}
+- {{domxref("HTMLCanvasElement.height")}}: Other property used to control the size of the canvas
+- {{domxref("HTMLEmbedElement.height")}}
+- {{domxref("HTMLIFrameElement.height")}}
+- {{domxref("HTMLImageElement.height")}}
+- {{domxref("HTMLObjectElement.height")}}
+- {{domxref("HTMLSourceElement.height")}}
+- {{domxref("HTMLVideoElement.height")}}

--- a/files/en-us/web/api/htmlcanvaselement/height/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/height/index.md
@@ -49,7 +49,7 @@ console.log(canvas.height); // 300
 ## See also
 
 - {{domxref("HTMLCanvasElement")}}: Interface used to define the `HTMLCanvasElement.height` property
-- {{domxref("HTMLCanvasElement.height")}}: Other property used to control the size of the canvas
+- {{domxref("HTMLCanvasElement.width")}}: Other property used to control the size of the canvas
 - {{domxref("HTMLEmbedElement.height")}}
 - {{domxref("HTMLIFrameElement.height")}}
 - {{domxref("HTMLImageElement.height")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/height
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/htmlcanvaselement/height/index.md
* Last commit: https://github.com/mdn/content/commit/c16ab7959173ec929df57d3916f8f4dbce485709
