### PR TITLE
Fix Sec-WebSocket-Extensions example

### DIFF
--- a/files/en-us/web/http/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-extensions/index.md
@@ -65,7 +65,7 @@ Upgrade: websocket
 Connection: Upgrade
 Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
 Sec-WebSocket-Version: 13
-Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
+Sec-WebSocket-Extensions: permessage-deflate, client_max_window_bits
 ```
 
 The request below with separate headers for each extension is equivalent:


### PR DESCRIPTION
Extension list is separated by comma, not semicolon (which is used for extension params)
