### PR TITLE
Correct wrong use of word "then"

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/button_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.md
@@ -153,7 +153,7 @@ function handleCommand(event) {
   // Handles both mouse clicks and keyboard
   // activate with Enter or Space
 
-  // Keypresses other then Enter and Space should not trigger a command
+  // Keypresses other than Enter and Space should not trigger a command
   if (
     event instanceof KeyboardEvent &&
     event.key !== "Enter" &&

--- a/files/en-us/web/xml/xpath/reference/functions/round/index.md
+++ b/files/en-us/web/xml/xpath/reference/functions/round/index.md
@@ -20,7 +20,7 @@ round( decimal )
 
 ### Return value
 
-The nearest integer less then, greater than, or equal to `decimal`.
+The nearest integer less than, greater than, or equal to `decimal`.
 
 ## Description
 

--- a/files/en-us/webassembly/reference/numeric/less_or_equal/index.md
+++ b/files/en-us/webassembly/reference/numeric/less_or_equal/index.md
@@ -18,7 +18,7 @@ The integer types have separate less or equal instructions for signed (**`le_s`*
 local.get $num
 i32.const 2
 
-;; check if $num is less then or equal to '2'
+;; check if $num is less than or equal to '2'
 i32.le_u
 
 ;; if $num is less than or equal to the `2`, `1` will be pushed on to the stack,

--- a/files/en-us/webassembly/reference/numeric/less_than/index.md
+++ b/files/en-us/webassembly/reference/numeric/less_than/index.md
@@ -18,7 +18,7 @@ The integer types have separate less than instructions for signed (**`lt_s`**) a
 local.get $num
 i32.const 2
 
-;; check if $num is less then '2'
+;; check if $num is less than '2'
 i32.lt_u
 
 ;; if $num is less than the `2`, `1` will be pushed on to the stack,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix incorrect use of "then" instead of the correct "than".

### Motivation

N/A

### Additional details

N/A

### Related issues and pull requests

N/A
