### PR TITLE
fix(requestVideoFrameCallback): drawing video frames on a canvas example

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/requestvideoframecallback/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestvideoframecallback/index.md
@@ -85,6 +85,23 @@ This example shows how to use `requestVideoFrameCallback()` to draw the frames o
 
 ```js
 if ("requestVideoFrameCallback" in HTMLVideoElement.prototype) {
+  const video = document.createElement("video");
+  const fpsInfo = document.createElement("div");
+  const metadataInfo = document.createElement("div");
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  // 'Big Buck Bunny' licensed under CC 3.0 by the Blender foundation. Hosted by archive.org
+  // Poster from peach.blender.org
+  video.src =
+    "https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4";
+  video.poster =
+    "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217";
+  video.width = 640;
+  video.controls = true;
+
+  document.body.append(video, fpsInfo, metadataInfo, canvas);
+
   let paintCount = 0;
   let startTime = 0.0;
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This update aims to make the example copy-paste ready, allowing users to easily test the functionality without additional setup.

- Add missing HTML elements
- Set video source to 'Big Buck Bunny' and add a poster image

Use the video and poster from https://github.com/mdn/content/blob/e439cd79166dbfd9bbe3a003abaf5898ae165509/files/en-us/web/html/element/video/index.md#html

### Related issues and pull requests

Relates to #31762
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
