### PR TITLE
Remove redundant examples on overscroll-behavior

### DIFF
--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -23,14 +23,6 @@ overscroll-behavior: contain;
 overscroll-behavior: none;
 ```
 
-```css interactive-example-choice
-overscroll-behavior: auto;
-```
-
-```css interactive-example-choice
-overscroll-behavior: contain;
-```
-
 ```html interactive-example
 <section class="default-example" id="default-example">
   <div class="example-container">


### PR DESCRIPTION
### Description

Remove redundant examples on overscroll-behavior.

### Motivation

Clean up redundant examples to prevent confusion.
