### PR TITLE
Remove anti-a11y preventDefault example

### DIFF
--- a/files/en-us/web/api/event/preventdefault/index.md
+++ b/files/en-us/web/api/event/preventdefault/index.md
@@ -23,6 +23,9 @@ non-cancelable event, such as one dispatched via
 
 If a passive listener calls `preventDefault()`, nothing will happen and a console warning may be generated.
 
+> [!NOTE]
+> Look for better alternatives than using `preventDefault()` to block default actions. For example, you can use the `disabled` or `readonly` attribute on a form control to prevent it from being interacted with, use [HTML constraint validation](/en-US/docs/Web/HTML/Constraint_validation) to reject invalid input, or use the {{cssxref("overflow")}} property to prevent scrolling.
+
 ## Syntax
 
 ```js-nolint
@@ -66,96 +69,6 @@ function checkboxClick(event) {
 #### Result
 
 {{EmbedLiveSample("Blocking_default_click_handling")}}
-
-### Stopping keystrokes from reaching an edit field
-
-The following example demonstrates how invalid text input can be stopped from reaching
-the input field with `preventDefault()`. Nowadays, you should usually use [native HTML form validation](/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation)
-instead.
-
-#### HTML
-
-The HTML form below captures user input.
-Since we're only interested in keystrokes, we're disabling `autocomplete` to prevent the browser from filling in the input field with cached values.
-
-```html
-<div class="container">
-  <p>Please enter your name using lowercase letters only.</p>
-
-  <form>
-    <input type="text" id="my-textbox" autocomplete="off" />
-  </form>
-</div>
-```
-
-#### CSS
-
-We use a little bit of CSS for the warning box we'll draw when the user presses an
-invalid key:
-
-```css
-.warning {
-  border: 2px solid #f39389;
-  border-radius: 2px;
-  padding: 10px;
-  position: absolute;
-  background-color: #fbd8d4;
-  color: #3b3c40;
-}
-```
-
-#### JavaScript
-
-And here's the JavaScript code that does the job. First, listen for
-{{domxref("Element/keydown_event", "keydown")}} events:
-
-```js
-const myTextbox = document.getElementById("my-textbox");
-myTextbox.addEventListener("keydown", checkName, false);
-```
-
-The `checkName()` function, which looks at the pressed key and decides
-whether to allow it:
-
-```js
-function checkName(evt) {
-  const key = evt.key;
-  const lowerCaseAlphabet = "abcdefghijklmnopqrstuvwxyz";
-  if (!lowerCaseAlphabet.includes(key)) {
-    evt.preventDefault();
-    displayWarning(`Please use lowercase letters only.\nKey pressed: ${key}\n`);
-  }
-}
-```
-
-The `displayWarning()` function presents a notification of a problem. It's
-not an elegant function but does the job for the purposes of this example:
-
-```js
-let warningTimeout;
-const warningBox = document.createElement("div");
-warningBox.className = "warning";
-
-function displayWarning(msg) {
-  warningBox.innerText = msg;
-
-  if (document.body.contains(warningBox)) {
-    clearTimeout(warningTimeout);
-  } else {
-    // insert warningBox after myTextbox
-    myTextbox.parentNode.insertBefore(warningBox, myTextbox.nextSibling);
-  }
-
-  warningTimeout = setTimeout(() => {
-    warningBox.parentNode.removeChild(warningBox);
-    warningTimeout = -1;
-  }, 2000);
-}
-```
-
-#### Result
-
-{{ EmbedLiveSample('Stopping_keystrokes_from_reaching_an_edit_field', 600, 200) }}
 
 ## Notes
 


### PR DESCRIPTION
This example is too overengineered to be illustrative for `preventDefault`. It's also fully replaced by constraint validation.

Fixes https://github.com/mdn/content/issues/27478