### PR TITLE
add missing return statement

### DIFF
--- a/files/en-us/learn_web_development/extensions/async_js/implementing_a_promise-based_api/index.md
+++ b/files/en-us/learn_web_development/extensions/async_js/implementing_a_promise-based_api/index.md
@@ -78,6 +78,7 @@ function alarm(person, delay) {
   return new Promise((resolve, reject) => {
     if (delay < 0) {
       reject(new Error("Alarm delay must not be negative"));
+      return;
     }
     setTimeout(() => {
       resolve(`Wake up, ${person}!`);
@@ -132,6 +133,7 @@ function alarm(person, delay) {
   return new Promise((resolve, reject) => {
     if (delay < 0) {
       reject(new Error("Alarm delay must not be negative"));
+      return;
     }
     setTimeout(() => {
       resolve(`Wake up, ${person}!`);
@@ -190,6 +192,7 @@ function alarm(person, delay) {
   return new Promise((resolve, reject) => {
     if (delay < 0) {
       reject(new Error("Alarm delay must not be negative"));
+      return;
     }
     setTimeout(() => {
       resolve(`Wake up, ${person}!`);

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -183,6 +183,7 @@ function myCoolPromiseAPI(/* …, */ { signal }) {
     // If the signal is already aborted, immediately throw in order to reject the promise.
     if (signal.aborted) {
       reject(signal.reason);
+      return;
     }
 
     // Perform the main purpose of the API


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

if the abort signal has already been fired, this function should not continue making a request (or whatever the "main purpose of the API" might be) or setting up an event listener that will never be called.
