### PR TITLE
Mention that REPLs won't freeze console when Promise.racing empty iterable

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
@@ -40,7 +40,7 @@ Promise.race(iterable)
 
 ### Return value
 
-A {{jsxref("Promise")}} that **asynchronously settles** with the eventual state of the first promise in the `iterable` to settle. In other words, it fulfills if the first promise to settle is fulfilled, and rejects if the first promise to settle is rejected. The returned promise remains pending forever if the `iterable` passed is empty. If the `iterable` passed is non-empty but contains no pending promises, the returned promise is still asynchronously (instead of synchronously) settled.
+A {{jsxref("Promise")}} that **asynchronously settles** with the eventual state of the first promise in the `iterable` to settle. In other words, it fulfills if the first promise to settle is fulfilled, and rejects if the first promise to settle is rejected. The returned promise remains pending forever if the `iterable` passed is empty (note that REPL environments may not reflect this behavior, in order to not leave the console stuck with a never-settling promise). If the `iterable` passed is non-empty but contains no pending promises, the returned promise is still asynchronously (instead of synchronously) settled.
 
 ## Description
 


### PR DESCRIPTION
### Description

See title.

### Motivation

Was testing `await Promise.race([])` in the Firefox console expecting an immediate return of an `undefined` value, and ran into behavior apparently contradicting the documentation.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race#return_value
