### PR TITLE
Fix CSS typo in `view-timeline` docs

### DIFF
--- a/files/en-us/web/css/view-timeline/index.md
+++ b/files/en-us/web/css/view-timeline/index.md
@@ -165,7 +165,7 @@ Last, an animation is specified on the element that animates its opacity and sca
   }
 
   to {
-    opacity: 1,
+    opacity: 1;
     transform: scaleX(1);
   }
 }


### PR DESCRIPTION
### Description

Typo in CSS code:
![image](https://github.com/user-attachments/assets/7565ec93-ebe0-4297-8ed2-71e9851fa060)

### Motivation

Code did not work out of the box.

### Additional details

Link to page: https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline
