### PR TITLE
Swap command and control key in navigator.platform example

### DIFF
--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -26,8 +26,8 @@ A string identifying the platform on which the user's browser is running; for ex
 ```js
 const modifierKeyPrefix =
   navigator.platform.startsWith("Mac") || navigator.platform === "iPhone"
-    ? "^" // control key
-    : "⌘"; // command key
+    ? "⌘" // command key
+    : "^"; // control key
 ```
 
 That is, check if `navigator.platform` starts with `"Mac"` or else is an exact match for `"iPhone"`, and then based on whether either of those is true, choose the modifier key your web application's UI will advise users to press in keyboard shortcuts.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This change swaps the command and control keys logic.

### Motivation

This should be the other way around: if Mac, then ⌘, else ^.
It used to be correct but it was broken in #38207 where the original logic was reversed.

