### PR TITLE
Moved explanation regarding pseudo-elements to the proper paragraph

### DIFF
--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -30,9 +30,9 @@ The `:has()` pseudo-class takes on the [specificity](/en-US/docs/Web/CSS/CSS_cas
 
 If the `:has()` pseudo-class itself is not supported in a browser, the entire selector block will fail unless `:has()` is in a forgiving selector list, such as in [`:is()`](/en-US/docs/Web/CSS/:is) and [`:where()`](/en-US/docs/Web/CSS/:where).
 
-The `:has()` pseudo-class cannot be nested within another `:has()`. This is because many pseudo-elements exist conditionally based on the styling of their ancestors and allowing these to be queried by `:has()` can introduce cyclic querying.
+The `:has()` pseudo-class cannot be nested within another `:has()`.
 
-Pseudo-elements are also not valid selectors within `:has()` and pseudo-elements are not valid anchors for `:has()`.
+Pseudo-elements are also not valid selectors within `:has()` and pseudo-elements are not valid anchors for `:has()`. This is because many pseudo-elements exist conditionally based on the styling of their ancestors and allowing these to be queried by `:has()` can introduce cyclic querying.
 
 ## Examples
 


### PR DESCRIPTION
### Description

The explanation about why pseudo-elements are not valid within the `:has()` function is in the wrong paragraph. It seemingly explains why the `:has()` pseudo-class cannot be nested, but more accurately explains the reason for the next paragraph: why _pseudo-elements_ are not valid with `:has()`.

### Motivation

Clears up a bit of confusion.

### Additional details

The [CSS Selectors Level 4](https://drafts.csswg.org/selectors/#relational) spec does not provide an explanation for why the `:has()` pseudo-class can't be nested, but it does explain why pseudo-elements are not valid.

From the spec:
> The `:has()` pseudo-class cannot be nested; :has() is not valid within :has(). Also, [...] `pseudo-elements` are not valid selectors within `:has()`.
>Pseudo-elements are generally excluded from `:has()` because many of them exist conditionally, based on the styling of their ancestors, so allowing these to be queried by `:has()` would introduce cycles.