### PR TITLE
FF137 Relnote: SVG <discard> element

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -784,47 +784,7 @@ The parts that have been implemented include:
 
 ## SVG
 
-### `<discard>` element for SVG animations
-
-The {{svgelement("discard")}} SVG element allows developers to specify a trigger, such as the elapsed time since the SVG was loaded into DOM or the end of a particular animation, at which a specified element and its children should be removed from the DOM.
-An SVG viewer can use this information to conserve memory by discarding elements that are no longer needed, such as animated elements that have completed.
-([Firefox bug 1069931](https://bugzil.la/1069931)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>136</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>svg.discard.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
+None.
 
 ## JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -26,6 +26,11 @@ This article provides information about the changes in Firefox 137 that affect d
 
 ### SVG
 
+- The {{svgelement("discard")}} SVG element is now supported, along with its corresponding {{domxref("SVGDiscardElement")}} JavaScript interface.
+  The element allows developers to specify a trigger time or event at which a specified element and its children should be removed from the DOM.
+  An SVG viewer can use this information to conserve memory by discarding elements that are no longer needed, such as animated elements that have completed.
+  ([Firefox bug 1945330](https://bugzil.la/1945330)).
+
 #### Removals
 
 ### HTTP


### PR DESCRIPTION
FF127 ships `<discard>` in https://bugzilla.mozilla.org/show_bug.cgi?id=1945330. This adds a release note and removes from experimental features.

Related docs work can be tracked in #38409