### PR TITLE
Remove ordinal number example from sup element documentation

### DIFF
--- a/files/en-us/web/html/element/sup/index.md
+++ b/files/en-us/web/html/element/sup/index.md
@@ -43,7 +43,6 @@ Appropriate use cases for `<sup>` include (but aren't necessarily limited to):
 
 - Displaying exponents, such as "x<sup>3</sup>". It may be worth considering the use of [MathML](/en-US/docs/Web/MathML) for these, especially in more complex cases. See [Exponents](#exponents) under [Examples](#examples) below.
 - Displaying [superior lettering](https://en.wikipedia.org/wiki/Superior_letter), which is used in some languages when rendering certain abbreviations. For example, in French, the word "mademoiselle" can be abbreviated "M<sup>lle</sup>"; this is an acceptable use case. See [Superior lettering](#superior_lettering) for examples.
-- Representing ordinal numbers, such as "4<sup>th</sup>" instead of "fourth." See [Ordinal numbers](#ordinal_numbers) for examples.
 
 ## Examples
 
@@ -73,24 +72,6 @@ Superior lettering is not technically the same thing as superscript. However, it
 #### Result
 
 {{EmbedLiveSample("Superior_lettering", 650, 80)}}
-
-### Ordinal numbers
-
-Ordinal numbers, such as "fourth" in English or "quinto" in Spanish may be abbreviated using numerals and language-specific text rendered in superscript:
-
-```html
-<p>
-  The ordinal number "fifth" can be abbreviated in various languages as follows:
-</p>
-<ul>
-  <li>English: 5<sup>th</sup></li>
-  <li>French: 5<sup>ème</sup></li>
-</ul>
-```
-
-#### Result
-
-{{EmbedLiveSample("Ordinal_numbers", 650, 160)}}
 
 ## Technical summary
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The [HTML5 specification of the `sup` element](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements) states that "In general, authors should use these elements only if the absence of those elements would change the meaning of the content."

The "Ordinal numbers" example in MDN stipulates that the `sup` element is a proper choice to mark up ordinal numbers in English like so: `4<sup>th</sup>`.

However, the absence of the elements would not change the meaning of the content. (`4<sup>th</sup>` has the same meaning as `4th`).

Hence, the example is not compliant with the spec (or at least its compliance is highly questionable). This MR removes the example.

### Motivation

The motivation is to keep the examples consistent with the specification.

### Additional details

https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
