### PR TITLE
fix(workflows/pr-review-companion): fix permissions

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -11,11 +11,20 @@ on:
     types:
       - completed
 
+  workflow_call:
+    secrets:
+      GCP_PROJECT_NAME:
+        required: true
+      WIP_PROJECT_ID:
+        required: true
+
 permissions:
   # Download artifact.
   actions: read
   # Post comment in pull request.
   pull-requests: write
+  # Authenticate with GCP.
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes an issue with the permissions of the `pr-review-companion` workflow, preventing authentication with GCP.

### Motivation

[This run](https://github.com/mdn/content/actions/runs/13594280638/job/38007507980) failed:

> Error: google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up to:

- https://github.com/mdn/content/pull/38380
- https://github.com/mdn/content/pull/38381