### PR TITLE
fix(ci): Remove fix-flaws command from auto-cleanup-bot.yml

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Lint markdown files
         run: |
-          # yarn content fix-flaws
+          yarn content:legacy fix-flaws
           yarn fix:md
           yarn fix:fm
           node scripts/sort_and_unique_file_lines.js .vscode/dictionaries

--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Lint markdown files
         run: |
-          yarn content fix-flaws
+          # yarn content fix-flaws
           yarn fix:md
           yarn fix:fm
           node scripts/sort_and_unique_file_lines.js .vscode/dictionaries


### PR DESCRIPTION
The `yarn content fix-flaws` has stopped working. Let's remove it till it is implemented in rari.
```log
$ yarn content fix-flaws

yarn run v1.22.22
$ yarn -s info:rari && env-cmd --silent cross-env CONTENT_ROOT=files rari-tool fix-flaws

🐥 This command is now using rari: https://github.com/mdn/rari
🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml

error: unrecognized subcommand 'fix-flaws'

Usage: rari content [OPTIONS] <COMMAND>

For more information, try '--help'.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
content on  main  o/  

-----------------------------------------------------------------------
fsh$ yarn content --help

yarn run v1.22.22
$ yarn -s info:rari && env-cmd --silent cross-env CONTENT_ROOT=files rari-tool --help

🐥 This command is now using rari: https://github.com/mdn/rari
🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml

Subcommands for altering content programmatically

Usage: rari content [OPTIONS] <COMMAND>

Commands:
  move                     Moves content pages from one slug to another
  delete                   Deletes content pages
  add-redirect             Adds a redirect from->to pair to the redirect map
  sync-translated-content  Syncs translated content for all or a list of locales
  fmt-sidebars             Formats all sidebars
  sync-sidebars            Sync sidebars with redirects
  fix-redirects            Fixes redirects across all locales
  validate-redirects       Validate redirects
  inventory                Create content inventory as JSON
  help                     Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Increase logging verbosity
  -q, --quiet...    Decrease logging verbosity
  -h, --help        Print help
  -V, --version     Print version
Done in 0.22s.
```