### PR TITLE
Add a link to a bug about support for console.time* in Firefox Profiler

### DIFF
--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.console.timeStamp_static
 
 {{APIRef("Console API")}}{{Non-standard_header}} {{AvailableInWorkers}}
 
-The **`console.timeStamp()`** static method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/performance/reference)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
+The **`console.timeStamp()`** static method adds a single marker to the browser's Performance tool ([Firefox bug 1387528](https://bugzil.la/1387528), [Chrome](https://developer.chrome.com/docs/devtools/performance/reference)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
 
 You can optionally supply an argument to label the timestamp, and this label will then be shown alongside the marker.
 
@@ -38,4 +38,6 @@ None ({{jsxref("undefined")}}).
 - {{domxref("console/time_static", "console.time()")}}
 - {{domxref("console/timeLog_static", "console.timeLog()")}}
 - {{domxref("console/timeEnd_static", "console.timeEnd()")}}
+- {{domxref("performance/mark", "performance.mark()")}}
+- {{domxref("performance/measure", "performance.measure()")}}
 - [Adding markers with the console API](https://web.archive.org/web/20211207010020/https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#adding-markers-with-the-console-api)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a link to a bug about support for `console.time*` functions in Firefox Profiler. Also added links to cross-browser functions that Firefox Profiler supports.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The `console.timeStamp()` function is non-standard. It works in different browsers, but it doesn't have support in Firefox Profiler. So I replaced the link to Firefox Profiler with a bug about support for this feature.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Also added links to cross-browser functions that Firefox Profiler supports

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1387528