### PR TITLE
move rel="alternate stylesheet" from CSS guide to HTML attribute

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -134,7 +134,7 @@
 /en-US/docs/Addons/Add-on_guidelines	https://extensionworkshop.com/documentation/publish/add-on-policies/
 /en-US/docs/Addons/Working_with_AMO	/en-US/docs/Mozilla/Add-ons
 /en-US/docs/Advanced_styling_for_HTML_forms	/en-US/docs/Learn_web_development/Extensions/Forms/Advanced_form_styling
-/en-US/docs/Alternative_style_sheets	/en-US/docs/Web/CSS/Alternative_style_sheets
+/en-US/docs/Alternative_style_sheets	/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet
 /en-US/docs/An_Overview_of_Accessible_Web_Applications_and_Widgets	/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets
 /en-US/docs/An_overview_of_NSS_Internals	https://firefox-source-docs.mozilla.org/security/nss/index.html
 /en-US/docs/Animation	/en-US/docs/Web/API/Animation
@@ -452,7 +452,7 @@
 /en-US/docs/CSS/@supports	/en-US/docs/Web/CSS/@supports
 /en-US/docs/CSS/Adjacent_sibling_selectors	/en-US/docs/Web/CSS/Next-sibling_combinator
 /en-US/docs/CSS/Alias	/en-US/docs/Web/CSS/cursor
-/en-US/docs/CSS/Alternative_style_sheets	/en-US/docs/Web/CSS/Alternative_style_sheets
+/en-US/docs/CSS/Alternative_style_sheets	/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet
 /en-US/docs/CSS/At-rule	/en-US/docs/Web/CSS/At-rule
 /en-US/docs/CSS/Attribute_selectors	/en-US/docs/Web/CSS/Attribute_selectors
 /en-US/docs/CSS/Aural	/en-US/docs/Web/CSS/@media/aural
@@ -11813,6 +11813,7 @@
 /en-US/docs/Web/CSS/Adjacent_sibling_selectors	/en-US/docs/Web/CSS/Next-sibling_combinator
 /en-US/docs/Web/CSS/Alias	/en-US/docs/Web/CSS/cursor
 /en-US/docs/Web/CSS/All_About_The_Containing_Block	/en-US/docs/Web/CSS/CSS_display/Containing_block
+/en-US/docs/Web/CSS/Alternative_style_sheets	/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet
 /en-US/docs/Web/CSS/Aural	/en-US/docs/Web/CSS/@media/aural
 /en-US/docs/Web/CSS/Block_formatting_context	/en-US/docs/Web/CSS/CSS_display/Block_formatting_context
 /en-US/docs/Web/CSS/CSS3_Columns	/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -453,7 +453,7 @@
 /en-US/docs/CSS/Adjacent_sibling_selectors	/en-US/docs/Web/CSS/Next-sibling_combinator
 /en-US/docs/CSS/Alias	/en-US/docs/Web/CSS/cursor
 /en-US/docs/CSS/Alternative_style_sheets	/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet
-/en-US/docs/CSS/At-rule	/en-US/docs/Web/CSS/At-rule
+/en-US/docs/CSS/At-rule	/en-US/docs/Web/CSS/CSS_syntax/At-rule
 /en-US/docs/CSS/Attribute_selectors	/en-US/docs/Web/CSS/Attribute_selectors
 /en-US/docs/CSS/Aural	/en-US/docs/Web/CSS/@media/aural
 /en-US/docs/CSS/CSS3_Columns	/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts
@@ -472,7 +472,7 @@
 /en-US/docs/CSS/Cascade	/en-US/docs/Web/CSS/CSS_cascade/Cascade
 /en-US/docs/CSS/Child_selectors	/en-US/docs/Web/CSS/Child_combinator
 /en-US/docs/CSS/Class_selectors	/en-US/docs/Web/CSS/Class_selectors
-/en-US/docs/CSS/Comments	/en-US/docs/Web/CSS/Comments
+/en-US/docs/CSS/Comments	/en-US/docs/Web/CSS/CSS_syntax/Comments
 /en-US/docs/CSS/Common_CSS_Questions	/en-US/docs/Learn_web_development/Howto/Solve_CSS_problems/CSS_FAQ
 /en-US/docs/CSS/Counters	/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters
 /en-US/docs/CSS/Currentcolor	/en-US/docs/Web/CSS/color_value#currentcolor_keyword
