### PR TITLE
FF136 ExprFeat - Clear-Site-Data: cache

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2106,6 +2106,47 @@ For more details see [Firefox bug 1687364](https://bugzil.la/1687364).
   </tbody>
 </table>
 
+### Clear-Site-Data: cache can clear the browser cache
+
+The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) can be used with the [`cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) or `*` directives to clear the local browser cache.
+For more details see [Firefox bug 1942272](https://bugzil.la/1942272).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>136</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>privacy.clearSiteDataHeader.cache.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## Developer tools
 
 Mozilla's developer tools are constantly evolving. We experiment with new ideas, add new features, and test them on the Nightly and Developer Edition channels before letting them go through to beta and release. The features below are the current crop of experimental developer tool features.

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -86,10 +86,13 @@ This article provides information about the changes in Firefox 136 that affect d
 
 These features are newly shipped in Firefox 136 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
-- **Error.captureStackTrace()**: <code>javascript.options.experimental.error_capture_stack_trace</code>.
+- **Error.captureStackTrace()**: `javascript.options.experimental.error_capture_stack_trace`</code>`.
   The {{jsxref("Error.captureStackTrace()")}} static method installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property.
   Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface.
   ([Firefox bug 1886820](https://bugzil.la/1886820)).
+- **Clear-Site-Data: cache**: `privacy.clearSiteDataHeader.cache.enabled`.
+  The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) can be used with the [`cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) or `*` directives to clear the local browser cache.
+  ([Firefox bug 1942272](https://bugzil.la/1942272)).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -86,12 +86,12 @@ This article provides information about the changes in Firefox 136 that affect d
 
 These features are newly shipped in Firefox 136 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
-- **Error.captureStackTrace()**: `javascript.options.experimental.error_capture_stack_trace`</code>`.
+- **Error.captureStackTrace()**: `javascript.options.experimental.error_capture_stack_trace`.
   The {{jsxref("Error.captureStackTrace()")}} static method installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property.
   Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface.
   ([Firefox bug 1886820](https://bugzil.la/1886820)).
 - **Clear-Site-Data: cache**: `privacy.clearSiteDataHeader.cache.enabled`.
-  The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) can be used with the [`cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) or `*` directives to clear the local browser cache.
+  The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) header can be used with the [`cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) or `*` directives to clear the browser cache.
   ([Firefox bug 1942272](https://bugzil.la/1942272)).
 
 ## Older versions

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -465,7 +465,7 @@ You may want to overwrite that response once it expired on the server, but there
 
 One of the methods mentioned in the specification is to send a request for the same URL with an unsafe method such as `POST`, but for many clients that is difficult to do.
 
-The [`Clear-Site-Data: cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) header and directive value (if supported) can be used to clear browser caches — but has no effect on intermediate caches.
+The [`Clear-Site-Data: cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) header and directive value can be used to clear browser caches — but has no effect on intermediate caches.
 Otherwise responses will remain in the browser cache until `max-age` expires, unless the user manually performs a reload, force-reload, or clear-history action.
 
 Caching reduces access to the server, which means that the server loses control of that URL. If the server does not want to lose control of a URL — for example, in the case that a resource is frequently updated — you should add `no-cache` so that the server will always receive requests and send the intended responses.

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -447,7 +447,7 @@ Note that, instead of implementing that directive, [Chrome has changed its imple
 
 ## Deleting stored responses
 
-There is basically no way to delete responses that have already been stored with a long `max-age`.
+There is no way to delete responses on an intermediate server that have been stored with a long `max-age`.
 
 Imagine that the following response from `https://example.com/` was stored.
 
@@ -463,11 +463,10 @@ Cache-Control: max-age=31536000
 
 You may want to overwrite that response once it expired on the server, but there is nothing the server can do once the response is stored — since no more requests reach the server due to caching.
 
-One of the methods mentioned in the specification is to send a request for the same URL with an unsafe method such as `POST`, but that is usually difficult to intentionally do for many clients.
+One of the methods mentioned in the specification is to send a request for the same URL with an unsafe method such as `POST`, but for many clients that is difficult to do.
 
-There is also a specification for a `Clear-Site-Data: cache` header and value, but [not all browsers support it](https://groups.google.com/a/mozilla.org/g/dev-platform/c/I939w1yrTp4) — and even when it's used, it only affects browser caches and has no effect on intermediate caches.
-
-Therefore, it should be assumed that any stored response will remain for its `max-age` period unless the user manually performs a reload, force-reload, or clear-history action.
+The [`Clear-Site-Data: cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) header and directive value (if supported) can be used to clear browser caches — but has no effect on intermediate caches.
+Otherwise responses will remain in the browser cache until `max-age` expires, unless the user manually performs a reload, force-reload, or clear-history action.
 
 Caching reduces access to the server, which means that the server loses control of that URL. If the server does not want to lose control of a URL — for example, in the case that a resource is frequently updated — you should add `no-cache` so that the server will always receive requests and send the intended responses.
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -423,11 +423,12 @@ But for now, you can simply use `no-cache` instead.
 
 ### Clearing an already-stored cache
 
-Unfortunately, there are no cache directives for clearing already-stored responses from caches.
+Unfortunately, there are no cache directives for clearing already-stored responses from caches on intermediate servers.
 
 Imagine that clients/caches store a [fresh](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
-Alternatively, `Clear-Site-Data` can clear a browser cache for a site. But be careful: that clears every stored response for a site — and only in browsers, not for a shared cache.
+[`Clear-Site-Data: cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) can be used to clear every stored response for a site in the browser cache (use with care).
+Note that this will not affected shared/intermediate caches.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -423,12 +423,12 @@ But for now, you can simply use `no-cache` instead.
 
 ### Clearing an already-stored cache
 
-Unfortunately, there are no cache directives for clearing already-stored responses from caches on intermediate servers.
+There are no cache directives for clearing already-stored responses from caches on _intermediate_ servers.
 
 Imagine that clients/caches store a [fresh](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) response for a path, with no request flight to the server. There is nothing a server could do to that path.
 
-[`Clear-Site-Data: cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) can be used to clear every stored response for a site in the browser cache (use with care).
-Note that this will not affected shared/intermediate caches.
+[`Clear-Site-Data: cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) can be used to clear every stored response for a site in the browser cache, so use this with care.
+Note that this will not affected shared or intermediate caches.
 
 ## Specifications
 


### PR DESCRIPTION
FF136 supports [`Clear-Site-Data: cache`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1942272 (and also clearing of cache in the `*` wildcard).

This adds experimental feature and relnote updates.

It also does some minor tidying of the other mentions of this header/directive in the docs, which previously referred to this as having limited browser support/being very new. Also to more clearly separate the fact it is used for browser caches vs the comments about intermediate cache clearing.

Related docs work can be tracked in #37946