### PR TITLE
added release note for hyphenate-limit-char property

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -784,46 +784,6 @@ The parts that have been implemented include:
   </tbody>
 </table>
 
-### `hyphenate-limit-chars` property
-
-The {{CSSXRef("hyphenate-limit-chars")}} CSS property is used to specifically the minimum word length for hyphenation as well as the number of characters before and after the hyphen. ([Firefox bug 1521723](https://bugzil.la/1521723)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>136</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>layout.css.hyphenate-limit-chars.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## SVG
 
 None.

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -18,6 +18,8 @@ This article provides information about the changes in Firefox 137 that affect d
 
 ### CSS
 
+- The {{CSSXRef("hyphenate-limit-chars")}} CSS property provides you with fine-grained control over hyphenation in text. It is used to specify the minimum word length for hyphenation as well as the number of characters before and after the hyphen. ([Firefox bug 1947183](https://bugzil.la/1947183)).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
### Description

- Added firefox 137 release note for hyphenate-limit-char property
- Removed firefox experimental release note for hyphenate-limit-char property

### Motivation

- Working on [issue #38406](https://github.com/mdn/content/issues/38406)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/26118)