### PR TITLE
Fixed erroneous reference to `mapSync`

### DIFF
--- a/files/en-us/web/api/gpubuffer/mapasync/index.md
+++ b/files/en-us/web/api/gpubuffer/mapasync/index.md
@@ -53,7 +53,7 @@ A {{jsxref("Promise")}} that resolves to {{jsxref("Undefined")}} when the `GPUBu
 
 ### Validation
 
-The following criteria must be met when calling **`mapSync()`**, otherwise an `OperationError` {{domxref("DOMException")}} is thrown, the promise is rejected, and a {{domxref("GPUValidationError")}} is generated:
+The following criteria must be met when calling **`mapAsync()`**, otherwise an `OperationError` {{domxref("DOMException")}} is thrown, the promise is rejected, and a {{domxref("GPUValidationError")}} is generated:
 
 - `offset` is a multiple of 8.
 - The total range to be mapped (`size` if specified, or {{domxref("GPUBuffer.size")}} - `offset` if not) is a multiple of 4.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaces reference to `mapSync` function with reference to `mapAsync` function.

### Motivation

There is no `mapSync` function, so the reference to it seems to be a simple error. This PR replaces that reference with a reference to the correct `mapAsync` function.
