### PR TITLE
New page: SVGImageElement.crossOrigin

### DIFF
--- a/files/en-us/web/api/svgimageelement/crossorigin/index.md
+++ b/files/en-us/web/api/svgimageelement/crossorigin/index.md
@@ -8,12 +8,11 @@ browser-compat: api.SVGImageElement.crossOrigin
 
 {{APIRef("SVG")}}
 
-The **`crossOrigin`** property of the {{domxref("SVGImageElement")}} interface is a string which specifies the Cross-Origin Resource Sharing ({{Glossary("CORS")}}) setting to use when
-retrieving the image. It reflects the {{SVGAttr("crossorigin")}} content attribute of the given {{SVGElement("image")}} element. Valid values include the keywords `anonymous` or `use-credentials`. If the `crossOrigin` property is specified with any other value, it is the same as specifying as the `anonymous`.
+The **`crossOrigin`** property of the {{domxref("SVGImageElement")}} interface is a string which specifies the Cross-Origin Resource Sharing ({{Glossary("CORS")}}) setting to use when retrieving the image. It reflects the {{SVGAttr("crossorigin")}} content attribute of the given {{SVGElement("image")}} element.
 
 ## Value
 
-A string which specifies the CORS mode used when fetching the image resource.
+A string which specifies the CORS mode used when fetching the image resource. Valid values are `"anonymous"` or `"use-credentials"`. If the `crossOrigin` property is set to any other value, it is the same as specifying `"anonymous"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/svgimageelement/crossorigin/index.md
+++ b/files/en-us/web/api/svgimageelement/crossorigin/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGImageElement: crossOrigin property"
+short-title: crossOrigin
+slug: Web/API/SVGImageElement/crossOrigin
+page-type: web-api-instance-property
+browser-compat: api.SVGImageElement.crossOrigin
+---
+
+{{APIRef("SVG")}}
+
+The **`crossOrigin`** property of the {{domxref("SVGImageElement")}} interface is a string which specifies the Cross-Origin Resource Sharing ({{Glossary("CORS")}}) setting to use when
+retrieving the image. It reflects the {{SVGAttr("crossorigin")}} content attribute of the given {{SVGElement("image")}} element. Valid values include the keywords `anonymous` or `use-credentials`. If the `crossOrigin` property is specified with any other value, it is the same as specifying as the `anonymous`.
+
+## Value
+
+A string which specifies the CORS mode used when fetching the image resource.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLImageElement.crossOrigin")}}
+- {{domxref("HTMLMediaElement.crossOrigin")}}

--- a/files/en-us/web/api/svgimageelement/index.md
+++ b/files/en-us/web/api/svgimageelement/index.md
@@ -16,33 +16,19 @@ The **`SVGImageElement`** interface corresponds to the {{SVGElement("image")}} e
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
 - {{domxref("SVGImageElement.crossOrigin")}}
-
   - : A string reflecting the {{SVGAttr("crossorigin")}} content attribute, which represents the CORS setting of the given {{SVGElement("image")}} element.
-
 - {{domxref("SVGImageElement.decoding")}}
-
   - : Represents a hint given to the browser on how it should decode the image.
-
 - {{domxref("SVGImageElement.height")}} {{ReadOnlyInline}}
-
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given {{SVGElement("image")}} element.
-
 - {{domxref("SVGImageElement.href")}} {{ReadOnlyInline}}
-
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("image")}} element.
-
 - {{domxref("SVGImageElement.preserveAspectRatio")}} {{ReadOnlyInline}}
-
   - : An {{domxref("SVGAnimatedPreserveAspectRatio")}} corresponding to the {{SVGAttr("preserveAspectRatio")}} attribute of the given {{SVGElement("image")}} element.
-
 - {{domxref("SVGImageElement.width")}} {{ReadOnlyInline}}
-
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("width")}} attribute of the given {{SVGElement("image")}} element.
-
 - {{domxref("SVGImageElement.x")}} {{ReadOnlyInline}}
-
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("x")}} attribute of the given {{SVGElement("image")}} element.
-
 - {{domxref("SVGImageElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given {{SVGElement("image")}} element.
 

--- a/files/en-us/web/api/svgimageelement/index.md
+++ b/files/en-us/web/api/svgimageelement/index.md
@@ -15,18 +15,34 @@ The **`SVGImageElement`** interface corresponds to the {{SVGElement("image")}} e
 
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
-- {{domxref("SVGImageElement.href")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("image")}} element.
+- {{domxref("SVGImageElement.crossOrigin")}}
+
+  - : A string reflecting the {{SVGAttr("crossorigin")}} content attribute, which represents the CORS setting of the given {{SVGElement("image")}} element.
+
 - {{domxref("SVGImageElement.decoding")}}
-  - : Represents a hint given to the browser on how it should decode the image. If this value is provided, it must be one of the possible permitted values: `"sync"` to decode the image synchronously, `"async"` to decode it asynchronously, or `"auto"` to indicate no preference (which is the default).
+
+  - : Represents a hint given to the browser on how it should decode the image.
+
 - {{domxref("SVGImageElement.height")}} {{ReadOnlyInline}}
+
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given {{SVGElement("image")}} element.
+
+- {{domxref("SVGImageElement.href")}} {{ReadOnlyInline}}
+
+  - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute of the given {{SVGElement("image")}} element.
+
 - {{domxref("SVGImageElement.preserveAspectRatio")}} {{ReadOnlyInline}}
+
   - : An {{domxref("SVGAnimatedPreserveAspectRatio")}} corresponding to the {{SVGAttr("preserveAspectRatio")}} attribute of the given {{SVGElement("image")}} element.
+
 - {{domxref("SVGImageElement.width")}} {{ReadOnlyInline}}
+
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("width")}} attribute of the given {{SVGElement("image")}} element.
+
 - {{domxref("SVGImageElement.x")}} {{ReadOnlyInline}}
+
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("x")}} attribute of the given {{SVGElement("image")}} element.
+
 - {{domxref("SVGImageElement.y")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("y")}} attribute of the given {{SVGElement("image")}} element.
 


### PR DESCRIPTION
added a feature now supported in all browsers.

put interfaces in alphabetical order

[#222](https://github.com/openwebdocs/project/issues/222)