### PR TITLE
Add missing {{Specifications}} macros

### DIFF
--- a/files/en-us/web/api/media_capture_and_streams_api/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/index.md
@@ -60,6 +60,10 @@ The [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Capture_
 
 The [Taking still photos with getUserMedia()](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos) article shows how to use [`getUserMedia()`](/en-US/docs/Web/API/MediaDevices/getUserMedia) to access the camera on a computer or mobile phone with `getUserMedia()` support and take a photo with it.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/webxr_device_api/index.md
+++ b/files/en-us/web/api/webxr_device_api/index.md
@@ -5,6 +5,17 @@ page-type: web-api-overview
 status:
   - experimental
 browser-compat: api.Navigator.xr
+spec-urls:
+  - https://immersive-web.github.io/webxr/
+  - https://immersive-web.github.io/anchors/
+  - https://immersive-web.github.io/webxr-ar-module/
+  - https://immersive-web.github.io/depth-sensing/
+  - https://immersive-web.github.io/dom-overlays/
+  - https://immersive-web.github.io/webxr-gamepads-module/
+  - https://immersive-web.github.io/webxr-hand-input/
+  - https://immersive-web.github.io/hit-test/
+  - https://immersive-web.github.io/layers/
+  - https://immersive-web.github.io/lighting-estimation/
 ---
 
 {{DefaultAPISidebar("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
@@ -164,75 +175,7 @@ The following guides and tutorials are a great resource to learn how to comprehe
 
 ## Specifications
 
-<table>
-  <thead>
-    <tr>
-      <th>Specification</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://immersive-web.github.io/webxr/"><strong>WebXR Device API</strong></a>
-      (<a href="https://github.com/immersive-web/webxr">Source</a>,
-       <a href="https://github.com/immersive-web/webxr/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/webxr/blob/master/explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/anchors/"><strong>WebXR Anchors Module</strong></a>
-      (<a href="https://github.com/immersive-web/anchors">Source</a>,
-       <a href="https://github.com/immersive-web/anchors/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/anchors/blob/master/explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/webxr-ar-module/"><strong>WebXR Augmented Reality Module</strong></a>
-      (<a href="https://github.com/immersive-web/webxr-ar-module">Source</a>,
-       <a href="https://github.com/immersive-web/webxr-ar-module/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/webxr-ar-module/blob/master/ar-module-explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/depth-sensing/"><strong>WebXR Depth Sensing Module</strong></a>
-      (<a href="https://github.com/immersive-web/depth-sensing">Source</a>,
-       <a href="https://github.com/immersive-web/depth-sensing/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/depth-sensing/blob/main/explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/dom-overlays/"><strong>WebXR DOM Overlays Module</strong></a>
-      (<a href="https://github.com/immersive-web/dom-overlays">Source</a>,
-       <a href="https://github.com/immersive-web/dom-overlays/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/dom-overlays/blob/master/explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/webxr-gamepads-module/"><strong>WebXR Gamepads Module</strong></a>
-      (<a href="https://github.com/immersive-web/webxr-gamepads-module">Source</a>,
-       <a href="https://github.com/immersive-web/webxr-gamepads-module/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/webxr-gamepads-module/blob/master/gamepads-module-explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/webxr-hand-input/"><strong>WebXR Hand Input Module</strong></a>
-      (<a href="https://github.com/immersive-web/webxr-hand-input">Source</a>,
-       <a href="https://github.com/immersive-web/webxr-hand-input/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/webxr-hand-input/blob/master/explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/hit-test/"><strong>WebXR Hit Test Module</strong></a>
-      (<a href="https://github.com/immersive-web/hit-test">Source</a>,
-       <a href="https://github.com/immersive-web/hit-test/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/hit-test/blob/master/hit-testing-explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/layers/"><strong>WebXR Layers API</strong></a>
-      (<a href="https://github.com/immersive-web/layers">Source</a>,
-       <a href="https://github.com/immersive-web/layers/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/layers/blob/master/explainer.md">Explainer</a>)</td>
-    </tr>
-    <tr>
-      <td><a href="https://immersive-web.github.io/lighting-estimation/"><strong>WebXR Lighting Estimation API</strong></a>
-      (<a href="https://github.com/immersive-web/lighting-estimation">Source</a>,
-       <a href="https://github.com/immersive-web/lighting-estimation/issues">Issues</a>,
-       <a href="https://github.com/immersive-web/lighting-estimation/blob/main/lighting-estimation-explainer.md">Explainer</a>)</td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -3,6 +3,7 @@ title: MathML
 slug: Web/MathML
 page-type: landing-page
 browser-compat: mathml.elements.math
+spec-urls: https://w3c.github.io/mathml/
 sidebar: mathmlref
 ---
 
@@ -88,6 +89,10 @@ The following demos mix MathML with other Web technologies to produce advanced c
 - [CSS](/en-US/docs/Web/CSS)
 - [HTML](/en-US/docs/Web/HTML)
 - [SVG](/en-US/docs/Web/SVG)
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
My tooling automatically detects pages that have associated spec URLs (via `spec-urls` or `browser-compat`) but don't have the `{{Specifications}}` macro. These pages have browser compat, and therefore should have an appropriate link to specs.