### PR TITLE
Fix code block language from C++ to C in markdown

### DIFF
--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -30,7 +30,7 @@ This is the simplest case we'll look at, whereby you get emscripten to generate 
 
 1. First we need an example to compile. Take a copy of the following simple C example, and save it in a file called `hello.c` in a new directory on your local drive:
 
-   ```cpp
+   ```c
    #include <stdio.h>
 
    int main() {
@@ -71,7 +71,7 @@ Sometimes you will want to use a custom HTML template. Let's look at how we can 
 
 1. First of all, save the following C code in a file called `hello2.c`, in a new directory:
 
-   ```cpp
+   ```c
    #include <stdio.h>
 
    int main() {
@@ -106,7 +106,7 @@ If you want to call a function defined in your C code from JavaScript, you can u
 
 1. To start with, save the following code as `hello3.c` in a new directory:
 
-   ```cpp
+   ```c
    #include <stdio.h>
    #include <emscripten/emscripten.h>
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Changed the syntax highlighting in a Markdown code block from C++ to C for more accurate language representation

In three separate occasions the code snippets are in C but the block code says it's C++. I just corrected that.

### Motivation
This change ensures the code block is correctly highlighted according to its programming language, improving readability and accuracy for readers.


### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
