### PR TITLE
Reflected aria attributes containing element references

### DIFF
--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -16,7 +16,7 @@ A number of HTML attributes are {{Glossary("Boolean/HTML", "boolean attributes")
 
 Attributes may be _reflected_ into a particular property of the specific interface.
 
-What this means is that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
+This means that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
 The reflected properties offer a more natural programming approach than getting and setting attribute using the {{domxref("Element.getAttribute()","getAttribute()")}} and {{domxref("Element.setAttribute()","setAttribute()")}} methods of the {{domxref("Element")}} interface.
 
 For more information see [Attribute reflection](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes).

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -17,7 +17,7 @@ A number of HTML attributes are {{Glossary("Boolean/HTML", "boolean attributes")
 Attributes may be _reflected_ into a particular property of the specific interface.
 
 This means that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
-The reflected properties offer a more natural programming approach than getting and setting attribute using the {{domxref("Element.getAttribute()","getAttribute()")}} and {{domxref("Element.setAttribute()","setAttribute()")}} methods of the {{domxref("Element")}} interface.
+The reflected properties offer a more natural programming approach than getting and setting attributes using the {{domxref("Element.getAttribute()","getAttribute()")}} and {{domxref("Element.setAttribute()","setAttribute()")}} methods of the {{domxref("Element")}} interface.
 
 For more information see [Attribute reflection](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes).
 

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -15,33 +15,16 @@ A number of HTML attributes are {{Glossary("Boolean/HTML", "boolean attributes")
 ## Reflection of an attribute
 
 Attributes may be _reflected_ into a particular property of the specific interface.
-It means that the value of the attribute can be read by accessing the property,
-and can be modified by setting the property to a different value.
 
-For example, the `placeholder` below is reflected into {{domxref("HTMLInputElement.placeholder")}}.
+What this means is that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
+The reflected properties offer a more natural programming approach than getting and setting attribute using the {{domxref("Element.getAttribute()","getAttribute()")}} and {{domxref("Element.setAttribute()","setAttribute()")}} methods of the {{domxref("Element")}} interface.
 
-Considering the following HTML:
-
-```html
-<input placeholder="Original placeholder" />
-```
-
-We can check the reflection between {{domxref("HTMLInputElement.placeholder")}} and the attribute using:
-
-```js
-const input = document.querySelector("input");
-const attr = input.getAttributeNode("placeholder");
-console.log(attr.value);
-console.log(input.placeholder); // Prints the same value as `attr.value`
-
-// Changing placeholder value will also change the value of the reflected attribute.
-input.placeholder = "Modified placeholder";
-console.log(attr.value); // Prints `Modified placeholder`
-```
+For more information see [Attribute reflection](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes).
 
 ## See also
 
 - [HTML attribute reference](/en-US/docs/Web/HTML/Reference/Attributes)
+- [Attribute reflection](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes)
 - Information about HTML's [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes)
 - XML StartTag Attribute Recommendation in [W3C XML Recommendation](https://www.w3.org/TR/xml#sec-starttags)
 - Related glossary terms:

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
@@ -40,7 +40,7 @@ The value of `aria-activedescendant` refers to an owned element of the controlle
 ## Associated interfaces
 
 - {{domxref("Element.ariaActiveDescendantElement")}} and {{domxref("ElementInternals.ariaActiveDescendantElement")}}
-  - : The `ariaActiveDescendantElement` property is part of each element's interface. Its value is an {{domxref("Element")}}s corresponding to the ID value specified in the `aria-activedescendant` attribute (for cases where the ID values references a valid and in-scope element).
+  - : The `ariaActiveDescendantElement` property is part of each element's interface. Its value is an {{domxref("Element")}} corresponding to the ID value specified in the `aria-activedescendant` attribute (for cases where the ID values references a valid and in-scope element).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
@@ -37,6 +37,11 @@ The value of `aria-activedescendant` refers to an owned element of the controlle
 - ID reference
   - : takes as its value the `id` of the currently focused element.
 
+## Associated interfaces
+
+- {{domxref("Element.ariaActiveDescendantElement")}} and {{domxref("ElementInternals.ariaActiveDescendantElement")}}
+  - : The `ariaActiveDescendantElement` property is part of each element's interface. Its value is an {{domxref("Element")}}s corresponding to the ID value specified in the `aria-activedescendant` attribute (for cases where the ID values references a valid and in-scope element).
+
 ## Associated roles
 
 Relevant only as an attribute on elements with the following roles:

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
@@ -41,10 +41,10 @@ The value of `aria-activedescendant` refers to an owned element of the controlle
 
 - {{domxref("Element.ariaActiveDescendantElement")}}
   - : The `ariaActiveDescendantElement` property is part of each element's interface.
-    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-activedescendant` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+    Its value is an instance of a subclass of {{domxref("Element")}} that reflects the `id` reference in the `aria-activedescendant` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 - {{domxref("ElementInternals.ariaActiveDescendantElement")}}
   - : The `ariaActiveDescendantElement` property is part of each custom element's interface.
-    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-activedescendant` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+    Its value is an instance of a subclass of {{domxref("Element")}} that reflects the `id` reference in the `aria-activedescendant` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-activedescendant/index.md
@@ -39,8 +39,12 @@ The value of `aria-activedescendant` refers to an owned element of the controlle
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaActiveDescendantElement")}} and {{domxref("ElementInternals.ariaActiveDescendantElement")}}
-  - : The `ariaActiveDescendantElement` property is part of each element's interface. Its value is an {{domxref("Element")}} corresponding to the ID value specified in the `aria-activedescendant` attribute (for cases where the ID values references a valid and in-scope element).
+- {{domxref("Element.ariaActiveDescendantElement")}}
+  - : The `ariaActiveDescendantElement` property is part of each element's interface.
+    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-activedescendant` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaActiveDescendantElement")}}
+  - : The `ariaActiveDescendantElement` property is part of each custom element's interface.
+    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-activedescendant` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-controls/index.md
@@ -84,8 +84,12 @@ In this tabs example, each tab controls one tabpanel:
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaControlsElements")}} and {{domxref("ElementInternals.ariaControlsElements")}}
-  - : The `ariaControlsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}} instances corresponding to the valid ID values specified in the `aria-controls` attribute.
+- {{domxref("Element.ariaControlsElements")}}
+  - : The `ariaControlsElements` property is part of each element's interface.
+    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-controls` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaControlsElements")}}
+  - : The `ariaControlsElements` property is part of each custom element's interface.
+    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-controls` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-controls/index.md
@@ -84,8 +84,8 @@ In this tabs example, each tab controls one tabpanel:
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaControlsElements")}}
-  - : The `ariaControlsElements` property is part of each element's interface. Its value is a list of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-controls` attribute.
+- {{domxref("Element.ariaControlsElements")}} and {{domxref("ElementInternals.ariaControlsElements")}}
+  - : The `ariaControlsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-controls` attribute (for cases where those ID values reference valid and in-scope elements).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-controls/index.md
@@ -85,7 +85,7 @@ In this tabs example, each tab controls one tabpanel:
 ## Associated interfaces
 
 - {{domxref("Element.ariaControlsElements")}} and {{domxref("ElementInternals.ariaControlsElements")}}
-  - : The `ariaControlsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-controls` attribute (for cases where those ID values reference valid and in-scope elements).
+  - : The `ariaControlsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}} instances corresponding to the valid ID values specified in the `aria-controls` attribute.
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-describedby/index.md
@@ -45,8 +45,12 @@ The `aria-describedby` property is appropriate when the associated content conta
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaDescribedByElements")}} and {{domxref("ElementInternals.ariaDescribedByElements")}}
-  - : The `ariaDescribedByElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-describedby` attribute (for cases where those ID values reference valid and in-scope elements).
+- {{domxref("Element.ariaDescribedByElements")}}
+  - : The `ariaDescribedByElements` property is part of each element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-describedby` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaDescribedByElements")}}
+  - : The `ariaDescribedByElements` property is part of each custom element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-describedby` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-describedby/index.md
@@ -57,4 +57,5 @@ Used in **all** roles. Usable in all HTML elements as well.
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
 - [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description)
 - [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details)
+- {{domxref("Element.ariaDescribedByElements")}} and {{domxref("ElementInternals.ariaDescribedByElements")}}
 - [Browser and AT support for `aria-describedby`](https://a11ysupport.io/tech/aria/aria-describedby_attribute)

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-describedby/index.md
@@ -43,6 +43,11 @@ The `aria-describedby` property is appropriate when the associated content conta
 - ID reference list
   - : The `id` or space-separated list of element `id`s that describe the current element.
 
+## Associated interfaces
+
+- {{domxref("Element.ariaDescribedByElements")}} and {{domxref("ElementInternals.ariaDescribedByElements")}}
+  - : The `ariaDescribedByElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-describedby` attribute (for cases where those ID values reference valid and in-scope elements).
+
 ## Associated roles
 
 Used in **all** roles. Usable in all HTML elements as well.
@@ -53,9 +58,7 @@ Used in **all** roles. Usable in all HTML elements as well.
 
 ## See also
 
-- {{HTMLElement('label')}}
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
 - [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description)
 - [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details)
-- {{domxref("Element.ariaDescribedByElements")}} and {{domxref("ElementInternals.ariaDescribedByElements")}}
 - [Browser and AT support for `aria-describedby`](https://a11ysupport.io/tech/aria/aria-describedby_attribute)

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-details/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-details/index.md
@@ -60,6 +60,11 @@ When it comes to definition and term roles, the `aria-details` would be included
 - ID reference list
   - : An `id` or space separated list of ids of elements that provide or link to additional related information.
 
+## Associated interfaces
+
+- {{domxref("Element.ariaDetailsElements")}} and {{domxref("ElementInternals.ariaDetailsElements")}}
+  - : The `ariaDetailsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-details` attribute (for cases where those ID values reference valid and in-scope elements).
+
 ## Associated roles
 
 Used in **ALL** roles.
@@ -74,6 +79,5 @@ Used in **ALL** roles.
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
 - [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description)
-- {{domxref("Element.ariaDetailsElements")}} and {{domxref("ElementInternals.ariaDetailsElements")}}
 - [The image `alt` attribute](/en-US/docs/Web/API/HTMLImageElement/alt)
 - HTML [title](/en-US/docs/Web/HTML/Reference/Global_attributes/title) attribute

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-details/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-details/index.md
@@ -74,5 +74,6 @@ Used in **ALL** roles.
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
 - [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-description)
+- {{domxref("Element.ariaDetailsElements")}} and {{domxref("ElementInternals.ariaDetailsElements")}}
 - [The image `alt` attribute](/en-US/docs/Web/API/HTMLImageElement/alt)
 - HTML [title](/en-US/docs/Web/HTML/Reference/Global_attributes/title) attribute

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-details/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-details/index.md
@@ -62,8 +62,12 @@ When it comes to definition and term roles, the `aria-details` would be included
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaDetailsElements")}} and {{domxref("ElementInternals.ariaDetailsElements")}}
-  - : The `ariaDetailsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-details` attribute (for cases where those ID values reference valid and in-scope elements).
+- {{domxref("Element.ariaDetailsElements")}}
+  - : The `ariaDetailsElements` property is part of each element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-details` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaDetailsElements")}}
+  - : The `ariaDetailsElements` property is part of each custom element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-details` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
@@ -66,6 +66,11 @@ When we went from valid to invalid, the only JavaScript change for this example 
 - ID reference list
   - : The `id` or space-separated list of element `id`s that contain the error message for the current element.
 
+## Associated interfaces
+
+- {{domxref("Element.ariaErrorMessageElements")}} and {{domxref("ElementInternals.ariaErrorMessageElements")}}
+  - : The `ariaErrorMessageElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-errormessage` attribute (for cases where those ID values reference valid and in-scope elements).
+
 ## Associated roles
 
 Used in roles:
@@ -99,4 +104,3 @@ Inherits from roles:
 - [`aria-invalid`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
 - [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live)
-- {{domxref("Element.ariaErrorMessageElements")}} and {{domxref("ElementInternals.ariaErrorMessageElements")}}

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
@@ -6,15 +6,15 @@ spec-urls: https://w3c.github.io/aria/#aria-errormessage
 sidebar: accessibilitysidebar
 ---
 
-The `aria-errormessage` attribute on an object identifies the element that provides an error message for that object.
+The `aria-errormessage` attribute on an object identifies the element(s) that provides an error message for that object.
 
 ## Description
 
-When there is a user-created error, you want to let them know it exists and tell them how to fix it. There are two attributes you need to use: set [`aria-invalid="true"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) to define the object as being in an error state, then add the `aria-errormessage` attribute with the value being the `id` of the element containing the error message text for that object.
+When there is a user-created error, you want to let them know it exists and tell them how to fix it. There are two attributes you need to use: set [`aria-invalid="true"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) to define the object as being in an error state, then add the `aria-errormessage` attribute with the value being the `id` of the element (or elements) containing the error message text for that object.
 
 The `aria-errormessage` attribute should only be used when the value of an object is not valid; when [`aria-invalid`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) is set to `true`. If the object is valid and you include the `aria-errormessage` attribute, make sure the element referenced is hidden, as the message it contains is not relevant.
 
-When `aria-errormessage` is relevant, the element it references must be visible so users can see or hear the error message.
+When `aria-errormessage` is relevant, the element(s) it references must be visible so users can see or hear the error message.
 
 Often times, you will want the element with the error message to be an [ARIA live region](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions), such as when an error message is displayed to users after they have provided an invalid value. The error message should describe what is wrong and inform the user what is required to make the object valid. Adding the error message as an ARIA live region informs assistive technologies that the user may benefit from the error message content even if the error message wouldn't otherwise be conveyed to the user.
 
@@ -63,8 +63,8 @@ When we went from valid to invalid, the only JavaScript change for this example 
 
 ## Values
 
-- `id` reference
-  - : The value of the `id` of the element containing the error message for the current element
+- ID reference list
+  - : The `id` or space-separated list of element `id`s that contain the error message for the current element.
 
 ## Associated roles
 
@@ -99,3 +99,4 @@ Inherits from roles:
 - [`aria-invalid`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
 - [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live)
+- {{domxref("Element.ariaErrorMessageElements")}} and {{domxref("ElementInternals.ariaErrorMessageElements")}}

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
@@ -68,8 +68,12 @@ When we went from valid to invalid, the only JavaScript change for this example 
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaErrorMessageElements")}} and {{domxref("ElementInternals.ariaErrorMessageElements")}}
-  - : The `ariaErrorMessageElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-errormessage` attribute (for cases where those ID values reference valid and in-scope elements).
+- {{domxref("Element.ariaErrorMessageElements")}}
+  - : The `ariaErrorMessageElements` property is part of each element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-errormessage` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaErrorMessageElements")}}
+  - : The `ariaErrorMessageElements` property is part of each custom element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-errormessage` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-errormessage/index.md
@@ -10,7 +10,7 @@ The `aria-errormessage` attribute on an object identifies the element(s) that pr
 
 ## Description
 
-When there is a user-created error, you want to let them know it exists and tell them how to fix it. There are two attributes you need to use: set [`aria-invalid="true"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) to define the object as being in an error state, then add the `aria-errormessage` attribute with the value being the `id` of the element (or elements) containing the error message text for that object.
+When there is a user-created error, you want to let the user know it exists and tell them how to fix it. There are two attributes you need to use: set [`aria-invalid="true"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) to define the object as being in an error state, then add the `aria-errormessage` attribute with the value being the `id` of the element (or elements) containing the error message text for that object.
 
 The `aria-errormessage` attribute should only be used when the value of an object is not valid; when [`aria-invalid`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid) is set to `true`. If the object is valid and you include the `aria-errormessage` attribute, make sure the element referenced is hidden, as the message it contains is not relevant.
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-flowto/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-flowto/index.md
@@ -26,6 +26,11 @@ When `aria-flowto` has a single [id](/en-US/docs/Web/HTML/Reference/Global_attri
 - `id` list
   - : Space separated list of ID values referencing the suggested elements the user may want to go to next in the alternate reading order of content.
 
+## Associated interfaces
+
+- {{domxref("Element.ariaFlowToElements")}} and {{domxref("ElementInternals.ariaFlowToElements")}}
+  - : The `ariaFlowToElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-flowto` attribute (for cases where those ID values reference valid and in-scope elements).
+
 ## Associated roles
 
 Used in **ALL** roles.

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-flowto/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-flowto/index.md
@@ -35,7 +35,6 @@ When `aria-flowto` has a single [id](/en-US/docs/Web/HTML/Reference/Global_attri
   - : The `ariaFlowToElements` property is part of each custom element's interface.
     Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-flowto` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
-
 ## Associated roles
 
 Used in **ALL** roles.

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-flowto/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-flowto/index.md
@@ -22,14 +22,19 @@ When `aria-flowto` has a single [id](/en-US/docs/Web/HTML/Reference/Global_attri
 ## Values
 
 - `id`
-  - : Suggested next element in the reading order.
+  - : The `id` of the next element in the alternate reading order.
 - `id` list
-  - : Space separated list of ID values referencing the suggested elements the user may want to go to next in the alternate reading order of content.
+  - : Space separated list of values referencing the `id` values of elements the user may want to go to next in the alternate reading order of content.
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaFlowToElements")}} and {{domxref("ElementInternals.ariaFlowToElements")}}
-  - : The `ariaFlowToElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-flowto` attribute (for cases where those ID values reference valid and in-scope elements).
+- {{domxref("Element.ariaFlowToElements")}}
+  - : The `ariaFlowToElements` property is part of each element's interface.
+    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-flowto` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaFlowToElements")}}
+  - : The `ariaFlowToElements` property is part of each custom element's interface.
+    Its value is an array of instances of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-flowto` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
@@ -89,6 +89,11 @@ Fortunately, the HTML {{HTMLElement('input')}} with `type="checkbox"` works with
 - ID reference list
   - : Space separated list of one or more ID values referencing the elements that label the current element.
 
+## Associated interfaces
+
+- {{domxref("Element.ariaLabelledByElements")}} and {{domxref("ElementInternals.ariaLabelledByElements")}}
+  - : The `ariaLabelledByElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-labelledby` attribute (for cases where those ID values reference valid and in-scope elements).
+
 ## Associated roles
 
 Used in almost all roles **except** roles that can not be provided an accessible name by the author.
@@ -122,4 +127,3 @@ The `aria-labelledby` attribute is **NOT** supported in:
 - HTML {{HTMLElement('caption')}} element
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
-- {{domxref("Element.ariaLabelledByElements")}} and {{domxref("ElementInternals.ariaLabelledByElements")}}

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
@@ -91,8 +91,12 @@ Fortunately, the HTML {{HTMLElement('input')}} with `type="checkbox"` works with
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaLabelledByElements")}} and {{domxref("ElementInternals.ariaLabelledByElements")}}
-  - : The `ariaLabelledByElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-labelledby` attribute (for cases where those ID values reference valid and in-scope elements).
+- {{domxref("Element.ariaLabelledByElements")}}
+  - : The `ariaLabelledByElements` property is part of each element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-labelledby` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaLabelledByElements")}}
+  - : The `ariaLabelledByElements` property is part of each custom element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-labelledby` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
@@ -122,3 +122,4 @@ The `aria-labelledby` attribute is **NOT** supported in:
 - HTML {{HTMLElement('caption')}} element
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
+- {{domxref("Element.ariaLabelledByElements")}} and {{domxref("ElementInternals.ariaLabelledByElements")}}

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-owns/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-owns/index.md
@@ -53,6 +53,11 @@ Make sure your owned elements have only one owner. Do not specify the `id` of an
 - `id` list
   - : Space separated list of one or more ID values referencing the elements being owned by the current element
 
+## Associated interfaces
+
+- {{domxref("Element.ariaOwnsElements")}} and {{domxref("ElementInternals.ariaOwnsElements")}}
+  - : The `ariaOwnsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-owns` attribute (for cases where those ID values reference valid and in-scope elements).
+
 ## Associated roles
 
 Used in **ALL** roles.

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-owns/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-owns/index.md
@@ -55,8 +55,12 @@ Make sure your owned elements have only one owner. Do not specify the `id` of an
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaOwnsElements")}} and {{domxref("ElementInternals.ariaOwnsElements")}}
-  - : The `ariaOwnsElements` property is part of each element's interface. Its value is an array of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-owns` attribute (for cases where those ID values reference valid and in-scope elements).
+- {{domxref("Element.ariaOwnsElements")}}
+  - : The `ariaOwnsElements` property is part of each element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-owns` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
+- {{domxref("ElementInternals.ariaOwnsElements")}}
+  - : The `ariaOwnsElements` property is part of each custom element's interface.
+    Its value is an array of subclasses of {{domxref("Element")}} that reflect the `id` references in the `aria-owns` attribute ([with some caveats](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references)).
 
 ## Associated roles
 

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -26,7 +26,7 @@ Consider the following HTML:
 <input placeholder="Original placeholder" />
 ```
 
-To get and set the [`placeholder`](/en-US/docs/Web/HTML/Attributes/placeholder) attribute:
+To get and set the [`placeholder`](/en-US/docs/Web/HTML/Reference/Attributes/placeholder) attribute:
 
 ```js
 const input = document.querySelector("input");
@@ -125,7 +125,7 @@ This example shows how you can get and set attributes and their reflected proper
 
 #### HTML
 
-The HTML defines an {{htmlelement("input")}} element where the [`placeholder`](/en-US/docs/Web/HTML/Attributes/placeholder) attribute has been set with the text "Original placeholder".
+The HTML defines an {{htmlelement("input")}} element where the [`placeholder`](/en-US/docs/Web/HTML/Reference/Attributes/placeholder) attribute has been set with the text "Original placeholder".
 We also define two {{htmlelement("button")}} elements for replacing the `placeholder` attribute.
 
 ```html
@@ -166,7 +166,7 @@ const inputElement = document.querySelector("input");
 log(
   `(Original) attr: "${inputElement.getAttribute("placeholder")}", prop: "${
     inputElement.placeholder
-  }"`
+  }"`,
 );
 ```
 
@@ -182,8 +182,8 @@ setAttributeButton.addEventListener("click", () => {
   inputElement.setAttribute("placeholder", "Set from attribute");
   log(
     `(Set attribute) attr: "${inputElement.getAttribute(
-      "placeholder"
-    )}", prop: "${inputElement.placeholder}"`
+      "placeholder",
+    )}", prop: "${inputElement.placeholder}"`,
   );
 });
 
