### PR TITLE
Remove incorrect minmax() values from height and width syntax sections

### DIFF
--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -36,7 +36,6 @@ height: min-content;
 height: fit-content;
 height: fit-content(20em);
 height: auto;
-height: minmax(min-content, anchor-size(width));
 height: stretch;
 
 /* Global values */

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -25,8 +25,8 @@ The specified value of `width` applies to the content area so long as its value 
 /* <length> values */
 width: 300px;
 width: 25em;
+width: anchor-size(width);
 width: anchor-size(--myAnchor inline, 120%);
-width: minmax(100px, anchor-size(width));
 
 /* <percentage> value */
 width: 75%;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `minmax()` function is not value as a value for the `width` and `height` properties, only in certain CSS grid values.

This PR removes the `minmax()` values from the syntax sections on those pages.

Fixes https://github.com/mdn/content/issues/38346.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
