### PR TITLE
Documentation - using `disabled` instead of `aria-disabled` to prevent focusing on HTML elements

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-readonly/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-readonly/index.md
@@ -20,7 +20,7 @@ Examples include:
 - Row and column headers in a spreadsheet.
 - The total value in a shopping cart.
 
-If the non-changeable value shouldn't be able to receive focus, use [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) instead.
+If the non-changeable value shouldn't be able to receive focus, use [`disabled`](/en-US/docs/Web/HTML/Attributes/disabled) instead.
 
 > [!NOTE]
 > When using semantic HTML form controls, if you set the `readonly` attribute, you don't need to include `aria-readonly="true"`.


### PR DESCRIPTION
### Description
Update the incorrectly worded sentence about using `aria-disabled` so that an element cannot receive focus.

### Motivation
The difference between `disabled` and `aria-disabled` is that HTML elements with `aria-disabled` property are **still focusable**. Elements with `disabled` property will suppress all functionality, including focusing and editing.
