### PR TITLE
move layout mode to glossary

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -506,7 +506,7 @@
 /en-US/docs/CSS/Getting_Started/Why_use_CSS?	/en-US/docs/Learn_web_development/Core/Styling_basics/What_is_CSS
 /en-US/docs/CSS/ID_selectors	/en-US/docs/Web/CSS/ID_selectors
 /en-US/docs/CSS/Interactive	/en-US/docs/Web/CSS/@media
-/en-US/docs/CSS/Layout_mode	/en-US/docs/Web/CSS/Layout_mode
+/en-US/docs/CSS/Layout_mode	/en-US/docs/Glossary/Layout_mode
 /en-US/docs/CSS/List_of_Proprietary_CSS_Features	/en-US/docs/Web/CSS/Reference
 /en-US/docs/CSS/Media/Bitmap	/en-US/docs/Web/CSS/@media
 /en-US/docs/CSS/Media/TV	/en-US/docs/Web/CSS/@media
@@ -12163,6 +12163,7 @@
 /en-US/docs/Web/CSS/Inheritance	/en-US/docs/Web/CSS/CSS_cascade/Inheritance
 /en-US/docs/Web/CSS/Interactive	/en-US/docs/Web/CSS/@media
 /en-US/docs/Web/CSS/Layout_cookbook/Recipe:_Media_Objects	/en-US/docs/Web/CSS/Layout_cookbook/Media_objects
+/en-US/docs/Web/CSS/Layout_mode	/en-US/docs/Glossary/Layout_mode
 /en-US/docs/Web/CSS/List_of_Proprietary_CSS_Features	/en-US/docs/Web/CSS/Reference
 /en-US/docs/Web/CSS/Media_Queries	/en-US/docs/Web/CSS/CSS_media_queries
 /en-US/docs/Web/CSS/Media_Queries/Testing_media_queries	/en-US/docs/Web/CSS/CSS_media_queries/Testing_media_queries

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -3183,6 +3183,23 @@
     "modified": "2019-05-31T08:14:09.470Z",
     "contributors": ["Sheppy", "chrisdavidmills", "andystevensname", "estelle"]
   },