@@ -192,8 +192,8 @@ setPropertyButton.addEventListener("click", () => {
   inputElement.placeholder = "Set from property";
   log(
     `(Set property) attr: "${inputElement.getAttribute(
-      "placeholder"
-    )}", prop: "${inputElement.placeholder}"`
+      "placeholder",
+    )}", prop: "${inputElement.placeholder}"`,
   );
 });
 ```

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -103,7 +103,7 @@ The way that these issues are resolved is that:
   If you read the attribute it will return `""`.
 - Setting the attribute (with {{domxref("Element.setAttribute()")}}) causes the property to reflect the valid and in-scope references.
 - Setting the attribute with a value reference that is subsequently moved out of scope will result in removal of the corresponding element from the property array.
-  Note however that the attribute still contains the reference, and if the element is moved back in-scope the property will again include the element (i.e. the relationship is restored).
+  Note however that the attribute still contains the reference, and if the element is moved back in-scope the property will again include the element (i.e., the relationship is restored).
 
 Note that the allowed scope of a reference is an element in the same scope or an ancestor scope of the element, but not a descendant scope.
 What this means that an element in a shadow root can reference an element from within its own shadow DOM or the parent DOM, but a DOM element can't set an element defined in a (descendent) shadow root.

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -1,0 +1,420 @@
+---
+title: Attribute reflection
+slug: Web/API/Document_Object_Model/Reflected_attributes
+page-type: guide
+---
+
+{{DefaultAPISidebar("DOM")}}
+
+An {{Glossary("attribute")}} extends an {{Glossary("HTML")}}, {{Glossary("XML")}}, {{Glossary("SVG")}} or other {{Glossary("element")}}, changing its behavior or providing metadata.
+
+Many attributes are _reflected_ in the corresponding [DOM](/en-US/docs/Web/API/Document_Object_Model) interface.
+What this means is that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
+The reflected properties offer a more natural programming approach than getting and setting attribute values using the {{domxref("Element.getAttribute()","getAttribute()")}} and {{domxref("Element.setAttribute()","setAttribute()")}} methods of the {{domxref("Element")}} interface.
+
+This guide provides an overview of reflected attributes and how they are used.
+
+## Attribute getter/setter
+
+First let's see the default mechanism for getting and setting an attribute, which can be used whether or not the attribute is reflected.
+To get the attribute you call the {{domxref("Element.getAttribute()","getAttribute()")}} method of the {{domxref("Element")}} interface, specifying the attribute name.
+To set the attribute you call the {{domxref("Element.setAttribute()","setAttribute()")}} methods, specifying the attribute name and new value.
+
+Consider the following HTML:
+
+```html
+<input placeholder="Original placeholder" />
+```
+
+To get and set the [`placeholder`](/en-US/docs/Web/HTML/Attributes/placeholder) attribute:
+
+```js
+const input = document.querySelector("input");
+
+// Get the placeholder attribute
+let attr = input.getAttribute("placeholder");
+
+// Set the placeholder attribute
+input.setAttribute("placeholder", "Modified placeholder");
+```
+
+## Reflected attributes
+
+For an {{htmlelement("input")}} the `placeholder` attribute is reflected by the {{domxref("HTMLInputElement.placeholder")}} property.
+Given the same HTML as before:
+
+```html
+<input placeholder="Original placeholder" />
+```
+
+The same operation can be performed more naturally using the `placeholder` property:
+
+```js
+const input = document.querySelector("input");
+
+// Get the placeholder attribute
+let attr = input.placeholder;
+
+// Set the placeholder attribute
+input.placeholder = "Modified placeholder";
+```
+
+Note that the name of the reflected attribute and the property are the same: `placeholder`.
+This is not always the case: properties are usually named following the {{glossary("Camel case","camelCase")}} convention.
+This is particularly true for multi-word attribute names that contain a characters that are not allowed in a property name, such as the hyphen.
+For example the [aria-checked](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-checked) attribute is reflected by the [`ariaChecked`](/en-US/docs/Web/API/Element/ariaChecked) property.
+
+### Boolean reflected attributes
+
+{{Glossary("Boolean/HTML", "Boolean attributes")}} are a little different than others in that they don't have to be declared with a name and a value.
+For example, the checkbox {{htmlelement("input")}} element below has the `checked` attribute, and will be checked on display:
+
+```html
+<input type="checkbox" checked />
+```
+
+The {{domxref("Element.getAttribute()")}} will return `""` if the input is checked or `null` if it is not.
+The corresponding {{domxref("HTMLInputElement.checked")}} property returns `true` or `false` for the checked state.
+Otherwise boolean reflected attributes are the same as any other reflected attributes.
+
+## Reflected element references
+
+> [!NOTE]
+> This section applies to [reflected aria attributes that contain element references](/en-US/docs/Web/API/Element#instance_properties_reflected_from_aria_element_references).
+> The same considerations are likely to apply to other/future attributes that reflect element references.
+
+Some attributes take element _references_ as values: either an element `id` value or a space-separated string of element `id` values.
+These attributes refer to other elements which are related to the attribute, or contain the information needed by the attribute.
+For example, the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute lists the elements controlled by a button, while [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) lists elements that contain the accessible name for an element in their inner text.
+
+The attribute's element references are reflected in the property as an array of the corresponding {{domxref("HTMLElement")}}-derived object instances, with some caveats!
+
+There are several potential issues with using element references in attributes:
+
+- Elements referenced in the attribute may not exist, for example because the developer omitted or mistyped an id, or because a specified `id` reference is not in scope for the element.
+- Elements referenced in the attribute may initially be in scope, but may later be removed.
+- The property may be assigned an element that does not have an `id`, and which therefore can't be referenced in the attribute (being able to assign elements without having to create an id is actually a benefit of using properties!)
+
+For these reasons, unlike for other reflected elements, there may not be a 1:1 correspondence between the reflected attributes and their associated property.
+The way that these issues are resolved is that:
+
+- The attribute is only reflected when it is defined, and only for listed reference `id` values that match valid in-scope elements.
+- Setting the property clears ("undefines") the attribute, so that the property and attribute no longer reflect each other.
+  If you read the attribute it will return `""`.
+- Setting the attribute (with {{domxref("Element.setAttribute()")}}) causes the property to reflect the valid and in-scope references.
+- Setting the attribute with a value reference that is subsequently moved out of scope will result in removal of the corresponding element from the property array.
+  Note however that the attribute still contains the reference, and if the element is moved back in-scope the property will again include the element (i.e. the relationship is restored).
+
+Note that the allowed scope of a reference is an element in the same scope or an ancestor scope of the element, but not a descendant scope.
+What this means that an element in a shadow root can reference an element from within its own shadow DOM or the parent DOM, but a DOM element can't set an element defined in a (descendent) shadow root.
+
+## Examples
+
+### Getting and setting reflected attributes
+
+This example shows how you can get and set attributes and their reflected properties, and demonstrates that the values match irrespective of what value is used.
+
+#### HTML
+
+The HTML defines an {{htmlelement("input")}} element where the [`placeholder`](/en-US/docs/Web/HTML/Attributes/placeholder) attribute has been set with the text "Original placeholder".
+We also define two {{htmlelement("button")}} elements for replacing the `placeholder` attribute.
+
+```html
+<input placeholder="Original placeholder" />
+<button id="attr">Set attribute</button>
+<button id="prop">Set property</button>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 270px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code first gets the input element and logs value of the placeholder attribute using {{domxref("Element.getAttribute()")}} and the property using {{domxref("HTMLInputElement.placeholder")}}.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const inputElement = document.querySelector("input");
+
+// Log placeholder attribute and property
+log(
+  `(Original) attr: "${inputElement.getAttribute("placeholder")}", prop: "${inputElement.placeholder}"`,
+);
+```
+
+We then define two event listeners for the buttons, which set the placeholder using {{domxref("Element.setAttribute()")}} and {{domxref("HTMLInputElement.placeholder")}}, respectively.
+In both cases the attribute and property are then logged.
+
+```js
+const setAttributeButton = document.querySelector("#attr");
+const setPropertyButton = document.querySelector("#prop");
+
+// Set placeholder attribute on button click
+setAttributeButton.addEventListener("click", () => {
+  inputElement.setAttribute("placeholder", "Set from attribute");
+  log(
+    `(Set attribute) attr: "${inputElement.getAttribute("placeholder")}", prop: "${inputElement.placeholder}"`,
+  );
+});
+
+// Set placeholder property on button click
+setPropertyButton.addEventListener("click", () => {
+  inputElement.placeholder = "Set from property";
+  log(
+    `(Set property) attr: "${inputElement.getAttribute("placeholder")}", prop: "${inputElement.placeholder}"`,
+  );
+});
+```
+
+#### Result
+
+The log below shows the output of the above code.
+Note that the value can be set using either the attribute or the property, and the result read via either approach is the same.
+
+{{EmbedLiveSample("Getting and setting reflected attributes","100%","350px")}}
+
+### Setting and getting reflected element references
+
+This example show how reflected element references work by demonstrating the effects of getting and setting the attribute and its reflected property.
+
+This code sets an attribute in HTML and then reads both the attribute and reflected property - demonstrating that invalid properties are not included.
+It then sets the property, demonstrating that the attribute is cleared, and then the attribute, demonstrating that it is restored.
+
+While the example uses the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute and corresponding property {{domxref("Element.ariaLabelledByElements")}}, other attributes containing element references should behave similarly.
+
+#### HTML
+
+The HTML defines two {{htmlelement("span")}} elements and references their ids in the `aria-labelledby` attribute of an {{htmlelement("input")}}.
+The accessible name of the `<input>` is then the concatenation of the inner text of the first two referenced elements.
+
+```html
+<span id="label_1">(Label 1 Text)</span>
+<input aria-labelledby="label_1 label_2" />
+<span id="label_2">(Label 2 Text)</span>
+<span>(Label 3 Text)</span>
+```
+
+There is also a final span `label_3` which will be programmatically added using `setAttribute()`.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 270px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code first defines a logging function to list the ids from the `aria-labelledby` attribute using {{domxref("Element.getAttribute()")}}, the elements from `ariaLabelledByElements`, and the accessible name constructed from the inner text of each of those elements.
+
+```js
+function logAccessibleInfo(element) {
+  const refids = element.getAttribute("aria-labelledby");
+
+  let text = "";
+  accessElements = element.ariaLabelledByElements;
+  accessElements.forEach((el) => {
+    text += el.textContent.trim() + " ";
+  });
+  text = text.trim();
+
+  log(` refs: "${refids}", el: ${accessElements}, label: ${text} `);
+}
+```
+
+If `ariaLabelledByElements` is supported, the code:
+
+1. Logs the original ids, elements, and element text, as set from the HTML (shows that properties are reflected when the attribute is set).
+2. Sets the property by selecting the `<span>` elements and logs the same information (shows that the attribute is cleared if you set the property).
+   Note that here we don't have to specify the `id` values, as we did in the attribute!
+3. Sets the `aria-labelledby` attribute to the reference `id` string of `label_1 label_4 label_3` and logs the same information.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const inputElement = document.querySelector("input");
+
+// Feature test for ariaLabelledByElements
+if ("ariaLabelledByElements" in Element.prototype) {
+  log("[1] Attributes set in HTML");
+  logAccessibleInfo(inputElement);
+
+  log("[2] Property set from span selector");
+  inputElement.ariaLabelledByElements = document.querySelectorAll("span");
+  logAccessibleInfo(inputElement);
+
+  log("[3] Attribute set from using setAttribute");
+  inputElement.setAttribute("aria-labelledby", "label_1 label_4");
+  logAccessibleInfo(inputElement);
+} else {
+  log("ariaLabelledByElements not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the output of the above code:
+
+- Line [1] demonstrates that the property reflects the references set in the HTML attribute.
+  It contains both the references in the original attribute, and we can see that their inner text is in the final output.
+- Line [2] demonstrates that setting the property clears the attribute, setting it to `""`.
+  The property no longer reflects the attribute, and contains one element (label 3) that doesn't even have an `id`.
+- Line [3] demonstrates that setting the attribute "restores" the reflection.
+  Note that the referenced element `label_4` does not exist, so there is no corresponding element in the property.
+
+{{EmbedLiveSample("Setting and getting reflected element references","100%","350px")}}
+
+### Reflected element reference DOM scope
+
+This example demonstrates that an element can't reference a descendent scope, but that a referenced that is moved out of scope will be reflected again when it is moved back into scope.
+
+While the example uses the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute and corresponding property {{domxref("Element.ariaLabelledByElements")}}, other attributes containing element references should behave similarly.
+
+#### HTML
+
+The HTML defines two {{htmlelement("span")}} elements in the DOM (`label_1` and `label_2`), and a third (`label_3`) in a shadow root.
+These are all referenced in the `aria-labelledby` attribute of an {{htmlelement("input")}} in the DOM.
+Note that the shadow root is a descendent scope of the input element, so `label_3` cannot be reflected by the property that reflects the attribute.
+There is also a toggle button for moving the `label_1` element in and out of the shadow root, and a reset button to clear the log.
+
+```html
+<div id="in_dom">
+  <span id="label_1">(Label 1 Text)</span>
+  <input aria-labelledby="label_1 label_2 label_3" />
+  <span id="label_2">(Label 2 Text)</span>
+</div>
+<div id="host">
+  <template shadowrootmode="open">
+    <span id="label_3">(Label 3 Text)</span>
+  </template>
+</div>
+
+<button id="toggle">Toggle label1</button>
+<button id="reset" type="button">Reset</button>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 270px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+The code first defines a logging function to list the ids from the `aria-labelledby` attribute using {{domxref("Element.getAttribute()")}}, the number of elements in `ariaLabelledByElements`, and the accessible name constructed from the inner text of each of those elements.
+
+```js
+function logAccessibleInfo(element) {
+  const refids = element.getAttribute("aria-labelledby");
+
+  let text = "";
+  accessElements = element.ariaLabelledByElements;
+  accessElements.forEach((el) => {
+    text += el.textContent.trim() + " ";
+  });
+  text = text.trim();
+
+  log(` refs: "${refids}", elLen: ${accessElements.length}, label: ${text} `);
+}
+```
+
+If `ariaLabelledByElements` is supported, the code:
+
+1. Logs the original reference ids, number of elements, and element text, as set from the HTML.
+   Note that the `label_1` element is initially in scope, but `label_3` is not.
+
+2. Adds an event listener on the toggle button which toggles the `label_1` element in and out of the shadow root.
+   This moves the element in and out of the property, though it will remain a reference.
+
+```js
+const inputElement = document.querySelector("input");
+const toggleButton = document.querySelector("#toggle");
+
+const host = document.querySelector("#host");
+const label1Element = document.querySelector("#label_1");
+const domDiv = document.querySelector("#in_dom");
+
+// Feature test for ariaLabelledByElements
+if ("ariaLabelledByElements" in Element.prototype) {
+  log("[1] Attributes set in HTML");
+  logAccessibleInfo(inputElement);
+
+  // Set placeholder property on button click
+  let toggle = true;
+  toggleButton.addEventListener("click", () => {
+    if (toggle) {
+      host.shadowRoot.appendChild(label1Element);
+      log("Label1 to shadow");
+    } else {
+      log("Label1 to dom");
+      domDiv.appendChild(label1Element);
+    }
+    toggle = !toggle;
+    logAccessibleInfo(inputElement);
+  });
+} else {
+  log("ariaLabelledByElements not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the output of the above code:
+
+- Line [1] demonstrates that the property reflects the references set in the HTML attribute.
+  This should show that `label_3` has no corresponding element reflected in the property, as it is out of scope.
+- As you toggle the button the `label_1` element should be added and removed from the property as it is moved in and out of scope.
+
+{{EmbedLiveSample("Reflected element reference DOM scope","100%","350px")}}

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -202,6 +202,7 @@ setPropertyButton.addEventListener("click", () => {
 
 The log below shows the output of the above code.
 Note that the value can be set using either the attribute or the property, and the result read via either approach is the same.
+The example doesn't do anything with text entered into the `<input>`.
 
 {{EmbedLiveSample("Getting and setting reflected attributes","100%","350px")}}
 
@@ -300,6 +301,8 @@ The log below shows the output of the above code:
   The property no longer reflects the attribute, and contains one element (label 3) that doesn't even have an `id`.
 - Line [3] demonstrates that setting the attribute "restores" the reflection.
   Note that the referenced element `label_4` does not exist, so there is no corresponding element in the property.
+
+Note that the example doesn't do anything with text entered into the `<input>`.
 
 {{EmbedLiveSample("Setting and getting reflected element references","100%","350px")}}
 
@@ -421,5 +424,7 @@ The log below shows the output of the above code:
 - Line [1] demonstrates that the property reflects the references set in the HTML attribute.
   This should show that `label_3` has no corresponding element reflected in the property, as it is out of scope.
 - As you toggle the button the `label_1` element should be added and removed from the property as it is moved in and out of scope.
+
+Note that the example doesn't do anything with text entered into the `<input>`.
 
 {{EmbedLiveSample("Reflected element reference DOM scope","100%","400px")}}

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -248,15 +248,10 @@ The code first defines a logging function to list the ids from the `aria-labelle
 ```js
 function logAccessibleInfo(element) {
   const refids = element.getAttribute("aria-labelledby");
+  const accessElements = element.ariaLabelledByElements;
+  const text = accessElements.map((e) => e.textContent).join(" ");
 
-  let text = "";
-  accessElements = element.ariaLabelledByElements;
-  accessElements.forEach((el) => {
-    text += el.textContent.trim() + " ";
-  });
-  text = text.trim();
-
-  log(` refs: "${refids}", el: ${accessElements}, label: ${text} `);
+  log(` ref ids: "${refids}", el: ${accessElements}, label: ${text} `);
 }
 ```
 
