### PR TITLE
Provide detail for async functions on error_events page 

### DIFF
--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -10,9 +10,7 @@ browser-compat: api.Window.error_event
 
 The `error` event is fired on a {{domxref("Window")}} object when a resource failed to load or couldn't be used — for example if a script has an execution error.
 
-> [!WARNING]
->
-> For `asynchronous` functions, the {{domxref("Window/unhandledrejection_event", "unhandledrejection")}} event is fired when a promise is rejected and there are no handlers attached.
+This event is only generated for script errors thrown synchronously, such as during initial loading or within event handlers. If a promise was rejected (including an uncaught `throw` within an `async function`) and no rejection handlers were attached, an {{domxref("Window/unhandledrejection_event", "unhandledrejection")}} event is fired instead.
 
 ## Syntax
 
@@ -186,4 +184,4 @@ scriptError.addEventListener("click", () => {
 ## See also
 
 - This event on `Element` targets: {{domxref("HTMLElement/error_event", "error")}} event
-- Asynchronous function errors: {{domxref("Window/unhandledrejection_event", "unhandledrejection")}} event
+- [`Window`: `unhandledrejection` event](/en-US/docs/Web/API/Window/unhandledrejection_event)

--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -10,6 +10,10 @@ browser-compat: api.Window.error_event
 
 The `error` event is fired on a {{domxref("Window")}} object when a resource failed to load or couldn't be used — for example if a script has an execution error.
 
+> [!WARNING]
+>
+> For `asynchronous` functions, the {{domxref("Window/unhandledrejection_event", "unhandledrejection")}} event is fired when a promise is rejected and there are no handlers attached.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -182,3 +186,4 @@ scriptError.addEventListener("click", () => {
 ## See also
 
 - This event on `Element` targets: {{domxref("HTMLElement/error_event", "error")}} event
+- Asynchronous function errors: {{domxref("Window/unhandledrejection_event", "unhandledrejection")}} event


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR adds a warning to show users that asynchronous functions do not throw an `error event` rather a `unhandled rejection` event. 
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Asynchronous functions always return a promise so it is important to understand what errors are thrown compared to a synchronous function. 
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #38246 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
