### PR TITLE
Mention HTMLElement.lang inheritance not reflected by IDL

### DIFF
--- a/files/en-us/web/api/htmlelement/lang/index.md
+++ b/files/en-us/web/api/htmlelement/lang/index.md
@@ -8,21 +8,13 @@ browser-compat: api.HTMLElement.lang
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLElement.lang`** property gets or sets the base
-language of an element's attribute values and text content.
+The **`lang`** property of the {{domxref("HTMLElement")}} interface indicates the base language of an element's attribute values and text content, in the form of a {{RFC(5646, "BCP 47 language identifier tag")}}. It reflects the element's [`lang`](/en-US/docs/Web/HTML/Global_attributes/lang) attribute; the `xml:lang` attribute does not affect this property.
 
-The language code returned by this property is defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
-Common examples include "en" for English, "ja" for
-Japanese, "es" for Spanish and so on. The default value of this attribute is
-`unknown`. Note that this attribute, though valid at the individual element
-level described here, is most often specified for the root element of the document.
-
-This also only works with the `lang` attribute and not with
-`xml:lang`.
+Note that if the `lang` attribute is unspecified, the element itself may still inherit the language from its parent. However, that inherited language is not reflected by this property's value.
 
 ## Value
 
-A string.
+A string. Common examples include "en" for English, "ja" for Japanese, "es" for Spanish and so on. If unspecified, the value is an empty string.
 
 ## Examples
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/37680 by adopting the same language as `HTMLElement.dir`. Also remove some confusing information like the default value being `unknown` (it's true but unobservable).