### PR TITLE
clarified code example: removed unnecessary button type

### DIFF
--- a/files/en-us/web/api/htmldialogelement/cancel_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/cancel_event/index.md
@@ -36,7 +36,7 @@ A generic {{domxref("Event")}}.
 
 ```html
 <dialog class="example-dialog">
-  <button class="close" type="reset">Close</button>
+  <button class="close">Close</button>
 </dialog>
 
 <button class="open-dialog">Open dialog</button>


### PR DESCRIPTION
The code example was misleading (Exhibit A: I was misled by it). How so:
- The button type attribute is known to carry behavior w.r.t. its ancestor element (button.type=submit will submit a `<form>` etc. ; see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type )
- The documentation page is all about closing a `<dialog>` and raising the cancel event.
- The presence of a `<button type="reset">` in the example suggests that the type attribute does actually contribute to the button behavior w.r.t. the `<dialog>`
- but it does nothing, the closing of the dialog is only the result of a click listener attached via script
- I might be oblivious to whether the original markup is considered best practice w.r.t. accessibility

### Description

I removed the attribute `type="reset"` in the code example, as I think it is confusing, even misleading.

### Motivation

I was misled by it. I want to spare others the same confusion in the interpretation of the code example.

### Additional details

I consulted the documentation for button.type to understand whether I missed anything
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type

### Related issues and pull requests

probably nothing related to it
