### PR TITLE
Add a multiple param example of `expects_no_vary_search`

### DIFF
--- a/files/en-us/web/html/element/script/type/speculationrules/index.md
+++ b/files/en-us/web/html/element/script/type/speculationrules/index.md
@@ -466,7 +466,7 @@ If the user hovers over another link before the prefetch completes, the `expects
 > [!WARNING]
 > Additional care must be taken when using prerender with `No-Vary-Search` since the page may initially be prerendered with different URL parameters. `No-Vary-Search` is used for URL parameters that deliver the same resource from the server, but are used by the client for various reasons (client-side rendering, UTM parameters for analytics measurement, etc.). As the initial prerender may be for different URL parameters, any code depending on them should only run after prerender activation.
 
-As this is for an [HTTP structured field](https://www.rfc-editor.org/rfc/rfc8941), multiple params can be provided in a space-separated array:
+Multiple params can be provided in a space-separated array:
 
 ```html
 <script type="speculationrules">
@@ -480,6 +480,9 @@ As this is for an [HTTP structured field](https://www.rfc-editor.org/rfc/rfc8941
   }
 </script>
 ```
+
+> [!NOTE]
+> As a [structured field](https://www.rfc-editor.org/rfc/rfc8941) the array of parameters should be space-separated quoted strings as shown above, and not comma-separated, which developers may be more used to.
 
 ### `eagerness` example
 

--- a/files/en-us/web/html/element/script/type/speculationrules/index.md
+++ b/files/en-us/web/html/element/script/type/speculationrules/index.md
@@ -466,6 +466,21 @@ If the user hovers over another link before the prefetch completes, the `expects
 > [!WARNING]
 > Additional care must be taken when using prerender with `No-Vary-Search` since the page may initially be prerendered with different URL parameters. `No-Vary-Search` is used for URL parameters that deliver the same resource from the server, but are used by the client for various reasons (client-side rendering, UTM parameters for analytics measurement, etc.). As the initial prerender may be for different URL parameters, any code depending on them should only run after prerender activation.
 
+As this is for an [HTTP structured field](https://www.rfc-editor.org/rfc/rfc8941), multiple params can be provided in a space-separated array:
+
+```html
+<script type="speculationrules">
+  {
+    "prefetch": [
+      {
+        { "where": { "href_matches": "/users?id=*" } },
+        "expects_no_vary_search": "params=(\"id\" \"order\" \"lang\")"
+      }
+    ]
+  }
+</script>
+```
+
 ### `eagerness` example
 
 The following set of document rules shows how `eagerness` can be used to hint at the eagerness with which the browser should prerender each matching set of links.

--- a/files/en-us/web/html/element/script/type/speculationrules/index.md
+++ b/files/en-us/web/html/element/script/type/speculationrules/index.md
@@ -482,7 +482,7 @@ Multiple params can be provided in a space-separated array:
 ```
 
 > [!NOTE]
-> As a [structured field](https://www.rfc-editor.org/rfc/rfc8941) the array of parameters should be space-separated quoted strings as shown above, and not comma-separated, which developers may be more used to.
+> As a [structured field](https://www.rfc-editor.org/rfc/rfc8941), the parameters should be space-separated, quoted strings — as shown above — and not comma-separated, which developers may be more used to.
 
 ### `eagerness` example
 

--- a/files/en-us/web/http/headers/no-vary-search/index.md
+++ b/files/en-us/web/http/headers/no-vary-search/index.md
@@ -118,7 +118,7 @@ No-Vary-Search: params=("id" "order" "lang")
 ```
 
 > [!NOTE]
-> As a [structured field](https://www.rfc-editor.org/rfc/rfc8941) the array of parameters should be space-separated quoted strings as shown above, and not comma-separated, which developers may be more used to.
+> As a [structured field](https://www.rfc-editor.org/rfc/rfc8941), the parameters should be space-separated, quoted strings — as shown above — and not comma-separated, which developers may be more used to.
 
 If you wanted the browser to ignore all of them _and_ any others that might be present when cache matching, you could use the boolean form of `params`:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Got a question from a developer as to how to add multiple params to `expects_no_vary_search` in Speculation Rules. This information is available in the equivalent [No-Vary-Search](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/No-Vary-Search#allowing_responses_from_urls_with_multiple_different_params_to_match_the_same_cache_entry) page, but not in the speculation rules page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Help developers confused by this.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
