### PR TITLE
refactor(lefthook): use only option for post-merge

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,15 +51,11 @@ pre-commit:
             run: yarn node scripts/update-moved-file-links.js --check
 
 post-merge:
+  only:
+    - ref: main
   commands:
-    yarn-install-post-merge-main:
-      run: |
-        BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-        if [ "$BRANCH" != "main" ]; then
-          exit 0
-        else
-          yarn install
-        fi
+    yarn-install:
+      run: yarn install
 
 output:
   - summary


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Refactors the Lefthook config to use the [`only` option](https://lefthook.dev/configuration/only.html) to restrict the `post-merge` hook to the `main` branch, rather than manually checking this. 

### Motivation

Makes the config more concise.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up to:

- https://github.com/mdn/content/pull/38399