### PR TITLE
Bug 1949955 userScripts API enabled on mobile release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -79,7 +79,7 @@ This article provides information about the changes in Firefox 136 that affect d
 
 - Adds the `preferred_environment` property to the [`background` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background), enabling extensions to request that the browser run their background scripts as a document or service worker ([Firefox bug 1798655](https://bugzil.la/1798655)).
 - {{WebExtAPIRef("menus.update")}} and {{WebExtAPIRef("menus.remove")}} and the aliases {{WebExtAPIRef("contextMenus.update")}} and {{WebExtAPIRef("contextMenus.remove")}} now reject with an error when the menu item doesn't exist. Previously, the error was ignored and the promise fulfilled. ([Firefox bug 1688743](https://bugzil.la/1688743)).
-- A new version of the {{WebExtAPIRef("userScripts")}} API is available. This version of the API is for use in Manifest V3 extensions and provides broad compatibility with Chrome, although [permissions mechanisms](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts#permissions) differ across the browsers. ([Firefox bug 1943050](https://bugzil.la/1943050)).
+- A new version of the {{WebExtAPIRef("userScripts")}} API is available on desktop Firefox. This version of the API is for use in Manifest V3 extensions and provides broad compatibility with Chrome, although [permissions mechanisms](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts#permissions) differ across the browsers. ([Firefox bug 1943050](https://bugzil.la/1943050)).
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 138 that affect d
 
 ## Changes for add-on developers
 
+- The new Manifest V3 version of the {{WebExtAPIRef("userScripts")}} API is now available on Firefox for Android. ([Firefox bug 1949955](https://bugzil.la/1949955))
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
### Description

Release note to indicate the availability of the userScript API in Firefox for Android in version 138 (to address the dev-doc-needed requirement of [Bug 1949955](https://bugzilla.mozilla.org/show_bug.cgi?id=1949955) Enable userScripts API by default on mobile). Also clarified the original release note, the API was only available on desktop.

### Related issues and pull requests

Related a BCD changes in https://github.com/mdn/browser-compat-data/pull/26234