### PR TITLE
Use the {{CSSSyntaxRaw}} macro for formal syntax

### DIFF
--- a/files/en-us/web/css/-moz-float-edge/index.md
+++ b/files/en-us/web/css/-moz-float-edge/index.md
@@ -38,10 +38,7 @@ The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property speci
 
 ## Formal syntax
 
-```plain
--moz-float-edge =
-  content-box | margin-box
-```
+{{CSSSyntaxRaw(`-moz-float-edge = content-box | margin-box`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/en-us/web/css/-moz-force-broken-image-icon/index.md
@@ -28,9 +28,7 @@ The **`-moz-force-broken-image-icon`** extended CSS property can be used to forc
 
 ## Formal syntax
 
-```plain
--moz-force-broken-image-icon = {{cssxref("&lt;integer&gt;")}}
-```
+{{CSSSyntaxRaw(`-moz-force-broken-image-icon = <integer>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-moz-image-region/index.md
+++ b/files/en-us/web/css/-moz-image-region/index.md
@@ -41,10 +41,7 @@ The syntax is similar to the {{CSSxRef("clip")}} property. All four values are r
 
 ## Formal syntax
 
-```plain
- -moz-image-region =
-   <shape> | auto
-```
+{{CSSSyntaxRaw(`-moz-image-region = <shape> | auto`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-moz-orient/index.md
+++ b/files/en-us/web/css/-moz-orient/index.md
@@ -32,10 +32,7 @@ The `-moz-orient` property is specified as one of the keyword values chosen from
 
 ## Formal syntax
 
-```plain
--moz-orient =
-  inline | block | horizontal | vertical
-```
+{{CSSSyntaxRaw(`-moz-orient = inline | block | horizontal | vertical`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -45,10 +45,7 @@ The default is `none`, which disables focussing on the element and removes focus
 
 ## Formal syntax
 
-```plain
--moz-user-focus =
-  ignore | normal | none
-```
+{{CSSSyntaxRaw(`-moz-user-focus = ignore | normal | none`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -42,10 +42,7 @@ The `user-input` property is currently not on a standards track.
 
 ## Formal syntax
 
-```plain
--moz-user-input =
-  auto | none
-```
+{{CSSSyntaxRaw(`-moz-user-input = auto | none`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-border-before/index.md
+++ b/files/en-us/web/css/-webkit-border-before/index.md
@@ -60,10 +60,7 @@ The standard-track equivalent of this property is {{cssxref("border-block-start"
 
 ## Formal syntax
 
-```plain
--webkit-border-before =
-  <'border-width'> || <'border-style'> || <color>
-```
+{{CSSSyntaxRaw(`-webkit-border-before = <'border-width'> || <'border-style'> || <color>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-box-reflect/index.md
+++ b/files/en-us/web/css/-webkit-box-reflect/index.md
@@ -49,10 +49,7 @@ The **`-webkit-box-reflect`** [CSS](/en-US/docs/Web/CSS) property lets you refle
 
 ## Formal syntax
 
-```plain
--webkit-box-reflect =
-  [ above | below | right | left ]? <length>? <image>?
-```
+{{CSSSyntaxRaw(`-webkit-box-reflect = [ above | below | right | left ]? <length>? <image>?`)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -85,17 +85,7 @@ Border repeat styles, when included, are interpreted in the order of `<repeat-x>
 
 ## Formal syntax
 
-```plain
--webkit-mask-box-image: <mask-image-source> [<mask-image-offset>{4} <mask-border-repeat>{1,2} ]
-
-Where:
-
-<mask-image-source> = {{cssxref("url_value", "&lt;url&gt;")}} | <gradient> | none
-
-<mask-image-offset> = <length> | <percentage> | <number>
-
-<repeat-style> = repeat | stretch | round | space
-```
+{{CSSSyntaxRaw(`-webkit-mask-box-image = <mask-image-source> [ <mask-image-offset>{4} <mask-border-repeat>{1,2} ]`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-mask-composite/index.md
+++ b/files/en-us/web/css/-webkit-mask-composite/index.md
@@ -69,10 +69,7 @@ The **`-webkit-mask-composite`** property specifies the manner in which multiple
 
 ## Formal syntax
 
-```plain
--webkit-mask-composite =
-  <composite-style>#
-```
+{{CSSSyntaxRaw(`-webkit-mask-composite = <composite-style>#`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -58,10 +58,7 @@ The `-webkit-mask-position-x` CSS property sets the initial horizontal position 
 
 ## Formal syntax
 
-```plain
--webkit-mask-position-x =
-  [ <length-percentage> | left | center | right ]#
-```
+{{CSSSyntaxRaw(`-webkit-mask-position-x = [ <length-percentage> | left | center | right ]#`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -58,10 +58,7 @@ The `-webkit-mask-position-y` CSS property sets the initial vertical position of
 
 ## Formal syntax
 
-```plain
--webkit-mask-position-y =
-  [ <length-percentage> | top | center | bottom ]#
-```
+{{CSSSyntaxRaw(`-webkit-mask-position-y = [ <length-percentage> | top | center | bottom ]#`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-x/index.md
@@ -50,10 +50,7 @@ The `-webkit-mask-repeat-x` property specifies whether and how a mask image is r
 
 ## Formal syntax
 
-```plain
--webkit-mask-repeat-x =
-  repeat | no-repeat | space | round
-```
+{{CSSSyntaxRaw(`-webkit-mask-repeat-x = repeat | no-repeat | space | round`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-repeat-y/index.md
@@ -50,10 +50,7 @@ The `-webkit-mask-repeat-y` property sets whether and how a mask image is repeat
 
 ## Formal syntax
 
-```plain
--webkit-mask-repeat-y =
-  repeat | no-repeat | space | round
-```
+{{CSSSyntaxRaw(`-webkit-mask-repeat-y = repeat | no-repeat | space | round`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/en-us/web/css/-webkit-tap-highlight-color/index.md
@@ -35,10 +35,7 @@ A {{Cssxref("&lt;color&gt;")}}.
 
 ## Formal syntax
 
-```plain
--webkit-tap-highlight-color =
-  <color>
-```
+{{CSSSyntaxRaw(`-webkit-tap-highlight-color = <color>`)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/-webkit-text-security/index.md
+++ b/files/en-us/web/css/-webkit-text-security/index.md
@@ -29,9 +29,7 @@ browser-compat: css.properties.-webkit-text-security
 
 ## Formal syntax
 
-```plain
--webkit-text-security = circle | disc | square | none
-```
+{{CSSSyntaxRaw(`-webkit-text-security = circle | disc | square | none`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/-webkit-touch-callout/index.md
+++ b/files/en-us/web/css/-webkit-touch-callout/index.md
@@ -41,10 +41,7 @@ When a target is touched and held on iOS, Safari displays a callout information 
 
 ## Formal syntax
 
-```plain
--webkit-touch-callout =
-  default | none
-```
+{{CSSSyntaxRaw(`-webkit-touch-callout = default | none`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-stretch/index.md
+++ b/files/en-us/web/css/@font-face/font-stretch/index.md
@@ -122,7 +122,7 @@ People with dyslexia and other cognitive conditions may have difficulty reading 
 
 ## Formal syntax
 
-{{csssyntax}}
+{{CSSSyntax("font-width")}}
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -162,6 +162,8 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 
 {{CSSSyntax}}
 
+{{CSSSyntaxRaw(`<font-src>`)}}
+
 ## Examples
 
 ### Specifying font resources using url() and local()

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -160,18 +160,7 @@ To check if a font technology is supported by a browser within CSS, use the {{cs
 
 ## Formal syntax
 
-```plain
-<url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]?  |
-local( <family-name> )
-
-<font-format> = [ <string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]
-
-<font-tech> = [ <font-features-tech> | <color-font-tech> | variations | palettes | incremental-patch | incremental-range | incremental-auto ]
-
-<font-features-tech> = [ features-opentype | features-aat | features-graphite ]
-
-<color-font-tech> = [ color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]
-```
+{{CSSSyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@import/layer_function/index.md
+++ b/files/en-us/web/css/@import/layer_function/index.md
@@ -20,7 +20,7 @@ The `framework.themes.dark` is the layer into which the CSS file would be import
 
 ## Formal syntax
 
-{{CSSSyntax}}
+{{CSSSyntaxRaw(`layer() = layer( <layer-name> )`)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -88,7 +88,7 @@ In effect, there are three style states to manage in these situations — starti
 
 ## Formal syntax
 
-{{csssyntax}}
+{{CSSSyntaxRaw(`@starting-style = @starting-style { <rule-list> }`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -67,10 +67,7 @@ If the alignment is set using the element's `align` attribute, then the style is
 
 ## Formal syntax
 
-```plain
-box-align =
-  start | center | end | baseline | stretch
-```
+{{CSSSyntaxRaw(`box-align = start | center | end | baseline | stretch`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-direction/index.md
+++ b/files/en-us/web/css/box-direction/index.md
@@ -56,10 +56,7 @@ If the direction is set using the element's `dir` attribute, then the style is i
 
 ## Formal syntax
 
-```plain
-box-direction =
-  normal | reverse | inherit
-```
+{{CSSSyntaxRaw(`box-direction = normal | reverse`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-flex-group/index.md
+++ b/files/en-us/web/css/box-flex-group/index.md
@@ -40,10 +40,7 @@ The `box-flex-group` property is specified as any positive {{CSSxRef("&lt;intege
 
 ## Formal syntax
 
-```plain
-box-flex-group =
-  <integer>
-```
+{{CSSSyntaxRaw(`box-flex-group = <integer>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -63,10 +63,7 @@ A trick to make all content elements in a containing box the same size, is to gi
 
 ## Formal syntax
 
-```plain
-box-flex =
-  <number>
-```
+{{CSSSyntaxRaw(`box-flex = <number>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-lines/index.md
+++ b/files/en-us/web/css/box-lines/index.md
@@ -53,10 +53,7 @@ The `box-lines` property is specified as one of the keyword values listed below.
 
 ## Formal syntax
 
-```plain
-box-lines =
-  single | multiple
-```
+{{CSSSyntaxRaw(`box-lines = single | multiple`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-ordinal-group/index.md
+++ b/files/en-us/web/css/box-ordinal-group/index.md
@@ -38,10 +38,7 @@ The `box-ordinal-group` property is specified as any positive {{CSSxRef("&lt;int
 
 ## Formal syntax
 
-```plain
-box-ordinal-group =
-  <integer>
-```
+{{CSSSyntaxRaw(`box-ordinal-group = <integer>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-orient/index.md
+++ b/files/en-us/web/css/box-orient/index.md
@@ -55,10 +55,7 @@ HTML DOM elements lay out their contents along the inline-axis by default. This 
 
 ## Formal syntax
 
-```plain
-box-orient =
-  horizontal | vertical | inline-axis | block-axis | inherit
-```
+{{CSSSyntaxRaw(`box-orient = horizontal | vertical | inline-axis | block-axis`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/box-pack/index.md
+++ b/files/en-us/web/css/box-pack/index.md
@@ -82,10 +82,7 @@ If the packing is set using the element's `pack` attribute, then the style is ig
 
 ## Formal syntax
 
-```plain
-box-pack =
-  start | center | end | justify
-```
+{{CSSSyntaxRaw(`box-pack = start | center | end | justify`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/font-smooth/index.md
+++ b/files/en-us/web/css/font-smooth/index.md
@@ -50,10 +50,7 @@ font-smooth: unset;
 
 ## Formal syntax
 
-```plain
-font-smooth =
-  auto | never | always | <absolute-size> | <length>
-```
+{{CSSSyntaxRaw(`font-smooth = auto | never | always | <absolute-size> | <length>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/stop-color/index.md
+++ b/files/en-us/web/css/stop-color/index.md
@@ -40,7 +40,7 @@ stop-color: unset;
 
 ## Formal syntax
 
-{{csssyntax}}
+{{CSSSyntaxRaw(`stop-color = <color>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/stop-opacity/index.md
+++ b/files/en-us/web/css/stop-opacity/index.md
@@ -49,7 +49,7 @@ With `0` or `0%` set, the stop is fully transparent. With `1` or `100%` set, the
 
 ## Formal syntax
 
-{{csssyntax}}
+{{CSSSyntaxRaw(`stop-opacity = <number> | <percentage>`)}}
 
 ## Examples
 

--- a/files/en-us/web/css/user-modify/index.md
+++ b/files/en-us/web/css/user-modify/index.md
@@ -45,10 +45,7 @@ The `-moz-user-modify` property is specified as one of the keyword values from t
 
 ## Formal syntax
 
-```plain
-user-modify =
-  read-only | read-write | read-write-plaintext-only | write-only
-```
+{{CSSSyntaxRaw(`user-modify = read-only | read-write | read-write-plaintext-only | write-only`)}}
 
 ## Examples
 


### PR DESCRIPTION
This produces much more nicely rendered CSS syntax.