### PR TITLE
"File a bug report" link to land on "Template choosing" dialog

### DIFF
--- a/files/en-us/mozilla/add-ons/contact_us/index.md
+++ b/files/en-us/mozilla/add-ons/contact_us/index.md
@@ -31,4 +31,4 @@ If you discover an add-on security vulnerability, even if the add-on is not host
 
 #### Bugs on addons.mozilla.org (AMO)
 
-If you find a problem with the site, we'd love to fix it. Please [file a bug report](https://github.com/mozilla/addons/issues/new) and include as much detail as possible.
+If you find a problem with the site, we'd love to fix it. Please [file a bug report](https://github.com/mozilla/addons/issues/new/choose) and include as much detail as possible.


### PR DESCRIPTION
Changed link from:
https://github.com/mozilla/addons/issues/new
to
https://github.com/mozilla/addons/issues/new/choose
for a landing on a template choosing dialog, instead of creating a completely blank issue without template.

This fixes https://github.com/mdn/content/issues/38463
