### PR TITLE
fix(workflows/pr-review-companion): auth before setup 

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -121,10 +121,6 @@ jobs:
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT
 
-      - name: Setup gcloud
-        if: env.HAS_ARTIFACT
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Authenticate with GCP
         if: env.HAS_ARTIFACT
         uses: google-github-actions/auth@v2
@@ -132,6 +128,10 @@ jobs:
           token_format: access_token
           service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
           workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Sync build with GCS
         if: env.HAS_ARTIFACT


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes an issue with the new GCS sync.

### Motivation

[This run](https://github.com/mdn/content/actions/runs/13594190800/job/38007226308) failed:

> Warning: The gcloud CLI is not authenticated (or it is not installed). Authenticate by adding the "google-github-actions/auth" step prior this one.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of MP-1889 (Mozilla-internal).

Follow-up to:

- https://github.com/mdn/content/pull/38380