### PR TITLE
Editorial review: Add docs for GPUTexture.createView() usage option

### DIFF
--- a/files/en-us/web/api/gputexture/createview/index.md
+++ b/files/en-us/web/api/gputexture/createview/index.md
@@ -88,6 +88,12 @@ createView(descriptor)
 
         If `mipLevelCount` is omitted, it will be given a value of {{domxref("GPUTexture.mipLevelCount")}} - `baseMipLevel`.
 
+    - `usage` {{optional_inline}}
+
+      - : A set of {{glossary("bitwise flags")}} representing a subset of the source texture's usage flags (available in the {{domxref("GPUTexture.usage")}} property) that are compatible with the chosen view format. This can be used to restrict the allowed view usage in cases where the view format is incompatible with certain usages. The available usage flags are listed in the [`GPUTexture.usage` value table](/en-US/docs/Web/API/GPUTexture/usage#value).
+
+        The default value is `0`, which represents the source texture's full set of usage flags. If the view's [`format`](#format) doesn't support all of the texture's usages, the default will fail, and the view's usage must be specified explicitly.
+
 ### Return value
 
 A {{domxref("GPUTextureView")}} object instance.
@@ -123,8 +129,11 @@ The following criteria must be met when calling **`createView()`**, otherwise a 
   - `"3d"`
     - {{domxref("GPUTexture.dimension")}} is `"3d"`
     - `arrayLayerCount` is 1
+- The view's [`format`](#format) supports all of the usages specified in the [`usage`](#usage) property.
 
 ## Examples
+
+### Typical `createView()` usage
 
 In the WebGPU Samples [Cubemap demo](https://webgpu.github.io/webgpu-samples/samples/cubemap/), you will see multiple examples of how `createView()` is used, both as to create a view `resource` for a {{domxref("GPUDevice.createBindGroup()")}} call, and to provide a `view` in the `depthStencilAttachment` object of a {{domxref("GPUCommandEncoder.beginRenderPass()")}} descriptor.
 
@@ -176,6 +185,27 @@ const commandEncoder = device.createCommandEncoder();
 const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
 
 // ...
+```
+
+### `createView()` with usage restriction
+
+In this snippet, we create a texture and then create a view that has its usage restricted via the `usage` property.
+
+```js
+const texture = myDevice.createTexture({
+  size: [4, 4],
+  format: "rgba8unorm",
+  usage:
+    GPUTextureUsage.RENDER_ATTACHMENT |
+    GPUTextureUsage.TEXTURE_BINDING |
+    GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ["rgba8unorm-srgb"],
+});
+
+const view = texture.createView({
+  format: "rgba8unorm-srgb",
+  usage: GPUTextureUsage.RENDER_ATTACHMENT, // Restrict allowed usage
+});
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 132 supports a new option, `usage`, in the descriptor of the `GPUTexture.createView()` method. This allows you to limit the view usage to a subset of the usages set on the source texture.

See https://developer.chrome.com/blog/new-in-webgpu-132#texture_view_usage and https://chromestatus.com/feature/5155252832305152 for more information.

This PR documents the new option.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/38360

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
