### PR TITLE
feat(api): Add allow property to live sample

### DIFF
--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -268,7 +268,7 @@ This calls the [`stop()`](#stopping_the_input_stream) function we covered earlie
 
 When put all together with the rest of the HTML and the CSS not shown above, it looks and works like this:
 
-{{ EmbedLiveSample('Example_of_recording_a_media_element', 600, 440) }}
+{{EmbedLiveSample('Example_of_recording_a_media_element', '600', '440', , , , 'camera;microphone')}}
 
 You can {{LiveSampleLink("Example_of_recording_a_media_element", "view the full demo here")}}, and use your browsers developer tools to inspect the page and look at all the code, including the parts hidden above because they aren't critical to the explanation of how the APIs are being used.
 


### PR DESCRIPTION
### Description

Add `camera` and `microphone` to `allow`.

See

* https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/allow
* https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Live_samples#allow

### Motivation

Fixing perm policy violations:

```
 [Violation] Permissions policy violation: microphone is not allowed in this document.
 [Violation] Permissions policy violation: camera is not allowed in this document.
```

### Additional details

Discussed on Discord at https://discord.com/channels/1009925603572600863/1170042997212184576/1342704407200137268
