### PR TITLE
chore: tidy up playable canvas examples

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -80,50 +80,38 @@ The following diagram from the [HTML spec](https://html.spec.whatwg.org/multipag
 
 ![The em-over baseline is roughly at the top of the glyphs in a font, the hanging baseline is where some glyphs like आ are anchored, the middle is half-way between the em-over and em-under baselines, the alphabetic baseline is where characters like Á, ÿ, f, and Ω are anchored, the ideographic-under baseline is where glyphs like 私 and 達 are anchored, and the em-under baseline is roughly at the bottom of the glyphs in a font. The top and bottom of the bounding box can be far from these baselines, due to glyphs extending far outside em-over and em-under baselines.](baselines.png)
 
-### A textBaseline example
+### A `textBaseline` example
 
-Edit the code below and see your changes update live in the canvas:
+This example demonstrates the various `textBaseline` property values.
+See the [`CanvasRenderingContext2D.textBaseline`](/en-US/docs/Web/API/CanvasRenderingContext2D/textBaseline) page for more information and detailed examples.
 
-```html hidden
-<canvas id="canvas" width="400" height="200" class="playable-canvas"></canvas>
-<div class="playable-buttons">
-  <input id="edit" type="button" value="Edit" />
-  <input id="reset" type="button" value="Reset" />
-</div>
-<textarea id="code" class="playable-code">
-ctx.font = "48px serif";
-ctx.textBaseline = "hanging";
-ctx.strokeText("Hello world", 0, 100);
-</textarea>
+```html hidden live-sample___textBaseline
+<canvas id="canvas" width="400" height="100"></canvas>
 ```
 
-```js hidden
-const canvas = document.getElementById("canvas");
-const ctx = canvas.getContext("2d");
-const textarea = document.getElementById("code");
-const reset = document.getElementById("reset");
-const edit = document.getElementById("edit");
-const code = textarea.value;
+```js live-sample___textBaseline
+function draw() {
+  const ctx = document.getElementById("canvas").getContext("2d");
+  ctx.font = "48px serif";
 
-function drawCanvas() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  eval(textarea.value);
+  ctx.textBaseline = "hanging";
+  ctx.strokeText("hanging", 10, 50);
+
+  ctx.textBaseline = "middle";
+  ctx.strokeText("middle", 250, 50);
+
+  ctx.beginPath();
+  ctx.moveTo(10, 50);
+  ctx.lineTo(300, 50);
+  ctx.stroke();
 }
-
-reset.addEventListener("click", () => {
-  textarea.value = code;
-  drawCanvas();
-});
-
-edit.addEventListener("click", () => {
-  textarea.focus();
-});
-
-textarea.addEventListener("input", drawCanvas);
-window.addEventListener("load", drawCanvas);
 ```
 
-{{ EmbedLiveSample('A_textBaseline_example', 700, 400) }}
+```js hidden live-sample___textBaseline
+draw();
+```
+
+{{EmbedLiveSample('textBaseline', 310, 110)}}
 
 ## Advanced text measurements
 

--- a/files/en-us/web/api/canvaspattern/settransform/index.md
+++ b/files/en-us/web/api/canvaspattern/settransform/index.md
@@ -29,22 +29,18 @@ None ({{jsxref("undefined")}}).
 
 ### Using the `setTransform` method
 
-This is just a simple code snippet which uses the `setTransform` method to
+This is a code snippet which uses the `setTransform` method to
 create a {{domxref("CanvasPattern")}} with the specified pattern transformation from a
 {{domxref("DOMMatrix")}}. The pattern gets applied if you set it as the current
 {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} and gets drawn onto the
 canvas when using the {{domxref("CanvasRenderingContext2D.fillRect", "fillRect()")}}
 method, for example.
 
-#### HTML
-
-```html
+```html live-sample___canvas
 <canvas id="canvas"></canvas>
 ```
 
-#### JavaScript
-
-```js
+```js live-sample___canvas
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
@@ -61,57 +57,7 @@ img.onload = () => {
 };
 ```
 
-#### Editable demo
-
-Here's an editable demo of the code snippet above. Try changing the argument to `SetTransform()` to see the effect it had.
-
-```html hidden
-<canvas id="canvas" width="400" height="200" class="playable-canvas"></canvas>
-<div class="playable-buttons">
-  <input id="edit" type="button" value="Edit" />
-  <input id="reset" type="button" value="Reset" />
-</div>
-<textarea id="code" class="playable-code" style="height:120px">
-const img = new Image();
-img.src = 'canvas_create_pattern.png';
-img.onload = () => {
-  const pattern = ctx.createPattern(img, 'repeat');
-  pattern.setTransform(matrix.rotate(-45).scale(1.5));
-  ctx.fillStyle = pattern;
-  ctx.fillRect(0, 0, 400, 400);
-};
-</textarea>
-```
-
-```js hidden
-const canvas = document.getElementById("canvas");
-const ctx = canvas.getContext("2d");
-const textarea = document.getElementById("code");
-const reset = document.getElementById("reset");
-const edit = document.getElementById("edit");
-const code = textarea.value;
-
-const matrix = new DOMMatrix([1, 0.2, 0.8, 1, 0, 0]);
-
-function drawCanvas() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  eval(textarea.value);
-}
-
-reset.addEventListener("click", () => {
-  textarea.value = code;
-  drawCanvas();
-});
-
-edit.addEventListener("click", () => {
-  textarea.focus();
-});
-
-textarea.addEventListener("input", drawCanvas);
-window.addEventListener("load", drawCanvas);
-```
-
-{{ EmbedLiveSample('Editable_demo', 700, 400) }}
+{{EmbedLiveSample('canvas', , 250)}}
 
 ## Specifications
 


### PR DESCRIPTION
### Description

There are some small canvas demos that use older playable editors, they work and look just fine as regular live samples, so I'm porting them over.

### Motivation

Cleaning up some of the playable examples that work well already without much modification.
