### PR TITLE
Add documentation for dialog.requestClose()

### DIFF
--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -4,6 +4,7 @@ slug: Web/API/HTMLDialogElement
 page-type: web-api-interface
 browser-compat:
   - api.HTMLDialogElement
+  - api.HTMLDialogElement.requestClose
   - api.HTMLElement.beforetoggle_event.dialog_elements
   - api.HTMLElement.toggle_event.dialog_elements
 ---
@@ -29,6 +30,8 @@ _Also inherits methods from its parent interface, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLDialogElement.close()")}}
   - : Closes the dialog. An optional string may be passed as an argument, updating the `returnValue` of the dialog.
+- {{domxref("HTMLDialogElement.requestClose()")}}
+  - : Requests to close the dialog. An optional string may be passed as an argument, updating the `returnValue` of the dialog.
 - {{domxref("HTMLDialogElement.show()")}}
   - : Displays the dialog modelessly, i.e. still allowing interaction with content outside of the dialog.
 - {{domxref("HTMLDialogElement.showModal()")}}
@@ -41,7 +44,7 @@ _Also inherits events from its parent interface, {{DOMxRef("HTMLElement")}}._
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
 - {{domxref("HTMLDialogElement/cancel_event", "cancel")}}
-  - : Fired when the user dismisses the current open dialog with the escape key.
+  - : Fired when the dialog is requested to close, whether with the escape key, or via the `HTMLDialogElement.requestClose()` method.
 - {{domxref("HTMLDialogElement/close_event", "close")}}
   - : Fired when the dialog is closed, whether with the escape key, the `HTMLDialogElement.close()` method, or via submitting a form within the dialog with [`method="dialog"`](/en-US/docs/Web/HTML/Element/form#method).
 
@@ -156,6 +159,7 @@ dialog.addEventListener("close", (event) => {
 ##### Cancel event
 
 The {{domxref("HTMLDialogElement/cancel_event", "cancel")}} event is fired when "platform specific methods" are used to close the dialog, such as the <kbd>Esc</kbd> key.
+It is also fired when the `HTMLDialogElement.requestClose()` method is called.
 The event is "cancelable" which means that we could use it to prevent the dialog from closing.
 Here we just treat the cancel as a "close" operation, and reset the {{domxref("HTMLDialogElement.returnValue")}} to `""` to clear any value that may have been set.
 

--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -1,0 +1,110 @@
+---
+title: "HTMLDialogElement: requestClose() method"
+short-title: requestClose()
+slug: Web/API/HTMLDialogElement/requestClose
+page-type: web-api-instance-method
+browser-compat: api.HTMLDialogElement.requestClose
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`requestClose()`** method of the {{domxref("HTMLDialogElement")}} interface requests to close the {{htmlelement("dialog")}}.
+An optional string may be passed as an argument, updating the `returnValue` of the dialog.
+
+This method differs from the `HTMLDialogElement.close()` method by firing a `cancel` event before firing the `close` event. This allows
+authors to prevent the dialog from closing. This method exposes the same behavior as the dialogs internal close watcher.
+
+## Syntax
+
+```js-nolint
+requestClose()
+requestClose(returnValue)
+```
+
+### Parameters
+
+- `returnValue` {{optional_inline}}
+  - : A string representing an updated value for the {{domxref("HTMLDialogElement.returnValue")}} of the dialog.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form via the `showModal()` method.
+From there you can click the _X_ button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the submit button.
+
+```html
+<!-- Simple pop-up dialog box, containing a form -->
+<dialog id="favDialog">
+  <form method="dialog">
+    <button id="close" aria-label="close" formnovalidate>X</button>
+    <section>
+      <p>
+        <label for="favAnimal">Favorite animal:</label>
+        <select id="favAnimal" name="favAnimal">
+          <option></option>
+          <option>Brine shrimp</option>
+          <option>Red panda</option>
+          <option>Spider monkey</option>
+        </select>
+      </p>
+    </section>
+    <menu>
+      <button type="reset">Reset</button>
+      <button type="submit">Confirm</button>
+    </menu>
+  </form>
+</dialog>
+
+<menu>
+  <button id="updateDetails">Update details</button>
+</menu>
+
+<script>
+  (() => {
+    const updateButton = document.getElementById("updateDetails");
+    const closeButton = document.getElementById("close");
+    const dialog = document.getElementById("favDialog");
+
+    // Update button opens a modal dialog
+    updateButton.addEventListener("click", () => {
+      dialog.showModal();
+    });
+
+    // Form close button requests to close the dialog box
+    closeButton.addEventListener("click", () => {
+      dialog.requestClose("animalNotChosen");
+    });
+
+    function dialogShouldNotClose() {
+      // Add logic to decide whether to prevent the dialog from closing
+    }
+
+    dialog.addEventListener("cancel", (event) => {
+      if (!event.cancelable) return;
+      if (dialogShouldNotClose()) event.preventDefault();
+    });
+  })();
+</script>
+```
+
+If the "X" button was of `type="submit"`, the dialog would have closed without requiring JavaScript.
+A form submission closes the `<dialog>` it is nested within if the [form's method is `dialog`](/en-US/docs/Web/HTML/Element/form#method), so no "close" button is required.
+
+### Result
+
+{{ EmbedLiveSample('Examples', '100%', '200px') }}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The HTML element implementing this interface: {{ HTMLElement("dialog") }}.

--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -12,7 +12,7 @@ The **`requestClose()`** method of the {{domxref("HTMLDialogElement")}} interfac
 An optional string may be passed as an argument, updating the `returnValue` of the dialog.
 
 This method differs from the `HTMLDialogElement.close()` method by firing a `cancel` event before firing the `close` event. This allows
-authors to prevent the dialog from closing. This method exposes the same behavior as the dialogs internal close watcher.
+authors to prevent the dialog from closing. This method exposes the same behavior as the dialog's internal close watcher.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form via the `showModal()` method.
+The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form, via the `showModal()` method.
 From there you can click the _X_ button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the submit button.
 
 ```html

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -106,7 +106,7 @@ We can style the backdrop of the dialog by using the {{cssxref('::backdrop')}} p
 
 #### JavaScript
 
-The dialog is opened modally using the `.showModal()` method and closed using the `.close()` method.
+The dialog is opened modally using the `.showModal()` method and closed using the `.close()` or `.requestClose()` methods.
 
 ```js
 const dialog = document.querySelector("dialog");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Adds documentation for the new dialog.requestClose() function.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This is shipping in Chrome 134 and is in Safari Tech Preview 213, so it would be good to get documented

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-requestclose

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Related to https://github.com/mdn/content/issues/37196


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
