### PR TITLE
Fix range request example

### DIFF
--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -102,7 +102,7 @@ This example requests the first 500 and last 500 bytes of the file.
 The request may be rejected by the server if these ranges overlap (if the requested resource was less than 1000 bytes long, for instance).
 
 ```http
-Range: bytes=0-499, -499
+Range: bytes=0-499, -500
 ```
 
 ### Checking if a server supports range requests


### PR DESCRIPTION
According to rfc7233 using `-499` in a range request will select the last 499 bytes, not the last 500 bytes as stated in the text above this change.

See: https://datatracker.ietf.org/doc/html/rfc7233#section-2.1
