### PR TITLE
Fix gulpfile instructions

### DIFF
--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -167,6 +167,7 @@ import gulp from "gulp";
 // Add any new task exports here
 // export function ...
 // export function ...
+```
 
 To add some real tasks to Gulp, we need to think about what we want to do. A reasonable set of basic functionalities to run on our project is as follows:
 

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -147,6 +147,8 @@ Let's look at setting up Gulp and using it to automate some testing tools.
    gulp
    ```
 
+### Adding some real tasks to Gulp
+
 Now we are ready to add more tasks to our Gulp file. Each addition may require you to modify the `gulpfile.mjs` file in the following way:
 
 - If we ask you to add some `import` statements, add them below the existing `import` statement.
@@ -166,8 +168,6 @@ import gulp from "gulp";
 // export function ...
 // export function ...
 ```
-
-### Adding some real tasks to Gulp
 
 To add some real tasks to Gulp, we need to think about what we want to do. A reasonable set of basic functionalities to run on our project is as follows:
 

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -113,8 +113,8 @@ Let's look at setting up Gulp and using it to automate some testing tools.
    ```
 
 2. Next, you'll need some sample HTML, CSS and JavaScript content to test your system on — make copies of our sample [index.html](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/index.html), [main.js](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/main.js), and [style.css](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/style.css) files in a subfolder with the name `src` inside your project folder.
-   You can try your own test content if you like, but bear in mind that such tools won't work on internal JS/CSS — you need external files.
-3. First, install gulp globally (meaning, it will be available across all projects) using the following command:
+   You can try your own test content if you like, but bear in mind that such tools don't work well with JS/CSS inlined in the HTML file — you need separate files.
+3. Install gulp globally (meaning, it will be available across all projects) using the following command:
 
    ```bash
    npm install --global gulp-cli
@@ -137,13 +137,35 @@ Let's look at setting up Gulp and using it to automate some testing tools.
    }
    ```
 
-   This requires the `gulp` module we installed earlier, and then exports a default task that does nothing except for printing a message to the terminal — this is useful for letting us know that Gulp is working. Each gulp task is exported in the same basic format — `exports.taskName = taskFunction`. Each function takes one parameter — a callback to run when the task is completed.
+   This requires the `gulp` module we installed earlier, and then exports a default task that does nothing except for printing a message to the terminal — this is useful for letting us know that Gulp is working. In the next few sections, we will change this `export default` statement to something more useful.
+
+   Each gulp task is exported in the same basic format — `exports function taskName(cb) {...}`. Each function takes one parameter — a callback to run when the task is completed.
 
 6. You can run your gulp's default task with the following command — try this now:
 
    ```bash
    gulp
    ```
+
+Now we are ready to add more tasks to our Gulp file. Each addition may require you to modify the `gulpfile.mjs` file in the following way:
+
+- If we ask you to add some `import` statements, add them below the existing `import` statement.
+- If we ask you to add a new `export function ...` statement, add it to the end of the file.
+- If we ask you to change the default export, change the `export default` statement in the way we specify.
+
+So your `gulpfile.mjs` file will grow like this:
+
+```js
+import gulp from "gulp";
+// Add any new imports here
+
+// Our latest default export
+// export default ...
+
+// Add any new task exports here
+// export function ...
+// export function ...
+```
 
 ### Adding some real tasks to Gulp
 
@@ -155,7 +177,7 @@ To add some real tasks to Gulp, we need to think about what we want to do. A rea
 
 See the links above for full instructions on the different gulp packages we are using.
 
-To use each plugin, you need to first install it via npm, then require any dependencies at the top of the `gulpfile.js` file, then add your test(s) to the bottom of it, and finally export the name of your task to be available via gulp's command.
+To use each plugin, you need to first install it via npm, then require any dependencies at the top of the `gulpfile.mjs` file, then add your test(s) to the bottom of it, and finally export the name of your task to be available via gulp's command.
 
 #### html-tidy
 
@@ -167,13 +189,13 @@ To use each plugin, you need to first install it via npm, then require any depen
 
    > **Note:** `--save-dev` adds the package as a dependency to your project. If you look in your project's `package.json` file, you'll see an entry for it in the `devDependencies` property.
 
-2. Add the following dependency to `gulpfile.js`:
+2. Add the following dependency to `gulpfile.mjs`:
 
    ```js
    import htmltidy from "gulp-htmltidy";
    ```
 
-3. Add the following test to the bottom of `gulpfile.js`:
+3. Add the following test to the bottom of `gulpfile.mjs`:
 
    ```js
    export function html() {
@@ -205,14 +227,14 @@ In the input version of the file, you may have noticed that we put an empty {{ht
    npm install --save-dev gulp-csslint
    ```
 
-2. Add the following dependencies to `gulpfile.js`:
+2. Add the following dependencies to `gulpfile.mjs`:
 
    ```js
    import autoprefixer from "gulp-autoprefixer";
    import csslint from "gulp-csslint";
    ```
 
-3. Add the following test to the bottom of `gulpfile.js`:
+3. Add the following test to the bottom of `gulpfile.mjs`:
 
    ```js
    export function css() {
@@ -255,14 +277,14 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
    npm install jshint gulp-jshint --save-dev
    ```
 
-2. Add the following dependencies to `gulpfile.js`:
+2. Add the following dependencies to `gulpfile.mjs`:
 
    ```js
    import babel from "gulp-babel";
    import jshint from "gulp-jshint";
    ```
 
-3. Add the following test to the bottom of `gulpfile.js`:
+3. Add the following test to the bottom of `gulpfile.mjs`:
 
    ```js
    export function js() {
@@ -297,7 +319,7 @@ You can then try out the files output by your automated tasks by looking at them
 
 If you get errors, check that you've added all the dependencies and the tests as shown above; also try commenting out the HTML/CSS/JavaScript code sections and then rerunning gulp to see if you can isolate what the problem is.
 
-Gulp comes with a `watch()` function that you can use to watch your files and run tests whenever you save a file. For example, try adding the following to the bottom of your `gulpfile.js`:
+Gulp comes with a `watch()` function that you can use to watch your files and run tests whenever you save a file. For example, try adding the following to the bottom of your `gulpfile.mjs`:
 
 ```js
 export function watch() {

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -151,9 +151,9 @@ Let's look at setting up Gulp and using it to automate some testing tools.
 
 Now we are ready to add more tasks to our Gulp file. Each addition may require you to modify the `gulpfile.mjs` file in the following way:
 
-- If we ask you to add some `import` statements, add them below the existing `import` statement.
-- If we ask you to add a new `export function ...` statement, add it to the end of the file.
-- If we ask you to change the default export, change the `export default` statement in the way we specify.
+- When we ask you to add some `import` statements, add them below the existing `import` statement.
+- When we ask you to add a new `export function ...` statement, add it to the end of the file.
+- When we ask you to change the default export, change the `export default` statement in the way we specify.
 
 So your `gulpfile.mjs` file will grow like this:
 
@@ -167,7 +167,6 @@ import gulp from "gulp";
 // Add any new task exports here
 // export function ...
 // export function ...
-```
 
 To add some real tasks to Gulp, we need to think about what we want to do. A reasonable set of basic functionalities to run on our project is as follows:
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/15272.

#30511 migrated us to use ESM in gulpfile, but left some stuff in an inconsistent state. This PR adds more instructions and fixes those inconsistencies.