### PR TITLE
move guide to module: inline formatting context

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12161,6 +12161,7 @@
 /en-US/docs/Web/CSS/General_sibling_selectors	/en-US/docs/Web/CSS/Subsequent-sibling_combinator
 /en-US/docs/Web/CSS/Grouping_selectors	/en-US/docs/Web/CSS/Selector_list
 /en-US/docs/Web/CSS/Inheritance	/en-US/docs/Web/CSS/CSS_cascade/Inheritance
+/en-US/docs/Web/CSS/Inline_formatting_context	/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context
 /en-US/docs/Web/CSS/Interactive	/en-US/docs/Web/CSS/@media
 /en-US/docs/Web/CSS/Layout_cookbook/Recipe:_Media_Objects	/en-US/docs/Web/CSS/Layout_cookbook/Media_objects
 /en-US/docs/Web/CSS/Layout_mode	/en-US/docs/Glossary/Layout_mode

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -77333,6 +77333,10 @@
       "BenoitL"
     ]
   },
+  "Web/CSS/CSS_inline_layout/Inline_formatting_context": {
+    "modified": "2020-04-27T22:33:13.546Z",
+    "contributors": ["pans9", "chrisdavidmills", "rachelandrew"]
+  },
   "Web/CSS/CSS_lists": {
     "modified": "2020-07-07T12:20:22.683Z",
     "contributors": [
@@ -78390,10 +78394,6 @@
       "teoli",
       "miken32"
     ]
-  },
-  "Web/CSS/Inline_formatting_context": {
-    "modified": "2020-04-27T22:33:13.546Z",
-    "contributors": ["pans9", "chrisdavidmills", "rachelandrew"]
   },
   "Web/CSS/Layout_cookbook": {
     "modified": "2020-07-07T12:18:05.178Z",

--- a/files/en-us/glossary/inline-level_content/index.md
+++ b/files/en-us/glossary/inline-level_content/index.md
@@ -46,5 +46,5 @@ body {
 
 - Related glossary terms:
   - {{Glossary("Block-level content")}}
-- [Inline formatting context](/en-US/docs/Web/CSS/Inline_formatting_context)
+- [Inline formatting context](/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context)
 - {{cssxref("display")}}

--- a/files/en-us/web/api/document_object_model/whitespace/index.md
+++ b/files/en-us/web/api/document_object_model/whitespace/index.md
@@ -91,7 +91,7 @@ The `<h1>` element contains only inline elements. In fact it contains:
 - An inline element (the `<span>`, which contains a space, and the word "World!").
 - Another text node (consisting only of tabs and spaces).
 
-Because of this, it establishes what is called an [inline formatting context](/en-US/docs/Web/CSS/Inline_formatting_context). This is one of the possible layout rendering contexts that browser engines work with.
+Because of this, it establishes what is called an [inline formatting context](/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context). This is one of the possible layout rendering contexts that browser engines work with.
 
 Inside this context, whitespace character processing can be summarized as follows:
 

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -32,11 +32,7 @@ The **CSS display** module defines how the CSS formatting box tree is generated 
 - [Block formatting context (BFC)](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 - {{glossary("Block-level content")}}
 - [Containing block](/en-US/docs/Web/CSS/CSS_display/Containing_block)
-- {{glossary("Flex")}}
 - [Flow layout](/en-US/docs/Web/CSS/CSS_display/Flow_layout)
-- {{glossary("Grid")}}
-- [Inline formatting context](/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context)
-- {{glossary("Inline-level content")}}
 - {{glossary("Replaced elements")}}
 - {{glossary("Ruby")}}
 
@@ -59,8 +55,15 @@ The **CSS display** module defines how the CSS formatting box tree is generated 
 
 ### Properties
 
-- {{cssxref("transition-behavior")}}
 - {{cssxref("overflow")}}
+- {{cssxref("transition-behavior")}}
+
+### Glossary and terms
+
+- {{glossary("Flex")}}
+- {{glossary("Grid")}}
+- [Inline formatting context](/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context)
+- {{glossary("Inline-level content")}}
 
 ### Guides
 

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -35,7 +35,7 @@ The **CSS display** module defines how the CSS formatting box tree is generated 
 - {{glossary("Flex")}}
 - [Flow layout](/en-US/docs/Web/CSS/CSS_display/Flow_layout)
 - {{glossary("Grid")}}
-- [Inline formatting context](/en-US/docs/Web/CSS/Inline_formatting_context)
+- [Inline formatting context](/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context)
 - {{glossary("Inline-level content")}}
 - {{glossary("Replaced elements")}}
 - {{glossary("Ruby")}}

--- a/files/en-us/web/css/css_inline_layout/index.md
+++ b/files/en-us/web/css/css_inline_layout/index.md
@@ -33,6 +33,11 @@ The specification also defines the `baseline-shift`, `baseline-source`, `initial
 - {{glossary("baseline/typography", "baseline")}}
 - {{glossary("leading")}}
 
+## Guides
+
+- [Inline formatting context](/en-US/docs/Web/CSS/CSS_inline_layout/Inline_formatting_context)
+  - : Explains the inline formatting context.
+
 ## Related concepts
 
 - {{cssxref("font-size")}} property

--- a/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
+++ b/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
@@ -1,6 +1,6 @@
 ---
 title: Inline formatting context
-slug: Web/CSS/Inline_formatting_context
+slug: Web/CSS/CSS_inline_layout/Inline_formatting_context
 page-type: guide
 ---
 

--- a/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
+++ b/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{CSSRef}}
 
-This article explains the inline formatting context.
+This guide explains the inline formatting context.
 
 ## Core concepts
 

--- a/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
+++ b/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
@@ -227,4 +227,5 @@ body {
 
 ## See also
 
+- [Block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)

--- a/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
+++ b/files/en-us/web/css/css_inline_layout/inline_formatting_context/index.md
@@ -227,5 +227,4 @@ body {
 
 ## See also
 
-- [Block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)


### PR DESCRIPTION
Moved guide to the module that defines the term.


[#218](https://github.com/openwebdocs/project/issues/218)