### PR TITLE
Fix `SharedArrayBuffer[Symbol.species]` subclassing example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/symbol.species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/symbol.species/index.md
@@ -39,7 +39,7 @@ Because of this polymorphic implementation, `[Symbol.species]` of derived subcla
 
 ```js
 class SubArrayBuffer extends SharedArrayBuffer {}
-SubArrayBuffer[Symbol.species] === SharedArrayBuffer; // true
+SubArrayBuffer[Symbol.species] === SubArrayBuffer; // true
 ```
 
 When calling array buffer methods that do not mutate the existing array but return a new array buffer instance (for example, [`slice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice)), the array's `constructor[Symbol.species]` will be accessed. The returned constructor will be used to construct the return value of the array buffer method.


### PR DESCRIPTION
### Description

The subclassing example for `SharedArrayBuffer[Symbol.species]` is incorrect: the intention is to show that the getter returns the subclass constructor, not the parent constructor.

The equivalent examples are correct on `ArrayBuffer[Symbol.species]` and others.
