### PR TITLE
fix: remove unrelated add() method reference from openCursor() doc

### DIFF
--- a/files/en-us/web/api/idbobjectstore/opencursor/index.md
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.md
@@ -13,7 +13,6 @@ The **`openCursor()`** method of the
 and, in a separate thread, returns a new {{domxref("IDBCursorWithValue")}} object.
 Used for iterating through an object store with a cursor.
 
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/idbobjectstore/opencursor/index.md
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.md
@@ -13,8 +13,6 @@ The **`openCursor()`** method of the
 and, in a separate thread, returns a new {{domxref("IDBCursorWithValue")}} object.
 Used for iterating through an object store with a cursor.
 
-To determine if the add operation has completed successfully, listen for the results's
-`success` event.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Removed an unrelated paragraph from the `IDBObjectStore.openCursor()` documentation that incorrectly referenced the `add()` method.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The second paragraph was confusing and not relevant to `openCursor()`. It referred to handling the result of `add()`, which does not apply to cursors and could mislead readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
MDN page: https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/openCursor

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #38985

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
