### PR TITLE
Update WebDriver Classic browser-compat keys

### DIFF
--- a/files/en-us/web/webdriver/reference/commands/closewindow/index.md
+++ b/files/en-us/web/webdriver/reference/commands/closewindow/index.md
@@ -2,7 +2,7 @@
 title: Close Window
 slug: Web/WebDriver/Reference/Commands/CloseWindow
 page-type: webdriver-command
-browser-compat: webdriver.commands.CloseWindow
+browser-compat: webdriver.classic.CloseWindow
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/getelementattribute/index.md
+++ b/files/en-us/web/webdriver/reference/commands/getelementattribute/index.md
@@ -2,7 +2,7 @@
 title: Get Element Attribute
 slug: Web/WebDriver/Reference/Commands/GetElementAttribute
 page-type: webdriver-command
-browser-compat: webdriver.commands.GetElementAttribute
+browser-compat: webdriver.classic.GetElementAttribute
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/getelementproperty/index.md
+++ b/files/en-us/web/webdriver/reference/commands/getelementproperty/index.md
@@ -2,7 +2,7 @@
 title: Get Element Property
 slug: Web/WebDriver/Reference/Commands/GetElementProperty
 page-type: webdriver-command
-browser-compat: webdriver.commands.GetElementProperty
+browser-compat: webdriver.classic.GetElementProperty
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/getelementtagname/index.md
+++ b/files/en-us/web/webdriver/reference/commands/getelementtagname/index.md
@@ -2,7 +2,7 @@
 title: Get Element Tag Name
 slug: Web/WebDriver/Reference/Commands/GetElementTagName
 page-type: webdriver-command
-browser-compat: webdriver.commands.GetElementTagName
+browser-compat: webdriver.classic.GetElementTagName
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/gettimeouts/index.md
+++ b/files/en-us/web/webdriver/reference/commands/gettimeouts/index.md
@@ -2,7 +2,7 @@
 title: Get Timeouts
 slug: Web/WebDriver/Reference/Commands/GetTimeouts
 page-type: webdriver-command
-browser-compat: webdriver.commands.GetTimeouts
+browser-compat: webdriver.classic.GetTimeouts
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/getwindowhandles/index.md
+++ b/files/en-us/web/webdriver/reference/commands/getwindowhandles/index.md
@@ -2,7 +2,7 @@
 title: Get Window Handles
 slug: Web/WebDriver/Reference/Commands/GetWindowHandles
 page-type: webdriver-command
-browser-compat: webdriver.commands.GetWindowHandles
+browser-compat: webdriver.classic.GetWindowHandles
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/getwindowrect/index.md
+++ b/files/en-us/web/webdriver/reference/commands/getwindowrect/index.md
@@ -2,7 +2,7 @@
 title: Get Window Rect
 slug: Web/WebDriver/Reference/Commands/GetWindowRect
 page-type: webdriver-command
-browser-compat: webdriver.commands.GetWindowRect
+browser-compat: webdriver.classic.GetWindowRect
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/index.md
+++ b/files/en-us/web/webdriver/reference/commands/index.md
@@ -3,7 +3,7 @@ title: WebDriver commands
 short-title: Commands
 slug: Web/WebDriver/Reference/Commands
 page-type: landing-page
-browser-compat: webdriver.commands
+browser-compat: webdriver.classic
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/newwindow/index.md
+++ b/files/en-us/web/webdriver/reference/commands/newwindow/index.md
@@ -2,7 +2,7 @@
 title: New Window
 slug: Web/WebDriver/Reference/Commands/NewWindow
 page-type: webdriver-command
-browser-compat: webdriver.commands.NewWindow
+browser-compat: webdriver.classic.NewWindow
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/settimeouts/index.md
+++ b/files/en-us/web/webdriver/reference/commands/settimeouts/index.md
@@ -2,7 +2,7 @@
 title: Set Timeouts
 slug: Web/WebDriver/Reference/Commands/SetTimeouts
 page-type: webdriver-command
-browser-compat: webdriver.commands.SetTimeouts
+browser-compat: webdriver.classic.SetTimeouts
 sidebar: webdriver
 ---
 

--- a/files/en-us/web/webdriver/reference/commands/setwindowrect/index.md
+++ b/files/en-us/web/webdriver/reference/commands/setwindowrect/index.md
@@ -2,7 +2,7 @@
 title: Set Window Rect
 slug: Web/WebDriver/Reference/Commands/SetWindowRect
 page-type: webdriver-command
-browser-compat: webdriver.commands.SetWindowRect
+browser-compat: webdriver.classic.SetWindowRect
 sidebar: webdriver
 ---
 


### PR DESCRIPTION
### Description

Updates `browser-compat` keys for WebDriver Classic pages.

### Motivation

WebDriver Classic support data was renamed from `webdriver.commands.*` to `webdriver.classic.*` in [BCD v5.7.0](https://github.com/mdn/browser-compat-data/releases/tag/v5.7.0).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See:

- https://github.com/mdn/browser-compat-data/pull/25802