### PR TITLE
Fix `tab-size` example

### DIFF
--- a/files/en-us/web/css/tab-size/index.md
+++ b/files/en-us/web/css/tab-size/index.md
@@ -29,7 +29,7 @@ tab-size: 4;
 
 ```html interactive-example
 <section id="default-example">
-  <pre id="example-element">		123</pre>
+  <pre id="example-element">&#9;123</pre>
 </section>
 ```
 

--- a/files/en-us/web/css/tab-size/index.md
+++ b/files/en-us/web/css/tab-size/index.md
@@ -29,7 +29,7 @@ tab-size: 4;
 
 ```html interactive-example
 <section id="default-example">
-  <pre id="example-element">  123</pre>
+  <pre id="example-element">		123</pre>
 </section>
 ```
 


### PR DESCRIPTION
It changes two spaces to two tabs in the CSS `tab-size` interactive example.