### PR TITLE
fix(accessibility docs): Remove "Best practices" section for roles that should not be used

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/alertdialog_role/index.md
@@ -34,6 +34,15 @@ Adding `role="alertdialog"` alone is not sufficient to make an alert dialog acce
 
 The `alertdialog` must have an accessible name, defined with [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label). The alert dialog text must have an {{glossary("accessible description")}} using [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby).
 
+## Associated WAI-ARIA roles, states, and properties
+
+- [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
+
+  - : Use this attribute to label the alertdialog. The `aria-labelledby` attribute is generally the id of the element used to title the alertdialog.
+
+- [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
+  - : Use this attribute to encompass the description of the contents of the alert dialog. The value of the `aria-describedby` attribute is generally the ID of the element containing the alert dialog's messaging, usually coming right after the title.
+
 ## Examples
 
 ### Example 1: A basic alert dialog
@@ -83,15 +92,6 @@ The code snippet above shows how to mark up an alert dialog that only provides a
   </ul>
 </div>
 ```
-
-### Associated WAI-ARIA roles, states, and properties
-
-- [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
-
-  - : Use this attribute to label the alertdialog. The `aria-labelledby` attribute is generally the id of the element used to title the alertdialog.
-
-- [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)
-  - : Use this attribute to encompass the description of the contents of the alert dialog. The value of the `aria-describedby` attribute is generally the ID of the element containing the alert dialog's messaging, usually coming right after the title.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/alertdialog_role/index.md
@@ -34,7 +34,7 @@ Adding `role="alertdialog"` alone is not sufficient to make an alert dialog acce
 
 The `alertdialog` must have an accessible name, defined with [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label). The alert dialog text must have an {{glossary("accessible description")}} using [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby).
 
-## Associated WAI-ARIA roles, states, and properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby)
 

--- a/files/en-us/web/accessibility/aria/reference/roles/banner_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/banner_role/index.md
@@ -24,15 +24,15 @@ Each page may have a `banner` landmark, but each page should generally be limite
 
 ### Associated ARIA roles, states, and properties
 
-None
+None.
 
 ### Keyboard interactions
 
-None
+None.
 
 ### Required JavaScript features
 
-None
+None.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/reference/roles/cell_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/cell_role/index.md
@@ -74,7 +74,7 @@ A cell can contain a number of property attributes clarifying the cell's positio
 
 ### Keyboard interactions
 
-None
+None.
 
 ### Required JavaScript features
 

--- a/files/en-us/web/accessibility/aria/reference/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/checkbox_role/index.md
@@ -54,7 +54,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 <div role="checkbox">Name of my checkbox</div>
 ```
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-checked)
 

--- a/files/en-us/web/accessibility/aria/reference/roles/columnheader_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/columnheader_role/index.md
@@ -55,7 +55,7 @@ JavaScript is only required if the `aria-sort` attribute is used.
 </table>
 ```
 
-## Best Practices
+## Best practices
 
 Column headers should contain a title or header information for the column.
 

--- a/files/en-us/web/accessibility/aria/reference/roles/comment_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/comment_role/index.md
@@ -81,7 +81,7 @@ It's possible to nest comments inside one another, like so:
 
 ## Accessibility concerns
 
-None
+None.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/composite_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/composite_role/index.md
@@ -13,11 +13,7 @@ The `composite` [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Rol
 
 ## Description
 
-`Composite` is an abstract role used for the ontology. Don't use this role in content. Instead, use the composite subclasses of [`grid`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role), [`select`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/select_role), [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/spinbutton_role), and [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role)
-
-## Best Practices
-
-Do not use.
+`Composite` is an abstract role used for the ontology. Don't use this role in content. Instead, use the composite subclasses of [`grid`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role), [`select`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/select_role), [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/spinbutton_role), and [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role).
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/composite_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/composite_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The `composite` [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles) indicates a widget that may contain navigable descendants or owned children.
 
-> [!NOTE]
+> [!WARNING]
 > The `composite` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/form_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/form_role/index.md
@@ -33,11 +33,11 @@ Use the HTML {{HTMLElement('form')}} element if possible. The `<form>` element d
 
 Use the `role="form"` to identify a region of the page; do not use it to identify every form field. Even if you are using the form landmark instead of `<form>`, you are encouraged to use native HTML form controls like {{HTMLElement('button')}}, {{HTMLElement('input')}}, {{HTMLElement('select')}}, and {{HTMLElement('textarea')}}.
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 No role specific states or properties.
 
-### Keyboard Interactions
+### Keyboard interactions
 
 No role specific keyboard interactions
 

--- a/files/en-us/web/accessibility/aria/reference/roles/gridcell_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/gridcell_role/index.md
@@ -88,7 +88,7 @@ Both `<td>` elements and elements with a role of `gridcell` applied to them can 
 
 In a [treegrid](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/treegrid_role), gridcells may be made expandable by toggling the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded) attribute. Note that if this attribute is provided, it applies only to the individual gridcell.
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 - `grid`
   - : Communicates that a parent element is a table or tree style grouping of information.

--- a/files/en-us/web/accessibility/aria/reference/roles/img_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/img_role/index.md
@@ -102,7 +102,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 <div role="img">Title of my image</div>
 ```
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 - `aria-label` or `aria-labelledby`
   - : An accessible name is required. For the HTML {{HTMLElement('img')}} element, use the `alt` attribute. For all other elements with the `img` role, use `aria-labelledby` if a visible label is present, otherwise use `aria-label`.

--- a/files/en-us/web/accessibility/aria/reference/roles/input_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/input_role/index.md
@@ -15,10 +15,6 @@ The `input` abstract role is a generic type of widget that allows user input.
 
 The `input` role is an abstract role. It must not be used by web authors. It is the superclass for input widgets that provide for user input, including [`checkbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/checkbox_role), [`radio`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/radio_role), and [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role). For all three, consider using the {{HTMLElement("input")}} element of type [`checkbox`](/en-US/docs/Web/HTML/Element/input/checkbox), [`radio`](/en-US/docs/Web/HTML/Element/input/radio) and [`text`](/en-US/docs/Web/HTML/Element/input/text), respectively.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/input_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/input_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The `input` abstract role is a generic type of widget that allows user input.
 
-> [!NOTE]
+> [!WARNING]
 > The `input` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It is not to be used by web authors.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/landmark_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/landmark_role/index.md
@@ -21,7 +21,7 @@ A visible label should be provided, referenced with [`aria-labelledby`](/en-US/d
 
 For screen reader users, adding landmark roles effectively creates 'skip links' for screen reader users, but don't replace in page navigation as the landmark roles are not otherwise surfaced.
 
-## Best Practices
+## Best practices
 
 Do not use `role="landmark"`. Do use HTML and subclass landmark roles.
 

--- a/files/en-us/web/accessibility/aria/reference/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/list_role/index.md
@@ -25,7 +25,7 @@ There are no hard and fast rules about which elements you should use to mark up 
 > [!NOTE]
 > Best practices dictate using the appropriate semantic HTML elements over ARIA roles to mark up lists and listitems — {{HTMLElement("ul")}}, {{HTMLElement("ol")}} and {{HTMLElement("li")}}. See [Best practices](#best_practices) for a full example.
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`listitem`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listitem_role) role
   - : A single item in a list. Elements with role `listitem` can only be found in an element with the role `list`.

--- a/files/en-us/web/accessibility/aria/reference/roles/log_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/log_role/index.md
@@ -30,7 +30,7 @@ By default, updates contain only the changes to the live region and these are an
 
   - : The `log` is required to have an accessible name. Use `aria-labelledby` if a visible label is present, otherwise use `aria-label`.
 
-## Best Practices
+## Best practices
 
 With an area that has scrolling text, such as a stock ticker, the [`marquee`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/marquee_role) role should be used instead.
 

--- a/files/en-us/web/accessibility/aria/reference/roles/menuitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/menuitem_role/index.md
@@ -37,7 +37,7 @@ Every `menuitem` must have an accessible name. This name comes from the element'
 - [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup)
   - : Indicates the availability and type of interactive popup that can be triggered by the `menuitem`
 
-## Keyboard interactions
+### Keyboard interactions
 
 - <kbd>Enter</kbd> and <kbd>Space</kbd>
   - : If the `menuitem` has a submenu, opens the submenu and places focus on its first item. Otherwise, activates the item and closes the menu.

--- a/files/en-us/web/accessibility/aria/reference/roles/menuitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/menuitem_role/index.md
@@ -24,7 +24,7 @@ A common convention for indicating that a `menuitem` launches a dialog box is to
 
 Every `menuitem` must have an accessible name. This name comes from the element's contents by default. If the contents don't provide for a useful accessible name, [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) can be used to reference visible label. If no visible content is available to provide the accessible name, an accessible name can be provided with [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label).
 
-## Associated WAI-ARIA roles, states, and properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`menu`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role) role
   - : A widget providing a list of choices. Required context role (or `menubar`)

--- a/files/en-us/web/accessibility/aria/reference/roles/navigation_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/navigation_role/index.md
@@ -32,7 +32,7 @@ It is preferable to use the HTML5 [`<nav>` element](/en-US/docs/Web/HTML/Element
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
   - : A brief description of the purpose of the navigation, omitting the term "navigation", as the screen reader will read both the role and the contents of the label.
 
-### Keyboard Interactions
+### Keyboard interactions
 
 None.
 

--- a/files/en-us/web/accessibility/aria/reference/roles/navigation_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/navigation_role/index.md
@@ -27,7 +27,7 @@ It is preferable to use the HTML5 [`<nav>` element](/en-US/docs/Web/HTML/Element
 > [!NOTE]
 > Using the {{HTMLElement('nav')}} element will automatically communicate a section has a role of `navigation`. Developers should always prefer using the correct semantic HTML element over using ARIA
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
   - : A brief description of the purpose of the navigation, omitting the term "navigation", as the screen reader will read both the role and the contents of the label.

--- a/files/en-us/web/accessibility/aria/reference/roles/progressbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/progressbar_role/index.md
@@ -83,7 +83,7 @@ Using semantic HTML, this could be written as:
 <progress id="loadinglabel" max="100" value="23"></progress>
 ```
 
-## Best Practices
+## Best practices
 
 If the progress bar is describing the loading progress of a particular region of a page, include the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to reference the progress bar's status, and set the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy) attribute to `true` on the region until it is finished loading.
 

--- a/files/en-us/web/accessibility/aria/reference/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/radio_role/index.md
@@ -101,7 +101,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 <div role="radio">name of my radio</div>
 ```
 
-## Associated WAI-ARIA roles, states, and properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`radiogroup`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/radiogroup_role) role
 

--- a/files/en-us/web/accessibility/aria/reference/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/radio_role/index.md
@@ -119,7 +119,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 > [!NOTE]
 > Use the [`tabindex` attribute](/en-US/docs/Web/HTML/Global_attributes/tabindex) if the `role="radio"` is used on an element that does not natively accept keyboard focus. E.g., a `<div>` or `<span>`.
 
-## Keyboard interactions
+### Keyboard interactions
 
 - <kbd>Tab</kbd> + <kbd>Shift</kbd>
 

--- a/files/en-us/web/accessibility/aria/reference/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/radio_role/index.md
@@ -101,7 +101,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 <div role="radio">name of my radio</div>
 ```
 
-## Associated WAI-ARIA Roles, States, and Properties
+## Associated WAI-ARIA roles, states, and properties
 
 - [`radiogroup`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/radiogroup_role) role
 

--- a/files/en-us/web/accessibility/aria/reference/roles/range_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/range_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The `range` abstract role is a generic type of structure role representing a range of values.
 
-> [!NOTE]
+> [!WARNING]
 > The `range` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It is not to be used by web authors.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/range_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/range_role/index.md
@@ -15,10 +15,6 @@ The `range` abstract role is a generic type of structure role representing a ran
 
 The `range` role is an abstract role. It must not be used by web authors. It is the superclass for structural roles for elements that accept a value within a range of values, including the [`meter`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/meter_role) role, [`progressbar`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/progressbar_role) and [`slider`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/slider_role). For these three, consider using the {{HTMLElement("meter")}} element, the {{HTMLElement("progress")}} element, and the {{HTMLElement("input/range")}}, respectively.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/region_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/region_role/index.md
@@ -27,7 +27,7 @@ The `region` landmark role's content should make sense if separated from the mai
 
 Using the {{HTMLElement('section')}} element will automatically communicate a section has a role of `region` if it is given an accessible name. Developers should always prefer using the correct semantic HTML element, in this case `<section>`, over using ARIA.
 
-### Associated WAI-ARIA Roles, States, and Properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
   - : Use this attribute to label the region. Often, the value of the `aria-labelledby` attribute will be the id of the element used to title the section. If no visible appropriate header is present, `aria-label` should be used.

--- a/files/en-us/web/accessibility/aria/reference/roles/roletype_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/roletype_role/index.md
@@ -14,11 +14,6 @@ The **`roletype`** role, an [abstract role](/en-US/docs/Web/Accessibility/ARIA/R
 ## Description
 
 The `roletype` role's properties describe the structural and functional purpose of objects that are assigned this role, or "instances". A role is a concept that can be used to understand and operate instances.
-Note
-
-## Best Practices
-
-Do not use.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/roletype_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/roletype_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The **`roletype`** role, an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles), is the base role from which all other ARIA roles inherit.
 
-> [!NOTE]
+> [!WARNING]
 > The `roletype` role is an abstract role used for the ontology. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/row_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/row_role/index.md
@@ -110,9 +110,9 @@ To create an interactive widget that has a tabular structure, use the grid patte
 
     If all the rows are present in the DOM, this attribute is not necessary.
 
-### Keyboard Interactions
+### Keyboard interactions
 
-None
+None.
 
 ### Required JavaScript features
 

--- a/files/en-us/web/accessibility/aria/reference/roles/rowgroup_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/rowgroup_role/index.md
@@ -60,7 +60,7 @@ To create an ARIA table header, table footer or table body, add `role="rowgroup"
 
 ### Keyboard interactions
 
-None
+None.
 
 ### Required JavaScript features
 

--- a/files/en-us/web/accessibility/aria/reference/roles/rowheader_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/rowheader_role/index.md
@@ -53,7 +53,7 @@ To create an ARIA row header, add `role="rowheader"` to the element. That row he
 
 ### Keyboard interactions
 
-None
+None.
 
 ### Required JavaScript features
 

--- a/files/en-us/web/accessibility/aria/reference/roles/section_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/section_role/index.md
@@ -8,8 +8,8 @@ sidebar: accessibilitysidebar
 
 The **`section` role**, an abstract role, is a superclass role for renderable structural containment components.
 
-> [!NOTE]
-> The `section` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It **should not be used** by web authors.
+> [!WARNING]
+> The `section` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/reference/roles/section_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/section_role/index.md
@@ -16,10 +16,6 @@ The **`section` role**, an abstract role, is a superclass role for renderable st
 The structural `section` role is an abstract role for categorizing all the section subclass roles. The role must not be used. Some subclasses, like [`alert`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role),
 [`note`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/note_role), and [`tooltip`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tooltip_role) are useful, and can be used to add semantics when no semantic HTML elements quite fit the purpose of a component. Others, like [`code`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles), [`figure`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/figure_role), and [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles), aren't necessary, as there are HTML element equivalents. In this case, {{HTMLElement('code')}} {{HTMLElement('figure')}} and {{HTMLElement('sub')}}, respectively.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/sectionhead_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/sectionhead_role/index.md
@@ -15,10 +15,6 @@ The **`sectionhead` role**, an abstract role, is superclass role for labels or s
 
 The structural `sectionhead` role is an abstract role for the subclass roles that identify the labels or summaries of the sections they label. The role must not be used. The four subclasses — [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/columnheader_role), [`heading`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/rowheader_role), and [`tab`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role). There are HTML element equivalents, like, {{HTMLElement('th', '<code>&lt;th scope="col"&gt;</code>')}} for `columnheader`, {{HTMLElement('th', '<code>&lt;th scope="row"&gt;</code>')}} for rowheader, and any of the HTML headings, {{HTMLElement("Heading_Elements", "h1")}} through {{HTMLElement("Heading_Elements", "h6")}} for `heading`. The `tab` role does not currently have an HTML equivalent.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/sectionhead_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/sectionhead_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The **`sectionhead` role**, an abstract role, is superclass role for labels or summaries of the topic of its related section.
 
-> [!NOTE]
+> [!WARNING]
 > The `sectionhead` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/select_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/select_role/index.md
@@ -8,8 +8,8 @@ sidebar: accessibilitysidebar
 
 The **`select` role**, an abstract role, is superclass role for form widgets that allows the user to make selections from a set of choices.
 
-> [!NOTE]
-> The `select` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It **should not be used** by web authors.
+> [!WARNING]
+> The `select` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/reference/roles/select_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/select_role/index.md
@@ -15,10 +15,6 @@ The **`select` role**, an abstract role, is superclass role for form widgets tha
 
 The structural `select` role, an abstract role, is superclass role for four form widgets, [`listbox`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listbox_role), [`menu`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role), [`radiogroup`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/radiogroup_role), and [`tree`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tree_role), which allow users to make selections from a set of choices.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/slider_role/index.md
@@ -28,7 +28,7 @@ While all three of these ranges have the same ARIA states and properties, the `s
 > To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
 > Fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before using the `slider` role (and all range widgets).
 
-#### Common attributes
+### Common attributes
 
 The [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemin) attribute sets the minimum value. If omitted or not a number, it defaults to `0` (zero).
 
@@ -89,7 +89,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 <div role="slider">Temperature in Celsius</div>
 ```
 
-## Associated roles, states, and properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) (required)
   - : Set to a decimal value between `aria-valuemin` and `aria-valuemax`, indicating the current value of the slider.
@@ -103,6 +103,19 @@ From the assistive technology user's perspective, the heading does not exist sin
   - : Defines the string value or identifies the element (or elements) that label the slider element providing an accessible name. An accessible name is required.
 - [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-orientation)
   - : Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. With a slider, the implicit value is `horizontal` but can be set to `vertical`. As it has an implicit value, the slider orientation is never ambiguous.
+
+### Keyboard interactions
+
+| Key(s)               | Action                                                              |
+| -------------------- | ------------------------------------------------------------------- |
+| Right and Up arrows  | Increase the selected value by one step                             |
+| Left and Down arrows | Decrease the selected value by one step                             |
+| Page Up              | (Optional) increase the value by a set amount greater than one step |
+| Page Down            | (Optional) decrease the value by a set amount greater than one step |
+| Home                 | Set the slider to the minimum value.                                |
+| End                  | Set the slider to the maximum value.                                |
+
+For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in slider value should be by an amount larger than the step changes made by up and down arrows.
 
 ## Examples
 
@@ -169,19 +182,6 @@ Using semantic HTML, this could have been written as:
 By using {{HTMLElement('input')}}, we get an already-styled range-input widget with keyboard focus, focus styling, keyboard interactions, and `value` updated on user interaction for free. We still need to use JavaScript to change the `aria-valuetext` and the value of the {{HTMLElement('output')}} element.
 
 There are a few ways to make a range input vertical. In this example, we used [CSS transforms](/en-US/docs/Web/CSS/transform).
-
-## Keyboard interactions
-
-| Key(s)               | Action                                                              |
-| -------------------- | ------------------------------------------------------------------- |
-| Right and Up arrows  | Increase the selected value by one step                             |
-| Left and Down arrows | Decrease the selected value by one step                             |
-| Page Up              | (Optional) increase the value by a set amount greater than one step |
-| Page Down            | (Optional) decrease the value by a set amount greater than one step |
-| Home                 | Set the slider to the minimum value.                                |
-| End                  | Set the slider to the maximum value.                                |
-
-For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in slider value should be by an amount larger than the step changes made by up and down arrows.
 
 ## Best practices
 

--- a/files/en-us/web/accessibility/aria/reference/roles/spinbutton_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/spinbutton_role/index.md
@@ -37,7 +37,7 @@ While all three of these ranges have the same ARIA states and properties, the `s
 > To change the spinbutton value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
 > Fully test spinbutton widgets using assistive technologies on devices where touch is a primary input mechanism before using the `spinbutton` role (and all range widgets).
 
-#### Common attributes
+### Common attributes
 
 The [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuemin) attribute sets the minimum value. If omitted or not a number, it defaults to `0` (zero).
 
@@ -59,7 +59,7 @@ When not using the HTML {{HTMLElement('input')}} element to create your spinbutt
 
 There are some types of user interface components that, when represented in a platform accessibility API, can only contain specific content. The children or owned elements of `spinbutton` are limited to a textbox and two buttons. Alternatively, the `spinbutton` role can be applied to a `text` input and sibling buttons can be used to support the increment and decrement functions.
 
-## Associated roles, states, and properties
+### Associated WAI-ARIA roles, states, and properties
 
 - [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-valuenow) (required)
 
@@ -81,6 +81,19 @@ There are some types of user interface components that, when represented in a pl
   - : Defines the string value or identifies the element (or elements) that label the spinbutton element providing an accessible name. An accessible name is required.
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
   - : Defines a string value that labels the spinbutton element. This provides an accessible name to the element when no visible label is available to provide the required accessible name via {{HTMLElement('label')}} or `aria-labelledby`.
+
+### Keyboard interactions
+
+| Key(s)               | Action                                                                          |
+| -------------------- | ------------------------------------------------------------------------------- |
+| Right and Up arrows  | Increase the selected value by one step                                         |
+| Left and Down arrows | Decrease the selected value by one step                                         |
+| Page Up              | (Optional) Increase the value by a set amount greater than or equal to one step |
+| Page Down            | (Optional) Decrease the value by a set amount greater than or equal to one step |
+| Home                 | Set the spinbutton to the minimum value                                         |
+| End                  | Set the spinbutton to the maximum value                                         |
+
+For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in spinbutton value should preferably be by an amount larger than the step changes made by Up and Down arrow keys.
 
 ## Examples
 
@@ -122,19 +135,6 @@ This could have also been written using semantic HTML, removing the need for any
 {{EmbedLiveSample("With_semantic_HTML", 50, 50)}}
 
 In this case, the only JavaScript needed would be to update the `aria-valuetext` when the input value changes, which really is an optional feature in this case.
-
-## Keyboard interactions
-
-| Key(s)               | Action                                                                          |
-| -------------------- | ------------------------------------------------------------------------------- |
-| Right and Up arrows  | Increase the selected value by one step                                         |
-| Left and Down arrows | Decrease the selected value by one step                                         |
-| Page Up              | (Optional) Increase the value by a set amount greater than or equal to one step |
-| Page Down            | (Optional) Decrease the value by a set amount greater than or equal to one step |
-| Home                 | Set the spinbutton to the minimum value                                         |
-| End                  | Set the spinbutton to the maximum value                                         |
-
-For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in spinbutton value should preferably be by an amount larger than the step changes made by Up and Down arrow keys.
 
 ## Best practices
 

--- a/files/en-us/web/accessibility/aria/reference/roles/structural_roles/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/structural_roles/index.md
@@ -11,7 +11,7 @@ ARIA document-structure roles are used to provide a structural description for a
 Structural ARIA roles were originally created as a bridge to inform assistive technologies of HTML5 elements that were not yet fully supported in browsers. Some roles, like `presentation`, `toolbar` and `tooltip`, provide information on the document structure to assistive technologies in cases where equivalent native HTML elements don't exist. Other roles, including those listed in the table below, are not needed, as there are semantic HTML elements with the same meanings. In many cases, these equivalent HTML elements have always been supported.
 
 > [!NOTE]
-> These structural roles all have semantic HTML equivalents. They are included here for completeness of documentation. Preferably, they should not be used by web authors.
+> These structural roles all have semantic HTML equivalents. They are included here for completeness of documentation. Preferably, they should not be used by web authors. Opt for HTML semantic elements instead.
 
 Some structural roles, like [`suggestion`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/suggestion_role), don't have HTML equivalents, and therefore have separate documentation. Some structural roles with HTML equivalents, like [`heading`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), have ARIA-attribute requirements. They are listed below with links to their individual role documentation.
 
@@ -49,10 +49,6 @@ The structure roles with HTML equivalents are listed below:
 
 > [!NOTE]
 > The `aria-label` and `aria-labelledby` attributes are prohibited on `code`, `caption`, `deletion`, `emphasis`, `generic`, `insertion`, `mark`, `paragraph`, `presentation`, `none`, `strong`, `subscript`, `superscript`, `suggestion`, `term`, and `time`, and should only be used on interactive content.
-
-## Best Practices
-
-Do not use structural roles. Opt for HTML semantic elements instead.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/structural_roles/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/structural_roles/index.md
@@ -10,7 +10,7 @@ ARIA document-structure roles are used to provide a structural description for a
 
 Structural ARIA roles were originally created as a bridge to inform assistive technologies of HTML5 elements that were not yet fully supported in browsers. Some roles, like `presentation`, `toolbar` and `tooltip`, provide information on the document structure to assistive technologies in cases where equivalent native HTML elements don't exist. Other roles, including those listed in the table below, are not needed, as there are semantic HTML elements with the same meanings. In many cases, these equivalent HTML elements have always been supported.
 
-> [!NOTE]
+> [!WARNING]
 > These structural roles all have semantic HTML equivalents. They are included here for completeness of documentation. Preferably, they should not be used by web authors. Opt for HTML semantic elements instead.
 
 Some structural roles, like [`suggestion`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/suggestion_role), don't have HTML equivalents, and therefore have separate documentation. Some structural roles with HTML equivalents, like [`heading`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), have ARIA-attribute requirements. They are listed below with links to their individual role documentation.

--- a/files/en-us/web/accessibility/aria/reference/roles/structure_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/structure_role/index.md
@@ -9,7 +9,7 @@ sidebar: accessibilitysidebar
 The `structure` role is for document structural elements.
 
 > [!NOTE]
-> The `structure` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
+> The `structure` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors. Use HTML and subclass structure roles.
 
 ## Description
 
@@ -18,10 +18,6 @@ The `structure` role is for document structural elements.
 [`section` role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/section_role), are in turn superclasses of other roles.
 
 The `structure` role is the superclass for all document structure roles, which are used to provide a structural description for a section of content. Most structure roles should no longer be used as browsers now support semantic HTML element with the same meaning. The structure roles without HTML equivalents, such as the [`presentation` role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) which means content is presentational only, provide information on the document structure to assistive technologies such as screen readers as equivalent native HTML tags are not available.
-
-## Best Practices
-
-Do not use `role="structure"`. Do use HTML and subclass structure roles.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/structure_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/structure_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The `structure` role is for document structural elements.
 
-> [!NOTE]
+> [!WARNING]
 > The `structure` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors. Use HTML and subclass structure roles.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/table_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/table_role/index.md
@@ -81,7 +81,7 @@ To create an interactive widget that has a tabular structure, use the `grid` pat
 
 ### Keyboard interactions
 
-None
+None.
 
 ### Required JavaScript features
 

--- a/files/en-us/web/accessibility/aria/reference/roles/table_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/table_role/index.md
@@ -134,10 +134,6 @@ The above is part of a table. While the full table has 81 entries, as indicated 
 
 Only use {{HTMLElement('table')}}, {{HTMLElement('tbody')}}, {{HTMLElement('thead')}}, {{HTMLElement('tr')}}, {{HTMLElement('th')}}, {{HTMLElement('td')}}, etc., for data table structure. You can add these ARIA roles to ensure accessibility should the native semantics of the table be removed, such as with CSS. A relevant use case for the ARIA table role is when CSS's display property overrides the native semantics of a table, such as by `display: grid`. In this case, you can use the ARIA table roles to re-add the semantics.
 
-### Added benefits
-
-none
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/term_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/term_role/index.md
@@ -74,11 +74,9 @@ or without any ARIA (but possibly not how you want it presented)
 
 Don't use the `role="term"` on interactive elements such as links as it can interfere with the assistive technology user's ability to interact with the element.
 
-## Best Practices
+## Best practices
 
 Allow the term itself to define the accessible name. Do not use `aria-label` or `aria-labelledby`.
-
-### Prefer HTML
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/reference/roles/textbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/textbox_role/index.md
@@ -120,7 +120,7 @@ The snippet below shows how the textbox role is added directly into the HTML sou
 
 ## Best practices
 
-- Be sure to add the `contenteditable="true"` attribute to the HTML element to which this role is applied. Do so even if you set `aria-readonly` to `true`; in this way, you communicate that the content would be editable if it were not read-only.
+Be sure to add the `contenteditable="true"` attribute to the HTML element to which this role is applied. Do so even if you set `aria-readonly` to `true`; in this way, you communicate that the content would be editable if it were not read-only.
 
 ## See also
 

--- a/files/en-us/web/accessibility/aria/reference/roles/tooltip_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/tooltip_role/index.md
@@ -102,7 +102,7 @@ If the information is important enough for a tooltip, isn't it important enough 
 
 The tooltip must stay open when hovered, even if that technically means the mouse moves out of the owning element. As content which appears on hover can be difficult or impossible to perceive if a user is required to keep their mouse pointer over the trigger, [WCAG 1.4.13](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background) states that content made visible should be persistent, meaning it should not disappear without user action.
 
-## Best Practices
+## Best practices
 
 Instead of using tooltips and hiding important information, consider writing clear, succinct, always visible descriptions. If you have space, don't use tooltips or toggletips. Just provide clear labels and sufficient body text.
 

--- a/files/en-us/web/accessibility/aria/reference/roles/widget_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/widget_role/index.md
@@ -19,10 +19,6 @@ The `widget` role is a superclass role several abstract interactive GUI roles, i
 
 The abstract `widget` role is also a superclass role for some grouping roles which can be used by web authors, including [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/gridcell_role), [`row`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/row_role), [`separator`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/separator_role) (when not focusable), and [`tab`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role), which can and should be used when appropriate. When the user navigates to one of these non-abstract roles of widget, keyboard events can switch to an application browsing mode, and pass keyboard events through to the browser.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/widget_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/widget_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The **`widget`** role, an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#6._abstract_roles), is an interactive component of a graphical user interface (GUI).
 
-> [!NOTE]
+> [!WARNING]
 > The `widget` role is an abstract role used for the ontology. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description

--- a/files/en-us/web/accessibility/aria/reference/roles/window_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/window_role/index.md
@@ -15,10 +15,6 @@ The `window` role defines a browser or app window.
 
 The `window` role, an abstract role, is a superclass for roles defining a browser or app window. The sub-class roles, currently only the [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role) role, have a window-like <abbr>GUI</abbr>, or graphical user interface, whether it's a full native window or just a section of a document styled to look like a window, where `role="dialog"` would be appropriate.
 
-## Best Practices
-
-Do not use.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/accessibility/aria/reference/roles/window_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/window_role/index.md
@@ -8,7 +8,7 @@ sidebar: accessibilitysidebar
 
 The `window` role defines a browser or app window.
 
-> [!NOTE]
+> [!WARNING]
 > The `window` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR removes the "Best practices" section from pages where there the advice is to not use the role, which is already conveyed via a note at the top of the page.

As a drive-by, also fixed the following problems:
- Incorrect placement of a section inside "Examples" (alertdialog_role) => Moved it into "Description" as an h3
- Inconsistent heading level for the section "Associated WAI-ARIA roles, states, and properties" => changed it to h3 where it was h2 (menuitem_role)
- Title casing for section titles => changed to sentence casing
- Typos with missing period (composite_role), stray word (roletype_role), and empty section (term_role)


### Motivation

Keep content relevant, non-confusing, and consistent