@@ -373,15 +368,10 @@ The code first defines a logging function to list the ids from the `aria-labelle
 ```js
 function logAccessibleInfo(element) {
   const refids = element.getAttribute("aria-labelledby");
+  const accessElements = element.ariaLabelledByElements;
+  const text = accessElements.map((e) => e.textContent).join(" ");
 
-  let text = "";
-  accessElements = element.ariaLabelledByElements;
-  accessElements.forEach((el) => {
-    text += el.textContent.trim() + " ";
-  });
-  text = text.trim();
-
-  log(` refs: "${refids}", elLen: ${accessElements.length}, label: ${text} `);
+  log(` ref ids: "${refids}", el: ${accessElements}, label: ${text} `);
 }
 ```
 
@@ -432,4 +422,4 @@ The log below shows the output of the above code:
   This should show that `label_3` has no corresponding element reflected in the property, as it is out of scope.
 - As you toggle the button the `label_1` element should be added and removed from the property as it is moved in and out of scope.
 
-{{EmbedLiveSample("Reflected element reference DOM scope","100%","350px")}}
+{{EmbedLiveSample("Reflected element reference DOM scope","100%","400px")}}

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -80,7 +80,7 @@ Otherwise boolean reflected attributes are the same as any other reflected attri
 ## Reflected element references
 
 > [!NOTE]
-> This section applies to [reflected aria attributes that contain element references](/en-US/docs/Web/API/Element#instance_properties_reflected_from_aria_element_references).
+> This section applies to [reflected ARIA attributes that contain element references](/en-US/docs/Web/API/Element#instance_properties_reflected_from_aria_element_references).
 > The same considerations are likely to apply to other/future attributes that reflect element references.
 
 Some attributes take element _references_ as values: either an element `id` value or a space-separated string of element `id` values.

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -6,10 +6,10 @@ page-type: guide
 
 {{DefaultAPISidebar("DOM")}}
 
-An {{Glossary("attribute")}} extends an {{Glossary("HTML")}}, {{Glossary("XML")}}, {{Glossary("SVG")}} or other {{Glossary("element")}}, changing its behavior or providing metadata.
+An {{glossary("attribute")}} extends an {{glossary("HTML")}}, {{glossary("XML")}}, {{glossary("SVG")}} or other {{glossary("element")}}, changing its behavior or providing metadata.
 
 Many attributes are _reflected_ in the corresponding [DOM](/en-US/docs/Web/API/Document_Object_Model) interface.
-What this means is that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
+This means that the value of the attribute can be read or written directly in JavaScript through a property on the corresponding interface, and vice versa.
 The reflected properties offer a more natural programming approach than getting and setting attribute values using the {{domxref("Element.getAttribute()","getAttribute()")}} and {{domxref("Element.setAttribute()","setAttribute()")}} methods of the {{domxref("Element")}} interface.
 
 This guide provides an overview of reflected attributes and how they are used.
@@ -96,7 +96,7 @@ There are several potential issues with using element references in attributes:
 - The property may be assigned an element that does not have an `id`, and which therefore can't be referenced in the attribute (being able to assign elements without having to create an id is actually a benefit of using properties!)
 
 For these reasons, unlike for other reflected elements, there may not be a 1:1 correspondence between the reflected attributes and their associated property.
-The way that these issues are resolved is that:
+These issues are resolved as follows:
 
 - The attribute is only reflected when it is defined, and only for listed reference `id` values that match valid in-scope elements.
 - Setting the property clears ("undefines") the attribute, so that the property and attribute no longer reflect each other.
@@ -106,7 +106,7 @@ The way that these issues are resolved is that:
   Note however that the attribute still contains the reference, and if the element is moved back in-scope the property will again include the element (i.e., the relationship is restored).
 
 Note that the allowed scope of a reference is an element in the same scope or an ancestor scope of the element, but not a descendant scope.
-What this means that an element in a shadow root can reference an element from within its own shadow DOM or the parent DOM, but a DOM element can't set an element defined in a (descendent) shadow root.
+This means that an element in a shadow root can reference an element from within its own shadow DOM or the parent DOM, but a DOM element can't set an element defined in a (descendent) shadow root.
 
 ## Examples
 

--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -84,10 +84,94 @@ Otherwise boolean reflected attributes are the same as any other reflected attri
 > The same considerations are likely to apply to other/future attributes that reflect element references.
 
 Some attributes take element _references_ as values: either an element `id` value or a space-separated string of element `id` values.
-These attributes refer to other elements which are related to the attribute, or contain the information needed by the attribute.
-For example, the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute lists the elements controlled by a button, while [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) lists elements that contain the accessible name for an element in their inner text.
+These `id` values refer to other elements which are related to the attribute, or that contain information needed by the attribute.
+These attributes are reflected by a corresponding property as an array of {{domxref("HTMLElement")}}-derived object instances that match the `id` values, with some caveats.
 
-The attribute's element references are reflected in the property as an array of the corresponding {{domxref("HTMLElement")}}-derived object instances, with some caveats.
+For example, the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute lists the `id` values of elements that contain the accessible name for an element in their inner text.
+The HTML below shows this for an {{htmlelement("input")}} that has a label defined in {{htmlelement("span")}} elements with `id` values of `label_1`, `label_2`, and `label_3`:
+
+```html
+<span id="label_1">(Label 1 Text)</span>
+<span id="label_2">(Label 2 Text)</span>
+<input aria-labelledby="label_1 label_2 label_3" />
+```
+
+This attribute is reflected by {{domxref("Element.ariaLabelledByElements")}} property, which returns the array of elements that have the corresponding `id` values.
+The attribute and corresponding property can be returned as shown:
+
+```js
+const inputElement = document.querySelector("input");
+
+console.log(inputElement.getAttribute("aria-labelledby"));
+// "label_1 label_2 label_3"
+
+console.log(inputElement.ariaLabelledByElements);
+// [HTMLSpanElement, HTMLSpanElement]
+```
+
+The first thing to note from the code above is that the attribute and the property contain different numbers of elements — the property doesn't _directly_ reflect the attribute because the reference `label_3` does not have a corresponding element.
+It is also possible that a reference will not match because it is [out of scope](#element_reference_scope) for the element, as discussed in a following section.
+
+We can iterate the elements in the property array, in this case to get the accessible name from their inner text (this is more natural than using the attribute, because we don't have to first get the element references and then use them to find the elements, and we only have to work with elements that we know to be available in the current scope):
+
+```js
+const inputElement = document.querySelector("input");
+const accessibleName = inputElement.ariaLabelledByElements
+  .map((e) => e.textContent.trim())
+  .join(" ");
+console.log(accessibleName);
+// (Label 1 Text) (Label 2 Text)
+```
+
+### Setting the property and attribute
+
+For normal reflected properties, updates to the property are reflected in the corresponding attribute and vice versa.
+For reflected element references this is not the case.
+Instead, setting the property clears ("undefines") the attribute, so that the property and attribute no longer reflect each other.
+For example, given the following HTML:
+
+```html
+<span id="label_1">(Label 1 Text)</span>
+<span id="label_2">(Label 2 Text)</span>
+<input aria-labelledby="label_1 label_2" />
+```
+
+The initial value of the `aria-labelledby` is `"label_1 label_2"`, but if we set it from the DOM API, the attribute is reset to `""`:
+
+```js
+const inputElement = document.querySelector("input");
+
+let attributeValue = inputElement.getAttribute("aria-labelledby");
+console.log(attributeValue);
+// "label_1 label_2"
+
+// Set attribute using the reflected property
+inputElement.ariaLabelledByElements = document.querySelectorAll("span");
+
+attributeValue = inputElement.getAttribute("aria-labelledby");
+console.log(attributeValue);
+// ""
+```
+
+This makes sense because you could otherwise assign elements to the property that don't have an `id` reference, and hence can't be represented in the attribute.
+
+Setting the attribute value restores the relationship between the attribute and the property.
+Continuing the example from above:
+
+```js
+inputElement.setAttribute("aria-labelledby", "input1");
+
+attributeValue = inputElement.getAttribute("aria-labelledby");
+console.log(attributeValue);
+// "label_1"
+
+// Set attribute using the reflected property
+console.log(inputElement.ariaLabelledByElements);
+// [HTMLSpanElement] - for `label_1`
+```
+
+The array returned by the property is static, so you can't modify the returned array to cause changes to the corresponding attribute.
+When an array is assigned to the property it is copied, so any changes to the attribute will not be reflected in a previously returned property array.
 
 ### Element reference scope
 
@@ -96,228 +180,11 @@ Element references can only match to elements that are "in scope" with the refer
 An HTML document is represented to JavaScript as a hierarchical tree of objects referred to as the [Document Object Model (DOM)](/en-US/docs/Web/API/Document_Object_Model).
 Elements within the model may contain and encapsulate "child" DOMs, referred to as [Shadow DOMs](/en-US/docs/Web/API/Web_components#shadow_dom_2) within a [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot), which can in turn nest their own Shadow DOMs.
 
-The scope of a referencing element is the DOM in which it is defined, and any parent DOMs in which that DOM is nested. Shadow DOMS that are nested children of the DOM in which the referencing element is defined are out of scope.
+The scope of a referencing element is the DOM in which it is defined, and any parent DOMs in which that DOM is nested.
+Shadow DOMS that are nested children of the DOM in which the referencing element is defined are out of scope.
 
-What this means is that an element in the main DOM can only reference elements in the main DOM (since elements in a Shadow DOM are necessarily children of its DOM, and hence out of scope).
-However an element in a shadow root can nest elements in that same shadow root and also in the main DOM (and any DOM's that are parents), since they are in scope.
-
-<!-- diagrams? -->
-
-Note that a referenced element may initially be "in scope" and then moved out of scope into a nested shadow root.
-In this case the referenced element may still be listed in the attribute
-
-### Relationship between attribute and property
-
-The relationship between attributes containing element references and their corresponding property is as follows:
-
-- Only attribute `id` values that match [in-scope elements](#element_reference_scope) are reflected in the property.
-- Setting the property clears the attribute and the property and attribute no longer reflect each other.
-  If the attributes is read, with {{domxref("Element.getAttribute()")}}, the value is `""`.
-- Setting the attribute, with {{domxref("Element.setAttribute()")}}, also sets the property and restores the "reflection relationship".
-- Setting the attribute with a value reference that is subsequently moved out of scope will result in removal of the corresponding element from the property array.
-  Note however that the attribute still contains the reference, and if the element is moved back in-scope the property will again include the element (i.e., the relationship is restored).
-
-## Examples
-
-### Getting and setting reflected attributes
-
-This example shows how you can get and set attributes and their reflected properties, and demonstrates that the values match irrespective of what value is used.
-
-#### HTML
-
-The HTML defines an {{htmlelement("input")}} element where the [`placeholder`](/en-US/docs/Web/HTML/Reference/Attributes/placeholder) attribute has been set with the text "Original placeholder".
-We also define two {{htmlelement("button")}} elements for replacing the `placeholder` attribute.
-
-```html
-<input placeholder="Original placeholder" />
-<button id="attr">Set attribute</button>
-<button id="prop">Set property</button>
-```
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 270px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-#### JavaScript
-
-The code first gets the input element and logs value of the placeholder attribute using {{domxref("Element.getAttribute()")}} and the property using {{domxref("HTMLInputElement.placeholder")}}.
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js
-const inputElement = document.querySelector("input");
-
-// Log placeholder attribute and property
-log(
-  `(Original) attr: "${inputElement.getAttribute("placeholder")}", prop: "${
-    inputElement.placeholder
-  }"`,
-);
-```
-
-We then define two event listeners for the buttons, which set the placeholder using {{domxref("Element.setAttribute()")}} and {{domxref("HTMLInputElement.placeholder")}}, respectively.
-In both cases the attribute and property are then logged.
-
-```js
-const setAttributeButton = document.querySelector("#attr");
-const setPropertyButton = document.querySelector("#prop");
-
-// Set placeholder attribute on button click
-setAttributeButton.addEventListener("click", () => {
-  inputElement.setAttribute("placeholder", "Set from attribute");
-  log(
-    `(Set attribute) attr: "${inputElement.getAttribute(
-      "placeholder",
-    )}", prop: "${inputElement.placeholder}"`,
-  );
-});
-
-// Set placeholder property on button click
-setPropertyButton.addEventListener("click", () => {
-  inputElement.placeholder = "Set from property";
-  log(
-    `(Set property) attr: "${inputElement.getAttribute(
-      "placeholder",
-    )}", prop: "${inputElement.placeholder}"`,
-  );
-});
-```
-
-#### Result
-
-The log below shows the output of the above code.
-Note that the value can be set using either the attribute or the property, and the result read via either approach is the same.
-The example doesn't do anything with text entered into the `<input>`.
-
-{{EmbedLiveSample("Getting and setting reflected attributes","100%","350px")}}
-
-### Setting and getting reflected element references
-
-This example show how reflected element references work by demonstrating the effects of getting and setting the attribute and its reflected property.
-
-This code sets an attribute in HTML and then reads both the attribute and reflected property - demonstrating that invalid properties are not included.
-It then sets the property, demonstrating that the attribute is cleared, and then the attribute, demonstrating that it is restored.
-
-While the example uses the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute and corresponding property {{domxref("Element.ariaLabelledByElements")}}, other attributes containing element references should behave similarly.
-
-#### HTML
-
-The HTML defines two {{htmlelement("span")}} elements and references their ids in the `aria-labelledby` attribute of an {{htmlelement("input")}}.
-The accessible name of the `<input>` is then the concatenation of the inner text of the first two referenced elements.
-
-```html
-<span id="label_1">(Label 1 Text)</span>
-<input aria-labelledby="label_1 label_2" />
-<span id="label_2">(Label 2 Text)</span>
-<span>(Label 3 Text)</span>
-```
-
-There is also a final span `label_3` which will be programmatically added using `setAttribute()`.
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 270px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-#### JavaScript
-
-The code first defines a logging function to list the ids from the `aria-labelledby` attribute using {{domxref("Element.getAttribute()")}}, the elements from `ariaLabelledByElements`, and the accessible name constructed from the inner text of each of those elements.
-
-```js
-function logAccessibleInfo(element) {
-  const refids = element.getAttribute("aria-labelledby");
-  const accessElements = element.ariaLabelledByElements;
-  const text = accessElements.map((e) => e.textContent).join(" ");
-
-  log(` ref ids: "${refids}", el: ${accessElements}, label: ${text} `);
-}
-```
-
-If `ariaLabelledByElements` is supported, the code:
-
-1. Logs the original ids, elements, and element text, as set from the HTML (shows that properties are reflected when the attribute is set).
-2. Sets the property by selecting the `<span>` elements and logs the same information (shows that the attribute is cleared if you set the property).
-   Note that here we don't have to specify the `id` values, as we did in the attribute!
-3. Sets the `aria-labelledby` attribute to the reference `id` string of `label_1 label_4 label_3` and logs the same information.
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js
-const inputElement = document.querySelector("input");
-
-// Feature test for ariaLabelledByElements
-if ("ariaLabelledByElements" in Element.prototype) {
-  log("[1] Attributes set in HTML");
-  logAccessibleInfo(inputElement);
-
-  log("[2] Property set from span selector");
-  inputElement.ariaLabelledByElements = document.querySelectorAll("span");
-  logAccessibleInfo(inputElement);
-
-  log("[3] Attribute set from using setAttribute");
-  inputElement.setAttribute("aria-labelledby", "label_1 label_4");
-  logAccessibleInfo(inputElement);
-} else {
-  log("ariaLabelledByElements not supported by browser");
-}
-```
-
-#### Result
-
-The log below shows the output of the above code:
-
-- Line [1] demonstrates that the property reflects the references set in the HTML attribute.
-  It contains both the references in the original attribute, and we can see that their inner text is in the final output.
-- Line [2] demonstrates that setting the property clears the attribute, setting it to `""`.
-  The property no longer reflects the attribute, and contains one element (label 3) that doesn't even have an `id`.
-- Line [3] demonstrates that setting the attribute "restores" the reflection.
-  Note that the referenced element `label_4` does not exist, so there is no corresponding element in the property.
-
-Note that the example doesn't do anything with text entered into the `<input>`.
-
-{{EmbedLiveSample("Setting and getting reflected element references","100%","350px")}}
-
-### Reflected element reference DOM scope
-
-This example demonstrates that an element can't reference a descendant scope, but that a referenced that is moved out of scope will be reflected again when it is moved back into scope.
-
-While the example uses the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute and corresponding property {{domxref("Element.ariaLabelledByElements")}}, other attributes containing element references should behave similarly.
-
-#### HTML
-
-The HTML defines two {{htmlelement("span")}} elements in the DOM (`label_1` and `label_2`), and a third (`label_3`) in a shadow root.
-These are all referenced in the `aria-labelledby` attribute of an {{htmlelement("input")}} in the DOM.
-Note that the shadow root is a descendant scope of the input element, so `label_3` cannot be reflected by the property that reflects the attribute.
-There is also a toggle button for moving the `label_1` element in and out of the shadow root, and a reset button to clear the log.
+What this means is that an element in the DOM can reference other elements in the DOM as they are in-scope, but not in a shadow DOM.
+For example, in the HTML below the element with the `id` of `label 3` would not be in scope for the {{htmlelement("input")}} element in the DOM, and would not be reflected in the corresponding property.
 
 ```html
 <div id="in_dom">
@@ -330,101 +197,35 @@ There is also a toggle button for moving the `label_1` element in and out of the
     <span id="label_3">(Label 3 Text)</span>
   </template>
 </div>
-
-<button id="toggle">Toggle label1</button>
-<button id="reset" type="button">Reset</button>
 ```
 
