### PR TITLE
Update FileSystemObserver links to point to dom-examples

### DIFF
--- a/files/en-us/web/api/filesystemobserver/filesystemobserver/index.md
+++ b/files/en-us/web/api/filesystemobserver/filesystemobserver/index.md
@@ -35,7 +35,7 @@ A new {{domxref("FileSystemObserver")}} object.
 ## Examples
 
 > [!NOTE]
-> For a complete working example, check out [File System Observer Demo](https://file-system-observer.glitch.me/) ([source code](https://glitch.com/edit/#!/file-system-observer)).
+> For a complete working example, check out [File System Observer Demo](https://mdn.github.io/dom-examples/filesystemobserver/) ([source code](https://github.com/mdn/dom-examples/tree/main/filesystemobserver)).
 
 ### Initializing a `FileSystemObserver`
 

--- a/files/en-us/web/api/filesystemobserver/index.md
+++ b/files/en-us/web/api/filesystemobserver/index.md
@@ -27,7 +27,7 @@ The **`FileSystemObserver`** interface of the {{domxref("File System API", "File
 ## Examples
 
 > [!NOTE]
-> For a complete working example, check out [File System Observer Demo](https://file-system-observer.glitch.me/) ([source code](https://glitch.com/edit/#!/file-system-observer)).
+> For a complete working example, check out [File System Observer Demo](https://mdn.github.io/dom-examples/filesystemobserver/) ([source code](https://github.com/mdn/dom-examples/tree/main/filesystemobserver)).
 
 ### Initialize a `FileSystemObserver`
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Originally, when we published our [`FileSystemObserver`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemObserver) docs, we linked to a complete demo that was published on Glitch. However, it is more convenient to host full demos on the dom-examples repo because the code is easier to maintain.

We checked that the licensing situation was compatible and then created a copy of the demo on dom-examples.

This PR updates the links in the docs to that example and its source code to link to the dom-examples version rather than glitch.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
