### PR TITLE
Add information about undefined WebGPU limit values

### DIFF
--- a/files/en-us/web/api/gpuadapter/requestdevice/index.md
+++ b/files/en-us/web/api/gpuadapter/requestdevice/index.md
@@ -31,7 +31,7 @@ requestDevice(descriptor)
     - `requiredFeatures` {{optional_inline}}
       - : An array of strings representing additional functionality that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these features. See {{domxref("GPUSupportedFeatures")}} for a full list of possible features. This defaults to an empty array if no value is provided.
     - `requiredLimits` {{optional_inline}}
-      - : An object containing properties representing the limits that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these limits. Each key must be the name of a member of {{domxref("GPUSupportedLimits")}}. This defaults to an empty object if no value is provided.
+      - : An object containing properties representing the limits that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these limits. Each key must be the name of a member of {{domxref("GPUSupportedLimits")}}; if the limit is unknown, a value of `undefined` is returned. The `requiredLimits` property returns an empty object if no value is provided.
 
 > [!NOTE]
 > Not all features and limits will be available to WebGPU in all browsers that support it, even if they are supported by the underlying hardware. See the {{domxref("GPUAdapter.features", "features")}} and {{domxref("GPUAdapter.limits", "limits")}} pages for more information.

--- a/files/en-us/web/api/gpuadapter/requestdevice/index.md
+++ b/files/en-us/web/api/gpuadapter/requestdevice/index.md
@@ -31,10 +31,11 @@ requestDevice(descriptor)
     - `requiredFeatures` {{optional_inline}}
       - : An array of strings representing additional functionality that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these features. See {{domxref("GPUSupportedFeatures")}} for a full list of possible features. This defaults to an empty array if no value is provided.
     - `requiredLimits` {{optional_inline}}
-      - : An object containing properties representing the limits that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these limits. Each key must be the name of a member of {{domxref("GPUSupportedLimits")}}; if the limit is unknown, a value of `undefined` is returned. The `requiredLimits` property returns an empty object if no value is provided.
+      - : An object containing properties representing the limits that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these limits. Each key with a non-`undefined` value must be the name of a member of {{domxref("GPUSupportedLimits")}}.
+        > [!NOTE]
+        > You can request unknown limits when requesting a GPU device without causing an error. Such limits will be `undefined`. This is useful because it makes WebGPU code less brittle — a codebase won't stop working because a limit no longer exists in the adapter.
 
-> [!NOTE]
-> Not all features and limits will be available to WebGPU in all browsers that support it, even if they are supported by the underlying hardware. See the {{domxref("GPUAdapter.features", "features")}} and {{domxref("GPUAdapter.limits", "limits")}} pages for more information.
+Not all features and limits will be available to WebGPU in all browsers that support it, even if they are supported by the underlying hardware. See the {{domxref("GPUAdapter.features", "features")}} and {{domxref("GPUAdapter.limits", "limits")}} pages for more information.
 
 ### Return value
 

--- a/files/en-us/web/api/gpusupportedlimits/index.md
+++ b/files/en-us/web/api/gpusupportedlimits/index.md
@@ -17,8 +17,6 @@ You should note that, rather than reporting the exact limits of each GPU, browse
 
 Given that different browsers will handle this differently and the tier values may change over time, it is hard to provide an accurate account of what limit values to expect — thorough testing is advised.
 
-If a limit is unknown, it will return a value of `undefined`.
-
 {{InheritanceDiagram}}
 
 ## Instance properties

--- a/files/en-us/web/api/gpusupportedlimits/index.md
+++ b/files/en-us/web/api/gpusupportedlimits/index.md
@@ -17,6 +17,8 @@ You should note that, rather than reporting the exact limits of each GPU, browse
 
 Given that different browsers will handle this differently and the tier values may change over time, it is hard to provide an accurate account of what limit values to expect — thorough testing is advised.
 
+If a limit is unknown, it will return a value of `undefined`.
+
 {{InheritanceDiagram}}
 
 ## Instance properties


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 133 supports requesting WebGPU devices with unknown `requiredLimits`. See https://developer.chrome.com/blog/new-in-webgpu-133#allow_unknown_limits_to_be_requested_with_undefined_value for details.

This PR adds information about this.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/38366

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
