### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -47,7 +47,7 @@ To make a request, call `fetch()`, passing in:
 
 1. a definition of the resource to fetch. This can be any one of:
    - a string containing the URL
-   - an object, such an instance of {{domxref("URL")}}, which has a {{glossary("stringifier")}} that produces a string containing the URL
+   - an object, such as an instance of {{domxref("URL")}}, which has a {{glossary("stringifier")}} that produces a string containing the URL
    - a {{domxref("Request")}} instance
 2. optionally, an object containing options to configure the request.
 


### PR DESCRIPTION
This PR fixes a minor grammatical issue in the **"Making a request"** section of the Fetch API documentation.

### Fix Details:
- **Incorrect:** "such an instance of URL"
- **Corrected to:** "such as an instance of URL"

This correction improves readability and ensures proper grammar. No functional changes were made to the documentation.

**MDN Page:** https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
**GitHub Issue:** https://github.com/mdn/content/issues/38726

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Fixed a **grammatical issue** in the 'Making a request' section of the Fetch API documentation. Changed **'such an instance'** to **'such as an instance'** for better readability and correctness.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The previous sentence contained a **grammatical error** that could cause confusion. This fix **improves clarity** and **ensures proper grammar**, making the documentation easier to understand.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
This change only affects the **documentation text** and does **not modify any technical content or examples**. The fix ensures **grammatical correctness** in the explanation of fetch parameters.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #38726
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
