### PR TITLE
added spellcheck to see also on autocorrect and vice versa

### DIFF
--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -155,3 +155,8 @@ If the device has a substitute for the entered word, this will be used to autoco
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- All [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+- [`spellcheck`](/en-US/docs/Web/HTML/Global_attributes/spellcheck).

--- a/files/en-us/web/html/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.md
@@ -39,3 +39,4 @@ You should consider setting `spellcheck` to `false` for elements that can contai
 ## See also
 
 - All [global attributes](/en-US/docs/Web/HTML/Global_attributes).
+- [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect).


### PR DESCRIPTION
### Description

- Added _See Also_ link to `autocorrect` global attribute to link to `spellcheck`
- Added link to `autocorrect` global attribute on `spellcheck` page

### Motivation

- Working on [issue #37942](https://github.com/mdn/content/issues/37942)

### Related issues and pull requests

- [Firefox Release note PR](https://github.com/mdn/content/pull/38196)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/25853)