### PR TITLE
Warn that cookie path does not protect against unauthorized reading

### DIFF
--- a/files/en-us/web/http/guides/cookies/index.md
+++ b/files/en-us/web/http/guides/cookies/index.md
@@ -182,8 +182,9 @@ The `Domain` and `Path` attributes define the _scope_ of a cookie: what URLs the
   - `/docsets`
   - `/fr/docs`
 
-  > [!NOTE]
-  > The `path` attribute [does _not_ protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+    > [!NOTE]
+    > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
+    > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
 
 ### Controlling third-party cookies with `SameSite`
 

--- a/files/en-us/web/http/guides/cookies/index.md
+++ b/files/en-us/web/http/guides/cookies/index.md
@@ -182,9 +182,9 @@ The `Domain` and `Path` attributes define the _scope_ of a cookie: what URLs the
   - `/docsets`
   - `/fr/docs`
 
-    > [!NOTE]
-    > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
-    > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+  > [!NOTE]
+  > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
+  > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
 
 ### Controlling third-party cookies with `SameSite`
 

--- a/files/en-us/web/http/guides/cookies/index.md
+++ b/files/en-us/web/http/guides/cookies/index.md
@@ -182,6 +182,9 @@ The `Domain` and `Path` attributes define the _scope_ of a cookie: what URLs the
   - `/docsets`
   - `/fr/docs`
 
+  > [!NOTE]
+  > The `path` attribute [does _not_ protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+
 ### Controlling third-party cookies with `SameSite`
 
 The [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute lets servers specify whether/when cookies are sent with cross-site requests — i.e., [third-party cookies](/en-US/docs/Web/Privacy/Guides/Third-party_cookies). Cross-site requests are requests where the {{Glossary("Site", "site")}} (the registrable domain) and/or the scheme (http or https) do not match the site the user is currently visiting. This includes requests sent when links are clicked on other sites to navigate to your site, and any request sent by embedded third-party content.

--- a/files/en-us/web/http/reference/headers/set-cookie/index.md
+++ b/files/en-us/web/http/reference/headers/set-cookie/index.md
@@ -131,9 +131,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     - the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
     - the request paths `/`, `/docsets`, `/fr/docs` will not match.
 
-  > [!NOTE]
-  > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
-  > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+    > [!NOTE]
+    > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
+    > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
 
 - `SameSite=<samesite-value>` {{optional_inline}}
 

--- a/files/en-us/web/http/reference/headers/set-cookie/index.md
+++ b/files/en-us/web/http/reference/headers/set-cookie/index.md
@@ -131,6 +131,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     - the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
     - the request paths `/`, `/docsets`, `/fr/docs` will not match.
 
+  > [!NOTE]
+  > The `path` attribute [does _not_ protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+
 - `SameSite=<samesite-value>` {{optional_inline}}
 
   - : Controls whether or not a cookie is sent with cross-site requests: that is, requests originating from a different {{glossary("site")}}, including the scheme, from the site that set the cookie. This provides some protection against certain cross-site attacks, including {{Glossary("CSRF", "cross-site request forgery (CSRF)")}} attacks.

--- a/files/en-us/web/http/reference/headers/set-cookie/index.md
+++ b/files/en-us/web/http/reference/headers/set-cookie/index.md
@@ -131,9 +131,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     - the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
     - the request paths `/`, `/docsets`, `/fr/docs` will not match.
 
-    > [!NOTE]
-    > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
-    > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+  > [!NOTE]
+  > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
+  > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
 
 - `SameSite=<samesite-value>` {{optional_inline}}
 

--- a/files/en-us/web/http/reference/headers/set-cookie/index.md
+++ b/files/en-us/web/http/reference/headers/set-cookie/index.md
@@ -131,8 +131,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     - the request paths `/docs`, `/docs/`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
     - the request paths `/`, `/docsets`, `/fr/docs` will not match.
 
-  > [!NOTE]
-  > The `path` attribute [does _not_ protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
+    > [!NOTE]
+    > The `path` attribute lets you control what cookies the browser sends based on the different parts of a site.
+    > It is not intended as a security measure, and [does not protect](/en-US/docs/Web/API/Document/cookie#security) against unauthorized reading of the cookie from a different path.
 
 - `SameSite=<samesite-value>` {{optional_inline}}
 


### PR DESCRIPTION
### Description

Added a note that the cookie `path` attribute does not protect against unauthorized reading.

### Motivation

I was about use the `path` attribute after reading the [MDN cookie guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#define_where_cookies_are_sent). I happen to come across a [StackExchange question](https://security.stackexchange.com/a/32698) linking back to a different page on MDN explaining this is should not be used as a security measure. However there was no mention of this in the guide.

