### PR TITLE
Fix incorrect composite transformation description

### DIFF
--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -163,9 +163,9 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
-- With `replace`, the final effect value for the `transform` property in the `0%, 20%` keyframe is `translateX(100px)` (completely replacing the underlying value `translateX(30px) rotate(45deg)`). In this case, the element rotates from 45deg to 0deg as it animates from the default value set on the element itself to the non-rotated value set at the 0% mark. This is the default behavior.
-- With `add`, the final effect value for the `transform` property in the `0%, 20%` keyframe is `translateX(30px) rotate(45deg)` followed by `translateX(100px)`. So the element is moved `30px` to the right, rotated `45deg`, then translated `100px` more along the redirected X axis.
-- With `accumulate`, the final effect value in the `0%, 20%` keyframe is `translateX(130px) rotate(45deg)`. This means that the two X-axis translation values of `30px` and `100px` are combined or "accumulated".
+- With `replace`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(100px)` (completely replacing the underlying value `translateX(30px) rotate(45deg)`). In this case, the element rotates from 45deg to 0deg as it animates from the default value set on the element itself to the non-rotated value set at the 20% mark. This is the default behavior.
+- With `add`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(30px) rotate(45deg) translateX(100px)`. So the element is first moved 100px to the right, rotated 45deg around the origin, then moved to the right by 30px.
+- With `accumulate`, the final effect value in the `20%, 40%` keyframe is `translateX(130px) rotate(45deg)`. This means that the two X-axis translation values of `30px` and `100px` are combined or "accumulated".
 
 ## Specifications
 


### PR DESCRIPTION
### Description

This change fixes an inaccurate composite transformation description for
an example. Additionally the percentages mentioned in the description
didn't match what was used in the at-rule, so those were changed as well
to reflect the actual keyframes.


### Motivation

While the description "matched" what the animation displays, it isn't
what happens under the hood when the transformations are applied, and
could confuse readers unfamiliar with chaining transforms. Specifically
the order described was incorrect as transforms are applied right to
left. Additionally the description said that the element was translated
along the "redirected X axis" which is misleading as rotate
transformations do not change an element's X axis orientation.

### Related issues and pull requests

Fixes #38537