### PR TITLE
Make Control flow effects of await section more technically precise

### DIFF
--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -235,7 +235,7 @@ function foo(name) {
 }
 ```
 
-The extra `then()` handler can be merged with the executor passed to the constructor because it's not waiting on any asynchronous operation. However, its existence splits the code into two microtasks. These microtasks are scheduled and executed in an intertwined manner, which can both make your code slower and introduce unnecessary race conditions. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
+The extra `then()` handler can be merged with the executor passed to the constructor because it's not waiting on any asynchronous operation. However, its existence splits the code into one additional microtask for each call to `foo`. These microtasks are scheduled and executed in an intertwined manner, which can both make your code slower and introduce unnecessary race conditions. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
 
 Microtasks are scheduled not only by promise resolution but by other web APIs as well, and they execute with the same priority. This example uses {{domxref("Window.queueMicrotask()", "queueMicrotask()")}} to demonstrate how the microtask queue is processed when each `await` expression is encountered.
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -169,7 +169,7 @@ export default await colors;
 
 ### Control flow effects of await
 
-When an `await` is encountered in code (either in an async function or in a module), the awaited expression is executed, while all code that depends on the expression's value is paused and pushed into the [microtask queue](/en-US/docs/Web/JavaScript/Event_loop). The main thread is then freed for the next task in the event loop. This happens even if the awaited value is an already-resolved promise or not a promise. For example, consider the following code:
+When an `await` is encountered in code (either in an async function or in a module), the awaited expression is executed, while all code that depends on the expression's value is paused. The main thread is then freed for the next task in the [microtask queue](/en-US/docs/Web/JavaScript/Event_loop). When the awaited expression's value is resolved, another microtask that continues the paused code gets scheduled. This happens even if the awaited value is an already-resolved promise or not a promise: execution doesn't return to the current function until all other already-scheduled microtasks are processed. For example, consider the following code:
 
 ```js
 async function foo(name) {
@@ -189,7 +189,7 @@ foo("Second");
 // Second end
 ```
 
-In this case, the two async functions are synchronous in effect, because they don't contain any `await` expression. The three statements happen in the same tick. In promise terms, the function corresponds to:
+In this case, the function `foo` is synchronous in effect, because it doesn't contain any `await` expression. The three statements happen in the same tick. Therefore, the two function calls executes all statements in sequence. In promise terms, the function corresponds to:
 
 ```js
 function foo(name) {
@@ -201,6 +201,8 @@ function foo(name) {
   });
 }
 ```
+
+Where there are only two microtasks, each defined by one `Promise()` executor.
 
 However, as soon as there's one `await`, the function becomes asynchronous, and execution of following statements is deferred to the next tick.
 
@@ -235,9 +237,9 @@ function foo(name) {
 }
 ```
 
-While the extra `then()` handler is not necessary, and the handler can be merged with the executor passed to the constructor, the `then()` handler's existence means the code will take one extra tick to complete. The same happens for `await`. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
+While the extra `then()` handler is not necessary and can be merged with the executor passed to the constructor, its existence splits the code into two microtasks. These microtasks are scheduled and executed in an intertwined manner, which can both make your code slower and introduce unnecessary race conditions. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
 
-Other microtasks can execute before the async function resumes. This example uses {{domxref("Window.queueMicrotask()", "queueMicrotask()")}} to demonstrate how the microtask queue is processed when each `await` expression is encountered.
+Microtasks are scheduled not only by promise resolution but by other web APIs as well, and they execute with the same priority. This example uses {{domxref("Window.queueMicrotask()", "queueMicrotask()")}} to demonstrate how the microtask queue is processed when each `await` expression is encountered.
 
 ```js
 let i = 0;

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -169,7 +169,7 @@ export default await colors;
 
 ### Control flow effects of await
 
-When an `await` is encountered in code (either in an async function or in a module), the awaited expression is executed, while all code that depends on the expression's value is paused. The main thread is then freed for the next task in the [microtask queue](/en-US/docs/Web/JavaScript/Event_loop). When the awaited expression's value is resolved, another microtask that continues the paused code gets scheduled. This happens even if the awaited value is an already-resolved promise or not a promise: execution doesn't return to the current function until all other already-scheduled microtasks are processed. For example, consider the following code:
+When an `await` is encountered in code (either in an async function or in a module), the awaited expression is executed, while all code that depends on the expression's value is paused. Control exits the function and returns to the caller. When the awaited expression's value is resolved, another [microtask](/en-US/docs/Web/JavaScript/Event_loop) that continues the paused code gets scheduled. This happens even if the awaited value is an already-resolved promise or not a promise: execution doesn't return to the current function until all other already-scheduled microtasks are processed. For example, consider the following code:
 
 ```js
 async function foo(name) {
@@ -189,7 +189,7 @@ foo("Second");
 // Second end
 ```
 
-In this case, the function `foo` is synchronous in effect, because it doesn't contain any `await` expression. The three statements happen in the same tick. Therefore, the two function calls executes all statements in sequence. In promise terms, the function corresponds to:
+In this case, the function `foo` is synchronous in effect, because it doesn't contain any `await` expression. The three statements happen in the same tick. Therefore, the two function calls execute all statements in sequence. In promise terms, the function corresponds to:
 
 ```js
 function foo(name) {
@@ -201,8 +201,6 @@ function foo(name) {
   });
 }
 ```
-
-Where there are only two microtasks, each defined by one `Promise()` executor.
 
 However, as soon as there's one `await`, the function becomes asynchronous, and execution of following statements is deferred to the next tick.
 
@@ -237,7 +235,7 @@ function foo(name) {
 }
 ```
 
-While the extra `then()` handler is not necessary and can be merged with the executor passed to the constructor, its existence splits the code into two microtasks. These microtasks are scheduled and executed in an intertwined manner, which can both make your code slower and introduce unnecessary race conditions. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
+The extra `then()` handler can be merged with the executor passed to the constructor because it's not waiting on any asynchronous operation. However, its existence splits the code into two microtasks. These microtasks are scheduled and executed in an intertwined manner, which can both make your code slower and introduce unnecessary race conditions. Therefore, make sure to use `await` only when necessary (to unwrap promises into their values).
 
 Microtasks are scheduled not only by promise resolution but by other web APIs as well, and they execute with the same priority. This example uses {{domxref("Window.queueMicrotask()", "queueMicrotask()")}} to demonstrate how the microtask queue is processed when each `await` expression is encountered.
 


### PR DESCRIPTION
- Fix https://github.com/mdn/content/issues/24177
- Fix https://github.com/mdn/content/issues/28795

Correctly explain when the continuation microtask gets scheduled.
Avoid using "event loop" and "microtask queue" interchangeably.
Some more explanation and rewording.