### PR TITLE
Fix wrong KEYCODE_APP_SWITCH code from 181 to 187

### DIFF
--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -2271,7 +2271,7 @@ These keys represent buttons which commonly exist on modern smartphones.
       <td></td>
       <td></td>
       <td></td>
-      <td><code>KEYCODE_APP_SWITCH</code> (181)</td>
+      <td><code>KEYCODE_APP_SWITCH</code> (187)</td>
     </tr>
     <tr>
       <td><code>"Call"</code></td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This page: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#phone_keys
First row in table.

Fixed wrong KEYCODE_APP_SWITCH code from 181 to 187.
Looks like a typo.
Code 181 is actually KEYCODE_AVR_POWER.

### Motivation

Fix typo

### Additional details

Android reference: https://developer.android.com/reference/android/view/KeyEvent#KEYCODE_APP_SWITCH

### Related issues and pull requests