### PR TITLE
Fix <hue-interpolation-method> BCD query

### DIFF
--- a/files/en-us/web/css/hue-interpolation-method/index.md
+++ b/files/en-us/web/css/hue-interpolation-method/index.md
@@ -2,14 +2,7 @@
 title: <hue-interpolation-method>
 slug: Web/CSS/hue-interpolation-method
 page-type: css-type
-browser-compat:
-  - css.types.color.color-mix
-  - css.types.image.gradient.conic-gradient.hue_interpolation_method
-  - css.types.image.gradient.linear-gradient.hue_interpolation_method
-  - css.types.image.gradient.radial-gradient.hue_interpolation_method
-  - css.types.image.gradient.repeating-conic-gradient.hue_interpolation_method
-  - css.types.image.gradient.repeating-linear-gradient.hue_interpolation_method
-  - css.types.image.gradient.repeating-radial-gradient.hue_interpolation_method
+browser-compat: css.types.gradient.conic-gradient.hue_interpolation_method
 spec-urls: https://drafts.csswg.org/css-color/#hue-interpolation
 ---
 


### PR DESCRIPTION
The BCD is broken, chiefly because `css.types.image.gradient` is now `css.types.gradient`; still I think it's not too useful to have so many queries, so I'm reducing the list to a single item.