### PR TITLE
forbidden_request_header/index.md: misspelling of -> or

### DIFF
--- a/files/en-us/glossary/forbidden_request_header/index.md
+++ b/files/en-us/glossary/forbidden_request_header/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **forbidden request header** is an [HTTP header](/en-US/docs/Web/HTTP/Headers) name-value pair that cannot be set of modified programmatically in a request. For headers forbidden to be modified in responses, see {{Glossary("forbidden response header name")}}.
+A **forbidden request header** is an [HTTP header](/en-US/docs/Web/HTTP/Headers) name-value pair that cannot be set or modified programmatically in a request. For headers forbidden to be modified in responses, see {{Glossary("forbidden response header name")}}.
 
 Modifying such headers is forbidden because the user agent retains full control over them.
 For example, the {{HTTPHeader("Date")}} header is a forbidden request header, so this code cannot set the message `Date` field:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Starting paragraph accidentally uses "of" (...cannot be set of modified...) instead of "or"

### Motivation
Noticed the mistake while looking up an unrelated HTTP header.

### Additional details
n/a

### Related issues and pull requests
n/a

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
