### PR TITLE
refactor(workflows/pr-review-companion): upload to GSC first

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -100,6 +100,28 @@ jobs:
           cd yari/deployer
           poetry install --no-interaction
 
+      - name: Authenticate with GCP
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload to GCS
+        if: env.HAS_ARTIFACT
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "build"
+          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
+          resumable: false
+          concurrency: 500
+          process_gcloudignore: false
+
       - name: Deploy and analyze built content
         if: env.HAS_ARTIFACT
         env:
@@ -132,25 +154,3 @@ jobs:
             --pr-number=$PR_NUMBER \
             --diff-file=$BUILD_OUT_ROOT/DIFF \
             $BUILD_OUT_ROOT
-
-      - name: Authenticate with GCP
-        if: env.HAS_ARTIFACT
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: access_token
-          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
-          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
-
-      - name: Setup gcloud
-        if: env.HAS_ARTIFACT
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Upload to GCS
-        if: env.HAS_ARTIFACT
-        uses: google-github-actions/upload-cloud-storage@v2
-        with:
-          path: "build"
-          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
-          resumable: false
-          concurrency: 500
-          process_gcloudignore: false


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Moves the GSC upload before the AWS upload.

### Motivation

Ensures that the GSC upload has finished when the GitHub comment is posted.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of MP-1889 (Mozilla-internal).

Follow-up to https://github.com/mdn/content/pull/38419.
