### PR TITLE
New pages: HTMLFormElement.rel and .relList

### DIFF
--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -15,26 +15,52 @@ The **`HTMLFormElement`** interface represents a {{HTMLElement("form")}} element
 
 _This interface also inherits properties from its parent, {{domxref("HTMLElement")}}._
 
+- {{domxref("HTMLFormElement.acceptCharset")}}
+
+  - : A string reflecting the value of the form's [`accept-charset`](/en-US/docs/Web/HTML/Element/form#accept-charset) HTML attribute.
+
+- {{domxref("HTMLFormElement.action")}}
+
+  - : A string reflecting the value of the form's [`action`](/en-US/docs/Web/HTML/Element/form#action) HTML attribute, containing the URI of a program that processes the information submitted by the form.
+
+- {{domxref("HTMLFormElement.autocomplete")}}
+
+  - : A string reflecting the value of the form's [`autocomplete`](/en-US/docs/Web/HTML/Element/form#autocomplete) HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
+
+- {{domxref("HTMLFormElement.encoding")}} or {{domxref("HTMLFormElement.enctype")}}
+
+  - : A string reflecting the value of the form's [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) HTML attribute, indicating the type of content that is used to transmit the form to the server. Only specified values can be set. The two properties are synonyms.
+
 - {{domxref("HTMLFormElement.elements")}} {{ReadOnlyInline}}
+
   - : A {{domxref("HTMLFormControlsCollection")}} holding all form controls belonging to this form element.
+
 - {{domxref("HTMLFormElement.length")}} {{ReadOnlyInline}}
+
   - : A `long` reflecting the number of controls in the form.
+
 - {{domxref("HTMLFormElement.name")}}
+
   - : A string reflecting the value of the form's [`name`](/en-US/docs/Web/HTML/Element/form#name) HTML attribute, containing the name of the form.
+
+- {{domxref("HTMLFormElement.noValidate")}}
+
+  - : A boolean value reflecting the value of the form's [`novalidate`](/en-US/docs/Web/HTML/Element/form#novalidate) HTML attribute, indicating whether the form should not be validated.
+
 - {{domxref("HTMLFormElement.method")}}
+
   - : A string reflecting the value of the form's [`method`](/en-US/docs/Web/HTML/Element/form#method) HTML attribute, indicating the HTTP method used to submit the form. Only specified values can be set.
+
+- {{domxref("HTMLFormElement.rel")}}
+
+  - : A string reflecting the value of the form's [`rel`](/en-US/docs/Web/HTML/Element/form#rel) HTML attribute, which represents the annotations and what kinds of links the form creates as a space-separated list of enumerated values.
+
+- {{domxref("HTMLFormElement.relList")}} {{ReadOnlyInline}}
+
+  - : A {{domxref("DOMTokenList")}} that reflects the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) HTML attribute, as a list of tokens.
+
 - {{domxref("HTMLFormElement.target")}}
   - : A string reflecting the value of the form's [`target`](/en-US/docs/Web/HTML/Element/form#target) HTML attribute, indicating where to display the results received from submitting the form.