@@ -524,7 +524,7 @@
 /en-US/docs/CSS/Scaling_of_SVG_backgrounds	/en-US/docs/Web/CSS/Scaling_of_SVG_backgrounds
 /en-US/docs/CSS/Shorthand_properties	/en-US/docs/Web/CSS/Shorthand_properties
 /en-US/docs/CSS/Specificity	/en-US/docs/Web/CSS/CSS_cascade/Specificity
-/en-US/docs/CSS/Syntax	/en-US/docs/Web/CSS/Syntax
+/en-US/docs/CSS/Syntax	/en-US/docs/Web/CSS/CSS_syntax/Syntax
 /en-US/docs/CSS/Text-overflow_TEST	/en-US/docs/Web/CSS/text-overflow
 /en-US/docs/CSS/Tutorial/Using_CSS_flexible_boxes	/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox
 /en-US/docs/CSS/Tutorials	/en-US/docs/Web/CSS/Tutorials
@@ -3603,7 +3603,7 @@
 /en-US/docs/Glossary/Static_property	/en-US/docs/Glossary/property/JavaScript
 /en-US/docs/Glossary/Transferable_objects	/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
 /en-US/docs/Glossary/Transmission_Control_Protocol_(TCP)	/en-US/docs/Glossary/TCP
-/en-US/docs/Glossary/URI/www_vs_non-www_URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
+/en-US/docs/Glossary/URI/www_vs_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
 /en-US/docs/Glossary/WWW	/en-US/docs/Glossary/World_Wide_Web
 /en-US/docs/Glossary/WebExtension	/en-US/docs/Glossary/WebExtensions
 /en-US/docs/Glossary/Web_Sockets	/en-US/docs/Glossary/WebSockets
@@ -6124,7 +6124,11 @@
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/registerProxyScript	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/unregister	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/moveInSuccession()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/moveInSuccession
-/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/RegisteredUserScript.unregister()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregister
+/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/RegisteredUserScript.unregister()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/RegisteredUserScript/unregister
+/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/RegisteredUserScript/unregister	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/RegisteredUserScript/unregister
+/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/UserScriptOptions	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/UserScriptOptions
+/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/Working_with_userScripts	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/Working_with_userScripts
+/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/onBeforeScript	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/onBeforeScript
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/update()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/update
 /en-US/docs/Mozilla/Add-ons/WebExtensions/Accessible_guidelines	https://extensionworkshop.com/documentation/develop/build-an-accessible-extension/
 /en-US/docs/Mozilla/Add-ons/WebExtensions/Add-on_ID	https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/
@@ -7259,7 +7263,7 @@
 /en-US/docs/The_XSLT_JavaScript_Interface_in_Gecko:Resources	/en-US/docs/Web/API/XSLTProcessor
 /en-US/docs/The_XSLT_JavaScript_Interface_in_Gecko:Setting_Parameters	/en-US/docs/Web/API/XSLTProcessor
 /en-US/docs/The_add-on_bar	/en-US/docs/Mozilla/Firefox/Releases/4/The_add-on_bar
-/en-US/docs/The_data_URL_scheme	/en-US/docs/Web/URI/Schemes/data
+/en-US/docs/The_data_URL_scheme	/en-US/docs/Web/URI/Reference/Schemes/data
 /en-US/docs/Thunderbird/Autoconfiguration	https://www.bucksch.org/1/projects/thunderbird/autoconfiguration/
 /en-US/docs/Thunderbird/Autoconfiguration/FileFormat/Definition	https://www.bucksch.org/1/projects/thunderbird/autoconfiguration/config-file-format.html
 /en-US/docs/Thunderbird/Autoconfiguration/FileFormat/HowTo	https://www.bucksch.org/1/projects/thunderbird/autoconfiguration/how-to-create-your-own
@@ -7686,8 +7690,8 @@
 /en-US/docs/Transforming_XML_with_XSLT:The_Netscape_XSLT_XPath_Reference:Functions	/en-US/docs/Web/XML/XPath/Reference/Functions
 /en-US/docs/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces	/en-US/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 /en-US/docs/URI	/en-US/docs/Glossary/URI
-/en-US/docs/URI/www and non-www URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
-/en-US/docs/URI/www_vs_non-www_URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
+/en-US/docs/URI/www and non-www URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
+/en-US/docs/URI/www_vs_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
 /en-US/docs/URL.createObjectURL	/en-US/docs/Web/API/URL/createObjectURL_static
 /en-US/docs/URLUtilsReadOnly.origin	/en-US/docs/Web/API/WorkerLocation/origin
 /en-US/docs/USA	/en-US/docs/Web/Progressive_web_apps
