### PR TITLE
Remove discouraged warning from `writeln()`

### DIFF
--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -8,14 +8,6 @@ browser-compat: api.Document.writeln
 
 {{ ApiRef("DOM") }}
 
-> [!WARNING]
-> Use of the `document.writeln()` method is strongly discouraged.
->
-> As [the HTML spec itself warns](<https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.write()>):
->
-> > This method has very idiosyncratic behavior. In some cases, this method can affect the state of the [HTML parser](https://html.spec.whatwg.org/multipage/parsing.html#html-parser) while the parser is running, resulting in a DOM that does not correspond to the source of the document (e.g. if the string written is the string "`<plaintext>`" or "`<!--`"). In other cases, the call can clear the current page first, as if [`document.open()`](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open) had been called. In yet more cases, the method is simply ignored, or throws an exception. Users agents are [explicitly allowed to avoid executing `script` elements inserted via this method](https://html.spec.whatwg.org/multipage/parsing.html#document-written-scripts-intervention). And to make matters even worse, the exact behavior of this method can in some cases be dependent on network latency, which can lead to failures that are very hard to debug. For all these reasons, use of this method is strongly discouraged.
-> > Therefore, avoid using `document.writeln()` — and if possible, update any existing code that is still using it.
-
 Writes a string of text followed by a newline character to a document.
 
 ## Syntax


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The reference page for `writeln()` quotes spec text for a different method (`write()`); the actual method is not actually warned off [in the spec](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.writeln()).

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

https://github.com/whatwg/html/issues/7977 proposes discouraging but the discouragement never actually happened. The compat data (which is correctly non-discouraged) and the page are in conflict. This made it really confusing to understand the feature, when dealing with new keys from BCD in web-features.

It'd be nice to reinstate the warning, if the spec ever gets fixed.

### Related issues and pull requests

This was originally added in https://github.com/mdn/content/pull/16854.
