### PR TITLE
window.location.search can be paramsString in URLSearchParams example

### DIFF
--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -98,7 +98,7 @@ console.log(searchParams.get("foo")); // "bar"
 
 ### Parsing window.location
 
-The {{domxref("Location")}} interface does not provide a readily-available `searchParams` property, like {{domxref("URL")}} does. We can parse `location.search` with `URLSearchParams`.
+Unlike {{domxref("URL")}}, the {{domxref("Location")}} interface does not provide a readily-available `searchParams` property. We can parse `location.search` with `URLSearchParams`.
 
 ```js
 // Assume page has location:

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -62,6 +62,7 @@ Although `URLSearchParams` is functionally similar to a {{jsxref("Map")}}, when 
 ## Examples
 
 ```js
+// const paramsString = window.location.search;
 const paramsString = "q=URLUtils.searchParams&topic=api";
 const searchParams = new URLSearchParams(paramsString);
 

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -61,8 +61,9 @@ Although `URLSearchParams` is functionally similar to a {{jsxref("Map")}}, when 
 
 ## Examples
 
+### Using URLSearchParams
+
 ```js
-// const paramsString = window.location.search;
 const paramsString = "q=URLUtils.searchParams&topic=api";
 const searchParams = new URLSearchParams(paramsString);
 
@@ -84,14 +85,27 @@ console.log(searchParams.delete("topic"));
 console.log(searchParams.toString()); // "q=URLUtils.searchParams"
 ```
 
+Search parameters can also be an object.
+
 ```js
-// Search parameters can also be an object
 const paramsObj = { foo: "bar", baz: "bar" };
 const searchParams = new URLSearchParams(paramsObj);
 
 console.log(searchParams.toString()); // "foo=bar&baz=bar"
 console.log(searchParams.has("foo")); // true
 console.log(searchParams.get("foo")); // "bar"
+```
+
+### Parsing window.location
+
+The {{domxref("Location")}} interface does not provide a readily-available `searchParams` property, like {{domxref("URL")}} does. We can parse `location.search` with `URLSearchParams`.
+
+```js
+// Assume page has location:
+// https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams?foo=a
+const paramsString = window.location.search;
+const searchParams = new URLSearchParams(paramsString);
+console.log(searchParams.get("foo")); // a
 ```
 
 ### Duplicate search parameters


### PR DESCRIPTION
See https://github.com/mdn/mdn/issues/634

For example, if you go to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams?a=b#examples 
then you can run the following in the browser console:
```js
new URLSearchParams(window.location.search).get('a');
```
and you'll get:
```js
"b"
```
<img width="384" alt="window.location.search gives you ?a=b and running my example code gives you the value 'b'" src="https://github.com/user-attachments/assets/6d3280e3-056c-4427-9133-84ff45d4c715" />
