### PR TITLE
Bug-1869171 alarms.create now async function

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -52,7 +52,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Create a one-time delay-based alarm with "" for the name:
 
 ```js
-function onAddad() {
+function onAdded() {
   console.log("Alarm Added!");
 }
 
@@ -61,7 +61,7 @@ let delayInMinutes = 5;
 let addingAlarm = browser.alarms.create({
   delayInMinutes,
 });
-addingAlarm.then(onAddad);
+addingAlarm.then(onAdded);
 ```
 
 Create a periodic delay-based alarm named "my-periodic-alarm":

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -43,16 +43,25 @@ browser.alarms.create(
     - `periodInMinutes` {{optional_inline}}
       - : `double`. If this is specified, the alarm will fire again every `periodInMinutes` after its initial firing. If you specify this value you may omit both `when` and `delayInMinutes`, and the alarm will then fire initially after `periodInMinutes`. If `periodInMinutes` is not specified, the alarm will only fire once.
 
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments.
+
 ## Examples
 
 Create a one-time delay-based alarm with "" for the name:
 
 ```js
-const delayInMinutes = 5;
+function onAddad() {
+  console.log("Alarm Added!");
+}
 
-browser.alarms.create({
+let delayInMinutes = 5;
+
+let addingAlarm = browser.alarms.create({
   delayInMinutes,
 });
+addingAlarm.then(onAddad);
 ```
 
 Create a periodic delay-based alarm named "my-periodic-alarm":

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -62,7 +62,7 @@ This article provides information about the changes in Firefox 138 that affect d
 - The {{WebExtAPIRef("contextualIdentities")}} API is no longer defined in Firefox for Android. Previously, it was defined but defective. ([Firefox bug 1659500](https://bugzil.la/1659500))
 - The `contextualIdentities` permission is now not recognized on Firefox for Android. Previously, it enabled a broken version of the "containers" feature. ([Firefox bug 1659500](https://bugzil.la/1659500))
 - The new Manifest V3 version of the {{WebExtAPIRef("userScripts")}} API is now available on Firefox for Android. ([Firefox bug 1949955](https://bugzil.la/1949955))
-- The {{WebExtAPIRef("alarms.create")}} API can now be called asynchronously. ([Firefox bug 1869171](https://bugzil.la/1869171)
+- The {{WebExtAPIRef("alarms.create")}} API now returns a Promise instead of undefined. ([Firefox bug 1869171](https://bugzil.la/1869171))
 
 ### Removals
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -62,6 +62,7 @@ This article provides information about the changes in Firefox 138 that affect d
 - The {{WebExtAPIRef("contextualIdentities")}} API is no longer defined in Firefox for Android. Previously, it was defined but defective. ([Firefox bug 1659500](https://bugzil.la/1659500))
 - The `contextualIdentities` permission is now not recognized on Firefox for Android. Previously, it enabled a broken version of the "containers" feature. ([Firefox bug 1659500](https://bugzil.la/1659500))
 - The new Manifest V3 version of the {{WebExtAPIRef("userScripts")}} API is now available on Firefox for Android. ([Firefox bug 1949955](https://bugzil.la/1949955))
+- The {{WebExtAPIRef("alarms.create")}} API can now be called asynchronously. ([Firefox bug 1869171](https://bugzil.la/1869171)
 
 ### Removals
 


### PR DESCRIPTION
### Description

Addresses the dev-doc-needed requirements of [Bug 1869171](https://bugzilla.mozilla.org/show_bug.cgi?id=1869171) "`alarms.create` is not declared as an async function" by:

- adding detail of the return value to `alarms.create` and modifying one of the examples to make an asynchronous call
- adding a release note

### Related issues and pull requests

Related to change to BCD in https://github.com/mdn/browser-compat-data/pull/26309