### PR TITLE
Mention lowercase doctype in style guide

### DIFF
--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -29,8 +29,6 @@ You should use the HTML5 {{Glossary("Doctype", "doctype")}}.
 ```html example-good
 <!doctype html>
 ```
-> [!NOTE]  
-> The <!doctype html> declaration is case-insensitive and is commonly written as <!DOCTYPE html>.
 
 ### Document language
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -27,7 +27,7 @@ Prettier formats all the code and keeps the style consistent. Nevertheless, ther
 You should use the HTML5 doctype. It is short, easy to remember, and backwards compatible.
 
 ```html example-good
-<!doctype html>
+<!DOCTYPE html>
 ```
 
 ### Document language

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -24,13 +24,13 @@ Prettier formats all the code and keeps the style consistent. Nevertheless, ther
 
 ### Doctype
 
-You should use the HTML5 doctype. It is short, easy to remember, and backwards compatible.
+You should use the HTML5 {{Glossary("Doctype", "doctype")}}.
 
 ```html example-good
 <!doctype html>
 ```
 > [!NOTE]  
-> The doctype declaration (`<!doctype html>`) is case-insensitive. While MDN follows the convention of using lowercase, it is also commonly written as `<!DOCTYPE html>`.  
+> The <!doctype html> declaration is case-insensitive and is commonly written as <!DOCTYPE html>.
 
 ### Document language
 
@@ -92,9 +92,9 @@ This is perfectly understandable and works fine. If a boolean HTML attribute is 
 <input required="required" />
 ```
 
-## Case
+## Casing convention on MDN
 
-Use lowercase for all element names and attribute names/values because it looks neater and means you can write markup faster. For example:
+Use lowercase for all HTML tags, including the doctype declaration, element names, and attribute names/values, which are case-insensitive. This creates a consistent appearance and allows for faster markup writing. This convention applies to all case-insensitive contexts.
 
 ```html example-good
 <p class="nice">This looks nice and neat</p>

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -27,8 +27,10 @@ Prettier formats all the code and keeps the style consistent. Nevertheless, ther
 You should use the HTML5 doctype. It is short, easy to remember, and backwards compatible.
 
 ```html example-good
-<!DOCTYPE html>
+<!doctype html>
 ```
+> [!NOTE]  
+> The doctype declaration (`<!doctype html>`) is case-insensitive. While MDN follows the convention of using lowercase, it is also commonly written as `<!DOCTYPE html>`.  
 
 ### Document language
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -94,7 +94,7 @@ This is perfectly understandable and works fine. If a boolean HTML attribute is 
 
 ## Casing convention on MDN
 
-Use lowercase for all HTML tags, including the doctype declaration, element names, and attribute names/values, which are case-insensitive. This creates a consistent appearance and allows for faster markup writing. This convention applies to all case-insensitive contexts.
+Use lowercase for all case-insensitive constructs, including the doctype declaration, element names, and attribute names/values. This creates a consistent appearance and allows for faster markup writing.
 
 ```html example-good
 <p class="nice">This looks nice and neat</p>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
Updated the <!doctype html> declaration to <!DOCTYPE html> in the HTML Code Style Guide to align with standard conventions and best practices.

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
The uppercase <!DOCTYPE html> is the widely accepted format for declaring the document type in HTML5. Ensuring consistency helps avoid confusion among readers and follows best coding practices.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
