### PR TITLE
fix(workflows/pr-review-companion): set environment on job

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -28,6 +28,7 @@ permissions:
 
 jobs:
   review:
+    environment: review
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes an issue with GCP authentication in the `pr-review-companion` workflow.

### Motivation

[This run](https://github.com/mdn/content/actions/runs/13594470355/job/38008073921) failed:

> "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist)."

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up to:

- https://github.com/mdn/content/pull/38380
- https://github.com/mdn/content/pull/38381
- https://github.com/mdn/content/pull/38382