### PR TITLE
Fix capitalization on Intl.NumberFormat

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -159,11 +159,11 @@ The following properties are also supported by {{jsxref("Intl.PluralRules")}}.
     - `"floor"`
       - : Round toward -∞. Positive values round down. Negative values round "more negative".
     - `"expand"`
-      - : round away from 0. The _magnitude_ of the value is always increased by rounding. Positive values round up. Negative values round "more negative".
+      - : Round away from 0. The _magnitude_ of the value is always increased by rounding. Positive values round up. Negative values round "more negative".
     - `"trunc"`
       - : Round toward 0. This _magnitude_ of the value is always reduced by rounding. Positive values round down. Negative values round "less negative".
     - `"halfCeil"`
-      - : ties toward +∞. Values above the half-increment round like `"ceil"` (towards +∞), and below like `"floor"` (towards -∞). On the half-increment, values round like `"ceil"`.
+      - : Ties toward +∞. Values above the half-increment round like `"ceil"` (towards +∞), and below like `"floor"` (towards -∞). On the half-increment, values round like `"ceil"`.
     - `"halfFloor"`
       - : Ties toward -∞. Values above the half-increment round like `"ceil"` (towards +∞), and below like `"floor"` (towards -∞). On the half-increment, values round like `"floor"`.
     - `"halfExpand"` (default)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I noticed a few spots weren't capitalized on the Intl.NumberFormat docs, so I fixed them.

### Motivation

It makes the documents more consistent and correct.

### Additional details

n/a

### Related issues and pull requests

n/a

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
