### PR TITLE
Fix markdownlint un-closed-md-link check

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -208,7 +208,7 @@
       {
         "name": "un-closed-md-link",
         "message": "Missing closing bracket ')'",
-        "searchPattern": "/\\[.*?\\]\\([^ )\\n\",:]+(?:[\\n\",:]| [^\"']| [\"'].+?[\"'][^)])/gm",
+        "searchPattern": "/\\[.*?\\]\\([^ )\\n\"]+(?:[\\n\"]| [^\"']| [\"'].+?[\"'][^)])/gm",
         "searchScope": "text",
       },
       {


### PR DESCRIPTION
https://github.com/mdn/content/pull/38540 accidentally borked the rule because it's now flagging all external links which contain `:`. I don't think `:` and `,` are special within links anyway.

cc @OnkarRuikar 