### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/html/global_attributes/draggable/index.md
+++ b/files/en-us/web/html/global_attributes/draggable/index.md
@@ -18,7 +18,7 @@ For more information about what namespace declarations look like, and what they 
 - `false`: the element cannot be dragged.
 
 > [!WARNING]
-> This attribute is _[enumerated](/en-US/docs/Glossary/Enumerated)_ and not _Boolean_. A value of `true` or `false` is mandatory, and shorthand like `<img draggable>` is forbidden. The correct usage is `<img draggable="false">`.
+> This attribute is _[enumerated](/en-US/docs/Glossary/Enumerated)_ and not _Boolean_. A value of `true` or `false` is mandatory, and shorthand like `<img draggable>` is forbidden. The correct usage is `<img draggable="true">`.
 
 If this attribute is not set, its default value is `auto`, which means drag behavior is the default browser behavior: only text selections, images, and links can be dragged. For other elements, the event {{domxref('HTMLElement.dragstart_event', 'ondragstart')}} must be set for drag and drop to work, as shown in this [comprehensive example](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The example code goes in hand with the description of what's trying to illustrate. 

### Motivation

The pseudo boolean attributes are very confusing, and while the description of the example is very welcome it just happens to illustrate the opposite of what one would do with other attributes

For example: `<div attr/>` is equal to `<div attr=""/>` which is a boolean attribute, so when the description goes to say that `<div draggable/>` is incorrect, it means that the user intention was to set it to true not to false, hence this pr changing the value. 
 
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

https://github.com/solidjs/solid/issues/2440

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
