### PR TITLE
Mention non-standard external.getHostEnvironmentValue

### DIFF
--- a/files/en-us/web/api/window/external/index.md
+++ b/files/en-us/web/api/window/external/index.md
@@ -24,7 +24,7 @@ The `External` object has the following methods:
     </tr>
     <tr>
       <td>
-        <code>AddSearchProvider(<em>descriptionURL)</em></code>
+        <code>AddSearchProvider(descriptionURL)</code>
       </td>
       <td>
         Dummy function; does nothing. See
@@ -36,6 +36,10 @@ The `External` object has the following methods:
     <tr>
       <td><code>IsSearchProviderInstalled()</code></td>
       <td>Dummy function; does nothing.</td>
+    </tr>
+    <tr>
+      <td><code>getHostEnvironmentValue(name)</code> {{non-standard_inline}}</td>
+      <td>Microsoft Edge proprietary API. See <a href="https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/mt795399(v=vs.85)">Microsoft docs</a> for more information.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/37198. Though this property is deprecated and non-standard, I think it's relatively low-stakes to document its existence, and it meets our documentation criteria anyway.