### PR TITLE
fix(workflows/pr-review-companion): exclude parent from upload

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -120,6 +120,7 @@ jobs:
           destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
           resumable: false
           concurrency: 500
+          parent: false
           process_gcloudignore: false
 
       - name: Deploy and analyze built content


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Excludes the parent folder (`build`) from the review upload.

### Motivation

Previously, the folder `build` was uploaded inside the target folder.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of MP-1889 (Mozilla-internal).

Fixup of https://github.com/mdn/content/pull/38419.