@@ -9894,10 +9898,14 @@
 /en-US/docs/Web/API/RTCOfferAnswerOptions/voiceActivityDetection	/en-US/docs/Web/API/RTCPeerConnection/createAnswer
 /en-US/docs/Web/API/RTCOfferOptions	/en-US/docs/Web/API/RTCPeerConnection/createOffer
 /en-US/docs/Web/API/RTCOfferOptions/iceRestart	/en-US/docs/Web/API/RTCPeerConnection/createOffer
+/en-US/docs/Web/API/RTCOutboundRtpStreamStats/averageRtcpInterval	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
 /en-US/docs/Web/API/RTCOutboundRtpStreamStats/firCount	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
 /en-US/docs/Web/API/RTCOutboundRtpStreamStats/lastPacketSentTimestamp	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
-/en-US/docs/Web/API/RTCOutboundRtpStreamStats/perDscpPacketsReceived	/en-US/docs/Web/API/RTCOutboundRtpStreamStats/perDscpPacketsSent
+/en-US/docs/Web/API/RTCOutboundRtpStreamStats/perDscpPacketsReceived	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
+/en-US/docs/Web/API/RTCOutboundRtpStreamStats/perDscpPacketsSent	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
 /en-US/docs/Web/API/RTCOutboundRtpStreamStats/pliCount	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
+/en-US/docs/Web/API/RTCOutboundRtpStreamStats/sliCount	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
+/en-US/docs/Web/API/RTCOutboundRtpStreamStats/trackId	/en-US/docs/Web/API/RTCOutboundRtpStreamStats
 /en-US/docs/Web/API/RTCPeerConnection.addStream	/en-US/docs/Web/API/RTCPeerConnection/addStream
 /en-US/docs/Web/API/RTCPeerConnection.close	/en-US/docs/Web/API/RTCPeerConnection/close
 /en-US/docs/Web/API/RTCPeerConnection.getIdentityAssertion	/en-US/docs/Web/API/RTCPeerConnection/getIdentityAssertion
@@ -11814,6 +11822,7 @@
 /en-US/docs/Web/CSS/Alias	/en-US/docs/Web/CSS/cursor
 /en-US/docs/Web/CSS/All_About_The_Containing_Block	/en-US/docs/Web/CSS/CSS_display/Containing_block
 /en-US/docs/Web/CSS/Alternative_style_sheets	/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet
+/en-US/docs/Web/CSS/At-rule	/en-US/docs/Web/CSS/CSS_syntax/At-rule
 /en-US/docs/Web/CSS/Aural	/en-US/docs/Web/CSS/@media/aural
 /en-US/docs/Web/CSS/Block_formatting_context	/en-US/docs/Web/CSS/CSS_display/Block_formatting_context
 /en-US/docs/Web/CSS/CSS3_Columns	/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts
@@ -11946,6 +11955,7 @@
 /en-US/docs/Web/CSS/CSS_values_syntax	/en-US/docs/Web/CSS
 /en-US/docs/Web/CSS/Cascade	/en-US/docs/Web/CSS/CSS_cascade/Cascade
 /en-US/docs/Web/CSS/Child_selectors	/en-US/docs/Web/CSS/Child_combinator
+/en-US/docs/Web/CSS/Comments	/en-US/docs/Web/CSS/CSS_syntax/Comments
 /en-US/docs/Web/CSS/Common_CSS_Questions	/en-US/docs/Learn_web_development/Howto/Solve_CSS_problems/CSS_FAQ
 /en-US/docs/Web/CSS/Compositing_and_Blending	/en-US/docs/Web/CSS/CSS_compositing_and_blending
 /en-US/docs/Web/CSS/Containing_block	/en-US/docs/Web/CSS/CSS_display/Containing_block
@@ -11977,6 +11987,7 @@
 /en-US/docs/Web/CSS/Selector_lists	/en-US/docs/Web/CSS/Selector_list
 /en-US/docs/Web/CSS/Selectors	/en-US/docs/Web/CSS/CSS_Selectors
 /en-US/docs/Web/CSS/Specificity	/en-US/docs/Web/CSS/CSS_cascade/Specificity
+/en-US/docs/Web/CSS/Syntax	/en-US/docs/Web/CSS/CSS_syntax/Syntax
 /en-US/docs/Web/CSS/Text-overflow_TEST	/en-US/docs/Web/CSS/text-overflow
 /en-US/docs/Web/CSS/Tools	/en-US/docs/Web/CSS
 /en-US/docs/Web/CSS/Tools/Border-image_generator	/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Border-image_generator
