### PR TITLE
CSS module: hide code / add playground

### DIFF
--- a/files/en-us/web/css/css_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/index.md
@@ -17,9 +17,9 @@ Shapes define geometries that can be used as CSS values. This module provides fu
 
 ## CSS shapes in action
 
-The example below shows an image that has been floated left, and the `shape-outside` property applied with a value of `circle(50%)`. This creates a circle shape, and the content wrapping the float now wraps around that shape. This changes the length of the wrapping text's line boxes.
+The example below shows an image that has been floated left, and the `shape-outside` property applied with a value of `circle(50%)`. This creates a circle shape, and the content wrapping the float now wraps around that shape. This changes the length of the wrapping text's line boxes. You can click "Play" to edit the code in the MDN Playground.
 
-```html live-sample___circle
+```html live-sample___circle hidden
 <div class="box">
   <img
     alt="A hot air balloon"
@@ -38,7 +38,7 @@ The example below shows an image that has been floated left, and the `shape-outs
 </div>
 ```
 
-```css live-sample___circle
+```css live-sample___circle hidden
 body {
   font: 1.2em / 1.5 sans-serif;
 }


### PR DESCRIPTION
hiding the code to match how module landing pages are presented.
added a sentence to inform user where they can view and play with the code. ([#147](https://github.com/openwebdocs/project/issues/147))