### PR TITLE
FF138 ExprFeat: Notification.actions in preview

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1025,6 +1025,48 @@ This subset of the API has been implemented:
   </tbody>
 </table>
 
+### Notification.actions
+
+The {{domxref("Notification.actions","actions")}} read only property of the {{domxref("Notification")}} interface is supported in nightly.
+This contains notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}} .
+([Firefox bug 1225110](https://bugzil.la/1225110)).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>138</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>138</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>138</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>138</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.webnotifications.actions.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Graphics: Canvas, WebGL, and WebGPU
 
 #### WebGL: Draft extensions

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1027,8 +1027,8 @@ This subset of the API has been implemented:
 
 ### Notification.actions
 
-The {{domxref("Notification.actions","actions")}} read only property of the {{domxref("Notification")}} interface is supported in nightly.
-This contains notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}} .
+The {{domxref("Notification.actions","actions")}} read-only property of the {{domxref("Notification")}} interface is supported in Nightly.
+This contains notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}}.
 ([Firefox bug 1225110](https://bugzil.la/1225110)).
 
 <table>

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -83,6 +83,7 @@ To experiment with them, search for the appropriate preference on the `about:con
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
 - **`MutationEvent` on path to removal**: {{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`,`DOMAttrModified`) are now disabled on Firefox Nightly by default. ([Firefox bug 1951772](https://bugzil.la/1951772)).
+- **`Notification.actions`:** (Nightly release): The {{domxref("Notification.actions")}} property can get the actions associated with a `Notification`, as set using {{domxref("ServiceWorkerRegistration.showNotification()")}}. ([Firefox bug 1225110](https://bugzil.la/1225110)).
 
 ## Older versions
 


### PR DESCRIPTION
FF138 implements [`Notification.actions`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/actions) behind preference `dom.webnotifications.actions.enabled` (enabled on nightly) in https://bugzilla.mozilla.org/show_bug.cgi?id=1225110

This adds an experimental features entry and a release note entry.

Related docs work can be tracked in #38886
