### PR TITLE
Remove warning about myIpAddress() in PAC

### DIFF
--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -306,14 +306,12 @@ myIpAddress()
 
 #### Return value
 
-Returns the server IP address of the machine Firefox is running on, as a string in the dot-separated integer format.
-
-> **Warning:** `myIpAddress()` returns the same IP address as the server address returned by **`nslookup localhost`** on a Linux machine. It does not return the public IP address.
+Returns the server IP address of the machine Firefox is running on, as a string in the dot-separated integer format. In order to be more helpful, it will try several alternatives before falling back to the loopback address (like `127.0.0.1`).
 
 #### Example
 
 ```js-nolint
-myIpAddress() //returns the string "127.0.1.1" if you were running Firefox on that localhost
+myIpAddress()
 ```
 
 ### dnsDomainLevels()


### PR DESCRIPTION
Fix #20801. This was fixed in 2014: https://bugzilla.mozilla.org/show_bug.cgi?id=347307