### PR TITLE
PublicKeyCredential: Remove NotAllowed exceptions and add security exceptions

### DIFF
--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -64,9 +64,8 @@ For example, the key `extension:appid` can be used to check if the [`appid` exte
 
 The returned {{jsxref("Promise")}} may be rejected with the following values:
 
-- `NotAllowedError` {{domxref("DOMException")}}
-  - : The Web Authentication API is not allowed in the current browsing context.
-    For example, it might be blocked by a permission policy.
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
 
 ## Description
 

--- a/files/en-us/web/api/publickeycredential/getclientextensionresults/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientextensionresults/index.md
@@ -8,13 +8,9 @@ browser-compat: api.PublicKeyCredential.getClientExtensionResults
 
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 
-The **`getClientExtensionResults()`** method of the
-{{domxref("PublicKeyCredential")}} interface returns a map between the identifiers of extensions requested during credential creation or authentication, and their results after processing by the user agent.
+The **`getClientExtensionResults()`** method of the {{domxref("PublicKeyCredential")}} interface returns a map between the identifiers of extensions requested during credential creation or authentication, and their results after processing by the user agent.
 
-During the creation or fetching of a `PublicKeyCredential` (via
-{{domxref("CredentialsContainer.create()","navigator.credentials.create()")}} and
-{{domxref("CredentialsContainer.get()","navigator.credentials.get()")}} respectively), it is possible
-to request "custom" processing by the client for different extensions, specified in the `publicKey` option's `extensions` property. You can find more information about requesting the different extensions in [Web Authentication extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions).
+During the creation or fetching of a `PublicKeyCredential` (via {{domxref("CredentialsContainer.create()","navigator.credentials.create()")}} and {{domxref("CredentialsContainer.get()","navigator.credentials.get()")}} respectively), it is possible to request "custom" processing by the client for different extensions, specified in the `publicKey` option's `extensions` property. You can find more information about requesting the different extensions in [Web Authentication extensions](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions).
 
 > **Note:** `getClientExtensionResults()` only returns the results from extensions processed by the user agent (client). The results from extensions processed by the authenticator can be found in the [authenticator data](/en-US/docs/Web/API/Web_Authentication_API/Authenticator_data) available in {{domxref("AuthenticatorAssertionResponse.authenticatorData")}}.
 
@@ -31,6 +27,11 @@ None.
 ### Return value
 
 A {{jsxref("Map", "map")}}, with each entry being an extensions' identifier string as the key, and the output from the processing of the extension by the client as the value.
+
+### Exceptions
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
 
 ## Examples
 

--- a/files/en-us/web/api/publickeycredential/isconditionalmediationavailable_static/index.md
+++ b/files/en-us/web/api/publickeycredential/isconditionalmediationavailable_static/index.md
@@ -24,6 +24,13 @@ None.
 
 A {{jsxref("Promise")}} which resolves to a boolean value indicating whether or not conditional mediation is available.
 
+### Exceptions
+
+The returned {{jsxref("Promise")}} may be rejected with the following values:
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
+
 ## Examples
 
 Before invoking a conditional WebAuthn API call, check if:

--- a/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable_static/index.md
+++ b/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable_static/index.md
@@ -31,12 +31,17 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} which resolves to a boolean value indicating whether or
-a not a user-verifying platform authenticator is available.
+A {{jsxref("Promise")}} which resolves to a boolean value indicating whether or a not a user-verifying platform authenticator is available.
 
 > [!NOTE]
-> In earlier versions of the specification, the boolean also
-> conveyed the consent of the user to disclose such an authenticator existed.
+> In earlier versions of the specification, the boolean also conveyed the consent of the user to disclose such an authenticator existed.
+
+### Exceptions
+
+The returned {{jsxref("Promise")}} may be rejected with the following values:
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
 
 ## Examples
 

--- a/files/en-us/web/api/publickeycredential/parsecreationoptionsfromjson_static/index.md
+++ b/files/en-us/web/api/publickeycredential/parsecreationoptionsfromjson_static/index.md
@@ -32,6 +32,8 @@ A {{domxref("PublicKeyCredentialCreationOptions")}} object.
 
 - `EncodingError` {{domxref("DOMException")}}
   - : Thrown the `options` object cannot be converted into a {{domxref("PublicKeyCredentialCreationOptions")}} object.
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
 
 ## Description
 

--- a/files/en-us/web/api/publickeycredential/parserequestoptionsfromjson_static/index.md
+++ b/files/en-us/web/api/publickeycredential/parserequestoptionsfromjson_static/index.md
@@ -32,6 +32,8 @@ A {{domxref("PublicKeyCredentialRequestOptions")}} instance.
 
 - `EncodingError` {{domxref("DOMException")}}
   - : Thrown if any part of the `options` object cannot be converted into a {{domxref("PublicKeyCredentialRequestOptions")}} instance.
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
 
 ## Description
 

--- a/files/en-us/web/api/publickeycredential/tojson/index.md
+++ b/files/en-us/web/api/publickeycredential/tojson/index.md
@@ -52,6 +52,11 @@ The object properties are:
 
     - When authenticating a user the returned value will be a JSON-type representation version of {{domxref("AuthenticatorAssertionResponse")}} where buffer values have been [base64url](/en-US/docs/Glossary/Base64) encoded.
 
+### Exceptions
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The RP domain is not valid.
+
 ## Examples
 
 When registering a new user, a relying party server will supply information about the expected credentials to the web app.


### PR DESCRIPTION
The WGC clarified that you don't need permissions to call `PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()` or `PublicKeyCredential.getClientCapabilities()` in https://github.com/w3c/webauthn/issues/2251#issuecomment-2686053156. This removes the corresponding `NotAllowed` exception.

The PR also adds the SecurityException for _all_ methods in this API, because a secure context is requried.

This fell out of work done in https://github.com/mdn/content/issues/37516