### PR TITLE
New pages: HTMLInput/TextAreaElement.dirName

### DIFF
--- a/files/en-us/web/api/htmlinputelement/dirname/index.md
+++ b/files/en-us/web/api/htmlinputelement/dirname/index.md
@@ -1,0 +1,37 @@
+---
+title: "HTMLInputElement: dirName property"
+short-title: dirName
+slug: Web/API/HTMLInputElement/dirName
+page-type: web-api-instance-property
+browser-compat: api.HTMLInputElement.dirName
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`dirName`** property of the {{domxref("HTMLInputElement")}} interface is the directionality of the element and enables the submission of that value. It reflects the value of the {{htmlelement("input")}} element's [`dirName`](/en-US/docs/Web/HTML/Attributes/dirname) attribute. This property can be retrieved or set.
+
+Valid only for [`hidden`](/en-US/docs/Web/HTML/Element/input/hidden), [`text`](/en-US/docs/Web/HTML/Element/input/text), [`search`](/en-US/docs/Web/HTML/Element/input/search), [`url`](/en-US/docs/Web/HTML/Element/input/url), [`tel`](/en-US/docs/Web/HTML/Element/input/tel), and [`email`](/en-US/docs/Web/HTML/Element/input/email) `<input>` types, the `dirname` attribute controls how the element's directionality is submitted. When included, the form control will submit with two name/value pairs: the first being the [`name`](/en-US/docs/Web/HTML/Element/input#name) and [`value`](/en-US/docs/Web/HTML/Element/input#value), and the second being the value of the [`dirname`](/en-US/docs/Web/HTML/Element/input#dirname) attribute as the name, with a value of `ltr` or `rtl` as set by the browser.
+
+## Value
+
+A string. The direction of the element.
+
+## Examples
+
+```js
+inputElement.dirName = "rtl";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.dirName")}}
+- [`dir` attribute](/en-US/docs/Web/HTML/Global_attributes/dir)
+- [Sending form data](/en-US/docs/Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data)

--- a/files/en-us/web/api/htmltextareaelement/dirname/index.md
+++ b/files/en-us/web/api/htmltextareaelement/dirname/index.md
@@ -1,0 +1,37 @@
+---
+title: "HTMLTextAreaElement: dirName property"
+short-title: dirName
+slug: Web/API/HTMLTextAreaElement/dirName
+page-type: web-api-instance-property
+browser-compat: api.HTMLTextAreaElement.dirName
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`dirName`** property of the {{domxref("HTMLTextAreaElement")}} interface is the directionality of the element. It reflects the value of the {{htmlelement("textarea")}} element's [`dirName`](/en-US/docs/Web/HTML/Attributes/dirname) attribute. This property can be retrieved or set.
+
+The `dirname` attribute controls how the element's directionality is submitted. When included, the form control will submit with two name/value pairs: the first being the [`name`](/en-US/docs/Web/HTML/Element/textarea#name) and [`value`](/en-US/docs/Web/HTML/Element/textarea#value) of the `<textarea>`, and the second being the value of the [`dirname`](/en-US/docs/Web/HTML/Element/textarea#dirname) attribute as the name, with a value of `ltr` or `rtl` as set by the browser.
+
+## Value
+
+A string. The direction of the element.
+
+## Examples
+
+```js
+textareaElement.dirName = "rtl";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLInputElement.dirName")}}
+- [`dir` attribute](/en-US/docs/Web/HTML/Global_attributes/dir)
+- [Sending form data](/en-US/docs/Learn_web_development/Extensions/Forms/Sending_and_retrieving_form_data)


### PR DESCRIPTION
Created two new docs

part of [#222](https://github.com/openwebdocs/project/issues/222): add missing newly available baseline pages