### PR TITLE
FF138 Expr: MutationEvent removal from nightly

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -984,6 +984,47 @@ This subset of the API has been implemented:
   </tbody>
 </table>
 
+### Removal of historical MutationEvent
+
+{{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`,`DOMAttrModified`) are on the path for removal, and have been disabled on nightly.
+([Firefox bug 1951772](https://bugzil.la/1951772)).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>138</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>138</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>138</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>138</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.mutation_events.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Graphics: Canvas, WebGL, and WebGPU
 
 #### WebGL: Draft extensions

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -984,7 +984,7 @@ This subset of the API has been implemented:
   </tbody>
 </table>
 
-### Removal of historical MutationEvent
+### Removal of MutationEvent
 
 {{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`,`DOMAttrModified`) are on the path for removal, and have been disabled on nightly.
 ([Firefox bug 1951772](https://bugzil.la/1951772)).

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -82,6 +82,10 @@ These features are newly shipped in Firefox 138 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **`MutationEvent` on path to removal**: {{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`,`DOMAttrModified`) are now disabled on Firefox Nightly by default. ([Firefox bug 1951772](https://bugzil.la/1951772)).
+
+
+
 ## Older versions
 
 {{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -84,8 +84,6 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **`MutationEvent` on path to removal**: {{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`,`DOMAttrModified`) are now disabled on Firefox Nightly by default. ([Firefox bug 1951772](https://bugzil.la/1951772)).
 
-
-
 ## Older versions
 
 {{Firefox_for_developers}}


### PR DESCRIPTION
FF138 puts the deprecated [MutationEvent](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent) interface and its associated events behind a preference on Nightly only in https://bugzilla.mozilla.org/show_bug.cgi?id=1951772 - i.e. you can use Nightly to your code behaves without this event.

This adds an experimental feature and release note entry to make developers aware of the change, and likely impact in future.

Related docs work can be tracked in #38889
