### PR TITLE
ci(system-file-changes): pass if author/actor is an admin

### DIFF
--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -36,7 +36,7 @@ jobs:
 
           # Check actor.
           ACTOR="${{ github.actor }}"
-          if [ "$ACTOR" !== "$AUTHOR" ]; then
+          if [ "$ACTOR" != "$AUTHOR" ]; then
             ACTOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR/permission --jq .permission)  
 
             if [ "$ACTOR_PERMISSION" != "admin"]; then

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/**"
       - package.json
       - yarn.lock
+  pull_request:
 
 # No GITHUB_TOKEN permissions, as we don't use it.
 permissions: {}

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Block if author/actor is not an admin
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Check author.
           AUTHOR="${{ github.event.pull_request.user.login }}"

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -9,7 +9,6 @@ on:
       - "scripts/**"
       - package.json
       - yarn.lock
-  pull_request:
 
 # No GITHUB_TOKEN permissions, as we don't use it.
 permissions: {}

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Block if author/actor is not an admin
         run: |
-          // Check author.
+          # Check author.
           AUTHOR="${{ github.event.pull_request.user.login }}"
           AUTHOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$AUTHOR/permission --jq .permission)
 
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
 
-          // Check actor.
+          # Check actor.
           ACTOR="${{ github.actor }}"
           if [ "$ACTOR" !== "$AUTHOR" ]; then
             ACTOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR/permission --jq .permission)  

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -39,7 +39,7 @@ jobs:
           if [ "$ACTOR" != "$AUTHOR" ]; then
             ACTOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR/permission --jq .permission)  
 
-            if [ "$ACTOR_PERMISSION" != "admin"]; then
+            if [ "$ACTOR_PERMISSION" != "admin" ]; then
               echo "PR actor ($ACTOR) is not an admin, please ping someone for a review."
               exit 1
             fi

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -20,14 +20,24 @@ jobs:
     if: github.repository_owner == 'mdn' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      # - uses: hmarr/debug-action@v2
-      - name: Stop anything and everything
+      - name: Block if author/actor is not an admin
         run: |
-          # It would be nice if we could disable this workflow if the PR
-          # was made from a branch within the origin repo. But it seems you
-          # can't do that :(
-          # See https://github.community/t/how-do-you-figure-out-if-a-pr-is-from-a-work-in-pull-request-target-workflows/170001
+          // Check author.
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          AUTHOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$AUTHOR/permission --jq .permission)
 
-          echo "If you're an admin, you have to use your admin privileges to override."
-          echo "If you're not an admin, please ping someone for a review."
-          exit 1
+          if [ "$AUTHOR_PERMISSION" != "admin" ]; then
+            echo "PR author ($AUTHOR) is not an admin, please ping someone for a review."
+            exit 1
+          fi
+
+          // Check actor.
+          ACTOR="${{ github.actor }}"
+          if [ "$ACTOR" !== "$AUTHOR" ]; then
+            ACTOR_PERMISSION=$(gh api https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR/permission --jq .permission)  
+
+            if [ "$ACTOR_PERMISSION" != "admin"]; then
+              echo "PR actor ($ACTOR) is not an admin, please ping someone for a review."
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Prevents the `system-file-changes` workflow from failing, if both PR author and actor are admin.

### Motivation

Reduces noise when admins update system files, and reduces the chances of missing other failing workflows.

### Additional details

Verified as follows:

- Temporarily added `pull_request` trigger, see: https://github.com/mdn/content/actions/runs/13838682590/job/38720221491
- Manually ran:
   ```shell
   AUTHOR="mdn-bot"
  AUTHOR_PERMISSION=$(gh api https://api.github.com/repos/mdn/content/collaborators/$AUTHOR/permission --jq .permission)
  
  if [ "$AUTHOR_PERMISSION" != "admin" ]; then
    echo "PR author ($AUTHOR) is not an admin, please ping someone for a review."
  fi
  # Output: PR author (mdn-bot) is not an admin, please ping someone for a review.
  ```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
