### PR TITLE
fix(manifest docs): Update `scope` note for better clarity

### DIFF
--- a/files/en-us/web/progressive_web_apps/manifest/reference/scope/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/reference/scope/index.md
@@ -51,7 +51,7 @@ This helps users understand that they're viewing pages outside the app's defined
 
 > [!NOTE]
 > The `scope` member doesn't prevent users from navigating to app pages outside of the defined scope.
-> Off-scope navigations are not blocked by browsers and are not opened in a new top-level browsing context.
+> Off-scope navigations are not blocked by browsers and are allowed to be opened in a new top-level browsing context.
 
 Consider a web app for exploring hiking trails with the following directory structure:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR updates the note on the page to better interpret the following text from the Note block in the [spec](https://w3c.github.io/manifest/#nav-scope):

> Unlike previous versions of this specification, user agents are no longer required or allowed to block off-scope navigations, or open them in a new [top-level browsing context](https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context). This practice broke some sites that navigate to an off-scope URL (e.g., to perform third-party authentication). See [Issue 646](https://github.com/w3c/manifest/issues/646).

### Motivation

Add accurate information