@@ -12746,15 +12757,15 @@
 /en-US/docs/Web/HTTP/Access_control_CORS	/en-US/docs/Web/HTTP/CORS
 /en-US/docs/Web/HTTP/Basic_access_authentication	/en-US/docs/Web/HTTP/Authentication
 /en-US/docs/Web/HTTP/Basics_of_HTTP	/en-US/docs/Web/HTTP
-/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
-/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs	/en-US/docs/Web/URI/Schemes/data
-/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs	/en-US/docs/Web/URI/Schemes/data
+/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
+/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs	/en-US/docs/Web/URI/Reference/Schemes/data
+/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs	/en-US/docs/Web/URI/Reference/Schemes/data
 /en-US/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP	/en-US/docs/Web/HTTP/Evolution_of_HTTP
-/en-US/docs/Web/HTTP/Basics_of_HTTP/Introduction_to_www_and_non-www_URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
+/en-US/docs/Web/HTTP/Basics_of_HTTP/Introduction_to_www_and_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
 /en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types	/en-US/docs/Web/HTTP/MIME_types
 /en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types	/en-US/docs/Web/HTTP/MIME_types/Common_types
 /en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types	/en-US/docs/Web/HTTP/MIME_types/Common_types
-/en-US/docs/Web/HTTP/Basics_of_HTTP/Resource_URLs	/en-US/docs/Web/URI/Schemes/resource
+/en-US/docs/Web/HTTP/Basics_of_HTTP/Resource_URLs	/en-US/docs/Web/URI/Reference/Schemes/resource
 /en-US/docs/Web/HTTP/CORS/Errors/Reason:_CORS_header_‘Origin’_cannot_be_added	/en-US/docs/Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
 /en-US/docs/Web/HTTP/Caching_FAQ	/en-US/docs/Web/HTTP/Caching
 /en-US/docs/Web/HTTP/Configuring_servers_for_Ogg_media	/en-US/docs/Web/Media/Guides/Formats/Configuring_servers_for_Ogg_media
@@ -12832,8 +12843,8 @@
 /en-US/docs/Web/HTTP/Status/506_Variant_Also_Negotiates	/en-US/docs/Web/HTTP/Status/506
 /en-US/docs/Web/HTTP/Status/510_Not_Extended	/en-US/docs/Web/HTTP/Status/510
 /en-US/docs/Web/HTTP/X-Frame-Options	/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-/en-US/docs/Web/HTTP/data_URIs	/en-US/docs/Web/URI/Schemes/data
-/en-US/docs/Web/HTTP/www_and_non-www_URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
+/en-US/docs/Web/HTTP/data_URIs	/en-US/docs/Web/URI/Reference/Schemes/data
+/en-US/docs/Web/HTTP/www_and_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
 /en-US/docs/Web/Houdini	/en-US/docs/Web/API/Houdini_APIs
 /en-US/docs/Web/Houdini/CSS_Painting_API	/en-US/docs/Web/API/CSS_Painting_API/Guide
 /en-US/docs/Web/Houdini/CSS_Typed_OM	/en-US/docs/Web/API/CSS_Typed_OM_API
@@ -13578,8 +13589,19 @@
 /en-US/docs/Web/Security/Securing_your_site	/en-US/docs/Web/Security/Practical_implementation_guides
 /en-US/docs/Web/Security/Securing_your_site/Configuring_server_MIME_types	/en-US/docs/Learn_web_development/Extensions/Server-side/Configuring_server_MIME_types
 /en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion	/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion
-/en-US/docs/Web/Text_fragments	/en-US/docs/Web/URI/Fragment/Text_fragments
+/en-US/docs/Web/Text_fragments	/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
 /en-US/docs/Web/Tutorials	/en-US/docs/MDN/Tutorials
