### PR TITLE
FF137 Relnote: HVEC support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -42,6 +42,8 @@ This article provides information about the changes in Firefox 137 that affect d
 
 #### Media, WebRTC, and Web Audio
 
+- [HEVC (H.265)](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#hevc_h.265) is now hardware enabled on Android, and hardware and software enabled on Linux. This adds to existing hardware and software support on Windows and macOS.
+
 #### Removals
 
 ### WebAssembly

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -42,7 +42,7 @@ This article provides information about the changes in Firefox 137 that affect d
 
 #### Media, WebRTC, and Web Audio
 
-- [HEVC (H.265)](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#hevc_h.265) is now hardware enabled on Android, and hardware and software enabled on Linux. This adds to existing hardware and software support on Windows and macOS.
+- [HEVC (H.265)](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#hevc_h.265) is now hardware enabled on Android, and hardware and software enabled on Linux. This adds to existing hardware and software support on Windows and macOS. ([Firefox bug 1950032](https://bugzil.la/1950032)).
 
 #### Removals
 

--- a/files/en-us/web/media/guides/formats/video_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/video_codecs/index.md
@@ -1049,7 +1049,14 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
           <a href="https://apps.microsoft.com/detail/9nmzlz57r3t7">HEVC video extensions from the Microsoft Store</a>
           is installed, and has the same support status as Chrome on other platforms. Edge (Legacy) only supports HEVC for devices with a hardware decoder.
         </p>
-        <p>Firefox 120 initially supported HEVC decoding in Nightly only. Support was enabled by default in Firefox 134 on Windows, Windows and macOS in Firefox 136, and Windows, macOS, and Linux in Firefox 137. HEVC support is provided only on devices with hardware support (the range is the same as Edge).</p>
+        <p>Firefox enables HEVC on:
+          <ul>
+            <li>Windows from Firefox 134 using either hardware (on devices that support it, where the range is the same as Edge) or software (on Windows the user must pay for and install an extension)</li>
+            <li>macOS from Firefox 136 using either hardware or software.</li>
+            <li>Linux from Firefox 137 using either hardware or software (via the system ffmpeg).</li>
+            <li>Android from Firefox 137 using hardware only.</li>
+          </ul>
+        </p>
         <p>Opera and other Chromium based browsers have the same support status as Chrome.</p>
         <p>Safari supports HEVC for all devices on macOS High Sierra or later.</p>
       </td>


### PR DESCRIPTION
FF137 adds HVEC support for Android and Linux in https://bugzilla.mozilla.org/show_bug.cgi?id=1950032

This adds a release note. It also adds an update to the [web video codec guide](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Video_codecs#hevc_h.265) to update the information provided in #38395