### PR TITLE
More precisely specify inert behavior

### DIFF
--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -11,8 +11,7 @@ browser-compat: api.HTMLDialogElement.showModal
 The **`showModal()`** method of the
 {{domxref("HTMLDialogElement")}} interface displays the dialog as a modal, over the top
 of any other dialogs that might be present. It displays in the {{glossary("top layer")}}, along with a
-{{cssxref('::backdrop')}} pseudo-element. Interaction outside the dialog is blocked and
-the content outside it is rendered inert.
+{{cssxref('::backdrop')}} pseudo-element. Elements inside the same document as the dialog, except the dialog and its descendants, become _inert_ (as if the [`inert`](/en-US/docs/Web/HTML/Global_attributes/inert) attribute is specified). Only the containing document becomes blocked; if the dialog is rendered inside an iframe, the rest of the page remains interactive.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -10,8 +10,7 @@ browser-compat: api.HTMLElement.inert
 
 The {{domxref("HTMLElement")}} property **`inert`** reflects the value of the element's [`inert`](/en-US/docs/Web/HTML/Global_attributes/inert) attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
 
-> [!NOTE]
-> Do not nest interactive elements or important content within elements with the `inert` attribute as inert content and their descendants are neither focusable nor perceivable by all users.
+Note that if the `inert` attribute is unspecified, the element itself may still inherit inertness from its parent. However, that inherited inertness is not reflected by this property's value.
 
 ## Value
 

--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -7,7 +7,7 @@ browser-compat: html.global_attributes.inert
 
 {{HTMLSidebar("Global_attributes")}}
 
-The **`inert`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a Boolean attribute indicating that the browser will ignore the element. With the `inert` attribute, all of the element's flat tree descendants (such as modal {{htmlelement("dialog")}}s) that don't otherwise escape inertness are ignored. The `inert` attribute also makes the browser ignore input events sent by the user, including focus-related events and events from assistive technologies.
+The **`inert`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is a Boolean attribute indicating that the element and all of its flat tree descendants become _inert_. Modal {{htmlelement("dialog")}}s generated with [`showModal()`](/en-US/docs/Web/API/HTMLDialogElement/showModal) escape inertness, meaning that they don't inherit inertness from their ancestors, but can only be made inert by having the `inert` attribute explicitly set on themselves.
 
 Specifically, `inert` does the following:
 


### PR DESCRIPTION
- Fix https://github.com/mdn/content/issues/35189
- Fix https://github.com/mdn/content/issues/34619

The main confusion about "escaping inertness" is because https://github.com/mdn/content/pull/22465 misplaced the "(such as modal {{htmlelement("dialog")}}s)" parenthetical. This part is meant to exemplify "escape inertness", not "all of the element's flat tree descendants". It's actually quite the opposite.