### PR TITLE
Fix HTMLIFrameElement casing

### DIFF
--- a/files/en-us/web/api/htmliframeelement/getsvgdocument/index.md
+++ b/files/en-us/web/api/htmliframeelement/getsvgdocument/index.md
@@ -1,14 +1,14 @@
 ---
-title: "HTMLIframeElement: getSVGDocument() method"
+title: "HTMLIFrameElement: getSVGDocument() method"
 short-title: getSVGDocument()
-slug: Web/API/HTMLIframeElement/getSVGDocument
+slug: Web/API/HTMLIFrameElement/getSVGDocument
 page-type: web-api-instance-method
-browser-compat: api.HTMLIframeElement.getSVGDocument
+browser-compat: api.HTMLIFrameElement.getSVGDocument
 ---
 
 {{APIRef("HTML DOM")}}
 
-The **`getSVGDocument()`** method of the {{domxref("HTMLIframeElement")}} interface returns the {{domxref("Document")}} object of the embedded SVG.
+The **`getSVGDocument()`** method of the {{domxref("HTMLIFrameElement")}} interface returns the {{domxref("Document")}} object of the embedded SVG.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -67,7 +67,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 
 _Also inherits methods from its parent interface, {{domxref("HTMLElement")}}._
 
-- {{domxref("HTMLIframeElement.getSVGDocument()")}}
+- {{domxref("HTMLIFrameElement.getSVGDocument()")}}
   - : Returns the embedded SVG as a {{domxref("Document")}}.
 
 ## Specifications


### PR DESCRIPTION
Wrong casing prevents BCD showing up