### PR TITLE
HTTP Referer header - note that refresh navigations can cause it to be sent

### DIFF
--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -13,6 +13,7 @@ This data can be used for analytics, logging, optimized caching, and more.
 
 When you click a link, the `Referer` contains the address of the page that includes the link.
 When you make resource requests to another domain, the `Referer` contains the address of the page that uses the requested resource.
+The `Referer` may also be sent in requests following a page refresh (see {{httpheader("Refresh")}}) that causes a navigation to a new page.
 
 The `Referer` header can contain an _origin_, _path_, and _querystring_, and may not contain [URL fragments](/en-US/docs/Web/URI/Fragment) (i.e., `#section`) or `username:password` information.
 The request's _referrer policy_ defines the data that can be included. See {{HTTPHeader("Referrer-Policy")}} for more [information](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives) and [examples](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples).

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -14,10 +14,10 @@ This data can be used for analytics, logging, optimized caching, and more.
 When you click a link, the `Referer` contains the address of the page that includes the link.
 When you make resource requests to another domain, the `Referer` contains the address of the page that uses the requested resource.
 
-The `Referer` may also be sent in requests following a {{httpheader("Refresh")}} response (or equivalent [`<meta http-equiv="refresh" content="...">`](/en-US/docs/Web/HTML/Element/meta#http-equiv)) that causes a navigation to a new page.
-
 The `Referer` header can contain an _origin_, _path_, and _querystring_, and may not contain [URL fragments](/en-US/docs/Web/URI/Fragment) (i.e., `#section`) or `username:password` information.
 The request's _referrer policy_ defines the data that can be included. See {{HTTPHeader("Referrer-Policy")}} for more [information](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives) and [examples](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples).
+
+The `Referer` should also be sent in requests following a {{httpheader("Refresh")}} response (or equivalent [`<meta http-equiv="refresh" content="...">`](/en-US/docs/Web/HTML/Element/meta#http-equiv)) that causes a navigation to a new page, if permitted by the referrer policy.
 
 > [!NOTE]
 > The header name "referer" is actually a misspelling of the word "referrer".

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -13,7 +13,8 @@ This data can be used for analytics, logging, optimized caching, and more.
 
 When you click a link, the `Referer` contains the address of the page that includes the link.
 When you make resource requests to another domain, the `Referer` contains the address of the page that uses the requested resource.
-The `Referer` may also be sent in requests following a page {{httpheader("Refresh")}} response that causes a navigation to a new page.
+
+The `Referer` may also be sent in requests following a {{httpheader("Refresh")}} response (or equivalent [`<meta http-equiv="refresh" content="...">`](/en-US/docs/Web/HTML/Element/meta#http-equiv)) that causes a navigation to a new page.
 
 The `Referer` header can contain an _origin_, _path_, and _querystring_, and may not contain [URL fragments](/en-US/docs/Web/URI/Fragment) (i.e., `#section`) or `username:password` information.
 The request's _referrer policy_ defines the data that can be included. See {{HTTPHeader("Referrer-Policy")}} for more [information](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives) and [examples](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples).

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -13,7 +13,7 @@ This data can be used for analytics, logging, optimized caching, and more.
 
 When you click a link, the `Referer` contains the address of the page that includes the link.
 When you make resource requests to another domain, the `Referer` contains the address of the page that uses the requested resource.
-The `Referer` may also be sent in requests following a page refresh (see {{httpheader("Refresh")}}) that causes a navigation to a new page.
+The `Referer` may also be sent in requests following a page {{httpheader("Refresh")}} response that causes a navigation to a new page.
 
 The `Referer` header can contain an _origin_, _path_, and _querystring_, and may not contain [URL fragments](/en-US/docs/Web/URI/Fragment) (i.e., `#section`) or `username:password` information.
 The request's _referrer policy_ defines the data that can be included. See {{HTTPHeader("Referrer-Policy")}} for more [information](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives) and [examples](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples).

--- a/files/en-us/web/http/headers/refresh/index.md
+++ b/files/en-us/web/http/headers/refresh/index.md
@@ -13,6 +13,11 @@ It is exactly equivalent to using [`<meta http-equiv="refresh" content="...">`](
 > [!NOTE]
 > Even though it's present in the HTTP response, the `Refresh` header is still handled by the HTML loading machinery and happens after HTTP or JavaScript redirects. See [redirection order of precedence](/en-US/docs/Web/HTTP/Redirections#order_of_precedence) for more information.
 
+> [!NOTE]
+> Following a refresh to a new page, the {{httpheader("Referer")}} header should be included in the subsequent request for the page (if permitted by the {{httpheader("Referrer-Policy")}}), and {{domxref("document.referrer")}} should be set to the referrer URL after navigating.
+> The header may not be sent for same-page refreshes on some browsers.
+> See [browser compatibility](#browser_compatibility) for more information.
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/http/headers/refresh/index.md
+++ b/files/en-us/web/http/headers/refresh/index.md
@@ -15,7 +15,6 @@ It is exactly equivalent to using [`<meta http-equiv="refresh" content="...">`](
 
 > [!NOTE]
 > Following a refresh to a new page, the {{httpheader("Referer")}} header should be included in the subsequent request for the page (if permitted by the {{httpheader("Referrer-Policy")}}), and {{domxref("document.referrer")}} should be set to the referrer URL after navigating.
-> The header may not be sent for same-page refreshes on some browsers.
 > See [browser compatibility](#browser_compatibility) for more information.
 
 <table class="properties">

--- a/files/en-us/web/http/headers/refresh/index.md
+++ b/files/en-us/web/http/headers/refresh/index.md
@@ -14,8 +14,7 @@ It is exactly equivalent to using [`<meta http-equiv="refresh" content="...">`](
 > Even though it's present in the HTTP response, the `Refresh` header is still handled by the HTML loading machinery and happens after HTTP or JavaScript redirects. See [redirection order of precedence](/en-US/docs/Web/HTTP/Redirections#order_of_precedence) for more information.
 
 > [!NOTE]
-> Following a refresh to a new page, the {{httpheader("Referer")}} header should be included in the subsequent request for the page (if permitted by the {{httpheader("Referrer-Policy")}}), and {{domxref("document.referrer")}} should be set to the referrer URL after navigating.
-> See [browser compatibility](#browser_compatibility) for more information.
+> When a refresh redirects to a new page, the {{httpheader("Referer")}} header is included in the request for the new page (if permitted by the {{httpheader("Referrer-Policy")}}), and {{domxref("document.referrer")}} is set to the referrer URL after navigating.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
When a `Refresh` response is sent to cause a refresh to another page the `Referer` header is supposed to be included in the new request, and `document.referrer` is supposed to be updated with the referrer URL. Chrome/Safari do this, but FF wasn't doing so until 136.
I have previously added a BCD note in `Refresh` noting the changed behaviour, and a release note.

This 
- adds a note to the `Referer` that it should be sent in response to a navigation refresh. 
- Adds a note to the Refresh header with similar information, pointing to browser compat.

Note that refresh to same page is an open compatibility issue (as discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1928291#c9). I have chosen not to address that here since it is less clear that it is important to users - and I'm not sure how the compat issue will fall out. I think this is OK.

Related docs work can be tracked in #37944
