### PR TITLE
Firefox 137 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -6,29 +6,24 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 137 that affect developers. Firefox 137 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [April 1, 2025](https://whattrainisitnow.com/release/?version=137).
+This article provides information about the changes in Firefox 137 that affect developers.
+Firefox 137 was released on [April 1, 2025](https://whattrainisitnow.com/release/?version=137).
 
 ## Changes for web developers
 
-### Developer Tools
-
 ### HTML
 
-#### Removals
+No notable changes
 
 ### CSS
 
 - The {{CSSXRef("hyphenate-limit-chars")}} CSS property provides you with fine-grained control over hyphenation in text. It is used to specify the minimum word length for hyphenation as well as the number of characters before and after the hyphen. ([Firefox bug 1947183](https://bugzil.la/1947183)).
 - The {{cssxref("text-decoration-line")}} CSS property now accepts the values `spelling-error` and `grammar-error`. These values use the browser's styling for spelling and grammar errors and disregard the other properties in the {{cssxref("text-decoration")}} shorthand. ([Firefox bug 1950844](https://bugzil.la/1950844)).
 
-#### Removals
-
 ### JavaScript
 
 - The {{jsxref("Math.sumPrecise()")}} static method is now supported. This takes an [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) (such as an {{jsxref("Array")}}) of numbers and returns their sum. It is more precise than summing the numbers in a loop because it avoids floating point precision loss in intermediate results. ([Firefox bug 1943120](https://bugzil.la/1943120)).
 - The {{jsxref("Atomics.pause()")}} static method is now supported. This method provides a hint to the CPU that the current thread is in a spinlock while waiting on access to a shared resource. The system can then reduce the resources allocated to the core (such as power) or thread, without yielding the current thread. ([Firefox bug 1937805](https://bugzil.la/1937805)).
-
-#### Removals
 
 ### SVG
 
@@ -37,21 +32,9 @@ This article provides information about the changes in Firefox 137 that affect d
   An SVG viewer can use this information to conserve memory by discarding elements that are no longer needed, such as animated elements that have completed.
   ([Firefox bug 1945330](https://bugzil.la/1945330)).
 
-#### Removals
-
-### HTTP
-
-#### Removals
-
-### Security
-
-#### Removals
-
 ### APIs
 
 - The {{domxref("SVGPathElement/getPathData", "getPathData()")}}, {{domxref("SVGPathElement/setPathData", "setPathData()")}}, and {{domxref("SVGPathElement/getPathSegmentAtLength", "getPathSegmentAtLength()")}} methods of the {{domxref("SVGPathElement")}} interface are now supported. These methods provide a convenient way to work with SVG path data instead of parsing raw string data. ([Firefox bug 1945312](https://bugzil.la/1945312)).
-
-#### DOM
 
 #### Media, WebRTC, and Web Audio
 
@@ -60,10 +43,6 @@ This article provides information about the changes in Firefox 137 that affect d
 #### Removals
 
 - The following non-standard events are now deprecated and proposed for removal: [`afterscriptexecute`](/en-US/docs/Web/API/Document/afterscriptexecute_event) and [`beforescriptexecute`](/en-US/docs/Web/API/Document/beforescriptexecute_event) in {{domxref("Document")}}, and [`afterscriptexecute`](/en-US/docs/Web/API/Element/afterscriptexecute_event), and [`beforescriptexecute`](/en-US/docs/Web/API/Element/beforescriptexecute_event) in {{domxref("Element")}}. A console warning is displayed when they are used. ([Firefox bug 1949373](https://bugzil.la/1949373)).
-
-### WebAssembly
-
-#### Removals
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -89,10 +68,6 @@ This article provides information about the changes in Firefox 137 that affect d
 
 - Adds {{WebExtAPIRef("commands.openShortcutSettings")}} that opens the Manage Extension Shortcuts page of Manage Your Extensions (`about:addons`) and, if the extension has shortcuts, scrolls to and highlights the extension's shortcut key options. ([Firefox bug 1538451](https://bugzil.la/1538451))
 - The 10 MB quota for data stored by the {{WebExtAPIRef("storage.session")}} API is now enforced. ([Firefox bug 1915688](https://bugzil.la/1915688))
-
-### Removals
-
-### Other
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -2,7 +2,7 @@
 title: Firefox 138 for developers
 slug: Mozilla/Firefox/Releases/138
 page-type: firefox-release-notes
-sidebar: FirefoxSidebar
+sidebar: firefoxsidebar
 ---
 
 This article provides information about the changes in Firefox 138 that affect developers.

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -2,9 +2,8 @@
 title: Firefox 138 for developers
 slug: Mozilla/Firefox/Releases/138
 page-type: firefox-release-notes
+sidebar: FirefoxSidebar
 ---
-
-{{FirefoxSidebar}}
 
 This article provides information about the changes in Firefox 138 that affect developers.
 Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [April 29, 2025](https://whattrainisitnow.com/release/?version=138).

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -6,7 +6,8 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 138 that affect developers. Firefox 138 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [April 29, 2025](https://whattrainisitnow.com/release/?version=138).
+This article provides information about the changes in Firefox 138 that affect developers.
+Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [April 29, 2025](https://whattrainisitnow.com/release/?version=138).
 
 ## Changes for web developers
 
@@ -70,7 +71,9 @@ This article provides information about the changes in Firefox 138 that affect d
 
 ## Experimental web features
 
-These features are newly shipped in Firefox 138 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+These features are newly shipped in Firefox 138 but are disabled by default.
+To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
+You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -2,7 +2,7 @@
 title: Firefox 139 for developers
 slug: Mozilla/Firefox/Releases/139
 page-type: firefox-release-notes
-sidebar: FirefoxSidebar
+sidebar: firefoxsidebar
 ---
 
 This article provides information about the changes in Firefox 139 that affect developers.

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -1,0 +1,74 @@
+---
+title: Firefox 139 for developers
+slug: Mozilla/Firefox/Releases/139
+page-type: firefox-release-notes
+---
+
+{{FirefoxSidebar}}
+
+This article provides information about the changes in Firefox 139 that affect developers.
+Firefox 139 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [May 27, 2025](https://whattrainisitnow.com/release/?version=139).
+
+## Changes for web developers
+
+### Developer Tools
+
+### HTML
+
+#### Removals
+
+### CSS
+
+#### Removals
+
+### JavaScript
+
+#### Removals
+
+### SVG
+
+#### Removals
+
+### HTTP
+
+#### Removals
+
+### Security
+
+#### Removals
+
+### APIs
+
+#### DOM
+
+#### Media, WebRTC, and Web Audio
+
+#### Removals
+
+### WebAssembly
+
+#### Removals
+
+### WebDriver conformance (WebDriver BiDi, Marionette)
+
+#### General
+
+#### WebDriver BiDi
+
+#### Marionette
+
+## Changes for add-on developers
+
+### Removals
+
+### Other
+
+## Experimental web features
+
+These features are newly shipped in Firefox 139 but are disabled by default.
+To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
+You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+## Older versions
+
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -2,9 +2,8 @@
 title: Firefox 139 for developers
 slug: Mozilla/Firefox/Releases/139
 page-type: firefox-release-notes
+sidebar: FirefoxSidebar
 ---
-
-{{FirefoxSidebar}}
 
 This article provides information about the changes in Firefox 139 that affect developers.
 Firefox 139 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [May 27, 2025](https://whattrainisitnow.com/release/?version=139).


### PR DESCRIPTION
### Description

Release notes for Firefox 137 release

__Additions:__
* 139 page for Nightly (May 27, 2025)

__Changes:__
* 137 is stable (April 1, 2025)
* 138 is Beta (April 29, 2025)
* Use `sidebar` front matter for future pages

