### PR TITLE
Bug-1636751 proxy.onRequest with proxyAuthorizationHeader HTTPS only

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -37,7 +37,7 @@ Values of this type are objects. They contain the following properties:
   - : `number`. Failover timeout in seconds. If the connection fails to connect the proxy server after this number of seconds, the next proxy server in the array returned from the `proxy.onRequest` listener will be used.
 - `proxyAuthorizationHeader`
 
-  - : `string`. When set, this is passed to the {{httpheader("Proxy-Authorization")}} request header sent to HTTP or HTTPS proxies as part of a [CONNECT](/en-US/docs/Web/HTTP/Methods/CONNECT) request. Used to authenticate to HTTP and HTTPS proxies that allow non-challenging authentication.
+  - : `string`. When set, this is passed to the {{httpheader("Proxy-Authorization")}} request header sent to a HTTPS proxy as part of a [CONNECT](/en-US/docs/Web/HTTP/Methods/CONNECT) request. Used to authenticate to HTTPS proxies that allow non-challenging authentication. Returns an error if an attempt is made to use a HTTP proxy.
 
     For instance, if you want to send "username" and "password" for "basic" authentication, you can set the `proxyAuthorizationHeader` property to `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`
 


### PR DESCRIPTION
### Description

Addresses the dev-docs-needed request for [Bug 1636751](https://bugzilla.mozilla.org/show_bug.cgi?id=1636751) "proxy.onRequest return with proxyAuthorizationHeader not proxying the request" by clarifying that only HTTPS proxies can be specified.