### PR TITLE
New pages: htmllinkelement image srcset and sizes

### DIFF
--- a/files/en-us/web/api/htmllinkelement/imagesizes/index.md
+++ b/files/en-us/web/api/htmllinkelement/imagesizes/index.md
@@ -10,13 +10,13 @@ browser-compat: api.HTMLLinkElement.imageSizes
 
 The **`imageSizes`** property of the {{domxref("HTMLLinkElement")}} interface indicates the size and conditions for the preloaded images defined by the {{domxref("HTMLLinkElement.imageSrcset", "imageSrcset")}} property. It reflects the value of the {{htmlelement("link")}} element's [`imagesizes`](/en-US/docs/Web/HTML/Element/link#imagesizes) attribute. This property can retrieve or set the `imagesizes` attribute value.
 
-The `<link>` element's `imagesizes` attribute is the same as the {{htmlelement("img")}} element's `sizes` attribute; a comma-separated **source size** list. Each source size includes a [media condition](/en-US/docs/Web/CSS/CSS_media_queries), the size of the image as a {{cssxref("length")}}, or the keyword `auto`, which must come first. For more information about the syntax of the `sizes` attribute, see [`<img>`](/en-US/docs/Web/HTML/Element/img#sizes).
+The `<link>` element's `imagesizes` attribute is the same as the {{htmlelement("img")}} element's `sizes` attribute: a comma-separated **source size** list. Each source size includes a [media condition](/en-US/docs/Web/CSS/CSS_media_queries), the size of the image as a {{cssxref("length")}}, or the keyword `auto`, which must come first. For more information about the syntax of the `sizes` attribute, see [`<img>`](/en-US/docs/Web/HTML/Element/img#sizes).
 
 The `imagesrcset` and `imagesizes` attributes are only relevant on `<link>` elements that have both a `rel` attribute set to `preload` and the `as` attribute set to `image`.
 
 ## Value
 
-A string; composed of comma separated source sizes or the empty string `""` if unspecified.
+A string composed of comma-separated source sizes, or the empty string `""` if unspecified.
 
 ## Examples
 
@@ -50,7 +50,7 @@ function log(text) {
 }
 ```
 
-We can retrieve and update the `imagesizes` attribute value with the `imageSizes` property:
+…we can retrieve and update the `imagesizes` attribute value with the `imageSizes` property:
 
 ```js
 const link = document.querySelector("link");

--- a/files/en-us/web/api/htmllinkelement/imagesizes/index.md
+++ b/files/en-us/web/api/htmllinkelement/imagesizes/index.md
@@ -1,0 +1,79 @@
+---
+title: HTMLLinkElement:imageSizes property
+short-title: imageSizes
+slug: Web/API/HTMLLinkElement/imageSizes
+page-type: web-api-instance-property
+browser-compat: api.HTMLLinkElement.imageSizes
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`imageSizes`** property of the {{domxref("HTMLLinkElement")}} interface indicates the size and conditions for the preloaded images defined by the {{domxref("HTMLLinkElement.imageSrcset", "imageSrcset")}} property. It reflects the value of the {{htmlelement("link")}} element's [`imagesizes`](/en-US/docs/Web/HTML/Element/link#imagesizes) attribute. This property can retrieve or set the `imagesizes` attribute value.
+
+The `<link>` element's `imagesizes` attribute is the same as the {{htmlelement("img")}} element's `sizes` attribute; a comma-separated **source size** list. Each source size includes a [media condition](/en-US/docs/Web/CSS/CSS_media_queries), the size of the image as a {{cssxref("length")}}, or the keyword `auto`, which must come first. For more information about the syntax of the `sizes` attribute, see [`<img>`](/en-US/docs/Web/HTML/Element/img#sizes).
+
+The `imagesrcset` and `imagesizes` attributes are only relevant on `<link>` elements that have both a `rel` attribute set to `preload` and the `as` attribute set to `image`.
+
+## Value
+
+A string; composed of comma separated source sizes or the empty string `""` if unspecified.
+
+## Examples
+
+Given the following `<link>` element:
+
+```html
+<link
+  rel="preload"
+  as="image"
+  imagesrcset="narrow.png, medium.png 600w, wide.png 1200w"
+  imagesizes="(max-width: 400px) 200px, (width < 600px) 75vw, 50vw" />
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  padding: 0 0.25rem;
+  font-size: 1.2em;
+  line-height: 1.4;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+We can retrieve and update the `imagesizes` attribute value with the `imageSizes` property:
+
+```js
+const link = document.querySelector("link");
+log(`Original: ${link.imageSizes}`);
+
+// Change the value
+link.imageSizes = "50vw";
+log(`Updated: ${link.imageSizes}`);
+```
+
+{{EmbedLiveSample('Examples',"","80")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLLinkElement.imageSrcset")}}
+- {{domxref("HTMLImageElement.sizes")}}
+- [Media queries](/en-US/docs/Web/CSS/CSS_media_queries)
+- [Using the `srcset` and `sizes` attributes](/en-US/docs/Web/HTML/Element/img#using_the_srcset_and_sizes_attributes)

--- a/files/en-us/web/api/htmllinkelement/imagesrcset/index.md
+++ b/files/en-us/web/api/htmllinkelement/imagesrcset/index.md
@@ -18,11 +18,11 @@ Each image candidate string contains an image URL and an optional width and/or p
 
 For HTML {{htmlelement("link")}} elements with [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) and [`as="image"`](/en-US/docs/Web/HTML/Element/link#as) set, the `imagesrcset` attribute has similar syntax and semantics as the {{htmlelement("img")}} element's [`srcset`](/en-US/docs/Web/HTML/Element/img#srcset) attribute, which indicates to preload the appropriate resource used by an `<img>` element with corresponding values for its `srcset` and `sizes` attributes.
 
-If the `imageSrcset` property includes width descriptors, the {{domxref("HTMLLinkElement.imageSizes", "imageSizes")}} property must be non-null, or the `imageSrcset` will be ignored.
+If the `imageSrcset` property includes width descriptors, the {{domxref("HTMLLinkElement.imageSizes", "imageSizes")}} property must be non-null, or the `imageSrcset` value will be ignored.
 
 ## Value
 
-A string; composed of a comma-separated list of one or more image candidate strings or the empty string `""` if unspecified..
+A string composed of a comma-separated list of one or more image candidate strings, or the empty string `""` if unspecified..
 
 ## Examples
 
@@ -56,7 +56,7 @@ function log(text) {
 }
 ```
 
-We can access the `imagesrcset` attribute value, and update it, using the `imageSrcset` property:
+…we can access the `imagesrcset` attribute value, and update it, using the `imageSrcset` property:
 
 ```js
 const link = document.querySelector("link");

--- a/files/en-us/web/api/htmllinkelement/imagesrcset/index.md
+++ b/files/en-us/web/api/htmllinkelement/imagesrcset/index.md
@@ -1,0 +1,85 @@
+---
+title: HTMLLinkElement:imageSrcset property
+short-title: imageSrcset
+slug: Web/API/HTMLLinkElement/imagesrcset
+page-type: web-api-instance-property
+browser-compat: api.HTMLLinkElement.imageSrcset
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`imageSrcset`** property of the {{domxref("HTMLLinkElement")}} interface is a string which identifies one or more comma-separated **image candidate strings**. This property reflects the value of the {{htmlelement("link")}} element's [`imagesrcset`](/en-US/docs/Web/HTML/Element/link#imagesrcset) attribute. This property can retrieved or set the `imagesrcset` attribute value.
+
+Each image candidate string contains an image URL and an optional width and/or pixel density descriptor indicating the conditions under which that candidate image should be used.
+
+```plain
+"images/team-photo.jpg, images/team-photo-retina.jpg 2x, images/team-photo-large.jpg 1400w"
+```
+
+For HTML {{htmlelement("link")}} elements with [`rel="preload"`](/en-US/docs/Web/HTML/Attributes/rel/preload) and [`as="image"`](/en-US/docs/Web/HTML/Element/link#as) set, the `imagesrcset` attribute has similar syntax and semantics as the {{htmlelement("img")}} element's [`srcset`](/en-US/docs/Web/HTML/Element/img#srcset) attribute, which indicates to preload the appropriate resource used by an `<img>` element with corresponding values for its `srcset` and `sizes` attributes.
+
+If the `imageSrcset` property includes width descriptors, the {{domxref("HTMLLinkElement.imageSizes", "imageSizes")}} property must be non-null, or the `imageSrcset` will be ignored.
+
+## Value
+
+A string; composed of a comma-separated list of one or more image candidate strings or the empty string `""` if unspecified..
+
+## Examples
+
+Given the following `<link>` element:
+
+```html
+<link
+  rel="preload"
+  as="image"
+  imagesizes="50vw"
+  imagesrcset="bg-narrow.png, bg-wide.png 800w" />
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  padding: 0 0.25rem;
+  font-size: 1.2em;
+  line-height: 1.4;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+We can access the `imagesrcset` attribute value, and update it, using the `imageSrcset` property:
+
+```js
+const link = document.querySelector("link");
+log(`Original: ${link.imageSrcset}`);
+
+// add an image candidate string
+link.imageSrcset += ", bg-huge.png 1200w";
+log(`Updated: ${link.imageSrcset}`);
+```
+
+{{EmbedLiveSample('Examples',"","80")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLLinkElement.imageSizes")}}
+- {{domxref("HTMLImageElement.srcset")}}
+- [Speculative loading](/en-US/docs/Web/Performance/Guides/Speculative_loading#link_relpreload)
+- [Responsive images](/en-US/docs/Web/HTML/Responsive_images)

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -29,6 +29,10 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : A string representing the URI for the target resource.
 - {{domxref("HTMLLinkElement.hreflang")}}
   - : A string representing the language code for the linked resource.
+- {{domxref("HTMLLinkElement.imageSizes")}}
+  - : A string reflecting the [`imagesizes`](/en-US/docs/Web/HTML/Element/link#imagesizes) HTML attribute; a list of comma-separated image conditions and sizes.
+- {{domxref("HTMLLinkElement.imageSrcset")}}
+  - : A string reflecting the [`imagesrcset`](/en-US/docs/Web/HTML/Element/link#imagesrcset) HTML attribute; a comma-separated list of image candidate strings.
 - {{domxref("HTMLLinkElement.integrity")}}
   - : A string that contains inline metadata that a browser can use to verify that a fetched resource has been delivered without unexpected manipulation. It reflects the `integrity` attribute of the {{HTMLElement("link")}} element.
 - {{domxref("HTMLLinkElement.media")}}


### PR DESCRIPTION
These two features are newly baseline, but were missing from MDN.

fixes [#222](https://github.com/openwebdocs/project/issues/222)