### PR TITLE
Change if...else to non-zero on control_flow page

### DIFF
--- a/files/en-us/webassembly/reference/control_flow/index.md
+++ b/files/en-us/webassembly/reference/control_flow/index.md
@@ -18,7 +18,7 @@ WebAssembly control flow instructions.
 - [`end`](/en-US/docs/WebAssembly/Reference/Control_flow/end)
   - : Can be used to end a `block`, `loop`, `if`, or `else`.
 - [`if...else`](/en-US/docs/WebAssembly/Reference/Control_flow/if...else)
-  - : Executes a statement if the last item on the stack is true (`1`).
+  - : Executes a statement if the last item on the stack is true (non-zero).
 - [`loop`](/en-US/docs/WebAssembly/Reference/Control_flow/loop)
   - : Creates a label that can later be branched to with a [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br).
 - [`nop`](/en-US/docs/WebAssembly/Reference/Control_flow/nop)


### PR DESCRIPTION
### Description

Update if...else conditional in WebAssembly instruction references control_flow page, from "`1`" to "non-zero".

### Motivation

Current information regarding if...else behaviour located on the control_flow reference page is incorrect and misleading, having been (understandably) overlooked when this information was clarified elsewhere on the site.

### Additional details

- [WebAssembly Reference : control flow instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Control_flow)
- [WebAssembly Reference : if...else](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Control_flow/if...else)

### Related issues and pull requests

Relates to #33959
Relates to #20193

(My apologies for any excessive spamming of the above references)