### PR TITLE
Remove external Web Speech API articles

### DIFF
--- a/files/en-us/web/api/web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/index.md
@@ -85,4 +85,3 @@ The [Web Speech API examples](https://github.com/mdn/dom-examples/tree/main/web-
 ## See also
 
 - [Using the Web Speech API](/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API)
-- [SitePoint article](https://www.sitepoint.com/talking-web-pages-and-the-speech-synthesis-api/)

--- a/files/en-us/web/api/web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/index.md
@@ -86,4 +86,3 @@ The [Web Speech API examples](https://github.com/mdn/dom-examples/tree/main/web-
 
 - [Using the Web Speech API](/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API)
 - [SitePoint article](https://www.sitepoint.com/talking-web-pages-and-the-speech-synthesis-api/)
-- [HTML5Rocks article](https://developer.chrome.com/blog/web-apps-that-talk-introduction-to-the-speech-synthesis-api/)


### PR DESCRIPTION
Based on a conversation about the external links in this page, and related to https://github.com/mdn/content/pull/38930.

Why? It doesn't add anything that's not in the page, all the code is 2014-style and has not been updated.

I would also be happy to remove the SitePoint article if people want me to do that.