### PR TITLE
Removing misleading assertion

### DIFF
--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -46,7 +46,7 @@ get(options)
 
         - `"required"`
 
-          - : The user will always be asked to authenticate, even if prevent silent access (see {{domxref("CredentialsContainer.preventSilentAccess()")}}) is set to `false`. This value is intended for situations where you want to force user authentication — for example if you want a user to reauthenticate when a sensitive operation is being performed (like confirming a credit card payment), or when switching users.
+          - : The user will always be asked to authenticate. This value is intended for situations where you want to force user authentication — for example if you want a user to reauthenticate when a sensitive operation is being performed (like confirming a credit card payment), or when switching users.
 
         - `"silent"`
           - : The user will not be asked to authenticate. The user agent will automatically reauthenticate the user and log them in if possible. If consent is required, the promise will fulfill with `null`. This value is intended for situations where you would want to automatically sign a user in upon visiting a web app if possible, but if not, you don't want to present them with a confusing login dialog box. Instead, you'd want to wait for them to explicitly click a "Login/Signup" button.


### PR DESCRIPTION
### Description

The removed phrase incorrectly implied that once can pass a `false` argument to `preventSilentAccess(..)` to turn it off (ie, allowing silent access). That is not true -- perhaps used to be? -- so removed the mention entirely, since it's not relevant here. The user will always be prompted regardless of whether that method had been called or not.

### Motivation

Reduces confusion by removing inaccurate/misleading (possibly outdated?) assertion.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/preventSilentAccess

https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-preventsilentaccess

### Related issues and pull requests

Relates to #38300.