### PR TITLE
Fixed possible type for MDN Learning content

### DIFF
--- a/files/en-us/learn_web_development/getting_started/web_standards/how_browsers_load_websites/index.md
+++ b/files/en-us/learn_web_development/getting_started/web_standards/how_browsers_load_websites/index.md
@@ -87,7 +87,7 @@ Certain HTML elements, when parsed, will trigger more HTTP requests:
 
 - {{htmlelement("link")}} elements referencing external [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics) stylesheets.
 - {{htmlelement("script")}} elements referencing external [JavaScript](/en-US/docs/Learn_web_development/Core/Scripting) files.
-- Elements such as {{htmlelement("img")}}, {{htmlelement("video")}}, and {{htmlelement("video")}}, which reference media files you want to embed in the web page.
+- Elements such as {{htmlelement("img")}}, {{htmlelement("video")}}, and {{htmlelement("audio")}}, which reference media files you want to embed in the web page.
 
 ## Parsing CSS and rendering the page
 


### PR DESCRIPTION
There were two <video> tags on "How browsers load websites" in "Handling HTML" section. By the context of the section, I think there should be <audio> tag.





![image](https://github.com/user-attachments/assets/bdfb6d4c-c0ac-4a07-96a1-8630f29f6e18)