### PR TITLE
Add a json patch generator tool

### DIFF
--- a/files/en-us/web/http/reference/methods/patch/index.md
+++ b/files/en-us/web/http/reference/methods/patch/index.md
@@ -130,3 +130,4 @@ Developers can set this request method using [`fetch()`](/en-US/docs/Web/API/Win
 - {{HTTPStatus("204")}}
 - {{HTTPHeader("Allow")}}, {{HTTPHeader("Access-Control-Allow-Methods")}} headers
 - {{HTTPHeader("Accept-Patch")}} – specifies the patch document formats accepted by the server
+- [JSON Patch Generator](https://jsoning.com/jsonpatch/)


### PR DESCRIPTION
I suggest adding the tool https://jsoning.com/jsonpatch/ (my website) to the list of resources.
It allows to generate a JSON Patch from two JSON files. I suppose it could be useful for people consulting the PATCH page.