### PR TITLE
chore: cache Prettier runs in lintstaged config

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -4,13 +4,13 @@ export default {
     `yarn content validate-redirects en-US`,
   ],
   "!*.md": (filenames) => [
-    `prettier --ignore-unknown --write ${filenames.join(" ")}`,
+    `prettier --ignore-unknown --write --cache ${filenames.join(" ")}`,
   ],
   "*.md": (filenames) => [
     `markdownlint-cli2 --fix ${filenames.join(" ")}`,
     `node scripts/front-matter_linter.js --fix true  ${filenames.join(" ")}`,
     `node scripts/update-moved-file-links.js --check`,
-    `prettier --write ${filenames.join(" ")}`,
+    `prettier --write --cache ${filenames.join(" ")}`,
   ],
   "tests/**/*.*": (filenames) => [`yarn test:front-matter-linter`],
   "*.{svg,png,jpeg,jpg,gif}": (filenames) => [


### PR DESCRIPTION
### Description

We're looking at using Lefthook for precommit hooks, but while we're at it, cache Prettier runs by `content` due to slow execution times during content moves.

__docs:__

* https://prettier.io/docs/cli#--cache

>(if --cache-strategy is `metadata`) file metadata, such as timestamps
>(if --cache-strategy is `content`) content of the file

And `--cache-strategy`:

>In general, metadata is faster. However, content is useful for updating the timestamp without changing the file content. This can happen, for example, during git operations such as git clone, because it does not track file modification times.
>
>If no strategy is specified, `content` will be used.


__Related issues and PRs:__

- [ ] https://github.com/mdn/content/pull/38399