### PR TITLE
Add note to `start_url` to warn users from leaving it unspecified

### DIFF
--- a/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
@@ -35,10 +35,11 @@ The `start_url` manifest member is used to specify the URL that should be opened
     If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not {{glossary("origin", "same-origin")}} as the page that links to the manifest), the URL of the page that links to the manifest is used.
 
     > [!NOTE]
-    > If [`scope`](/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).
+    > On some browsers the `start_url` _must_ be specified for a [PWA to be installable](/en-US/docs/web/progressive_web_apps/guides/making_pwas_installable#installability) (see the compatibility section below).
+    > You can set `"start_url": "./"` to use the default behavior on all browsers.
 
     > [!NOTE]
-    > Leaving the `start_url` unspecified can lead to unwanted consequences (see [Installability](/docs/web/progressive_web_apps/guides/making_pwas_installable#installability)). Set it specifically to a relative path instead: `"start_url": "./"`.
+    > If [`scope`](/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).
 
 ## Description
 

--- a/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
@@ -37,6 +37,10 @@ The `start_url` manifest member is used to specify the URL that should be opened
     > [!NOTE]
     > If [`scope`](/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).
 
+    > [!NOTE]
+    > Leaving the `start_url` unspecified can lead to unwanted consequences (see [Installability](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability)). Set it specifically to a relative path instead: `"start_url": "./"`.
+
+
 ## Description
 
 The `start_url` allows you to recommend an appropriate common entry point for all users.

--- a/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
@@ -38,8 +38,7 @@ The `start_url` manifest member is used to specify the URL that should be opened
     > If [`scope`](/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).
 
     > [!NOTE]
-    > Leaving the `start_url` unspecified can lead to unwanted consequences (see [Installability](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability)). Set it specifically to a relative path instead: `"start_url": "./"`.
-
+    > Leaving the `start_url` unspecified can lead to unwanted consequences (see [Installability](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability)). Set it specifically to a relative path instead: `"start_url": "./"`.
 
 ## Description
 

--- a/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/reference/start_url/index.md
@@ -38,7 +38,7 @@ The `start_url` manifest member is used to specify the URL that should be opened
     > If [`scope`](/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope) is not specified in the manifest it will be inferred from the `start_url` (or effective `start_url` if the value is undefined or invalid).
 
     > [!NOTE]
-    > Leaving the `start_url` unspecified can lead to unwanted consequences (see [Installability](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability)). Set it specifically to a relative path instead: `"start_url": "./"`.
+    > Leaving the `start_url` unspecified can lead to unwanted consequences (see [Installability](/docs/web/progressive_web_apps/guides/making_pwas_installable#installability)). Set it specifically to a relative path instead: `"start_url": "./"`.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add note to `start_url` to warn users from leaving it unspecified

### Motivation

Reading the documentation it sounds as if omitting `start_url` is valid as it leads to the default behavior of using the URL of the page that links to the manifest.
This PR adds a note to warn the user that this is not recommended as it leads to installability issues on chromium based browsers. Instead users should use `"share_url": "./"` to get the desired behavior without breaking installability. 