### PR TITLE
Advise checking WheelEvent.deltaMode before WheelEvent.delta*

### DIFF
--- a/files/en-us/web/api/wheelevent/deltamode/index.md
+++ b/files/en-us/web/api/wheelevent/deltamode/index.md
@@ -18,6 +18,8 @@ Permitted values are:
 | `DOM_DELTA_LINE`  | `0x01` | The delta values are specified in lines.  |
 | `DOM_DELTA_PAGE`  | `0x02` | The delta values are specified in pages.  |
 
+You must check the `deltaMode` property to determine the unit of the `deltaX`, `deltaY`, and `deltaZ` values. Do not assume that those values are specified in pixels. Some browsers, for compatibility reasons, may return different units for the `delta*` values depending on whether `deltaMode` has been accessed, to accommodate for websites not explicitly checking the `deltaMode` property.
+
 ## Value
 
 An `unsigned long`.

--- a/files/en-us/web/api/wheelevent/deltax/index.md
+++ b/files/en-us/web/api/wheelevent/deltax/index.md
@@ -12,6 +12,8 @@ The **`WheelEvent.deltaX`** read-only property is a
 `double` representing the horizontal scroll amount in the
 {{domxref("WheelEvent.deltaMode")}} unit.
 
+You must check the `deltaMode` property to determine the unit of the `deltaX` value. Do not assume that the `deltaX` value is specified in pixels. Some browsers, for compatibility reasons, may return different units for the `deltaX` value depending on whether `deltaMode` has been accessed, to accommodate for websites not explicitly checking the `deltaMode` property.
+
 ## Value
 
 A number.

--- a/files/en-us/web/api/wheelevent/deltay/index.md
+++ b/files/en-us/web/api/wheelevent/deltay/index.md
@@ -12,6 +12,8 @@ The **`WheelEvent.deltaY`** read-only property is a
 `double` representing the vertical scroll amount in the
 {{domxref("WheelEvent.deltaMode")}} unit.
 
+You must check the `deltaMode` property to determine the unit of the `deltaY` value. Do not assume that the `deltaY` value is specified in pixels. Some browsers, for compatibility reasons, may return different units for the `deltaY` value depending on whether `deltaMode` has been accessed, to accommodate for websites not explicitly checking the `deltaMode` property.
+
 ## Value
 
 A number.

--- a/files/en-us/web/api/wheelevent/deltaz/index.md
+++ b/files/en-us/web/api/wheelevent/deltaz/index.md
@@ -12,6 +12,8 @@ The **`WheelEvent.deltaZ`** read-only property is a
 `double` representing the scroll amount along the z-axis, in the
 {{domxref("WheelEvent.deltaMode")}} unit.
 
+You must check the `deltaMode` property to determine the unit of the `deltaZ` value. Do not assume that the `deltaZ` value is specified in pixels. Some browsers, for compatibility reasons, may return different units for the `deltaZ` value depending on whether `deltaMode` has been accessed, to accommodate for websites not explicitly checking the `deltaMode` property.
+
 ## Value
 
 A number.

--- a/files/en-us/web/api/wheelevent/index.md
+++ b/files/en-us/web/api/wheelevent/index.md
@@ -36,15 +36,7 @@ _This interface inherits properties from its ancestors, {{DOMxRef("MouseEvent")}
 - {{DOMxRef("WheelEvent.deltaZ")}} {{ReadOnlyInline}}
   - : Returns a `double` representing the scroll amount for the z-axis.
 - {{DOMxRef("WheelEvent.deltaMode")}} {{ReadOnlyInline}}
-
-  - : Returns an `unsigned long` representing the unit of the `delta*` values' scroll amount. Permitted values are:
-
-    | Constant                     | Value  | Description                                                                                                                                                  |
-    | ---------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-    | `WheelEvent.DOM_DELTA_PIXEL` | `0x00` | The `delta*` values are specified in pixels.                                                                                                                 |
-    | `WheelEvent.DOM_DELTA_LINE`  | `0x01` | The `delta*` values are specified in lines. Each mouse click scrolls a line of content, where the method used to calculate line height is browser dependent. |
-    | `WheelEvent.DOM_DELTA_PAGE`  | `0x02` | The `delta*` values are specified in pages. Each mouse click scrolls a page of content.                                                                      |
-
+  - : Returns an `unsigned long` representing the unit of the `delta*` values' scroll amount.
 - {{DOMxRef("WheelEvent.wheelDelta")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns an integer (32-bit) representing the distance in pixels.
 - {{DOMxRef("WheelEvent.wheelDeltaX")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/11811. Instead of adding BCD and properly documenting it as a compat issue, I'm just asking users to always explicitly check `deltaMode`, which would mitigate the initial problem that this quirk fixes.