### PR TITLE
Change the second argument deleteCount of Array.prototype.toSpliced to skipCount.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md
@@ -30,7 +30,7 @@ toSpliced(start, skipCount, item1, item2, /* …, */ itemN)
 
 - `skipCount` {{optional_inline}}
 
-  - : An integer indicating the number of elements in the array to remove from `start`.
+  - : An integer indicating the number of elements in the array to remove (or, to skip) from `start`.
 
     If `skipCount` is omitted, or if its value is greater than or equal to the number of elements after the position specified by `start`, then all the elements from `start` to the end of the array will be deleted. However, if you wish to pass any `itemN` parameter, you should pass `Infinity` as `skipCount` to delete all elements after `start`, because an explicit `undefined` gets [converted](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion) to `0`.
 
@@ -49,7 +49,7 @@ A new array that consists of all elements before `start`, `item1`, `item2`, …,
 
 ## Description
 
-The `toSpliced()` method, like `splice()`, does multiple things at once: it removes the given number of elements from the array, starting at a given index, and then inserts the given elements at the same index. However, it returns a new array instead of modifying the original array. The deleted elements therefore are not returned from this method.
+The `toSpliced()` method, like `splice()`, does multiple things at once: it removes the given number of elements from the array, starting at a given index, and then inserts the given elements at the same index. However, it returns a new array instead of modifying the original array. The deleted elements therefore are not returned from this method, but they remain accessible in the original array.
 
 The `toSpliced()` method never produces a [sparse array](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays). If the source array is sparse, the empty slots will be replaced with `undefined` in the new array.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/tospliced/index.md
@@ -13,10 +13,10 @@ The **`toSpliced()`** method of {{jsxref("Array")}} instances is the [copying](/
 
 ```js-nolint
 toSpliced(start)
-toSpliced(start, deleteCount)
-toSpliced(start, deleteCount, item1)
-toSpliced(start, deleteCount, item1, item2)
-toSpliced(start, deleteCount, item1, item2, /* …, */ itemN)
+toSpliced(start, skipCount)
+toSpliced(start, skipCount, item1)
+toSpliced(start, skipCount, item1, item2)
+toSpliced(start, skipCount, item1, item2, /* …, */ itemN)
 ```
 
 ### Parameters
@@ -28,13 +28,13 @@ toSpliced(start, deleteCount, item1, item2, /* …, */ itemN)
     - If `start < -array.length` or `start` is omitted, `0` is used.
     - If `start >= array.length`, no element will be deleted, but the method will behave as an adding function, adding as many elements as provided.
 
-- `deleteCount` {{optional_inline}}
+- `skipCount` {{optional_inline}}
 
   - : An integer indicating the number of elements in the array to remove from `start`.
 
-    If `deleteCount` is omitted, or if its value is greater than or equal to the number of elements after the position specified by `start`, then all the elements from `start` to the end of the array will be deleted. However, if you wish to pass any `itemN` parameter, you should pass `Infinity` as `deleteCount` to delete all elements after `start`, because an explicit `undefined` gets [converted](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion) to `0`.
+    If `skipCount` is omitted, or if its value is greater than or equal to the number of elements after the position specified by `start`, then all the elements from `start` to the end of the array will be deleted. However, if you wish to pass any `itemN` parameter, you should pass `Infinity` as `skipCount` to delete all elements after `start`, because an explicit `undefined` gets [converted](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion) to `0`.
 
-    If `deleteCount` is `0` or negative, no elements are removed.
+    If `skipCount` is `0` or negative, no elements are removed.
     In this case, you should specify at least one new element (see below).
 
 - `item1`, …, `itemN` {{optional_inline}}
@@ -45,7 +45,7 @@ toSpliced(start, deleteCount, item1, item2, /* …, */ itemN)
 
 ### Return value
 
-A new array that consists of all elements before `start`, `item1`, `item2`, …, `itemN`, and all elements after `start + deleteCount`.
+A new array that consists of all elements before `start`, `item1`, `item2`, …, `itemN`, and all elements after `start + skipCount`.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I changed all instances of deleteCount to skipCount in the documentation for toSpliced.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

In the first place, the ECMA-262 specification for toSpliced actually uses skipCount, not deleteCount.
The word “delete” implies mutation, which is why it was likely avoided. (https://github.com/tc39/ecma262/pull/2997#discussion_r1123772935)

To align with the ECMA spec, and because “skip” is semantically more accurate than “delete” in this context, I believe it would be better to update it.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Also, it seems that the term deleteCount was used during the initial proposal stage of this method.
(https://github.com/tc39/proposal-change-array-by-copy?tab=readme-ov-file#overview)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- ecma262: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tospliced
- mdn: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced
- toSpliced add ecma262 pr: https://github.com/tc39/ecma262/pull/2997#discussion_r1123772935

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
