### PR TITLE
Remove extraneous span

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/roles/menu_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/menu_role/index.md
@@ -130,7 +130,7 @@ The following snippet of code is a popup menu nested in a menubar. It is display
     aria-controls="colormenu"
     tabindex="0"
     aria-label="Text Color: purple">
-    <span>Purple</span>
+    Purple
   </button>
   <ul role="menu" id="colormenu" aria-label="Color Options" tabindex="-1">
     <li

--- a/files/en-us/web/accessibility/aria/reference/roles/menu_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/menu_role/index.md
@@ -130,8 +130,9 @@ The following snippet of code is a popup menu nested in a menubar. It is display
     aria-controls="colormenu"
     tabindex="0"
     aria-label="Text Color: purple">
-    Purple
-    <span></span>
+    <span>
+      Purple
+    </span>
   </button>
   <ul role="menu" id="colormenu" aria-label="Color Options" tabindex="-1">
     <li

--- a/files/en-us/web/accessibility/aria/reference/roles/menu_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/menu_role/index.md
@@ -130,9 +130,7 @@ The following snippet of code is a popup menu nested in a menubar. It is display
     aria-controls="colormenu"
     tabindex="0"
     aria-label="Text Color: purple">
-    <span>
-      Purple
-    </span>
+    <span>Purple</span>
   </button>
   <ul role="menu" id="colormenu" aria-label="Color Options" tabindex="-1">
     <li


### PR DESCRIPTION
### Description

In the second example of [ARIA Role "menu"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role), fix text `"Purple"` outside if `span` element.

### Motivation

This fixes an unintended mistake in the example possibly causing confusion over an empty element.

