### PR TITLE
Fix typo in aria-relevant documentation

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-relevant/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-relevant/index.md
@@ -20,7 +20,7 @@ When `aria-relevant` is not defined, the value is inherited from the nearest anc
 
 While not a supported value, if the value of `none` makes the most sense, it should not be a live region.
 
-The values of `removals` and `all` should be used sparingly. For example, when a goal happens in the World Cup, the new score (the addition) is important, the old value (the removal) is not. Assistive technologies only need to be informed of content removal when its removal represents an important change, such as a when a player is taken out of the game.
+The values of `removals` and `all` should be used sparingly. For example, when a goal happens in the World Cup, the new score (the addition) is important, the old value (the removal) is not. Assistive technologies only need to be informed of content removal when its removal represents an important change, such as when a player is taken out of the game.
 
 ## Values
 


### PR DESCRIPTION
This PR corrects a minor typo in the aria-relevant documentation by removing the extra "a" in the phrase "such as a when," improving readability and clarity.