### PR TITLE
content property alt text

### DIFF
--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -418,7 +418,7 @@ Check the [browser compatibility chart](#browser_compatibility). All browsers su
 
 ### Element replacement with `image-set()`
 
-This example replaces an element's content with a {{cssxref("image/image-set", "image-set()")}}. If the users display has normal resolution the `1x.png` will be displayed screens with a higher resolution will display the `2x.png` image.
+This example replaces an element's content with a {{cssxref("image/image-set", "image-set()")}}. If the users display has normal resolution the `1x.png` will be displayed. Screens with a higher resolution will display the `2x.png` image.
 
 #### HTML
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -325,6 +325,7 @@ The generated content is the value of the `href` attribute, prepended by "URL: "
 ### Adding an image with alternative text
 
 This example inserts an image before all links. Two `content` values are provided. The later `content` value includes an image with alternative text that a screen reader can output as speech.
+
 #### HTML
 
 ```html

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -15,15 +15,15 @@ Objects inserted using the `content` property are **anonymous {{ glossary("repla
 
 ```css interactive-example
 .topic-games::before {
-  content: "🎮 ";
+  content: "🎮 " / "games";
 }
 
 .topic-weather::before {
-  content: "⛅ ";
+  content: "⛅ " / "cloudy";
 }
 
 .topic-hot::before {
-  content: url("/shared-assets/images/examples/fire.png");
+  content: url("/shared-assets/images/examples/fire.png") / "On fire";
   margin-right: 6px;
 }
 ```
@@ -142,7 +142,7 @@ The keywords and data types mentioned above are described in more detail below:
   - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element, or the pseudo-element's originating element. The value of the element's attribute `x` is an unparsed string representing the attribute name. If there is no attribute `x`, an empty string is returned. The case sensitivity of the attribute name parameter depends on the document language.
 
 - alternative text: `/ <string> | <counter>`
-  - : Alternative text may be specified for an image or any `<content-list>` items, by appending a forward slash and then a string of text or a counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} data types specify the "alt text" for the element.
+  - : Alternative text may be specified for an image or any `<content-list>` items, by appending a forward slash and then a string of text or a counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} data types specify the "alt text" for the element.
 
 ## Formal definition
 
@@ -324,8 +324,7 @@ The generated content is the value of the `href` attribute, prepended by "URL: "
 
 ### Adding an image with alternative text
 
-This example inserts an image before all links. Two `content` values are provided. The later `content` value includes an image with alternative text that a screen reader can output as speech. If a browser does not support alternative text, this declaration will be considered invalid, with the previous `content` value displaying. This fallback content list includes an image and the message " - alt text is not supported - ".
-
+This example inserts an image before all links. Two `content` values are provided. The later `content` value includes an image with alternative text that a screen reader can output as speech.
 #### HTML
 
 ```html
@@ -336,20 +335,11 @@ This example inserts an image before all links. Two `content` values are provide
 
 The CSS to show the image and set the alternative text is shown below.
 This also sets the font and color for the content.
-This will be used on browsers that _display_ the alternative text and in browsers that don't support alternative text and show the fallback `content` value.
 
 ```css
 a::before {
-  /* fallback content */
-  content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico")
-    " - alt text is not supported - ";
-  /* content with alternative text */
   content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico") /
     " MOZILLA: ";
-  font:
-    x-small Arial,
-    sans-serif;
-  color: gray;
 }
 ```
 
@@ -358,11 +348,9 @@ a::before {
 {{EmbedLiveSample('Adding_an_image_with_alternative_text', '100%', 60)}}
 
 > [!NOTE]
-> If the alternative text syntax is supported, the value will be exposed in the browser's accessibility tree. Refer to the [See also](#see_also) section for browser-specific accessibility panels.
+> The alternative text value is exposed in the browser's accessibility tree. Refer to the [See also](#see_also) section for browser-specific accessibility panels.
 
-If using a screen reader, it should speak the word "MOZILLA" when it reaches the image. If supported (if the "alt text is not supported" is not showing), you can select the `::before` pseudo-element with your developer tools selection tool, and view the {{glossary("accessible name")}} in the accessibility panel.
-
-In browsers that don't support the alternative text syntax the whole declaration containing the alt text is invalid. In this case, the previous `content` value will be used, showing the image and "alt text is not supported" text.
+If using a screen reader, it should speak the word "MOZILLA" when it reaches the image. You can select the `::before` pseudo-element with your developer tools selection tool, and view the {{glossary("accessible name")}} in the accessibility panel.
 
 ### Element replacement with URL
 
@@ -397,7 +385,7 @@ When generating content on regular elements (rather than just on pseudo-elements
 
 ### Element replacement with `<gradient>`
 
-This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The element's contents are replaced with a {{cssxref("gradient/linear-gradient", "linear-gradient()")}}. With {{cssxref("@supports")}}, we provide alt text support and a {{cssxref("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}} for browsers that support alt text with element content replacement.
+This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The element's contents are replaced with a {{cssxref("gradient/linear-gradient", "linear-gradient()")}}. We provide alt text because all images should be described for accessibility.
 
 #### HTML
 
@@ -416,14 +404,8 @@ div {
 }
 
 #replaced {
-  content: linear-gradient(#639f, #c96a);
-}
-
-@supports (content: linear-gradient(#000, #fff) / "alt text") {
-  #replaced {
-    content: repeating-linear-gradient(blue 0, orange 10%) /
-      "Gradients and alt text are supported";
-  }
+  content: repeating-linear-gradient(blue 0, orange 10%) /
+    "Gradients and alt text are supported";
 }
 ```
 
@@ -431,7 +413,7 @@ div {
 
 {{EmbedLiveSample('Element_replacement_with_gradient', '100%', 200)}}
 
-Check the [browser compatibility chart](#browser_compatibility). All browsers support gradients and all browsers support replacing elements with images, but not all browsers support gradients as a `content` value and not all browsers support alt text on replacements. If the browser displays a box with no gradient, replacing elements is supported, but gradients are not supported as a content replacement value. If the element is replaced with a striped gradient, the browser supports both.
+Check the [browser compatibility chart](#browser_compatibility). All browsers support gradients and all browsers support replacing elements with images, but not all browsers support gradients as a `content` value.
 
 ### Element replacement with `image-set()`
 
@@ -440,7 +422,7 @@ This example replaces an element's content with a {{cssxref("image/image-set", "
 #### HTML
 
 ```html
-<div id="replaced">Mozilla</div>
+<div id="replaced">I disappear!</div>
 ```
 
 #### CSS
@@ -457,7 +439,7 @@ div {
   content: image-set(
     "1x.png" 1x,
     "2x.png" 2x
-  );
+  ) / "DPI";
 }
 ```
 
@@ -486,5 +468,4 @@ div {
 - {{glossary("Replaced elements")}}
 - [CSS generated content](/en-US/docs/Web/CSS/CSS_generated_content) module
 - [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
-
 - Browser accessibility panels: [Firefox Accessibility inspector](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/), [Chrome Accessibility pane](https://developer.chrome.com/docs/devtools/accessibility/reference#pane), and [Safari Accessibility tree](https://webflow.com/glossary/accessibility-tree#:~:text=To%20view%20a%20website%E2%80%99s%20accessibility%20tree%20in%20Safari)


### PR DESCRIPTION
alt is supported everywhere.

removed the "in case your browser doesn't support" language and all fallbacks, as everything is now supported except for graidents on before and after only in ff only