### PR TITLE
Remove the mention of "redirect forgery"

### DIFF
--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Response.redirected
 The **`redirected`** read-only property of the {{domxref("Response")}} interface indicates whether or not the response is the result of a request you made which was redirected.
 
 > [!NOTE]
-> Relying on redirected to filter out redirects makes it easy for a forged redirect to prevent your content from working as expected.
+> Checking `redirected` to prevent redirects is not recommended, because by the time a response is received, the redirect has already happened, and you may have sent the request to an unintended destination, potentially sending sensitive information.
 > Instead, you should do the filtering when you call {{domxref("Window/fetch", "fetch()")}}.
 > See the example [Disallowing redirects](#disallowing_redirects), which shows this being done.
 
@@ -46,7 +46,7 @@ fetch("awesome-picture.jpg")
 
 ### Disallowing redirects
 
-Because using redirected to manually filter out redirects can allow forgery of redirects, you should instead set the redirect mode to `"error"` in the `init` parameter when calling {{domxref("Window/fetch", "fetch()")}}, like this:
+Checking `redirected` is a bad way to prevent redirects, because the redirect has already happened. Instead, you should set the redirect mode to `"error"` in the `options` parameter when calling {{domxref("Window/fetch", "fetch()")}}, like this:
 
 ```js
 fetch("awesome-picture.jpg", { redirect: "error" })


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/36231.

I've never heard of this term and Google showed nothing. I can only assume it's about redirecting to a malicious site.