### PR TITLE
move page: css at rule functions

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11827,6 +11827,7 @@
 /en-US/docs/Web/CSS/All_About_The_Containing_Block	/en-US/docs/Web/CSS/CSS_display/Containing_block
 /en-US/docs/Web/CSS/Alternative_style_sheets	/en-US/docs/Web/HTML/Attributes/rel/alternate_stylesheet
 /en-US/docs/Web/CSS/At-rule	/en-US/docs/Web/CSS/CSS_syntax/At-rule
+/en-US/docs/Web/CSS/At-rule-functions	/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions
 /en-US/docs/Web/CSS/Aural	/en-US/docs/Web/CSS/@media/aural
 /en-US/docs/Web/CSS/Block_formatting_context	/en-US/docs/Web/CSS/CSS_display/Block_formatting_context
 /en-US/docs/Web/CSS/CSS3_Columns	/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts

--- a/files/en-us/web/css/@container/index.md
+++ b/files/en-us/web/css/@container/index.md
@@ -322,3 +322,4 @@ The global `revert` and `revert-layer` are invalid as values in a `<style-featur
 - {{Cssxref("contain")}}
 - {{Cssxref("content-visibility")}}
 - [CSS containment module](/en-US/docs/Web/CSS/CSS_containment)
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -161,3 +161,4 @@ This is an example of creating two separate unnamed cascade layers and importing
 - {{CSSxRef("@media")}}
 - {{CSSxRef("@supports")}}
 - [CSS cascading and inheritance](/en-US/docs/Web/CSS/CSS_cascade) module
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)

--- a/files/en-us/web/css/@namespace/index.md
+++ b/files/en-us/web/css/@namespace/index.md
@@ -102,3 +102,4 @@ svg|a {
 ## See also
 
 - [Namespaces crash course](/en-US/docs/Web/SVG/Namespaces_Crash_Course)
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -318,4 +318,6 @@ The following example applies the CSS style if the browser supports the `woff2` 
 ## See also
 
 - [Using feature queries](/en-US/docs/Web/CSS/CSS_conditional_rules/Using_feature_queries)
-- The CSSOM class {{DOMxRef("CSSSupportsRule")}}, and the {{DOMxref("CSS.supports_static", "CSS.supports()")}} method that allows the same check to be performed via JavaScript.
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)
+- {{DOMxRef("CSSSupportsRule")}}
+- {{DOMxref("CSS.supports_static", "CSS.supports()")}} method

--- a/files/en-us/web/css/@view-transition/index.md
+++ b/files/en-us/web/css/@view-transition/index.md
@@ -102,4 +102,4 @@ See this [transitions multi-page app](https://mdn.github.io/dom-examples/view-tr
 - {{cssxref("::view-transition-image-pair", "::view-transition-image-pair()")}}
 - [View Transition API](/en-US/docs/Web/API/View_Transition_API)
 - [CSS at-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule)
-- [CSS at-rule functions](/en-US/docs/Web/CSS/At-rule-functions)
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -64,5 +64,5 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 - [`<a>`](/en-US/docs/Web/SVG/Element/a#example) SVG element
 - [CSS `<url>` type](/en-US/docs/Web/CSS/url_value)
 - [CSS at-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule)
-- [CSS at-rule functions](/en-US/docs/Web/CSS/At-rule-functions)
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)
 - [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors)

--- a/files/en-us/web/css/css_syntax/at-rule/index.md
+++ b/files/en-us/web/css/css_syntax/at-rule/index.md
@@ -102,7 +102,7 @@ Block at-rules end in a `{}`-block that contain nested rules, other at-rules, or
 
 ## See also
 
-- [CSS at-rule functions](/en-US/docs/Web/CSS/At-rule-functions)
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)
 - [Nesting CSS at-rules](/en-US/docs/Web/CSS/CSS_nesting/Nesting_at-rules)
 - [CSS statements](/en-US/docs/Web/CSS/CSS_syntax/Syntax#css_statements)
 - [CSSRule](/en-US/docs/Web/API/CSSRule) interface

--- a/files/en-us/web/css/css_syntax/at-rule_functions/index.md
+++ b/files/en-us/web/css/css_syntax/at-rule_functions/index.md
@@ -53,9 +53,8 @@ The {{CSSxRef("@namespace")}} at-rule is used to specify XML namespaces to be us
 The {{CSSxRef("@container")}} at-rule is used to specify styles for a containment context.
 
 - {{CSSxRef("@container", "@container style()")}}
-
   - : Defines the containment context style.
 
-  ## See also
+## See also
 
 - [CSS syntax](/en-US/docs/Web/CSS/CSS_syntax) module

--- a/files/en-us/web/css/css_syntax/at-rule_functions/index.md
+++ b/files/en-us/web/css/css_syntax/at-rule_functions/index.md
@@ -1,6 +1,6 @@
 ---
 title: CSS at-rule functions
-slug: Web/CSS/At-rule-functions
+slug: Web/CSS/CSS_syntax/At-rule_functions
 page-type: guide
 ---
 
@@ -53,4 +53,9 @@ The {{CSSxRef("@namespace")}} at-rule is used to specify XML namespaces to be us
 The {{CSSxRef("@container")}} at-rule is used to specify styles for a containment context.
 
 - {{CSSxRef("@container", "@container style()")}}
+
   - : Defines the containment context style.
+
+  ## See also
+
+- [CSS syntax](/en-US/docs/Web/CSS/CSS_syntax) module

--- a/files/en-us/web/css/css_syntax/index.md
+++ b/files/en-us/web/css/css_syntax/index.md
@@ -102,5 +102,6 @@ This module doesn't define any properties, [data types](/en-US/docs/Web/CSS/CSS_
 
 ## See also
 
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)
 - [CSS selectors](/en-US/docs/Web/CSS/CSS_selectors) module
 - [CSS values and units](/en-US/docs/Web/CSS/CSS_Values_and_Units) module


### PR DESCRIPTION
moved the page to under sntax
add links to the see also's of the syntax page and all the pages listed in the guide.


did not add the page to the guides section in the css module landing page as it's not really a guide, but more of a reference list; but not a ref, so did not change the page type.

related to https://github.com/openwebdocs/project/issues/218