### PR TITLE
Add Express v4 disclaimers

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -10,8 +10,8 @@ page-type: learn-module-chapter
 Now that you know what [Express](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Introduction#introducing_express) is for, we'll show you how to set up and test a Node/Express development environment on Windows, or Linux (Ubuntu), or macOS. For any of those operating systems, this article provides what you need to start developing Express apps.
 
 > [!WARNING]
-> The Express tutorial is written for Express 4, while the head revision is Express 5.
-> We plan to update the documentation in the second half of 2025.
+> The Express tutorial is written for Express version 4, while the latest version is Express 5.
+> We plan to update the documentation to support Express 5 in the second half of 2025. Until then, we have updated the installation commands so they install Express 4 rather than the latest version, to avoid any potential compatibility problems. 
 
 <table>
   <tbody>

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -11,7 +11,7 @@ Now that you know what [Express](/en-US/docs/Learn_web_development/Extensions/Se
 
 > [!WARNING]
 > The Express tutorial is written for Express version 4, while the latest version is Express 5.
-> We plan to update the documentation to support Express 5 in the second half of 2025. Until then, we have updated the installation commands so they install Express 4 rather than the latest version, to avoid any potential compatibility problems. 
+> We plan to update the documentation to support Express 5 in the second half of 2025. Until then, we have updated the installation commands so they install Express 4 rather than the latest version, to avoid any potential compatibility problems.
 
 <table>
   <tbody>

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -9,6 +9,10 @@ page-type: learn-module-chapter
 
 Now that you know what [Express](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Introduction#introducing_express) is for, we'll show you how to set up and test a Node/Express development environment on Windows, or Linux (Ubuntu), or macOS. For any of those operating systems, this article provides what you need to start developing Express apps.
 
+> [!WARNING]
+> The Express tutorial is written for Express 4, while the head revision is Express 5.
+> We plan to update the documentation in the second half of 2025.
+
 <table>
   <tbody>
     <tr>
@@ -224,7 +228,7 @@ The following steps show how you can use npm to download a package, save it into
 3. Now install Express in the `myapp` directory and save it in the dependencies list of your **package.json** file:
 
    ```bash
-    npm install express
+   npm install express @4
    ```
 
    The dependencies section of your **package.json** will now appear at the end of the **package.json** file and will include _Express_.
@@ -241,7 +245,7 @@ The following steps show how you can use npm to download a package, save it into
      "author": "",
      "license": "ISC",
      "dependencies": {
-       "express": "^4.17.1"
+       "express": "^4.21.2"
      }
    }
    ```

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/index.md
@@ -10,6 +10,10 @@ page-type: learn-module
 
 Express is a popular unopinionated web framework, written in JavaScript and hosted within the Node.js runtime environment. This module explains some of the key benefits of the framework, how to set up your development environment and how to perform common web development and deployment tasks.
 
+> [!WARNING]
+> The Express documentation and tutorial are written for Express 4, while the head revision is Express 5.
+> We plan to update the documentation in the second half of 2025.
+
 ## Prerequisites
 
 Before starting this module you will need to understand what server-side web programming and web frameworks are, ideally by reading the topics in our [Server-side website programming first steps](/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps) module. A general knowledge of programming concepts and [JavaScript](/en-US/docs/Web/JavaScript) is highly recommended, but not essential to understanding the core concepts.

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/index.md
@@ -11,7 +11,7 @@ page-type: learn-module
 Express is a popular unopinionated web framework, written in JavaScript and hosted within the Node.js runtime environment. This module explains some of the key benefits of the framework, how to set up your development environment and how to perform common web development and deployment tasks.
 
 > [!WARNING]
-> The Express documentation and tutorial are written for Express 4, while the head revision is Express 5.
+> The Express documentation and tutorial are written for Express version 4, while the latest version is Express 5.
 > We plan to update the documentation in the second half of 2025.
 
 ## Prerequisites

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -9,7 +9,7 @@ page-type: learn-module-chapter
 In this first Express article we answer the questions "What is Node?" and "What is Express?", and give you an overview of what makes the Express web framework special. We'll outline the main features, and show you some of the main building blocks of an Express application (although at this point you won't yet have a development environment in which to test it).
 
 > [!WARNING]
-> The Express tutorial is written for Express 4, while the head revision is Express 5.
+> The Express tutorial is written for Express version 4, while the latest version is Express 5.
 > We plan to update the documentation in the second half of 2025.
 
 <table>

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -8,6 +8,10 @@ page-type: learn-module-chapter
 
 In this first Express article we answer the questions "What is Node?" and "What is Express?", and give you an overview of what makes the Express web framework special. We'll outline the main features, and show you some of the main building blocks of an Express application (although at this point you won't yet have a development environment in which to test it).
 
+> [!WARNING]
+> The Express tutorial is written for Express 4, while the head revision is Express 5.
+> We plan to update the documentation in the second half of 2025.
+
 <table>
   <tbody>
     <tr>
@@ -107,7 +111,7 @@ While _Express_ itself is fairly minimalist, developers have created compatible 
 
 Node was initially released, for Linux only, in 2009. The npm package manager was released in 2010, and native Windows support was added in 2012. Delve into [Wikipedia](https://en.wikipedia.org/wiki/Node.js#History) if you want to know more.
 
-Express was initially released in November 2010 and is currently on major version 4 of the API. You can check out the [changelog](https://expressjs.com/en/changelog/4x.html) for information about changes in the current release, and [GitHub](https://github.com/expressjs/express/blob/master/History.md) for more detailed historical release notes.
+Express was initially released in November 2010 and is currently on major version 5 of the API. You can check out the [changelog](https://expressjs.com/en/changelog/#5.x) for information about changes in the current release, and [GitHub](https://github.com/expressjs/express/blob/master/History.md) for more detailed historical release notes.
 
 ## How popular are Node and Express?
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
@@ -11,6 +11,10 @@ page-type: learn-module-chapter
 
 This second article in our [Express Tutorial](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) shows how you can create a "skeleton" website project which you can then go on to populate with site-specific routes, templates/views, and database calls.
 
+> [!WARNING]
+> The Express tutorial is written for Express 4, while the head revision is Express 5.
+> We plan to update the documentation in the second half of 2025.
+
 <table>
   <tbody>
     <tr>

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
@@ -12,7 +12,7 @@ page-type: learn-module-chapter
 This second article in our [Express Tutorial](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) shows how you can create a "skeleton" website project which you can then go on to populate with site-specific routes, templates/views, and database calls.
 
 > [!WARNING]
-> The Express tutorial is written for Express 4, while the head revision is Express 5.
+> The Express tutorial is written for Express version 4, while the latest version is Express 5.
 > We plan to update the documentation in the second half of 2025.
 
 <table>


### PR DESCRIPTION
Express has iterated major version from 4 to 5, as raised in #38922.

We need to update the docs but this requires some investigation and testing. The changelog says the update is relatively minor, but has some breaks. The work is therefore likely to be constrained, but we won't know until we try.

This won't happen in the coming month. I have therefore added a disclaimer on the main entry points of the docs and the tutorial (the bits where you might try install express) about this being for version 4. I have also modified the line that installs express to specify version 4. 

The disclaimer says we'll do this in the second half. Hope to get to it sooner but better to undercommit.