### PR TITLE
Fix spacing in Korean translation: '시도해보기' to '시도해 보기'

### DIFF
--- a/files/jsondata/L10n-Template.json
+++ b/files/jsondata/L10n-Template.json
@@ -125,7 +125,7 @@
     "en-US": "Try it",
     "fr": "Exemple interactif",
     "ja": "試してみましょう",
-    "ko": "시도해보기",
+    "ko": "시도해 보기",
     "ru": "Интерактивный пример",
     "pt-BR": "Experimente",
     "es": "Pruébalo",


### PR DESCRIPTION
### Description

Fix the spacing in Korean translation of "Try it" from "시도해보기" to "시도해 보기" to follow proper Korean grammar rules.

### Motivation

In Korean grammar, the verb '시도하다' (to try) and the auxiliary verb '보다' (to see/try) should be separated by a space. This change improves the correctness of the Korean language content on MDN and follows standard Korean orthography rules.

### Additional details

The change is made in the L10n-Template.json file for the Korean translation of the interactive example heading. This follows standard Korean language spacing rules between verb stems and auxiliary verbs.

### Related issues and pull requests

N/A
