### PR TITLE
Additional Chrome `browsingData.RemovalOptions` properties

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -20,11 +20,19 @@ Values of this type are objects. They contain the following properties:
     > [!NOTE]
     > On Firefox Nightly removal of localStorage items by `cookieStoreId` is also supported.
 
+- `excludeOrigin` {{optional_inline}}
+
+  - : `array` of `string`. List of origins to exclude from the removal process. Can't be used together with `origins`. Only supported for cookies, storage, and cache. Cookies are excluded for the entire registrable domain.
+
 - `hostnames` {{optional_inline}}
 
-  - : `Array` of `string`. This property applies to cookie, indexedDB, local storage, and service worker registration items. Remove only cookie, indexedDB, local storage, and service worker registration items associated with these hostnames.
+  - : `array` of `string`. This property applies to cookie, indexedDB, local storage, and service worker registration items. Remove only cookie, indexedDB, local storage, and service worker registration items associated with these hostnames.
 
     You must pass in just a hostname here, without protocol (for example, `"google.com"` not `"https://google.com"`). You can use the [`URL`](/en-US/docs/Web/API/URL) interface to parse a raw URL and retrieve the hostname. Items associated with subdomains of a given hostname are _not_ removed: you must explicitly list subdomains.
+
+- `origin` {{optional_inline}}
+
+  - : `array` of `string`. List of origins to remove data for. Can't be used together with `excludeOrigins`. Only supported for cookies, storage, and cache. Cookies are cleared for the entire registrable domain.
 
 - `originTypes` {{optional_inline}}
 


### PR DESCRIPTION
### Description

Adds documentation for the `origin` and `excludeOrigin` properties of `browsingData.RemovalOptions` introduced into Chrome in release 74.

### Related issues and pull requests

Fixes #27629
Related BCD changes in https://github.com/mdn/browser-compat-data/pull/26357