### PR TITLE
fix: Flexbox Aligning items on the cross axis example

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -96,7 +96,6 @@ In the example below, the value of `align-items` is `stretch`. Try the other val
 
 .box div {
   width: 100px;
-  height: 100px;
   background-color: rgb(96 139 168 / 0.2);
   border: 2px solid rgb(96 139 168);
   border-radius: 5px;


### PR DESCRIPTION
Fixed the "Aligning items on the cross axis" example (thanks to @ Takatin for pointing this out in MDN discord community), by removing the height for the `.box div`.

