### PR TITLE
Sync with fetch spec for Forbidden request header

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -3566,6 +3566,7 @@
 /en-US/docs/Glossary/Empty_element	/en-US/docs/Glossary/Void_element
 /en-US/docs/Glossary/Error	/en-US/docs/Glossary/Exception
 /en-US/docs/Glossary/First_interactive	/en-US/docs/Glossary/First_CPU_idle
+/en-US/docs/Glossary/Forbidden_header_name	/en-US/docs/Glossary/Forbidden_request_header
 /en-US/docs/Glossary/GZip	/en-US/docs/Glossary/gzip_compression
 /en-US/docs/Glossary/Global_attribute	/en-US/docs/Web/HTML/Global_attributes
 /en-US/docs/Glossary/Grid_Rows	/en-US/docs/Glossary/Grid_Row

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -2367,7 +2367,7 @@
       "rachelandrew"
     ]
   },
-  "Glossary/Forbidden_header_name": {
+  "Glossary/Forbidden_request_header": {
     "modified": "2020-06-17T22:05:57.083Z",
     "contributors": [
       "s.zeid",

--- a/files/en-us/glossary/cors-safelisted_request_header/index.md
+++ b/files/en-us/glossary/cors-safelisted_request_header/index.md
@@ -33,5 +33,5 @@ CORS-safelisted headers must also fulfill the following requirements in order to
 
 - Related glossary terms:
   - {{Glossary("CORS-safelisted response header")}}
-  - {{Glossary("Forbidden header name")}}
+  - {{Glossary("Forbidden request header")}}
   - {{Glossary("Request header")}}

--- a/files/en-us/glossary/cors-safelisted_response_header/index.md
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.md
@@ -40,5 +40,5 @@ Access-Control-Expose-Headers: X-Custom-Header, Content-Encoding
 - Related glossary terms:
   - {{Glossary("CORS")}}
   - {{Glossary("CORS-safelisted_request_header", "CORS-safelisted request header")}}
-  - {{Glossary("Forbidden header name")}}
+  - {{Glossary("Forbidden request header")}}
   - {{Glossary("Request header")}}

--- a/files/en-us/glossary/fetch_metadata_request_header/index.md
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.md
@@ -10,7 +10,7 @@ A **fetch metadata request header** is an {{Glossary("Request header", "HTTP req
 
 With this information a server can implement a resource isolation policy, allowing external sites to request only those resources that are intended for sharing, and that are used appropriately. This approach can help mitigate common cross-site web vulnerabilities such as {{Glossary("CSRF")}}, Cross-site Script Inclusion (XSSI), timing attacks, and cross-origin information leaks.
 
-These headers are prefixed with `Sec-`, and hence have {{Glossary("Forbidden header name", "forbidden header names")}}. As such, they cannot be modified from JavaScript.
+These headers are prefixed with `Sec-`, and hence are {{Glossary("Forbidden request header", "forbidden request headers")}}. As such, they cannot be modified from JavaScript.
 
 The fetch metadata request headers are:
 

--- a/files/en-us/glossary/forbidden_request_header/index.md
+++ b/files/en-us/glossary/forbidden_request_header/index.md
@@ -1,15 +1,15 @@
 ---
-title: Forbidden header name
-slug: Glossary/Forbidden_header_name
+title: Forbidden request header
+slug: Glossary/Forbidden_request_header
 page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}
 
-A **forbidden header name** is the name of any [HTTP header](/en-US/docs/Web/HTTP/Headers) that cannot be modified programmatically; specifically, an HTTP **request** header name (in contrast with a {{Glossary("Forbidden response header name")}}).
+A **forbidden request header** is an [HTTP header](/en-US/docs/Web/HTTP/Headers) name-value pair that cannot be set of modified programmatically in a request. For headers forbidden to be modified in responses, see {{Glossary("forbidden response header name")}}.
 
 Modifying such headers is forbidden because the user agent retains full control over them.
-For example, the {{HTTPHeader("Date")}} header is a forbidden header name, so this code cannot set the message `Date` field:
+For example, the {{HTTPHeader("Date")}} header is a forbidden request header, so this code cannot set the message `Date` field:
 
 ```js example-bad
 fetch("https://httpbin.org/get", {
@@ -20,8 +20,9 @@ fetch("https://httpbin.org/get", {
 ```
 
 Names starting with `Sec-` are reserved for creating new headers safe from {{glossary("API","APIs")}} that grant developers control over headers, such as {{domxref("Window/fetch", "fetch()")}}.
-Forbidden header names start with `Proxy-` or `Sec-`, or are one of the following names:
+Forbidden headers are one of the following:
 
+- {{HTTPHeader("Accept-Charset")}}
 - {{HTTPHeader("Accept-Encoding")}}
 - {{HTTPHeader("Access-Control-Request-Headers")}}
 - {{HTTPHeader("Access-Control-Request-Method")}}
@@ -43,9 +44,12 @@ Forbidden header names start with `Proxy-` or `Sec-`, or are one of the followin
 - {{HTTPHeader("Transfer-Encoding")}}
 - {{HTTPHeader("Upgrade")}}
 - {{HTTPHeader("Via")}}
+- `X-HTTP-Method`, but only when it contains a forbidden method name ({{HTTPMethod("CONNECT")}}, {{HTTPMethod("TRACE")}}, {{HTTPMethod("TRACK")}})
+- `X-HTTP-Method-Override`, but only when it contains a forbidden method name
+- `X-Method-Override`, but only when it contains a forbidden method name
 
 > [!NOTE]
-> The {{HTTPHeader("User-Agent")}} header is no longer forbidden, [as per spec](https://fetch.spec.whatwg.org/#terminology-headers) — see forbidden header name list (this was implemented in Firefox 43) — it can now be set in a Fetch [Headers](/en-US/docs/Web/API/Headers) object, or with the [setRequestHeader()](/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader) method of `XMLHttpRequest`. However, Chrome will silently drop the header from Fetch requests (see [Chromium bug 571722](https://crbug.com/571722)).
+> The {{HTTPHeader("User-Agent")}} header used to be forbidden, but no longer is. However, Chrome still silently drops the header from Fetch requests (see [Chromium bug 571722](https://crbug.com/571722)).
 
 > [!NOTE]
 > While the {{HTTPHeader("Referer")}} header is listed as a forbidden header [in the spec](https://fetch.spec.whatwg.org/#forbidden-request-header), the user agent does not retain full control over it and the header can be programmatically modified. For example, when using [`fetch()`](/en-US/docs/Web/API/Window/fetch), the {{HTTPHeader("Referer")}} header can be programmatically modified via the [`referrer` option](/en-US/docs/Web/API/RequestInit#referrer).

--- a/files/en-us/glossary/forbidden_response_header_name/index.md
+++ b/files/en-us/glossary/forbidden_response_header_name/index.md
@@ -12,4 +12,4 @@ A _forbidden response header name_ is an [HTTP header](/en-US/docs/Web/HTTP/Head
 
 - [Fetch specification: forbidden response-header name](https://fetch.spec.whatwg.org/#forbidden-response-header-name)
 - Related glossary terms:
-  - {{Glossary("Forbidden header name")}}
+  - {{Glossary("Forbidden request header")}}

--- a/files/en-us/glossary/http_header/index.md
+++ b/files/en-us/glossary/http_header/index.md
@@ -62,7 +62,7 @@ X-Cache-Info: cached
   - {{Glossary("Response header")}}
   - {{Glossary("Representation header")}}
   - {{Glossary("Fetch metadata request header")}}
-  - {{Glossary("Forbidden header name")}}
+  - {{Glossary("Forbidden request header")}}
   - {{Glossary("Forbidden response header name")}}
   - {{Glossary("CORS-safelisted request header")}}
   - {{Glossary("CORS-safelisted response header")}}

--- a/files/en-us/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -35,7 +35,7 @@ This article explains how to create a new reference page for an HTTP header.
 - Make sure you have these sections:
 
   - Introductory text where the first sentence mentions the header name (bold) and summarizes its purpose.
-  - Information box containing at least the header type and if the header is a {{Glossary("Forbidden header name")}}.
+  - Information box containing at least the header type and if the header is a {{Glossary("Forbidden request header")}}.
   - A syntax box containing all possible directives/parameters/values of the HTTP header.
   - A section that explains these directives/values.
   - An example section that contains a practical use case for this header or shows where and how it occurs usually.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -93,7 +93,7 @@ Two or three paragraphs in this section is appropriate, and if there are substan
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>"Yes" or "No"</td>
     </tr>
     <tr>

--- a/files/en-us/mozilla/firefox/releases/43/index.md
+++ b/files/en-us/mozilla/firefox/releases/43/index.md
@@ -75,7 +75,7 @@ _No change._
 #### Miscellaneous
 
 - The [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) now uses the new promise syntax for {{domxref("Navigator.getBattery()")}}, as specified in the recent evolution of the specification ([Firefox bug 1050749](https://bugzil.la/1050749)).
-- The `User-Agent` header is no longer in the list of {{Glossary("Forbidden_header_name", "forbidden header names")}} so it can now be set in a [Fetch](/en-US/docs/Web/API/Fetch_API) {{domxref("Headers")}} object, via XHR {{domxref("XMLHttpRequest.setRequestHeader()")}},… ([Firefox bug 1188932](https://bugzil.la/1188932)).
+- The `User-Agent` header is no longer in the list of {{Glossary("Forbidden_request_header", "forbidden request headers")}} so it can now be set in a [Fetch](/en-US/docs/Web/API/Fetch_API) {{domxref("Headers")}} object, via XHR {{domxref("XMLHttpRequest.setRequestHeader()")}},… ([Firefox bug 1188932](https://bugzil.la/1188932)).
 - The {{domxref("MediaRecorder.MediaRecorder", "MediaRecorder()")}} constructor can now accept an options dictionary as a parameter, which allows you to set custom bitrates for the audio/video to be recorded ([Firefox bug 1161276](https://bugzil.la/1161276)).
 - The {{domxref("PerformanceObserver")}} interface, belonging to the [Performance APIs](/en-US/docs/Web/API/Performance_API) has been implemented ([Firefox bug 1165796](https://bugzil.la/1165796)).
 - The Frame Timing API has been added: the `PerformanceRenderTiming` and `PerformanceCompositeTiming` interfaces are now available ([Firefox bug 1191178](https://bugzil.la/1191178)).

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -174,7 +174,7 @@ const response = await fetch("https://example.org/post", {
 });
 ```
 
-Compared to using plain objects, the `Headers` object provides some additional input sanitization. For example, it normalizes header names to lowercase, strips leading and trailing whitespace from header values, and prevents certain headers from being set. Many headers are set automatically by the browser and can't be set by a script: these are called {{glossary("Forbidden header name", "Forbidden header names")}}. If the {{domxref("Request.mode", "mode")}} option is set to `no-cors`, then the set of permitted headers is further restricted.
+Compared to using plain objects, the `Headers` object provides some additional input sanitization. For example, it normalizes header names to lowercase, strips leading and trailing whitespace from header values, and prevents certain headers from being set. Many headers are set automatically by the browser and can't be set by a script: these are called {{glossary("Forbidden request header", "Forbidden request headers")}}. If the {{domxref("Request.mode", "mode")}} option is set to `no-cors`, then the set of permitted headers is further restricted.
 
 ### Sending data in a GET request
 

--- a/files/en-us/web/api/headers/append/index.md
+++ b/files/en-us/web/api/headers/append/index.md
@@ -18,7 +18,7 @@ that if the specified header already exists and accepts multiple values,
 `append()` will append the new value onto the end of the set of values.
 
 For security reasons, some headers can only be controlled by the user agent. These
-headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
+headers include the {{Glossary("Forbidden_request_header", "forbidden request headers")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
 
 ## Syntax

--- a/files/en-us/web/api/headers/delete/index.md
+++ b/files/en-us/web/api/headers/delete/index.md
@@ -12,7 +12,7 @@ The **`delete()`** method of the {{domxref("Headers")}}
 interface deletes a header from the current `Headers` object.
 
 For security reasons, some headers can only be controlled by the user agent. These
-headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
+headers include the {{Glossary("Forbidden_request_header", "forbidden request headers")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
 
 ## Syntax

--- a/files/en-us/web/api/headers/get/index.md
+++ b/files/en-us/web/api/headers/get/index.md
@@ -14,7 +14,7 @@ with a given name. If the requested header doesn't exist in the `Headers`
 object, it returns `null`.
 
 For security reasons, some headers can only be controlled by the user agent. These
-headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
+headers include the {{Glossary("Forbidden_request_header", "forbidden request headers")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
 
 ## Syntax

--- a/files/en-us/web/api/headers/has/index.md
+++ b/files/en-us/web/api/headers/has/index.md
@@ -13,7 +13,7 @@ returns a boolean stating whether a `Headers` object contains a certain
 header.
 
 For security reasons, some headers can only be controlled by the user agent. These
-headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
+headers include the {{Glossary("Forbidden_request_header", "forbidden request headers")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
 
 ## Syntax

--- a/files/en-us/web/api/headers/index.md
+++ b/files/en-us/web/api/headers/index.md
@@ -27,7 +27,7 @@ Some `Headers` objects have restrictions on whether the {{domxref("Headers.set",
 - For headers created with {{domxref("Headers.Headers","Headers()")}} constructor, there are no modification restrictions.
 - For headers of {{domxref("Request")}} objects:
   - If the request's {{domxref("Request.mode","mode")}} is `no-cors`, you can modify any {{Glossary("CORS-safelisted request header")}} name/value.
-  - Otherwise, you can modify any {{Glossary("forbidden header name", "non-forbidden header")}} name/value.
+  - Otherwise, you can modify any {{Glossary("forbidden request header", "non-forbidden request header")}} name/value.
 - For headers of {{domxref("Response")}} objects:
   - If the response is created using {{domxref("Response.error_static", "Response.error()")}} or {{domxref("Response.redirect_static", "Response.redirect()")}}, or received from a {{domxref("Window/fetch", "fetch()")}} call, the headers are immutable and cannot be modified.
   - Otherwise, if the response is created using {{domxref("Response.Response","Response()")}} or {{domxref("Response.json_static","Response.json()")}}, you can modify any {{Glossary("forbidden response header name", "non-forbidden response header")}} name/value.

--- a/files/en-us/web/api/headers/set/index.md
+++ b/files/en-us/web/api/headers/set/index.md
@@ -18,7 +18,7 @@ overwrites the existing value with the new one, whereas {{domxref("Headers.appen
 appends the new value to the end of the set of values.
 
 For security reasons, some headers can only be controlled by the user agent. These
-headers include the {{Glossary("Forbidden_header_name", "forbidden header names")}}
+headers include the {{Glossary("Forbidden_request_header", "forbidden request headers")}}
 and {{Glossary("Forbidden_response_header_name", "forbidden response header names")}}.
 
 ## Syntax

--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -109,7 +109,7 @@ You can also construct a `Request` with a `RequestInit`, and pass the `Request` 
   - : Any headers you want to add to your request, contained
     within a {{domxref("Headers")}} object or an object literal whose keys are the names of headers and whose values are the header values.
 
-    Many headers are set automatically by the browser and can't be set by a script: these are called {{glossary("Forbidden header name", "Forbidden header names")}}.
+    Many headers are set automatically by the browser and can't be set by a script: these are called {{glossary("Forbidden request headers", "Forbidden request headers")}}.
 
     If the `mode` option is set to `no-cors`, you can only set {{glossary("CORS-safelisted request header", "CORS-safelisted request headers")}}.
 

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -16,7 +16,7 @@ Each time you call `setRequestHeader()` after the first time you call it, the sp
 
 If no {{HTTPHeader("Accept")}} header has been set using this, an `Accept` header with the type `"*/*"` is sent with the request when {{domxref("XMLHttpRequest.send", "send()")}} is called.
 
-For security reasons, there are several {{Glossary("Forbidden_header_name", "forbidden header names")}} whose values are controlled by the user agent. Any attempt to set a value for one of those headers from frontend JavaScript code will be ignored without warning or error.
+For security reasons, there are several {{Glossary("Forbidden_request_header", "forbidden request headers")}} whose values are controlled by the user agent. Any attempt to set a value for one of those headers from frontend JavaScript code will be ignored without warning or error.
 
 In addition, the [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) HTTP header may be added to a request, but will be removed if the request is redirected cross-origin.
 

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -55,7 +55,7 @@ A _simple request_ is one that **meets all the following conditions**:
   - {{HTTPMethod("HEAD")}}
   - {{HTTPMethod("POST")}}
 
-- Apart from the headers automatically set by the user agent (for example, {{HTTPHeader("Connection")}}, {{HTTPHeader("User-Agent")}}, or [the other headers defined in the Fetch spec as a _forbidden header name_](https://fetch.spec.whatwg.org/#forbidden-header-name)), the only headers which are allowed to be manually set are [those which the Fetch spec defines as a CORS-safelisted request-header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header), which are:
+- Apart from the headers automatically set by the user agent (for example, {{HTTPHeader("Connection")}}, {{HTTPHeader("User-Agent")}}, or the {{glossary("Forbidden request header", "forbidden request headers")}}), the only headers which are allowed to be manually set are the [CORS-safelisted request-headers](/en-US/docs/Glossary/CORS-safelisted_request_header), which are:
 
   - {{HTTPHeader("Accept")}}
   - {{HTTPHeader("Accept-Language")}}

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -17,7 +17,7 @@ To ensure client hints are sent reliably, the `Accept-CH` header should be persi
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/accept-encoding/index.md
+++ b/files/en-us/web/http/headers/accept-encoding/index.md
@@ -32,7 +32,7 @@ As long as the `identity;q=0` or `*;q=0` directives do not explicitly forbid the
       <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/accept-language/index.md
+++ b/files/en-us/web/http/headers/accept-language/index.md
@@ -28,7 +28,7 @@ Servers often ignore the `Accept-Language` header in such cases and send a succe
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/accept-patch/index.md
+++ b/files/en-us/web/http/headers/accept-patch/index.md
@@ -24,7 +24,7 @@ An `Accept-Patch` header in a response to any request method implicitly means th
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/accept-post/index.md
+++ b/files/en-us/web/http/headers/accept-post/index.md
@@ -24,7 +24,7 @@ An `Accept-Post` header in a response to any request method implicitly means tha
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/accept-ranges/index.md
+++ b/files/en-us/web/http/headers/accept-ranges/index.md
@@ -19,7 +19,7 @@ For example, a response with an `Accept-Ranges` header indicates that the server
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/accept/index.md
+++ b/files/en-us/web/http/headers/accept/index.md
@@ -22,7 +22,7 @@ For example, a browser uses different values in a request when fetching a CSS st
       {{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/access-control-allow-credentials/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-credentials/index.md
@@ -31,7 +31,7 @@ When credentials are included:
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.md
@@ -20,7 +20,7 @@ This header is required if the preflight request contains {{HTTPHeader("Access-C
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.md
@@ -16,7 +16,7 @@ The HTTP **`Access-Control-Allow-Methods`** {{Glossary("response header")}} spec
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-allow-origin/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-origin/index.md
@@ -16,7 +16,7 @@ The HTTP **`Access-Control-Allow-Origin`** {{Glossary("response header")}} indic
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -18,7 +18,7 @@ Only the {{Glossary("CORS-safelisted response header", "CORS-safelisted response
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-max-age/index.md
+++ b/files/en-us/web/http/headers/access-control-max-age/index.md
@@ -16,7 +16,7 @@ The HTTP **`Access-Control-Max-Age`** {{Glossary("response header")}} indicates 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-request-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-request-headers/index.md
@@ -16,7 +16,7 @@ The HTTP **`Access-Control-Request-Headers`** {{Glossary("request header")}} is 
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/access-control-request-method/index.md
+++ b/files/en-us/web/http/headers/access-control-request-method/index.md
@@ -17,7 +17,7 @@ This header is necessary because the preflight request is always an {{HTTPMethod
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/age/index.md
+++ b/files/en-us/web/http/headers/age/index.md
@@ -19,7 +19,7 @@ If the value is `0`, the object was probably fetched from the origin server; oth
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/allow/index.md
+++ b/files/en-us/web/http/headers/allow/index.md
@@ -18,7 +18,7 @@ An empty `Allow` value indicates that the resource allows no request methods, wh
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/alt-svc/index.md
+++ b/files/en-us/web/http/headers/alt-svc/index.md
@@ -18,7 +18,7 @@ Doing so allows new protocol versions to be advertised without affecting in-flig
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/alt-used/index.md
+++ b/files/en-us/web/http/headers/alt-used/index.md
@@ -20,7 +20,7 @@ When a client uses an alternative service for a request, it can indicate this to
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/attribution-reporting-eligible/index.md
+++ b/files/en-us/web/http/headers/attribution-reporting-eligible/index.md
@@ -22,7 +22,7 @@ See the [Attribution Reporting API](/en-US/docs/Web/API/Attribution_Reporting_AP
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/attribution-reporting-register-source/index.md
+++ b/files/en-us/web/http/headers/attribution-reporting-register-source/index.md
@@ -23,7 +23,7 @@ See the [Attribution Reporting API](/en-US/docs/Web/API/Attribution_Reporting_AP
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/attribution-reporting-register-trigger/index.md
+++ b/files/en-us/web/http/headers/attribution-reporting-register-trigger/index.md
@@ -23,7 +23,7 @@ See the [Attribution Reporting API](/en-US/docs/Web/API/Attribution_Reporting_AP
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -27,7 +27,7 @@ This header is stripped from cross-origin redirects.
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -19,7 +19,7 @@ The HTTP **`Cache-Control`** header holds _directives_ (instructions) in both re
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/headers/clear-site-data/index.md
@@ -17,7 +17,7 @@ It allows web developers to have more control over the data stored by browsers f
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/connection/index.md
+++ b/files/en-us/web/http/headers/connection/index.md
@@ -38,7 +38,7 @@ Therefore, to ensure backwards compatibility, browsers often send `Connection: k
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/content-digest/index.md
+++ b/files/en-us/web/http/headers/content-digest/index.md
@@ -24,7 +24,7 @@ For this reason, a `Content-Digest` is identical to a {{HTTPHeader("Repr-Digest"
       <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}, {{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/content-disposition/index.md
+++ b/files/en-us/web/http/headers/content-disposition/index.md
@@ -23,7 +23,7 @@ The `Content-Disposition` header is defined in the larger context of MIME messag
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/content-dpr/index.md
+++ b/files/en-us/web/http/headers/content-dpr/index.md
@@ -31,7 +31,7 @@ If the `Content-DPR` header appears more than once in a message, the last occurr
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/content-encoding/index.md
+++ b/files/en-us/web/http/headers/content-encoding/index.md
@@ -25,7 +25,7 @@ Content encoding differs to {{HTTPHeader("Transfer-Encoding")}} in that `Transfe
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/content-language/index.md
+++ b/files/en-us/web/http/headers/content-language/index.md
@@ -20,7 +20,7 @@ If no `Content-Language` is specified, the default is that the content is intend
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/content-length/index.md
+++ b/files/en-us/web/http/headers/content-length/index.md
@@ -20,7 +20,7 @@ The HTTP **`Content-Length`** header indicates the size, in bytes, of the messag
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/content-location/index.md
+++ b/files/en-us/web/http/headers/content-location/index.md
@@ -21,7 +21,7 @@ The `Content-Location` header is different from the {{HTTPHeader("Location")}} h
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -21,7 +21,7 @@ It should only be included in {{HTTPStatus("206", "206 Partial Content")}} or {{
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -27,7 +27,7 @@ For more information, see our [Content Security Policy (CSP)](/en-US/docs/Web/HT
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -20,7 +20,7 @@ See the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) guide for deta
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>no</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/content-type/index.md
+++ b/files/en-us/web/http/headers/content-type/index.md
@@ -27,7 +27,7 @@ The `Content-Type` header differs from {{HTTPHeader("Content-Encoding")}} in tha
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/cookie/index.md
+++ b/files/en-us/web/http/headers/cookie/index.md
@@ -18,7 +18,7 @@ The `Cookie` header is optional and may be omitted if, for example, the browser'
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/critical-ch/index.md
+++ b/files/en-us/web/http/headers/critical-ch/index.md
@@ -24,7 +24,7 @@ Each header listed in the `Critical-CH` header should also be present in the `Ac
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -24,7 +24,7 @@ The behaviour depends on the policies of both the new document and its opener, a
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.md
@@ -18,7 +18,7 @@ It specifies resource owner's policy for what sites/origins should be allowed to
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/date/index.md
+++ b/files/en-us/web/http/headers/date/index.md
@@ -19,7 +19,7 @@ The HTTP **`Date`** {{Glossary("request header", "request")}} and {{Glossary("re
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>
@@ -67,7 +67,7 @@ Date: Tue, 29 Oct 2024 16:56:32 GMT
 
 ### Attempting to set the field value in JavaScript
 
-The `Date` header is a {{Glossary("forbidden header name")}}, so this code cannot set the message `Date` field:
+The `Date` header is a {{Glossary("Forbidden request header")}}, so this code cannot set the message `Date` field:
 
 ```js example-bad
 fetch("https://httpbin.org/get", {

--- a/files/en-us/web/http/headers/device-memory/index.md
+++ b/files/en-us/web/http/headers/device-memory/index.md
@@ -24,7 +24,7 @@ Servers that opt in to the `Device-Memory` client hint will typically also speci
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -25,7 +25,7 @@ DNT is deprecated in favor of [Global Privacy Control](https://globalprivacycont
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/downlink/index.md
+++ b/files/en-us/web/http/headers/downlink/index.md
@@ -28,7 +28,7 @@ For example, a server might choose to send smaller versions of images and other 
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/dpr/index.md
+++ b/files/en-us/web/http/headers/dpr/index.md
@@ -36,7 +36,7 @@ Servers that opt in to the `DPR` client hint will typically also specify it in t
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/early-data/index.md
+++ b/files/en-us/web/http/headers/early-data/index.md
@@ -23,7 +23,7 @@ The `Early-Data` header is **not** set by the originator of the request (i.e., a
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/ect/index.md
+++ b/files/en-us/web/http/headers/ect/index.md
@@ -29,7 +29,7 @@ The hint allows a server to choose what information is sent based on the broad c
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/etag/index.md
+++ b/files/en-us/web/http/headers/etag/index.md
@@ -21,7 +21,7 @@ A comparison of them can determine whether two representations of a resource are
       <td>{{Glossary("Response header")}}, {{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -40,7 +40,7 @@ CT requirements can be satisfied via any one of the following mechanisms:
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/expect/index.md
+++ b/files/en-us/web/http/headers/expect/index.md
@@ -23,7 +23,7 @@ None of the more common browsers send the `Expect` header, but some clients (com
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/expires/index.md
+++ b/files/en-us/web/http/headers/expires/index.md
@@ -21,7 +21,7 @@ The value `0` is used to represent a date in the past, indicating the resource h
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -25,7 +25,7 @@ The alternative and de-facto standard versions of this header are the {{HTTPHead
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/from/index.md
+++ b/files/en-us/web/http/headers/from/index.md
@@ -21,7 +21,7 @@ If you are running a robotic user agent (a web crawler, for example), the `From`
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/host/index.md
+++ b/files/en-us/web/http/headers/host/index.md
@@ -21,7 +21,7 @@ A {{HTTPStatus("400", "400 Bad Request")}} status code may be sent to any HTTP/1
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/if-match/index.md
+++ b/files/en-us/web/http/headers/if-match/index.md
@@ -28,7 +28,7 @@ There are two common use cases:
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/if-modified-since/index.md
+++ b/files/en-us/web/http/headers/if-modified-since/index.md
@@ -23,7 +23,7 @@ The most common use case is to update a cached entity that has no associated {{H
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/if-none-match/index.md
+++ b/files/en-us/web/http/headers/if-none-match/index.md
@@ -31,7 +31,7 @@ There are two common cases for using `If-None-Match` in requests:
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/if-range/index.md
+++ b/files/en-us/web/http/headers/if-range/index.md
@@ -22,7 +22,7 @@ The most common use case is to resume a download with guarantees that the resour
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/if-unmodified-since/index.md
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.md
@@ -23,7 +23,7 @@ The `If-Unmodified-Since` header is commonly used in the following situations:
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/keep-alive/index.md
+++ b/files/en-us/web/http/headers/keep-alive/index.md
@@ -30,7 +30,7 @@ Additional parameters for the connection can be requested with the `Keep-Alive` 
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/last-modified/index.md
+++ b/files/en-us/web/http/headers/last-modified/index.md
@@ -20,7 +20,7 @@ It is less accurate than an {{HTTPHeader("ETag")}} for determining file contents
       <td>{{glossary("Response header")}}, {{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -25,7 +25,7 @@ The only relations that work reliably are [`preconnect`](/en-US/docs/Web/HTML/At
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/location/index.md
+++ b/files/en-us/web/http/headers/location/index.md
@@ -31,7 +31,7 @@ In cases of resource creation, it indicates the URL of the newly-created resourc
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/max-forwards/index.md
+++ b/files/en-us/web/http/headers/max-forwards/index.md
@@ -22,7 +22,7 @@ If the `Max-Forwards` header is not present in a `TRACE` request, a node will as
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/nel/index.md
+++ b/files/en-us/web/http/headers/nel/index.md
@@ -18,7 +18,7 @@ The HTTP **`NEL`** {{Glossary("response header")}} is used to configure network 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/no-vary-search/index.md
+++ b/files/en-us/web/http/headers/no-vary-search/index.md
@@ -21,7 +21,7 @@ This allows the browser to reuse existing resources despite mismatching URL para
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/observe-browsing-topics/index.md
+++ b/files/en-us/web/http/headers/observe-browsing-topics/index.md
@@ -27,7 +27,7 @@ See [Using the Topics API](/en-US/docs/Web/API/Topics_API/Using) for more detail
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/origin-agent-cluster/index.md
+++ b/files/en-us/web/http/headers/origin-agent-cluster/index.md
@@ -20,7 +20,7 @@ The effect of this is that a resource-intensive document will be less likely to 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/origin/index.md
+++ b/files/en-us/web/http/headers/origin/index.md
@@ -17,7 +17,7 @@ For example, if a user agent needs to request resources included in a page, or f
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/index.md
@@ -20,7 +20,7 @@ For more information, see the main [Permissions Policy](/en-US/docs/Web/HTTP/Per
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/pragma/index.md
+++ b/files/en-us/web/http/headers/pragma/index.md
@@ -26,7 +26,7 @@ This header serves for backwards compatibility with HTTP/1.0 caches that do not 
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/priority/index.md
+++ b/files/en-us/web/http/headers/priority/index.md
@@ -33,7 +33,7 @@ This request may be cached, and the server is expected to control the cacheabili
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/proxy-authenticate/index.md
+++ b/files/en-us/web/http/headers/proxy-authenticate/index.md
@@ -17,7 +17,7 @@ It is sent in a {{HTTPStatus("407", "407 Proxy Authentication Required")}} respo
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -16,7 +16,7 @@ The HTTP **`Proxy-Authorization`** {{Glossary("request header")}} contains the c
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -27,7 +27,7 @@ The header is a [CORS-safelisted request header](/en-US/docs/Glossary/CORS-safel
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -34,7 +34,7 @@ The `Referer` should also be sent in requests following a {{httpheader("Refresh"
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/headers/referrer-policy/index.md
@@ -17,7 +17,7 @@ Aside from the HTTP header, you can [set this policy in HTML](#integration_with_
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/refresh/index.md
+++ b/files/en-us/web/http/headers/refresh/index.md
@@ -23,7 +23,7 @@ It is exactly equivalent to using [`<meta http-equiv="refresh" content="...">`](
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/report-to/index.md
+++ b/files/en-us/web/http/headers/report-to/index.md
@@ -26,7 +26,7 @@ For example, the {{HTTPHeader("Content-Security-Policy")}} header {{CSP("report-
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/reporting-endpoints/index.md
+++ b/files/en-us/web/http/headers/reporting-endpoints/index.md
@@ -26,7 +26,7 @@ For more details on setting up CSP reporting, see the [Content Security Policy (
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/repr-digest/index.md
+++ b/files/en-us/web/http/headers/repr-digest/index.md
@@ -23,7 +23,7 @@ A {{HTTPHeader("Content-Digest")}} applies to the content of a specific message,
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/retry-after/index.md
+++ b/files/en-us/web/http/headers/retry-after/index.md
@@ -21,7 +21,7 @@ There are three main cases this header is used:
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/rtt/index.md
+++ b/files/en-us/web/http/headers/rtt/index.md
@@ -29,7 +29,7 @@ The hint allows a server to choose what information is sent based on the network
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -32,7 +32,7 @@ When communicated to origins, this allows them to deliver alternative content to
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-browsing-topics/index.md
+++ b/files/en-us/web/http/headers/sec-browsing-topics/index.md
@@ -29,7 +29,7 @@ See [Using the Topics API](/en-US/docs/Web/API/Topics_API/Using) for more detail
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-prefers-color-scheme/index.md
+++ b/files/en-us/web/http/headers/sec-ch-prefers-color-scheme/index.md
@@ -26,7 +26,7 @@ This header is modeled on the {{cssxref("@media/prefers-color-scheme", "prefers-
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-prefers-reduced-motion/index.md
+++ b/files/en-us/web/http/headers/sec-ch-prefers-reduced-motion/index.md
@@ -25,7 +25,7 @@ This header is modeled on the {{cssxref("@media/prefers-reduced-motion", "prefer
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-prefers-reduced-transparency/index.md
+++ b/files/en-us/web/http/headers/sec-ch-prefers-reduced-transparency/index.md
@@ -25,7 +25,7 @@ This header is modeled on the {{cssxref("@media/prefers-reduced-transparency", "
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-arch/index.md
@@ -23,7 +23,7 @@ This might be used by a server, for example, to select and offer the correct bin
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-bitness/index.md
@@ -24,7 +24,7 @@ This might be used by a server, for example, to select and offer the correct bin
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-form-factors/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-form-factors/index.md
@@ -21,7 +21,7 @@ The HTTP **`Sec-CH-UA-Form-Factors`** {{Glossary("request header")}} is a [user 
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version-list/index.md
@@ -29,7 +29,7 @@ This is a feature designed to prevent servers from rejecting unknown user agents
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-full-version/index.md
@@ -24,7 +24,7 @@ The HTTP **`Sec-CH-UA-Full-Version`** {{Glossary("request header")}} is a [user 
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-mobile/index.md
@@ -25,7 +25,7 @@ Unless blocked by a user agent permission policy, it is sent by default, without
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-model/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-model/index.md
@@ -21,7 +21,7 @@ The HTTP **`Sec-CH-UA-Model`** {{Glossary("request header")}} is a [user agent c
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform-version/index.md
@@ -21,7 +21,7 @@ The HTTP **`Sec-CH-UA-Platform-Version`** {{Glossary("request header")}} is a [u
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-platform/index.md
@@ -25,7 +25,7 @@ Unless blocked by a user agent permission policy, it is sent by default (without
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua-wow64/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua-wow64/index.md
@@ -24,7 +24,7 @@ This client hint header is used for backwards compatibility considerations, to p
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/headers/sec-ch-ua/index.md
@@ -33,7 +33,7 @@ This is a feature designed to prevent servers from rejecting unknown user agents
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.md
@@ -19,7 +19,7 @@ This allows servers to determine whether to service a request based on whether i
       <td>{{Glossary("Fetch Metadata Request Header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-fetch-mode/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-mode/index.md
@@ -19,7 +19,7 @@ For example, this header would contain `navigate` for top level navigation reque
       <td>{{Glossary("Fetch Metadata Request Header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-fetch-site/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-site/index.md
@@ -20,7 +20,7 @@ Same-origin requests would usually be allowed by default, but what happens for r
       <td>{{Glossary("Fetch Metadata Request Header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-fetch-user/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-user/index.md
@@ -18,7 +18,7 @@ A server can use this header to identify whether a navigation request from a doc
       <td>{{Glossary("Fetch Metadata Request Header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -21,7 +21,7 @@ The specification does not define how the user can withdraw or grant consent for
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-purpose/index.md
+++ b/files/en-us/web/http/headers/sec-purpose/index.md
@@ -22,7 +22,7 @@ Note that if this header is set then a {{HTTPHeader("Sec-Fetch-Dest")}} header i
       <td>{{Glossary("Fetch Metadata Request Header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/sec-websocket-accept/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-accept/index.md
@@ -19,7 +19,7 @@ This header must appear no more than once in the response, and has a directive v
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-extensions/index.md
@@ -25,7 +25,7 @@ The request header is automatically added by the browser based on its own capabi
       <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-websocket-key/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-key/index.md
@@ -25,7 +25,7 @@ The user agent can then validate this before this before confirming the connecti
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-websocket-protocol/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-protocol/index.md
@@ -27,7 +27,7 @@ The sub-protocol selected by the server is made available to the web application
       <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sec-websocket-version/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-version/index.md
@@ -28,7 +28,7 @@ The header should not be sent in responses if the server understands the version
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes (<code>Sec-</code> prefix)</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/server-timing/index.md
+++ b/files/en-us/web/http/headers/server-timing/index.md
@@ -17,7 +17,7 @@ It is used to surface backend server timing metrics (for example, database read/
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/server/index.md
+++ b/files/en-us/web/http/headers/server/index.md
@@ -26,7 +26,7 @@ In general, a more robust approach to server security is to ensure software is r
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/service-worker-allowed/index.md
+++ b/files/en-us/web/http/headers/service-worker-allowed/index.md
@@ -22,7 +22,7 @@ A service worker intercepts all network requests within its scope, so you should
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/service-worker-navigation-preload/index.md
+++ b/files/en-us/web/http/headers/service-worker-navigation-preload/index.md
@@ -21,7 +21,7 @@ For more information see {{domxref("NavigationPreloadManager.setHeaderValue()")}
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/service-worker/index.md
+++ b/files/en-us/web/http/headers/service-worker/index.md
@@ -17,7 +17,7 @@ This header helps administrators log service worker script requests for monitori
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -24,7 +24,7 @@ For more information, see the guide on [Using HTTP cookies](/en-US/docs/Web/HTTP
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/set-login/index.md
+++ b/files/en-us/web/http/headers/set-login/index.md
@@ -25,7 +25,7 @@ See [Update login status using the Login Status API](/en-US/docs/Web/API/FedCM_A
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/sourcemap/index.md
+++ b/files/en-us/web/http/headers/sourcemap/index.md
@@ -18,7 +18,7 @@ The HTTP `SourceMap` header has precedence over a source annotation (`sourceMapp
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/speculation-rules/index.md
+++ b/files/en-us/web/http/headers/speculation-rules/index.md
@@ -23,7 +23,7 @@ The resource file containing the speculation rules JSON can have any valid name 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -19,7 +19,7 @@ The HTTP **`Strict-Transport-Security`** {{Glossary("response header")}} (often 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/supports-loading-mode/index.md
+++ b/files/en-us/web/http/headers/supports-loading-mode/index.md
@@ -18,7 +18,7 @@ The HTTP **`Supports-Loading-Mode`** {{Glossary("response header")}} allows a re
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/http/headers/te/index.md
+++ b/files/en-us/web/http/headers/te/index.md
@@ -22,7 +22,7 @@ Transfer encodings are applied at the protocol layer, so an application consumin
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/timing-allow-origin/index.md
+++ b/files/en-us/web/http/headers/timing-allow-origin/index.md
@@ -16,7 +16,7 @@ The HTTP **`Timing-Allow-Origin`** {{Glossary("response header")}} specifies ori
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/tk/index.md
+++ b/files/en-us/web/http/headers/tk/index.md
@@ -23,7 +23,7 @@ The HTTP **`Tk`** {{Glossary("response header")}} indicates the tracking status 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/trailer/index.md
+++ b/files/en-us/web/http/headers/trailer/index.md
@@ -28,7 +28,7 @@ The HTTP **Trailer** {{glossary("request header", "request")}} and {{glossary("r
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -29,7 +29,7 @@ When present on a response to a {{HTTPMethod("HEAD")}} request that has no body,
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/upgrade-insecure-requests/index.md
+++ b/files/en-us/web/http/headers/upgrade-insecure-requests/index.md
@@ -16,7 +16,7 @@ The HTTP **`Upgrade-Insecure-Requests`** {{Glossary("request header")}} sends a 
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/upgrade/index.md
+++ b/files/en-us/web/http/headers/upgrade/index.md
@@ -23,7 +23,7 @@ For example, it can be used by a client to upgrade a connection from HTTP/1.1 to
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/user-agent/index.md
+++ b/files/en-us/web/http/headers/user-agent/index.md
@@ -19,7 +19,7 @@ The HTTP **User-Agent** {{Glossary("request header")}} is a characteristic strin
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/vary/index.md
+++ b/files/en-us/web/http/headers/vary/index.md
@@ -20,7 +20,7 @@ The same `Vary` header value should be used on all responses for a given URL, in
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/via/index.md
+++ b/files/en-us/web/http/headers/via/index.md
@@ -20,7 +20,7 @@ It is used for tracking message forwards, avoiding request loops, and identifyin
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>Yes</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/viewport-width/index.md
+++ b/files/en-us/web/http/headers/viewport-width/index.md
@@ -33,7 +33,7 @@ Servers that opt-in will typically also specify it in the {{HTTPHeader("Vary")}}
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/want-content-digest/index.md
+++ b/files/en-us/web/http/headers/want-content-digest/index.md
@@ -21,7 +21,7 @@ Some implementations may send unsolicited `Content-Digest` headers without requi
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/want-repr-digest/index.md
+++ b/files/en-us/web/http/headers/want-repr-digest/index.md
@@ -21,7 +21,7 @@ Some implementations may send unsolicited `Repr-Digest` headers without requirin
       <td>{{Glossary("Representation header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -29,7 +29,7 @@ However, some warn-codes are specific to caches and can only be applied to respo
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/width/index.md
+++ b/files/en-us/web/http/headers/width/index.md
@@ -30,7 +30,7 @@ If the `Width` header appears more than once in a message the last occurrence is
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -29,7 +29,7 @@ The client is expected to select the most secure of the challenges it understand
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-content-type-options/index.md
+++ b/files/en-us/web/http/headers/x-content-type-options/index.md
@@ -23,7 +23,7 @@ Site security testers usually expect this header to be set.
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
@@ -21,7 +21,7 @@ This reduces latency when the user clicks a link, for example.
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -23,7 +23,7 @@ A standardized version of this header is the HTTP {{HTTPHeader("Forwarded")}} he
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-forwarded-host/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-host/index.md
@@ -21,7 +21,7 @@ A standardized version of this header is the HTTP {{HTTPHeader("Forwarded")}} he
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-forwarded-proto/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-proto/index.md
@@ -22,7 +22,7 @@ A standardized version of this header is the HTTP {{HTTPHeader("Forwarded")}} he
       <td>{{Glossary("Request header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -21,7 +21,7 @@ The added security is provided only if the user accessing the document is using 
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
+++ b/files/en-us/web/http/headers/x-permitted-cross-domain-policies/index.md
@@ -22,7 +22,7 @@ Some security testing tools will still check for the presence of a `X-Permitted-
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-robots-tag/index.md
+++ b/files/en-us/web/http/headers/x-robots-tag/index.md
@@ -26,7 +26,7 @@ Specifying indexing rules in a HTTP header is useful for non-HTML documents like
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>

--- a/files/en-us/web/http/headers/x-xss-protection/index.md
+++ b/files/en-us/web/http/headers/x-xss-protection/index.md
@@ -26,7 +26,7 @@ It is recommended that you use [`Content-Security-Policy`](/en-US/docs/Web/HTTP/
       <td>{{Glossary("Response header")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/22502.

https://github.com/whatwg/fetch/pull/1541 changes both the terminology and its definition. This PR makes docs in sync with latest spec.