### PR TITLE
fix(html): Update decimal value guidance when step size is 1

### DIFF
--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -164,14 +164,11 @@ In this updated version, you should find that the up and down step buttons will 
 
 ### Allowing decimal values
 
-One issue with number inputs is that their step size is 1 by default. If you try to enter a number with a decimal (such as "1.1"), it will be considered invalid. If you want to enter a value that requires decimals, you'll need to reflect this in the `step` value (e.g. `step="0.01"` to allow decimals to two decimal places). Here's a basic example:
+One issue with number inputs is that their step size is 1 by default. If you try to enter a number with a decimal value that's not a whole number (such as "1.1"), it will be considered invalid. Note that values like "1.0" are considered valid because they are numerically equivalent to whole numbers. If you want to enter values with fractions, you'll need to reflect this in the `step` value (e.g., `step="0.01"` to allow decimals to two decimal places). Here's a basic example:
 
 ```html
 <input type="number" placeholder="1.0" step="0.01" min="0" max="10" />
 ```
-
-> [!NOTE]
-> When step size is 1, decimal values like "1.0" are considered valid.
 
 {{EmbedLiveSample("Allowing_decimal_values", 600, 40)}}
 

--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -164,11 +164,14 @@ In this updated version, you should find that the up and down step buttons will 
 
 ### Allowing decimal values
 
-One issue with number inputs is that their step size is 1 by default. If you try to enter a number with a decimal (such as "1.0"), it will be considered invalid. If you want to enter a value that requires decimals, you'll need to reflect this in the `step` value (e.g. `step="0.01"` to allow decimals to two decimal places). Here's a basic example:
+One issue with number inputs is that their step size is 1 by default. If you try to enter a number with a decimal (such as "1.1"), it will be considered invalid. If you want to enter a value that requires decimals, you'll need to reflect this in the `step` value (e.g. `step="0.01"` to allow decimals to two decimal places). Here's a basic example:
 
 ```html
 <input type="number" placeholder="1.0" step="0.01" min="0" max="10" />
 ```
+
+> [!NOTE]
+> When step size is 1, decimal values like "1.0" are considered valid.
 
 {{EmbedLiveSample("Allowing_decimal_values", 600, 40)}}
 


### PR DESCRIPTION
When step size is 1 values like "5.0" are considered valid.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added a Note that makes it clear that not all decimal values are invalid when step size is 1 for an input number type tag.
Values that have a decimal point followed by zero are valid. For example: "5.0"

### Reproduce

```html
<input type="number" value="1.0"  step="1" min="0" max="10" />

```

```js
console.log(document.querySelector('input').reportValidity())
```

### Motivation

I have an app that is using a number input tag. In JavaScript I was calling the `reportValidity` method on that tag then I saw values like "50.0" being considered valid. Then I visited MDN to check the documentation and I came accross [this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#allowing_decimal_values) 

> One issue with number inputs is that their step size is 1 by default. If you try to enter a number with a decimal (such as "1.0"), it will be considered invalid.

which is a bit misleading.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
