### PR TITLE
FF137 Relnote: beforescriptexecution and afterscript execution events deprecated 

### DIFF
--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -44,6 +44,8 @@ This article provides information about the changes in Firefox 137 that affect d
 
 #### Removals
 
+- The following non-standard events are now deprecated and proposed for removal: [`afterscriptexecute`](/en-US/docs/Web/API/Document/afterscriptexecute_event) and [`beforescriptexecute`](/en-US/docs/Web/API/Document/beforescriptexecute_event) in {{domxref("Document")}}, and [`afterscriptexecute`](/en-US/docs/Web/API/Element/afterscriptexecute_event), and [`beforescriptexecute`](/en-US/docs/Web/API/Element/beforescriptexecute_event) in {{domxref("Element")}}. A console warning is displayed when they are used. ([Firefox bug 1949373](https://bugzil.la/1949373)).
+
 ### WebAssembly
 
 #### Removals


### PR DESCRIPTION
FF137 is adding deprecation warnings for [`Document.afterscriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Document/afterscriptexecute_event), [`Document.beforescriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Document/beforescriptexecute_event), [`Element.afterscriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/afterscriptexecute_event), and [`Element.beforescriptexecute` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforescriptexecute_event), in https://bugzilla.mozilla.org/show_bug.cgi?id=1949373

This is part of a usage test, on the way to unimplementation in https://bugzilla.mozilla.org/show_bug.cgi?id=1584269

This PR adds a release note about the deprecation, because we'd like people to know they should start not using it.