### PR TITLE
fixed the see also link for details

### DIFF
--- a/files/en-us/web/css/_colon_open/index.md
+++ b/files/en-us/web/css/_colon_open/index.md
@@ -180,6 +180,6 @@ The result is as follows. Try opening the `<select>` dropdown to see the effect 
 
 ## See also
 
-- {htmlelement("details")}}, {{htmlelement("dialog")}}, {{htmlelement("select")}}, and {{htmlelement("input")}} elements
+- {{htmlelement("details")}}, {{htmlelement("dialog")}}, {{htmlelement("select")}}, and {{htmlelement("input")}} elements
 - {{cssxref(":popover-open")}} pseudo-class
 - {{Cssxref(":modal")}}


### PR DESCRIPTION
### Description

- Corrected the See Also link for `<details>` element

### Motivation

- Working on issue [#37938](https://github.com/mdn/content/issues/37938)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/25853)
- Firefox Release PR - coming soon