### PR TITLE
Give consistent titles to interactive examples

### DIFF
--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -12,7 +12,7 @@ The **`constructor`** method is a special method of a [class](/en-US/docs/Web/Ja
 > [!NOTE]
 > This page introduces the `constructor` syntax. For the `constructor` property present on all objects, see {{jsxref("Object.prototype.constructor")}}.
 
-{{InteractiveExample("JavaScript Demo: Classes Constructor")}}
+{{InteractiveExample("JavaScript Demo: Class constructor")}}
 
 ```js interactive-example
 class Polygon {

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.classes.extends
 
 The **`extends`** keyword is used in [class declarations](/en-US/docs/Web/JavaScript/Reference/Statements/class) or [class expressions](/en-US/docs/Web/JavaScript/Reference/Operators/class) to create a class that is a child of another class.
 
-{{InteractiveExample("JavaScript Demo: Classes Extends", "taller")}}
+{{InteractiveExample("JavaScript Demo: Class extends", "taller")}}
 
 ```js interactive-example
 class DateFormatter extends Date {

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -14,7 +14,7 @@ Static methods are often utility functions, such as functions to create or clone
 > [!NOTE]
 > In the context of classes, MDN Web Docs content uses the terms properties and [fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) interchangeably.
 
-{{InteractiveExample("JavaScript Demo: Classes Static", "taller")}}
+{{InteractiveExample("JavaScript Demo: Class static", "taller")}}
 
 ```js interactive-example
 class ClassWithStaticMethod {

--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.classes.static_initialization_blocks
 
 **Static initialization blocks** are declared within a {{jsxref("Statements/class", "class")}}. It contains statements to be evaluated during class initialization. This permits more flexible initialization logic than {{jsxref("Classes/static", "static")}} properties, such as using `try...catch` or setting multiple fields from a single value. Initialization is performed in the context of the current class declaration, with access to private state, which allows the class to share information of its private properties with other classes or functions declared in the same scope (analogous to "friend" classes in C++).
 
-{{InteractiveExample("JavaScript Demo: Class Static Initialization Blocks")}}
+{{InteractiveExample("JavaScript Demo: Class static initialization blocks")}}
 
 ```js interactive-example
 class ClassWithStaticInitializationBlock {

--- a/files/en-us/web/javascript/reference/functions/arguments/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.arguments
 
 **`arguments`** is an array-like object accessible inside [functions](/en-US/docs/Web/JavaScript/Guide/Functions) that contains the values of the arguments passed to that function.
 
-{{InteractiveExample("JavaScript Demo: Functions Arguments")}}
+{{InteractiveExample("JavaScript Demo: The arguments object")}}
 
 ```js interactive-example
 function func1(a, b, c) {

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -13,7 +13,7 @@ An **arrow function expression** is a compact alternative to a traditional [func
 - Arrow functions cannot be used as [constructors](/en-US/docs/Glossary/Constructor). Calling them with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) throws a {{jsxref("TypeError")}}. They also don't have access to the [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) keyword.
 - Arrow functions cannot use [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield) within their body and cannot be created as generator functions.
 
-{{InteractiveExample("JavaScript Demo: Functions =>")}}
+{{InteractiveExample("JavaScript Demo: Arrow function expressions")}}
 
 ```js interactive-example
 const materials = ["Hydrogen", "Helium", "Lithium", "Beryllium"];

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.default_parameters
 
 **Default function parameters** allow named parameters to be initialized with default values if no value or `undefined` is passed.
 
-{{InteractiveExample("JavaScript Demo: Functions Default")}}
+{{InteractiveExample("JavaScript Demo: Default parameters")}}
 
 ```js interactive-example
 function multiply(a, b = 1) {

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.get
 
 The **`get`** syntax binds an object property to a function that will be called when that property is looked up. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 
-{{InteractiveExample("JavaScript Demo: Functions Getter")}}
+{{InteractiveExample("JavaScript Demo: Getter declaration")}}
 
 ```js interactive-example
 const obj = {

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.method_definitions
 
 **Method definition** is a shorter syntax for defining a function property in an object initializer. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 
-{{InteractiveExample("JavaScript Demo: Functions Definitions")}}
+{{InteractiveExample("JavaScript Demo: Method definitions")}}
 
 ```js interactive-example
 const obj = {

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.rest_parameters
 
 The **rest parameter** syntax allows a function to accept an indefinite number of arguments as an array, providing a way to represent [variadic functions](https://en.wikipedia.org/wiki/Variadic_function) in JavaScript.
 
-{{InteractiveExample("JavaScript Demo: Functions Rest Parameters", "taller")}}
+{{InteractiveExample("JavaScript Demo: Rest parameters", "taller")}}
 
 ```js interactive-example
 function sum(...theArgs) {

--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.set
 
 The **`set`** syntax binds an object property to a function to be called when there is an attempt to set that property. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 
-{{InteractiveExample("JavaScript Demo: Functions Setter")}}
+{{InteractiveExample("JavaScript Demo: Setter declaration")}}
 
 ```js interactive-example
 const language = {

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.at
 
 The **`at()`** method of {{jsxref("Array")}} instances takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.
 
-{{InteractiveExample("JavaScript Demo: Array.at()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.at()")}}
 
 ```js interactive-example
 const array1 = [5, 12, 8, 130, 44];

--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.concat
 The **`concat()`** method of {{jsxref("Array")}} instances is used to merge two or more arrays.
 This method does not change the existing arrays, but instead returns a new array.
 
-{{InteractiveExample("JavaScript Demo: Array.concat()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.concat()", "shorter")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.copyWithin
 
 The **`copyWithin()`** method of {{jsxref("Array")}} instances shallow copies part of this array to another location in the same array and returns this array without modifying its length.
 
-{{InteractiveExample("JavaScript Demo: Array.copyWithin()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.copyWithin()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c", "d", "e"];

--- a/files/en-us/web/javascript/reference/global_objects/array/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/entries/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.entries
 
 The **`entries()`** method of {{jsxref("Array")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the key/value pairs for each index in the array.
 
-{{InteractiveExample("JavaScript Demo: Array.entries()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.entries()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -11,7 +11,7 @@ The **`every()`** method of {{jsxref("Array")}} instances tests whether
 all elements in the array pass the test implemented by the provided function. It
 returns a Boolean value.
 
-{{InteractiveExample("JavaScript Demo: Array.every()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.every()", "shorter")}}
 
 ```js interactive-example
 const isBelowThreshold = (currentValue) => currentValue < 40;

--- a/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.fill
 
 The **`fill()`** method of {{jsxref("Array")}} instances changes all elements within a range of indices in an array to a static value. It returns the modified array.
 
-{{InteractiveExample("JavaScript Demo: Array.fill()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.fill()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3, 4];

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.filter
 
 The **`filter()`** method of {{jsxref("Array")}} instances creates a [shallow copy](/en-US/docs/Glossary/Shallow_copy) of a portion of a given array, filtered down to just the elements from the given array that pass the test implemented by the provided function.
 
-{{InteractiveExample("JavaScript Demo: Array.filter()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.filter()", "shorter")}}
 
 ```js interactive-example
 const words = ["spray", "elite", "exuberant", "destruction", "present"];

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -18,7 +18,7 @@ If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 - If you need to find if any element satisfies the provided testing function, use {{jsxref("Array/some", "some()")}}.
 - If you need to find all elements that satisfy the provided testing function, use {{jsxref("Array/filter", "filter()")}}.
 
-{{InteractiveExample("JavaScript Demo: Array.find()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.find()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 8, 130, 44];

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -12,7 +12,7 @@ If no elements satisfy the testing function, -1 is returned.
 
 See also the {{jsxref("Array/find", "find()")}} method, which returns the first element that satisfies the testing function (rather than its index).
 
-{{InteractiveExample("JavaScript Demo: Array.findIndex()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findIndex()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 8, 130, 44];

--- a/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
@@ -20,7 +20,7 @@ If you need to find:
   Again, it checks each element for equality with the value instead of using a testing function.
 - if any element satisfies the provided testing function, use {{jsxref("Array/some", "some()")}}.
 
-{{InteractiveExample("JavaScript Demo: Array.findLast()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findLast()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 50, 130, 44];

--- a/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
@@ -12,7 +12,7 @@ If no elements satisfy the testing function, -1 is returned.
 
 See also the {{jsxref("Array/findLast", "findLast()")}} method, which returns the value of last element that satisfies the testing function (rather than its index).
 
-{{InteractiveExample("JavaScript Demo: Array.findLastIndex()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.findLastIndex()", "shorter")}}
 
 ```js interactive-example
 const array1 = [5, 12, 50, 130, 44];

--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.flat
 The **`flat()`** method of {{jsxref("Array")}} instances creates a new array with all sub-array
 elements concatenated into it recursively up to the specified depth.
 
-{{InteractiveExample("JavaScript Demo: Array.flat()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.flat()")}}
 
 ```js interactive-example
 const arr1 = [0, 1, 2, [3, 4]];

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.flatMap
 
 The **`flatMap()`** method of {{jsxref("Array")}} instances returns a new array formed by applying a given callback function to each element of the array, and then flattening the result by one level. It is identical to a {{jsxref("Array/map", "map()")}} followed by a {{jsxref("Array/flat", "flat()")}} of depth 1 (`arr.map(...args).flat()`), but slightly more efficient than calling those two methods separately.
 
-{{InteractiveExample("JavaScript Demo: Array.flatMap()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.flatMap()", "shorter")}}
 
 ```js interactive-example
 const arr1 = [1, 2, 1];

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.forEach
 The **`forEach()`** method of {{jsxref("Array")}} instances executes a provided function once
 for each array element.
 
-{{InteractiveExample("JavaScript Demo: Array.forEach()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.forEach()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.md
@@ -11,7 +11,7 @@ The **`includes()`** method of {{jsxref("Array")}} instances determines whether 
 includes a certain value among its entries, returning `true` or
 `false` as appropriate.
 
-{{InteractiveExample("JavaScript Demo: Array.includes()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.includes()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.indexOf
 The **`indexOf()`** method of {{jsxref("Array")}} instances returns the first index at which a
 given element can be found in the array, or -1 if it is not present.
 
-{{InteractiveExample("JavaScript Demo: Array.indexOf()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.indexOf()")}}
 
 ```js interactive-example
 const beasts = ["ant", "bison", "camel", "duck", "bison"];

--- a/files/en-us/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/join/index.md
@@ -12,7 +12,7 @@ returns a new string by concatenating all of the elements in this array,
 separated by commas or a specified separator string. If the array has
 only one item, then that item will be returned without using the separator.
 
-{{InteractiveExample("JavaScript Demo: Array.join()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.join()")}}
 
 ```js interactive-example
 const elements = ["Fire", "Air", "Water"];

--- a/files/en-us/web/javascript/reference/global_objects/array/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/keys/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.keys
 
 The **`keys()`** method of {{jsxref("Array")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the keys for each index in the array.
 
-{{InteractiveExample("JavaScript Demo: Array.keys()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.keys()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -11,7 +11,7 @@ The **`lastIndexOf()`** method of {{jsxref("Array")}} instances returns the last
 a given element can be found in the array, or -1 if it is not present. The array is
 searched backwards, starting at `fromIndex`.
 
-{{InteractiveExample("JavaScript Demo: Array.lastIndexOf()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.lastIndexOf()")}}
 
 ```js interactive-example
 const animals = ["Dodo", "Tiger", "Penguin", "Dodo"];

--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.length
 
 The **`length`** data property of an {{jsxref("Array")}} instance represents the number of elements in that array. The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.
 
-{{InteractiveExample("JavaScript Demo: Array.length", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array: length", "shorter")}}
 
 ```js interactive-example
 const clothing = ["shoes", "shirts", "socks", "sweaters"];

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -11,7 +11,7 @@ The **`map()`** method of {{jsxref("Array")}} instances creates
 a new array populated with the results of calling a provided function on
 every element in the calling array.
 
-{{InteractiveExample("JavaScript Demo: Array.map()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.map()")}}
 
 ```js interactive-example
 const array1 = [1, 4, 9, 16];

--- a/files/en-us/web/javascript/reference/global_objects/array/pop/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/pop/index.md
@@ -11,7 +11,7 @@ The **`pop()`** method of {{jsxref("Array")}} instances removes the **last**
 element from an array and returns that element. This method changes the length of the
 array.
 
-{{InteractiveExample("JavaScript Demo: Array.pop()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.pop()")}}
 
 ```js interactive-example
 const plants = ["broccoli", "cauliflower", "cabbage", "kale", "tomato"];

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.push
 The **`push()`** method of {{jsxref("Array")}} instances adds the specified elements to the end of
 an array and returns the new length of the array.
 
-{{InteractiveExample("JavaScript Demo: Array.push()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.push()")}}
 
 ```js interactive-example
 const animals = ["pigs", "goats", "sheep"];

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -11,7 +11,7 @@ The **`reduce()`** method of {{jsxref("Array")}} instances executes a user-suppl
 
 The first time that the callback is run there is no "return value of the previous calculation". If supplied, an initial value may be used in its place. Otherwise the array element at index 0 is used as the initial value and iteration starts from the next element (index 1 instead of index 0).
 
-{{InteractiveExample("JavaScript Demo: Array.reduce()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.reduce()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3, 4];

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -11,7 +11,7 @@ The **`reduceRight()`** method of {{jsxref("Array")}} instances applies a functi
 
 See also {{jsxref("Array.prototype.reduce()")}} for left-to-right.
 
-{{InteractiveExample("JavaScript Demo: Array.reduceRight()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.reduceRight()")}}
 
 ```js interactive-example
 const array1 = [

--- a/files/en-us/web/javascript/reference/global_objects/array/reverse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reverse/index.md
@@ -11,7 +11,7 @@ The **`reverse()`** method of {{jsxref("Array")}} instances reverses an array _[
 
 To reverse the elements in an array without mutating the original array, use {{jsxref("Array/toReversed", "toReversed()")}}.
 
-{{InteractiveExample("JavaScript Demo: Array.reverse()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.reverse()")}}
 
 ```js interactive-example
 const array1 = ["one", "two", "three"];

--- a/files/en-us/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/shift/index.md
@@ -11,7 +11,7 @@ The **`shift()`** method of {{jsxref("Array")}} instances removes the **first**
 element from an array and returns that removed element. This method changes the length
 of the array.
 
-{{InteractiveExample("JavaScript Demo: Array.shift()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.shift()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -12,7 +12,7 @@ an array into a new array object selected from `start` to `end`
 (`end` not included) where `start` and `end` represent
 the index of items in that array. The original array will not be modified.
 
-{{InteractiveExample("JavaScript Demo: Array.slice()", "taller")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.slice()", "taller")}}
 
 ```js interactive-example
 const animals = ["ant", "bison", "camel", "duck", "elephant"];

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -11,7 +11,7 @@ The **`some()`** method of {{jsxref("Array")}} instances tests whether
 at least one element in the array passes the test implemented by the provided
 function. It returns true if, in the array, it finds an element for which the provided function returns true; otherwise it returns false. It doesn't modify the array.
 
-{{InteractiveExample("JavaScript Demo: Array.some()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.some()")}}
 
 ```js interactive-example
 const array = [1, 2, 3, 4, 5];

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -14,7 +14,7 @@ implementation.
 
 To sort the elements in an array without mutating the original array, use {{jsxref("Array/toSorted", "toSorted()")}}.
 
-{{InteractiveExample("JavaScript Demo: Array.sort()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.sort()")}}
 
 ```js interactive-example
 const months = ["March", "Jan", "Feb", "Dec"];

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -12,7 +12,7 @@ removing or replacing existing elements and/or adding new elements [in place](ht
 
 To create a new array with a segment removed and/or replaced without mutating the original array, use {{jsxref("Array/toSpliced", "toSpliced()")}}. To access part of an array without modifying it, see {{jsxref("Array/slice", "slice()")}}.
 
-{{InteractiveExample("JavaScript Demo: Array.splice()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.splice()")}}
 
 ```js interactive-example
 const months = ["Jan", "March", "April", "June"];

--- a/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.md
@@ -12,7 +12,7 @@ the elements of the array. The elements are converted to strings using their
 `toLocaleString` methods and these strings are separated by a locale-specific
 string (such as a comma ",").
 
-{{InteractiveExample("JavaScript Demo: Array.toLocaleString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.toLocaleString()", "shorter")}}
 
 ```js interactive-example
 const array1 = [1, "a", new Date("21 Dec 1997 14:12:00 UTC")];

--- a/files/en-us/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tostring/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.toString
 The **`toString()`** method of {{jsxref("Array")}} instances returns a string representing the
 specified array and its elements.
 
-{{InteractiveExample("JavaScript Demo: Array.toString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.toString()", "shorter")}}
 
 ```js interactive-example
 const array1 = [1, 2, "a", "1a"];

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Array.unshift
 The **`unshift()`** method of {{jsxref("Array")}} instances adds the specified elements to the
 beginning of an array and returns the new length of the array.
 
-{{InteractiveExample("JavaScript Demo: Array.unshift()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.unshift()")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Array.values
 
 The **`values()`** method of {{jsxref("Array")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that iterates the value of each item in the array.
 
-{{InteractiveExample("JavaScript Demo: Array.values()")}}
+{{InteractiveExample("JavaScript Demo: Array.prototype.values()")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.ArrayBuffer.ArrayBuffer
 
 The **`ArrayBuffer()`** constructor creates {{jsxref("ArrayBuffer")}} objects.
 
-{{InteractiveExample("JavaScript Demo: ArrayBuffer Constructor", "shorter")}}
+{{InteractiveExample("JavaScript Demo: ArrayBuffer() constructor", "shorter")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.ArrayBuffer.byteLength
 
 The **`byteLength`** accessor property of {{jsxref("ArrayBuffer")}} instances returns the length (in bytes) of this array buffer.
 
-{{InteractiveExample("JavaScript Demo: ArrayBuffer.byteLength")}}
+{{InteractiveExample("JavaScript Demo: ArrayBuffer.prototype.byteLength")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/maxbytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/maxbytelength/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.ArrayBuffer.maxByteLength
 
 The **`maxByteLength`** accessor property of {{jsxref("ArrayBuffer")}} instances returns the maximum length (in bytes) that this array buffer can be resized to.
 
-{{InteractiveExample("JavaScript Demo: ArrayBuffer.maxByteLength")}}
+{{InteractiveExample("JavaScript Demo: ArrayBuffer.prototype.maxByteLength")}}
 
 ```js interactive-example
 const buffer = new ArrayBuffer(8, { maxByteLength: 16 });

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/resizable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/resizable/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.ArrayBuffer.resizable
 
 The **`resizable`** accessor property of {{jsxref("ArrayBuffer")}} instances returns whether this array buffer can be resized or not.
 
-{{InteractiveExample("JavaScript Demo: ArrayBuffer.resizable")}}
+{{InteractiveExample("JavaScript Demo: ArrayBuffer.prototype.resizable")}}
 
 ```js interactive-example
 const buffer1 = new ArrayBuffer(8, { maxByteLength: 16 });

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/resize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/resize/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.ArrayBuffer.resize
 
 The **`resize()`** method of {{jsxref("ArrayBuffer")}} instances resizes the `ArrayBuffer` to the specified size, in bytes.
 
-{{InteractiveExample("JavaScript Demo: ArrayBuffer.resize()")}}
+{{InteractiveExample("JavaScript Demo: ArrayBuffer.prototype.resize()")}}
 
 ```js interactive-example
 const buffer = new ArrayBuffer(8, { maxByteLength: 16 });

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.ArrayBuffer.slice
 
 The **`slice()`** method of {{jsxref("ArrayBuffer")}} instances returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `start`, inclusive, up to `end`, exclusive. If either `start` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning.
 
-{{InteractiveExample("JavaScript Demo: ArrayBuffer.slice()")}}
+{{InteractiveExample("JavaScript Demo: ArrayBuffer.prototype.slice()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -13,28 +13,6 @@ Async generator methods always yield {{jsxref("Promise")}} objects.
 
 `AsyncGenerator` is a subclass of the hidden {{jsxref("AsyncIterator")}} class.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Async Function Asterisk", "taller")}}
-
-```js interactive-example
-async function* foo() {
-  yield await Promise.resolve("a");
-  yield await Promise.resolve("b");
-  yield await Promise.resolve("c");
-}
-
-let str = "";
-
-async function generate() {
-  for await (const val of foo()) {
-    str = str + val;
-  }
-  console.log(str);
-}
-
-generate();
-// Expected output: "abc"
-```
-
 ## Constructor
 
 There's no JavaScript entity that corresponds to the `AsyncGenerator` constructor. Instances of `AsyncGenerator` must be returned from [async generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/async_function*):

--- a/files/en-us/web/javascript/reference/global_objects/asyncgeneratorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgeneratorfunction/index.md
@@ -17,7 +17,7 @@ const AsyncGeneratorFunction = async function* () {}.constructor;
 
 `AsyncGeneratorFunction` is a subclass of {{jsxref("Function")}}.
 
-{{InteractiveExample("JavaScript Demo: AsyncGeneratorFunction()", "taller")}}
+{{InteractiveExample("JavaScript Demo: AsyncGeneratorFunction", "taller")}}
 
 ```js interactive-example
 const AsyncGeneratorFunction = async function* () {}.constructor;

--- a/files/en-us/web/javascript/reference/global_objects/bigint/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tolocalestring/index.md
@@ -11,7 +11,7 @@ The **`toLocaleString()`** method of {{jsxref("BigInt")}} values returns a strin
 
 Every time `toLocaleString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.NumberFormat")}} object and use its {{jsxref("Intl/NumberFormat/format", "format()")}} method, because a `NumberFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
 
-{{InteractiveExample("JavaScript Demo: BigInt.toLocaleString()")}}
+{{InteractiveExample("JavaScript Demo: BigInt.prototype.toLocaleString()")}}
 
 ```js interactive-example
 const bigint = 123456789123456789n;

--- a/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.BigInt.toString
 
 The **`toString()`** method of {{jsxref("BigInt")}} values returns a string representing the specified {{jsxref("BigInt")}} value. The trailing "n" is not part of the string.
 
-{{InteractiveExample("JavaScript Demo: BigInt.toString()")}}
+{{InteractiveExample("JavaScript Demo: BigInt.prototype.toString()")}}
 
 ```js interactive-example
 console.log(1024n.toString());

--- a/files/en-us/web/javascript/reference/global_objects/bigint/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/valueof/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.BigInt.valueOf
 The **`valueOf()`** method of {{jsxref("BigInt")}} values returns the wrapped primitive value
 of a {{jsxref("BigInt")}} object.
 
-{{InteractiveExample("JavaScript Demo: BigInt.valueOf()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: BigInt.prototype.valueOf()", "shorter")}}
 
 ```js interactive-example
 console.log(typeof Object(1n));

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -11,7 +11,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 
 `BigInt64Array` is a subclass of the hidden {{jsxref("TypedArray")}} class.
 
-{{InteractiveExample("JavaScript Demo: BigInt64Array()", "taller")}}
+{{InteractiveExample("JavaScript Demo: BigInt64Array", "taller")}}
 
 ```js interactive-example
 const buffer = new ArrayBuffer(24);

--- a/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.md
@@ -9,13 +9,20 @@ browser-compat: javascript.builtins.Boolean.Boolean
 
 The **`Boolean()`** constructor creates {{jsxref("Boolean")}} objects. When called as a function, it returns primitive values of type Boolean.
 
-{{InteractiveExample("JavaScript Demo: Boolean Constructor", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Boolean() constructor")}}
 
 ```js interactive-example
 const flag = new Boolean();
-
-console.log(flag);
+console.log(typeof flag);
+// Expected output: object
+console.log(flag === false);
 // Expected output: false
+
+const flag2 = Boolean();
+console.log(typeof flag2);
+// Expected output: boolean
+console.log(flag2 === false);
+// Expected output: true
 ```
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/boolean/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Boolean.toString
 
 The **`toString()`** method of {{jsxref("Boolean")}} values returns a string representing the specified boolean value.
 
-{{InteractiveExample("JavaScript Demo: Boolean.toString()")}}
+{{InteractiveExample("JavaScript Demo: Boolean.prototype.toString()")}}
 
 ```js interactive-example
 const flag1 = new Boolean(true);

--- a/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Boolean.valueOf
 The **`valueOf()`** method of {{jsxref("Boolean")}} values returns the primitive value of a
 {{jsxref("Boolean")}} object.
 
-{{InteractiveExample("JavaScript Demo: Boolean.valueOf()")}}
+{{InteractiveExample("JavaScript Demo: Boolean.prototype.valueOf()")}}
 
 ```js interactive-example
 const x = new Boolean();

--- a/files/en-us/web/javascript/reference/global_objects/dataview/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/buffer/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.buffer
 
 The **`buffer`** accessor property of {{jsxref("DataView")}} instances returns the {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}} referenced by this view at construction time.
 
-{{InteractiveExample("JavaScript Demo: DataView.buffer")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.buffer")}}
 
 ```js interactive-example
 // Create an ArrayBuffer

--- a/files/en-us/web/javascript/reference/global_objects/dataview/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/bytelength/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.byteLength
 
 The **`byteLength`** accessor property of {{jsxref("DataView")}} instances returns the length (in bytes) of this view.
 
-{{InteractiveExample("JavaScript Demo: DataView.byteLength")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.byteLength")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/byteoffset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/byteoffset/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.byteOffset
 
 The **`byteOffset`** accessor property of {{jsxref("DataView")}} instances returns the offset (in bytes) of this view from the start of its {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}.
 
-{{InteractiveExample("JavaScript Demo: DataView.byteOffset")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.byteOffset")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/dataview/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/dataview/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.DataView
 
 The **`DataView()`** constructor creates {{jsxref("DataView")}} objects.
 
-{{InteractiveExample("JavaScript Demo: DataView Constructor")}}
+{{InteractiveExample("JavaScript Demo: DataView() constructor")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getbigint64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getbigint64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getBigInt64
 
 The **`getBigInt64()`** method of {{jsxref("DataView")}} instances reads 8 bytes starting at the specified byte offset of this `DataView` and interprets them as a 64-bit signed integer. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getBigInt64()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getBigInt64()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getBigUint64
 
 The **`getBigUint64()`** method of {{jsxref("DataView")}} instances reads 8 bytes starting at the specified byte offset of this `DataView` and interprets them as a 64-bit unsigned integer. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getBigUint64()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getBigUint64()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getfloat16/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getfloat16/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getFloat16
 
 The **`getFloat16()`** method of {{jsxref("DataView")}} instances reads 2 bytes starting at the specified byte offset of this `DataView` and interprets them as a 16-bit floating point number. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getFloat16()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getFloat16()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getfloat32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getfloat32/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getFloat32
 
 The **`getFloat32()`** method of {{jsxref("DataView")}} instances reads 4 bytes starting at the specified byte offset of this `DataView` and interprets them as a 32-bit floating point number. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getFloat32()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getFloat32()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getfloat64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getfloat64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getFloat64
 
 The **`getFloat64()`** method of {{jsxref("DataView")}} instances reads 8 bytes starting at the specified byte offset of this `DataView` and interprets them as a 64-bit floating point number. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getFloat64()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getFloat64()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getint16/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getint16/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getInt16
 
 The **`getInt16()`** method of {{jsxref("DataView")}} instances reads 2 bytes starting at the specified byte offset of this `DataView` and interprets them as a 16-bit signed integer. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getInt16()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getInt16()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getint32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getint32/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getInt32
 
 The **`getInt32()`** method of {{jsxref("DataView")}} instances reads 4 bytes starting at the specified byte offset of this `DataView` and interprets them as a 32-bit signed integer. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getInt32()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getInt32()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getint8/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getint8/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getInt8
 
 The **`getInt8()`** method of {{jsxref("DataView")}} instances reads 1 byte at the specified byte offset of this `DataView` and interprets it as an 8-bit signed integer.
 
-{{InteractiveExample("JavaScript Demo: DataView.getInt8()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getInt8()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getuint16/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getuint16/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getUint16
 
 The **`getUint16()`** method of {{jsxref("DataView")}} instances reads 2 bytes starting at the specified byte offset of this `DataView` and interprets them as a 16-bit unsigned integer. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getUint16()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getUint16()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getuint32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getuint32/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getUint32
 
 The **`getUint32()`** method of {{jsxref("DataView")}} instances reads 4 bytes starting at the specified byte offset of this `DataView` and interprets them as a 32-bit unsigned integer. There is no alignment constraint; multi-byte values may be fetched from any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.getUint32()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getUint32()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getuint8/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getuint8/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.getUint8
 
 The **`getUint8()`** method of {{jsxref("DataView")}} instances reads 1 byte at the specified byte offset of this `DataView` and interprets it as an 8-bit unsigned integer.
 
-{{InteractiveExample("JavaScript Demo: DataView.getUint8()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.getUint8()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setbigint64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setbigint64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setBigInt64
 
 The **`setBigInt64()`** method of {{jsxref("DataView")}} instances takes a BigInt and stores it as a 64-bit signed integer in the 8 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setBigInt64()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setBigInt64()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setbiguint64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setbiguint64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setBigUint64
 
 The **`setBigUint64()`** method of {{jsxref("DataView")}} instances takes a BigInt and stores it as a 64-bit unsigned integer in the 8 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setBigUint64()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setBigUint64()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setfloat16/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setfloat16/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setFloat16
 
 The **`setFloat16()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 16-bit floating point number in the 2 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setFloat16()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setFloat16()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setfloat32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setfloat32/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setFloat32
 
 The **`setFloat32()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 32-bit floating point number in the 4 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setFloat32()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setFloat32()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setfloat64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setfloat64/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setFloat64
 
 The **`setFloat64()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 64-bit floating point number in the 8 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setFloat64()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setFloat64()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setint16/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setint16/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setInt16
 
 The **`setInt16()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 16-bit signed integer in the 2 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setInt16()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setInt16()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setint32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setint32/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setInt32
 
 The **`setInt32()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 32-bit signed integer in the 4 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setInt32()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setInt32()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setint8/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setint8/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setInt8
 
 The **`setInt8()`** method of {{jsxref("DataView")}} instances takes a number and stores it as an 8-bit signed integer in the byte at the specified byte offset of this `DataView`.
 
-{{InteractiveExample("JavaScript Demo: DataView.setInt8()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setInt8()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setuint16/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setuint16/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setUint16
 
 The **`setUint16()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 16-bit unsigned integer in the 2 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setUint16()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setUint16()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setuint32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setuint32/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setUint32
 
 The **`setUint32()`** method of {{jsxref("DataView")}} instances takes a number and stores it as a 32-bit unsigned integer in the 4 bytes starting at the specified byte offset of this `DataView`. There is no alignment constraint; multi-byte values may be stored at any offset within bounds.
 
-{{InteractiveExample("JavaScript Demo: DataView.setUint32()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setUint32()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setuint8/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setuint8/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.DataView.setUint8
 
 The **`setUint8()`** method of {{jsxref("DataView")}} instances takes a number and stores it as an 8-bit unsigned integer in the byte at the specified byte offset of this `DataView`.
 
-{{InteractiveExample("JavaScript Demo: DataView.setUint8()")}}
+{{InteractiveExample("JavaScript Demo: DataView.prototype.setUint8()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.Date
 
 The **`Date()`** constructor creates {{jsxref("Date")}} objects. When called as a function, it returns a string representing the current time.
 
-{{InteractiveExample("JavaScript Demo: Date Constructor")}}
+{{InteractiveExample("JavaScript Demo: Date() constructor")}}
 
 ```js interactive-example
 const date1 = new Date("December 17, 1995 03:24:00");
@@ -18,11 +18,8 @@ const date1 = new Date("December 17, 1995 03:24:00");
 const date2 = new Date("1995-12-17T03:24:00");
 // Sun Dec 17 1995 03:24:00 GMT...
 
-console.log(date1 === date2);
-// Expected output: false
-
-console.log(date1 - date2);
-// Expected output: 0
+console.log(date1.getTime() === date2.getTime());
+// Expected output: true
 ```
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/date/getdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getdate/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getDate
 
 The **`getDate()`** method of {{jsxref("Date")}} instances returns the day of the month for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.getDate()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getDate()", "shorter")}}
 
 ```js interactive-example
 const birthday = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/getday/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getday/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getDay
 
 The **`getDay()`** method of {{jsxref("Date")}} instances returns the day of the week for this date according to local time, where 0 represents Sunday. For the day of the month, see {{jsxref("Date.prototype.getDate()")}}.
 
-{{InteractiveExample("JavaScript Demo: Date.getDay()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getDay()", "shorter")}}
 
 ```js interactive-example
 const birthday = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/getfullyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getfullyear/index.md
@@ -11,7 +11,7 @@ The **`getFullYear()`** method of {{jsxref("Date")}} instances returns the year 
 
 Use this method instead of the {{jsxref("Date/getYear", "getYear()")}} method.
 
-{{InteractiveExample("JavaScript Demo: Date.getFullYear()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getFullYear()", "shorter")}}
 
 ```js interactive-example
 const moonLanding = new Date("July 20, 69 00:20:18");

--- a/files/en-us/web/javascript/reference/global_objects/date/gethours/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/gethours/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getHours
 
 The **`getHours()`** method of {{jsxref("Date")}} instances returns the hours for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.getHours()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getHours()", "shorter")}}
 
 ```js interactive-example
 const birthday = new Date("March 13, 08 04:20");

--- a/files/en-us/web/javascript/reference/global_objects/date/getmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getmilliseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getMilliseconds
 
 The **`getMilliseconds()`** method of {{jsxref("Date")}} instances returns the milliseconds for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.getMilliseconds()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getMilliseconds()", "shorter")}}
 
 ```js interactive-example
 const moonLanding = new Date("July 20, 69 00:20:18");

--- a/files/en-us/web/javascript/reference/global_objects/date/getminutes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getminutes/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getMinutes
 
 The **`getMinutes()`** method of {{jsxref("Date")}} instances returns the minutes for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.getMinutes()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getMinutes()", "shorter")}}
 
 ```js interactive-example
 const birthday = new Date("March 13, 08 04:20");

--- a/files/en-us/web/javascript/reference/global_objects/date/getmonth/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getmonth/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getMonth
 
 The **`getMonth()`** method of {{jsxref("Date")}} instances returns the month for this date according to local time, as a zero-based value (where zero indicates the first month of the year).
 
-{{InteractiveExample("JavaScript Demo: Date.getMonth()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getMonth()", "shorter")}}
 
 ```js interactive-example
 const moonLanding = new Date("July 20, 69 00:20:18");

--- a/files/en-us/web/javascript/reference/global_objects/date/getseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getSeconds
 
 The **`getSeconds()`** method of {{jsxref("Date")}} instances returns the seconds for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.getSeconds()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getSeconds()", "shorter")}}
 
 ```js interactive-example
 const moonLanding = new Date("July 20, 69 00:20:18");

--- a/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getTime
 
 The **`getTime()`** method of {{jsxref("Date")}} instances returns the number of milliseconds for this date since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date), which is defined as the midnight at the beginning of January 1, 1970, UTC.
 
-{{InteractiveExample("JavaScript Demo: Date.getTime()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getTime()", "shorter")}}
 
 ```js interactive-example
 const moonLanding = new Date("July 20, 69 20:17:40 GMT+00:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/gettimezoneoffset/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettimezoneoffset/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getTimezoneOffset
 
 The **`getTimezoneOffset()`** method of {{jsxref("Date")}} instances returns the difference, in minutes, between this date as evaluated in the UTC time zone, and the same date as evaluated in the local time zone.
 
-{{InteractiveExample("JavaScript Demo: Date.getTimezoneOffset()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getTimezoneOffset()")}}
 
 ```js interactive-example
 const date1 = new Date("August 19, 1975 23:15:30 GMT+07:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCDate
 
 The **`getUTCDate()`** method of {{jsxref("Date")}} instances returns the day of the month for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCDate()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCDate()")}}
 
 ```js interactive-example
 const date1 = new Date("August 19, 1975 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCDay
 
 The **`getUTCDay()`** method of {{jsxref("Date")}} instances returns the day of the week for this date according to universal time, where 0 represents Sunday.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCDay()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCDay()")}}
 
 ```js interactive-example
 const date1 = new Date("August 19, 1975 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCFullYear
 
 The **`getUTCFullYear()`** method of {{jsxref("Date")}} instances returns the year for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCFullYear()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCFullYear()")}}
 
 ```js interactive-example
 const date1 = new Date("December 31, 1975, 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCHours
 
 The **`getUTCHours()`** method of {{jsxref("Date")}} instances returns the hours for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCHours()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCHours()")}}
 
 ```js interactive-example
 const date1 = new Date("December 31, 1975, 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCMilliseconds
 
 The **`getUTCMilliseconds()`** method of {{jsxref("Date")}} instances returns the milliseconds for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCMilliseconds()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCMilliseconds()", "shorter")}}
 
 ```js interactive-example
 const exampleDate = new Date("2018-01-02T03:04:05.678Z"); // 2 January 2018, 03:04:05.678 (UTC)

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCMinutes
 
 The **`getUTCMinutes()`** method of {{jsxref("Date")}} instances returns the minutes for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCMinutes()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCMinutes()")}}
 
 ```js interactive-example
 const date1 = new Date("1 January 2000 03:15:30 GMT+07:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCMonth
 
 The **`getUTCMonth()`** method of {{jsxref("Date")}} instances returns the month for this date according to universal time, as a zero-based value (where zero indicates the first month of the year).
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCMonth()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCMonth()")}}
 
 ```js interactive-example
 const date1 = new Date("December 31, 1975, 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.getUTCSeconds
 
 The **`getUTCSeconds()`** method of {{jsxref("Date")}} instances returns the seconds in the specified date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.getUTCSeconds()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.getUTCSeconds()", "shorter")}}
 
 ```js interactive-example
 const moonLanding = new Date("July 20, 1969, 20:18:04 UTC");

--- a/files/en-us/web/javascript/reference/global_objects/date/setdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setdate/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setDate
 
 The **`setDate()`** method of {{jsxref("Date")}} instances changes the day of the month for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setDate()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setDate()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/setfullyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setfullyear/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setFullYear
 
 The **`setFullYear()`** method of {{jsxref("Date")}} instances changes the year, month, and/or day of month for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setFullYear()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setFullYear()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/sethours/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/sethours/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setHours
 
 The **`setHours()`** method of {{jsxref("Date")}} instances changes the hours, minutes, seconds, and/or milliseconds for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setHours()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setHours()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/setmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setmilliseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setMilliseconds
 
 The **`setMilliseconds()`** method of {{jsxref("Date")}} instances changes the milliseconds for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setMilliseconds()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setMilliseconds()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/setminutes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setminutes/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setMinutes
 
 The **`setMinutes()`** method of {{jsxref("Date")}} instances changes the minutes for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setMinutes()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setMinutes()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setMonth
 
 The **`setMonth()`** method of {{jsxref("Date")}} instances changes the month and/or day of the month for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setMonth()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setMonth()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/setseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setSeconds
 
 The **`setSeconds()`** method of {{jsxref("Date")}} instances changes the seconds and/or milliseconds for this date according to local time.
 
-{{InteractiveExample("JavaScript Demo: Date.setSeconds()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setSeconds()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/settime/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setTime
 
 The **`setTime()`** method of {{jsxref("Date")}} instances changes the [timestamp](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date) for this date, which is the number of milliseconds since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date), defined as the midnight at the beginning of January 1, 1970, UTC.
 
-{{InteractiveExample("JavaScript Demo: Date.setTime()", "taller")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setTime()", "taller")}}
 
 ```js interactive-example
 const launchDate = new Date("July 1, 1999, 12:00:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcdate/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCDate
 
 The **`setUTCDate()`** method of {{jsxref("Date")}} instances changes the day of the month for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCDate()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCDate()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30 GMT-3:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcfullyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcfullyear/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCFullYear
 
 The **`setUTCFullYear()`** method of {{jsxref("Date")}} instances changes the year for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCFullYear()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCFullYear()")}}
 
 ```js interactive-example
 const event = new Date("December 31, 1975 23:15:30 GMT-3:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutchours/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutchours/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCHours
 
 The **`setUTCHours()`** method of {{jsxref("Date")}} instances changes the hours, minutes, seconds, and/or milliseconds for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCHours()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCHours()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30 GMT-3:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcmilliseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCMilliseconds
 
 The **`setUTCMilliseconds()`** method of {{jsxref("Date")}} instances changes the milliseconds for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCMilliseconds()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCMilliseconds()")}}
 
 ```js interactive-example
 const date1 = new Date("2018-01-24T12:38:29.069Z");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcminutes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcminutes/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCMinutes
 
 The **`setUTCMinutes()`** method of {{jsxref("Date")}} instances changes the minutes for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCMinutes()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCMinutes()")}}
 
 ```js interactive-example
 const date1 = new Date("December 31, 1975, 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcmonth/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcmonth/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCMonth
 
 The **`setUTCMonth()`** method of {{jsxref("Date")}} instances changes the month and/or day of the month for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCMonth()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCMonth()")}}
 
 ```js interactive-example
 const event = new Date("December 31, 1975 23:15:30 GMT-3:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcseconds/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.setUTCSeconds
 
 The **`setUTCSeconds()`** method of {{jsxref("Date")}} instances changes the seconds and/or milliseconds for this date according to universal time.
 
-{{InteractiveExample("JavaScript Demo: Date.setUTCSeconds()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.setUTCSeconds()")}}
 
 ```js interactive-example
 const date1 = new Date("December 31, 1975, 23:15:30 GMT+11:00");

--- a/files/en-us/web/javascript/reference/global_objects/date/todatestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/todatestring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toDateString
 
 The **`toDateString()`** method of {{jsxref("Date")}} instances returns a string representing the date portion of this date interpreted in the local timezone.
 
-{{InteractiveExample("JavaScript Demo: Date.toDateString()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toDateString()")}}
 
 ```js interactive-example
 const event = new Date(1993, 6, 28, 14, 39, 7);

--- a/files/en-us/web/javascript/reference/global_objects/date/toisostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/toisostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toISOString
 
 The **`toISOString()`** method of {{jsxref("Date")}} instances returns a string representing this date in the [date time string format](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format), a _simplified_ format based on [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), which is always 24 or 27 characters long (`YYYY-MM-DDTHH:mm:ss.sssZ` or `±YYYYYY-MM-DDTHH:mm:ss.sssZ`, respectively). The timezone is always UTC, as denoted by the suffix `Z`.
 
-{{InteractiveExample("JavaScript Demo: Date.toISOString()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toISOString()")}}
 
 ```js interactive-example
 const event = new Date("05 October 2011 14:48 UTC");

--- a/files/en-us/web/javascript/reference/global_objects/date/tojson/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tojson/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toJSON
 
 The **`toJSON()`** method of {{jsxref("Date")}} instances returns a string representing this date in the same ISO format as {{jsxref("Date/toISOString", "toISOString()")}}.
 
-{{InteractiveExample("JavaScript Demo: Date.toJSON()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toJSON()")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30 UTC");

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -11,7 +11,7 @@ The **`toLocaleDateString()`** method of {{jsxref("Date")}} instances returns a 
 
 Every time `toLocaleString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.DateTimeFormat")}} object and use its {{jsxref("Intl/DateTimeFormat/format", "format()")}} method, because a `DateTimeFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
 
-{{InteractiveExample("JavaScript Demo: Date.toLocaleDateString()", "taller")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toLocaleDateString()", "taller")}}
 
 ```js interactive-example
 const event = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -11,7 +11,7 @@ The **`toLocaleString()`** method of {{jsxref("Date")}} instances returns a stri
 
 Every time `toLocaleString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.DateTimeFormat")}} object and use its {{jsxref("Intl/DateTimeFormat/format", "format()")}} method, because a `DateTimeFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
 
-{{InteractiveExample("JavaScript Demo: Date.toLocaleString()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toLocaleString()")}}
 
 ```js interactive-example
 const event = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -11,7 +11,7 @@ The **`toLocaleTimeString()`** method of {{jsxref("Date")}} instances returns a 
 
 Every time `toLocaleTimeString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.DateTimeFormat")}} object and use its {{jsxref("Intl/DateTimeFormat/format", "format()")}} method, because a `DateTimeFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
 
-{{InteractiveExample("JavaScript Demo: Date.toLocaleTimeString()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toLocaleTimeString()")}}
 
 ```js interactive-example
 // Depending on timezone, your results will vary

--- a/files/en-us/web/javascript/reference/global_objects/date/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toString
 
 The **`toString()`** method of {{jsxref("Date")}} instances returns a string representing this date interpreted in the local timezone.
 
-{{InteractiveExample("JavaScript Demo: Date.toString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toString()", "shorter")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/totimestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/totimestring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toTimeString
 
 The **`toTimeString()`** method of {{jsxref("Date")}} instances returns a string representing the time portion of this date interpreted in the local timezone.
 
-{{InteractiveExample("JavaScript Demo: Date.toTimeString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toTimeString()", "shorter")}}
 
 ```js interactive-example
 const event = new Date("August 19, 1975 23:15:30");

--- a/files/en-us/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toUTCString
 
 The **`toUTCString()`** method of {{jsxref("Date")}} instances returns a string representing this date in the [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1) format, with negative years allowed. The timezone is always UTC. `toGMTString()` is an alias of this method.
 
-{{InteractiveExample("JavaScript Demo: Date.toUTCString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.toUTCString()", "shorter")}}
 
 ```js interactive-example
 const event = new Date("14 Jun 2017 00:00:00 PDT");

--- a/files/en-us/web/javascript/reference/global_objects/date/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/valueof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.valueOf
 
 The **`valueOf()`** method of {{jsxref("Date")}} instances returns the number of milliseconds for this date since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date), which is defined as the midnight at the beginning of January 1, 1970, UTC.
 
-{{InteractiveExample("JavaScript Demo: Date.valueOf()")}}
+{{InteractiveExample("JavaScript Demo: Date.prototype.valueOf()")}}
 
 ```js interactive-example
 const date1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));

--- a/files/en-us/web/javascript/reference/global_objects/decodeuri/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/decodeuri/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.decodeURI
 
 The **`decodeURI()`** function decodes a Uniform Resource Identifier (URI) previously created by {{jsxref("encodeURI()")}} or a similar routine.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - decodeURI()")}}
+{{InteractiveExample("JavaScript Demo: decodeURI()")}}
 
 ```js interactive-example
 const uri = "https://mozilla.org/?x=шеллы";

--- a/files/en-us/web/javascript/reference/global_objects/decodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/decodeuricomponent/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.decodeURIComponent
 
 The **`decodeURIComponent()`** function decodes a Uniform Resource Identifier (URI) component previously created by {{jsxref("encodeURIComponent()")}} or by a similar routine.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - decodeURIComponent()")}}
+{{InteractiveExample("JavaScript Demo: decodeURIComponent()")}}
 
 ```js interactive-example
 function containsEncodedComponents(x) {

--- a/files/en-us/web/javascript/reference/global_objects/encodeuri/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuri/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.encodeURI
 
 The **`encodeURI()`** function encodes a {{Glossary("URI")}} by replacing each instance of certain characters by one, two, three, or four escape sequences representing the {{Glossary("UTF-8")}} encoding of the character (will only be four escape sequences for characters composed of two surrogate characters). Compared to {{jsxref("encodeURIComponent()")}}, this function encodes fewer characters, preserving those that are part of the URI syntax.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - encodeURI()")}}
+{{InteractiveExample("JavaScript Demo: encodeURI()")}}
 
 ```js interactive-example
 const uri = "https://mozilla.org/?x=шеллы";

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.encodeURIComponent
 
 The **`encodeURIComponent()`** function encodes a {{Glossary("URI")}} by replacing each instance of certain characters by one, two, three, or four escape sequences representing the {{Glossary("UTF-8")}} encoding of the character (will only be four escape sequences for characters composed of two surrogate characters). Compared to {{jsxref("encodeURI()")}}, this function encodes more characters, including those that are part of the URI syntax.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - encodeURIComponent()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: encodeURIComponent()", "shorter")}}
 
 ```js interactive-example
 // Encodes characters such as ?,=,/,&,:

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.eval
 
 The **`eval()`** function evaluates JavaScript code represented as a string and returns its completion value. The source is parsed as a script.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - eval()")}}
+{{InteractiveExample("JavaScript Demo: eval()")}}
 
 ```js interactive-example
 console.log(eval("2 + 2"));

--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.apply
 
 The **`apply()`** method of {{jsxref("Function")}} instances calls this function with a given `this` value, and `arguments` provided as an array (or an [array-like object](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects)).
 
-{{InteractiveExample("JavaScript Demo: Function.apply()")}}
+{{InteractiveExample("JavaScript Demo: Function.prototype.apply()")}}
 
 ```js interactive-example
 const numbers = [5, 6, 2, 3, 7];

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.bind
 
 The **`bind()`** method of {{jsxref("Function")}} instances creates a new function that, when called, calls this function with its `this` keyword set to the provided value, and a given sequence of arguments preceding any provided when the new function is called.
 
-{{InteractiveExample("JavaScript Demo: Function.bind()", "taller")}}
+{{InteractiveExample("JavaScript Demo: Function.prototype.bind()", "taller")}}
 
 ```js interactive-example
 const module = {

--- a/files/en-us/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/call/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.call
 
 The **`call()`** method of {{jsxref("Function")}} instances calls this function with a given `this` value and arguments provided individually.
 
-{{InteractiveExample("JavaScript Demo: Function.call()")}}
+{{InteractiveExample("JavaScript Demo: Function.prototype.call()")}}
 
 ```js interactive-example
 function Product(name, price) {

--- a/files/en-us/web/javascript/reference/global_objects/function/function/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/function/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.Function
 
 The **`Function()`** constructor creates {{jsxref("Function")}} objects. Calling the constructor directly can create functions dynamically, but suffers from security and similar (but far less significant) performance issues as {{jsxref("Global_Objects/eval", "eval()")}}. However, unlike `eval` (which may have access to the local scope), the `Function` constructor creates functions which execute in the global scope only.
 
-{{InteractiveExample("JavaScript Demo: Function()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Function() constructor", "shorter")}}
 
 ```js interactive-example
 const sum = new Function("a", "b", "return a + b");

--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.length
 
 The **`length`** data property of a {{jsxref("Function")}} instance indicates the number of parameters expected by the function.
 
-{{InteractiveExample("JavaScript Demo: Function.length")}}
+{{InteractiveExample("JavaScript Demo: Function: length")}}
 
 ```js interactive-example
 function func1() {}

--- a/files/en-us/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/name/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.name
 
 The **`name`** data property of a {{jsxref("Function")}} instance indicates the function's name as specified when it was created, or it may be either `anonymous` or `''` (an empty string) for functions created anonymously.
 
-{{InteractiveExample("JavaScript Demo: Function.name")}}
+{{InteractiveExample("JavaScript Demo: Function: name")}}
 
 ```js interactive-example
 const func1 = function () {};

--- a/files/en-us/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Function.toString
 
 The **`toString()`** method of {{jsxref("Function")}} instances returns a string representing the source code of this function.
 
-{{InteractiveExample("JavaScript Demo: Function.toString()")}}
+{{InteractiveExample("JavaScript Demo: Function.prototype.toString()")}}
 
 ```js interactive-example
 function sum(a, b) {

--- a/files/en-us/web/javascript/reference/global_objects/generator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.md
@@ -11,24 +11,6 @@ The **`Generator`** object is returned by a {{jsxref("Statements/function*", "ge
 
 `Generator` is a subclass of the hidden {{jsxref("Iterator")}} class.
 
-{{InteractiveExample("JavaScript Demo: Expressions - function* expression", "taller")}}
-
-```js interactive-example
-const foo = function* () {
-  yield "a";
-  yield "b";
-  yield "c";
-};
-
-let str = "";
-for (const val of foo()) {
-  str = str + val;
-}
-
-console.log(str);
-// Expected output: "abc"
-```
-
 ## Constructor
 
 There's no JavaScript entity that corresponds to the `Generator` constructor. Instances of `Generator` must be returned from [generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*):

--- a/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
@@ -17,7 +17,7 @@ const GeneratorFunction = function* () {}.constructor;
 
 `GeneratorFunction` is a subclass of {{jsxref("Function")}}.
 
-{{InteractiveExample("JavaScript Demo: GeneratorFunction()", "taller")}}
+{{InteractiveExample("JavaScript Demo: GeneratorFunction", "taller")}}
 
 ```js interactive-example
 const GeneratorFunction = function* () {}.constructor;

--- a/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.globalThis
 
 The **`globalThis`** global property contains the [global `this`](/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context) value, which is usually akin to the [global object](/en-US/docs/Glossary/Global_object).
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - globalThis", "shorter")}}
+{{InteractiveExample("JavaScript Demo: globalThis", "shorter")}}
 
 ```js interactive-example
 function canMakeHTTPRequest() {

--- a/files/en-us/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/infinity/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Infinity
 
 The **`Infinity`** global property is a numeric value representing infinity.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - infinity")}}
+{{InteractiveExample("JavaScript Demo: Infinity")}}
 
 ```js interactive-example
 const maxNumber = Math.pow(10, 1000); // Max positive number

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Collator.Collator
 
 The **`Intl.Collator()`** constructor creates {{jsxref("Intl.Collator")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.Collator")}}
+{{InteractiveExample("JavaScript Demo: Intl.Collator() constructor")}}
 
 ```js interactive-example
 console.log(["Z", "a", "z", "ä"].sort(new Intl.Collator("de").compare));

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Intl.Collator.compare
 The **`compare()`** method of {{jsxref("Intl.Collator")}} instances compares two
 strings according to the sort order of this collator object.
 
-{{InteractiveExample("JavaScript Demo: Intl.Collator.prototype.compare")}}
+{{InteractiveExample("JavaScript Demo: Intl.Collator.prototype.compare()")}}
 
 ```js interactive-example
 const enCollator = new Intl.Collator("en");

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Collator.resolvedOptions
 
 The **`resolvedOptions()`** method of {{jsxref("Intl.Collator")}} instances returns a new object with properties reflecting the options computed during initialization of this `Collator` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.Collator.prototype.resolvedOptions")}}
+{{InteractiveExample("JavaScript Demo: Intl.Collator.prototype.resolvedOptions()")}}
 
 ```js interactive-example
 const numberDe = new Intl.NumberFormat("de-DE");

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Collator.supportedLocalesOf
 
 The **`Intl.Collator.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in collation without having to fall back to the runtime's default locale.
 
-{{InteractiveExample("JavaScript Demo: Intl.Collator.supportedLocalesOf", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Intl.Collator.supportedLocalesOf()", "shorter")}}
 
 ```js interactive-example
 const locales1 = ["ban", "id-u-co-pinyin", "de-ID"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.DateTimeFormat
 
 The **`Intl.DateTimeFormat()`** constructor creates {{jsxref("Intl.DateTimeFormat")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat() constructor", "taller")}}
 
 ```js interactive-example
 const date = new Date(Date.UTC(2020, 11, 20, 3, 23, 16, 738));

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.format
 
 The **`format()`** method of {{jsxref("Intl.DateTimeFormat")}} instances formats a date according to the locale and formatting options of this `Intl.DateTimeFormat` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.prototype.format", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.prototype.format()", "taller")}}
 
 ```js interactive-example
 const options1 = {

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.resolvedOptions
 
 The **`resolvedOptions()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns a new object with properties reflecting the options computed during initialization of this `DateTimeFormat` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.prototype.resolvedOptions")}}
+{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.prototype.resolvedOptions()")}}
 
 ```js interactive-example
 const region1 = new Intl.DateTimeFormat("zh-CN", { timeZone: "UTC" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.supportedLocalesOf
 
 The **`Intl.DateTimeFormat.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in date and time formatting without having to fall back to the runtime's default locale.
 
-{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.supportedLocalesOf", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.supportedLocalesOf()", "shorter")}}
 
 ```js interactive-example
 const locales1 = ["ban", "id-u-co-pinyin", "de-ID"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DisplayNames.DisplayNames
 
 The **`Intl.DisplayNames()`** constructor creates {{jsxref("Intl.DisplayNames")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.DisplayNames")}}
+{{InteractiveExample("JavaScript Demo: Intl.DisplayNames() constructor")}}
 
 ```js interactive-example
 const regionNamesInEnglish = new Intl.DisplayNames(["en"], { type: "region" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DisplayNames.of
 
 The **`of()`** method of {{jsxref("Intl.DisplayNames")}} instances receives a code and returns a string based on the locale and options provided when instantiating this `Intl.DisplayNames` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.DisplayNames")}}
+{{InteractiveExample("JavaScript Demo: Intl.DisplayNames.prototype.of()")}}
 
 ```js interactive-example
 const regionNamesInEnglish = new Intl.DisplayNames(["en"], { type: "region" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -11,7 +11,7 @@ The **`Intl.getCanonicalLocales()`** static method returns an array
 containing the canonical locale names. Duplicates will be omitted and elements will be
 validated as structurally valid language tags.
 
-{{InteractiveExample("JavaScript Demo: Intl.GetCanonicalLocales")}}
+{{InteractiveExample("JavaScript Demo: Intl.getCanonicalLocales()")}}
 
 ```js interactive-example
 console.log(Intl.getCanonicalLocales("EN-US"));

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.format
 The **`format()`** method of {{jsxref("Intl.ListFormat")}} instances returns a string with a
 language-specific representation of the list.
 
-{{InteractiveExample("JavaScript Demo: Intl.ListFormat", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.ListFormat.prototype.format()", "taller")}}
 
 ```js interactive-example
 const vehicles = ["Motorcycle", "Bus", "Car"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.ListFormat.ListFormat
 
 The **`Intl.ListFormat()`** constructor creates {{jsxref("Intl.ListFormat")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.ListFormat", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.ListFormat() constructor", "taller")}}
 
 ```js interactive-example
 const vehicles = ["Motorcycle", "Bus", "Car"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Locale.Locale
 
 The **`Intl.Locale()`** constructor creates {{jsxref("Intl.Locale")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.Locale")}}
+{{InteractiveExample("JavaScript Demo: Intl.Locale() constructor")}}
 
 ```js interactive-example
 const korean = new Intl.Locale("ko", {

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.format
 
 The **`format()`** method of {{jsxref("Intl.NumberFormat")}} instances formats a number according to the [locale and formatting options](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters) of this `Intl.NumberFormat` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.prototype.format", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.prototype.format()", "taller")}}
 
 ```js interactive-example
 const amount = 654321.987;

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.formatToParts
 
 The **`formatToParts()`** method of {{jsxref("Intl.NumberFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/NumberFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
-{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.prototype.formatToParts")}}
+{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.prototype.formatToParts()")}}
 
 ```js interactive-example
 const amount = 654321.987;

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.NumberFormat
 
 The **`Intl.NumberFormat()`** constructor creates {{jsxref("Intl.NumberFormat")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.NumberFormat", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.NumberFormat() constructor", "taller")}}
 
 ```js interactive-example
 const number = 123456.789;

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.resolvedOptions
 
 The **`resolvedOptions()`** method of {{jsxref("Intl.NumberFormat")}} instances returns a new object with properties reflecting the options computed during initialization of this `NumberFormat` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.prototype.resolvedOptions")}}
+{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.prototype.resolvedOptions()")}}
 
 ```js interactive-example
 const numberFormat1 = new Intl.NumberFormat("de-DE");

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.supportedLocalesOf
 
 The **`Intl.NumberFormat.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in number formatting without having to fall back to the runtime's default locale.
 
-{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.supportedLocalesOf", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Intl.NumberFormat.supportedLocalesOf()", "shorter")}}
 
 ```js interactive-example
 const locales1 = ["ban", "id-u-co-pinyin", "de-ID"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.PluralRules.supportedLocalesOf
 
 The **`Intl.PluralRules.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in plural rules without having to fall back to the runtime's default locale.
 
-{{InteractiveExample("JavaScript Demo: Intl.PluralRules.supportedLocalesOf", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Intl.PluralRules.supportedLocalesOf()", "shorter")}}
 
 ```js interactive-example
 const locales = ["en-US", "ban", "ar-OM", "de-DE"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.format
 
 The **`format()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances formats a `value` and `unit` according to the locale and formatting options of this `Intl.RelativeTimeFormat` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.format")}}
+{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.format()")}}
 
 ```js interactive-example
 const rtf1 = new Intl.RelativeTimeFormat("en", { style: "short" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.formatToParts
 
 The **`formatToParts()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/RelativeTimeFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
-{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.formatToParts")}}
+{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.formatToParts()")}}
 
 ```js interactive-example
 const rtf1 = new Intl.RelativeTimeFormat("en", { numeric: "auto" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions
 
 The **`resolvedOptions()`** method of {{jsxref("Intl.RelativeTimeFormat")}} instances returns a new object with properties reflecting the options computed during initialization of this `RelativeTimeFormat` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.resolvedOptions")}}
+{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.prototype.resolvedOptions()")}}
 
 ```js interactive-example
 const rtf1 = new Intl.RelativeTimeFormat("en", { style: "narrow" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.RelativeTimeFormat.supportedLocalesOf
 
 The **`Intl.RelativeTimeFormat.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in relative time formatting without having to fall back to the runtime's default locale.
 
-{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.supportedLocalesOf", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Intl.RelativeTimeFormat.supportedLocalesOf()", "shorter")}}
 
 ```js interactive-example
 const locales1 = ["ban", "id-u-co-pinyin", "de-ID"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/resolvedoptions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.resolvedOptions
 
 The **`resolvedOptions()`** method of {{jsxref("Intl.Segmenter")}} instances returns a new object with properties reflecting the options computed during initialization of this `Segmenter` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.Segmenter.prototype.resolvedOptions")}}
+{{InteractiveExample("JavaScript Demo: Intl.Segmenter.prototype.resolvedOptions()")}}
 
 ```js interactive-example
 const segmenter1 = new Intl.Segmenter("fr-FR");

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.segment
 
 The **`segment()`** method of {{jsxref("Intl.Segmenter")}} instances segments a string according to the locale and granularity of this `Intl.Segmenter` object.
 
-{{InteractiveExample("JavaScript Demo: Intl.Segmenter.prototype.segment")}}
+{{InteractiveExample("JavaScript Demo: Intl.Segmenter.prototype.segment()")}}
 
 ```js interactive-example
 const string1 = "Que ma joie demeure";

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/containing/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Segments.containing
 
 The **`containing()`** method of [`Segments`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) instances returns an object describing the segment in the string that includes the code unit at the specified index.
 
-{{InteractiveExample("JavaScript Demo: Segments.prototype.containing")}}
+{{InteractiveExample("JavaScript Demo: Segments.prototype.containing()")}}
 
 ```js interactive-example
 const segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segment/segments/index.md
@@ -9,19 +9,6 @@ browser-compat: javascript.builtins.Intl.Segments
 
 A **`Segments`** object is an iterable collection of the segments of a text string. It is returned by a call to the [`segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method of an [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object.
 
-{{InteractiveExample("JavaScript Demo: Segments.prototype.containing")}}
-
-```js interactive-example
-const segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });
-const string1 = "Que ma joie demeure";
-
-const segments = segmenterFr.segment(string1);
-
-console.log(segments.containing(5));
-// Expected output:
-// Object {segment: 'ma', index: 4, input: 'Que ma joie demeure', isWordLike: true}
-```
-
 ## Instance methods
 
 - [`Segments.prototype.containing()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/containing)

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segmenter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segmenter/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.Segmenter
 
 The **`Intl.Segmenter()`** constructor creates {{jsxref("Intl.Segmenter")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Intl.Segmenter")}}
+{{InteractiveExample("JavaScript Demo: Intl.Segmenter() constructor")}}
 
 ```js interactive-example
 const segmenterFr = new Intl.Segmenter("fr", { granularity: "word" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/supportedlocalesof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.supportedLocalesOf
 
 The **`Intl.Segmenter.supportedLocalesOf()`** static method returns an array containing those of the provided locales that are supported in segmentation without having to fall back to the runtime's default locale.
 
-{{InteractiveExample("JavaScript Demo: Intl.Segmenter.supportedLocalesOf", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Intl.Segmenter.supportedLocalesOf()", "shorter")}}
 
 ```js interactive-example
 const locales1 = ["ban", "id-u-co-pinyin", "de-ID"];

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -16,7 +16,7 @@ It can also be used to build UIs that allow users to select their preferred loca
 
 This method is locale-unaware: it is possible that certain identifiers are only supported or preferred in certain locales. If you want to determine the preferred values for a specific locale, you should use the {{jsxref("Intl.Locale")}} object, such as {{jsxref("Intl/Locale/getCalendars", "Intl.Locale.prototype.getCalendars()")}}.
 
-{{InteractiveExample("JavaScript Demo: Intl.supportedValuesOf", "taller")}}
+{{InteractiveExample("JavaScript Demo: Intl.supportedValuesOf()", "taller")}}
 
 ```js interactive-example
 console.log(Intl.supportedValuesOf("calendar"));

--- a/files/en-us/web/javascript/reference/global_objects/isfinite/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/isfinite/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.isFinite
 
 The **`isFinite()`** function determines whether a value is finite, first converting the value to a number if necessary. A finite number is one that's not {{jsxref("NaN")}} or ±{{jsxref("Infinity")}}. Because coercion inside the `isFinite()` function can be [surprising](/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description), you may prefer to use {{jsxref("Number.isFinite()")}}.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - isFinite()")}}
+{{InteractiveExample("JavaScript Demo: isFinite()")}}
 
 ```js interactive-example
 function div(x) {

--- a/files/en-us/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/isnan/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.isNaN
 
 The **`isNaN()`** function determines whether a value is {{jsxref("NaN")}}, first converting the value to a number if necessary. Because coercion inside the `isNaN()` function can be [surprising](#description), you may prefer to use {{jsxref("Number.isNaN()")}}.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - isNaN()")}}
+{{InteractiveExample("JavaScript Demo: isNaN()")}}
 
 ```js interactive-example
 function milliseconds(x) {

--- a/files/en-us/web/javascript/reference/global_objects/map/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/values/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Map.values
 
 The **`values()`** method of {{jsxref("Map")}} instances returns a new _[map iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the values for each element in this map in insertion order.
 
-{{InteractiveExample("JavaScript Demo: Map.prototype.values")}}
+{{InteractiveExample("JavaScript Demo: Map.prototype.values()")}}
 
 ```js interactive-example
 const map1 = new Map();

--- a/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10e/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Math.LOG10E
 
 The **`Math.LOG10E`** static data property represents the base 10 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 0.434.
 
-{{InteractiveExample("JavaScript Demo: Math.log10e()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Math.LOG10E", "shorter")}}
 
 ```js interactive-example
 function getLog10e() {

--- a/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2e/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Math.LOG2E
 
 The **`Math.LOG2E`** static data property represents the base 2 logarithm of [e](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/E), approximately 1.443.
 
-{{InteractiveExample("JavaScript Demo: Math.log2e()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Math.LOG2E", "shorter")}}
 
 ```js interactive-example
 function getLog2e() {

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.NaN
 
 The **`NaN`** global property is a value representing Not-A-Number.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - NaN")}}
+{{InteractiveExample("JavaScript Demo: NaN")}}
 
 ```js interactive-example
 function sanitize(x) {

--- a/files/en-us/web/javascript/reference/global_objects/number/toexponential/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/toexponential/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.Number.toExponential
 The **`toExponential()`** method of {{jsxref("Number")}} values returns a string representing
 this number in exponential notation.
 
-{{InteractiveExample("JavaScript Demo: Number.toExponential()")}}
+{{InteractiveExample("JavaScript Demo: Number.prototype.toExponential()")}}
 
 ```js interactive-example
 function expo(x, f) {

--- a/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -11,7 +11,7 @@ The **`toLocaleString()`** method of {{jsxref("Number")}} values returns a strin
 
 Every time `toLocaleString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.NumberFormat")}} object and use its {{jsxref("Intl/NumberFormat/format", "format()")}} method, because a `NumberFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
 
-{{InteractiveExample("JavaScript Demo: Number.toLocaleString()")}}
+{{InteractiveExample("JavaScript Demo: Number.prototype.toLocaleString()")}}
 
 ```js interactive-example
 function eArabic(x) {

--- a/files/en-us/web/javascript/reference/global_objects/number/toprecision/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/toprecision/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Number.toPrecision
 
 The **`toPrecision()`** method of {{jsxref("Number")}} values returns a string representing this number to the specified number of significant digits.
 
-{{InteractiveExample("JavaScript Demo: Number.toPrecision()")}}
+{{InteractiveExample("JavaScript Demo: Number.prototype.toPrecision()")}}
 
 ```js interactive-example
 function precise(x) {

--- a/files/en-us/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Number.toString
 
 The **`toString()`** method of {{jsxref("Number")}} values returns a string representing this number value.
 
-{{InteractiveExample("JavaScript Demo: Number.toString()")}}
+{{InteractiveExample("JavaScript Demo: Number.prototype.toString()")}}
 
 ```js interactive-example
 function hexColour(c) {

--- a/files/en-us/web/javascript/reference/global_objects/number/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/valueof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Number.valueOf
 
 The **`valueOf()`** method of {{jsxref("Number")}} values returns the value of this number.
 
-{{InteractiveExample("JavaScript Demo: Number.valueOf()")}}
+{{InteractiveExample("JavaScript Demo: Number.prototype.valueOf()")}}
 
 ```js interactive-example
 const numObj = new Number(42);

--- a/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
@@ -14,7 +14,25 @@ The **`Object.groupBy()`** static method groups the elements of a given iterable
 
 This method should be used when group names can be represented by strings. If you need to group elements using a key that is some arbitrary value, use {{jsxref("Map.groupBy()")}} instead.
 
-<!-- {{EmbedInteractiveExample("pages/js/object-groupby.html")}} -->
+{{InteractiveExample("JavaScript Demo: Object.groupBy()", "taller")}}
+
+```js interactive-example
+const inventory = [
+  { name: "asparagus", type: "vegetables", quantity: 9 },
+  { name: "bananas", type: "fruit", quantity: 5 },
+  { name: "goat", type: "meat", quantity: 23 },
+  { name: "cherries", type: "fruit", quantity: 12 },
+  { name: "fish", type: "meat", quantity: 22 },
+];
+
+const restock = { restock: true };
+const sufficient = { restock: false };
+const result = Object.groupBy(inventory, ({ quantity }) =>
+  quantity < 6 ? "restock" : "sufficient",
+);
+console.log(result.restock);
+// [{ name: "bananas", type: "fruit", quantity: 5 }]
+```
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tolocalestring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Object.toLocaleString
 
 The **`toLocaleString()`** method of {{jsxref("Object")}} instances returns a string representing this object. This method is meant to be overridden by derived objects for locale-specific purposes.
 
-{{InteractiveExample("JavaScript Demo: Object.prototype.tolocalestring()")}}
+{{InteractiveExample("JavaScript Demo: Object.prototype.toLocaleString()")}}
 
 ```js interactive-example
 const date1 = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.parseFloat
 
 The **`parseFloat()`** function parses a string argument and returns a floating point number.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - parseFloat()")}}
+{{InteractiveExample("JavaScript Demo: parseFloat()")}}
 
 ```js interactive-example
 function circumference(r) {

--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.parseInt
 
 The **`parseInt()`** function parses a string argument and returns an integer of the specified [radix](https://en.wikipedia.org/wiki/Radix) (the base in mathematical numeral systems).
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - parseInt()")}}
+{{InteractiveExample("JavaScript Demo: parseInt()")}}
 
 ```js interactive-example
 console.log(parseInt("123"));

--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Promise.catch
 
 The **`catch()`** method of {{jsxref("Promise")}} instances schedules a function to be called when the promise is rejected. It immediately returns another {{jsxref("Promise")}} object, allowing you to [chain](/en-US/docs/Web/JavaScript/Guide/Using_promises#chaining) calls to other promise methods. It is a shortcut for {{jsxref("Promise/then", "then(undefined, onRejected)")}}.
 
-{{InteractiveExample("JavaScript Demo: Promise.catch()")}}
+{{InteractiveExample("JavaScript Demo: Promise.prototype.catch()")}}
 
 ```js interactive-example
 const promise1 = new Promise((resolve, reject) => {

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -11,7 +11,7 @@ The **`finally()`** method of {{jsxref("Promise")}} instances schedules a functi
 
 This lets you avoid duplicating code in both the promise's {{jsxref("Promise/then", "then()")}} and {{jsxref("Promise/catch", "catch()")}} handlers.
 
-{{InteractiveExample("JavaScript Demo: Promise.finally()", "taller")}}
+{{InteractiveExample("JavaScript Demo: Promise.prototype.finally()", "taller")}}
 
 ```js interactive-example
 function checkMail() {

--- a/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Promise.Promise
 
 The **`Promise()`** constructor creates {{jsxref("Promise")}} objects. It is primarily used to wrap callback-based APIs that do not already support promises.
 
-{{InteractiveExample("JavaScript Demo: Promise Constructor", "taller")}}
+{{InteractiveExample("JavaScript Demo: Promise() constructor", "taller")}}
 
 ```js interactive-example
 const promise1 = new Promise((resolve, reject) => {

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Promise.then
 
 The **`then()`** method of {{jsxref("Promise")}} instances takes up to two arguments: callback functions for the fulfilled and rejected cases of the `Promise`. It stores the callbacks within the promise it is called on and immediately returns another {{jsxref("Promise")}} object, allowing you to [chain](/en-US/docs/Web/JavaScript/Guide/Using_promises#chaining) calls to other promise methods.
 
-{{InteractiveExample("JavaScript Demo: Promise.then()")}}
+{{InteractiveExample("JavaScript Demo: Promise.prototype.then()")}}
 
 ```js interactive-example
 const promise1 = new Promise((resolve, reject) => {

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.RegExp.lastIndex
 
 The **`lastIndex`** data property of a {{jsxref("RegExp")}} instance specifies the index at which to start the next match.
 
-{{InteractiveExample("JavaScript Demo: RegExp.lastIndex")}}
+{{InteractiveExample("JavaScript Demo: RegExp: lastIndex")}}
 
 ```js interactive-example
 const regex1 = new RegExp("foo", "g");

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -11,7 +11,7 @@ The **`RegExp()`** constructor creates {{jsxref("RegExp")}} objects.
 
 For an introduction to regular expressions, read the [Regular Expressions chapter](/en-US/docs/Web/JavaScript/Guide/Regular_expressions) in the [JavaScript Guide](/en-US/docs/Web/JavaScript/Guide).
 
-{{InteractiveExample("JavaScript Demo: RegExp Constructor")}}
+{{InteractiveExample("JavaScript Demo: RegExp() constructor")}}
 
 ```js interactive-example
 const regex1 = /\w+/;

--- a/files/en-us/web/javascript/reference/global_objects/regexp/symbol.species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/symbol.species/index.md
@@ -12,22 +12,6 @@ The **`RegExp[Symbol.species]`** static accessor property returns the constructo
 > [!WARNING]
 > The existence of `[Symbol.species]` allows execution of arbitrary code and may create security vulnerabilities. It also makes certain optimizations much harder. Engine implementers are [investigating whether to remove this feature](https://github.com/tc39/proposal-rm-builtin-subclassing). Avoid relying on it if possible.
 
-{{InteractiveExample("JavaScript Demo: RegExp[Symbol.species]")}}
-
-```js interactive-example
-class MyRegExp extends RegExp {
-  // Overwrite MyRegExp species to the parent RegExp constructor
-  static get [Symbol.species]() {
-    return RegExp;
-  }
-}
-
-const regex1 = new MyRegExp("foo", "g");
-
-console.log(regex1.test("football"));
-// Expected output: true
-```
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
@@ -16,7 +16,7 @@ set (e.g., `/foo/g` or `/foo/y`). They store a
 internally, `test()` can be used to iterate over multiple matches in a string
 of text (with capture groups).
 
-{{InteractiveExample("JavaScript Demo: RegExp.prototype.test", "taller")}}
+{{InteractiveExample("JavaScript Demo: RegExp.prototype.test()", "taller")}}
 
 ```js interactive-example
 const str = "table football";

--- a/files/en-us/web/javascript/reference/global_objects/set/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/set/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Set.Set
 
 The **`Set()`** constructor creates {{jsxref("Set")}} objects.
 
-{{InteractiveExample("JavaScript Demo: Set.prototype Constructor")}}
+{{InteractiveExample("JavaScript Demo: Set() constructor")}}
 
 ```js interactive-example
 const set1 = new Set([1, 2, 3, 4, 5]);

--- a/files/en-us/web/javascript/reference/global_objects/set/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/values/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Set.values
 
 The **`values()`** method of {{jsxref("Set")}} instances returns a new _[set iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the values for each element in this set in insertion order.
 
-{{InteractiveExample("JavaScript Demo: Set.prototype.values")}}
+{{InteractiveExample("JavaScript Demo: Set.prototype.values()")}}
 
 ```js interactive-example
 const set1 = new Set();

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.SharedArrayBuffer.byteLength
 
 The **`byteLength`** accessor property of {{jsxref("SharedArrayBuffer")}} instances returns the length (in bytes) of this `SharedArrayBuffer`.
 
-{{InteractiveExample("JavaScript Demo: SharedArrayBuffer.byteLength", "shorter")}}
+{{InteractiveExample("JavaScript Demo: SharedArrayBuffer.prototype.byteLength", "shorter")}}
 
 ```js interactive-example
 // Create a SharedArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.SharedArrayBuffer.SharedArrayBuffer
 
 The **`SharedArrayBuffer()`** constructor creates {{jsxref("SharedArrayBuffer")}} objects.
 
-{{InteractiveExample("JavaScript Demo: SharedArrayBuffer Constructor", "shorter")}}
+{{InteractiveExample("JavaScript Demo: SharedArrayBuffer() constructor", "shorter")}}
 
 ```js interactive-example
 // Create a SharedArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.SharedArrayBuffer.slice
 
 The **`slice()`** method of {{jsxref("SharedArrayBuffer")}} instances returns a new `SharedArrayBuffer` whose contents are a copy of this `SharedArrayBuffer`'s bytes from `start`, inclusive, up to `end`, exclusive. If either `start` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning.
 
-{{InteractiveExample("JavaScript Demo: SharedArrayBuffer.slice()")}}
+{{InteractiveExample("JavaScript Demo: SharedArrayBuffer.prototype.slice()")}}
 
 ```js interactive-example
 // Create a SharedArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.at
 
 The **`at()`** method of {{jsxref("String")}} values takes an integer value and returns a new {{jsxref("String")}} consisting of the single UTF-16 code unit located at the specified offset. This method allows for positive and negative integers. Negative integers count back from the last string character.
 
-{{InteractiveExample("JavaScript Demo: String.at()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.at()")}}
 
 ```js interactive-example
 const sentence = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/charat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/charat/index.md
@@ -11,7 +11,7 @@ The **`charAt()`** method of {{jsxref("String")}} values returns a new string co
 
 `charAt()` always indexes the string as a sequence of [UTF-16 code units](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters), so it may return lone surrogates. To get the full Unicode code point at the given index, use {{jsxref("String.prototype.codePointAt()")}} and {{jsxref("String.fromCodePoint()")}}.
 
-{{InteractiveExample("JavaScript Demo: String.charAt()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.charAt()", "shorter")}}
 
 ```js interactive-example
 const sentence = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/charcodeat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/charcodeat/index.md
@@ -11,7 +11,7 @@ The **`charCodeAt()`** method of {{jsxref("String")}} values returns an integer 
 
 `charCodeAt()` always indexes the string as a sequence of [UTF-16 code units](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters), so it may return lone surrogates. To get the full Unicode code point at the given index, use {{jsxref("String.prototype.codePointAt()")}}.
 
-{{InteractiveExample("JavaScript Demo: String.charCodeAt()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.charCodeAt()", "shorter")}}
 
 ```js interactive-example
 const sentence = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.codePointAt
 
 The **`codePointAt()`** method of {{jsxref("String")}} values returns a non-negative integer that is the Unicode code point value of the character starting at the given index. Note that the index is still based on UTF-16 code units, not Unicode code points.
 
-{{InteractiveExample("JavaScript Demo: String.codePointAt()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.codePointAt()", "shorter")}}
 
 ```js interactive-example
 const icons = "☃★♲";

--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.String.concat
 The **`concat()`** method of {{jsxref("String")}} values concatenates
 the string arguments to this string and returns a new string.
 
-{{InteractiveExample("JavaScript Demo: String.concat()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.concat()")}}
 
 ```js interactive-example
 const str1 = "Hello";

--- a/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.endsWith
 
 The **`endsWith()`** method of {{jsxref("String")}} values determines whether a string ends with the characters of this string, returning `true` or `false` as appropriate.
 
-{{InteractiveExample("JavaScript Demo: String.endsWith()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.endsWith()")}}
 
 ```js interactive-example
 const str1 = "Cats are the best!";

--- a/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/includes/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.includes
 
 The **`includes()`** method of {{jsxref("String")}} values performs a case-sensitive search to determine whether a given string may be found within this string, returning `true` or `false` as appropriate.
 
-{{InteractiveExample("JavaScript Demo: String.includes()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.includes()", "shorter")}}
 
 ```js interactive-example
 const sentence = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.indexOf
 
 The **`indexOf()`** method of {{jsxref("String")}} values searches this string and returns the index of the first occurrence of the specified substring. It takes an optional starting position and returns the first occurrence of the specified substring at an index greater than or equal to the specified number.
 
-{{InteractiveExample("JavaScript Demo: String.indexOf()", "taller")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.indexOf()", "taller")}}
 
 ```js interactive-example
 const paragraph = "I think Ruth's dog is cuter than your dog!";

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.lastIndexOf
 
 The **`lastIndexOf()`** method of {{jsxref("String")}} values searches this string and returns the index of the last occurrence of the specified substring. It takes an optional starting position and returns the last occurrence of the specified substring at an index less than or equal to the specified number.
 
-{{InteractiveExample("JavaScript Demo: String.lastIndexOf()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.lastIndexOf()")}}
 
 ```js interactive-example
 const paragraph = "I think Ruth's dog is cuter than your dog!";

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.length
 
 The **`length`** data property of a {{jsxref("String")}} value contains the length of the string in UTF-16 code units.
 
-{{InteractiveExample("JavaScript Demo: String.length", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String: length", "shorter")}}
 
 ```js interactive-example
 const str = "Life, the universe and everything. Answer:";

--- a/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -11,7 +11,7 @@ The **`localeCompare()`** method of {{jsxref("String")}} values returns a number
 
 When comparing large numbers of strings, such as in sorting large arrays, it is better to create an {{jsxref("Intl.Collator")}} object and use the function provided by its {{jsxref("Intl/Collator/compare", "compare()")}} method.
 
-{{InteractiveExample("JavaScript Demo: String.localeCompare()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.localeCompare()")}}
 
 ```js interactive-example
 const a = "réservé"; // With accents, lowercase

--- a/files/en-us/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/match/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.match
 
 The **`match()`** method of {{jsxref("String")}} values retrieves the result of matching this string against a [regular expression](/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
 
-{{InteractiveExample("JavaScript Demo: String.match()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.match()", "shorter")}}
 
 ```js interactive-example
 const paragraph = "The quick brown fox jumps over the lazy dog. It barked.";

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.matchAll
 
 The **`matchAll()`** method of {{jsxref("String")}} values returns an iterator of all results matching this string against a [regular expression](/en-US/docs/Web/JavaScript/Guide/Regular_expressions), including [capturing groups](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences).
 
-{{InteractiveExample("JavaScript Demo: String.matchAll()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.matchAll()")}}
 
 ```js interactive-example
 const regexp = /t(e)(st(\d?))/g;

--- a/files/en-us/web/javascript/reference/global_objects/string/normalize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/normalize/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.String.normalize
 The **`normalize()`** method of {{jsxref("String")}} values returns the Unicode Normalization
 Form of this string.
 
-{{InteractiveExample("JavaScript Demo: String.normalize()", "taller")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.normalize()", "taller")}}
 
 ```js interactive-example
 const name1 = "\u0041\u006d\u00e9\u006c\u0069\u0065";

--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
@@ -11,7 +11,7 @@ The **`padEnd()`** method of {{jsxref("String")}} values pads this string with a
 string (repeated, if needed) so that the resulting string reaches a given length. The
 padding is applied from the end of this string.
 
-{{InteractiveExample("JavaScript Demo: String.padEnd()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.padEnd()")}}
 
 ```js interactive-example
 const str1 = "Breaded Mushrooms";

--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.String.padStart
 The **`padStart()`** method of {{jsxref("String")}} values pads this string with another string (multiple times, if needed) until the resulting
 string reaches the given length. The padding is applied from the start of this string.
 
-{{InteractiveExample("JavaScript Demo: String.padStart()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.padStart()")}}
 
 ```js interactive-example
 const str1 = "5";

--- a/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.String.repeat
 The **`repeat()`** method of {{jsxref("String")}} values constructs and returns a new string
 which contains the specified number of copies of this string, concatenated together.
 
-{{InteractiveExample("JavaScript Demo: String.repeat()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.repeat()", "shorter")}}
 
 ```js interactive-example
 const mood = "Happy! ";

--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.replace
 
 The **`replace()`** method of {{jsxref("String")}} values returns a new string with one, some, or all matches of a `pattern` replaced by a `replacement`. The `pattern` can be a string or a {{jsxref("RegExp")}}, and the `replacement` can be a string or a function called for each match. If `pattern` is a string, only the first occurrence will be replaced. The original string is left unchanged.
 
-{{InteractiveExample("JavaScript Demo: String.replace()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.replace()")}}
 
 ```js interactive-example
 const paragraph = "I think Ruth's dog is cuter than your dog!";

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.replaceAll
 
 The **`replaceAll()`** method of {{jsxref("String")}} values returns a new string with all matches of a `pattern` replaced by a `replacement`. The `pattern` can be a string or a {{jsxref("RegExp")}}, and the `replacement` can be a string or a function to be called for each match. The original string is left unchanged.
 
-{{InteractiveExample("JavaScript Demo: String.replaceAll()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.replaceAll()")}}
 
 ```js interactive-example
 const paragraph = "I think Ruth's dog is cuter than your dog!";

--- a/files/en-us/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/search/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.search
 
 The **`search()`** method of {{jsxref("String")}} values executes a search for a match between a regular expression and this string, returning the index of the first match in the string.
 
-{{InteractiveExample("JavaScript Demo: String.search()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.search()")}}
 
 ```js interactive-example
 const paragraph = "I think Ruth's dog is cuter than your dog!";

--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.String.slice
 The **`slice()`** method of {{jsxref("String")}} values extracts a section of this string and
 returns it as a new string, without modifying the original string.
 
-{{InteractiveExample("JavaScript Demo: String.slice()", "taller")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.slice()", "taller")}}
 
 ```js interactive-example
 const str = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.split
 
 The **`split()`** method of {{jsxref("String")}} values takes a pattern and divides this string into an ordered list of substrings by searching for the pattern, puts these substrings into an array, and returns the array.
 
-{{InteractiveExample("JavaScript Demo: String.split()", "taller")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.split()", "taller")}}
 
 ```js interactive-example
 const str = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.startsWith
 
 The **`startsWith()`** method of {{jsxref("String")}} values determines whether this string begins with the characters of a specified string, returning `true` or `false` as appropriate.
 
-{{InteractiveExample("JavaScript Demo: String.startsWith()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.startsWith()")}}
 
 ```js interactive-example
 const str1 = "Saturday night plans";

--- a/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
@@ -13,7 +13,7 @@ The **`substr()`** method of {{jsxref("String")}} values returns a portion of th
 
 > **Note:** `substr()` is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [`String.prototype.substring()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [`String.prototype.slice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [`String.prototype.substring()` page](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.
 
-{{InteractiveExample("JavaScript Demo: String.substr()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.substr()")}}
 
 ```js interactive-example
 const str = "Mozilla";

--- a/files/en-us/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.substring
 
 The **`substring()`** method of {{jsxref("String")}} values returns the part of this string from the start index up to and excluding the end index, or to the end of the string if no end index is supplied.
 
-{{InteractiveExample("JavaScript Demo: String.substring()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.substring()")}}
 
 ```js interactive-example
 const str = "Mozilla";

--- a/files/en-us/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.toLocaleLowerCase
 
 The **`toLocaleLowerCase()`** method of {{jsxref("String")}} values returns this string converted to lower case, according to any locale-specific case mappings.
 
-{{InteractiveExample("JavaScript Demo: String.toLocaleLowerCase()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.toLocaleLowerCase()")}}
 
 ```js interactive-example
 const dotted = "İstanbul";

--- a/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.toLocaleUpperCase
 
 The **`toLocaleUpperCase()`** method of {{jsxref("String")}} values returns this string converted to upper case, according to any locale-specific case mappings.
 
-{{InteractiveExample("JavaScript Demo: String.toLocaleUpperCase()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.toLocaleUpperCase()")}}
 
 ```js interactive-example
 const city = "istanbul";

--- a/files/en-us/web/javascript/reference/global_objects/string/tolowercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolowercase/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.toLowerCase
 
 The **`toLowerCase()`** method of {{jsxref("String")}} values returns this string converted to lower case.
 
-{{InteractiveExample("JavaScript Demo: String.toLowerCase()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.toLowerCase()", "shorter")}}
 
 ```js interactive-example
 const sentence = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.toString
 
 The **`toString()`** method of {{jsxref("String")}} values returns this string value.
 
-{{InteractiveExample("JavaScript Demo: String.toString()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.toString()")}}
 
 ```js interactive-example
 const stringObj = new String("foo");

--- a/files/en-us/web/javascript/reference/global_objects/string/touppercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/touppercase/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.toUpperCase
 
 The **`toUpperCase()`** method of {{jsxref("String")}} values returns this string converted to uppercase.
 
-{{InteractiveExample("JavaScript Demo: String.toUpperCase()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.toUpperCase()", "shorter")}}
 
 ```js interactive-example
 const sentence = "The quick brown fox jumps over the lazy dog.";

--- a/files/en-us/web/javascript/reference/global_objects/string/trim/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/trim/index.md
@@ -11,7 +11,7 @@ The **`trim()`** method of {{jsxref("String")}} values removes whitespace from b
 
 To return a new string with whitespace trimmed from just one end, use {{jsxref("String/trimStart", "trimStart()")}} or {{jsxref("String/trimEnd", "trimEnd()")}}.
 
-{{InteractiveExample("JavaScript Demo: String.trim()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.trim()")}}
 
 ```js interactive-example
 const greeting = "   Hello world!   ";

--- a/files/en-us/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimend/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.trimEnd
 
 The **`trimEnd()`** method of {{jsxref("String")}} values removes whitespace from the end of this string and returns a new string, without modifying the original string. `trimRight()` is an alias of this method.
 
-{{InteractiveExample("JavaScript Demo: String.trimEnd()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.trimEnd()")}}
 
 ```js interactive-example
 const greeting = "   Hello world!   ";

--- a/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.trimStart
 
 The **`trimStart()`** method of {{jsxref("String")}} values removes whitespace from the beginning of this string and returns a new string, without modifying the original string. `trimLeft()` is an alias of this method.
 
-{{InteractiveExample("JavaScript Demo: String.trimStart()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.trimStart()")}}
 
 ```js interactive-example
 const greeting = "   Hello world!   ";

--- a/files/en-us/web/javascript/reference/global_objects/string/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/valueof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.valueOf
 
 The **`valueOf()`** method of {{jsxref("String")}} values returns this string value.
 
-{{InteractiveExample("JavaScript Demo: String.valueOf()")}}
+{{InteractiveExample("JavaScript Demo: String.prototype.valueOf()")}}
 
 ```js interactive-example
 const stringObj = new String("foo");

--- a/files/en-us/web/javascript/reference/global_objects/symbol/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/symbol/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Symbol.Symbol
 
 The **`Symbol()`** function returns primitive values of type Symbol.
 
-{{InteractiveExample("JavaScript Demo: Symbol - Constructor", "taller")}}
+{{InteractiveExample("JavaScript Demo: Symbol() constructor", "taller")}}
 
 ```js interactive-example
 const symbol1 = Symbol();

--- a/files/en-us/web/javascript/reference/global_objects/temporal/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/now/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Temporal.Now
 
 {{JSRef}}{{SeeCompatTable}}
 
-The **`Temporal.Now`** object provides methods for getting the current time in various formats.
+The **`Temporal.Now`** namespace object contains static methods for getting the current time in various formats.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.at
 
 The **`at()`** method of {{jsxref("TypedArray")}} instances takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.at()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.at()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.at()")}}
 
 ```js interactive-example
 const int8 = new Int8Array([0, 10, -10, 20, -30, 40, -50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/buffer/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.buffer
 
 The **`buffer`** accessor property of {{jsxref("TypedArray")}} instances returns the {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}} referenced by this typed array at construction time.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.buffer", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.buffer", "shorter")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/bytelength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/bytelength/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.byteLength
 
 The **`byteLength`** accessor property of {{jsxref("TypedArray")}} instances returns the length (in bytes) of this typed array.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.byteLength", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.byteLength", "shorter")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.copyWithin
 
 The **`copyWithin()`** method of {{jsxref("TypedArray")}} instances shallow copies part of this typed array to another location in the same typed array and returns this typed array without modifying its length. This method has the same algorithm as {{jsxref("Array.prototype.copyWithin()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.copyWithin()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.copyWithin()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.entries
 
 The **`entries()`** method of {{jsxref("TypedArray")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the key/value pairs for each index in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.entries()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.entries()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.entries()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.every
 
 The **`every()`** method of {{jsxref("TypedArray")}} instances tests whether all elements in the typed array pass the test implemented by the provided function. It returns a Boolean value. This method has the same algorithm as {{jsxref("Array.prototype.every()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.every()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.every()")}}
 
 ```js interactive-example
 function isNegative(element, index, array) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.fill
 
 The **`fill()`** method of {{jsxref("TypedArray")}} instances changes all elements within a range of indices in a typed array to a static value. It returns the modified typed array. This method has the same algorithm as {{jsxref("Array.prototype.fill()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.fill()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.fill()", "shorter")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([0, 0, 0, 0]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.filter
 
 The **`filter()`** method of {{jsxref("TypedArray")}} instances creates a copy of a portion of a given typed array, filtered down to just the elements from the given typed array that pass the test implemented by the provided function. This method has the same algorithm as {{jsxref("Array.prototype.filter()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.filter()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.filter()")}}
 
 ```js interactive-example
 function isNegative(element, index, array) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.find
 
 The **`find()`** method of {{jsxref("TypedArray")}} instances returns the first element in the provided typed array that satisfies the provided testing function. If no values satisfy the testing function, {{jsxref("undefined")}} is returned. This method has the same algorithm as {{jsxref("Array.prototype.find()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.find()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.find()")}}
 
 ```js interactive-example
 function isNegative(element, index, array) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.findIndex
 
 The **`findIndex()`** method of {{jsxref("TypedArray")}} instances returns the index of the first element in a typed array that satisfies the provided testing function. If no elements satisfy the testing function, -1 is returned. This method has the same algorithm as {{jsxref("Array.prototype.findIndex()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.findIndex()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.findIndex()")}}
 
 ```js interactive-example
 function isNegative(element, index, array) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.findLast
 
 The **`findLast()`** method of {{jsxref("TypedArray")}} instances iterates the typed array in reverse order and returns the value of the first element that satisfies the provided testing function. If no elements satisfy the testing function, {{jsxref("undefined")}} is returned. This method has the same algorithm as {{jsxref("Array.prototype.findLast()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.findLast()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.findLast()")}}
 
 ```js interactive-example
 function isNegative(element /*, index, array */) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlastindex/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.findLastIndex
 
 The **`findLastIndex()`** method of {{jsxref("TypedArray")}} instances iterates the typed array in reverse order and returns the index of the first element that satisfies the provided testing function. If no elements satisfy the testing function, -1 is returned. This method has the same algorithm as {{jsxref("Array.prototype.findLastIndex()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.findLastIndex()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.findLastIndex()")}}
 
 ```js interactive-example
 function isNegative(element /*, index, array */) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.forEach
 
 The **`forEach()`** method of {{jsxref("TypedArray")}} instances executes a provided function once for each typed array element. This method has the same algorithm as {{jsxref("Array.prototype.forEach()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.forEach()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.forEach()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.includes
 
 The **`includes()`** method of {{jsxref("TypedArray")}} instances determines whether a typed array includes a certain value among its entries, returning `true` or `false` as appropriate. This method has the same algorithm as {{jsxref("Array.prototype.includes()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.includes()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.includes()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -15,23 +15,6 @@ different global properties, whose values are typed array constructors for speci
 element types, listed below. On the following pages you will find common properties and
 methods that can be used with any typed array containing elements of any type.
 
-{{InteractiveExample("JavaScript Demo: TypedArray Constructor")}}
-
-```js interactive-example
-// Create a TypedArray with a size in bytes
-const typedArray1 = new Int8Array(8);
-typedArray1[0] = 32;
-
-const typedArray2 = new Int8Array(typedArray1);
-typedArray2[1] = 42;
-
-console.log(typedArray1);
-// Expected output: Int8Array [32, 0, 0, 0, 0, 0, 0, 0]
-
-console.log(typedArray2);
-// Expected output: Int8Array [32, 42, 0, 0, 0, 0, 0, 0]
-```
-
 ## Description
 
 The `TypedArray` constructor (often referred to as `%TypedArray%` to indicate its "intrinsicness", since it does not correspond to any global exposed to a JavaScript program) serves as the common superclass of all `TypedArray` subclasses. Think about `%TypedArray%` as an "abstract class" providing a common interface of utility methods for all typed array subclasses. This constructor is not directly exposed: there is no global `TypedArray` property. It is only accessible through `Object.getPrototypeOf(Int8Array)` and similar.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.indexOf
 
 The **`indexOf()`** method of {{jsxref("TypedArray")}} instances returns the first index at which a given element can be found in the typed array, or -1 if it is not present. This method has the same algorithm as {{jsxref("Array.prototype.indexOf()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.indexOf()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.indexOf()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.join
 
 The **`join()`** method of {{jsxref("TypedArray")}} instances creates and returns a new string by concatenating all of the elements in this typed array, separated by commas or a specified separator string. If the typed array has only one item, then that item will be returned without using the separator. This method has the same algorithm as {{jsxref("Array.prototype.join()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.join()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.join()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.keys
 
 The **`keys()`** method of {{jsxref("TypedArray")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that contains the keys for each index in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.keys()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.keys()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.keys()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.lastIndexOf
 
 The **`lastIndexOf()`** method of {{jsxref("TypedArray")}} instances returns the last index at which a given element can be found in the typed array, or -1 if it is not present. The typed array is searched backwards, starting at `fromIndex`. This method has the same algorithm as {{jsxref("Array.prototype.lastIndexOf()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.lastIndexOf()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.lastIndexOf()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 50, 50, 50, 60]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.length
 
 The **`length`** accessor property of {{jsxref("TypedArray")}} instances returns the length (in elements) of this typed array.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.length", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.length", "shorter")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.map
 
 The **`map()`** method of {{jsxref("TypedArray")}} instances creates a new typed array populated with the results of calling a provided function on every element in the calling typed array. This method has the same algorithm as {{jsxref("Array.prototype.map()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.map()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.map()", "shorter")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([25, 36, 49]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.reduce
 
 The **`reduce()`** method of {{jsxref("TypedArray")}} instances executes a user-supplied "reducer" callback function on each element of the typed array, in order, passing in the return value from the calculation on the preceding element. The final result of running the reducer across all elements of the typed array is a single value. This method has the same algorithm as {{jsxref("Array.prototype.reduce()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.reduce()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.reduce()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([0, 1, 2, 3]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.reduceRight
 
 The **`reduceRight()`** method of {{jsxref("TypedArray")}} instances applies a function against an accumulator and each value of the typed array (from right-to-left) to reduce it to a single value. This method has the same algorithm as {{jsxref("Array.prototype.reduceRight()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.reduceRight()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.reduceRight()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.reverse
 
 The **`reverse()`** method of {{jsxref("TypedArray")}} instances reverses a typed array _[in place](https://en.wikipedia.org/wiki/In-place_algorithm)_ and returns the reference to the same typed array, the first typed array element now becoming the last, and the last typed array element becoming the first. In other words, elements order in the typed array will be turned towards the direction opposite to that previously stated. This method has the same algorithm as {{jsxref("Array.prototype.reverse()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.reverse()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.reverse()", "shorter")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([1, 2, 3]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.builtins.TypedArray.set
 The **`set()`** method of {{jsxref("TypedArray")}} instances stores multiple values in the typed
 array, reading input values from a specified array.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.set()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.set()")}}
 
 ```js interactive-example
 // Create an ArrayBuffer with a size in bytes

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.slice
 
 The **`slice()`** method of {{jsxref("TypedArray")}} instances returns a copy of a portion of a typed array into a new typed array object selected from `start` to `end` (`end` not included) where `start` and `end` represent the index of items in that typed array. The original typed array will not be modified. This method has the same algorithm as {{jsxref("Array.prototype.slice()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.slice()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.slice()", "shorter")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.some
 
 The **`some()`** method of {{jsxref("TypedArray")}} instances tests whether at least one element in the typed array passes the test implemented by the provided function. It returns true if, in the typed array, it finds an element for which the provided function returns true; otherwise it returns false. It doesn't modify the typed array. This method has the same algorithm as {{jsxref("Array.prototype.some()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.some()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.some()")}}
 
 ```js interactive-example
 function isNegative(element, index, array) {

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.sort
 
 The **`sort()`** method of {{jsxref("TypedArray")}} instances sorts the elements of a typed array _[in place](https://en.wikipedia.org/wiki/In-place_algorithm)_ and returns the reference to the same typed array, now sorted. This method has the same algorithm as {{jsxref("Array.prototype.sort()")}}, except that it sorts the values numerically instead of as strings by default.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.sort()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.sort()", "shorter")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([40, 10, 50, 20, 30]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/subarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/subarray/index.md
@@ -12,7 +12,7 @@ on the same {{jsxref("ArrayBuffer")}} store and with the same element types as f
 typed array. The begin offset is **inclusive** and the end
 offset is **exclusive**.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.subarray()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.subarray()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.toLocaleString
 
 The **`toLocaleString()`** method of {{jsxref("TypedArray")}} instances returns a string representing the elements of the typed array. The elements are converted to strings using their `toLocaleString` methods and these strings are separated by a locale-specific string (such as a comma ","). This method has the same algorithm as {{jsxref("Array.prototype.toLocaleString()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.toLocaleString()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.toLocaleString()")}}
 
 ```js interactive-example
 const uint8 = new Uint32Array([500, 8123, 12]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.toString
 
 The **`toString()`** method of {{jsxref("TypedArray")}} instances returns a string representing the specified typed array and its elements. This method has the same algorithm as {{jsxref("Array.prototype.toString()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.toString()", "shorter")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.toString()", "shorter")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.TypedArray.values
 
 The **`values()`** method of {{jsxref("TypedArray")}} instances returns a new _[array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator)_ object that iterates the value of each item in the typed array. This method has the same algorithm as {{jsxref("Array.prototype.values()")}}.
 
-{{InteractiveExample("JavaScript Demo: TypedArray.values()")}}
+{{InteractiveExample("JavaScript Demo: TypedArray.prototype.values()")}}
 
 ```js interactive-example
 const uint8 = new Uint8Array([10, 20, 30, 40, 50]);

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.md
@@ -11,7 +11,7 @@ The **`undefined`** global property represents the primitive
 value [`undefined`](/en-US/docs/Web/JavaScript/Guide/Data_structures#undefined_type). It is one of JavaScript's
 {{Glossary("Primitive", "primitive types")}}.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - undefined")}}
+{{InteractiveExample("JavaScript Demo: undefined")}}
 
 ```js interactive-example
 function test(t) {

--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.addition
 
 The **addition (`+`)** operator produces the sum of numeric operands or string concatenation.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Addition operator")}}
+{{InteractiveExample("JavaScript Demo: Addition (+) operator")}}
 
 ```js interactive-example
 console.log(2 + 2);

--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.addition_assignment
 
 The **addition assignment (`+=`)** operator performs [addition](/en-US/docs/Web/JavaScript/Reference/Operators/Addition) (which is either numeric addition or string concatenation) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Addition assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Addition assignment (+=) operator")}}
 
 ```js interactive-example
 let a = 2;

--- a/files/en-us/web/javascript/reference/operators/assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.assignment
 
 The **assignment (`=`)** operator is used to assign a value to a variable or property. The assignment expression itself has a value, which is the assigned value. This allows multiple assignments to be chained in order to assign a single value to multiple variables.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Assignment")}}
+{{InteractiveExample("JavaScript Demo: Assignment (=) operator")}}
 
 ```js interactive-example
 let x = 2;

--- a/files/en-us/web/javascript/reference/operators/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/async_function_star_/index.md
@@ -11,7 +11,7 @@ The **`async function*`** keywords can be used to define an async generator func
 
 You can also define async generator functions using the [`async function*` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/async_function*).
 
-{{InteractiveExample("JavaScript Demo: Expressions - Async Function Asterisk", "taller")}}
+{{InteractiveExample("JavaScript Demo: async function* expression", "taller")}}
 
 ```js interactive-example
 async function joinAll(generator) {

--- a/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_and
 
 The **bitwise AND (`&`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bits of both operands are `1`.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise AND", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Bitwise AND (&) operator", "shorter")}}
 
 ```js interactive-example
 const a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_and_assignment
 
 The **bitwise AND assignment (`&=`)** operator performs [bitwise AND](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise AND assignment", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Bitwise AND assignment (&=) operator", "shorter")}}
 
 ```js interactive-example
 let a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/bitwise_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_not/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_not
 
 The **bitwise NOT (`~`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bit of the operand is `0`, and a `0` otherwise.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise NOT")}}
+{{InteractiveExample("JavaScript Demo: Bitwise NOT (~) operator")}}
 
 ```js interactive-example
 const a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_or
 
 The **bitwise OR (`|`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bits of either or both operands are `1`.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise OR", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Bitwise OR (|) operator", "shorter")}}
 
 ```js interactive-example
 const a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_or_assignment
 
 The **bitwise OR assignment (`|=`)** operator performs [bitwise OR](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise OR assignment", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Bitwise OR assignment (|=) operator", "shorter")}}
 
 ```js interactive-example
 let a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_xor
 
 The **bitwise XOR (`^`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bits of either but not both operands are `1`.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise XOR", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Bitwise XOR (^) operator", "shorter")}}
 
 ```js interactive-example
 const a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.bitwise_xor_assignment
 
 The **bitwise XOR assignment (`^=`)** operator performs [bitwise XOR](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Bitwise XOR assignment", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Bitwise XOR assignment (^=) operator", "shorter")}}
 
 ```js interactive-example
 let a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/class/index.md
+++ b/files/en-us/web/javascript/reference/operators/class/index.md
@@ -11,7 +11,7 @@ The **`class`** keyword can be used to define a class inside an expression.
 
 You can also define classes using the [`class` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/class).
 
-{{InteractiveExample("JavaScript Demo: Expressions - class expression")}}
+{{InteractiveExample("JavaScript Demo: class expression")}}
 
 ```js interactive-example
 const Rectangle = class {

--- a/files/en-us/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/comma_operator/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.comma
 
 The **comma (`,`)** operator evaluates each of its operands (from left to right) and returns the value of the last operand. This is commonly used to provide multiple updaters to a [`for`](/en-US/docs/Web/JavaScript/Reference/Statements/for) loop's afterthought.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Comma operator")}}
+{{InteractiveExample("JavaScript Demo: Comma (,) operator")}}
 
 ```js interactive-example
 let x = 1;

--- a/files/en-us/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/conditional_operator/index.md
@@ -11,7 +11,7 @@ The **conditional (ternary) operator** is the only JavaScript operator that take
 a condition followed by a question mark (`?`), then an expression to execute if the condition is {{Glossary("truthy")}} followed by a colon (`:`), and finally the expression to execute if the condition is {{Glossary("falsy")}}.
 This operator is frequently used as an alternative to an [`if...else`](/en-US/docs/Web/JavaScript/Reference/Statements/if...else) statement.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Conditional operator")}}
+{{InteractiveExample("JavaScript Demo: Conditional operator")}}
 
 ```js interactive-example
 function getFee(isMember) {

--- a/files/en-us/web/javascript/reference/operators/decrement/index.md
+++ b/files/en-us/web/javascript/reference/operators/decrement/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.decrement
 
 The **decrement (`--`)** operator decrements (subtracts one from) its operand and returns the value before or after the decrement, depending on where the operator is placed.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Decrement operator")}}
+{{InteractiveExample("JavaScript Demo: Decrement (--) operator")}}
 
 ```js interactive-example
 let x = 3;

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.delete
 
 The **`delete`** operator removes a property from an object. If the property's value is an object and there are no more references to the object, the object held by that property is eventually released automatically.
 
-{{InteractiveExample("JavaScript Demo: Expressions - delete operator")}}
+{{InteractiveExample("JavaScript Demo: delete operator")}}
 
 ```js interactive-example
 const Employee = {

--- a/files/en-us/web/javascript/reference/operators/destructuring/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.destructuring
 
 The **destructuring** syntax is a JavaScript syntax that makes it possible to unpack values from arrays, or properties from objects, into distinct variables. It can be used in locations that receive data (such as the left-hand side of an assignment or anywhere that creates new identifier bindings).
 
-{{InteractiveExample("JavaScript Demo: Expressions - Destructuring", "taller")}}
+{{InteractiveExample("JavaScript Demo: Destructuring", "taller")}}
 
 ```js interactive-example
 let a, b, rest;

--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.division
 
 The **division (`/`)** operator produces the quotient of its operands where the left operand is the dividend and the right operand is the divisor.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Division operator")}}
+{{InteractiveExample("JavaScript Demo: Division (/) operator")}}
 
 ```js interactive-example
 console.log(12 / 2);

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.division_assignment
 
 The **division assignment (`/=`)** operator performs [division](/en-US/docs/Web/JavaScript/Reference/Operators/Division) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Division assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Division assignment (/=) operator")}}
 
 ```js interactive-example
 let a = 3;

--- a/files/en-us/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.exponentiation
 
 The **exponentiation (`**`)** operator returns the result of raising the first operand to the power of the second operand. It is equivalent to {{jsxref("Math.pow()")}}, except it also accepts [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) as operands.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Exponentiation operator")}}
+{{InteractiveExample("JavaScript Demo: Exponentiation (**) operator")}}
 
 ```js interactive-example
 console.log(3 ** 4);

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.exponentiation_assignment
 
 The **exponentiation assignment (`**=`)** operator performs [exponentiation](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Exponentiation assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Exponentiation assignment (**=) operator")}}
 
 ```js interactive-example
 let a = 3;

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -11,7 +11,7 @@ The **`function`** keyword can be used to define a function inside an expression
 
 You can also define functions using the [`function` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function) or the [arrow syntax](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
-{{InteractiveExample("JavaScript Demo: Expressions - function expression", "shorter")}}
+{{InteractiveExample("JavaScript Demo: function expression", "shorter")}}
 
 ```js interactive-example
 const getRectArea = function (width, height) {

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.md
@@ -11,7 +11,7 @@ The **`function*`** keyword can be used to define a generator function inside an
 
 You can also define generator functions using the [`function*` declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function*).
 
-{{InteractiveExample("JavaScript Demo: Expressions - function* expression", "taller")}}
+{{InteractiveExample("JavaScript Demo: function* expression", "taller")}}
 
 ```js interactive-example
 const foo = function* () {

--- a/files/en-us/web/javascript/reference/operators/greater_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.operators.greater_than
 The **greater than (`>`)** operator returns `true` if the left
 operand is greater than the right operand, and `false` otherwise.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Greater than operator")}}
+{{InteractiveExample("JavaScript Demo: Greater than (>) operator")}}
 
 ```js interactive-example
 console.log(5 > 3);

--- a/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
@@ -11,7 +11,7 @@ The **greater than or equal (`>=`)** operator returns `true` if
 the left operand is greater than or equal to the right operand, and `false`
 otherwise.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Greater than or equal operator")}}
+{{InteractiveExample("JavaScript Demo: Greater than or equal (>=) operator")}}
 
 ```js interactive-example
 console.log(5 >= 3);

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.grouping
 
 The **grouping `( )`** operator controls the precedence of evaluation in expressions. It also acts as a container for arbitrary expressions in certain syntactic constructs, where ambiguity or syntax errors would otherwise occur.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Grouping operator")}}
+{{InteractiveExample("JavaScript Demo: Grouping operator")}}
 
 ```js interactive-example
 console.log(1 + 2 * 3); // 1 + 6

--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -11,7 +11,7 @@ The **`in`** operator returns `true` if the specified property is in the specifi
 
 The `in` operator cannot be used to search for values in other collections. To test if a certain value exists in an array, use {{jsxref("Array.prototype.includes()")}}. For sets, use {{jsxref("Set.prototype.has()")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - in operator")}}
+{{InteractiveExample("JavaScript Demo: in operator")}}
 
 ```js interactive-example
 const car = { make: "Honda", model: "Accord", year: 1998 };

--- a/files/en-us/web/javascript/reference/operators/increment/index.md
+++ b/files/en-us/web/javascript/reference/operators/increment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.increment
 
 The **increment (`++`)** operator increments (adds one to) its operand and returns the value before or after the increment, depending on where the operator is placed.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Increment operator")}}
+{{InteractiveExample("JavaScript Demo: Increment (++) operator")}}
 
 ```js interactive-example
 let x = 3;

--- a/files/en-us/web/javascript/reference/operators/inequality/index.md
+++ b/files/en-us/web/javascript/reference/operators/inequality/index.md
@@ -12,7 +12,7 @@ equal, returning a Boolean result.
 Unlike the [strict inequality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality) operator,
 it attempts to convert and compare operands that are of different types.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Inequality operator")}}
+{{InteractiveExample("JavaScript Demo: Inequality (!=) operator")}}
 
 ```js interactive-example
 console.log(1 != 1);

--- a/files/en-us/web/javascript/reference/operators/instanceof/index.md
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.instanceof
 
 The **`instanceof`** operator tests to see if the `prototype` property of a constructor appears anywhere in the prototype chain of an object. The return value is a boolean value. Its behavior can be customized with [`Symbol.hasInstance`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance).
 
-{{InteractiveExample("JavaScript Demo: Expressions - instanceof")}}
+{{InteractiveExample("JavaScript Demo: instanceof operator")}}
 
 ```js interactive-example
 function Car(make, model, year) {

--- a/files/en-us/web/javascript/reference/operators/left_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.left_shift
 
 The **left shift (`<<`)** operator returns a number or BigInt whose binary representation is the first operand shifted by the specified number of bits to the left. Excess bits shifted off to the left are discarded, and zero bits are shifted in from the right.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Left shift operator", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Left shift (<<) operator", "shorter")}}
 
 ```js interactive-example
 const a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.left_shift_assignment
 
 The **left shift assignment (`<<=`)** operator performs [left shift](/en-US/docs/Web/JavaScript/Reference/Operators/Left_shift) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Left shift assignment operator", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Left shift assignment (<<=) operator", "shorter")}}
 
 ```js interactive-example
 let a = 5; // 00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.less_than
 
 The **less than (`<`)** operator returns `true` if the left operand is less than the right operand, and `false` otherwise.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Less than operator")}}
+{{InteractiveExample("JavaScript Demo: Less than (<) operator")}}
 
 ```js interactive-example
 console.log(5 < 3);

--- a/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.less_than_or_equal
 
 The **less than or equal (`<=`)** operator returns `true` if the left operand is less than or equal to the right operand, and `false` otherwise.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Less than or equal operator")}}
+{{InteractiveExample("JavaScript Demo: Less than or equal (<=) operator")}}
 
 ```js interactive-example
 console.log(5 <= 3);

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -11,7 +11,7 @@ The **logical AND (`&&`)** (logical conjunction) operator for a set of boolean o
 
 More generally, the operator returns the value of the first {{Glossary("falsy")}} operand encountered when evaluating from left to right, or the value of the last operand if they are all {{Glossary("truthy")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Logical AND", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Logical AND (&&) operator", "shorter")}}
 
 ```js interactive-example
 const a = 3;

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.logical_and_assignment
 
 The **logical AND assignment (`&&=`)** operator only evaluates the right operand and assigns to the left if the left operand is {{Glossary("truthy")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Logical AND assignment")}}
+{{InteractiveExample("JavaScript Demo: Logical AND assignment (&&=) operator")}}
 
 ```js interactive-example
 let a = 1;

--- a/files/en-us/web/javascript/reference/operators/logical_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_not/index.md
@@ -12,7 +12,7 @@ falsity and vice versa. It is typically used with boolean (logical)
 values. When used with non-Boolean values, it returns `false` if its single
 operand can be converted to `true`; otherwise, returns `true`.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Logical NOT", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Logical NOT (!) operator", "shorter")}}
 
 ```js interactive-example
 const a = 3;

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.md
@@ -14,7 +14,7 @@ the `||` operator actually returns the value of one of the specified
 operands, so if this operator is used with non-Boolean values, it will return a
 non-Boolean value.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Logical OR", "shorter")}}
+{{InteractiveExample("JavaScript Demo: Logical OR (||) operator", "shorter")}}
 
 ```js interactive-example
 const a = 3;

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.logical_or_assignment
 
 The **logical OR assignment (`||=`)** operator only evaluates the right operand and assigns to the left if the left operand is {{Glossary("falsy")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Logical OR assignment")}}
+{{InteractiveExample("JavaScript Demo: Logical OR assignment (||=) operator")}}
 
 ```js interactive-example
 const a = { duration: 50, title: "" };

--- a/files/en-us/web/javascript/reference/operators/multiplication/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.multiplication
 
 The **multiplication (`*`)** operator produces the product of the operands.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Multiplication operator")}}
+{{InteractiveExample("JavaScript Demo: Multiplication (*) operator")}}
 
 ```js interactive-example
 console.log(3 * 4);

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.multiplication_assignment
 
 The **multiplication assignment (`*=`)** operator performs [multiplication](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Multiplication assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Multiplication assignment (*=) operator")}}
 
 ```js interactive-example
 let a = 2;

--- a/files/en-us/web/javascript/reference/operators/new.target/index.md
+++ b/files/en-us/web/javascript/reference/operators/new.target/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.new_target
 
 The **`new.target`** meta-property lets you detect whether a function or constructor was called using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. In constructors and functions invoked using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator, `new.target` returns a reference to the constructor or function that `new` was called upon. In normal function calls, `new.target` is {{jsxref("undefined")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - new.target")}}
+{{InteractiveExample("JavaScript Demo: new.target")}}
 
 ```js interactive-example
 function Foo() {

--- a/files/en-us/web/javascript/reference/operators/new/index.md
+++ b/files/en-us/web/javascript/reference/operators/new/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.new
 
 The **`new`** operator lets developers create an instance of a user-defined object type or of one of the built-in object types that has a constructor function.
 
-{{InteractiveExample("JavaScript Demo: Expressions - new operator")}}
+{{InteractiveExample("JavaScript Demo: new operator")}}
 
 ```js interactive-example
 function Car(make, model, year) {

--- a/files/en-us/web/javascript/reference/operators/null/index.md
+++ b/files/en-us/web/javascript/reference/operators/null/index.md
@@ -11,7 +11,7 @@ The **`null`** value represents the intentional absence of any object value. It
 is one of JavaScript's [primitive values](/en-US/docs/Glossary/Primitive) and
 is treated as [falsy](/en-US/docs/Glossary/Falsy) for boolean operations.
 
-{{InteractiveExample("JavaScript Demo: Standard built-in objects - Null")}}
+{{InteractiveExample("JavaScript Demo: null")}}
 
 ```js interactive-example
 function getVowels(str) {

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -12,7 +12,7 @@ operator that returns its right-hand side operand when its left-hand side operan
 [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, and otherwise returns its left-hand side
 operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Nullish coalescing operator")}}
+{{InteractiveExample("JavaScript Demo: Nullish coalescing (??) operator")}}
 
 ```js interactive-example
 const foo = null ?? "default string";

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.nullish_coalescing_assignment
 
 The **nullish coalescing assignment (`??=`)** operator, also known as the **logical nullish assignment** operator, only evaluates the right operand and assigns to the left if the left operand is {{Glossary("nullish")}} (`null` or `undefined`).
 
-{{InteractiveExample("JavaScript Demo: Expressions - Nullish coalescing assignment")}}
+{{InteractiveExample("JavaScript Demo: Nullish coalescing assignment (??=) operator")}}
 
 ```js interactive-example
 const a = { duration: 50 };

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.object_initializer
 
 An **object initializer** is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces (`{}`). Objects can also be initialized using [`Object.create()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) or [by invoking a constructor function](/en-US/docs/Web/JavaScript/Guide/Working_with_objects#using_a_constructor_function) with the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Object initializer", "taller")}}
+{{InteractiveExample("JavaScript Demo: Object initializer", "taller")}}
 
 ```js interactive-example
 const object1 = { a: "foo", b: 42, c: {} };

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.optional_chaining
 
 The **optional chaining (`?.`)** operator accesses an object's property or calls a function. If the object accessed or function called using this operator is {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), the expression short circuits and evaluates to {{jsxref("undefined")}} instead of throwing an error.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Optional chaining operator", "taller")}}
+{{InteractiveExample("JavaScript Demo: Optional chaining (?.) operator", "taller")}}
 
 ```js interactive-example
 const adventurer = {

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.property_accessors
 
 **Property accessors** provide access to an object's properties by using the dot notation or the bracket notation.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Property accessors", "taller")}}
+{{InteractiveExample("JavaScript Demo: Property accessors", "taller")}}
 
 ```js interactive-example
 const person1 = {};

--- a/files/en-us/web/javascript/reference/operators/remainder/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.remainder
 
 The **remainder (`%`)** operator returns the remainder left over when one operand is divided by a second operand. It always takes the sign of the dividend.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Remainder operator")}}
+{{InteractiveExample("JavaScript Demo: Remainder (%) operator")}}
 
 ```js interactive-example
 console.log(13 % 5);

--- a/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.remainder_assignment
 
 The **remainder assignment (`%=`)** operator performs [remainder](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Remainder assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Remainder assignment (%=) operator")}}
 
 ```js interactive-example
 let a = 3;

--- a/files/en-us/web/javascript/reference/operators/right_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.right_shift
 
 The **right shift (`>>`)** operator returns a number or BigInt whose binary representation is the first operand shifted by the specified number of bits to the right. Excess bits shifted off to the right are discarded, and copies of the leftmost bit are shifted in from the left. This operation is also called "sign-propagating right shift" or "arithmetic right shift", because the sign of the resulting number is the same as the sign of the first operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Right shift operator")}}
+{{InteractiveExample("JavaScript Demo: Right shift (>>) operator")}}
 
 ```js interactive-example
 const a = 5; //  00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.right_shift_assignment
 
 The **right shift assignment (`>>=`)** operator performs [right shift](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Right shift assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Right shift assignment (>>=) operator")}}
 
 ```js interactive-example
 let a = 5; //  00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -11,7 +11,7 @@ The **spread (`...`)** syntax allows an iterable, such as an array or string, to
 
 Spread syntax looks exactly like rest syntax. In a way, spread syntax is the opposite of rest syntax. Spread syntax "expands" an array into its elements, while rest syntax collects multiple elements and "condenses" them into a single element. See [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) and [rest property](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring#rest_property).
 
-{{InteractiveExample("JavaScript Demo: Expressions - Spread syntax")}}
+{{InteractiveExample("JavaScript Demo: Spread syntax (...)")}}
 
 ```js interactive-example
 function sum(x, y, z) {

--- a/files/en-us/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_equality/index.md
@@ -12,7 +12,7 @@ equal, returning a Boolean result. Unlike the [equality](/en-US/docs/Web/JavaScr
 the strict equality operator always considers operands of different types to be
 different.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Strict equality operator")}}
+{{InteractiveExample("JavaScript Demo: Strict equality (===) operator")}}
 
 ```js interactive-example
 console.log(1 === 1);

--- a/files/en-us/web/javascript/reference/operators/strict_inequality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_inequality/index.md
@@ -12,7 +12,7 @@ not equal, returning a Boolean result. Unlike the [inequality](/en-US/docs/Web/J
 operator, the strict inequality operator always considers operands of different types to
 be different.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Strict inequality operator")}}
+{{InteractiveExample("JavaScript Demo: Strict inequality (!==) operator")}}
 
 ```js interactive-example
 console.log(1 !== 1);

--- a/files/en-us/web/javascript/reference/operators/subtraction/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.subtraction
 
 The **subtraction (`-`)** operator subtracts the two operands, producing their difference.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Subtraction operator")}}
+{{InteractiveExample("JavaScript Demo: Subtraction (-) operator")}}
 
 ```js interactive-example
 console.log(5 - 3);

--- a/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.subtraction_assignment
 
 The **subtraction assignment (`-=`)** operator performs [subtraction](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Subtraction assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Subtraction assignment (-=) operator")}}
 
 ```js interactive-example
 let a = 2;

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -11,7 +11,7 @@ The **`super`** keyword is used to access properties on an object literal or cla
 
 The `super.prop` and `super[expr]` expressions are valid in any [method definition](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) in both [classes](/en-US/docs/Web/JavaScript/Reference/Classes) and [object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer). The `super(...args)` expression is valid in class constructors.
 
-{{InteractiveExample("JavaScript Demo: Expressions - super", "taller")}}
+{{InteractiveExample("JavaScript Demo: super expression", "taller")}}
 
 ```js interactive-example
 class Foo {

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -13,7 +13,7 @@ The value of `this` in JavaScript depends on how a function is invoked (runtime 
 
 [Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) differ in their handling of `this`: they inherit `this` from the parent scope at the time they are defined. This behavior makes arrow functions particularly useful for callbacks and preserving context. However, arrow functions do not have their own `this` binding. Therefore, their `this` value cannot be set by `bind()`, `apply()` or `call()` methods, nor does it point to the current object in object methods.
 
-{{InteractiveExample("JavaScript Demo: Expressions - this")}}
+{{InteractiveExample("JavaScript Demo: this expression")}}
 
 ```js interactive-example
 const test = {

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.typeof
 
 The **`typeof`** operator returns a string indicating the type of the operand's value.
 
-{{InteractiveExample("JavaScript Demo: Expressions - typeof")}}
+{{InteractiveExample("JavaScript Demo: typeof operator")}}
 
 ```js interactive-example
 console.log(typeof 42);

--- a/files/en-us/web/javascript/reference/operators/unary_negation/index.md
+++ b/files/en-us/web/javascript/reference/operators/unary_negation/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.unary_negation
 
 The **unary negation (`-`)** operator precedes its operand and negates it.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Unary negation operator")}}
+{{InteractiveExample("JavaScript Demo: Unary negation (-) operator")}}
 
 ```js interactive-example
 const x = 4;

--- a/files/en-us/web/javascript/reference/operators/unary_plus/index.md
+++ b/files/en-us/web/javascript/reference/operators/unary_plus/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.operators.unary_plus
 The **unary plus (`+`)** operator precedes its operand and evaluates to its
 operand but attempts to [convert it into a number](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion), if it isn't already.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Unary plus operator", "taller")}}
+{{InteractiveExample("JavaScript Demo: Unary plus (+) operator", "taller")}}
 
 ```js interactive-example
 const x = 1;

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.unsigned_right_shift
 
 The **unsigned right shift (`>>>`)** operator returns a number whose binary representation is the first operand shifted by the specified number of bits to the right. Excess bits shifted off to the right are discarded, and zero bits are shifted in from the left. This operation is also called "zero-filling right shift", because the sign bit becomes `0`, so the resulting number is always positive. Unsigned right shift does not accept [BigInt](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) values.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Unsigned right shift operator")}}
+{{InteractiveExample("JavaScript Demo: Unsigned right shift (>>>) operator")}}
 
 ```js interactive-example
 const a = 5; //  00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.unsigned_right_shift_assignment
 
 The **unsigned right shift assignment (`>>>=`)** operator performs [unsigned right shift](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift) on the two operands and assigns the result to the left operand.
 
-{{InteractiveExample("JavaScript Demo: Expressions - Unsigned right shift assignment operator")}}
+{{InteractiveExample("JavaScript Demo: Unsigned right shift assignment (>>>=) operator")}}
 
 ```js interactive-example
 let a = 5; //  00000000000000000000000000000101

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.operators.void
 The **`void`** operator evaluates the given
 `expression` and then returns {{jsxref("undefined")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - void operator", "taller")}}
+{{InteractiveExample("JavaScript Demo: void operator", "taller")}}
 
 ```js interactive-example
 const output = void 1;

--- a/files/en-us/web/javascript/reference/operators/yield/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.yield
 
 The **`yield`** operator is used to pause and resume a [generator function](/en-US/docs/Web/JavaScript/Reference/Statements/function*).
 
-{{InteractiveExample("JavaScript Demo: Expressions - yield", "taller")}}
+{{InteractiveExample("JavaScript Demo: yield operator", "taller")}}
 
 ```js interactive-example
 function* foo(index) {

--- a/files/en-us/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield_star_/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.yield_star
 
 The **`yield*`** operator can be used within generator (sync or async) functions to delegate to another [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) object, such as a {{jsxref("Generator")}}. Inside async generator functions, it can additionally be used to delegate to another async iterable object, such as an {{jsxref("AsyncGenerator")}}.
 
-{{InteractiveExample("JavaScript Demo: Expressions - yield*")}}
+{{InteractiveExample("JavaScript Demo: yield* operator")}}
 
 ```js interactive-example
 function* func1() {

--- a/files/en-us/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.regular_expressions.unicode_character_class_escape
 
 A **unicode character class escape** is a kind of [character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape) that matches a set of characters specified by a Unicode property. It's only supported in [Unicode-aware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode). When the [`v`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) flag is enabled, it can also be used to match finite-length strings.
 
-{{InteractiveExample("JavaScript Demo: RegExp Unicode property escapes", "taller")}}
+{{InteractiveExample("JavaScript Demo: Regex Unicode character class escape", "taller")}}
 
 ```js interactive-example
 const sentence = "A ticket to 大阪 costs ¥2000 👌.";

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -11,7 +11,7 @@ The **`async function`** declaration creates a {{Glossary("binding")}} of a new 
 
 You can also define async functions using the [`async function` expression](/en-US/docs/Web/JavaScript/Reference/Operators/async_function).
 
-{{InteractiveExample("JavaScript Demo: Statement - Async", "taller")}}
+{{InteractiveExample("JavaScript Demo: async function declaration", "taller")}}
 
 ```js interactive-example
 function resolveAfter2Seconds() {

--- a/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
@@ -11,7 +11,7 @@ The **`async function*`** declaration creates a {{Glossary("binding")}} of a new
 
 You can also define async generator functions using the [`async function*` expression](/en-US/docs/Web/JavaScript/Reference/Operators/async_function*).
 
-{{InteractiveExample("JavaScript Demo: Expressions - Async Function Asterisk", "taller")}}
+{{InteractiveExample("JavaScript Demo: async function* declaration", "taller")}}
 
 ```js interactive-example
 async function* foo() {

--- a/files/en-us/web/javascript/reference/statements/block/index.md
+++ b/files/en-us/web/javascript/reference/statements/block/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.block
 
 A **block statement** is used to group zero or more statements. The block is delimited by a pair of braces ("curly braces") and contains a list of zero or more statements and declarations.
 
-{{InteractiveExample("JavaScript Demo: Statement - Block", "taller")}}
+{{InteractiveExample("JavaScript Demo: Block statement", "taller")}}
 
 ```js interactive-example
 var x = 1;

--- a/files/en-us/web/javascript/reference/statements/break/index.md
+++ b/files/en-us/web/javascript/reference/statements/break/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.break
 
 The **`break`** statement terminates the current loop or {{jsxref("Statements/switch", "switch")}} statement and transfers program control to the statement following the terminated statement. It can also be used to jump past a [labeled statement](/en-US/docs/Web/JavaScript/Reference/Statements/label) when used within that labeled statement.
 
-{{InteractiveExample("JavaScript Demo: Statement - Break")}}
+{{InteractiveExample("JavaScript Demo: break statement")}}
 
 ```js interactive-example
 let i = 0;

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -11,7 +11,7 @@ The **`class`** declaration creates a {{Glossary("binding")}} of a new [class](/
 
 You can also define classes using the [`class` expression](/en-US/docs/Web/JavaScript/Reference/Operators/class).
 
-{{InteractiveExample("JavaScript Demo: Statement - Class")}}
+{{InteractiveExample("JavaScript Demo: class declaration")}}
 
 ```js interactive-example
 class Polygon {

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.const
 
 The **`const`** declaration declares block-scoped local variables. The value of a constant can't be changed through reassignment using the [assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment), but if a constant is an [object](/en-US/docs/Web/JavaScript/Guide/Data_structures#objects), its properties can be added, updated, or removed.
 
-{{InteractiveExample("JavaScript Demo: Statement - Const")}}
+{{InteractiveExample("JavaScript Demo: const declaration")}}
 
 ```js interactive-example
 const number = 42;

--- a/files/en-us/web/javascript/reference/statements/continue/index.md
+++ b/files/en-us/web/javascript/reference/statements/continue/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.continue
 
 The **`continue`** statement terminates execution of the statements in the current iteration of the current or labeled loop, and continues execution of the loop with the next iteration.
 
-{{InteractiveExample("JavaScript Demo: Statement - Continue")}}
+{{InteractiveExample("JavaScript Demo: continue statement")}}
 
 ```js interactive-example
 let text = "";

--- a/files/en-us/web/javascript/reference/statements/do...while/index.md
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.do_while
 
 The **`do...while`** statement creates a loop that executes a specified statement as long as the test condition evaluates to true. The condition is evaluated after executing the statement, resulting in the specified statement executing at least once.
 
-{{InteractiveExample("JavaScript Demo: Statement - Do...While")}}
+{{InteractiveExample("JavaScript Demo: do...while statement")}}
 
 ```js interactive-example
 let result = "";

--- a/files/en-us/web/javascript/reference/statements/empty/index.md
+++ b/files/en-us/web/javascript/reference/statements/empty/index.md
@@ -10,7 +10,7 @@ browser-compat: javascript.statements.empty
 An **empty statement** is used to provide no statement, although the
 JavaScript syntax would expect one.
 
-{{InteractiveExample("JavaScript Demo: Statement - Empty")}}
+{{InteractiveExample("JavaScript Demo: Empty statement")}}
 
 ```js interactive-example
 const array1 = [1, 2, 3];

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.for_await_of
 
 The **`for await...of`** statement creates a loop iterating over [async iterable objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) as well as [sync iterables](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol). This statement can only be used in contexts where [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) can be used, which includes inside an [async function](/en-US/docs/Web/JavaScript/Reference/Statements/async_function) body and in a [module](/en-US/docs/Web/JavaScript/Guide/Modules).
 
-{{InteractiveExample("JavaScript Demo: Statement - For Await...Of", "taller")}}
+{{InteractiveExample("JavaScript Demo: for await...of statement", "taller")}}
 
 ```js interactive-example
 async function* foo() {

--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.for_in
 
 The **`for...in`** statement iterates over all [enumerable string properties](/en-US/docs/Web/JavaScript/Guide/Enumerability_and_ownership_of_properties) of an object (ignoring properties keyed by [symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)), including inherited enumerable properties.
 
-{{InteractiveExample("JavaScript Demo: Statement - For...In")}}
+{{InteractiveExample("JavaScript Demo: for...in statement")}}
 
 ```js interactive-example
 const object = { a: 1, b: 2, c: 3 };

--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.for_of
 
 The **`for...of`** statement executes a loop that operates on a sequence of values sourced from an [iterable object](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol). Iterable objects include instances of built-ins such as {{jsxref("Array")}}, {{jsxref("String")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}}, {{domxref("NodeList")}} (and other DOM collections), as well as the {{jsxref("Functions/arguments", "arguments")}} object, [generators](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) produced by [generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*), and user-defined iterables.
 
-{{InteractiveExample("JavaScript Demo: Statement - For...Of")}}
+{{InteractiveExample("JavaScript Demo: for...of statement")}}
 
 ```js interactive-example
 const array1 = ["a", "b", "c"];

--- a/files/en-us/web/javascript/reference/statements/for/index.md
+++ b/files/en-us/web/javascript/reference/statements/for/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.for
 
 The **`for`** statement creates a loop that consists of three optional expressions, enclosed in parentheses and separated by semicolons, followed by a statement (usually a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block)) to be executed in the loop.
 
-{{InteractiveExample("JavaScript Demo: Statement - For")}}
+{{InteractiveExample("JavaScript Demo: for statement")}}
 
 ```js interactive-example
 let str = "";

--- a/files/en-us/web/javascript/reference/statements/function/index.md
+++ b/files/en-us/web/javascript/reference/statements/function/index.md
@@ -11,7 +11,7 @@ The **`function`** declaration creates a {{Glossary("binding")}} of a new functi
 
 You can also define functions using the [`function` expression](/en-US/docs/Web/JavaScript/Reference/Operators/function).
 
-{{InteractiveExample("JavaScript Demo: Statement - Function", "shorter")}}
+{{InteractiveExample("JavaScript Demo: function declaration", "shorter")}}
 
 ```js interactive-example
 function calcRectArea(width, height) {

--- a/files/en-us/web/javascript/reference/statements/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/function_star_/index.md
@@ -11,7 +11,7 @@ The **`function*`** declaration creates a {{Glossary("binding")}} of a new gener
 
 You can also define generator functions using the [`function*` expression](/en-US/docs/Web/JavaScript/Reference/Operators/function*).
 
-{{InteractiveExample("JavaScript Demo: Statement - Function*")}}
+{{InteractiveExample("JavaScript Demo: function* declaration")}}
 
 ```js interactive-example
 function* generator(i) {

--- a/files/en-us/web/javascript/reference/statements/if...else/index.md
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.if_else
 
 The **`if...else`** statement executes a statement if a specified condition is {{Glossary("truthy")}}. If the condition is {{Glossary("falsy")}}, another statement in the optional `else` clause will be executed.
 
-{{InteractiveExample("JavaScript Demo: Statement - If...Else")}}
+{{InteractiveExample("JavaScript Demo: if...else statement")}}
 
 ```js interactive-example
 function testNum(a) {

--- a/files/en-us/web/javascript/reference/statements/label/index.md
+++ b/files/en-us/web/javascript/reference/statements/label/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.label
 
 A **labeled statement** is any [statement](/en-US/docs/Web/JavaScript/Reference/Statements) that is prefixed with an identifier. You can jump to this label using a {{jsxref("Statements/break", "break")}} or {{jsxref("Statements/continue", "continue")}} statement nested within the labeled statement.
 
-{{InteractiveExample("JavaScript Demo: Statement - Label")}}
+{{InteractiveExample("JavaScript Demo: Labeled statement")}}
 
 ```js interactive-example
 let str = "";

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.let
 
 The **`let`** declaration declares re-assignable, block-scoped local variables, optionally initializing each to a value.
 
-{{InteractiveExample("JavaScript Demo: Statement - Let")}}
+{{InteractiveExample("JavaScript Demo: let declaration")}}
 
 ```js interactive-example
 let x = 1;

--- a/files/en-us/web/javascript/reference/statements/return/index.md
+++ b/files/en-us/web/javascript/reference/statements/return/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.return
 
 The **`return`** statement ends function execution and specifies a value to be returned to the function caller.
 
-{{InteractiveExample("JavaScript Demo: Statement - Return")}}
+{{InteractiveExample("JavaScript Demo: return statement")}}
 
 ```js interactive-example
 function getRectArea(width, height) {

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.switch
 
 The **`switch`** statement evaluates an [expression](/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators), matching the expression's value against a series of `case` clauses, and executes [statements](/en-US/docs/Web/JavaScript/Reference/Statements) after the first `case` clause with a matching value, until a `break` statement is encountered. The `default` clause of a `switch` statement will be jumped to if no `case` matches the expression's value.
 
-{{InteractiveExample("JavaScript Demo: Statement - Switch", "taller")}}
+{{InteractiveExample("JavaScript Demo: switch statement", "taller")}}
 
 ```js interactive-example
 const expr = "Papayas";

--- a/files/en-us/web/javascript/reference/statements/throw/index.md
+++ b/files/en-us/web/javascript/reference/statements/throw/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.throw
 
 The **`throw`** statement throws a user-defined exception. Execution of the current function will stop (the statements after `throw` won't be executed), and control will be passed to the first [`catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block in the call stack. If no `catch` block exists among caller functions, the program will terminate.
 
-{{InteractiveExample("JavaScript Demo: Statement - Throw")}}
+{{InteractiveExample("JavaScript Demo: throw statement")}}
 
 ```js interactive-example
 function getRectArea(width, height) {

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.try_catch
 
 The **`try...catch`** statement is comprised of a `try` block and either a `catch` block, a `finally` block, or both. The code in the `try` block is executed first, and if it throws an exception, the code in the `catch` block will be executed. The code in the `finally` block will always be executed before control flow exits the entire construct.
 
-{{InteractiveExample("JavaScript Demo: Statement - Try...Catch")}}
+{{InteractiveExample("JavaScript Demo: try...catch statement")}}
 
 ```js interactive-example
 try {

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.var
 
 The **`var`** statement declares function-scoped or globally-scoped variables, optionally initializing each to a value.
 
-{{InteractiveExample("JavaScript Demo: Statement - Var")}}
+{{InteractiveExample("JavaScript Demo: var statement")}}
 
 ```js interactive-example
 var x = 1;

--- a/files/en-us/web/javascript/reference/statements/while/index.md
+++ b/files/en-us/web/javascript/reference/statements/while/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.statements.while
 
 The **`while`** statement creates a loop that executes a specified statement as long as the test condition evaluates to true. The condition is evaluated before executing the statement.
 
-{{InteractiveExample("JavaScript Demo: Statement - While")}}
+{{InteractiveExample("JavaScript Demo: while statement")}}
 
 ```js interactive-example
 let n = 0;


### PR DESCRIPTION
I am writing page templates for JS docs, and I noticed that interactive examples aren't consistent. This gives them consistent titles. The PR is big, but most changes should be skimmable.