### PR TITLE
FF136 Expr Feat/Relnote - SVG discard element

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -784,7 +784,47 @@ The parts that have been implemented include:
 
 ## SVG
 
-None.
+### `<discard>` element for SVG animations
+
+The {{svgelement("discard")}} SVG element allows developers to specify a trigger, such as the elapsed time since the SVG was loaded into DOM or the end of a particular animation, at which a specified element and its children should be removed from the DOM.
+An SVG viewer can use this information to conserve memory by discarding elements that are no longer needed, such as animated elements that have completed.
+([Firefox bug 1069931](https://bugzil.la/1069931)).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>136</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>136</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>svg.discard.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
 
 ## JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -120,6 +120,9 @@ These features are newly shipped in Firefox 136 but are disabled by default. To 
 - **Clear-Site-Data: cache**: `privacy.clearSiteDataHeader.cache.enabled`.
   The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) header can be used with the [`cache`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#cache) or `*` directives to clear the browser cache.
   ([Firefox bug 1942272](https://bugzil.la/1942272)).
+- **SVG `<discard>` element for SVG animations**: `svg.discard.enabled`.
+  The {{svgelement("discard")}} SVG element allows developers to specify a trigger, such as the elapsed time since the SVG was loaded into DOM or the end of a particular animation, at which a specified element and its children should be removed from the DOM. This allows an SVG viewer to conserve memory by discarding animated elements that no longer needed.
+  ([Firefox bug 1069931](https://bugzil.la/1069931)).
 
 ## Older versions
 


### PR DESCRIPTION
FF136 adds support for `discard` SVG element behind a flag. This adds and experimental feature/release note entry. The docs for the SVG element itself are coming in a separate PR.

Related docs work can be tracked in #37939