### PR TITLE
JS console docs: Remove 'obj1' mentions

### DIFF
--- a/files/en-us/web/api/console/debug_static/index.md
+++ b/files/en-us/web/api/console/debug_static/index.md
@@ -22,7 +22,7 @@ console.debug(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `val1` … `valN`
-  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `obj1` is a string, which is described subsequently.
+  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `val1` is a string, which is described subsequently.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order up to the number of substitution strings. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 - `subst1` … `substN`

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -22,7 +22,7 @@ console.error(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `val1` … `valN`
-  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `obj1` is a string, which is described subsequently.
+  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `val1` is a string, which is described subsequently.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order up to the number of substitution strings. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 - `subst1` … `substN`

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -22,7 +22,7 @@ console.info(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `val1` … `valN`
-  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `obj1` is a string, which is described subsequently.
+  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `val1` is a string, which is described subsequently.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order up to the number of substitution strings. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 - `subst1` … `substN`

--- a/files/en-us/web/api/console/log_static/index.md
+++ b/files/en-us/web/api/console/log_static/index.md
@@ -22,7 +22,7 @@ console.log(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `val1` … `valN`
-  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `obj1` is a string, which is described subsequently.
+  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `val1` is a string, which is described subsequently.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order up to the number of substitution strings. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 - `subst1` … `substN`

--- a/files/en-us/web/api/console/warn_static/index.md
+++ b/files/en-us/web/api/console/warn_static/index.md
@@ -22,7 +22,7 @@ console.warn(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `val1` … `valN`
-  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `obj1` is a string, which is described subsequently.
+  - : A list of JavaScript values to output. A representation of each of these values is output to the console in the order given with some type of separation between each of them. There is a special case if `val1` is a string, which is described subsequently.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order up to the number of substitution strings. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 - `subst1` … `substN`


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the parameter description for console printing commands, to replace mentions of parameter `obj1` (which no longer appears in the Syntax section) with `val1` (which does).

### Motivation

Mentions of `obj1` are now non-sequiturs, as that parameter appears nowhere else in the documentation. This is confusing to readers.

### Additional details

Commit c607327 standardized the documentation for console printing commands, including updating syntax statements from e.g.

```js
assert(assertion, obj1)
assert(assertion, obj1, obj2)
assert(assertion, obj1, obj2, /* …, */ objN)
```
to
```js
assert(assertion, val1)
assert(assertion, val1, val2)
assert(assertion, val1, val2, /* …, */ valN)
```

...However, it left a mention of `obj1` in the parameter descriptions, which now seems out-of-context as there's no other mention of `obj1` anywhere. This was subsequently corrected for a couple of commands, but others were left as-is. This PR replaces all remaining `obj1` mentions with `val1`, for further consistency and clarity.

### Related issues and pull requests

Updates #34284

cc: @Josh-Cena, author of #34284

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