+/en-US/docs/Web/URI/Authority	/en-US/docs/Web/URI/Reference/Authority
+/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
+/en-US/docs/Web/URI/Fragment	/en-US/docs/Web/URI/Reference/Fragment
+/en-US/docs/Web/URI/Fragment/Text_fragments	/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
+/en-US/docs/Web/URI/Guides/Text_fragments	/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
+/en-US/docs/Web/URI/Reference/Authority/Choosing_between_www_and_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
+/en-US/docs/Web/URI/Reference/Text_fragments	/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
+/en-US/docs/Web/URI/Schemes	/en-US/docs/Web/URI/Reference/Schemes
+/en-US/docs/Web/URI/Schemes/data	/en-US/docs/Web/URI/Reference/Schemes/data
+/en-US/docs/Web/URI/Schemes/javascript	/en-US/docs/Web/URI/Reference/Schemes/javascript
+/en-US/docs/Web/URI/Schemes/resource	/en-US/docs/Web/URI/Reference/Schemes/resource
 /en-US/docs/Web/WebDriver/Commands/New_Window	/en-US/docs/Web/WebDriver/Commands/NewWindow
 /en-US/docs/Web/WebGL	/en-US/docs/Web/API/WebGL_API
 /en-US/docs/Web/WebGL/Adding_2D_content_to_a_WebGL_context	/en-US/docs/Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
@@ -14328,7 +14350,7 @@
 /en-US/docs/cssText	/en-US/docs/Web/API/CSSRule/cssText
 /en-US/docs/ctrlKey	/en-US/docs/Web/API/MouseEvent/ctrlKey
 /en-US/docs/currentTarget	/en-US/docs/Web/API/Event/currentTarget
-/en-US/docs/data_URIs	/en-US/docs/Web/URI/Schemes/data
+/en-US/docs/data_URIs	/en-US/docs/Web/URI/Reference/Schemes/data
 /en-US/docs/de_temp	/en-US/docs/Web/API/document/documentElement
 /en-US/docs/defineGetter	/en-US/docs/Web/JavaScript/Guide/Working_with_objects
 /en-US/docs/defineSetter	/en-US/docs/Web/JavaScript/Guide/Working_with_objects
@@ -14583,5 +14605,5 @@
 /en-US/docs/window.toolbar	/en-US/docs/Web/API/Window/toolbar
 /en-US/docs/window.unescape	/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape
 /en-US/docs/window.window	/en-US/docs/Web/API/Window/window
-/en-US/docs/www_vs_non-www_URLs	/en-US/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs
+/en-US/docs/www_vs_non-www_URLs	/en-US/docs/Web/URI/Guides/Choosing_between_www_and_non-www_URLs
 /en-US/docs/xml:base	/en-US/docs/Web/API/Node/baseURI

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -75809,27 +75809,6 @@
       "webinista"
     ]
   },
