### PR TITLE
fix: 'image/jpg' -> 'image/jpeg' media type

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/node_server_without_framework/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/node_server_without_framework/index.md
@@ -6,12 +6,12 @@ page-type: guide
 
 {{LearnSidebar}}
 
-This article provides a simple static file server built with pure [Node.js](https://nodejs.org/en/) without the use of a framework.
-The current state of Node.js is such that almost everything we needed is provided by the inbuilt APIs and just a few lines of code.
+This article shows a static file server built in [Node.js](https://nodejs.org/en/) without using any frameworks.
+The current state of Node.js is such that almost everything we need for the static file server is provided by built-in APIs and a few lines of code.
 
 ## Example
 
-A simple static file server built with Node.js:
+A static file server built with Node.js:
 
 ```js
 import * as fs from "node:fs";
@@ -26,7 +26,7 @@ const MIME_TYPES = {
   js: "application/javascript",
   css: "text/css",
   png: "image/png",
-  jpg: "image/jpg",
+  jpg: "image/jpeg",
   gif: "image/gif",
   ico: "image/x-icon",
   svg: "image/svg+xml",

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -19,7 +19,7 @@ The **`url()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Va
 url("https://example.com/images/myImg.jpg");
 url('https://example.com/images/myImg.jpg');
 url(https://example.com/images/myImg.jpg);
-url("data:image/jpg;base64,iRxVB0…");
+url("data:image/jpeg;base64,iRxVB0…");
 url(myImg.jpg);
 url(#IDofSVGpath);
 


### PR DESCRIPTION
### Description

Small follow-up after a related PR fixed similar issues.

- https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data#syntax
- https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types#image
- https://www.iana.org/assignments/media-types/media-types.xhtml#image

Fixing `image/jpg` -> `image/jpeg`

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/37961