-```html hidden
-<pre id="log"></pre>
+However an element in a shadow root can reference elements in both the shadow root or in the DOM.
+For the HTML below, `label 3` would be present in the reflected property.
+
+```html
+<div id="in_dom">
+  <span id="label_3">(Label 3 Text)</span>
+</div>
+<div id="host">
+  <template shadowrootmode="open">
+    <span id="label_1">(Label 1 Text)</span>
+    <input aria-labelledby="label_1 label_2 label_3" />
+    <span id="label_2">(Label 2 Text)</span>
+  </template>
+</div>
 ```
 
-```css hidden
-#log {
-  height: 270px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
+Note that a referenced element may initially be "in scope" and then moved out of scope into a nested shadow root.
+In this case the referenced element will still be listed in the attribute, but will not be returned in the property.
+Note however that if the element is moved back into scope, it will again be present in the reflected property.
 
-#### JavaScript
+### Summary of the attribute/property relationship
 
-```js hidden
-const reload = document.querySelector("#reset");
+The relationship between attributes containing element references and their corresponding property is as follows:
 
-reload.addEventListener("click", () => {
-  window.location.reload(true);
-});
-```
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-The code first defines a logging function to list the ids from the `aria-labelledby` attribute using {{domxref("Element.getAttribute()")}}, the number of elements in `ariaLabelledByElements`, and the accessible name constructed from the inner text of each of those elements.
-
-```js
-function logAccessibleInfo(element) {
-  const refids = element.getAttribute("aria-labelledby");
-  const accessElements = element.ariaLabelledByElements;
-  const text = accessElements.map((e) => e.textContent).join(" ");
-
-  log(` ref ids: "${refids}", el: ${accessElements}, label: ${text} `);
-}
-```
-
-If `ariaLabelledByElements` is supported, the code:
-
-1. Logs the original reference ids, number of elements, and element text, as set from the HTML.
-   Note that the `label_1` element is initially in scope, but `label_3` is not.
-
-2. Adds an event listener on the toggle button which toggles the `label_1` element in and out of the shadow root.
-   This moves the element in and out of the property, though it will remain a reference.
-
-```js
-const inputElement = document.querySelector("input");
-const toggleButton = document.querySelector("#toggle");
-
-const host = document.querySelector("#host");
-const label1Element = document.querySelector("#label_1");
-const domDiv = document.querySelector("#in_dom");
-
-// Feature test for ariaLabelledByElements
-if ("ariaLabelledByElements" in Element.prototype) {
-  log("[1] Attributes set in HTML");
-  logAccessibleInfo(inputElement);
-
-  // Set placeholder property on button click
-  let toggle = true;
-  toggleButton.addEventListener("click", () => {
-    if (toggle) {
-      host.shadowRoot.appendChild(label1Element);
-      log("Label1 to shadow");
-    } else {
-      log("Label1 to dom");
-      domDiv.appendChild(label1Element);
-    }
-    toggle = !toggle;
-    logAccessibleInfo(inputElement);
-  });
-} else {
-  log("ariaLabelledByElements not supported by browser");
-}
-```
-
-#### Result
-
-The log below shows the output of the above code:
-
-- Line [1] demonstrates that the property reflects the references set in the HTML attribute.
-  This should show that `label_3` has no corresponding element reflected in the property, as it is out of scope.
-- As you toggle the button the `label_1` element should be added and removed from the property as it is moved in and out of scope.
-
-Note that the example doesn't do anything with text entered into the `<input>`.
-
-{{EmbedLiveSample("Reflected element reference DOM scope","100%","400px")}}
+- Only attribute `id` values that match [in-scope elements](#element_reference_scope) are reflected in the property.
+- Setting the property clears the attribute and the property and attribute no longer reflect each other.
+  If the attributes is read, with {{domxref("Element.getAttribute()")}}, the value is `""`.
+- Setting the attribute, with {{domxref("Element.setAttribute()")}}, also sets the property and restores the "reflection relationship".
+- Setting the attribute with a value reference that is subsequently moved out of scope will result in removal of the corresponding element from the property array.
+  Note however that the attribute still contains the reference, and if the element is moved back in-scope the property will again include the element (i.e., the relationship is restored).

--- a/files/en-us/web/api/element/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/element/ariaactivedescendantelement/index.md
@@ -27,8 +27,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the active descendant
 
 This example shows how `ariaActiveDescendantElement` can be used to get the current active descendant.

--- a/files/en-us/web/api/element/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/element/ariaactivedescendantelement/index.md
@@ -102,4 +102,4 @@ The value returned from the `aria-activedescendant` property should be `"avenue"
 
 - [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute
 - {{domxref("ElementInternals.ariaActiveDescendantElement")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/element/ariaactivedescendantelement/index.md
@@ -14,12 +14,12 @@ The [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attri
 
 ## Value
 
-An element that is the active descendant, or `null` if there is no active descendant.
+A subclass of {{domxref("HTMLElement")}} that is the active descendant, or `null` if there is no active descendant.
 
 ## Description
 
 The property is a flexible alternative to using the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute.
-Unlike `aria-activedescendant`, the element assigned to this property can be selected: it does not have to have an `id`.
+Unlike `aria-activedescendant`, the element assigned to this property does not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/element/ariaactivedescendantelement/index.md
@@ -29,14 +29,14 @@ For more information about reflected element references and scope see [Reflected
 
 The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
 
-### Get the active descendent
+### Get the active descendant
 
 This example shows how `ariaActiveDescendantElement` can be used to get the current active descendant.
 
 #### HTML
 
 The HTML defines a listbox for selecting different kinds of streets, consisting of a {{htmlelement("div")}} element with the [`listbox` role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listbox_role) and nested `<div>` items for each of the options.
-The active descendent is initially set to the element with `id` of `avenue` using `aria-activedescendant`.
+The active descendant is initially set to the element with `id` of `avenue` using `aria-activedescendant`.
 
 ```html
 <div id="streetType" role="listbox" aria-activedescendant="avenue">
@@ -88,7 +88,7 @@ if ("ariaActiveDescendantElement" in Element.prototype) {
 The log below shows the output of the above code.
 The value returned from the `aria-activedescendant` property should be `"avenue"`, the associated element should be a `HTMLDivElement` element, and the text in that element should be `Avenue`.
 
-{{EmbedLiveSample("Get the active descendent","100%","190px")}}
+{{EmbedLiveSample("Get the active descendant","100%","190px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/element/ariaactivedescendantelement/index.md
@@ -14,7 +14,7 @@ The [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attri
 
 ## Value
 
-A subclass of {{domxref("HTMLElement")}} that is the active descendant, or `null` if there is no active descendant.
+An subclass of {{domxref("HTMLElement")}} that represents the active descendant, or `null` if there is no active descendant.
 
 ## Description
 

--- a/files/en-us/web/api/element/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/element/ariaactivedescendantelement/index.md
@@ -1,0 +1,105 @@
+---
+title: "Element: ariaActiveDescendantElement property"
+short-title: ariaActiveDescendantElement
+slug: Web/API/Element/ariaActiveDescendantElement
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaActiveDescendantElement
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaActiveDescendantElement`** property of the {{domxref("Element")}} interface represents the current active element when focus is on a [`composite`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/composite_role) widget, [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role), [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role), [`group`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role), or [`application`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role).
+
+The [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An element that is the active descendant, or `null` if there is no active descendant.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute.
+Unlike `aria-activedescendant`, the element assigned to this property can be selected: it does not have to have an `id`.
+
+The property reflects the element's [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the active descendent
+
+This example shows how `ariaActiveDescendantElement` can be used to get the current active descendant.
+
+#### HTML
+
+The HTML defines a listbox for selecting different kinds of streets, consisting of a {{htmlelement("div")}} element with the [`listbox` role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listbox_role) and nested `<div>` items for each of the options.
+The active descendent is initially set to the element with `id` of `avenue` using `aria-activedescendant`.
+
+```html
+<div id="streetType" role="listbox" aria-activedescendant="avenue">
+  <div>Street</div>
+  <div id="avenue">Avenue</div>
+  <div>Lane</div>
+</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code below first checks whether the `ariaActiveDescendantElement` is supported.
+It the property is supported the code then logs the value of `aria-activedescendant` (the `id` of the referenced element) using {{domxref("Element.getAttribute()")}}, the property element, and the element's text content.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+// Feature test for ariaActiveDescendantElement
+if ("ariaActiveDescendantElement" in Element.prototype) {
+  log(`getAttribute(): ${streetType.getAttribute("aria-activedescendant")}`);
+  log(`ariaActiveDescendantElement: ${streetType.ariaActiveDescendantElement}`);
+  log(`text: ${streetType.ariaActiveDescendantElement?.textContent.trim()}`);
+} else {
+  log("ariaActiveDescendantElement not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the output of the above code.
+The value returned from the `aria-activedescendant` property should be `"avenue"`, the associated element should be a `HTMLDivElement` element, and the text in that element should be `Avenue`.
+
+{{EmbedLiveSample("Get the active descendent","100%","190px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute
+- {{domxref("ElementInternals.ariaActiveDescendantElement")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -20,8 +20,7 @@ An array of subclasses of {{domxref("HTMLElement")}}, representing the elements 
 ## Description
 
 The property is a flexible alternative to using the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute to set the controlled elements.
-Unlike `aria-controls`, the elements assigned to this property do not have to have an `id`: they can be selected.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to set them as controlled.
+Unlike `aria-controls`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -109,7 +109,7 @@ toggleButton.addEventListener("click", () => {
 
 Next the example gets the value of the `aria-controls` attribute with {{domxref("Element.getAttribute()")}} (a string listing the `id` values of the referenced elements).
 It then checks whether the `ariaControlsElements` property is supported, and if so, logs its value.
-Finally it returns and logs the inner text of each of the controlled elements.
+Finally it returns and logs the inner text for each of the controlled elements.
 
 ```js
 log(`aria-controls: ${toggleButton.getAttribute("aria-controls")}`);
@@ -120,11 +120,9 @@ if ("ariaControlsElements" in Element.prototype) {
   log(`ariaControlsElements: ${controlledElements}`);
 
   // List innerText for each of the ariaControlsElements
-  let textOfControllingElements = "";
   controlledElements.forEach((controlled) => {
-    textOfControllingElements += `"${controlled.textContent.trim()}" `;
+    log(` Controlled element text: ${controlled.textContent.trim()}`);
   });
-  log(`Controlled element text: ${textOfControllingElements.trim()}`);
 } else {
   log("element.ariaControlsElements: not supported by browser");
 }

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -17,6 +17,9 @@ The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ar
 
 An array of subclasses of {{domxref("HTMLElement")}}, representing the elements that are controlled by this element.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute to set the controlled elements.

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -1,0 +1,150 @@
+---
+title: "Element: ariaControlsElements property"
+short-title: ariaControlsElements
+slug: Web/API/Element/ariaControlsElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaControlsElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaControlsElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that are controlled by the element it is applied to.
+For example, this might be set on a [combobox](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role) to indicate the element that it pops up, or on a [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/scrollbar_role) to indicate the ID of the element it controls.
+
+The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements that are controlled by this element.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute to set the controlled elements.
+Unlike `aria-controls`, the elements assigned to this property do not have to have an `id`: they can be selected.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to set them as controlled.
+
+The property reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the controlled elements
+
+This example shows how `ariaControlsElements` can be used to get the controlled elements that were set using `aria-controls`.
+
+#### HTML
+
+The HTML defines first defines a {{htmlelement("button")}} element and two {{htmlelement("div")}} elements, `panel1` and `panel2`, that it controls.
+The references to the controlled panels are listed in the button's `aria-controls` attribute.
+
+```html
+<button id="toggleButton" aria-controls="panel1 panel2" aria-expanded="false">
+  Show Details
+</button>
+
+<div class="panel" id="panel1" aria-hidden="true">
+  <p>Panel1 opened/closed by button.</p>
+</div>
+
+<div class="panel" id="panel2" aria-hidden="true">
+  <p>Panel2 opened/closed by button.</p>
+</div>
+```
+
+```css
+.panel {
+  display: none; /* Initially hidden */
+  border: 1px solid #ccc;
+  padding: 5px;
+  margin-top: 5px;
+}
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code first sets up the panels to be toggled open or hidden based on the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded) attribute of the button.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const toggleButton = document.querySelector("#toggleButton");
+const panel1 = document.querySelector("#panel1");
+const panel2 = document.querySelector("#panel2");
+
+toggleButton.addEventListener("click", () => {
+  const isExpanded = toggleButton.getAttribute("aria-expanded") === "true";
+
+  toggleButton.setAttribute("aria-expanded", !isExpanded);
+  panel1.style.display = isExpanded ? "none" : "block";
+  panel1.setAttribute("aria-hidden", isExpanded); //true when hidden, false when shown.
+
+  panel2.style.display = isExpanded ? "none" : "block";
+  panel2.setAttribute("aria-hidden", isExpanded); //true when hidden, false when shown.
+});
+```
+
+Next the example gets the value of the `aria-controls` attribute with {{domxref("Element.getAttribute()")}} (a string listing the `id` values of the referenced elements).
+It then checks whether the `ariaControlsElements` property is supported, and if so, logs its value.
+Finally it returns and logs the inner text of each of the controlled elements.
+
+```js
+log(`aria-controls: ${toggleButton.getAttribute("aria-controls")}`);
+// Feature test for ariaControlsElements
+if ("ariaControlsElements" in Element.prototype) {
+  // Get ariaControlsElements
+  const controlledElements = toggleButton.ariaControlsElements;
+  log(`ariaControlsElements: ${controlledElements}`);
+
+  // List innerText for each of the ariaControlsElements
+  let textOfControllingElements = "";
+  controlledElements.forEach((controlled) => {
+    textOfControllingElements += `"${controlled.textContent.trim()}" `;
+  });
+  log(`Controlled element text: ${textOfControllingElements.trim()}`);
+} else {
+  log("element.ariaControlsElements: not supported by browser");
+}
+```
+
+#### Result
+
+Click the button below to show and hide the panels.
+The log shows the original element references, the associated/returned elements, and the inner text of each element.
+
+{{EmbedLiveSample("Get the controlled elements","100%","280px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute
+- {{domxref("ElementInternals.ariaControlsElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -8,14 +8,14 @@ browser-compat: api.Element.ariaControlsElements
 
 {{APIRef("DOM")}}
 
-The **`ariaControlsElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that are controlled by the element it is applied to.
+The **`ariaControlsElements`** property of the {{domxref("Element")}} interface is an array containing the elements that are controlled by the element it is applied to.
 For example, this might be set on a [combobox](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role) to indicate the element that it pops up, or on a [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/scrollbar_role) to indicate the ID of the element it controls.
 
 The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) topic contains additional information about how the attribute and property should be used.
 
 ## Value
 
-An array of elements that are controlled by this element.
+An array of subclasses of {{domxref("HTMLElement")}}, representing the elements that are controlled by this element.
 
 ## Description
 
@@ -147,4 +147,4 @@ The log shows the original element references, the associated/returned elements,
 
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute
 - {{domxref("ElementInternals.ariaControlsElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -31,8 +31,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the controlled elements
 
 This example shows how `ariaControlsElements` can be used to get the controlled elements that were set using `aria-controls`.

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -17,7 +17,7 @@ The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ar
 
 An array of subclasses of {{domxref("HTMLElement")}}, representing the elements that are controlled by this element.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -18,6 +18,9 @@ The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible description.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to set the accessible description.

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -15,7 +15,7 @@ The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible description.
 
 ## Description

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -1,0 +1,125 @@
+---
+title: "Element: ariaDescribedByElements property"
+short-title: ariaDescribedByElements
+slug: Web/API/Element/ariaDescribedByElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaDescribedByElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaDescribedByElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that provide an accessible description for the element it is applied to.
+The accessible description is similar to the accessible label (see {{domxref("Element/ariaLabelledByElements","ariaLabelledByElements")}}), but provides more verbose information.
+
+The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the accessible description.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to set the accessible description.
+Unlike `aria-describedby`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+
+The property reflects the element's [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the accessible description
+
+This example shows how `ariaDescribedByElements` can be used to get the accessible description defined using `aria-describedby`.
+
+#### HTML
+
+The HTML defines two {{htmlelement("span")}} elements and references their ids in the `aria-describedby` attribute of a {{htmlelement("button")}}.
+
+```html
+<button aria-describedby="trash-desc1 trash-desc2">Move to trash</button>
+…
+<span id="trash-desc1">Trash will be permanently removed after 30 days.</span>
+<span id="trash-desc2">Or Else!</span>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+Here we'll just hide the `<span>` elements that contain our accessible text.
+
+```css
+span {
+  display: none;
+}
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code below first logs the value of the `aria-describedby` attribute from {{domxref("Element.getAttribute()")}} (a string listing the `id` values of the referenced elements).
+It then checks whether the `ariaDescribedByElements` is supported, and if so, logs its value.
+Finally it returns the accessible string, calculated by iterating through the returned elements and concatenating their inner text.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const buttonElement = document.querySelector("button");
+log(`aria-describedby: ${buttonElement.getAttribute("aria-describedby")}`);
+// Feature test for ariaDescribedByElements
+if ("ariaDescribedByElements" in Element.prototype) {
+  // Get ariaDescribedByElements
+  const buttonElements = buttonElement.ariaDescribedByElements;
+  log(`ariaDescribedByElements: ${buttonElements}`);
+
+  // Accessible description from the elements
+  let ariaDescription = "";
+  buttonElements.forEach((descElement) => {
+    ariaDescription += descElement.textContent.trim() + " ";
+  });
+  log(`Accessible description: ${ariaDescription.trim()}`);
+} else {
+  log("element.ariaDescribedByElements: not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the original element references, the associated/returned elements, and the accessible description.
+
+{{EmbedLiveSample("Get the accessible description","100%","150px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute
+- {{domxref("ElementInternals.ariaDescribedByElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -21,8 +21,7 @@ The inner text of these elements can be joined with spaces to get the accessible
 ## Description
 
 The property is a flexible alternative to using the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to set the accessible description.
-Unlike `aria-describedby`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+Unlike `aria-describedby`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -122,4 +122,4 @@ The log below shows the original element references, the associated/returned ele
 
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute
 - {{domxref("ElementInternals.ariaDescribedByElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -96,11 +96,8 @@ if ("ariaDescribedByElements" in Element.prototype) {
   log(`ariaDescribedByElements: ${buttonElements}`);
 
   // Accessible description from the elements
-  let ariaDescription = "";
-  buttonElements.forEach((descElement) => {
-    ariaDescription += descElement.textContent.trim() + " ";
-  });
-  log(`Accessible description: ${ariaDescription.trim()}`);
+  const text = buttonElements.map((e) => e.textContent.trim()).join(" ");
+  log(`Accessible description: ${text.trim()}`);
 } else {
   log("element.ariaDescribedByElements: not supported by browser");
 }

--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -32,8 +32,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the accessible description
 
 This example shows how `ariaDescribedByElements` can be used to get the accessible description defined using `aria-describedby`.

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -1,0 +1,115 @@
+---
+title: "Element: ariaDetailsElements property"
+short-title: ariaDetailsElements
+slug: Web/API/Element/ariaDetailsElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaDetailsElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaDetailsElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that provide an accessible details for the element it is applied to.
+The accessible details are similar to the accessible description (see {{domxref("Element/ariaDescribedByElements","ariaDescribedByElements")}}), but provides more verbose information.
+
+The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the accessible details.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute to set the accessible details information.
+Unlike `aria-details`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the details information.
+
+The property reflects the element's [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the accessible details
+
+This example shows how `ariaDetailsElements` can be used to get the information defined using the `aria-details` attribute in HTML.
+
+#### HTML
+
+The HTML defines two {{htmlelement("span")}} elements and references their ids in the `aria-details` attribute of a {{htmlelement("button")}}.
+
+```html
+<button aria-details="details1 details2">Button text</button>
+…
+<span id="details1">Details 1 information about the element.</span>
+<span id="details2">Details 2 information about the element.</span>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code below first logs the value of the `aria-details` attribute from {{domxref("Element.getAttribute()")}} (a string listing the `id` values of the referenced elements).
+It then checks whether the `ariaDetailsElements` is supported, and if so, logs its value.
+Finally it returns the accessible string, calculated by iterating through the returned elements and concatenating their inner text.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const buttonElement = document.querySelector("button");
+log(`aria-details: ${buttonElement.getAttribute("aria-details")}`);
+// Feature test for ariaDetailsElements
+if ("ariaDetailsElements" in Element.prototype) {
+  // Get ariaDetailsElements
+  const buttonElements = buttonElement.ariaDetailsElements;
+  log(`ariaDetailsElements: ${buttonElements}`);
+
+  // Accessible details from ariaDetailsElements
+  let ariaDetails = "";
+  buttonElements.forEach((descElement) => {
+    ariaDetails += descElement.textContent.trim() + " ";
+  });
+  log(`Accessible details: ${ariaDetails.trim()}`);
+} else {
+  log("element.ariaDetailsElements: not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the original element references, the associated/returned elements, and the accessible details.
+
+{{EmbedLiveSample("Get the accessible details","100%","150px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute
+- {{domxref("ElementInternals.ariaDetailsElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -56,7 +56,7 @@ The HTML defines two {{htmlelement("span")}} elements and references their ids i
 ```css hidden
 #log {
   height: 70px;
-  overflow: scroll;
+  overflow-x: scroll;
   padding: 0.5rem;
   border: 1px solid black;
 }
@@ -86,11 +86,8 @@ if ("ariaDetailsElements" in Element.prototype) {
   log(`ariaDetailsElements: ${buttonElements}`);
 
   // Accessible details from ariaDetailsElements
-  let ariaDetails = "";
-  buttonElements.forEach((descElement) => {
-    ariaDetails += descElement.textContent.trim() + " ";
-  });
-  log(`Accessible details: ${ariaDetails.trim()}`);
+  const text = buttonElements.map((e) => e.textContent.trim()).join(" ");
+  log(`Accessible details: ${text.trim()}`);
 } else {
   log("element.ariaDetailsElements: not supported by browser");
 }

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -21,8 +21,7 @@ The inner text of these elements can be joined with spaces to get the accessible
 ## Description
 
 The property is a flexible alternative to using the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute to set the accessible details information.
-Unlike `aria-details`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the details information.
+Unlike `aria-details`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -32,8 +32,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the accessible details
 
 This example shows how `ariaDetailsElements` can be used to get the information defined using the `aria-details` attribute in HTML.

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -112,4 +112,4 @@ The log below shows the original element references, the associated/returned ele
 
 - [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute
 - {{domxref("ElementInternals.ariaDetailsElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -18,6 +18,9 @@ The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ari
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible details.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute to set the accessible details information.

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -15,7 +15,7 @@ The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ari
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible details.
 
 ## Description

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -144,4 +144,4 @@ Note that the log shows the error message reference read from the attribute, the
 
 - [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute
 - {{domxref("ElementInternals.ariaErrorMessageElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -1,0 +1,147 @@
+---
+title: "Element: ariaErrorMessageElements property"
+short-title: ariaErrorMessageElements
+slug: Web/API/Element/ariaErrorMessageElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaErrorMessageElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaErrorMessageElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that provide an error message for the element it is applied to.
+
+The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the error message.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute to set the error message for an element.
+Unlike `aria-errormessage`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to assign them as the message.
+
+The property reflects the element's [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Email input with error message
+
+This example shows how we use the `aria-errormessage` to set the error message for reporting entry of an invalid email address, and demonstrates how we can get and set the message using `ariaErrorMessageElements`.
+
+#### HTML
+
+First we define an HTML email input, setting its `aria-errormessage` attribute to reference an element with the `id` of `err1`.
+We then define a `<span>` element that has this id, and which contains an error message.
+
+```html
+<p>
+  <label for="email">Email address:</label>
+  <input type="email" name="email" id="email" aria-errormessage="err1" />
+  <span id="err1" class="errormessage">Error: Enter a valid email address</span>
+</p>
+```
+
+#### CSS
+
+We create some styles to hide the error message by default, but make it visible and styled as an error when `aria-invalid` is set on the element.
+
+```css
+.errormessage {
+  visibility: hidden;
+}
+
+[aria-invalid="true"] {
+  outline: 2px solid red;
+}
+
+[aria-invalid="true"] ~ .errormessage {
+  visibility: visible;
+}
+```
+
+#### JavaScript
+
+We then check for input, and set {{domxref("ariaInvalid")}} to `true` or `false` based on the [`typeMismatch`](/en-US/docs/Web/API/ValidityState/typeMismatch) constraint violation.
+`ariaInvalid` is in turn reflected in the `aria-invalid` attribute, which hides and displays the error as needed.
+
+```js
+const email = document.querySelector("#email");
+
+email.addEventListener("input", (event) => {
+  if (email.validity.typeMismatch) {
+    email.ariaInvalid = true;
+  } else {
+    email.ariaInvalid = false;
+  }
+});
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+We then log the value of the `aria-errormessage` attribute, the `ariaErrorMessageElements` and the inner text of the `ariaErrorMessageElements`
+
+```js
+log(`aria-errormessage: ${email.getAttribute("aria-errormessage")}`);
+// Feature test for ariaErrorMessageElements
+if ("ariaErrorMessageElements" in Element.prototype) {
+  // Get ariaErrorMessageElements
+  const propElements = email.ariaErrorMessageElements;
+  log(`ariaErrorMessageElements: ${propElements}`);
+
+  // Accessible text from element inner text
+  let innerText = "";
+  propElements.forEach((elem) => {
+    innerText += elem.textContent.trim() + " ";
+  });
+  log(`Error message details: ${innerText.trim()}`);
+} else {
+  log("element.ariaErrorMessageElements: not supported by browser");
+}
+```
+
+#### Result
+
+As you enter an email address, the error text will be displayed until the email address is valid.
+Note that the log shows the error message reference read from the attribute, the element from `ariaErrorMessageElements`, and the inner text of the element, which is its error message.
+
+{{EmbedLiveSample("Email input with error message","100%","150px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute
+- {{domxref("ElementInternals.ariaErrorMessageElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -31,8 +31,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Email input with error message
 
 This example shows how we use the `aria-errormessage` to set the error message for reporting entry of an invalid email address, and demonstrates how we can get and set the message using `ariaErrorMessageElements`.

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -14,7 +14,7 @@ The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attribute
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the error message.
 
 ## Description

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -17,6 +17,9 @@ The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attribute
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the error message.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute to set the error message for an element.

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -117,11 +117,8 @@ if ("ariaErrorMessageElements" in Element.prototype) {
   log(`ariaErrorMessageElements: ${propElements}`);
 
   // Accessible text from element inner text
-  let innerText = "";
-  propElements.forEach((elem) => {
-    innerText += elem.textContent.trim() + " ";
-  });
-  log(`Error message details: ${innerText.trim()}`);
+  const text = propElements.map((e) => e.textContent.trim).join(" ");
+  log(`Error message details: ${text.trim()}`);
 } else {
   log("element.ariaErrorMessageElements: not supported by browser");
 }
@@ -132,7 +129,7 @@ if ("ariaErrorMessageElements" in Element.prototype) {
 As you enter an email address, the error text will be displayed until the email address is valid.
 Note that the log shows the error message reference read from the attribute, the element from `ariaErrorMessageElements`, and the inner text of the element, which is its error message.
 
-{{EmbedLiveSample("Email input with error message","100%","150px")}}
+{{EmbedLiveSample("Email input with error message","100%","180px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -20,8 +20,7 @@ The inner text of these elements can be joined with spaces to get the error mess
 ## Description
 
 The property is a flexible alternative to using the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute to set the error message for an element.
-Unlike `aria-errormessage`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to assign them as the message.
+Unlike `aria-errormessage`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -21,8 +21,7 @@ An array of subclasses of {{domxref("HTMLElement")}}.
 ## Description
 
 The property is a flexible alternative to using the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute to set an alternative reading order.
-Unlike `aria-flowto`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the flow.
+Unlike `aria-flowto`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -16,7 +16,7 @@ The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 
 ## Description
 

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -128,4 +128,4 @@ We note here that the attribute and property identify the same flow-to elements.
 
 - [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
 - {{domxref("ElementInternals.ariaFlowToElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -32,8 +32,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the flow-to element
 
 This example demonstrates the normal flow through three elements `section1`, `section2`, `section3` in order, and an alternative order that jumps from `section1` to `section3`, and back again.

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -1,0 +1,131 @@
+---
+title: "Element: ariaFlowToElements property"
+short-title: ariaFlowToElements
+slug: Web/API/Element/ariaFlowToElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaFlowToElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaFlowToElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that provide an alternate reading order of content, overriding the general default reading order at the user's discretion.
+If just one element is provided this is the next element in the reading order.
+If multiple elements are provided, then each element represents a possible path that should be offered to the user for selection.
+
+The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute to set an alternative reading order.
+Unlike `aria-flowto`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the flow.
+
+The property reflects the element's [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the flow-to element
+
+This example demonstrates the normal flow through three elements `section1`, `section2`, `section3` in order, and an alternative order that jumps from `section1` to `section3`, and back again.
+Note that the example is illustrative unless you have accessibility tools running: we don't actually follow this alternate path.
+
+#### HTML
+
+The HTML defines three {{htmlelement("div")}} elements that define sections, with a class `"section"`, and `id` values: `section1`, `section2`, and `section3`.
+Each section has a normal flow defined by it's order, starting from `section1` and ending at `section3`.
+An alternative flow is defined in sections 1 and 3 using the `aria-flowto` attribute.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 180px;
+  overflow: scroll;
+  padding: 0.5rem;
+  margin: 5px;
+  border: 1px solid black;
+}
+```
+
+```html
+<div id="section1" class="section" aria-flowto="section3">
+  <h2>Section 1</h2>
+  <p>First section in normal flow. Section 3 is alternate flow.</p>
+  <a href="#section2">Jump to Section 2 (normal flow)</a>
+</div>
+
+<div id="section2" class="section">
+  <h2>Section 2</h2>
+  <p>Second section in normal flow.</p>
+  <a href="#section3">Jump to Section 3 (normal flow)</a>
+</div>
+
+<div id="section3" class="section" aria-flowto="section1">
+  <h2>Section 3</h2>
+  <p>
+    Third section in normal flow (end of flow). Section 1 is alternate flow.
+  </p>
+</div>
+```
+
+#### JavaScript
+
+The code first checks whether the `ariaFlowToElements` is supported, and if so, logs its value.
+It then iterates through the sections, logging the section `id`, `aria-flowto` attribute value, and `ariaFlowToElements` property value.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+// Feature test for ariaFlowToElements
+if ("ariaFlowToElements" in Element.prototype) {
+  const sections = document.querySelectorAll(".section");
+  sections.forEach((sectionDivElement) => {
+    log(`${sectionDivElement.id}`);
+    log(` aria-flowto: ${sectionDivElement.getAttribute("aria-flowto")}`);
+    log(" ariaFlowToElements:");
+    // Get the ids of each of the elements in the array
+    sectionDivElement.ariaFlowToElements?.forEach((elem) => {
+      log(`  id: ${elem.id}`);
+    });
+  });
+} else {
+  log("element.ariaFlowToElements: not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows each of the sections (identified by `id`) and the corresponding flow-to element ids that might be selected by accessibility tools.
+We note here that the attribute and property identify the same flow-to elements.
+
+{{EmbedLiveSample("Get the flow-to element","100%","450px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
+- {{domxref("ElementInternals.ariaFlowToElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -18,6 +18,9 @@ The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria
 
 An array of subclasses of {{domxref("HTMLElement")}}.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute to set an alternative reading order.

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -51,7 +51,7 @@ An alternative flow is defined in sections 1 and 3 using the `aria-flowto` attri
 
 ```css hidden
 #log {
-  height: 180px;
+  height: 200px;
   overflow: scroll;
   padding: 0.5rem;
   margin: 5px;
@@ -116,7 +116,7 @@ if ("ariaFlowToElements" in Element.prototype) {
 The log below shows each of the sections (identified by `id`) and the corresponding flow-to element ids that might be selected by accessibility tools.
 We note here that the attribute and property identify the same flow-to elements.
 
-{{EmbedLiveSample("Get the flow-to element","100%","450px")}}
+{{EmbedLiveSample("Get the flow-to element","100%","570px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -37,7 +37,7 @@ For more information about reflected element references and scope see [Reflected
 
 ### Get the accessible name
 
-This example shows how `ariaLabelledByElements` can be used to get an aria label defined using `aria-labelledby`.
+This example shows how `ariaLabelledByElements` can be used to get an ARIA label defined using `aria-labelledby`.
 
 #### HTML
 

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -21,6 +21,9 @@ The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/
 An array of elements.
 The inner text of these elements can be joined with spaces to get the accessible name.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -24,8 +24,7 @@ The inner text of these elements can be joined with spaces to get the accessible
 ## Description
 
 The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.
-Unlike `aria-labelledby`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+Unlike `aria-labelledby`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -115,4 +115,4 @@ The log below shows the original element references, the associated/returned ele
 
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute
 - {{domxref("ElementInternals.ariaLabelledByElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -1,0 +1,118 @@
+---
+title: "Element: ariaLabelledByElements property"
+short-title: ariaLabelledByElements
+slug: Web/API/Element/ariaLabelledByElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaLabelledByElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaLabelledByElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that provide an accessible name for the element it is applied to.
+
+The property is primarily intended to provide a label for elements that don't have a standard method for defining their accessible name.
+For example, this might be used to name a generic container element, such as a {{htmlelement("div")}} or {{htmlelement("span")}}, or a grouping of elements, such as an image with a slider that can be used to change its opacity.
+The property takes precedence over other mechanisms for providing an accessible name for elements, and may therefore also be used to provide a name for elements that would normally get it from their inner content or from an associated element such as a label.
+
+The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the accessible name.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.
+Unlike `aria-labelledby`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+
+The property reflects the element's [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the accessible name
+
+This example shows how `ariaLabelledByElements` can be used to get an aria label defined using `aria-labelledby`.
+
+#### HTML
+
+The HTML defines two {{htmlelement("span")}} elements and references their ids in the `aria-labelledby` attribute of an {{htmlelement("input")}}.
+The accessible name of the `<input>` is the concatenation of the inner text of the two referenced elements, separated by a space.
+
+```html
+<span id="label_1">Street name</span>
+<input aria-labelledby="label_1 label_2" />
+<span id="label_2">(just the name, no "Street" or "Road" or "Place")</span>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code below first logs the value of the `aria-labelledby` attribute from {{domxref("Element.getAttribute()")}} (a string listing the `id` values of the referenced elements).
+It then checks whether the `ariaLabelledByElements` is supported, and if so, logs its value.
+Finally it returns the accessible string, calculated by iterating through the elements and concatenating their inner text.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const inputElement = document.querySelector("input");
+log(`aria-labelledby: ${inputElement.getAttribute("aria-labelledby")}`);
+// Feature test for ariaLabelledByElements
+if ("ariaLabelledByElements" in Element.prototype) {
+  // Get ariaLabelledByElements
+  const labelElements = inputElement.ariaLabelledByElements;
+  log(`ariaLabelledByElements: ${labelElements}`);
+
+  // Accessible name from ariaLabelledByElements
+  let accessibleName = "";
+  labelElements.forEach((labelElement) => {
+    accessibleName += labelElement.textContent.trim() + " ";
+  });
+  log(`Accessible name: ${accessibleName.trim()}`);
+} else {
+  log("element.ariaLabelledByElements: not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the original element references, the associated/returned elements, and the accessible name.
+
+{{EmbedLiveSample("Get the accessible name","100%","150px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute
+- {{domxref("ElementInternals.ariaLabelledByElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -99,6 +99,7 @@ if ("ariaLabelledByElements" in Element.prototype) {
 #### Result
 
 The log below shows the original element references, the associated/returned elements, and the accessible name.
+Note that the example doesn't do anything with text entered into the street name `<input>`.
 
 {{EmbedLiveSample("Get the accessible name","100%","150px")}}
 

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -35,8 +35,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the accessible name
 
 This example shows how `ariaLabelledByElements` can be used to get an aria label defined using `aria-labelledby`.

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -88,12 +88,9 @@ if ("ariaLabelledByElements" in Element.prototype) {
   const labelElements = inputElement.ariaLabelledByElements;
   log(`ariaLabelledByElements: ${labelElements}`);
 
-  // Accessible name from ariaLabelledByElements
-  let accessibleName = "";
-  labelElements.forEach((labelElement) => {
-    accessibleName += labelElement.textContent.trim() + " ";
-  });
-  log(`Accessible name: ${accessibleName.trim()}`);
+  // Log inner text of elements to get accessible name
+  const text = labelElements.map((e) => e.textContent.trim()).join(" ");
+  log(`Accessible name: ${text.trim()}`);
 } else {
   log("element.ariaLabelledByElements: not supported by browser");
 }

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -20,8 +20,7 @@ An array of subclasses of {{domxref("HTMLElement")}}.
 ## Description
 
 The property is a flexible alternative to using the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute to indicate ownership of an element.
-Unlike `aria-owns`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them.
+Unlike `aria-owns`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -1,0 +1,163 @@
+---
+title: "Element: ariaOwnsElements property"
+short-title: ariaOwnsElements
+slug: Web/API/Element/ariaOwnsElements
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaOwnsElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaOwnsElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that define a visual, functional, or contextual relationship between a parent element that it is applied to, and its child elements.
+This is used when the DOM hierarchy cannot be used to represent the relationship, and it would not otherwise be available to assistive technology,
+
+The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute to indicate ownership of an element.
+Unlike `aria-owns`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them.
+
+The property reflects the element's [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the owned element
+
+This example demonstrates how the `aria-owns` attribute and property are used.
+
+The code defines a menu and its associated submenu in separate and non-nested {{htmlelement("div")}} elements.
+Because these elements are not nested the ownership relationship between the menu and submenu is not captured by the DOM.
+Here we provide that information to accessibility tools using the `aria-owns` attribute, but we could also do it using the reflected property.
+
+Note that we could construct a menu where the submenu was nested: the example has been _contrived_ to make it easier to demonstrate a case where the relationship needs to be defined.
+
+#### HTML
+
+The HTML defines {{htmlelement("div")}} elements for the menu, with `id=parentMenu` and the submenu with `id="subMenu1"`.
+We've added a `<div>` in between just to make it even more obvious that there is no direct ownership model defined in the DOM.
+
+The parent menu `<div>` includes the attribute `aria-owns="subMenu1"` to create this ownership relationship.
+
+```html
+<div class="menu" id="parentMenu" role="menubar" aria-owns="subMenu1">
+  Top level menu (hover over)
+</div>
+
+<div>Some other element</div>
+
+<div class="submenu" id="subMenu1" role="menu">
+  <a href="#" role="menuitem">Menu item 1</a>
+  <a href="#" role="menuitem">Menu item 2</a>
+  <a href="#" role="menuitem">Menu item 3</a>
+</div>
+```
+
+#### CSS
+
+The CSS styles the menu and submenu, and displays the submenu when the menu is hovered over.
+
+```css
+.menu {
+  position: relative;
+  display: inline-block;
+  color: purple;
+}
+
+.submenu {
+  display: none;
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 160px;
+  box-shadow: 0px 6px 14px 0px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  top: 20px;
+  left: 0;
+}
+
+.menu:hover ~ .submenu {
+  display: block;
+}
+
+.submenu a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+.submenu a:hover {
+  background-color: #f1f1f1;
+}
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  margin: 5px;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code first checks whether the `ariaOwnsElements` is supported.
+If it is, we log the attribute, the elements in the property, and the `id` value for each element.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+// Feature test for ariaOwnsElements
+if ("ariaOwnsElements" in Element.prototype) {
+  const parentMenu = document.querySelector("#parentMenu");
+  log(`parentMenu.getAttribute(): ${parentMenu.getAttribute("aria-owns")}`);
+  log(`parentMenu.ariaOwnsElements: ${parentMenu.ariaOwnsElements}`);
+  parentMenu.ariaOwnsElements?.forEach((elem) => {
+    log(`  id: ${elem.id}`);
+  });
+} else {
+  log("element.ariaOwnsElements: not supported by browser");
+}
+```
+
+#### Result
+
+The result of running the code is shown below.
+The log shows that the relationship defined using the `aria-owns` attribute is reflected in the `ariaOwnsElements` property (elements in the array match the attribute element references).
+
+{{EmbedLiveSample("Get the flow-to element","100%","200px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
+- {{domxref("ElementInternals.ariaOwnsElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -31,8 +31,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the owned element
 
 This example demonstrates how the `aria-owns` attribute and property are used.

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -15,7 +15,7 @@ The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-o
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 
 ## Description
 

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -17,6 +17,9 @@ The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-o
 
 An array of subclasses of {{domxref("HTMLElement")}}.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute to indicate ownership of an element.

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -160,4 +160,4 @@ The log shows that the relationship defined using the `aria-owns` attribute is r
 
 - [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
 - {{domxref("ElementInternals.ariaOwnsElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -171,11 +171,39 @@ _The `Element` interface also includes the following properties._
 - {{domxref("Element.ariaValueNow")}}
   - : A string reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 - {{domxref("Element.ariaValueText")}}
-
-  - : A string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of aria-valuenow for a range widget.
-
+  - : A string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of `aria-valuenow` for a range widget.
 - {{domxref("Element.role")}}
   - : A string reflecting the explicitly set [`role`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) attribute, which provides the semantic role of the element.
+
+#### Instance properties reflected from aria element references
+
+The properties reflect the elements specified by `id` reference in the corresponding attributes, but with some caveats. See [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide for more information.
+
+- {{domxref("Element.ariaActiveDescendantElement")}}
+  - : An element that represents the current active element when focus is on a [`composite`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/composite_role) widget, [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role), [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role), [`group`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role), or [`application`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role).
+    Reflects the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute.
+- {{domxref("Element.ariaControlsElements")}}
+  - : An array of elements whose contents or presence are controlled by the element it is applied to.
+    Reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute.
+- {{domxref("Element.ariaDescribedByElements")}}
+  - : An array of elements that contain the accessible description for the element it is applied to.
+    Reflects the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute.
+- {{domxref("Element.ariaDetailsElements")}}
+  - : An array of elements that provide accessible details for the element it is applied to.
+    Reflects the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute.
+- {{domxref("Element.ariaErrorMessageElements")}}
+  - : An array of elements that provide an error message for the element it is applied to.
+    Reflects the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute.
+- {{domxref("Element.ariaFlowToElements")}}
+  - : An array of elements that identify the next element (or elements) in an alternate reading order of content, overriding the general default reading order at the user's discretion.
+    Reflects the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute.
+- {{domxref("Element.ariaLabelledByElements")}}
+  - : An array of elements that provide the accessible name for the element it is applied to.
+    Reflects the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute.
+- {{domxref("Element.ariaOwnsElements")}}
+  - : An array of elements owned by the element this is applied to.
+    This is used to define a visual, functional, or contextual relationship between a parent and its child elements when the DOM hierarchy cannot be used to represent the relationship.
+    Reflects the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute.
 
 ## Instance methods
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -175,7 +175,7 @@ _The `Element` interface also includes the following properties._
 - {{domxref("Element.role")}}
   - : A string reflecting the explicitly set [`role`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) attribute, which provides the semantic role of the element.
 
-#### Instance properties reflected from aria element references
+#### Instance properties reflected from ARIA element references
 
 The properties reflect the elements specified by `id` reference in the corresponding attributes, but with some caveats. See [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide for more information.
 

--- a/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
@@ -14,12 +14,12 @@ The [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attri
 
 ## Value
 
-An element that is the active descendant, or `null` if there is no active descendant.
+An subclass of {{domxref("HTMLElement")}} that represents the active descendant, or `null` if there is no active descendant.
 
 ## Description
 
 The property is a flexible alternative to using the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute.
-Unlike `aria-activedescendant`, the element assigned to this property can be selected: it does not have to have an `id`.
+Unlike `aria-activedescendant`, the element assigned to this property does not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
@@ -1,0 +1,48 @@
+---
+title: "Element: ariaActiveDescendantElement property"
+short-title: ariaActiveDescendantElement
+slug: Web/API/ElementInternals/ariaActiveDescendantElement
+page-type: web-api-instance-property
+browser-compat: api.Element.ariaActiveDescendantElement
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaActiveDescendantElement`** property of the {{domxref("ElementInternals")}} interface represents the current active element when focus is on a [`composite`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/composite_role) widget, [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role), [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role), [`group`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role), or [`application`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role).
+
+The [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An element that is the active descendant, or `null` if there is no active descendant.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute.
+Unlike `aria-activedescendant`, the element assigned to this property can be selected: it does not have to have an `id`.
+
+The property reflects the element's [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaActiveDescendantElement")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute
+- {{domxref("Element.ariaActiveDescendantElement")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
@@ -45,4 +45,4 @@ The examples in the following documents are relevant:
 
 - [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute
 - {{domxref("Element.ariaActiveDescendantElement")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
+++ b/files/en-us/web/api/elementinternals/ariaactivedescendantelement/index.md
@@ -25,14 +25,6 @@ The property reflects the element's [`aria-activedescendant`](/en-US/docs/Web/Ac
 If the property is set, then the corresponding attribute is cleared.
 For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
 
-## Examples
-
-The examples in the following documents are relevant:
-
-- {{domxref("Element.ariaActiveDescendantElement")}} is the DOM equivalent of this property.
-  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
@@ -20,8 +20,7 @@ An array of subclasses of {{domxref("HTMLElement")}}, representing the elements 
 ## Description
 
 The property is a flexible alternative to using the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute to set the controlled elements.
-Unlike `aria-controls`, the elements assigned to this property do not have to have an `id`: they can be selected.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to set them as controlled.
+Unlike `aria-controls`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
@@ -17,6 +17,9 @@ The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ar
 
 An array of subclasses of {{domxref("HTMLElement")}}, representing the elements that are controlled by this element.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute to set the controlled elements.

--- a/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
@@ -47,4 +47,4 @@ The examples in the following documents are relevant:
 
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute
 - {{domxref("Element.ariaControlsElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
@@ -1,0 +1,50 @@
+---
+title: "ElementInternals: ariaControlsElements property"
+short-title: ariaControlsElements
+slug: Web/API/ElementInternals/ariaControlsElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaControlsElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaControlsElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that are controlled by the element it is applied to.
+For example, this might be set on a [combobox](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role) to indicate the element that it pops up, or on a [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/scrollbar_role) to indicate the ID of the element it controls.
+
+The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements that are controlled by this element.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute to set the controlled elements.
+Unlike `aria-controls`, the elements assigned to this property do not have to have an `id`: they can be selected.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to set them as controlled.
+
+The property reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaControlsElements")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute
+- {{domxref("Element.ariaControlsElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
@@ -15,7 +15,7 @@ The [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ar
 
 ## Value
 
-An array of elements that are controlled by this element.
+An array of subclasses of {{domxref("HTMLElement")}}, representing the elements that are controlled by this element.
 
 ## Description
 

--- a/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariacontrolselements/index.md
@@ -29,14 +29,6 @@ The property reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/R
 If the property is set, then the corresponding attribute is cleared.
 For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
 
-## Examples
-
-The examples in the following documents are relevant:
-
-- {{domxref("Element.ariaControlsElements")}} is the DOM equivalent of this property.
-  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
@@ -18,6 +18,9 @@ The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible description.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to set the accessible description.

--- a/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
@@ -15,7 +15,7 @@ The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible description.
 
 ## Description

--- a/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
@@ -48,4 +48,4 @@ The examples in the following documents are relevant:
 
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute
 - {{domxref("Element.ariaDescribedByElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
@@ -21,8 +21,7 @@ The inner text of these elements can be joined with spaces to get the accessible
 ## Description
 
 The property is a flexible alternative to using the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to set the accessible description.
-Unlike `aria-describedby`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+Unlike `aria-describedby`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
@@ -36,7 +36,6 @@ The examples in the following documents are relevant:
 
 - {{domxref("Element.ariaDescribedByElements")}} is the DOM equivalent of this property.
   It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescribedbyelements/index.md
@@ -1,0 +1,51 @@
+---
+title: "ElementInternals: ariaDescribedByElements property"
+short-title: ariaDescribedByElements
+slug: Web/API/ElementInternals/ariaDescribedByElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaDescribedByElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaDescribedByElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that provide an accessible description for the element it is applied to.
+The accessible description is similar to the accessible label (see {{domxref("Element/ariaLabelledByElements","ariaLabelledByElements")}}), but provides more verbose information.
+
+The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the accessible description.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to set the accessible description.
+Unlike `aria-describedby`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+
+The property reflects the element's [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaDescribedByElements")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute
+- {{domxref("Element.ariaDescribedByElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide

--- a/files/en-us/web/api/elementinternals/ariadetailselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadetailselements/index.md
@@ -21,8 +21,7 @@ The inner text of these elements can be joined with spaces to get the accessible
 ## Description
 
 The property is a flexible alternative to using the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute to set the accessible details information.
-Unlike `aria-details`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the details information.
+Unlike `aria-details`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariadetailselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadetailselements/index.md
@@ -36,7 +36,6 @@ The examples in the following documents are relevant:
 
 - {{domxref("Element.ariaDetailsElements")}} is the DOM equivalent of this property.
   It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/elementinternals/ariadetailselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadetailselements/index.md
@@ -48,4 +48,4 @@ The examples in the following documents are relevant:
 
 - [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute
 - {{domxref("Element.ariaDetailsElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariadetailselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadetailselements/index.md
@@ -18,6 +18,9 @@ The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ari
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible details.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute to set the accessible details information.

--- a/files/en-us/web/api/elementinternals/ariadetailselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadetailselements/index.md
@@ -1,0 +1,51 @@
+---
+title: "ElementInternals: ariaDetailsElements property"
+short-title: ariaDetailsElements
+slug: Web/API/ElementInternals/ariaDetailsElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaDetailsElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaDetailsElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that provide an accessible details for the element it is applied to.
+The accessible details are similar to the accessible description (see {{domxref("ElementInternals/ariaDescribedByElements","ariaDescribedByElements")}}), but provides more verbose information.
+
+The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the accessible details.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute to set the accessible details information.
+Unlike `aria-details`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the details information.
+
+The property reflects the element's [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaDetailsElements")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute
+- {{domxref("Element.ariaDetailsElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariadetailselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariadetailselements/index.md
@@ -15,7 +15,7 @@ The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ari
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible details.
 
 ## Description

--- a/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
@@ -47,4 +47,4 @@ The examples in the following documents are relevant:
 
 - [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute
 - {{domxref("Element.ariaErrorMessageElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
@@ -1,0 +1,50 @@
+---
+title: "ElementInternals: ariaErrorMessageElements property"
+short-title: ariaErrorMessageElements
+slug: Web/API/ElementInternals/ariaErrorMessageElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaErrorMessageElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaErrorMessageElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that provide an error message for the element it is applied to.
+
+The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the error message.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute to set the error message for an element.
+Unlike `aria-errormessage`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to assign them as the message.
+
+The property reflects the element's [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaErrorMessageElements")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute
+- {{domxref("Element.ariaErrorMessageElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
@@ -35,7 +35,6 @@ The examples in the following documents are relevant:
 
 - {{domxref("Element.ariaErrorMessageElements")}} is the DOM equivalent of this property.
   It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
@@ -14,7 +14,7 @@ The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attribute
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the error message.
 
 ## Description

--- a/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
@@ -17,6 +17,9 @@ The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attribute
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the error message.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute to set the error message for an element.

--- a/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaerrormessageelements/index.md
@@ -20,8 +20,7 @@ The inner text of these elements can be joined with spaces to get the error mess
 ## Description
 
 The property is a flexible alternative to using the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute to set the error message for an element.
-Unlike `aria-errormessage`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to assign them as the message.
+Unlike `aria-errormessage`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
@@ -21,8 +21,7 @@ An array of subclasses of {{domxref("HTMLElement")}}.
 ## Description
 
 The property is a flexible alternative to using the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute to set an alternative reading order.
-Unlike `aria-flowto`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the flow.
+Unlike `aria-flowto`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
@@ -16,7 +16,7 @@ The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 
 ## Description
 

--- a/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
@@ -48,4 +48,4 @@ The examples in the following documents are relevant:
 
 - [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
 - {{domxref("Element.ariaFlowToElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
@@ -36,7 +36,6 @@ The examples in the following documents are relevant:
 
 - {{domxref("Element.ariaFlowToElements")}} is the DOM equivalent of this property.
   It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
@@ -18,6 +18,9 @@ The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria
 
 An array of subclasses of {{domxref("HTMLElement")}}.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute to set an alternative reading order.

--- a/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaflowtoelements/index.md
@@ -1,0 +1,51 @@
+---
+title: "ElementInternals: ariaFlowToElements property"
+short-title: ariaFlowToElements
+slug: Web/API/ElementInternals/ariaFlowToElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaFlowToElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaFlowToElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that provide an alternate reading order of content, overriding the general default reading order at the user's discretion.
+If just one element is provided this is the next element in the reading order.
+If multiple elements are provided, then each element represents a possible path that should be offered to the user for selection.
+
+The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute to set an alternative reading order.
+Unlike `aria-flowto`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the flow.
+
+The property reflects the element's [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaFlowToElements")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
+- {{domxref("Element.ariaFlowToElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -21,6 +21,9 @@ The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/
 An array of elements.
 The inner text of these elements can be joined with spaces to get the accessible name.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -35,8 +35,6 @@ For more information about reflected element references and scope see [Reflected
 
 ## Examples
 
-The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
-
 ### Get the accessible name
 
 This example shows how `ariaLabelledByElements` can be used to programmatically get a label defined using `aria-labelledby` within the shadow root.

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -24,8 +24,7 @@ The inner text of these elements can be joined with spaces to get the accessible
 ## Description
 
 The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.
-Unlike `aria-labelledby`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+Unlike `aria-labelledby`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -1,0 +1,130 @@
+---
+title: "ElementInternals: ariaLabelledByElements property"
+short-title: ariaLabelledByElements
+slug: Web/API/ElementInternals/ariaLabelledByElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaLabelledByElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaLabelledByElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that provide an accessible name for the element it is applied to.
+
+The property is primarily intended to provide a label for elements that don't have a standard method for defining their accessible name.
+For example, this might be used to name a generic container element, such as a {{htmlelement("div")}} or {{htmlelement("span")}}, or a grouping of elements, such as an image with a slider that can be used to change its opacity.
+The property takes precedence over other mechanisms for providing an accessible name for elements, and may therefore also be used to provide a name for elements that would normally get it from their inner content or from an associated element such as a label.
+
+The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+The inner text of these elements can be joined with spaces to get the accessible name.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.
+Unlike `aria-labelledby`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them for the description.
+
+The property reflects the element's [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide are also relevant.
+
+### Get the accessible name
+
+This example shows how `ariaLabelledByElements` can be used to programmatically get a label defined using `aria-labelledby` within the shadow root.
+
+#### HTML
+
+The HTML defines two {{htmlelement("span")}} elements and references their ids in the `aria-labelledby` attribute of an {{htmlelement("input")}}.
+The accessible name of the `<input>` is therefore the concatenation of the inner text of the two referenced elements.
+
+```html
+<div id="host">
+  <template shadowrootmode="open">
+    <span id="label_1">Street name</span>
+    <input aria-labelledby="label_1 label_2" />
+    <span id="label_2">(just the name, no "Street" or "Road" or "Place")</span>
+  </template>
+</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 70px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The code below first checks whether the `ariaLabelledByElements` is supported and if not, logs the result and exits.
+If the property is supported it first logs the value of the property.
+It then iterates through the returned elements, concatenating their inner text, and logs the resulting accessible name of the element.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+// Get access to the input within shadowRoot
+const hostElement = document.getElementById("host");
+const shadowRoot = hostElement.shadowRoot;
+const inputElement = shadowRoot.querySelector("input");
+
+// Feature test for ariaLabelledByElements
+if ("ariaLabelledByElements" in ElementInternals.prototype) {
+
+  // Get and log attribute that provides the accessible name
+  log(`aria-labelledby: ${inputElement.getAttribute("aria-labelledby")}`);
+
+  // Get and log elements that provide the accessible name
+  const labelElements = inputElement.ariaLabelledByElements;
+  log(`ariaLabelledByElements: ${labelElements}`);
+
+  // Log inner text of elements to get accessible name
+  ariaLabelText = "";
+  labelElements.forEach((labelElement) => {
+    ariaLabelText += labelElement.textContent.trim() + " ";
+  });
+  log(`Accessible name: ${ariaLabelText.trim()}`);
+} else {
+  log("ariaLabelledByElements not supported by browser");
+}
+```
+
+#### Result
+
+The log below shows the output of the above code.
+This should show the array of referenced {{domxref("HTMLSpanElement")}} elements, and the resulting accessible name from their inner text.
+
+{{EmbedLiveSample("Get the accessible name","100%","150px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute
+- {{domxref("Element.ariaLabelledByElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -89,7 +89,6 @@ const inputElement = shadowRoot.querySelector("input");
 
 // Feature test for ariaLabelledByElements
 if ("ariaLabelledByElements" in ElementInternals.prototype) {
-
   // Get and log attribute that provides the accessible name
   log(`aria-labelledby: ${inputElement.getAttribute("aria-labelledby")}`);
 

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -99,11 +99,8 @@ if ("ariaLabelledByElements" in ElementInternals.prototype) {
   log(`ariaLabelledByElements: ${labelElements}`);
 
   // Log inner text of elements to get accessible name
-  ariaLabelText = "";
-  labelElements.forEach((labelElement) => {
-    ariaLabelText += labelElement.textContent.trim() + " ";
-  });
-  log(`Accessible name: ${ariaLabelText.trim()}`);
+  const text = labelElements.map((e) => e.textContent.trim()).join(" ");
+  log(`Accessible name: ${text.trim()}`);
 } else {
   log("ariaLabelledByElements not supported by browser");
 }

--- a/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/elementinternals/arialabelledbyelements/index.md
@@ -126,4 +126,4 @@ This should show the array of referenced {{domxref("HTMLSpanElement")}} elements
 
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute
 - {{domxref("Element.ariaLabelledByElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -47,4 +47,4 @@ The examples in the following documents are relevant:
 
 - [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
 - {{domxref("Element.ariaOwnsElements")}}
-- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.
+- [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -20,8 +20,7 @@ An array of subclasses of {{domxref("HTMLElement")}}.
 ## Description
 
 The property is a flexible alternative to using the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute to indicate ownership of an element.
-Unlike `aria-owns`, the elements assigned to this property can be selected: they do not have to have an `id`.
-This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them.
+Unlike `aria-owns`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute.
 
 The property reflects the element's [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -1,0 +1,50 @@
+---
+title: "ElementInternals: ariaOwnsElements property"
+short-title: ariaOwnsElements
+slug: Web/API/ElementInternals/ariaOwnsElements
+page-type: web-api-instance-property
+browser-compat: api.ElementInternals.ariaOwnsElements
+---
+
+{{APIRef("DOM")}}
+
+The **`ariaOwnsElements`** property of the {{domxref("ElementInternals")}} interface is an array containing the element (or elements) that define a visual, functional, or contextual relationship between a parent element that it is applied to, and its child elements.
+This is used when the shadow DOM hierarchy cannot be used to represent the relationship, and it would not otherwise be available to assistive technology,
+
+The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) topic contains additional information about how the attribute and property should be used.
+
+## Value
+
+An array of elements.
+
+## Description
+
+The property is a flexible alternative to using the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute to indicate ownership of an element.
+Unlike `aria-owns`, the elements assigned to this property can be selected: they do not have to have an `id`.
+This can be convenient as it avoids having to unnecessarily create ids for elements in order to use them.
+
+The property reflects the element's [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
+If the property is set, then the corresponding attribute is cleared.
+For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+## Examples
+
+The examples in the following documents are relevant:
+
+- {{domxref("Element.ariaOwnsElements")}} is the DOM equivalent of this property.
+  It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
+- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
+- {{domxref("Element.ariaOwnsElements")}}
+- [Reflected element references](2/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -44,6 +44,6 @@ The examples in the following documents are relevant:
 
 ## See also
 
-- [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute
+- [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute
 - {{domxref("Element.ariaOwnsElements")}}
 - [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Attribute reflection_ guide.

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -35,7 +35,6 @@ The examples in the following documents are relevant:
 
 - {{domxref("Element.ariaOwnsElements")}} is the DOM equivalent of this property.
   It is used in the same way, but within the DOM instead of a shadow DOM and/or custom element.
-- [Reflected element reference examples](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#setting_and_getting_reflected_element_references) in the _Attribute reflection_ guide demonstrates the mapping between references in the attribute and elements properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -15,7 +15,7 @@ The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-o
 
 ## Value
 
-An array of elements.
+An array of subclasses of {{domxref("HTMLElement")}}.
 
 ## Description
 

--- a/files/en-us/web/api/elementinternals/ariaownselements/index.md
+++ b/files/en-us/web/api/elementinternals/ariaownselements/index.md
@@ -17,6 +17,9 @@ The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-o
 
 An array of subclasses of {{domxref("HTMLElement")}}.
 
+When read, the returned array is a static and read-only.
+When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
+
 ## Description
 
 The property is a flexible alternative to using the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute to indicate ownership of an element.

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -71,9 +71,9 @@ The `ElementInternals` interface also includes the following properties.
 - {{domxref("ElementInternals.ariaHidden")}}
   - : A string reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 - {{domxref("ElementInternals.ariaKeyShortcuts")}}
-  - : A string reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
+  - : A string reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an object.
 - {{domxref("ElementInternals.ariaLabel")}}
-  - : A string reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) attribute, which defines a string value that labels the current ElementInternals.
+  - : A string reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) attribute, which defines a string value that labels the current object.
 - {{domxref("ElementInternals.ariaLevel")}}
   - : A string reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 - {{domxref("ElementInternals.ariaLive")}}
@@ -124,6 +124,36 @@ The `ElementInternals` interface also includes the following properties.
   - : A string reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 - {{domxref("ElementInternals.ariaValueText")}}
   - : A string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of aria-valuenow for a range widget.
+
+#### Instance properties reflected from aria element references
+
+The properties reflect the elements specified by `id` reference in the corresponding attributes, but with some caveats. See [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide for more information.
+
+- {{domxref("ElementInternals.ariaActiveDescendantElement")}}
+  - : An element that represents the current active element when focus is on a [`composite`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/composite_role) widget, [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role), [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role), [`group`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role), or [`application`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role).
+    Reflects the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-activedescendant) attribute.
+- {{domxref("ElementInternals.ariaControlsElements")}}
+  - : An array of elements whose contents or presence are controlled by the element it is applied to.
+    Reflects the [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-controls) attribute.
+- {{domxref("ElementInternals.ariaDescribedByElements")}}
+  - : An array of elements that contain the accessible description for the element it is applied to.
+    Reflects the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute.
+- {{domxref("ElementInternals.ariaDetailsElements")}}
+  - : An array of elements that provide accessible details for the element it is applied to.
+    Reflects the [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-details) attribute.
+- {{domxref("ElementInternals.ariaErrorMessageElements")}}
+  - : An array of elements that provide an error message for the element it is applied to.
+    Reflects the [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) attribute.
+- {{domxref("ElementInternals.ariaFlowToElements")}}
+  - : An array of elements that identify the next element (or elements) in an alternate reading order of content, overriding the general default reading order at the user's discretion.
+    Reflects the [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-flowto) attribute.
+- {{domxref("ElementInternals.ariaLabelledByElements")}}
+  - : An array of elements that provide the accessible name for the element it is applied to.
+    Reflects the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute.
+- {{domxref("ElementInternals.ariaOwnsElements")}}
+  - : An array of elements owned by the element this is applied to.
+    This is used to define a visual, functional, or contextual relationship between a parent and its child elements when the DOM hierarchy cannot be used to represent the relationship.
+    Reflects the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-owns) attribute.
 
 ## Instance methods
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -125,7 +125,7 @@ The `ElementInternals` interface also includes the following properties.
 - {{domxref("ElementInternals.ariaValueText")}}
   - : A string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of aria-valuenow for a range widget.
 
-#### Instance properties reflected from aria element references
+#### Instance properties reflected from ARIA element references
 
 The properties reflect the elements specified by `id` reference in the corresponding attributes, but with some caveats. See [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide for more information.
 

--- a/files/en-us/web/api/htmlinputelement/placeholder/index.md
+++ b/files/en-us/web/api/htmlinputelement/placeholder/index.md
@@ -16,87 +16,10 @@ A string.
 
 ## Examples
 
-### Getting and setting the placeholder attribute
-
-This example shows how you can get and set the placeholder using both the attribute and its reflected property.
-
-#### HTML
-
-The HTML defines an {{htmlelement("input")}} element where the [`placeholder`](/en-US/docs/Web/HTML/Reference/Attributes/placeholder) attribute has been set with the text "Original placeholder".
-We also define two {{htmlelement("button")}} elements for replacing the `placeholder` attribute.
-
-```html
-<input placeholder="Original placeholder" />
-<button id="attr">Set attribute</button>
-<button id="prop">Set property</button>
 ```
-
-```html hidden
-<pre id="log"></pre>
+const inputElement = document.getElementById("phone");
+console.log(input.placeholder);
 ```
-
-```css hidden
-#log {
-  height: 120px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-#### JavaScript
-
-First we define a logging function that gets the value of placeholder attribute using {{domxref("Element.getAttribute()")}} and the placeholder property using {{domxref("HTMLInputElement.placeholder")}}.
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js
-function logPlaceholder() {
-  const inputElement = document.querySelector("input");
-  log(
-    `attr: "${inputElement.getAttribute(
-      "placeholder",
-    )}", prop: "${inputElement.placeholder}"`,
-  );
-}
-```
-
-We then define two event listeners for the buttons, which set the placeholder using {{domxref("Element.setAttribute()")}} and {{domxref("HTMLInputElement.placeholder")}}, respectively.
-In both cases the attribute and property are then logged.
-
-```js
-logPlaceholder();
-
-const setAttributeButton = document.querySelector("#attr");
-const setPropertyButton = document.querySelector("#prop");
-const inputElement = document.querySelector("input");
-
-// Set placeholder attribute on button click
-setAttributeButton.addEventListener("click", () => {
-  inputElement.setAttribute("placeholder", "Set from attribute");
-  logPlaceholder();
-});
-
-// Set placeholder property on button click
-setPropertyButton.addEventListener("click", () => {
-  inputElement.placeholder = "Set from property";
-  logPlaceholder();
-});
-```
-
-#### Result
-
-The log below shows the output of the above code.
-Note that the value can be set using either the attribute or the property, and the result read via either approach is the same.
-The example doesn't do anything with text entered into the `<input>`.
-
-{{EmbedLiveSample("Getting and setting reflected attributes","100%","200px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/placeholder/index.md
+++ b/files/en-us/web/api/htmlinputelement/placeholder/index.md
@@ -16,10 +16,87 @@ A string.
 
 ## Examples
 
-```js
-const inputElement = document.getElementById("phone");
-console.log(input.placeholder);
+### Getting and setting the placeholder attribute
+
+This example shows how you can get and set the placeholder using both the attribute and its reflected property.
+
+#### HTML
+
+The HTML defines an {{htmlelement("input")}} element where the [`placeholder`](/en-US/docs/Web/HTML/Reference/Attributes/placeholder) attribute has been set with the text "Original placeholder".
+We also define two {{htmlelement("button")}} elements for replacing the `placeholder` attribute.
+
+```html
+<input placeholder="Original placeholder" />
+<button id="attr">Set attribute</button>
+<button id="prop">Set property</button>
 ```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 120px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+First we define a logging function that gets the value of placeholder attribute using {{domxref("Element.getAttribute()")}} and the placeholder property using {{domxref("HTMLInputElement.placeholder")}}.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+function logPlaceholder() {
+  const inputElement = document.querySelector("input");
+  log(
+    `attr: "${inputElement.getAttribute(
+      "placeholder",
+    )}", prop: "${inputElement.placeholder}"`,
+  );
+}
+```
+
+We then define two event listeners for the buttons, which set the placeholder using {{domxref("Element.setAttribute()")}} and {{domxref("HTMLInputElement.placeholder")}}, respectively.
+In both cases the attribute and property are then logged.
+
+```js
+logPlaceholder();
+
+const setAttributeButton = document.querySelector("#attr");
+const setPropertyButton = document.querySelector("#prop");
+const inputElement = document.querySelector("input");
+
+// Set placeholder attribute on button click
+setAttributeButton.addEventListener("click", () => {
+  inputElement.setAttribute("placeholder", "Set from attribute");
+  logPlaceholder();
+});
+
+// Set placeholder property on button click
+setPropertyButton.addEventListener("click", () => {
+  inputElement.placeholder = "Set from property";
+  logPlaceholder();
+});
+```
+
+#### Result
+
+The log below shows the output of the above code.
+Note that the value can be set using either the attribute or the property, and the result read via either approach is the same.
+The example doesn't do anything with text entered into the `<input>`.
+
+{{EmbedLiveSample("Getting and setting reflected attributes","100%","200px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/placeholder/index.md
+++ b/files/en-us/web/api/htmlinputelement/placeholder/index.md
@@ -16,7 +16,7 @@ A string.
 
 ## Examples
 
-```
+```js
 const inputElement = document.getElementById("phone");
 console.log(input.placeholder);
 ```

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -406,6 +406,7 @@
       "guides": [
         "/docs/Web/API/Document_Object_Model/Introduction",
         "/docs/Web/API/Document_Object_Model/Using_the_Document_Object_Model",
+        "/docs/Web/API/Document_Object_Model/Reflected_attributes",
         "/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces",
         "/docs/Web/API/Document_Object_Model/Locating_DOM_elements_using_selectors",
         "/docs/Web/API/Document_Object_Model/Transforming_with_XSLT",


### PR DESCRIPTION
FF136 adds support for a lot of aria reflected elements that reference other elements. [Out-of-date explainer](https://wicg.github.io/aom/aria-reflection-explainer.html#reflecting-element-references).

NOTE FOR REVIEWER:
- These are attributes that contain id references to other elements. 
- They don't just say "reflects the attribute" because they don't. 
  - The attribute is a reference id or string of ids, but these ids might not map to actual elements, or might map to out of scope elements.
  - The property is an array of elements, which will take the valid values from the attribute if it is set.
  - If you set the property you clear the attribute. Last setter wins.

Because there is a lot to explain, that would otherwise have to be duplicated: 
- I have created [Document_Object_Model/Reflected_attributes ](https://pr38678.review.mdn.allizom.net/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes) to cover reflected attributes, including this special case. That has examples that show the rules for scoping etc
- Each individual doc summarises those rules and cross links to them.
- Element property docs have a simple example that shows how the attribute might be used, and shows how the property is read (not as good as showing how the property might be used instead of the attribute - but simple and enough to get the idea)
- `ElementInternals` docs are _mostly_ a duplicate of the `Element` docs but with links to the examples in corresponding Element doc and the reflected attributes. Didn't seem worth duplicating the examples for what they show.

One thing I am still considering doing is another example in  [Document_Object_Model/Reflected_attributes ](https://pr38678.review.mdn.allizom.net/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes)  that shows how a shadow root can access an element from the DOM.

Docs

- [x] Element.ariaActiveDescendantElement
- [x] Element.ariaControlsElements
- [x] Element.ariaDescribedByElements
- [x] Element.ariaDetailsElements
- [x] Element.ariaErrorMessageElements - in prog
- [x] Element.ariaFlowToElements
- [x] Element.ariaLabelledByElements - in progress
- [x] Element.ariaOwnsElements
- [x] ElementInternals.ariaActiveDescendantElement
- [x] ElementInternals.ariaControlsElements
- [x] ElementInternals.ariaDescribedByElements
- [x] ElementInternals.ariaDetailsElements
- [x] ElementInternals.ariaErrorMessageElements
- [x] ElementInternals.ariaFlowToElements
- [x] ElementInternals.ariaLabelledByElements  - in progress
- [x] ElementInternals.ariaOwnsElements
- [x] Element - top level ref links
- [x] ElementInternals - top level ref links
- [x] Reflecting attribute guide

Related docs can be tracked in https://github.com/mdn/content/issues/38402

