### PR TITLE
Make grid axis use a more typical writing mode example

### DIFF
--- a/files/en-us/glossary/grid_axis/index.md
+++ b/files/en-us/glossary/grid_axis/index.md
@@ -10,15 +10,15 @@ CSS grid layout is a two-dimensional layout method enabling the laying out of co
 
 It is along these axes that items can be aligned and justified using the properties defined in the [Box Alignment specification](/en-US/docs/Web/CSS/CSS_box_alignment).
 
-In CSS the _block or column axis_ is the axis used when laying out blocks of text. If you have two paragraphs and are working in a right to left, top to bottom language they lay out one below the other, on the block axis.
+The _inline axis_ (also called row axis, or main axis) is the direction along which regular text flows. The _block axis_ (also called column axis, or cross axis) is the axis used when laying out blocks of text. The physical direction of these axes can change according to the [writing mode](/en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes) of the document.
 
-![Diagram showing the block axis in CSS grid layout.](7_block_axis.png)
-
-The _inline or row axis_ runs across the Block Axis and is the direction along which regular text flows. These are our rows in CSS grid layout.
+For example, if you are writing left to right, top to bottom (like typical English prose), then the individual characters are placed along the inline axis, which runs from left to right.
 
 ![Diagram showing the inline axis in CSS grid layout.](7_inline_axis.png)
 
-The physical direction of these axes can change according to the [writing mode](/en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes) of the document.
+And, if the text contains multiple lines, these lines are placed along the block axis, which runs from top to bottom.
+
+![Diagram showing the block axis in CSS grid layout.](7_block_axis.png)
 
 ## See also
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/32283. We should use a more typical example to not distract readers from non-common cases. The description should also give enough information to help them figure out how other writing modes would differ.