### PR TITLE
Use `Object.hasOwn` on undefined and null property values

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -15,17 +15,25 @@ If the property is inherited, or does not exist, the method returns `false`.
 {{InteractiveExample("JavaScript Demo: Object.hasOwn()")}}
 
 ```js interactive-example
-const object1 = {
-  prop: "exists",
+const object = {
+  propertyNameValue: "exists",
+  propertyNameUndefined: undefined,
+  propertyNameNull: null,
 };
 
-console.log(Object.hasOwn(object1, "prop"));
+console.log(Object.hasOwn(object, "propertyNameValue"));
 // Expected output: true
 
-console.log(Object.hasOwn(object1, "toString"));
+console.log(Object.hasOwn(object, "propertyNameUndefined"));
+// Expected output: true
+
+console.log(Object.hasOwn(object, "propertyNameNull"));
+// Expected output: true
+
+console.log(Object.hasOwn(object, "toString"));
 // Expected output: false
 
-console.log(Object.hasOwn(object1, "undeclaredPropertyValue"));
+console.log(Object.hasOwn(object, "undeclaredPropertyValue"));
 // Expected output: false
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Use `Object.hasOwn` on undefined and null property values

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
- In my experience, the output of `Object.hasOwn` on `undefined`/`null` property values can be unexpected, so I wanted to document it in the example.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