-- {{domxref("HTMLFormElement.action")}}
-  - : A string reflecting the value of the form's [`action`](/en-US/docs/Web/HTML/Element/form#action) HTML attribute, containing the URI of a program that processes the information submitted by the form.
-- {{domxref("HTMLFormElement.encoding")}} or {{domxref("HTMLFormElement.enctype")}}
-  - : A string reflecting the value of the form's [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) HTML attribute, indicating the type of content that is used to transmit the form to the server. Only specified values can be set. The two properties are synonyms.
-- {{domxref("HTMLFormElement.acceptCharset")}}
-  - : A string reflecting the value of the form's [`accept-charset`](/en-US/docs/Web/HTML/Element/form#accept-charset) HTML attribute.
-- {{domxref("HTMLFormElement.autocomplete")}}
-  - : A string reflecting the value of the form's [`autocomplete`](/en-US/docs/Web/HTML/Element/form#autocomplete) HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
-- {{domxref("HTMLFormElement.noValidate")}}
-  - : A boolean value reflecting the value of the form's [`novalidate`](/en-US/docs/Web/HTML/Element/form#novalidate) HTML attribute, indicating whether the form should not be validated.
 
 Named inputs are added to their owner form instance as properties, and can overwrite native properties if they share the same name (e.g. a form with an input named `action` will have its `action` property return that input instead of the form's [`action`](/en-US/docs/Web/HTML/Element/form#action) HTML attribute).
 

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -16,49 +16,27 @@ The **`HTMLFormElement`** interface represents a {{HTMLElement("form")}} element
 _This interface also inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLFormElement.acceptCharset")}}
-
   - : A string reflecting the value of the form's [`accept-charset`](/en-US/docs/Web/HTML/Element/form#accept-charset) HTML attribute.
-
 - {{domxref("HTMLFormElement.action")}}
-
   - : A string reflecting the value of the form's [`action`](/en-US/docs/Web/HTML/Element/form#action) HTML attribute, containing the URI of a program that processes the information submitted by the form.
-
 - {{domxref("HTMLFormElement.autocomplete")}}
-
   - : A string reflecting the value of the form's [`autocomplete`](/en-US/docs/Web/HTML/Element/form#autocomplete) HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
-
 - {{domxref("HTMLFormElement.encoding")}} or {{domxref("HTMLFormElement.enctype")}}
-
   - : A string reflecting the value of the form's [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) HTML attribute, indicating the type of content that is used to transmit the form to the server. Only specified values can be set. The two properties are synonyms.
-
 - {{domxref("HTMLFormElement.elements")}} {{ReadOnlyInline}}
-
   - : A {{domxref("HTMLFormControlsCollection")}} holding all form controls belonging to this form element.
-
 - {{domxref("HTMLFormElement.length")}} {{ReadOnlyInline}}
-
   - : A `long` reflecting the number of controls in the form.
-
 - {{domxref("HTMLFormElement.name")}}
-
   - : A string reflecting the value of the form's [`name`](/en-US/docs/Web/HTML/Element/form#name) HTML attribute, containing the name of the form.
-
 - {{domxref("HTMLFormElement.noValidate")}}
-
   - : A boolean value reflecting the value of the form's [`novalidate`](/en-US/docs/Web/HTML/Element/form#novalidate) HTML attribute, indicating whether the form should not be validated.
-
 - {{domxref("HTMLFormElement.method")}}
-
   - : A string reflecting the value of the form's [`method`](/en-US/docs/Web/HTML/Element/form#method) HTML attribute, indicating the HTTP method used to submit the form. Only specified values can be set.
-
 - {{domxref("HTMLFormElement.rel")}}
-
-  - : A string reflecting the value of the form's [`rel`](/en-US/docs/Web/HTML/Element/form#rel) HTML attribute, which represents the annotations and what kinds of links the form creates as a space-separated list of enumerated values.
-
+  - : A string reflecting the value of the form's [`rel`](en-US/docs/Web/HTML/Attributes/rel) HTML attribute, which represents what kinds of links the form creates as a space-separated list of enumerated values.
 - {{domxref("HTMLFormElement.relList")}} {{ReadOnlyInline}}
-
-  - : A {{domxref("DOMTokenList")}} that reflects the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) HTML attribute, as a list of tokens.
-
+  - : A {{domxref("DOMTokenList")}} that reflects the [`rel`](en-US/docs/Web/HTML/Attributes/rel) HTML attribute, as a list of tokens.
 - {{domxref("HTMLFormElement.target")}}
   - : A string reflecting the value of the form's [`target`](/en-US/docs/Web/HTML/Element/form#target) HTML attribute, indicating where to display the results received from submitting the form.
 

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -20,7 +20,7 @@ _This interface also inherits properties from its parent, {{domxref("HTMLElement
 - {{domxref("HTMLFormElement.action")}}
   - : A string reflecting the value of the form's [`action`](/en-US/docs/Web/HTML/Element/form#action) HTML attribute, containing the URI of a program that processes the information submitted by the form.
 - {{domxref("HTMLFormElement.autocomplete")}}
-  - : A string reflecting the value of the form's [`autocomplete`](/en-US/docs/Web/HTML/Element/form#autocomplete) HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
+  - : A string reflecting the value of the form's [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
 - {{domxref("HTMLFormElement.encoding")}} or {{domxref("HTMLFormElement.enctype")}}
   - : A string reflecting the value of the form's [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) HTML attribute, indicating the type of content that is used to transmit the form to the server. Only specified values can be set. The two properties are synonyms.
 - {{domxref("HTMLFormElement.elements")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/htmlformelement/rel/index.md
+++ b/files/en-us/web/api/htmlformelement/rel/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLFormElement.rel
 
 {{APIRef("HTML DOM")}}
 
-The **`rel`** property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a string containing a the annotations and what kinds of links the HTML {{HTMLElement("form")}} element creates as a space-separated list of enumerated values.
+The **`rel`** property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a string containing what kinds of links the HTML {{HTMLElement("form")}} element creates, as a space-separated list of enumerated values.
 
 To retrieve the value as an array of tokens, see {{domxref("HTMLFormElement.relList")}}.
 
@@ -19,10 +19,10 @@ A string.
 ## Examples
 
 ```js
-const forms = document.getElementsByTagName("form");
-for (const form of forms) {
-  console.log(form);
-}
+const form = document.querySelector("form");
+console.log(form.rel);
+
+form.rel = "noopener noreferrer";
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/rel/index.md
+++ b/files/en-us/web/api/htmlformelement/rel/index.md
@@ -1,0 +1,40 @@
+---
+title: "HTMLFormElement: rel property"
+short-title: rel
+slug: Web/API/HTMLFormElement/rel
+page-type: web-api-instance-property
+browser-compat: api.HTMLFormElement.rel
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`rel`** property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a string containing a the annotations and what kinds of links the HTML {{HTMLElement("form")}} element creates as a space-separated list of enumerated values.
+
+To retrieve the value as an array of tokens, see {{domxref("HTMLFormElement.relList")}}.
+
+## Value
+
+A string.
+
+## Examples
+
+```js
+const forms = document.getElementsByTagName("form");
+for (const form of forms) {
+  console.log(form);
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLFormElement.relList")}}
+- {{domxref("HTMLLinkElement.rel")}}
+- {{domxref("HTMLAnchorElement.rel")}}

--- a/files/en-us/web/api/htmlformelement/rel/index.md
+++ b/files/en-us/web/api/htmlformelement/rel/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLFormElement.rel
 
 The **`rel`** property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a string containing what kinds of links the HTML {{HTMLElement("form")}} element creates, as a space-separated list of enumerated values.
 
-To retrieve the value as an array of tokens, see {{domxref("HTMLFormElement.relList")}}.
+To retrieve the value as an array of tokens, use {{domxref("HTMLFormElement.relList")}}.
 
 ## Value
 

--- a/files/en-us/web/api/htmlformelement/rellist/index.md
+++ b/files/en-us/web/api/htmlformelement/rellist/index.md
@@ -8,13 +8,11 @@ browser-compat: api.HTMLFormElement.relList
 
 {{APIRef("HTML DOM")}}
 
-The **`relList`** read-only property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a live {{domxref("DOMTokenList")}} containing the set of form types indicating the relationship between the resource represented by the {{HTMLElement("form")}} element and the current document.
+The **`relList`** read-only property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a live {{domxref("DOMTokenList")}} containing the set of link types indicating the relationship between the resource represented by the {{HTMLElement("form")}} element and the current document.
 
-The property itself is read-only, meaning you can not substitute the
-{{domxref("DOMTokenList")}} by another one, but the content of the returned list can be
-changed.
+The property itself is read-only, meaning you can not reassign the property with another {{domxref("DOMTokenList")}}, but the content of the returned list can be changed.
 
-For a string containing the values as space-separated tokens, see {{domxref("HTMLFormElement.rel")}}. The `rel` property can also be used to set the `rel` attribute value.
+To retrieve a string containing the values as space-separated tokens, use {{domxref("HTMLFormElement.rel")}}. The `rel` property can also be used to set the `rel` attribute value.
 
 ## Value
 
@@ -23,13 +21,10 @@ A live {{domxref("DOMTokenList")}} of strings.
 ## Examples
 
 ```js
-const forms = document.getElementsByTagName("form");
-for (const form of forms) {
-  console.log("New form found.");
-  form.relList.forEach((relEntry) => {
-    console.log(relEntry);
-  });
-}
+const form = document.querySelector("form");
+form.relList.forEach((relEntry) => {
+  console.log(relEntry);
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/rellist/index.md
+++ b/files/en-us/web/api/htmlformelement/rellist/index.md
@@ -1,0 +1,47 @@
+---
+title: "HTMLFormElement: relList property"
+short-title: relList
+slug: Web/API/HTMLFormElement/relList
+page-type: web-api-instance-property
+browser-compat: api.HTMLFormElement.relList
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`relList`** read-only property of the {{domxref("HTMLFormElement")}} interface reflects the [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute. It is a live {{domxref("DOMTokenList")}} containing the set of form types indicating the relationship between the resource represented by the {{HTMLElement("form")}} element and the current document.
+
+The property itself is read-only, meaning you can not substitute the
+{{domxref("DOMTokenList")}} by another one, but the content of the returned list can be
+changed.
+
+For a string containing the values as space-separated tokens, see {{domxref("HTMLFormElement.rel")}}. The `rel` property can also be used to set the `rel` attribute value.
+
+## Value
+
+A live {{domxref("DOMTokenList")}} of strings.
+
+## Examples
+
+```js
+const forms = document.getElementsByTagName("form");
+for (const form of forms) {
+  console.log("New form found.");
+  form.relList.forEach((relEntry) => {
+    console.log(relEntry);
+  });
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLAnchorElement.relList")}}
+- {{domxref("HTMLLinkElement.relList")}}
+- {{domxref("HTMLFormElement.rel")}}


### PR DESCRIPTION
Created two new docs
added themn to the index page

part of [#222](https://github.com/openwebdocs/project/issues/222): add missing newly available baseline pages