### PR TITLE
Add a note to hashchange about pushState() behavior

### DIFF
--- a/files/en-us/web/api/window/hashchange_event/index.md
+++ b/files/en-us/web/api/window/hashchange_event/index.md
@@ -10,6 +10,8 @@ browser-compat: api.Window.hashchange_event
 
 The **`hashchange`** event is fired when the fragment identifier of the URL has changed (the part of the URL beginning with and following the `#` symbol).
 
+This event does not fire when the hash is modified using {{domxref("history.pushState()")}} or {{domxref("history.replaceState()")}}.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a note that `hashchange` won't fire when using a URL with a hash in `pushState()` or `replaceState()`.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The [`pushState` description](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState#description) already includes this note that it doesn't cause the `hashchange` event to fire. But when I was wondering why `hashchange` won't fire, I first checked the `hashchange` page. I couldn't find anything, so I googled it, which yielded no immediate results. `history.pushState()` is often abstracted away by libraries and frameworks, meaning that many developers aren't even actively calling `pushState()`. So the connection between `pushState()` and `hashchange` isn't immediately obvious.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

- https://developer.mozilla.org/en-US/docs/Web/API/History/pushState#description

### Related issues and pull requests

none I could find

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
