### PR TITLE
Update HEVC support status for Firefox

### DIFF
--- a/files/en-us/web/media/guides/formats/video_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/video_codecs/index.md
@@ -1038,7 +1038,7 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
               <th scope="row">HEVC / H.265 support</th>
               <td>107</td>
               <td>18</td>
-              <td>No</td>
+              <td>120</td>
               <td>94</td>
               <td>11</td>
             </tr>
@@ -1049,7 +1049,7 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
           <a href="https://apps.microsoft.com/detail/9nmzlz57r3t7">HEVC video extensions from the Microsoft Store</a>
           is installed, and has the same support status as Chrome on other platforms. Edge (Legacy) only supports HEVC for devices with a hardware decoder.
         </p>
-        <p>Mozilla will not support HEVC while it is encumbered by patents.</p>
+        <p>Firefox 120 initially supported HEVC decoding in Nightly only. Support was enabled by default in Firefox 134 on Windows, Windows and macOS in Firefox 136, and Windows, macOS, and Linux in Firefox 137. HEVC support is provided only on devices with hardware support (the range is the same as Edge).</p>
         <p>Opera and other Chromium based browsers have the same support status as Chrome.</p>
         <p>Safari supports HEVC for all devices on macOS High Sierra or later.</p>
       </td>


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
FireFox supports HEVC since version 120 and support windows, macOS and Linux as same range as Edge Chromium since version 137, so update docs.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Make web developer clear what's the support status of HEVC codec on each platform.

### Additional details

Reference: https://github.com/Fyrd/caniuse/pull/7244
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
