### PR TITLE
fix(ci): fix URL RXs in linters

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -208,7 +208,7 @@
       {
         "name": "un-closed-md-link",
         "message": "Missing closing bracket ')'",
-        "searchPattern": "/(\\[[^\\]]*?\\]\\(([^\\)\\n]|\\([^\\)\\n]\\)|\\s[\"'])+?)(\\n|\\s|[,:][\\s\\n])/gm",
+        "searchPattern": "/\\[[^\\]]*?\\]\\(([^ )\n\",:])+?([\n,:\"]| \\w| [\"'][^\"']+?[\"'][^)])/gm",
         "searchScope": "text",
       },
       {

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -208,7 +208,7 @@
       {
         "name": "un-closed-md-link",
         "message": "Missing closing bracket ')'",
-        "searchPattern": "/\\[[^\\]]*?\\]\\(([^ )\n\",:])+?([\n,:\"]| \\w| [\"'][^\"']+?[\"'][^)])/gm",
+        "searchPattern": "/\\[.*?\\]\\([^ )\\n\",:]+(?:[\\n\",:]| [^\"']| [\"'].+?[\"'][^)])/gm",
         "searchScope": "text",
       },
       {

--- a/scripts/log-url-issues.js
+++ b/scripts/log-url-issues.js
@@ -189,12 +189,12 @@ for await (const filePath of walkSync(rootDir)) {
 
       // check broken URL fragment
       for (const fragment of deletedFragmentDetails) {
-        const locations = getLocations(content, `${fragment}( "|[\)])`);
+        const locations = getLocations(content, `${fragment}(?: "|\\))`);
         // check fragments in the same file
         const urlParts = fragment.split("#");
         if (filePath.includes(`${urlParts[0]}/index.md`)) {
           locations.push(
-            ...getLocations(content, `[(]#${urlParts[1]}( "|[\)])`),
+            ...getLocations(content, `\\(#${urlParts[1]}(?: "|\\))`),
           );
         }
         if (locations.length) {

--- a/scripts/log-url-issues.js
+++ b/scripts/log-url-issues.js
@@ -189,11 +189,13 @@ for await (const filePath of walkSync(rootDir)) {
 
       // check broken URL fragment
       for (const fragment of deletedFragmentDetails) {
-        const locations = getLocations(content, fragment);
+        const locations = getLocations(content, `${fragment}( "|[\)])`);
         // check fragments in the same file
         const urlParts = fragment.split("#");
         if (filePath.includes(`${urlParts[0]}/index.md`)) {
-          locations.push(...getLocations(content, `[(]#${urlParts[1]}`));
+          locations.push(
+            ...getLocations(content, `[(]#${urlParts[1]}( "|[\)])`),
+          );
         }
         if (locations.length) {
           isAllOk = false;


### PR DESCRIPTION
## Issues

1. URL checker flags `#stack_and_execution_contexts` when `## Stack` header is changed to `##Stack and execution contexts`.
2. In markdownlint search-replace the "un-clossed-md-link" rule flags valid URLs with description, e.g., `[abcd efg](/en-us/abcd "desc")`

## Solution

1. In log-url-issues.js file, make the fragment matching RXes closed ended with `${fragment}( "|[\)])`.
2. Update search update RX to handle `[\"'][^\"']+?[\"'][^)]`.
	```log
    The new RX flags:
    [abcd efg](/en-us/abcd
    [abcd efg](/en-us/abcd ac
    [abcd efg](/en-us/abcd, ac
    [abcd efg](/en-us/abcd: ac
    [abcd efg](/en-us/abcd "desc" ac
    [abcd efg](/en-us/abcd"abc" ac

    and allows:
    [abcd efg](/en-us/abcd)
    [abcd efg](/en-us/abcd) ac
    [abcd efg](/en-us/abcd): ac
    [abcd efg](/en-us/abcd), ac
    [abcd efg](/en-us/abcd "desc") ac
    [abcd efg](/en-us/abcd 'desc') ac
    [abcd efg](/en-us/abcd "desc")
    ```

