### PR TITLE
temporal api enabled by default in nightly

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -819,8 +819,8 @@ This includes:
   <tbody>
     <tr>
       <th>Nightly</th>
-      <td>135</td>
-      <td>No</td>
+      <td>137</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Developer Edition</th>

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -84,6 +84,8 @@ This article provides information about the changes in Firefox 137 that affect d
 
 These features are newly shipped in Firefox 137 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **Temporal API** (Nightly release): is now enabled in Firefox Nightly by default. The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations. ([Firefox bug 1946823](https://bugzil.la/1946823)).
+
 ## Older versions
 
 {{Firefox_for_developers}}


### PR DESCRIPTION
### Description

- Updated the information table about Temporal API on experimental features
- Added experimental note to Firefox 137 release note

### Motivation

- Working on [issue #38404](https://github.com/mdn/content/issues/38404)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/26212)