### PR TITLE
Fix the length of the FileList is 0, not null

### DIFF
--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -365,7 +365,7 @@ function handleFiles() {
 
 This starts by fetching the URL of the {{HTMLElement("div")}} with the ID `fileList`. This is the block into which we'll insert our file list, including thumbnails.
 
-If the {{DOMxRef("FileList")}} object passed to `handleFiles()` is `null`, we set the inner HTML of the block to display "No files selected!". Otherwise, we start building our file list, as follows:
+If the {{DOMxRef("FileList")}} object passed to `handleFiles()` is empty, we set the inner HTML of the block to display "No files selected!". Otherwise, we start building our file list, as follows:
 
 1. A new unordered list ({{HTMLElement("ul")}}) element is created.
 2. The new list element is inserted into the {{HTMLElement("div")}} block by calling its {{DOMxRef("Node.appendChild()")}} method.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

To disambiguation, this should be changed to "empty" or "The length of the `FileList` object passed to `handleFiles()` is `0`", not `null`.