### PR TITLE
Move DASH streaming guide to media source extensions API, remove info about client configuration

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1121,7 +1121,7 @@
 /en-US/docs/Cryptanalysis	/en-US/docs/Glossary/Cryptanalysis
 /en-US/docs/Cryptographic_hash_function	/en-US/docs/Glossary/Cryptographic_hash_function
 /en-US/docs/CustomElements	/en-US/docs/Web/API/Web_components/Using_custom_elements
-/en-US/docs/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video
+/en-US/docs/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming
 /en-US/docs/DOM	/en-US/docs/Web/API/Document_Object_Model
 /en-US/docs/DOM/About_the_Document_Object_Model	/en-US/docs/Web/API/Document_Object_Model
 /en-US/docs/DOM/AbstractView	/en-US/docs/Web/API/Document/defaultView
@@ -12860,7 +12860,7 @@
 /en-US/docs/Web/HTML/Content_Editable	/en-US/docs/Web/HTML/Global_attributes/contenteditable
 /en-US/docs/Web/HTML/Controlling_spell_checking_in_HTML_forms	/en-US/docs/Web/HTML/Global_attributes/spellcheck
 /en-US/docs/Web/HTML/Controlling_spell_checking_in_HTML_formsControlling_spell_checking_in_HTML_forms	/en-US/docs/Web/HTML/Global_attributes/spellcheck
-/en-US/docs/Web/HTML/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video
+/en-US/docs/Web/HTML/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming
 /en-US/docs/Web/HTML/Element/<rb>:_The_Ruby_Base_element	/en-US/docs/Web/HTML/Element/rb
 /en-US/docs/Web/HTML/Element/Input/<input_type=_checkbox_>	/en-US/docs/Web/HTML/Element/input/checkbox
 /en-US/docs/Web/HTML/Element/Input/<input_type=_color_>	/en-US/docs/Web/HTML/Element/input/color
@@ -13544,7 +13544,7 @@
 /en-US/docs/Web/Media/Audio_and_video_delivery/cross_browser_video_player	/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player
 /en-US/docs/Web/Media/Audio_and_video_manipulation	/en-US/docs/Web/Media/Guides/Audio_and_video_manipulation
 /en-US/docs/Web/Media/Autoplay_guide	/en-US/docs/Web/Media/Guides/Autoplay
-/en-US/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video
+/en-US/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming
 /en-US/docs/Web/Media/Formats	/en-US/docs/Web/Media/Guides/Formats
 /en-US/docs/Web/Media/Formats/Audio_codecs	/en-US/docs/Web/Media/Guides/Formats/Audio_codecs
 /en-US/docs/Web/Media/Formats/Audio_concepts	/en-US/docs/Web/Media/Guides/Formats/Audio_concepts
@@ -13557,6 +13557,7 @@
 /en-US/docs/Web/Media/Formats/Video_concepts	/en-US/docs/Web/Media/Guides/Formats/Video_concepts
 /en-US/docs/Web/Media/Formats/WebRTC_codecs	/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs
 /en-US/docs/Web/Media/Formats/codecs_parameter	/en-US/docs/Web/Media/Guides/Formats/codecs_parameter
+/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video	/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming
 /en-US/docs/Web/Media/HTML_media	/en-US/docs/Web/Media/Guides/Audio_and_video_delivery
 /en-US/docs/Web/Media/Streaming	/en-US/docs/Web/Media/Guides/Streaming
 /en-US/docs/Web/Media/images	/en-US/docs/Web/Media/Guides/Images

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -46296,6 +46296,28 @@
       "NickDesaulniers"
     ]
   },
