### PR TITLE
FF138 Relnote: FedCM Login Status API

### DIFF
--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -41,7 +41,7 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 
 ### APIs
 
-- The [Login Status API](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) can be used to set and check whether any browser users are logged-in to a server, when using the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API).
+- The [Login Status API](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) is now supported when using the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API). It can be used to set and check whether a browser user is logged in to an identity provider.
   This includes support for the {{domxref("NavigatorLogin")}} interface, the {{domxref("navigator.login")}} property, and the {{httpheader("Set-Login")}} HTTP response header.
   ([Firefox bug 1945576](https://bugzil.la/1945576) and [Firefox bug 1945573](https://bugzil.la/1945573)).
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -41,6 +41,10 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 
 ### APIs
 
+- The [Login Status API](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) can be used to set and check whether any browser users are logged-in to a server, when using the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API).
+  This includes support for the {{domxref("NavigatorLogin")}} interface, the {{domxref("navigator.login")}} property, and the {{httpheader("Set-Login")}} HTTP response header.
+  ([Firefox bug 1945576](https://bugzil.la/1945576) and [Firefox bug 1945573](https://bugzil.la/1945573)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF138 adds support for the FedCM Login Status API in https://bugzilla.mozilla.org/show_bug.cgi?id=1945573 and https://bugzilla.mozilla.org/show_bug.cgi?id=1945576. This adds a release note.

Related docs work can be tracked in #38949
