### PR TITLE
Update Content-Range to add 416 example

### DIFF
--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -9,6 +9,8 @@ browser-compat: http.headers.Content-Range
 
 The HTTP **`Content-Range`** {{Glossary("response header")}} is used in [range requests](/en-US/docs/Web/HTTP/Range_requests) to indicate where the content of a response body belongs in relation to a complete resource.
 
+It should only be included in {{HTTPStatus("206", "206 Partial Content")}} or {{HTTPStatus("416", "416 Range Not Satisfiable")}} responses.
+
 <table class="properties">
   <tbody>
     <tr>
@@ -34,8 +36,8 @@ The HTTP **`Content-Range`** {{Glossary("response header")}} is used in [range r
 ## Syntax
 
 ```http
-Content-Range: <unit> <range-start>-<range-end>/<size>
-Content-Range: <unit> <range-start>-<range-end>/*
+Content-Range: <unit> <range>/<size>
+Content-Range: <unit> <range>/*
 Content-Range: <unit> */<size>
 ```
 
@@ -44,27 +46,38 @@ Content-Range: <unit> */<size>
 - `<unit>`
   - : The unit for specifying ranges.
     Currently, only `bytes` is supported.
-- `<range-start>`
-  - : An integer in the given unit indicating the start position (zero-indexed & inclusive) of the request range.
-- `<range-end>`
-  - : An integer in the given unit indicating the end position (zero-indexed & inclusive) of the requested range.
+- `<range>`
+  - : A range with the format `<range-start>-<range-end>`, where `<range-start>` and `<range-end>` are integers for the start and end position (zero-indexed & inclusive) of the range in the given `<unit>`, respectively.
+    `*` is used in a {{httpstatus("416")}} (Range Not Satisfiable) response to indicate that the value is not a range.
 - `<size>`
   - : The total length of the document (or `*` if unknown).
 
 ## Examples
 
+### Partial content response
+
+This {{HTTPStatus("206", "206 Partial Content")}} response shows a partial response, with the `Content-Range` indicating that it contains the first 1024 bytes of a 146515 byte file.
+
 ```http
-Content-Range: bytes 200-1000/67589
+HTTP/2 206
+content-type: image/jpeg
+content-length: 1024
+content-range: bytes 0-1023/146515
+…
+
+(binary content)
 ```
 
 ### Range not satisfiable
 
-If the server cannot satisfy the requested range request, it should respond with 416 Range Not Satisfiable and a header like this:
+If the server cannot satisfy the requested range request, it should respond with a {{HTTPStatus("416", "416 Range Not Satisfiable")}} status, and the `Content-Range` should specify `*` for the range along with the total size of the resource.
 
 ```http
+HTTP/2 416
+
 Content-Range: bytes */67589
 ```
-
+   
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -48,7 +48,7 @@ Content-Range: <unit> */<size>
     Currently, only `bytes` is supported.
 - `<range>`
   - : A range with the format `<range-start>-<range-end>`, where `<range-start>` and `<range-end>` are integers for the start and end position (zero-indexed & inclusive) of the range in the given `<unit>`, respectively.
-    `*` is used in a {{httpstatus("416")}} (Range Not Satisfiable) response to indicate that the value is not a range.
+    `*` is used in a {{HTTPStatus("416", "416 Range Not Satisfiable")}} response to indicate that the value is not a range.
 - `<size>`
   - : The total length of the document (or `*` if unknown).
 
@@ -77,7 +77,7 @@ HTTP/2 416
 
 Content-Range: bytes */67589
 ```
-   
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -57,6 +57,14 @@ Content-Range: <unit> */<size>
 Content-Range: bytes 200-1000/67589
 ```
 
+### Range not satisfiable
+
+If the server cannot satisfy the requested range request, it should respond with 416 Range Not Satisfiable and a header like this:
+
+```http
+Content-Range: bytes */67589
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
### Description

This PR adds an example to the [Content-Range header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range) doc about "range not satisfiable" responses.

### Motivation

I wanted to learn more about the Content-Range header. The MDN page says `Content-Range: <unit> */<size>` is a valid syntax, but it doesn't explain what that syntax means. I had to read the RFC to find the answer. This PR adds the answer to the MDN page.

### Additional details

- [RFC 7233 HTTP/1.1 Range Requests](https://www.rfc-editor.org/rfc/rfc7233)
	- [4.2. Content-Range](https://www.rfc-editor.org/rfc/rfc7233#section-4.2)
	- [4.4. 416 Range Not Satisfiable](https://www.rfc-editor.org/rfc/rfc7233#section-4.4)

### Related issues and pull requests

N/A