### PR TITLE
script tag: fix grammar

### DIFF
--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -96,7 +96,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     See {{domxref("HTMLScriptElement.fetchPriority")}} for more information.
 
 - `integrity`
-  - : This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered without unexpected manipulation. The attribute must not specified when the `src` attribute is not specified. See [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity).
+  - : This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered without unexpected manipulation. The attribute must not be specified when the `src` attribute is absent. See [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity).
 - `nomodule`
   - : This Boolean attribute is set to indicate that the script should not be executed in browsers that support [ES modules](/en-US/docs/Web/JavaScript/Guide/Modules) — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.
 - `nonce`


### PR DESCRIPTION
s/must not specified/must not be specified/ and while at it, use ‘src attribute is absent’ to use the same wording as in other places on the page.