### PR TITLE
Fix HTTP example so that the Host header is correct

### DIFF
--- a/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
+++ b/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
@@ -109,9 +109,9 @@ Basically, when data is sent across the web, it is sent in thousands of small ch
 HTTP uses a simple language of verbs to perform actions such as making requests (see [HTTP request methods](/en-US/docs/Web/HTTP/Methods)). The HTTP [`GET`](/en-US/docs/Web/HTTP/Methods/GET) method is the one normally used to make HTTP requests of the type described above. For example, a request for the MDN home page might look like this:
 
 ```http
-GET / HTTP/2
+GET /en-US/ HTTP/2
 
-Host: https://developer.mozilla.org/en-US/
+Host: developer.mozilla.org
 ```
 
 The response sent by the server might looks something like this:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The `Host` header value in the [How the web works](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Web_standards/How_the_web_works) article is in the incorrect format. `Host` headers do not contain the protocol or path. They only contain the domain and an optional port number.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The value was incorrect, so it would teach people the wrong thing. I want to make sure people are being taught the right thing.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
