### PR TITLE
FF138 Relnote: JS Error.captureStackTrace() and .isError()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -844,48 +844,6 @@ This includes:
   </tbody>
 </table>
 
-### Error.captureStackTrace
-
-The {{jsxref("Error.captureStackTrace()")}} static method installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property.
-Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface.
-([Firefox bug 1886820](https://bugzil.la/1886820)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>136</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>javascript.options.experimental.error_capture_stack_trace</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## APIs
 
 ### CloseWatcher Interface

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -22,6 +22,9 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 
 ### JavaScript
 
+- The {{jsxref("Error.captureStackTrace()")}} static method is now supported. This installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property. Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface. ([Firefox bug 1950508](https://bugzil.la/1950508)).
+- The {{jsxref("Error.isError()")}} static method can now be used to check whether or not an object is an instance of an {{jsxref("Error")}} or a {{domxref("DOMException")}}. This is more reliable than using `instanceof` for the same purpose. ([Firefox bug 1952249](https://bugzil.la/1952249)).
+
 #### Removals
 
 ### SVG

--- a/files/en-us/web/javascript/reference/global_objects/error/capturestacktrace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/capturestacktrace/index.md
@@ -9,9 +9,6 @@ browser-compat: javascript.builtins.Error.captureStackTrace
 
 {{JSRef}}{{Non-standard_Header}}
 
-> [!NOTE]
-> This feature is part of the non-standard [V8 stack trace API](https://v8.dev/docs/stack-trace-api). However, for compatibility reasons, it is de facto implemented by all major JavaScript engines.
-
 The **`Error.captureStackTrace()`** static method installs stack trace information on a provided object as the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) property.
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/error/iserror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/iserror/index.md
@@ -31,7 +31,7 @@ This is the same mechanism used by {{jsxref("Array.isArray()")}}, which is in tu
 
 It is a more robust alternative to [`instanceof Error`](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) because it avoids false positives and false negatives:
 
-- `Error.isError()` rejects values that aren't actual `Error` instances, even if they have `Error.prototype` their prototype chain — `instanceof Error` would accept these as it does check the prototype chain.
+- `Error.isError()` rejects values that aren't actual `Error` instances, even if they have `Error.prototype` in their prototype chain — `instanceof Error` would accept these as it does check the prototype chain.
 - `Error.isError()` accepts `Error` objects constructed in another realm — `instanceof Error` returns `false` for these because the identity of the `Error` constructor is different across realms.
 
 `Error.isError()` returns `true` for {{domxref("DOMException")}} instances. This is because, although `DOMException` is not specified as a real subclass of `Error` (the `Error` constructor is not the prototype of the `DOMException` constructor), `DOMException` still behaves like `Error` for all branded checking purposes.


### PR DESCRIPTION
FF138 supports `Error.captureStackTrace()` and `Error.isError()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1952249 and
https://bugzilla.mozilla.org/show_bug.cgi?id=1950508

This adds a release note and removes from Experimental features.

Related docs work can be tracked in #38879