### PR TITLE
remove image and add links to css cookbook

### DIFF
--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -24,7 +24,7 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground:
   <header class="page-header">This is the header</header>
   <main class="page-body">
     <p contenteditable>
-      The footer sticks to the bottom even thought this paragraph is short. Add
+      The footer sticks to the bottom even though this paragraph is short. Add
       content to this editable area to see the footer push down when needed to
       fit the content.
     </p>

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -90,7 +90,7 @@ You can also use [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to creat
   <header class="page-header">This is the header</header>
   <main class="page-body">
     <p contenteditable>
-      The footer sticks to the bottom even thought this paragraph is short. Add
+      The footer sticks to the bottom even though this paragraph is short. Add
       content to this editable area to see the footer push down when needed to
       fit the content.
     </p>

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -24,8 +24,9 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground:
   <header class="page-header">This is the header</header>
   <main class="page-body">
     <p contenteditable>
-      The footer sticks to the bottom even thought this paragraph is short. Add content to this editable area to see the
-      footer push down when needed to fit the content.
+      The footer sticks to the bottom even thought this paragraph is short. Add
+      content to this editable area to see the footer push down when needed to
+      fit the content.
     </p>
   </main>
   <footer class="page-footer">Sticky footer</footer>
@@ -89,8 +90,9 @@ You can also use [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to creat
   <header class="page-header">This is the header</header>
   <main class="page-body">
     <p contenteditable>
-      The footer sticks to the bottom even thought this paragraph is short. Add content to this editable area to see the
-      footer push down when needed to fit the content.
+      The footer sticks to the bottom even thought this paragraph is short. Add
+      content to this editable area to see the footer push down when needed to
+      fit the content.
     </p>
   </main>
   <footer class="page-footer">Sticky footer</footer>

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -10,10 +10,10 @@ A sticky footer pattern is one where the footer of your page "sticks" to the bot
 
 ## Requirements
 
-The Sticky footer pattern needs to meet the following requirements:
+The sticky footer pattern needs to meet the following requirements:
 
 - Footer sticks to the bottom of the viewport when content is short.
-- If the content of the page extends past the viewport bottom, the footer then sits below the content as normal.
+- If the content of the page extends past the viewport bottom, the footer gets pushed down, always sitting below the content as normal.
 
 ## The recipe
 
@@ -24,8 +24,8 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground:
   <header class="page-header">This is the header</header>
   <main class="page-body">
     <p contenteditable>
-      Main page content here, add more to this text if you want to see the
-      footer push down.
+      The footer sticks to the bottom even thought this paragraph is short. Add content to this editable area to see the
+      footer push down when needed to fit the content.
     </p>
   </main>
   <footer class="page-footer">Sticky footer</footer>
@@ -69,7 +69,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("sticky-footer-example", "", "350px")}}
+{{EmbedLiveSample("sticky-footer-example", "", "400px")}}
 
 > [!NOTE]
 > In this example and the following one we are using a wrapper set to `min-height: 100%`. You can also achieve this for a full page by setting a {{cssxref("min-height")}} of `100vh` on the {{htmlelement("body")}} and then using it as your grid container.
@@ -89,8 +89,8 @@ You can also use [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to creat
   <header class="page-header">This is the header</header>
   <main class="page-body">
     <p contenteditable>
-      Main page content here, add more to this text if you want to see the
-      footer push down.
+      The footer sticks to the bottom even thought this paragraph is short. Add content to this editable area to see the
+      footer push down when needed to fit the content.
     </p>
   </main>
   <footer class="page-footer">Sticky footer</footer>
@@ -140,7 +140,7 @@ body {
 }
 ```
 
-{{EmbedLiveSample("sticky-footer-flexbox-example", "", "350px")}}
+{{EmbedLiveSample("sticky-footer-flexbox-example", "", "400px")}}
 
 The flexbox example starts out in the same way, but we use `display:flex` rather than `display:grid` on the `.wrapper`; we also set {{cssxref("flex-direction")}} to `column`. Then we set our main content to [`flex-grow: 1`](/en-US/docs/Web/CSS/flex-grow) and the other two elements to [`flex-shrink: 0`](/en-US/docs/Web/CSS/flex-shrink) — this prevents them from shrinking smaller when content fills the main area.
 

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -8,8 +8,6 @@ page-type: guide
 
 A sticky footer pattern is one where the footer of your page "sticks" to the bottom of the viewport in cases where the content is shorter than the viewport height. We'll look at a couple of techniques for creating one in this recipe.
 
-![A sticky footer pushed to the bottom of a box](cookbook-footer.png)
-
 ## Requirements
 
 The Sticky footer pattern needs to meet the following requirements:
@@ -71,20 +69,20 @@ body {
 }
 ```
 
-{{EmbedLiveSample("sticky-footer-example", "", "400px")}}
+{{EmbedLiveSample("sticky-footer-example", "", "350px")}}
 
 > [!NOTE]
 > In this example and the following one we are using a wrapper set to `min-height: 100%`. You can also achieve this for a full page by setting a {{cssxref("min-height")}} of `100vh` on the {{htmlelement("body")}} and then using it as your grid container.
 
 ## Choices made
 
-In the above example we achieve the sticky footer using CSS grid layout. The `.wrapper` has a minimum height of `100%` which means it is as tall as the container it is in. We then create a single column grid layout with three rows, one row for each part of our layout.
+In the above example we achieve the sticky footer using [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout). The `.wrapper` has a minimum height of `100%` which means it is as tall as the container it is in. We then create a single column grid layout with three rows, one row for each part of our layout.
 
-Grid auto-placement will place our items in source order and so the header goes into the first auto sized track, the main content into the `1fr` track and the footer into the final auto sized track. The `1fr` track will take up all available space and so grows to fill the gap.
+[Grid auto-placement](/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout) will place our items in source order and so the header goes into the first auto sized track, the main content into the `1fr` track and the footer into the final auto sized track. The `1fr` track will take up all available space and so grows to fill the gap.
 
 ## Alternate method
 
-You can also use flexbox to create a sticky footer.
+You can also use [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to create a sticky footer.
 
 ```html live-sample___sticky-footer-flexbox-example
 <div class="wrapper">
@@ -142,9 +140,9 @@ body {
 }
 ```
 
-{{EmbedLiveSample("sticky-footer-flexbox-example", "", "400px")}}
+{{EmbedLiveSample("sticky-footer-flexbox-example", "", "350px")}}
 
-The flexbox example starts out in the same way, but we use `display:flex` rather than `display:grid` on the `.wrapper`; we also set `flex-direction` to `column`. Then we set our main content to `flex-grow: 1` and the other two elements to `flex-shrink: 0` — this prevents them from shrinking smaller when content fills the main area.
+The flexbox example starts out in the same way, but we use `display:flex` rather than `display:grid` on the `.wrapper`; we also set {{cssxref("flex-direction")}} to `column`. Then we set our main content to [`flex-grow: 1`](/en-US/docs/Web/CSS/flex-grow) and the other two elements to [`flex-shrink: 0`](/en-US/docs/Web/CSS/flex-shrink) — this prevents them from shrinking smaller when content fills the main area.
 
 ## Resources on MDN
 


### PR DESCRIPTION
it helps to have links within the content of the page

i removed the image because the image had instructions to edit the content, and the content was not editable, which created UI issues, and made the content super inaccessible for people with cognitive differences.

Changed the text of the examples to make it clearer