### PR TITLE
FF137 Relnote: SVGPathSegment path data API

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1682,46 +1682,6 @@ Notifications have the [`requireInteraction`](/en-US/docs/Web/API/Notification/r
   </tbody>
 </table>
 
-### SVG path API methods
-
-The `SVGPathSegment` interface now supports the `getPathData()`, `setPathData()`, and `getPathSegmentAtLength()` methods. These methods provide a convenient way to work with SVG path data instead of parsing raw string data. ([Firefox bug 1934525](https://bugzil.la/1934525)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>136</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.svg.pathSegment.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## Security and privacy
 
 ### Block plain text requests from Flash on encrypted pages

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -47,6 +47,8 @@ This article provides information about the changes in Firefox 137 that affect d
 
 ### APIs
 
+- The {{domxref("SVGPathSegment/getPathData","getPathData()")}}, {{domxref("SVGPathSegment/setPathData","setPathData()")}}, and {{domxref("SVGPathSegment/getPathSegmentAtLength","getPathSegmentAtLength()")}} methods of the {{domxref("SVGPathSegment")}} interface are now supported. These methods provide a convenient way to work with SVG path data instead of parsing raw string data. ([Firefox bug 1945312](https://bugzil.la/1945312)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF137 adds support for `SVGPathSegment.getPathData()`, `SVGPathSegment.setPathData()`, and `SVGPathSegment.segmentAtLength()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1945312

This adds a release note and removes from experimental features. The note is is just copied from the experimental feature - I don't know anything else special to say about this.

Note that this introduced broken links, which should be fixed when @pepelsbey does the docs in #37940

Related docs work can be tracked in #38408