-  "Web/CSS/Alternative_style_sheets": {
-    "modified": "2020-10-15T21:15:55.661Z",
-    "contributors": [
-      "wbamberg",
-      "mfuji09",
-      "sideshowbarker",
-      "chrisdavidmills",
-      "mfluehr",
-      "Nickolay",
-      "r-o-b",
-      "Sebastianz",
-      "teoli",
-      "Sheppy",
-      "justinpotts",
-      "minitech",
-      "Mgjbot",
-      "Kohei",
-      "Sevenspade",
-      "DBaron"
-    ]
-  },
   "Web/CSS/At-rule": {
     "modified": "2020-11-13T09:49:20.788Z",
     "contributors": [
@@ -91392,6 +91371,27 @@
       "Itazulay",
       "estelle",
       "perfmattersconf"
+    ]
+  },
+  "Web/HTML/Attributes/rel/alternate_stylesheet": {
+    "modified": "2020-10-15T21:15:55.661Z",
+    "contributors": [
+      "wbamberg",
+      "mfuji09",
+      "sideshowbarker",
+      "chrisdavidmills",
+      "mfluehr",
+      "Nickolay",
+      "r-o-b",
+      "Sebastianz",
+      "teoli",
+      "Sheppy",
+      "justinpotts",
+      "minitech",
+      "Mgjbot",
+      "Kohei",
+      "Sevenspade",
+      "DBaron"
     ]
   },
   "Web/HTML/Attributes/rel/dns-prefetch": {

--- a/files/en-us/web/api/stylesheet/disabled/index.md
+++ b/files/en-us/web/api/stylesheet/disabled/index.md
@@ -13,7 +13,7 @@ The **`disabled`** property of the
 applying to the document.
 
 A style sheet may be disabled by manually setting this property to `true` or
-if it's an inactive [alternative style sheet](/en-US/docs/Web/CSS/Alternative_style_sheets). Note that `disabled === false` does not guarantee the style
+if it's an inactive [alternative style sheet](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet). Note that `disabled === false` does not guarantee the style
 sheet is applied (it could be removed from the document, for instance).
 
 ## Value

--- a/files/en-us/web/api/svgstyleelement/title/index.md
+++ b/files/en-us/web/api/svgstyleelement/title/index.md
@@ -9,7 +9,7 @@ browser-compat: api.SVGStyleElement.title
 {{APIRef("SVG")}}
 
 The **`SVGStyleElement.title`** property is a string corresponding to the [`title`](/en-US/docs/Web/SVG/Element/style#title) attribute of the given SVG style element.
-It may be used to select between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
+It may be used to select between [alternate style sheets](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet).
 
 ## Value
 

--- a/files/en-us/web/html/attributes/rel/alternate_stylesheet/index.md
+++ b/files/en-us/web/html/attributes/rel/alternate_stylesheet/index.md
@@ -1,22 +1,22 @@
 ---
-title: Alternative style sheets
-slug: Web/CSS/Alternative_style_sheets
+title: Alternate stylesheet
+slug: Web/HTML/Attributes/rel/alternate_stylesheet
 page-type: guide
 browser-compat: html.elements.link.rel.alternate_stylesheet
 ---
 
-{{CSSRef}}
+{{HTMLSidebar}}
 
-Specifying **alternative style sheets** in a web page provides a way for users to see multiple versions of a page, based on their needs or preferences.
+The **`alternate stylesheet`** keyword pair for the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute of the {{HTMLElement("link")}} element indicates that the target resource an _alternative style sheet_. Specifying **alternative style sheets** in a web page provides a way for users to see multiple versions of a page, based on their needs or preferences.
 
 > [!NOTE]
 > This feature is not well supported in browsers without an extension. To offer alternative presentations that work with a user's existing preferences, see the CSS [media features](/en-US/docs/Web/CSS/@media#media_features) {{cssxref("@media/prefers-color-scheme","prefers-color-scheme")}} and {{cssxref("@media/prefers-contrast","prefers-contrast")}}.
 
-Firefox lets the user select the stylesheet using the _View > Page Style_ submenu. Other browsers require an extension to enable this functionality. The web page can also provide its own user interface to let the user switch styles.
+Firefox lets the user select the {{glossary("stylesheet")}} using the _View > Page Style_ submenu, which displays the values of the [`title`](/en-US/docs/Web/HTML/Global_attributes/title) attributes. Other browsers require an extension to enable this functionality. The web page can also provide its own user interface to let the user switch styles.
 
 ## An example: specifying the alternative stylesheets
 
-The alternate stylesheets are commonly specified using a {{HTMLElement("link")}} element with `rel="alternate stylesheet"` and `title="…"` attributes. For example:
+Alternate stylesheets are specified using {{HTMLElement("link")}} elements with `rel="alternate stylesheet"` and `title="…"` attributes. For example:
 
 ```html
 <link href="reset.css" rel="stylesheet" />
@@ -28,7 +28,7 @@ The alternate stylesheets are commonly specified using a {{HTMLElement("link")}}
 
 In this example, the styles "Default Style", "Fancy", and "Basic" will be listed in the _Page Style_ submenu, with "Default Style" pre-selected. When the user selects a different style, the page will immediately be re-rendered using that style sheet.
 
-No matter what style is selected, the rules from the reset.css stylesheet will always be applied.
+No matter what style is selected, the rules from the `reset.css` stylesheet will always be applied.
 
 ### Try it out
 
@@ -42,7 +42,7 @@ Any stylesheet in a document falls into one of the following categories:
 - **Preferred** (has `rel="stylesheet"`, with `title="…"` specified): applied by default, but {{domxref("StyleSheet.disabled", "disabled", "", 1)}} if an alternate stylesheet is selected. **There can only be one preferred stylesheet**, so providing stylesheets with different title attributes will cause some of them to be ignored.
 - **Alternate** (`rel="alternate stylesheet"`, with `title="…"` specified): disabled by default, can be selected.
 
-When style sheets are referenced with a `title` attribute on the {{HTMLElement("link", "&lt;link rel=\"stylesheet\"&gt;")}} or {{HTMLElement("style")}} element, the title becomes one of the choices offered to the user. Style sheets linked with the same `title` are part of the same choice. Style sheets linked without a `title` attribute are always applied.
+When style sheets are referenced with a `title` attribute on the {{HTMLElement("link", "&lt;link rel=\"stylesheet\"&gt;")}} or {{HTMLElement("style")}} element, the title becomes one of the choices offered to the user. Style sheets linked with the same [`title`](/en-US/docs/Web/HTML/Global_attributes/title) are part of the same choice. Style sheets linked without a `title` attribute are always applied.
 
 Use `rel="stylesheet"` to link to the default style, and `rel="alternate stylesheet"` to link to alternative style sheets. This tells the browser which style sheet title should be selected by default, and makes that default selection apply in browsers that do not support alternate style sheets.
 
@@ -53,3 +53,8 @@ Use `rel="stylesheet"` to link to the default style, and `rel="alternate stylesh
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [CSS](/en-US/docs/Web/CSS)
+- [Using dynamic styling information](/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information)

--- a/files/en-us/web/html/attributes/rel/alternate_stylesheet/index.md
+++ b/files/en-us/web/html/attributes/rel/alternate_stylesheet/index.md
@@ -7,14 +7,16 @@ browser-compat: html.elements.link.rel.alternate_stylesheet
 
 {{HTMLSidebar}}
 
-The **`alternate stylesheet`** keyword pair for the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute of the {{HTMLElement("link")}} element indicates that the target resource an _alternative style sheet_. Specifying **alternative style sheets** in a web page provides a way for users to see multiple versions of a page, based on their needs or preferences.
+The **`alternate stylesheet`** keyword pair, when used as a value for the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute of the {{HTMLElement("link")}} element, indicates that the target resource is an _alternative style sheet_. Specifying **alternative style sheets** in a web page allows users to see multiple versions of a page based on their needs or preferences.
 
 > [!NOTE]
 > This feature is not well supported in browsers without an extension. To offer alternative presentations that work with a user's existing preferences, see the CSS [media features](/en-US/docs/Web/CSS/@media#media_features) {{cssxref("@media/prefers-color-scheme","prefers-color-scheme")}} and {{cssxref("@media/prefers-contrast","prefers-contrast")}}.
 
-Firefox lets the user select the {{glossary("stylesheet")}} using the _View > Page Style_ submenu, which displays the values of the [`title`](/en-US/docs/Web/HTML/Global_attributes/title) attributes. Other browsers require an extension to enable this functionality. The web page can also provide its own user interface to let the user switch styles.
+Firefox lets users select alternate {{glossary("stylesheet", "stylesheets")}} using the _View > Page Style_ submenu, which displays the values of the [`title`](/en-US/docs/Web/HTML/Global_attributes/title) attributes. Other browsers require an extension to enable this functionality. The web page can also provide its own user interface to let users switch styles.
 
-## An example: specifying the alternative stylesheets
+## Examples
+
+### Specifying alternate stylesheets
 
 Alternate stylesheets are specified using {{HTMLElement("link")}} elements with `rel="alternate stylesheet"` and `title="…"` attributes. For example:
 
@@ -26,7 +28,7 @@ Alternate stylesheets are specified using {{HTMLElement("link")}} elements with 
 <link href="basic.css" rel="alternate stylesheet" title="Basic" />
 ```
 
-In this example, the styles "Default Style", "Fancy", and "Basic" will be listed in the _Page Style_ submenu, with "Default Style" pre-selected. When the user selects a different style, the page will immediately be re-rendered using that style sheet.
+In this example, the styles "Default Style", "Fancy", and "Basic" will be listed in the Firefox _Page Style_ submenu with "Default Style" pre-selected. When the user selects a different style, the page will immediately be re-rendered using that style sheet.
 
 No matter what style is selected, the rules from the `reset.css` stylesheet will always be applied.
 
@@ -42,7 +44,7 @@ Any stylesheet in a document falls into one of the following categories:
 - **Preferred** (has `rel="stylesheet"`, with `title="…"` specified): applied by default, but {{domxref("StyleSheet.disabled", "disabled", "", 1)}} if an alternate stylesheet is selected. **There can only be one preferred stylesheet**, so providing stylesheets with different title attributes will cause some of them to be ignored.
 - **Alternate** (`rel="alternate stylesheet"`, with `title="…"` specified): disabled by default, can be selected.
 
-When style sheets are referenced with a `title` attribute on the {{HTMLElement("link", "&lt;link rel=\"stylesheet\"&gt;")}} or {{HTMLElement("style")}} element, the title becomes one of the choices offered to the user. Style sheets linked with the same [`title`](/en-US/docs/Web/HTML/Global_attributes/title) are part of the same choice. Style sheets linked without a `title` attribute are always applied.
+In cases where a stylesheet menu exists, when style sheets are referenced with a `title` attribute on the {{HTMLElement("link", "&lt;link rel=\"stylesheet\"&gt;")}} or {{HTMLElement("style")}} element, the title becomes one of the choices offered to the user. Style sheets linked with the same [`title`](/en-US/docs/Web/HTML/Global_attributes/title) are part of the same choice. Style sheets linked without a `title` attribute are always applied.
 
 Use `rel="stylesheet"` to link to the default style, and `rel="alternate stylesheet"` to link to alternative style sheets. This tells the browser which style sheet title should be selected by default, and makes that default selection apply in browsers that do not support alternate style sheets.
 

--- a/files/en-us/web/html/attributes/rel/alternate_stylesheet/index.md
+++ b/files/en-us/web/html/attributes/rel/alternate_stylesheet/index.md
@@ -1,7 +1,7 @@
 ---
 title: Alternate stylesheet
 slug: Web/HTML/Attributes/rel/alternate_stylesheet
-page-type: guide
+page-type: html-attribute-value
 browser-compat: html.elements.link.rel.alternate_stylesheet
 ---
 

--- a/files/en-us/web/html/attributes/rel/index.md
+++ b/files/en-us/web/html/attributes/rel/index.md
@@ -60,7 +60,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 
   - : Indicates an alternate representation of the current document. Valid for {{htmlelement('link')}}, {{htmlelement('a')}}, and {{htmlelement('area')}}, the meaning depends on the values of the other attributes.
 
-    - With the [`stylesheet`](#stylesheet) keyword on a `<link>`, it creates an [alternate stylesheet](/en-US/docs/Web/CSS/Alternative_style_sheets).
+    - With the [`stylesheet`](#stylesheet) keyword on a `<link>`, it creates an [alternate stylesheet](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet).
 
       ```html
       <!-- a persistent style sheet -->

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -265,7 +265,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - `title`
   - : The `title` attribute has special semantics on the `<link>` element.
-    When used on a `<link rel="stylesheet">` it defines a [default or an alternate stylesheet](/en-US/docs/Web/CSS/Alternative_style_sheets).
+    When used on a `<link rel="stylesheet">` it defines a [default or an alternate stylesheet](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet).
 - `type`
   - : This attribute is used to define the type of the content linked to.
     The value of the attribute should be a MIME type such as **text/html**, **text/css**, and so on.
@@ -310,7 +310,7 @@ To include a stylesheet in a page, use the following syntax:
 
 ### Providing alternative stylesheets
 
-You can also specify [alternative style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
+You can also specify [alternative style sheets](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet).
 
 The user can choose which style sheet to use by choosing it from the **View > Page Style** menu.
 This provides a way for users to see multiple versions of a page.

--- a/files/en-us/web/html/element/style/index.md
+++ b/files/en-us/web/html/element/style/index.md
@@ -29,7 +29,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - `nonce`
   - : A cryptographic nonce (number used once) used to allow inline styles in a [style-src Content-Security-Policy](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial.
 - `title`
-  - : This attribute specifies [alternative style sheet](/en-US/docs/Web/CSS/Alternative_style_sheets) sets.
+  - : This attribute specifies [alternative style sheet](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet) sets.
 
 ### Deprecated attributes
 
@@ -200,4 +200,4 @@ In this example we build on the previous one, including a `media` attribute on t
 ## See also
 
 - The {{HTMLElement("link")}} element, which allows us to apply external stylesheets to a document.
-- [Alternative Style Sheets](/en-US/docs/Web/CSS/Alternative_style_sheets)
+- [Alternative Style Sheets](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet)

--- a/files/en-us/web/svg/element/style/index.md
+++ b/files/en-us/web/svg/element/style/index.md
@@ -47,7 +47,7 @@ svg {
   - : This attribute defines to which {{cssxref('@media', 'media')}} the style applies.
     _Value type_: [**`<media-query-list>`**](/en-US/docs/Web/CSS/@media#syntax); _Default value_: `all`; _Animatable_: **no**
 - {{SVGAttr("title")}}
-  - : This attribute is the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
+  - : This attribute is the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/HTML/Attributes/rel/Alternate_stylesheet).
     _Value type_: [**`<string>`**](/en-US/docs/Web/CSS/string); _Default value_: _none_; _Animatable_: **no**
 
 ## Usage context


### PR DESCRIPTION
This is an HTML feature (and contains no CSS), so it belongs under HTML.

The moved page defines "Alternative style sheet", which is the main place where the term is defined, so link terms my read "alternate stylesheet" which is the slug value and attribute value, while others read Alternative style sheet, which is defined in the intro, so can't link to a  #heading.
