### PR TITLE
Add constraint for initial value in @property rule

### DIFF
--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -42,9 +42,9 @@ The following conditions must be met for the `@property` rule to be valid:
   If either is missing, the entire `@property` rule is invalid and ignored.
 - The {{cssxref("@property/initial-value","initial-value")}} descriptor is optional if the value of the `syntax` descriptor is the universal syntax definition (that is, `syntax: "*"`).
   If the `initial-value` descriptor is required but omitted, the entire `@property` rule is invalid and ignored.
-- If the value of the `syntax` descriptor is not the universal syntax definition, the {{cssxref("@property/initial-value","initial-value")}} descriptor has to be a [computationally independent](https://www.w3.org/TR/css-properties-values-api-1/#computationally-independent) value.
+- If the value of the `syntax` descriptor is not the universal syntax definition, the {{cssxref("@property/initial-value","initial-value")}} descriptor has to be a [computationally independent](https://drafts.css-houdini.org/css-properties-values-api-1/#computationally-independent) value.
   This means the value can be converted into a computed value without depending on other values, except for "global" definitions independent of CSS.
-  For example, a pixel value like `10px` is computationally independent and therefore valid — it doesn't change when converted to a computed value. An inch value like `2in` is also valid, because `1in` is always equivalent to `96px`. However, an em value like `3em` is not valid, because the value of an em is dependent on the parent's {{cssxref("font-size")}}.
+  For example, `10px` is computationally independent—it doesn't change when converted to a computed value. `2in` is also valid, because `1in` is always equivalent to `96px`. However, `3em` is not valid, because the value of an `em` is dependent on the parent's {{cssxref("font-size")}}.
 - Unknown descriptors are invalid and ignored, but do not invalidate the `@property` rule.
 
 ## Formal syntax

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -42,9 +42,9 @@ The following conditions must be met for the `@property` rule to be valid:
   If either is missing, the entire `@property` rule is invalid and ignored.
 - The {{cssxref("@property/initial-value","initial-value")}} descriptor is optional if the value of the `syntax` descriptor is the universal syntax definition (that is, `syntax: "*"`).
   If the `initial-value` descriptor is required but omitted, the entire `@property` rule is invalid and ignored.
-- The {{cssxref("@property/initial-value","initial-value")}} descriptor has to be a [computationally independent value](https://www.w3.org/TR/css-properties-values-api-1/#computationally-independent)
-  if the value of the `syntax` descriptor is not the universal syntax definition (that is, `syntax: "*"`).
-  This excludes relative units like `rem`.
+- If the value of the `syntax` descriptor is not the universal syntax definition, the {{cssxref("@property/initial-value","initial-value")}} descriptor has to be a [computationally independent](https://www.w3.org/TR/css-properties-values-api-1/#computationally-independent) value.
+  This means the value can be converted into a computed value without depending on other values, except for "global" definitions independent of CSS.
+  For example, a pixel value like `10px` is computationally independent and therefore valid — it doesn't change when converted to a computed value. An inch value like `2in` is also valid, because `1in` is always equivalent to `96px`. However, an em value like `3em` is not valid, because the value of an em is dependent on the parent's {{cssxref("font-size")}}.
 - Unknown descriptors are invalid and ignored, but do not invalidate the `@property` rule.
 
 ## Formal syntax

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -42,6 +42,9 @@ The following conditions must be met for the `@property` rule to be valid:
   If either is missing, the entire `@property` rule is invalid and ignored.
 - The {{cssxref("@property/initial-value","initial-value")}} descriptor is optional if the value of the `syntax` descriptor is the universal syntax definition (that is, `syntax: "*"`).
   If the `initial-value` descriptor is required but omitted, the entire `@property` rule is invalid and ignored.
+- The {{cssxref("@property/initial-value","initial-value")}} descriptor has to be a [computationally independent value](https://www.w3.org/TR/css-properties-values-api-1/#computationally-independent)
+  if the value of the `syntax` descriptor is not the universal syntax definition (that is, `syntax: "*"`).
+  This excludes relative units like `rem`.
 - Unknown descriptors are invalid and ignored, but do not invalidate the `@property` rule.
 
 ## Formal syntax


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Adds the constraint of computationally independence for the initial value of @property rules.

> The [initial-value](https://www.w3.org/TR/css-properties-values-api-1/#descdef-property-initial-value) must be [computationally independent](https://www.w3.org/TR/css-properties-values-api-1/#computationally-independent).
> &mdash; https://www.w3.org/TR/css-properties-values-api-1/#initial-value-descriptor

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

We were confused as the browser ignored our rem-based initial value until we got a hint to this specific constraint in the spec.  
https://stackoverflow.com/a/79466455/6625414

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
