### PR TITLE
added links for debugging

### DIFF
--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -817,15 +817,13 @@ To learn how to debug web workers, see the documentation for each browser's Java
 - [Chrome Sources panel](https://developer.chrome.com/docs/devtools/sources)
 - [Firefox JavaScript Debugger](https://firefox-source-docs.mozilla.org/devtools-user/debugger/)
 
-To open devtools for web workers, one can use the following shortcuts:
+To open devtools for web workers, you can use the following URLs:
 
-| browser | shortcut                              |
-| ------- | ------------------------------------- |
-| edge    | edge://inspect/                       |
-| chrome  | chrome://inspect/                     |
-| firefox | about:debugging#/runtime/this-firefox |
+- Edge: `edge://inspect/`
+- Chrome: `chrome://inspect/`
+- Firefox: `about:debugging#/runtime/this-firefox`
 
-This pages show an overview over all service workers, one needs to find the relevant one by the URL and then click _inspect_. The devtools will open for that worker and give access to the console and debugger.
+These pages show an overview over all service workers. You need to find the relevant one by the URL and then click _inspect_ to access devtools such as the console and debugger for that worker.
 
 ## Functions and interfaces available in workers
 

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -819,11 +819,11 @@ To learn how to debug web workers, see the documentation for each browser's Java
 
 To open devtools for web workers, one can use the following shortcuts:
 
-browser | shortcut
---- | ---
-edge | edge://inspect/
-chrome | chrome://inspect/
-firefox | about:debugging#/runtime/this-firefox
+| browser | shortcut                              |
+| ------- | ------------------------------------- |
+| edge    | edge://inspect/                       |
+| chrome  | chrome://inspect/                     |
+| firefox | about:debugging#/runtime/this-firefox |
 
 This pages show an overview over all service workers, one needs to find the relevant one by the URL and then click *inspect*. The devtools will open for that worker and give access to the console and debugger.
 

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -817,6 +817,16 @@ To learn how to debug web workers, see the documentation for each browser's Java
 - [Chrome Sources panel](https://developer.chrome.com/docs/devtools/sources)
 - [Firefox JavaScript Debugger](https://firefox-source-docs.mozilla.org/devtools-user/debugger/)
 
+To open devtools for web workers, one can use the following shortcuts:
+
+browser | shortcut
+--- | ---
+edge | edge://inspect/
+chrome | chrome://inspect/
+firefox | about:debugging#/runtime/this-firefox
+
+This pages show an overview over all service workers, one needs to find the relevant one by the URL and then click *inspect*. The devtools will open for that worker and give access to the console and debugger.
+
 ## Functions and interfaces available in workers
 
 You can use most standard JavaScript features inside a web worker, including:

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -825,7 +825,7 @@ To open devtools for web workers, one can use the following shortcuts:
 | chrome  | chrome://inspect/                     |
 | firefox | about:debugging#/runtime/this-firefox |
 
-This pages show an overview over all service workers, one needs to find the relevant one by the URL and then click *inspect*. The devtools will open for that worker and give access to the console and debugger.
+This pages show an overview over all service workers, one needs to find the relevant one by the URL and then click _inspect_. The devtools will open for that worker and give access to the console and debugger.
 
 ## Functions and interfaces available in workers
 


### PR DESCRIPTION
Edge, Chrome, and Firefox offer devtools for webworkers, but not via the source tree, but via dedicated internal pages. The pull request adds links to those pages.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added links to the devtools for web workers.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I needed access to the console to read log messages and it took me ages to find out how. The existing linked documents did not help much.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
