### PR TITLE
Remove `port` mention for URL `protocol` documentation

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/protocol/index.md
+++ b/files/en-us/web/api/htmlanchorelement/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.protocol
 
 {{ApiRef("HTML DOM")}}
 
-The **`protocol`** property of the {{domxref("HTMLAnchorElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`. If the port is the default for the protocol (`80` for `ws:` and `http:`, `443` for `wss:` and `https:`, and `21` for `ftp:`), this property contains an empty string, `""`.
+The **`protocol`** property of the {{domxref("HTMLAnchorElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`.
 
 This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
 

--- a/files/en-us/web/api/htmlareaelement/protocol/index.md
+++ b/files/en-us/web/api/htmlareaelement/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAreaElement.protocol
 
 {{ApiRef("HTML DOM")}}
 
-The **`protocol`** property of the {{domxref("HTMLAreaElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`. If the port is the default for the protocol (`80` for `ws:` and `http:`, `443` for `wss:` and `https:`, and `21` for `ftp:`), this property contains an empty string, `""`.
+The **`protocol`** property of the {{domxref("HTMLAreaElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`.
 
 This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
 

--- a/files/en-us/web/api/location/protocol/index.md
+++ b/files/en-us/web/api/location/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Location.protocol
 
 {{ApiRef("Location")}}
 
-The **`protocol`** property of the {{domxref("Location")}} interface is a string containing the protocol or scheme of the location's URL, including the final `":"`. If the port is the default for the protocol (`80` for `ws:` and `http:`, `443` for `wss:` and `https:`, and `21` for `ftp:`), this property contains an empty string, `""`.
+The **`protocol`** property of the {{domxref("Location")}} interface is a string containing the protocol or scheme of the location's URL, including the final `":"`.
 
 This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
 

--- a/files/en-us/web/api/url/protocol/index.md
+++ b/files/en-us/web/api/url/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.URL.protocol
 
 {{ApiRef("URL API")}} {{AvailableInWorkers}}
 
-The **`protocol`** property of the {{domxref("URL")}} interface is a string containing the protocol or scheme of the URL, including the final `":"`. If the port is the default for the protocol (`80` for `ws:` and `http:`, `443` for `wss:` and `https:`, and `21` for `ftp:`), this property contains an empty string, `""`.
+The **`protocol`** property of the {{domxref("URL")}} interface is a string containing the protocol or scheme of the URL, including the final `":"`.
 
 This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove the mention of the `port` property from the URL `protocol` documentation

### Motivation

Current documentation for `protocol` was confusing because it said "**this property** contains an empty string", but actually referred to the `port` property?

Possibly a copy & paste error?

### Related issues and pull requests

Was introduced by #38029
@Josh-Cena, was the original change intentional, and am I maybe misunderstanding something here?
