### PR TITLE
Fix tag name typo in "Using CSS nesting"

### DIFF
--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -329,7 +329,7 @@ As opposed to:
 
 #### Appending nesting selector
 
-In this example there are 3 cards, one of which is featured. The cards are all exactly the same except the featured card will have an alternative color for the heading. By appending the `&` nesting selector the style for the `.featured .h2` can be nested in the style for the `h2`.
+In this example there are 3 cards, one of which is featured. The cards are all exactly the same except the featured card will have an alternative color for the heading. By appending the `&` nesting selector the style for the `.featured h2` can be nested in the style for the `h2`.
 
 ##### HTML
 


### PR DESCRIPTION
### Description

Removed . from ".h2" in the "Appending nesting selector" paragraph

### Motivation

The rest of the code uses and references a h2 tag, but the ".h2" from ".featured .h2" makes the tag into a class. Clearly you are referencing the tag, so I just removed the period to change it from a class to an HTML tag.

### Additional details

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
