### PR TITLE
Remove experimental mark from `NodeIterator.referenceNode`

### DIFF
--- a/files/en-us/web/api/nodeiterator/index.md
+++ b/files/en-us/web/api/nodeiterator/index.md
@@ -48,7 +48,6 @@ _This interface doesn't inherit any property._
 - {{domxref("NodeIterator.filter")}} {{ReadOnlyInline}}
   - : Returns a `NodeFilter` used to select the relevant nodes.
 - {{domxref("NodeIterator.referenceNode")}} {{ReadOnlyInline}}
-  {{experimental_inline() }}
   - : Returns the {{domxref("Node")}} to which the iterator is anchored.
 - {{domxref("NodeIterator.pointerBeforeReferenceNode")}} {{ReadOnlyInline}}
   - : Returns a boolean indicating whether or not the `NodeIterator` is anchored _before_ the {{domxref("NodeIterator.referenceNode")}}. If `false`, it indicates that the iterator is anchored _after_ the reference node.


### PR DESCRIPTION
It doesn't have the experimental flag in @mdn/browser-compat-data