### PR TITLE
OpenSearch is not a plugin; mention Chrome activation

### DIFF
--- a/files/en-us/web/xml/guides/opensearch/index.md
+++ b/files/en-us/web/xml/guides/opensearch/index.md
@@ -11,20 +11,20 @@ Firefox also supports additional features not in the OpenSearch standard, such a
 
 ## Overview
 
-Browsers have an address bar which is dual-purpose: you can type a URL and go there directly, or you can type a search term, which is sent as a query to a search engine. The search engine then returns a list of results which you can navigate to, or you can open up the search engine's web interface to see more results.
+The address bar in browsers has a dual purpose: you can type a URL to directly go to a site, or you can type a search term to query a search engine. The search engine returns a list of results that you can browse directly, or you can open the search engine's full results page.
 
-By default, browsers can connect to a few popular search engines such as Google, Bing, or Yandex. The OpenSearch protocol allows websites to define their own search engines, so that users can search that website directly from the browser's address bar. For example, the MDN website has a site-wide search engine, so if MDN registers itself as a search engine, users can search MDN directly from the address bar.
+By default, browsers can connect to a few popular search engines, such as Google, Bing, or Yandex. The OpenSearch protocol allows websites to define their own search engines, enabling users to search those websites directly from the browser's address bar. For example, the MDN website has a site-wide search engine. If MDN registers itself as a search engine, users can search MDN directly from the address bar.
 
-Browsers query a search engine by requesting a URL. The site defines a template for the URL to be requested, and the browser will fill the search terms inside the placeholders. For example, if the search engine is at `https://example.com/search?q={searchTerms}`, then the browser will request `https://example.com/search?q=foo` when the user types "foo" into the address bar. The search engine then generates a response, either as a list of search results or as a search results page.
+Browsers query a search engine by requesting a URL. The site defines a template for the URL to be requested, and the browser fills in the user's search terms in the specified placeholders. For example, if the search engine URL is `https://example.com/search?q={searchTerms}`, then the browser will request `https://example.com/search?q=foo` when the user types "foo" into the address bar. The search engine then generates a response—either a list of search results or a full search results page.
 
-A site defines its search engine by linking to an XML file in its HTML. When the user first visits the site, the browser recognizes the description file and registers the search engine. The browser then uses the search engine to handle searches from the address bar.
+A site defines its search engine by linking to an XML description file in its HTML. When the user first visits the site, the browser detects this description file and registers the search engine. The browser then uses the registered search engine to handle searches from the address bar.
 
 > [!NOTE]
 > Chrome registers site search engines as "inactive" by default. Users must manually activate each site in the search engine settings.
 
 ## OpenSearch description file
 
-The XML file that describes a search engine follows the basic template below. Sections in _\[square brackets]_ should be customized for the specific engine you're writing.
+The XML file that describes a search engine follows the basic template below. Sections in _\[square brackets]_ should be customized for your specific engine.
 
 ```xml
 <OpenSearchDescription
@@ -92,10 +92,10 @@ To support autodiscovery, add a `<link>` element for each search engine to the `
 
 Replace the items in _\[square brackets\]_ as explained below:
 
-- searchTitle
+- `searchTitle`
   - : The name of the search to perform, such as "Search MDC" or "Yahoo! Search". This must match your plugin file's `<ShortName>`.
-- descriptionURL
-  - : The URL to the XML search description file, so the browser can download it.
+- `descriptionURL`
+  - : The URL to the XML description file, so the browser can download it.
 
 If your site offers multiple search engines, you can support autodiscovery for them all. For example:
 
@@ -113,14 +113,14 @@ If your site offers multiple search engines, you can support autodiscovery for t
   href="http://example.com/mysitetitle.xml" />
 ```
 
-This way, your site can offer two engines to search by author, or by title.
+This way, your site can offer two engines to search: one by author and another by title.
 
 > [!NOTE]
 > In Firefox, an icon change in the search box indicates there's a provided search plugin. (See image, the green plus sign.) Thus if a search box is not shown in the user's UI, they will receive _no_ indication. _In general, behavior varies among browsers_.
 
 ## Supporting automatic updates for OpenSearch description
 
-OpenSearch description can automatically update. To support this, include an extra `Url` element with `type="application/opensearchdescription+xml"` and `rel="self"`. The `template` attribute should be the URL of the OpenSearch document to automatically update to.
+The OpenSearch description file can update automatically. To support this, include an extra `Url` element with `type="application/opensearchdescription+xml"` and `rel="self"`. The `template` attribute should be the URL of the OpenSearch document to automatically update to.
 
 For example:
 
@@ -131,16 +131,16 @@ For example:
   template="https://example.com/mysearchdescription.xml" />
 ```
 
-## Troubleshooting Tips
+## Troubleshooting tips
 
-If there is a mistake in your search description XML, you could run into errors when adding the search engine. If the error message isn't be helpful, the following tips could help you find the problem.
+If there is a mistake in your XML description file, you could run into errors when adding the search engine. If the error message isn't helpful, use the following tips to troubleshoot the problem:
 
-- Your server should serve OpenSearch descriptions using `Content-Type: application/opensearchdescription+xml`.
-- Be sure that your search description XML is well formed. You can check by loading the file directly into Firefox. Ampersands (&) in the `template` URL must be escaped as `&amp;`, and tags must be closed with a trailing slash or matching end tag.
-- The `xmlns` attribute is important — without it you could get the error message "Firefox could not download the search plugin".
+- Check that your server serves OpenSearch descriptions with `Content-Type: application/opensearchdescription+xml`.
+- Make sure that your XML description file is well-formed. You can check by loading the file directly into a browser. Ampersands (`&`) in the `template` URL must be escaped as `&amp;`, and tags must be closed with a trailing slash or a matching end tag.
+- Make sure to include the `xmlns` attribute—without it, you could get the error message like "Firefox could not download the search plugin".
 - You **must** include a `text/html` URL — search engines including only Atom or [RSS](/en-US/docs/Glossary/RSS) URL types (which is valid, but Firefox doesn't support) will also generate the "could not download the search plugin" error.
 - Remotely fetched favicons must not be larger than 10KB (see [Firefox bug 361923](https://bugzil.la/361923)).
-- As aforementioned, browsers may not activate site search shortcuts by default. Check the browser's settings and make sure the search engine is activated.
+- As mentioned earlier, browsers may not activate site search shortcuts by default. Check the browser's settings and make sure the search engine is activated.
 
 In addition, the search plugin service provides a logging mechanism that may be useful to plugin developers. Use `about:config` to set the pref `browser.search.log` to `true`. Then, logging information will appear in Firefox's [Browser Console](https://firefox-source-docs.mozilla.org/devtools-user/browser_console/index.html) (Tools ➤ Browser Tools ➤ Browser Console) when search plugins are added.
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/23987.

The current content is worded as if OpenSearch is a custom browser plugin. That may be how it's implemented in Firefox, but not how it works generally—it's more like a PWA.