### PR TITLE
ArrayBuffer is not a ArrayBufferView

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
@@ -48,7 +48,7 @@ bufferData(target, srcData, usage, srcOffset, length)
     store.
     One of `size` and `srcData` must be provided.
 - `srcData` {{optional_inline}}
-  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}}, a {{jsxref("TypedArray")}} or a {{jsxref("DataView")}}
+  - : A {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} that views an {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}
     that will be copied into the data store.
     If `null`, a data store is still created, but the content is uninitialized and undefined.
     One of `size` and `srcData` must be provided.

--- a/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
@@ -48,7 +48,7 @@ bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
   - : A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in bytes where the data replacement
     will start.
 - `srcData` {{optional_inline}}
-  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}}, a {{jsxref("DataView")}}, or a {{jsxref("TypedArray")}}
+  - : A {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} that views an {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}
     that will be copied into the data store.
 - `srcOffset` {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
@@ -49,7 +49,8 @@ bufferData(target, srcData, usage)
   - : A {{domxref("WebGL_API/Types", "GLsizeiptr")}} setting the size in bytes of the buffer object's data
     store.
 - `srcData` {{optional_inline}}
-  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}}, a {{jsxref("TypedArray")}} or a {{jsxref("DataView")}}
+  - : A {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} that views an {{jsxref("ArrayBuffer")}} or
+    {{jsxref("SharedArrayBuffer")}}
     that will be copied into the data store.
     If `null`, a data store is still created, but the content is uninitialized and undefined.
 - `usage`

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
@@ -52,7 +52,7 @@ bufferSubData(target, offset, srcData)
   - : A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in bytes where the data replacement
     will start.
 - `srcData` {{optional_inline}}
-  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}}, a {{jsxref("DataView")}}, or a {{jsxref("TypedArray")}}
+  - : A {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} that views an {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}
     that will be copied into the data store.
 - `srcOffset`
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/30749. WebGL requires `srcData` to be an `ArrayBufferView`, not `ArrayBufferSource`.