### PR TITLE
Fix browser compatibility for Chromium browers

### DIFF
--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -71,7 +71,7 @@ Chromium browsers:
 
 - Reading requires the [Permissions API](/en-US/docs/Web/API/Permissions_API) `clipboard-read` permission be granted.
   Transient activation is not required.
-- Writing requires either the `clipboard-read` permission or transient activation.
+- Writing requires either the `clipboard-write` permission or transient activation.
   If the permission is granted, it persists, and further transient activation is not required.
 - The HTTP [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) permissions `clipboard-read` and `clipboard-write` must be allowed for {{HTMLElement("iframe")}} elements that access the clipboard.
 - No persistent paste-prompt is displayed when a read operation is caused by a browser or OS "paste element".


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed typo, where it said chromium browsers writing requires clipboard-read permission, instead of clipboard-write permission. 