### PR TITLE
Remove irrelevant note

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -262,10 +262,15 @@ function foo(n) {
 }
 
 foo(3); // 3 + 3 = 6
+
+(function () {
+  'use strict';
+  let arguments = [1, 2, 3]; // SyntaxError: Unexpected eval or arguments in strict mode
+})()
 ```
 
 > [!NOTE]
-> You cannot declare a variable called `arguments` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode#making_eval_and_arguments_simpler), so the code above would be a syntax error. This makes the scoping effect of `arguments` much easier to comprehend.
+> You cannot declare a variable called `arguments` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode#making_eval_and_arguments_simpler). This makes the scoping effect of `arguments` much easier to comprehend.
 
 In most cases, using [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
 is a good alternative to using an `arguments` object.

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -262,15 +262,7 @@ function foo(n) {
 }
 
 foo(3); // 3 + 3 = 6
-
-(function () {
-  "use strict";
-  let arguments = [1, 2, 3]; // SyntaxError: Unexpected eval or arguments in strict mode
-})();
 ```
-
-> [!NOTE]
-> You cannot declare a variable called `arguments` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode#making_eval_and_arguments_simpler). This makes the scoping effect of `arguments` much easier to comprehend.
 
 In most cases, using [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
 is a good alternative to using an `arguments` object.

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -266,7 +266,7 @@ foo(3); // 3 + 3 = 6
 (function () {
   'use strict';
   let arguments = [1, 2, 3]; // SyntaxError: Unexpected eval or arguments in strict mode
-})()
+})();
 ```
 
 > [!NOTE]

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -264,7 +264,7 @@ function foo(n) {
 foo(3); // 3 + 3 = 6
 
 (function () {
-  'use strict';
+  "use strict";
   let arguments = [1, 2, 3]; // SyntaxError: Unexpected eval or arguments in strict mode
 })();
 ```


### PR DESCRIPTION
adding an example of defining `arguments` object throws error in strict mode to avoid inconsistency in docs.


### Additional details

An example got removed from earlier commit.

[Earlier commit](https://github.com/mdn/content/pull/18147/commits/b8dcf97f3aabbcc15f1a4dcbcd377083d0cb0fd4#diff-9f9135e74adeaa2acec4259961951bde9e134b4bc81407aa9df03366611389c9L347)


