### PR TITLE
Clarify exception details in the `CredentialsContainer: get()` method documentation

### DIFF
--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -126,7 +126,7 @@ If a single credential cannot be unambiguously obtained, the promise resolves wi
 
   - : Thrown in one of the following situations:
 
-    - This exception is most likely triggered when the user cancels the request.
+    - The user canceled the request.
 
     - Use of this API was blocked by one of the following [permissions policies](/en-US/docs/Web/HTTP/Permissions_Policy):
 

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -126,6 +126,8 @@ If a single credential cannot be unambiguously obtained, the promise resolves wi
 
   - : Thrown in one of the following situations:
 
+    - This exception is most likely triggered when the user cancels the request.
+
     - Use of this API was blocked by one of the following [permissions policies](/en-US/docs/Web/HTTP/Permissions_Policy):
 
       - {{HTTPHeader("Permissions-Policy/identity-credentials-get","identity-credentials-get")}}


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Clarified `NotAllowedError` exception details in the `CredentialsContainer: get()` method documentation when the user cancels a request.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This change helps the reader understand that the `NotAllowedError` exception  can be triggered if the user cancels a request.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None.
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #37728

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
