### PR TITLE
chore(css): turn css-examples embed into live sample

### DIFF
--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.md
@@ -12,21 +12,24 @@ The [box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) module details how al
 
 In this flexbox example, three flex items are aligned on the main axis using {{cssxref("justify-content")}} and on the cross axis using {{cssxref("align-items")}}. The first item overrides the `align-items` values set on the group by setting {{cssxref("align-self")}} to `center`.
 
-```html live-sample___flex-align-items
-<div class="box">
-  <div>One</div>
-  <div>Two</div>
-  <div>Three <br />has <br />extra <br />text</div>
-</div>
-```
-
-```css hidden live-sample___flex-align-items
+```css hidden live-sample___gap live-sample___flex-align-items live-sample___auto-margins
+body {
+  font-family: sans-serif;
+}
 .box > * {
   padding: 20px;
   border: 2px solid rgb(96 139 168);
   border-radius: 5px;
   background-color: rgb(96 139 168 / 0.2);
 }
+```
+
+```html live-sample___flex-align-items
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three <br />has <br />extra <br />text</div>
+</div>
 ```
 
 ```css live-sample___flex-align-items
@@ -87,15 +90,6 @@ By setting a {{cssxref("margin")}} of `auto` on one item in a set of flex items 
 </div>
 ```
 
-```css hidden live-sample___auto-margins
-.box > * {
-  padding: 20px;
-  border: 2px solid rgb(96 139 168);
-  border-radius: 5px;
-  background-color: rgb(96 139 168 / 0.2);
-}
-```
-
 ```css live-sample___auto-margins
 .box {
   display: flex;
@@ -129,15 +123,6 @@ On the cross axis the `row-gap` property creates spacing between adjacent flex l
   <div>Five</div>
   <div>Six</div>
 </div>
-```
-
-```css hidden live-sample___gap
-.box > * {
-  padding: 20px;
-  border: 2px solid rgb(96 139 168);
-  border-radius: 5px;
-  background-color: rgb(96 139 168 / 0.2);
-}
 ```
 
 ```css live-sample___gap

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
@@ -14,7 +14,44 @@ As this guide aims to detail things which are specific to CSS grid layout and Bo
 
 In this example using [grid layout](/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout), there is extra space in the {{glossary("grid container")}} after laying out the fixed-width tracks on the inline {{glossary("main axis")}}. This space is distributed using {{cssxref("justify-content")}}. On the block {{glossary("cross axis")}} the alignment of the items inside their grid areas is controlled with {{cssxref("align-items")}}. The first item overrides the `align-items` value set on the group by setting {{cssxref("align-self")}} to `center`.
 
-{{EmbedGHLiveSample("css-examples/box-alignment/overview/grid-align-items.html", '100%', 500)}}
+```html live-sample___grid-align-items
+<div class="box">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three <br />has <br />extra <br />text</div>
+  <div>Four</div>
+  <div>Five</div>
+  <div>Six</div>
+</div>
+```
+
+```css hidden live-sample___grid-align-items
+body {
+  font-family: sans-serif;
+}
+.box > * {
+  padding: 20px;
+  border: 2px solid rgb(96 139 168);
+  border-radius: 5px;
+  background-color: rgb(96 139 168 / 0.2);
+}
+```
+
+```css live-sample___grid-align-items
+.box {
+  display: grid;
+  grid-template-columns: 120px 120px 120px;
+  align-items: start;
+  justify-content: space-between;
+  border: 2px dotted rgb(96 139 168);
+}
+
+.box :first-child {
+  align-self: center;
+}
+```
+
+{{EmbedLiveSample("grid-align-items", , 200)}}
 
 ## Grid axes
 


### PR DESCRIPTION
### Description

__Changes:__
* `EmbedGHLiveSample` -> `EmbedLiveSample`
* Reuse CSS across multiple live samples

### Motivation

Moving external examples into content, making styles / examples easier to maintain and look more uniform.