### PR TITLE
FF136 HTTP Referrer sent on refresh

### DIFF
--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -32,6 +32,11 @@ This article provides information about the changes in Firefox 136 that affect d
 
 ### HTTP
 
+- The {{httpheader("Referer")}} HTTP header is now sent in requests following a page refresh that redirects to a new page (if permitted by the {{httpheader("Referrer-Policy")}}), and {{domxref("document.referrer")}} will be set to the referrer URL after navigating.
+  The page refresh may be triggered by the {{httpheader("Refresh")}} response header, or equivalent {{htmlelement("meta")}} in markup (for example `<meta http-equiv="refresh" content="3;url=https://www.mozilla.org" />`).
+  Note that same-page refreshes are treated as same-page navigation to a page fragment: since the page isn't re-requested, {{httpheader("Referer")}} isn't sent.
+  ([Firefox bug 1928291](https://bugzil.la/1928291))
+
 #### Removals
 
 ### Security


### PR DESCRIPTION
FF136 sends HTTP Referer on Refresh. This adds a release note.

Related docs work can be tracked in #37944