### PR TITLE
chore(uri): Get rid of 'reference' page type in URI section

### DIFF
--- a/files/en-us/web/uri/reference/authority/index.md
+++ b/files/en-us/web/uri/reference/authority/index.md
@@ -2,7 +2,7 @@
 title: URI authority
 short-title: Authority
 slug: Web/URI/Reference/Authority
-page-type: reference
+page-type: uri-component
 spec-urls: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1
 sidebar: urlsidebar
 ---

--- a/files/en-us/web/uri/reference/fragment/index.md
+++ b/files/en-us/web/uri/reference/fragment/index.md
@@ -2,7 +2,7 @@
 title: URI fragment
 short-title: Fragment
 slug: Web/URI/Reference/Fragment
-page-type: reference
+page-type: uri-component
 spec-urls: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.5
 sidebar: urlsidebar
 ---

--- a/files/en-us/web/uri/reference/fragment/text_fragments/index.md
+++ b/files/en-us/web/uri/reference/fragment/text_fragments/index.md
@@ -1,7 +1,7 @@
 ---
 title: Text fragments
 slug: Web/URI/Reference/Fragment/Text_fragments
-page-type: reference
+page-type: uri-component
 browser-compat:
   - html.elements.a.text_fragments
   - api.FragmentDirective

--- a/files/en-us/web/uri/reference/schemes/data/index.md
+++ b/files/en-us/web/uri/reference/schemes/data/index.md
@@ -2,7 +2,7 @@
 title: "data: URLs"
 short-title: "data:"
 slug: Web/URI/Reference/Schemes/data
-page-type: reference
+page-type: uri-scheme
 browser-compat: http.data-url
 sidebar: urlsidebar
 ---

--- a/files/en-us/web/uri/reference/schemes/index.md
+++ b/files/en-us/web/uri/reference/schemes/index.md
@@ -2,7 +2,7 @@
 title: URI schemes
 short-title: Scheme
 slug: Web/URI/Reference/Schemes
-page-type: reference
+page-type: uri-component
 spec-urls: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1
 sidebar: urlsidebar
 ---

--- a/files/en-us/web/uri/reference/schemes/javascript/index.md
+++ b/files/en-us/web/uri/reference/schemes/javascript/index.md
@@ -2,7 +2,7 @@
 title: "javascript: URLs"
 short-title: "javascript:"
 slug: Web/URI/Reference/Schemes/javascript
-page-type: reference
+page-type: uri-scheme
 spec-urls: https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-javascript:-url-special-case
 sidebar: urlsidebar
 ---

--- a/files/en-us/web/uri/reference/schemes/resource/index.md
+++ b/files/en-us/web/uri/reference/schemes/resource/index.md
@@ -2,7 +2,7 @@
 title: "resource: URLs"
 short-title: "resource:"
 slug: Web/URI/Reference/Schemes/resource
-page-type: reference
+page-type: uri-scheme
 sidebar: urlsidebar
 ---
 

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -529,7 +529,7 @@
         "then": {
           "properties": {
             "page-type": {
-              "enum": ["guide", "landing-page", "reference"]
+              "enum": ["guide", "landing-page", "uri-scheme", "uri-component"]
             }
           }
         },


### PR DESCRIPTION
### Description

__removals:__
* `reference` page type in fm config for URIs

__Changes:__
* `reference` to `uri-scheme` and `uri-component`

### Motivation

`reference` is not a good page type
