### PR TITLE
fix: typo on `Error.isError()` page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/iserror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/iserror/index.md
@@ -76,7 +76,7 @@ const xError = window.frames[window.frames.length - 1].Error;
 const error = new xError();
 
 // Correctly checking for Error
-Error.isERror(error); // true
+Error.isError(error); // true
 // The prototype of error is xError.prototype, which is a
 // different object from Error.prototype
 error instanceof Error; // false


### PR DESCRIPTION
### Description

There was a typo in the code snippet on the `Error.isError()` page

### Motivation

The code didn't work due to the typo.

### Additional details

None

### Related issues and pull requests

The typo was introduced in a previous PR:

- https://github.com/mdn/content/pull/38251
