### PR TITLE
Add fallback note for container query length units

### DIFF
--- a/files/en-us/web/css/css_containment/container_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_queries/index.md
@@ -119,8 +119,7 @@ When applying styles to a container using container queries, you can use contain
 These units specify a length relative to the dimensions of a query container.
 Components that use units of length relative to their container are more flexible to use in different containers without having to recalculate concrete length values.
 
-> [!NOTE]
-> If no eligible container is available for the query, the corresponding container query length unit defaults to using the small viewport size for that axis.
+If no eligible container is available for the query, the container query length unit defaults to the [small viewport unit](/en-US/docs/Web/CSS/length#small_viewport_units) for that axis (`sv*`).
 
 The container query length units are:
 

--- a/files/en-us/web/css/css_containment/container_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_queries/index.md
@@ -119,6 +119,9 @@ When applying styles to a container using container queries, you can use contain
 These units specify a length relative to the dimensions of a query container.
 Components that use units of length relative to their container are more flexible to use in different containers without having to recalculate concrete length values.
 
+> [!NOTE]
+> If no eligible container is available for the query, the corresponding container query length unit defaults to using the small viewport size for that axis.
+
 The container query length units are:
 
 - `cqw`: 1% of a query container's width

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -156,8 +156,7 @@ When applying styles to a container using container queries, you can use contain
 These units specify a length relative to the dimensions of a query container.
 Components that use units of length relative to their container are more flexible to use in different containers without having to recalculate concrete length values.
 
-> [!NOTE]
-> If no eligible container is available for the query, the corresponding container query length unit defaults to using the small viewport size for that axis.
+If no eligible container is available for the query, the container query length unit defaults to the [small viewport unit](#small_viewport_units) for that axis (`sv*`).
 
 For more information, see [Container queries](/en-US/docs/Web/CSS/CSS_containment/Container_queries).
 

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -155,6 +155,10 @@ Viewport-percentage lengths define `<length>` values in percentage relative to t
 When applying styles to a container using container queries, you can use container query length units.
 These units specify a length relative to the dimensions of a query container.
 Components that use units of length relative to their container are more flexible to use in different containers without having to recalculate concrete length values.
+
+> [!NOTE]
+> If no eligible container is available for the query, the corresponding container query length unit defaults to using the small viewport size for that axis.
+
 For more information, see [Container queries](/en-US/docs/Web/CSS/CSS_containment/Container_queries).
 
 - `cqw`


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a note clarifying that if no eligible container is available for the query, the corresponding container query length unit defaults to using the small viewport size for that axis.

### Motivation

Clarifies expected fallback behavior for container query length units as per the CSS Conditional Rules specification.

### Additional details

### Related issues and pull requests

Fixes #38875
