### PR TITLE
Fix set property invalid description of priority parameter

### DIFF
--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -29,8 +29,10 @@ setProperty(propertyName, value, priority)
     > **Note:** `value` must not contain `"!important"`, that should be set using the `priority` parameter.
 - `priority` {{optional_inline}}
   - : A string allowing the CSS priority to be set to important. Only the values listed below are accepted:
+
     - `"important"` (case-insensitive) for setting the property as `!important`;
     - `""`, `undefined`, or `null` for removing the `!important` flag if present.
+
     Anything else causes the method to return early and no change to happen (unless `value` is empty, in which case the property is removed regardless of the `priority` value). `false`, for example, is not a valid priority value.
 
 ### Return value

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -29,12 +29,20 @@ setProperty(propertyName, value, priority)
     > **Note:** `value` must not contain `"!important"`, that should be set using the `priority` parameter.
 - `priority` {{optional_inline}}
 
-  - : A string allowing the "important" CSS priority to be set. If not
-    specified, treated as the empty string. The following values are accepted:
+  - : A string allowing the CSS priority to be set to important.
+  Only the values listed below are accepted, anything else will cause no changes to be applied.
+  `false` for example is not a valid value.
+    - `"important"`
+    - `""`
+    - `undefined`
+    - `null`
 
-    - String value `"important"`
-    - Keyword `undefined`
-    - String empty value `""`
+```js-nolint
+element.style.setProperty("background", "red", "important")
+element.style.cssText // "background: red !important;"
+element.style.setProperty("background", "blue", false) // no changes will be applied
+element.style.cssText // "background: red !important;
+```
 
 ### Return value
 

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -28,21 +28,10 @@ setProperty(propertyName, value, priority)
     as the empty string. A [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) value is treated the same as the empty string (`""`).
     > **Note:** `value` must not contain `"!important"`, that should be set using the `priority` parameter.
 - `priority` {{optional_inline}}
-
-  - : A string allowing the CSS priority to be set to important.
-    Only the values listed below are accepted, anything else will cause no changes to be applied.
-    `false` for example is not a valid value.
-    - `"important"`
-    - `""`
-    - `undefined`
-    - `null`
-
-```js-nolint
-element.style.setProperty("background", "red", "important")
-element.style.cssText // "background: red !important;"
-element.style.setProperty("background", "blue", false) // no changes will be applied
-element.style.cssText // "background: red !important;
-```
+  - : A string allowing the CSS priority to be set to important. Only the values listed below are accepted:
+    - `"important"` (case-insensitive) for setting the property as `!important`;
+    - `""`, `undefined`, or `null` for removing the `!important` flag if present.
+    Anything else causes the method to return early and no change to happen (unless `value` is empty, in which case the property is removed regardless of the `priority` value). `false`, for example, is not a valid priority value.
 
 ### Return value
 

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -30,8 +30,8 @@ setProperty(propertyName, value, priority)
 - `priority` {{optional_inline}}
 
   - : A string allowing the CSS priority to be set to important.
-  Only the values listed below are accepted, anything else will cause no changes to be applied.
-  `false` for example is not a valid value.
+    Only the values listed below are accepted, anything else will cause no changes to be applied.
+    `false` for example is not a valid value.
     - `"important"`
     - `""`
     - `undefined`

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -28,6 +28,7 @@ setProperty(propertyName, value, priority)
     as the empty string. A [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) value is treated the same as the empty string (`""`).
     > **Note:** `value` must not contain `"!important"`, that should be set using the `priority` parameter.
 - `priority` {{optional_inline}}
+
   - : A string allowing the CSS priority to be set to important. Only the values listed below are accepted:
 
     - `"important"` (case-insensitive) for setting the property as `!important`;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This change corrects the parameter description for CSSStyleDeclaration setProperty method.

### Motivation
These changes reflect the full list of accepted values and more accurately describe what happens when an invalid value is passed.

### Additional details
-
### Related issues and pull requests
- I am not sure if there are related issues.
