### PR TITLE
feat(workflows/pr-review-companion): sync build to GCS as well

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -120,3 +120,23 @@ jobs:
             --pr-number=$PR_NUMBER \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT
+
+      - name: Setup gcloud
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Authenticate with GCP
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Sync build with GCS
+        if: env.HAS_ARTIFACT
+        run: |-
+          PR_NUMBER=`cat build/NR`
+          PREFIX="pr$PR_NUMBER"
+          gsutil -q -m -h "Cache-Control: public, max-age=3600" cp -r build/static "gs://content-review-mdn/$PREFIX/"
+          gsutil -q -m -h "Cache-Control: public, max-age=3600" rsync -cdrj html,json,txt -y "^static/" build "gs://content-review-mdn/$PREFIX"


### PR DESCRIPTION
### Description

Syncs PR Review Companion builds to GCS in addition to AWS.

### Motivation

Prepares for the upcoming Review environment in GCP.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of MP-1889 (Mozilla-internal).

See also:

- https://github.com/mdn/yari/pull/12694
