### PR TITLE
Remove most GH gist links

### DIFF
--- a/files/en-us/web/accessibility/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/seizure_disorders/index.md
@@ -199,7 +199,7 @@ All image types are potentially dangerous, however, animated GIFs deserve specia
 
 #### Detect if a GIF is animated
 
-- [npm's animated-gif-detector](https://www.npmjs.com/package/animated-gif-detector) allows for the ability to determine animate _as early as possible_ in a given HTTP request.
+- The [animated-gif-detector](https://www.npmjs.com/package/animated-gif-detector) npm package allows for the ability to determine animate _as early as possible_ in a given HTTP request.
 - Zakirt provides a gist for [animated-gif-detect.js](https://gist.github.com/zakirt/faa4a58cec5a7505b10e3686a226f285)
 
 With animated GIFs, ensure animation is inactive until the user chooses to activate it. For example, the user must push a button or check a box in order to start the animation.

--- a/files/en-us/web/api/node/isconnected/index.md
+++ b/files/en-us/web/api/node/isconnected/index.md
@@ -77,7 +77,3 @@ console.log(style.isConnected); // Returns true
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [Node.prototype.isConnected polyfill](https://gist.github.com/eligrey/f109a6d0bf4efe3461201c3d7b745e8f)

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -41,10 +41,7 @@ To be able to use localStorage, we should first verify that it is supported and 
 
 ### Testing for availability
 
-> [!NOTE]
-> This API is available in current versions of all major browsers. Testing for availability is necessary only if you must support very old browsers, or in the limited circumstances described below.
-
-Browsers that support localStorage have a property on the window object named `localStorage`. However, just asserting that the property exists may throw exceptions. If the `localStorage` object does exist, there is still no guarantee that the localStorage API is actually available, as various browsers offer settings that disable localStorage. So a browser may _support_ localStorage, but not make it _available_ to the scripts on the page.
+Browsers that support localStorage have a property on the window object named `localStorage`. However, just testing that the property exists, like in normal feature detection, may be insufficient. Various browsers offer settings that disable the storage API, without hiding the global object. So a browser may _support_ `localStorage`, but not make it _available_ to the scripts on the page.
 
 For example, for a document viewed in a browser's private browsing mode, some browsers might give us an empty `localStorage` object with a quota of zero, effectively making it unusable. Conversely, we might get a legitimate `QuotaExceededError`, which means that we've used up all available storage space, but storage _is_ actually _available_. Our feature detection should take these scenarios into account.
 
@@ -81,9 +78,7 @@ if (storageAvailable("localStorage")) {
 }
 ```
 
-You can test for sessionStorage instead by calling `storageAvailable('sessionStorage')`.
-
-See here for a [brief history of feature-detecting localStorage](https://gist.github.com/paulirish/5558557).
+You can test for `sessionStorage` instead by calling `storageAvailable("sessionStorage")`.
 
 ## Example
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
@@ -40,6 +40,148 @@ So let's get started by setting up the basis for our WebRTC-powered phone app.
    }
    ```
 
-4. To finish the setup, you'll want to copy the following [HTML](https://gist.github.com/lolaodelola/578d692e4700dfe2c9d239c80bbdbabc) and [CSS](https://gist.github.com/lolaodelola/b4498288b86ddce995603546a64abb29) files into the root of your project folder. You can name both files 'index', so the HTML file will be 'index.html' and the CSS file will be 'index.css'. You won't need to modify these much in the articles that follow.
+4. To finish the setup, you should copy the following HTML and CSS files into the root of your project folder. You can name both files `index`, so the HTML file will be `index.html` and the CSS file will be `index.css`. You won't need to modify these much in the articles that follow.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Lola's Web Phone!</title>
+
+    <meta property="og:title" content="Teleprompter!" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@lady_ada_king" />
+    <meta name="twitter:creator" content="@lady_ada_king" />
+    <meta property="og:url" content="https://teleprompter.glitch.me" />
+    <meta
+      property="og:description"
+      content="Cast your computer to your phone or tablet to use it in a teleprompter" />
+    <meta
+      name="description"
+      content="Cast your computer to your phone or tablet to use it in a teleprompter" />
+    <!--     <meta property="og:image" content="https://cdn.glitch.com/1695682e-08d3-41c8-a322-1e235b5782e1%2Fimage.png?v=1561449954420"> -->
+
+    <!-- import the webpage's stylesheet -->
+    <link rel="stylesheet" href="/index.css" />
+
+    <link rel="manifest" href="/manifest.json" />
+
+    <!-- import the webpage's javascript file -->
+    <script src="https://unpkg.com/peerjs@1.3.1/dist/peerjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/davidshimjs-qrcodejs@0.0.2/qrcode.min.js"></script>
+    <script src="script.js" defer></script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Phone a friend</h1>
+      <p id="cast-status" class="big">Connecting...</p>
+      <p>Please use headphones!</p>
+      <button class="call-btn">Call</button>
+      <section class="call-container" hidden>
+        <div class="audio-container">
+          <p>You're automatically muted, unmute yourself!</p>
+          <audio controls id="remoteAudio" muted="true"></audio>
+          <audio controls id="localAudio" muted="true"></audio>
+        </div>
+        <button class="hangup-btn">Hang up</button>
+      </section>
+    </div>
+
+    <section class="modal" hidden>
+      <div id="close">close</div>
+      <div class="inner-modal">
+        <label>Give us your friend's device ID</label>
+        <input placeholder="Enter your friend's device ID" aria-colcount="10" />
+        <button class="connect-btn">Connect</button>
+      </div>
+    </section>
+  </body>
+</html>
+```
+
+```css
+*,
+*:before,
+*:after {
+  box-sizing: border-box;
+}
+
+body {
+  color: darkslategrey;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: antiquewhite;
+}
+
+h1 {
+  font-size: 6rem;
+  letter-spacing: 0.2rem;
+  margin-bottom: auto;
+}
+
+p {
+  text-align: center;
+  font-size: 2rem;
+}
+
+button {
+  background-color: -internal-light-dark(white, black);
+  padding: 1rem 10rem;
+  border-radius: 3rem;
+  border: none;
+  cursor: pointer;
+}
+
+.call-btn {
+  background-color: darkslategrey;
+  color: antiquewhite;
+  font-size: 3rem;
+  margin-left: 7rem;
+}
+
+.hangup-btn {
+  background-color: darkred;
+  color: white;
+  font-size: 1.5rem;
+  margin-left: 6rem;
+  margin-top: 4rem;
+}
+
+.modal {
+  padding: 5rem;
+  background-color: whitesmoke;
+  border-radius: 2rem;
+  width: 40rem;
+  height: 20rem;
+}
+
+.inner-modal {
+  text-align: center;
+}
+
+.modal label {
+  font-size: 1.5rem;
+}
+.modal input {
+  margin: 1rem 7rem 3rem;
+  display: block;
+  padding: 1rem;
+  border-radius: 3rem;
+  box-shadow: 0 0 15px 4px rgba(0, 0, 0, 0.19);
+  border: none;
+  width: 50%;
+}
+
+.connect-btn {
+  background-color: #0c1d1d;
+  color: whitesmoke;
+  font-size: 1.5rem;
+}
+```
 
 {{PreviousMenuNext("Web/API/WebRTC_API/Build_a_phone_with_peerjs", "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Build_the_server")}}

--- a/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
@@ -35,7 +35,7 @@ const helperPath = import.meta.resolve("./lib/helper.js");
 console.log(helperPath); // "https://example.com/lib/helper.js"
 ```
 
-Note that `import.meta.resolve()` only performs resolution and does not attempt to load or import the resulting path. (The [explainer for the specification](https://gist.github.com/domenic/f2a0a9cb62d499bcc4d12aebd1c255ab#sync-vs-async) describes the reasoning for this behavior.) Therefore, its return value is the same _regardless of whether the returned path corresponds to a file that exists, and regardless of whether that file contains valid code for a module_.
+Note that `import.meta.resolve()` only performs resolution and does not attempt to load or import the resulting path. Therefore, its return value is the same _regardless of whether the returned path corresponds to a file that exists, and regardless of whether that file contains valid code for a module_. This allows `import.meta.resolve()` to be a _synchronous_ operation.
 
 It is different from [dynamic import](/en-US/docs/Web/JavaScript/Reference/Operators/import), because although both accept a module specifier as the first argument, `import.meta.resolve()` returns the path that _would be imported_ without making any attempt to access that path. Therefore, the following two are effectively the same code:
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/37804.

In the spirit of moving examples into pages, we should also move gists, because they would not be in sync with other code linting infra we have.