### PR TITLE
Update chained JS timers throttling behaviour in Chrome 88.

### DIFF
--- a/files/en-us/web/api/window/settimeout/index.md
+++ b/files/en-us/web/api/window/settimeout/index.md
@@ -330,14 +330,14 @@ The specifics of this are browser-dependent:
   - **Minimal throttling**: Applies to timers when the page is visible, has made sound recently, or is otherwise considered active by Chrome. Timers run close to the requested interval.
 
   - **Throttling**: Applies to timers when minimal throttle conditions are not met and any of these conditions are true:
-    - Chain count (timer invocations) is lower than 5.
+    - Nesting count (i.e., number of chained timer calls) is lower than 5.
     - Page has been invisible for less than 5 minutes.
     - WebRTC is active.
 
   Timers in this state are checked once per second, which may be batched together with other timers that have similar timeouts.
 
   - **Intensive throttling**: Introduced in Chrome 88 (January 2021). Applies to timers when neither minimal throttling nor throttling conditions are met, and all of the following conditions are met:
-    - Chain count (timer invocations) is 5 or higher.
+    - Nesting count is 5 or higher.
     - Page has been invisible for more than 5 minutes.
     - Page has been silent for more than 30 seconds.
     - WebRTC is inactive.

--- a/files/en-us/web/api/window/settimeout/index.md
+++ b/files/en-us/web/api/window/settimeout/index.md
@@ -322,9 +322,27 @@ using a Web Audio API {{domxref("AudioContext")}}.
 
 The specifics of this are browser-dependent:
 
-- Firefox Desktop and Chrome both have a minimum timeout of 1 second for inactive tabs.
+- Firefox Desktop has a minimum timeout of 1 second for inactive tabs.
 - Firefox for Android has a minimum timeout of 15 minutes for inactive tabs and may unload them entirely.
 - Firefox does not throttle inactive tabs if the tab contains an {{domxref("AudioContext")}}.
+- Chrome uses different levels of throttling depending on the tab activity:
+
+  - **Minimal throttling**: Applies to timers when the page is visible, has made sound recently, or is otherwise considered active by Chrome. Timers run close to the requested interval.
+
+  - **Throttling**: Applies to timers when minimal throttle conditions are not met and any of these conditions are true:
+    - Chain count (timer invocations) is lower than 5.
+    - Page has been invisible for less than 5 minutes.
+    - WebRTC is active.
+
+  Timers in this state are checked once per second, which may be batched together with other timers that have similar timeouts.
+
+  - **Intensive throttling**: Introduced in Chrome 88 (January 2021). Applies to timers when neither minimal throttling nor throttling conditions are met, and all of the following conditions are met:
+    - Chain count (timer invocations) is 5 or higher.
+    - Page has been invisible for more than 5 minutes.
+    - Page has been silent for more than 30 seconds.
+    - WebRTC is inactive.
+
+  Timers in this state are checked once per minute, which may be batched together with other timers that have similar timeouts.
 
 #### Throttling of tracking scripts
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updated chained JS timers throttling behaviour in Chrome 88, which impacts the performance for timers in inactive tabs with chrome throttling stages.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This update clarifies the updated throttling behavior of JavaScript timers in Chrome 88, which impacts performance for timers in inactive taps. It ensures the reader is aware of chrome throttling  stages.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None.
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #38988.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
