### PR TITLE
Bug-1915688 release notes for enforcing the `storage.session` quota

### DIFF
--- a/files/en-us/mozilla/firefox/releases/131/index.md
+++ b/files/en-us/mozilla/firefox/releases/131/index.md
@@ -52,7 +52,7 @@ This article provides information about the changes in Firefox 131 that affect d
 
 ## Changes for add-on developers
 
-- The 10 MB quota for data stored by the {{WebExtAPIRef("storage.session")}} API is now enforced in Firefox Nightly 131. Previously, Firefox didn't implement this quota. This enforcement rolls out to release versions of Firefox from version 134 ([Firefox bug 1915688](https://bugzil.la/1915688)). This enables extensions that rely on the previous behavior to correct any issues. ([Firefox bug 1908925](https://bugzil.la/1908925))
+- The 10 MB quota for data stored by the {{WebExtAPIRef("storage.session")}} API is now enforced in Firefox Nightly 131. Previously, Firefox didn't implement this quota. This enforcement rolls out to release versions of Firefox from version 137 ([Firefox bug 1915688](https://bugzil.la/1915688)). This enables extensions that rely on the previous behavior to correct any issues. ([Firefox bug 1908925](https://bugzil.la/1908925))
 - {{WebExtAPIRef("storage.session")}} now supports the {{WebExtAPIRef("storage.StorageArea.getBytesInUse()")}} API and the {{WebExtAPIRef("storage.session.QUOTA_BYTES")}} property. ([Firefox bug 1908925](https://bugzil.la/1908925))
 - {{WebExtAPIRef("tabs.onUpdated")}} is now triggered when `openerTabId` is changed through `tabs.update()` ([Firefox bug 1409262](https://bugzil.la/1409262)).
 - {{WebExtAPIRef("tabs.update")}} now accepts `openerTabId` set to `-1` to clear `openerTabId` ([Firefox bug 1409262](https://bugzil.la/1409262)).

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 137 that affect d
 
 ## Changes for add-on developers
 
+- The 10 MB quota for data stored by the {{WebExtAPIRef("storage.session")}} API is now enforced. ([Firefox bug 1915688](https://bugzil.la/1915688))
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
### Description

Addresses the dev-docs-needed request for [Bug 1915688](https://bugzilla.mozilla.org/show_bug.cgi?id=1915688) _Enforce storage.session quota on release_ by updating the 131 release notes to correct the implementation version number and adding release notes for 137.

Checked and confirmed that there were no references to the absence of quota enforcement in either the MDN documentation or BCD notes.