### PR TITLE
Remove browser-compat for CSS types without BCD

### DIFF
--- a/files/en-us/web/css/baseline-position/index.md
+++ b/files/en-us/web/css/baseline-position/index.md
@@ -2,7 +2,7 @@
 title: <baseline-position>
 slug: Web/CSS/baseline-position
 page-type: css-type
-browser-compat: css.types.baseline-position
+spec-urls: https://drafts.csswg.org/css-align/#typedef-baseline-position
 ---
 
 {{CSSRef}}
@@ -35,10 +35,6 @@ The `<baseline-position>` enumerated value type is specified using an optional `
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/calc-sum/index.md
+++ b/files/en-us/web/css/calc-sum/index.md
@@ -2,7 +2,7 @@
 title: <calc-sum>
 slug: Web/CSS/calc-sum
 page-type: css-type
-browser-compat: css.types.calc-sum
+spec-urls: https://drafts.csswg.org/css-values/#typedef-calc-sum
 ---
 
 {{CSSRef}}
@@ -38,10 +38,6 @@ The `+` and `-` operators **must be surrounded by {{Glossary("whitespace")}}**. 
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/content-distribution/index.md
+++ b/files/en-us/web/css/content-distribution/index.md
@@ -2,7 +2,7 @@
 title: <content-distribution>
 slug: Web/CSS/content-distribution
 page-type: css-type
-browser-compat: css.types.content-distribution
+spec-urls: https://drafts.csswg.org/css-align/#typedef-content-distribution
 ---
 
 {{CSSRef}}
@@ -38,10 +38,6 @@ The following keyword values are represented by the `<content-distribution>` gra
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/content-position/index.md
+++ b/files/en-us/web/css/content-position/index.md
@@ -2,7 +2,7 @@
 title: <content-position>
 slug: Web/CSS/content-position
 page-type: css-type
-browser-compat: css.types.content-position
+spec-urls: https://drafts.csswg.org/css-align/#typedef-content-position
 ---
 
 {{CSSRef}}
@@ -36,10 +36,6 @@ The `<content-position>` enumerated value type is specified using one of the fol
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/overflow-position/index.md
+++ b/files/en-us/web/css/overflow-position/index.md
@@ -2,7 +2,7 @@
 title: <overflow-position>
 slug: Web/CSS/overflow-position
 page-type: css-type
-browser-compat: css.types.overflow-position
+spec-urls: https://drafts.csswg.org/css-align/#typedef-overflow-position
 ---
 
 {{CSSRef}}
@@ -32,10 +32,6 @@ The following keyword values are represented by the `<overflow-position>` gramma
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/self-position/index.md
+++ b/files/en-us/web/css/self-position/index.md
@@ -2,7 +2,7 @@
 title: <self-position>
 slug: Web/CSS/self-position
 page-type: css-type
-browser-compat: css.types.self-position
+spec-urls: https://drafts.csswg.org/css-align/#typedef-self-position
 ---
 
 {{CSSRef}}
@@ -40,10 +40,6 @@ The following keyword values are represented by the `<self-position>` grammar te
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/time-percentage/index.md
+++ b/files/en-us/web/css/time-percentage/index.md
@@ -2,7 +2,7 @@
 title: <time-percentage>
 slug: Web/CSS/time-percentage
 page-type: css-type
-specl-urls: https://drafts.csswg.org/css-values/#typedef-time-percentage
+spec-urls: https://drafts.csswg.org/css-values/#typedef-time-percentage
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/time-percentage/index.md
+++ b/files/en-us/web/css/time-percentage/index.md
@@ -2,7 +2,7 @@
 title: <time-percentage>
 slug: Web/CSS/time-percentage
 page-type: css-type
-browser-compat: css.types.time-percentage
+specl-urls: https://drafts.csswg.org/css-values/#typedef-time-percentage
 ---
 
 {{CSSRef}}
@@ -59,10 +59,6 @@ Where a `<time-percentage>` is specified as an allowable type, this means that t
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
These types don't have BCD and they likely never won't. I think it's best to just remove browser compat, as we do for many other CSS types. I can also find a representative actual CSS feature to replace, but I think the benefit is not very clear.