### PR TITLE
Link quality factor glossary page on Content negotiation page

### DIFF
--- a/files/en-us/web/http/guides/content_negotiation/index.md
+++ b/files/en-us/web/http/guides/content_negotiation/index.md
@@ -42,7 +42,7 @@ Even if server-driven content negotiation is the most common way to agree on a s
 
 ### The `Accept` header
 
-The {{HTTPHeader("Accept")}} header lists the MIME types of media resources that the agent is willing to process. This is a comma-separated list of MIME types, each combined with a quality factor, a parameter that indicates the relative degree of preference between the different MIME types.
+The {{HTTPHeader("Accept")}} header lists the MIME types of media resources that the agent is willing to process. This is a comma-separated list of MIME types, each combined with a [quality factor](/en-US/docs/Glossary/Quality_values), a parameter that indicates the relative degree of preference between the different MIME types.
 
 The `Accept` header is defined by the browser, or any other user agent, and can vary according to the context. For example, fetching an HTML page or an image, a video, or a script. It's different when fetching a document entered in the address bar or an element linked via an {{ HTMLElement("img") }}, {{ HTMLElement("video") }}, or {{ HTMLElement("audio") }} element. Browsers are free to use the value of the header that they think is the most adequate; an exhaustive list of [default values for common browsers](/en-US/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values) is available.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds a link to the glossary entry for quality factors/values (https://developer.mozilla.org/en-US/docs/Glossary/Quality_values) under the first occurence/mention of quality factors on the page for Content negotation (https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation#the_accept_header).

### Motivation

While reading the Content negotiation page, I was unfamiliar with so-called quality factors and found it difficult to locate a page explaining what they were as they were not linked. This change will hopefully help other readers unaccustomed with the term learn about it.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Fwiw there is a brief conversation in the community Discord where I initially asked about this: https://discord.com/channels/1009925603572600863/1170042553979121704/1355927428345630912.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
