### PR TITLE
Clarity on Safari support for custom elements

### DIFF
--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -14,12 +14,12 @@ This article introduces custom elements, and walks through some examples.
 
 There are two types of custom element:
 
+- **Autonomous custom elements** inherit from the HTML element base class {{domxref("HTMLElement")}}. You have to implement their behavior from scratch.
+
 - **Customized built-in elements** inherit from standard HTML elements such as {{domxref("HTMLImageElement")}} or {{domxref("HTMLParagraphElement")}}. Their implementation extends the behavior of select instances of the standard element.
 
   > [!NOTE]
   > Safari does not plan to support custom built-in elements. See the [`is` attribute](/en-US/docs/Web/HTML/Global_attributes/is) for more information.
-
-- **Autonomous custom elements** inherit from the HTML element base class {{domxref("HTMLElement")}}. You have to implement their behavior from scratch.
 
 ## Implementing a custom element
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Moved the note about Safari's lack of support for customized built-in elements to follow that section, making it clear that only this specific type is unsupported, while autonomous custom elements are supported.

### Motivation

To reduce confusion for users that are new to custom elements, to make it clear that Safari supports custom components.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define

### Related issues and pull requests

n/a

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
