### PR TITLE
Remove closing slashes from <wbr> examples

### DIFF
--- a/files/en-us/web/html/element/wbr/index.md
+++ b/files/en-us/web/html/element/wbr/index.md
@@ -14,7 +14,7 @@ The **`<wbr>`** [HTML](/en-US/docs/Web/HTML) element represents a word break opp
 ```html interactive-example
 <div id="example-paragraphs">
   <p>Fernstraßenbauprivatfinanzierungsgesetz</p>
-  <p>Fernstraßen<wbr />bau<wbr />privat<wbr />finanzierungs<wbr />gesetz</p>
+  <p>Fernstraßen<wbr>bau<wbr>privat<wbr>finanzierungs<wbr>gesetz</p>
   <p>Fernstraßen&shy;bau&shy;privat&shy;finanzierungs&shy;gesetz</p>
 </div>
 ```
@@ -45,7 +45,7 @@ _[The Yahoo Style Guide](https://web.archive.org/web/20121014054923/http://style
 
 ```html
 <p>
-  http://this<wbr />.is<wbr />.a<wbr />.really<wbr />.long<wbr />.example<wbr />.com/With<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages
+  http://this<wbr>.is<wbr>.a<wbr>.really<wbr>.long<wbr>.example<wbr>.com/With<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages
 </p>
 ```
 


### PR DESCRIPTION
### Description

Remove the closing space and forward slash from the `<wbr>` examples.

### Motivation

They don’t do anything per https://jakearchibald.com/2023/against-self-closing-tags-in-html/ .

### Additional details

n/a

### Related issues and pull requests

n/a