### PR TITLE
Adding note about usage with PublicKeyCredential

### DIFF
--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
@@ -12,7 +12,7 @@ The **`preventSilentAccess()`** method of the {{domxref("CredentialsContainer")}
 For example, you might call this, after a user signs out of a website to ensure that they aren't automatically signed in on the next site visit.
 Mediation varies by origin, and is an added check point of browser stored credentials, informing a user of an account login status. This method is typically called after a user signs out of a website, ensuring this user's login information is not automatically passed on the next site visit.
 
-This method [generally has no effect](https://www.w3.org/TR/webauthn-2/#sctn-preventSilentAccessCredential) when called on a {{domxref("PublicKeyCredential")}}; such authenticators typically require user interaction. However, it _is possible_ that certain authenticators may be excluded, which could otherwise have operated silently.
+This method [generally has no effect](https://www.w3.org/TR/webauthn-2/#sctn-preventSilentAccessCredential) when using a {{domxref("PublicKeyCredential")}}; such authenticators typically require user interaction. However, it _is possible_ that certain authenticators may be excluded, which could otherwise have operated silently.
 
 Earlier versions of the spec called this method `requireUserMediation()`.
 The [Browser compatibility](/en-US/docs/Web/API/CredentialsContainer#browser_compatibility) section has support details.

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
@@ -12,6 +12,8 @@ The **`preventSilentAccess()`** method of the {{domxref("CredentialsContainer")}
 For example, you might call this, after a user signs out of a website to ensure that they aren't automatically signed in on the next site visit.
 Mediation varies by origin, and is an added check point of browser stored credentials, informing a user of an account login status. This method is typically called after a user signs out of a website, ensuring this user's login information is not automatically passed on the next site visit.
 
+This method [generally has no effect](https://www.w3.org/TR/webauthn-2/#sctn-preventSilentAccessCredential) when called on a {{domxref("PublicKeyCredential")}}; such authenticators typically require user interaction. However, it *is possible* that certain authenticators may be excluded, which could otherwise have operated silently.
+
 Earlier versions of the spec called this method `requireUserMediation()`.
 The [Browser compatibility](/en-US/docs/Web/API/CredentialsContainer#browser_compatibility) section has support details.
 

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
@@ -12,7 +12,7 @@ The **`preventSilentAccess()`** method of the {{domxref("CredentialsContainer")}
 For example, you might call this, after a user signs out of a website to ensure that they aren't automatically signed in on the next site visit.
 Mediation varies by origin, and is an added check point of browser stored credentials, informing a user of an account login status. This method is typically called after a user signs out of a website, ensuring this user's login information is not automatically passed on the next site visit.
 
-This method [generally has no effect](https://www.w3.org/TR/webauthn-2/#sctn-preventSilentAccessCredential) when called on a {{domxref("PublicKeyCredential")}}; such authenticators typically require user interaction. However, it *is possible* that certain authenticators may be excluded, which could otherwise have operated silently.
+This method [generally has no effect](https://www.w3.org/TR/webauthn-2/#sctn-preventSilentAccessCredential) when called on a {{domxref("PublicKeyCredential")}}; such authenticators typically require user interaction. However, it _is possible_ that certain authenticators may be excluded, which could otherwise have operated silently.
 
 Earlier versions of the spec called this method `requireUserMediation()`.
 The [Browser compatibility](/en-US/docs/Web/API/CredentialsContainer#browser_compatibility) section has support details.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The spec for webauthn says that this method has essentially no effect when called on PublicKeyCredential values. Adding a note citing this detail.

### Motivation

I was confused as to whether this method was useful for WebAuthn credentials, so I wanted to add the note for clarity sake.

### Additional details

Spec: https://www.w3.org/TR/webauthn-2/#sctn-preventSilentAccessCredential

### Related issues and pull requests

n/a