+  "Glossary/Layout_mode": {
+    "modified": "2020-07-07T12:36:23.002Z",
+    "contributors": [
+      "wbamberg",
+      "lcchueri",
+      "chrisdavidmills",
+      "rachelandrew",
+      "mfluehr",
+      "Sebastianz",
+      "markg",
+      "evalica",
+      "velvel53",
+      "Sheppy",
+      "FredB",
+      "teoli"
+    ]
+  },
   "Glossary/Layout_viewport": {
     "modified": "2020-03-27T15:15:46.041Z",
     "contributors": ["RafeyIqbalRahman", "Sheppy"]
@@ -78429,23 +78446,6 @@
   "Web/CSS/Layout_cookbook/Sticky_footers": {
     "modified": "2020-10-15T22:08:03.870Z",
     "contributors": ["wbamberg", "chrisdavidmills", "rachelandrew"]
-  },
-  "Web/CSS/Layout_mode": {
-    "modified": "2020-07-07T12:36:23.002Z",
-    "contributors": [
-      "wbamberg",
-      "lcchueri",
-      "chrisdavidmills",
-      "rachelandrew",
-      "mfluehr",
-      "Sebastianz",
-      "markg",
-      "evalica",
-      "velvel53",
-      "Sheppy",
-      "FredB",
-      "teoli"
-    ]
   },
   "Web/CSS/Mozilla_Extensions": {
     "modified": "2020-08-09T13:09:17.030Z",

--- a/files/en-us/glossary/layout_mode/index.md
+++ b/files/en-us/glossary/layout_mode/index.md
@@ -1,40 +1,41 @@
 ---
 title: Layout mode
 slug: Glossary/Layout_mode
-page-type: guide
+page-type: glossary-definition
 ---
 
-{{CSSRef}}
+{{GlossarySidebar}}
 
-A [CSS](/en-US/docs/Web/CSS) **layout mode**, sometimes called _layout_, is an algorithm that determines the position and size of boxes based on the way they interact with their sibling and ancestor boxes. There are several of them:
+A **layout mode**, sometimes called _layout_, is a [CSS](/en-US/docs/Web/CSS) algorithm that determines the position and size of element boxes based on the way they interact with their sibling and ancestor boxes.
 
-- _[Normal flow](/en-US/docs/Web/CSS/CSS_display/Flow_layout)_ — all elements are part of normal flow until you do something to take them out of it. Normal flow includes _block layout_, designed for laying out boxes such as paragraphs and _inline layout_, which lays out inline items such as text.
-- [_Table layout_](/en-US/docs/Web/CSS/CSS_table), designed for laying out tables.
-- _Float layout_, designed to cause an item to position itself left or right with the rest of the content in normal flow wrapping around it.
-- [_Positioned layout_](/en-US/docs/Web/CSS/CSS_positioned_layout), designed for positioning elements without much interaction with other elements.
-- [_Multi-column layout_](/en-US/docs/Web/CSS/CSS_multicol_layout), designed for laying content out in columns as in a newspaper.
-- [_Flexible box layout_](/en-US/docs/Web/CSS/CSS_flexible_box_layout), designed for laying out complex pages that can be resized smoothly.
-- [_Grid layout_](/en-US/docs/Web/CSS/CSS_grid_layout), designed for laying out elements relative to a fixed grid.
+There are several layout modes:
+
+- **[Flow layout or normal flow](/en-US/docs/Web/CSS/CSS_display/Flow_layout)**
+
+  - : All elements are part of normal flow until you do something to take them out of it.Normal flow includes:
+
+    - **[Block layout](/en-US/docs/Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow)**
+      - : Designed for laying out boxes such as paragraphs.
+    - **[Inline layout](/en-US/docs/Web/CSS/CSS_inline_layout)**
+      - : Designed for laying out inline items such as text.
+
+- **[Table layout](/en-US/docs/Web/CSS/CSS_table)**
+  - : Designed for laying out tables.
+- **Float layout**
+  - : Designed to cause an item to position itself left or right with the rest of the content in normal flow wrapping around it.
+- **[Positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout)**
+  - : Designed for positioning elements without much interaction with other elements.
+- **[Multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout)**
+  - : Designed for laying content out in columns as in a newspaper.
+- **[Flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout)**
+  - : Designed for laying out complex pages that can be resized smoothly.
+- **[Grid layout](/en-US/docs/Web/CSS/CSS_grid_layout)**
+  - : Designed for laying out elements relative to a fixed grid.
 
 > [!NOTE]
 > Not all [CSS properties](/en-US/docs/Web/CSS/Reference) apply to all _layout modes_. Most of them apply to one or two of them and have no effect if they are set on an element participating in another layout mode.
 
 ## See also
 
-- CSS key concepts:
-  - [CSS syntax](/en-US/docs/Web/CSS/CSS_syntax/Syntax)
-  - [At-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule)
-  - [Comments](/en-US/docs/Web/CSS/CSS_syntax/Comments)
-  - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
-  - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
-  - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
-  - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-  - Values
-    - [Initial values](/en-US/docs/Web/CSS/CSS_cascade/initial_value)
-    - [Computed values](/en-US/docs/Web/CSS/CSS_cascade/computed_value)
-    - [Used values](/en-US/docs/Web/CSS/CSS_cascade/used_value)
-    - [Actual values](/en-US/docs/Web/CSS/CSS_cascade/actual_value)
-  - [Value definition syntax](/en-US/docs/Web/CSS/CSS_Values_and_Units/Value_definition_syntax)
-  - [Shorthand properties](/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties)
-  - {{glossary("Replaced elements")}}
+- [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
+- [CSS display](/en-US/docs/Web/CSS/CSS_display) module

--- a/files/en-us/glossary/layout_mode/index.md
+++ b/files/en-us/glossary/layout_mode/index.md
@@ -1,6 +1,6 @@
 ---
 title: Layout mode
-slug: Web/CSS/Layout_mode
+slug: Glossary/Layout_mode
 page-type: guide
 ---
 

--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -49,7 +49,7 @@ Finally, note that for non-replaced inline elements, the amount of space taken u
   - [Comments](/en-US/docs/Web/CSS/CSS_syntax/Comments)
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -79,7 +79,7 @@ p {
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - Values
     - [Initial values](/en-US/docs/Web/CSS/CSS_cascade/initial_value)

--- a/files/en-us/web/css/css_cascade/actual_value/index.md
+++ b/files/en-us/web/css/css_cascade/actual_value/index.md
@@ -33,7 +33,7 @@ The {{glossary("user agent")}} performs four steps to calculate a property's act
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values

--- a/files/en-us/web/css/css_cascade/computed_value/index.md
+++ b/files/en-us/web/css/css_cascade/computed_value/index.md
@@ -35,7 +35,7 @@ However, for some properties (those where percentages are relative to something 
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values

--- a/files/en-us/web/css/css_cascade/initial_value/index.md
+++ b/files/en-us/web/css/css_cascade/initial_value/index.md
@@ -33,7 +33,7 @@ You can explicitly specify the initial value by using the {{cssxref("initial")}}
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values

--- a/files/en-us/web/css/css_cascade/specified_value/index.md
+++ b/files/en-us/web/css/css_cascade/specified_value/index.md
@@ -64,7 +64,7 @@ p {
 - [CSS syntax](/en-US/docs/Web/CSS/CSS_syntax/Syntax)
 - [At-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule)
 - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+- [Layout modes](/en-US/docs/Glossary/Layout_mode)
 - [Visual formatting models](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
 - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - [Initial](/en-US/docs/Web/CSS/CSS_cascade/initial_value), [computed](/en-US/docs/Web/CSS/CSS_cascade/computed_value), [used](/en-US/docs/Web/CSS/CSS_cascade/used_value), and [actual](/en-US/docs/Web/CSS/CSS_cascade/actual_value) values

--- a/files/en-us/web/css/css_cascade/used_value/index.md
+++ b/files/en-us/web/css/css_cascade/used_value/index.md
@@ -110,7 +110,7 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values

--- a/files/en-us/web/css/css_display/block_formatting_context/index.md
+++ b/files/en-us/web/css/css_display/block_formatting_context/index.md
@@ -231,7 +231,7 @@ In this example, we wrap the second `<div>` in an outer `<div>`, and create a ne
 - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
 - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
 - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+- [Layout modes](/en-US/docs/Glossary/Layout_mode)
 - [Visual formatting models](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
 - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - [Initial](/en-US/docs/Web/CSS/CSS_cascade/initial_value), [computed](/en-US/docs/Web/CSS/CSS_cascade/computed_value), [used values](/en-US/docs/Web/CSS/CSS_cascade/used_value), and [actual](/en-US/docs/Web/CSS/CSS_cascade/actual_value) values

--- a/files/en-us/web/css/css_display/containing_block/index.md
+++ b/files/en-us/web/css/css_display/containing_block/index.md
@@ -260,7 +260,7 @@ p {
 - [Learn: sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing)
 - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module
-- [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+- [Layout modes](/en-US/docs/Glossary/Layout_mode)
 - [Visual formatting models](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
 - [Block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context)

--- a/files/en-us/web/css/css_display/visual_formatting_model/index.md
+++ b/files/en-us/web/css/css_display/visual_formatting_model/index.md
@@ -256,7 +256,7 @@ A block box is a block-level box that is also a block container. As described in
 - [Stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context)
 - [Block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-- [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+- [Layout modes](/en-US/docs/Glossary/Layout_mode)
 - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - {{glossary("Replaced elements")}}
 - {{DOMxRef("VisualViewport")}} interface

--- a/files/en-us/web/css/css_values_and_units/value_definition_syntax/index.md
+++ b/files/en-us/web/css/css_values_and_units/value_definition_syntax/index.md
@@ -448,7 +448,7 @@ Here are some more examples:
   - [Specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity)
   - [Inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance)
   - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
-  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Layout modes](/en-US/docs/Glossary/Layout_mode)
   - [Visual formatting model](/en-US/docs/Web/CSS/CSS_display/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -135,7 +135,7 @@ Combinators are selectors that establish a relationship between two or more simp
 - [Block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
 - [Box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [Containing block](/en-US/docs/Web/CSS/CSS_display/Containing_block)
-- [Layout mode](/en-US/docs/Web/CSS/Layout_mode)
+- [Layout mode](/en-US/docs/Glossary/Layout_mode)
 - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
 - {{glossary("Replaced elements")}}
 - [Stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context)


### PR DESCRIPTION
replaces https://github.com/mdn/content/pull/38636

this is more a definition than a guide, so moved it to glossary

[#218](https://github.com/openwebdocs/project/issues/218)