+  "Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming": {
+    "modified": "2020-11-09T07:34:43.578Z",
+    "contributors": [
+      "mfuji09",
+      "Sidewinder53",
+      "DeividasBakanas",
+      "formatkaka",
+      "chrysn",
+      "LeroyScandal",
+      "wbamberg",
+      "jswisher",
+      "wyrewolwerowany",
+      "anotherkabab",
+      "rogerxas",
+      "teoli",
+      "gmarty",
+      "Kinetik",
+      "kscarfone",
+      "sworkman",
+      "joshmoz"
+    ]
+  },
   "Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE": {
     "modified": "2019-11-17T06:14:01.055Z",
     "contributors": [
@@ -71445,6 +71467,16 @@
       "SteveLee"
     ]
   },
+  "Web/Accessibility/ARIA/How_to/File_ARIA-related_bugs": {
+    "modified": "2019-03-24T00:12:10.850Z",
+    "contributors": [
+      "chrisdavidmills",
+      "carlkibler",
+      "bledwards1",
+      "Sheppy",
+      "Aaronlev"
+    ]
+  },
   "Web/Accessibility/ARIA/Reference/Roles": {
     "modified": "2020-04-01T14:49:41.249Z",
     "contributors": [
@@ -71858,16 +71890,6 @@
       "Sheppy",
       "Fleshgrinder",
       "hhillen"
-    ]
-  },
-  "Web/Accessibility/ARIA/How_to/File_ARIA-related_bugs": {
-    "modified": "2019-03-24T00:12:10.850Z",
-    "contributors": [
-      "chrisdavidmills",
-      "carlkibler",
-      "bledwards1",
-      "Sheppy",
-      "Aaronlev"
     ]
   },
   "Web/Accessibility/Guides/Accessibility_and_Spatial_Patterns": {
@@ -121672,28 +121694,6 @@
   "Web/Media/Guides/Autoplay": {
     "modified": "2020-10-11T23:21:36.266Z",
     "contributors": ["Malvoz", "scunliffe", "MrAlexWeber", "Sheppy"]
-  },
-  "Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video": {
-    "modified": "2020-11-09T07:34:43.578Z",
-    "contributors": [
-      "mfuji09",
-      "Sidewinder53",
-      "DeividasBakanas",
-      "formatkaka",
-      "chrysn",
-      "LeroyScandal",
-      "wbamberg",
-      "jswisher",
-      "wyrewolwerowany",
-      "anotherkabab",
-      "rogerxas",
-      "teoli",
-      "gmarty",
-      "Kinetik",
-      "kscarfone",
-      "sworkman",
-      "joshmoz"
-    ]
   },
   "Web/Media/Guides/Formats": {
     "modified": "2019-11-15T11:45:09.792Z",

--- a/files/en-us/web/api/media_source_extensions_api/dash_adaptive_streaming/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/dash_adaptive_streaming/index.md
@@ -1,27 +1,15 @@
 ---
 title: DASH Adaptive Streaming for HTML video
-slug: Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video
+slug: Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming
 page-type: guide
 sidebar: mediasidebar
 ---
 
 Dynamic Adaptive Streaming over HTTP (DASH) is an adaptive streaming protocol. This means that it allows for a video stream to switch between bit rates on the basis of network performance, in order to keep a video playing.
 
-## Browser Support
-
-Firefox 21 includes an implementation of DASH for HTML WebM video which is turned off by default. It can be enabled via "about:config" and the "media.dash.enabled" preference.
-
-Firefox 23 removed support for DASH for HTML WebM video. It will be replaced by an implementation of the [Media Source Extensions API](https://www.w3.org/TR/media-source/) which will allow support for DASH via JavaScript libraries such as dash.js. See bug [778617](https://bugzil.la/778617) for details.
-
-## Using DASH - Server Side
-
 First you'll need to convert your WebM video to a DASH manifest with the accompanying video files in various bit rates. To start with you'll only need the FFmpeg program from [ffmpeg.org](https://www.ffmpeg.org/), with libvpx and libvorbis support for WebM video and audio, at least version 2.5 (probably; this was tested with 3.2.5).
 
-### 1. Use your existing WebM file to create one audio file and multiple video files
-
-For example:
-
-The file **_in.video_** can be any container with at least one audio and one video stream that can be decoded by FFmpeg,
+First, use your existing WebM file to create one audio file and multiple video files. In the example below, the file **_in.video_** can be any container with at least one audio and one video stream that can be decoded by FFmpeg.
 
 Create the audio using:
 
@@ -68,7 +56,7 @@ ffmpeg -i in.video -c:v libvpx-vp9 -keyint_min 150 \
 -an -vf scale=1280:720 -b:v 1500k -dash 1 video_1280x720_1500k.webm
 ```
 
-### 2. Create the manifest file
+Then, create the manifest file.
 
 ```bash
 ffmpeg \
@@ -86,21 +74,9 @@ ffmpeg \
 
 The `-map` arguments correspond to the input files in the sequence they are given; you should have one for each file. The `-adaptation_sets` argument assigns them into adaptation sets; for example, this creates one set (0) that contains the streams 0, 1, 2 and 3 (the videos), and another set (1) that contains only stream 4, the audio stream.
 
-Put the manifest and the associated video files on your web server or CDN. DASH works via HTTP, so as long as your HTTP server supports byte range requests, and it's set up to serve `.mpd` files with `mimetype="application/dash+xml"`, then you're all set.
+Put the manifest and the associated video files on your web server or CDN. DASH works via HTTP, so as long as your HTTP server supports byte range requests, and it's set up to serve `.mpd` files with `Content-Type: application/dash+xml`, then you're all set.
 
-## Using DASH - Client Side
-
-You'll want to modify your web page to point to the DASH manifest first, instead of directly to a particular video file:
-
-```html
-<video>
-  <source src="movie.mpd" />
-  <source src="movie.webm" />
-  Your browser does not support the video tag.
-</video>
-```
-
-That's it! If DASH is supported by the browser, your video will now stream adaptively.
+Then, in order to correctly connect this `.mpd` file to your `<video>` element, you need a JavaScript library like dash.js, because no browser has native support for DASH. Read [dash.js quickstart](https://dashif.org/dash.js/pages/quickstart/) for how to set up your page to use it.
 
 ## See also
 

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -35,7 +35,7 @@ The two most common use cases for DASH involve watching content "on demand" or "
 
 Live profile content can introduce latency due to its transcoding and broadcasting, so DASH is not suitable for real time communication like [WebRTC](/en-US/docs/Web/API/WebRTC_API) is. It can however support significantly more client connections than WebRTC.
 
-There are numerous available free and open source tools for transcoding content and preparing it for use with DASH, DASH file servers, and DASH client libraries written in JavaScript.
+There are numerous available free and open source tools for transcoding content and preparing it for use with DASH, DASH file servers, and DASH client libraries written in JavaScript. The [DASH Adaptive Streaming for HTML video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming) article provides an example of how to use DASH with MSE.
 
 ### Availability in workers
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/index.md
@@ -513,7 +513,7 @@ A number of audio and video JavaScript libraries exist. The most popular librari
   - : Live streaming technology is often employed to relay live events such as sports, concerts and more generally TV and Radio programmes that are output live. Often shortened to just streaming, live streaming is the process of transmitting media 'live' to computers and devices. This is a fairly complex and nascent subject with a lot of variables, so in this article we'll introduce you to the subject and let you know how you can get started.
 - [Setting up adaptive streaming media sources](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources)
   - : Let's say you want to set up an adaptive streaming media source on a server, to be consumed inside an HTML media element. How would you do that? This article explains how, looking at two of the most common formats: MPEG-DASH and HLS (HTTP Live Streaming.)
-- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video)
+- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming)
   - : Details how to set up adaptive streaming using DASH and WebM.
 
 ### Advanced topics

--- a/files/en-us/web/media/guides/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -151,7 +151,7 @@ Although you can install software like GStreamer, SHOUTcast and Icecast you will
 - [HLS Browser Support](https://jwplayer.com/blog/http-live-streaming/)
 - [HTTP Live Streaming JavaScript player](https://github.com/RReverser/mpegts)
 - [The Basics of HTTP Live Streaming](https://larryjordan.com/articles/basics-of-http-live-streaming/)
-- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video)
+- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming)
 - [Dynamic Adaptive Streaming over HTTP (MPEG-DASH)](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP)
 - [MPEG-DASH Media Source Demo](https://web.archive.org/web/20170703160817/https://dash-mse-test.appspot.com/media.html)
 - [DASH Reference Client](https://reference.dashif.org/dash.js/v4.4.0/samples/dash-if-reference-player/index.html)

--- a/files/en-us/web/media/guides/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
@@ -114,7 +114,7 @@ A useful piece of software when dealing with MPEG-DASH is [Dash Encoder](https:/
 > Since MPEG-DASH decoding is done partially using JavaScript and MSE files are often grabbed using XHR, keep same origin rules in mind.
 
 > [!NOTE]
-> If you use WebM you can use the methods shown in this tutorial [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video).
+> If you use WebM you can use the methods shown in this tutorial [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming).
 
 Once encoded your file structure may look something like this:
 
@@ -266,7 +266,7 @@ Further resources on adaptive streaming.
 ### MPEG-DASH overview and references
 
 - [Dynamic Adaptive Streaming over HTTP Dataset](https://www-itec.uni-klu.ac.at/bib/files/p89-lederer.pdf)
-- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video)
+- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming)
 - [Dynamic Adaptive Streaming over HTTP: From Content Creation to Consumption](https://www.slideshare.net/slideshow/dynamic-adaptive-streaming-over-http-from-content-creation-to-consumption/14933566)
 
 ### MPEG-DASH tools

--- a/files/en-us/web/media/index.md
+++ b/files/en-us/web/media/index.md
@@ -18,7 +18,7 @@ This article lists guides and references for various features you may use when i
   - : Having native audio and video in the browser means we can use these data streams with technologies such as {{htmlelement("canvas")}}, [WebGL](/en-US/docs/Web/API/WebGL_API) or [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) to modify audio and video directly, for example adding reverb/compression effects to audio, or grayscale/sepia filters to video.
 - [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Guides/Autoplay)
   - : Unexpected automatic playback of media or audio can be an unwelcome surprise to users. While autoplay serves a purpose, it should be used carefully. To give users control over this, many browsers now provide forms of autoplay blocking. This article is a guide to autoplay, with tips on when and how to use it and how to work with browsers to handle autoplay blocking gracefully.
-- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video)
+- [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming)
   - : Dynamic Adaptive Streaming over HTTP (DASH) is an adaptive streaming protocol. This means that it allows for a video stream to switch between bit rates on the basis of network performance, in order to keep a video playing.
 - [Streaming audio and video](/en-US/docs/Web/Media/Guides/Streaming)
   - : A guide which covers how to stream audio and video, as well as techniques and technologies you can take advantage of to ensure the best possible quality and/or performance of your streams.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1037,6 +1037,10 @@
     },
     "Media Source Extensions": {
       "overview": ["Media Source Extensions API"],
+      "guides": [
+        "/docs/Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE",
+        "/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming"
+      ],
       "interfaces": [
         "MediaSource",
         "MediaSourceHandle",

--- a/files/sidebars/mediasidebar.yaml
+++ b/files/sidebars/mediasidebar.yaml
@@ -10,7 +10,6 @@ sidebar:
   - /Web/Media/Guides/Audio_and_video_manipulation
   - /Web/Media/Guides/Autoplay
   - /Web/Media/Guides/Streaming
-  - /Web/Media/Guides/DASH_Adaptive_Streaming_for_HTML_5_Video
   - type: listSubPages
     path: /Web/Media/Guides/Audio_and_video_delivery
     link: /Web/Media/Guides/Audio_and_video_delivery


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/1217. This guide was written when Firefox still had native support for DASH, presumably; that is no longer the case, and I don't think we should document dash.js, so just pointing to their docs. This guide also feels more topical under the API guides.