### PR TITLE
Editorial review: Document GPUDevice.adapterInfo property

### DIFF
--- a/files/en-us/web/api/gpuadapter/info/index.md
+++ b/files/en-us/web/api/gpuadapter/info/index.md
@@ -13,13 +13,13 @@ browser-compat: api.GPUAdapter.info
 The **`info`** read-only property of the
 {{domxref("GPUAdapter")}} interface returns a {{domxref("GPUAdapterInfo")}} object containing identifying information about the adapter.
 
-The intention behind this property is to allow developers to request specific details about the user's GPU so that they can preemptively apply workarounds for GPU-specific bugs, or provide different codepaths to better suit different GPU architectures. Providing such information does present a security risk — it could be used for fingerprinting — therefore the information shared is to be kept at a minimum, and different browser vendors are likely to share different information types and granularities.
-
 ## Value
 
 A {{domxref("GPUAdapterInfo")}} object instance.
 
 ## Examples
+
+### Basic info usage
 
 ```js
 const adapter = await navigator.gpu.requestAdapter();

--- a/files/en-us/web/api/gpuadapterinfo/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GPUAdapterInfo
 
 The **`GPUAdapterInfo`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} contains identifying information about a {{domxref("GPUAdapter")}}.
 
-An adapter's `GPUAdapterInfo` can retrieved using the {{domxref("GPUAdapter.info")}} property of the adapter itself, or the {{domxref("GPUDevice.adapterInfo")}} property of a device that originated from the adapter.
+An adapter's `GPUAdapterInfo` can be retrieved using the {{domxref("GPUAdapter.info")}} property of the adapter itself, or the {{domxref("GPUDevice.adapterInfo")}} property of a device that originated from the adapter.
 
 This object allows developers to access specific details about the user's GPU so that they can preemptively apply workarounds for GPU-specific bugs, or provide different codepaths to better suit different GPU architectures. Providing such information does present a security risk — it could be used for fingerprinting — therefore the information shared is kept at a minimum, and different browser vendors are likely to share different information types and granularities.
 

--- a/files/en-us/web/api/gpuadapterinfo/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/index.md
@@ -11,7 +11,9 @@ browser-compat: api.GPUAdapterInfo
 
 The **`GPUAdapterInfo`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} contains identifying information about a {{domxref("GPUAdapter")}}.
 
-A `GPUAdapterInfo` object instance is retrieved using the {{domxref("GPUAdapter.info")}} property.
+An adapter's `GPUAdapterInfo` can retrieved using the {{domxref("GPUAdapter.info")}} property of the adapter itself, or the {{domxref("GPUDevice.adapterInfo")}} property of a device that originated from the adapter.
+
+This object allows developers to access specific details about the user's GPU so that they can preemptively apply workarounds for GPU-specific bugs, or provide different codepaths to better suit different GPU architectures. Providing such information does present a security risk — it could be used for fingerprinting — therefore the information shared is kept at a minimum, and different browser vendors are likely to share different information types and granularities.
 
 {{InheritanceDiagram}}
 
@@ -28,6 +30,8 @@ A `GPUAdapterInfo` object instance is retrieved using the {{domxref("GPUAdapter.
 
 ## Examples
 
+### Access GPUAdapterInfo via GPUAdapter.info
+
 ```js
 const adapter = await navigator.gpu.requestAdapter();
 if (!adapter) {
@@ -37,6 +41,27 @@ if (!adapter) {
 const adapterInfo = adapter.info;
 console.log(adapterInfo.vendor);
 console.log(adapterInfo.architecture);
+```
+
+### Access GPUAdapterInfo via GPUDevice.adapterInfo
+
+```js
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
+}
+
+const myDevice = await adapter.requestDevice();
+
+function optimizeForGpuDevice(device) {
+  if (device.adapterInfo.vendor === "amd") {
+    // Use AMD-specific optimizations
+  } else if (device.adapterInfo.architecture.includes("turing")) {
+    // Optimize for NVIDIA Turing architecture
+  }
+}
+
+optimizeForGpuDevice(myDevice);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpudevice/adapterinfo/index.md
+++ b/files/en-us/web/api/gpudevice/adapterinfo/index.md
@@ -1,0 +1,55 @@
+---
+title: "GPUDevice: adapterInfo property"
+short-title: adapterInfo
+slug: Web/API/GPUDevice/adapterInfo
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.GPUDevice.adapterInfo
+---
+
+{{APIRef("WebGPU API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+The **`adapterInfo`** read-only property of the
+{{domxref("GPUDevice")}} interface returns a {{domxref("GPUAdapterInfo")}} object containing identifying information about the device's originating adapter.
+
+Using `GPUDevice.adapterInfo` to retrieve an adapter's info is often preferred to accessing {{domxref("GPUAdapter.info")}} on the adapter itself, as it means the user has to share less information with the app.
+
+## Value
+
+A {{domxref("GPUAdapterInfo")}} object instance.
+
+## Examples
+
+### Basic adapterInfo usage
+
+```js
+const adapter = await navigator.gpu.requestAdapter();
+if (!adapter) {
+  throw Error("Couldn't request WebGPU adapter.");
+}
+
+const myDevice = await adapter.requestDevice();
+
+function optimizeForGpuDevice(device) {
+  if (device.adapterInfo.vendor === "amd") {
+    // Use AMD-specific optimizations
+  } else if (device.adapterInfo.architecture.includes("turing")) {
+    // Optimize for NVIDIA Turing architecture
+  }
+}
+
+optimizeForGpuDevice(myDevice);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The [WebGPU API](/en-US/docs/Web/API/WebGPU_API)

--- a/files/en-us/web/api/gpudevice/adapterinfo/index.md
+++ b/files/en-us/web/api/gpudevice/adapterinfo/index.md
@@ -13,8 +13,6 @@ browser-compat: api.GPUDevice.adapterInfo
 The **`adapterInfo`** read-only property of the
 {{domxref("GPUDevice")}} interface returns a {{domxref("GPUAdapterInfo")}} object containing identifying information about the device's originating adapter.
 
-Using `GPUDevice.adapterInfo` to retrieve an adapter's info is often preferred to accessing {{domxref("GPUAdapter.info")}} on the adapter itself, as it means the user has to share less information with the app.
-
 ## Value
 
 A {{domxref("GPUAdapterInfo")}} object instance.

--- a/files/en-us/web/api/gpudevice/index.md
+++ b/files/en-us/web/api/gpudevice/index.md
@@ -19,6 +19,10 @@ A `GPUDevice` object is requested using the {{domxref("GPUAdapter.requestDevice(
 
 _Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
 
+- {{domxref("GPUDevice.adapterInfo", "adapterInfo")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+
+  - : A {{domxref("GPUAdapterInfo")}} object containing identifying information about the device's originating adapter.
+
 - {{domxref("GPUDevice.features", "features")}} {{Experimental_Inline}} {{ReadOnlyInline}}
 
   - : A {{domxref("GPUSupportedFeatures")}} object that describes additional functionality supported by the device.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 132 supports the `GPUDevice.adapterInfo` property. See https://developer.chrome.com/blog/new-in-webgpu-132#gpudevice_adapterinfo_attribute and https://chromestatus.com/feature/6221851301511168 for info.

This PR documents the new property and adjusts some of the surrounding info as appropriate.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/38363

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
