### PR TITLE
Add comment to empty CSS blocks in HTML examples

### DIFF
--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -20,8 +20,8 @@ The **`<em>`** [HTML](/en-US/docs/Web/HTML) element marks text that has stress e
 ```
 
 ```css interactive-example
-/* stylelint-disable-next-line block-no-empty */
 em {
+  /* Add your styles here */
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
- Added a comment `/* Add your styles here */` to empty CSS blocks in HTML interactive examples to clarify their purpose.
- Also removed the `stylelint-disable` comment from the same blocks.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This change addresses confusion among beginners about why empty CSS declaration blocks like `em {}` exist. The comment provides a helpful hint and improves the learning experience.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Decision discussed and approved in [#38599](https://github.com/mdn/content/issues/38599). Previously related to issues [#796](https://github.com/mdn/interactive-examples/issues/796) and [#700](https://github.com/mdn/interactive-examples/issues/700).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #38599
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
