### PR TITLE
docs: make SVG `tabindex` Example clearer

### DIFF
--- a/files/en-us/web/svg/reference/attribute/tabindex/index.md
+++ b/files/en-us/web/svg/reference/attribute/tabindex/index.md
@@ -23,10 +23,10 @@ svg {
 ```html
 <?xml version="1.0"?>
 <svg viewBox="0 0 260 260" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="60" cy="60" r="15" tabindex="0" />
-  <circle cx="60" cy="160" r="30" tabindex="0" />
-  <circle cx="160" cy="60" r="30" tabindex="0" />
-  <circle cx="160" cy="160" r="60" tabindex="0" />
+  <circle r="10" tabindex="0" fill="green" cx="60" cy="60" />
+  <circle r="40" tabindex="0" fill="red" cx="60" cy="160" />
+  <circle r="60" tabindex="0" fill="blue" cx="160" cy="60" />
+  <circle r="20" tabindex="0" fill="black" cx="160" cy="160" />
 </svg>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This makes [The SVG `tabindex` Example](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/tabindex#example) clearer by more strongly differentiating different `circle` elements.

### Motivation

[The SVG `tabindex` Example](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/tabindex#example) could be clearer.

When either of the 2 `r="30"` circles gets tabbed to, it's not immediately obvious which line of code that corresponds to.

Readers might be able to distinguish them based on their `cx` and `cy` values, but that requires more cognitive effort.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Related issues and pull requests

Fixes #38776

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->