### PR TITLE
Fix example code for picker-icon and checkmark pseudo-elements

### DIFF
--- a/files/en-us/web/css/_doublecolon_checkmark/index.md
+++ b/files/en-us/web/css/_doublecolon_checkmark/index.md
@@ -99,7 +99,7 @@ To opt-in to customizable select functionality, the `<select>` element and its p
 
 ```css
 select,
-::checkmark(select) {
+::picker(select) {
   appearance: base-select;
 }
 ```

--- a/files/en-us/web/css/_doublecolon_picker-icon/index.md
+++ b/files/en-us/web/css/_doublecolon_picker-icon/index.md
@@ -38,7 +38,7 @@ To opt-in to customizable select functionality, the `<select>` element and its p
 
 ```css
 select,
-::picker-icon(select) {
+::picker(select) {
   appearance: base-select;
 }
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR updates the example code for [picker-icon](https://developer.mozilla.org/en-US/docs/Web/CSS/::picker-icon#animating_the_picker_icon) and [checkmark](https://developer.mozilla.org/en-US/docs/Web/CSS/::checkmark#customizing_the_checkmark) to match their respective descriptions. The correct selector should be ::picker(select) for the styling to work properly.

> ### Animating the picker icon
>
> To opt-in to customizable select functionality, the `<select>` element and its picker both need to have an [appearance](https://developer.mozilla.org/en-US/docs/Web/CSS/appearance) value of `base-select` set on them:
>
> ```css
> select,
> ::picker-icon(select) {
>  appearance: base-select;
> }
> ```

> ### Customizing the checkmark
>
> To opt-in to customizable select functionality, the `<select>` element and its picker both need to have an [appearance](https://developer.mozilla.org/en-US/docs/Web/CSS/appearance) value of `base-select` set on them:
>
> ```css
> select,
> ::checkmark(select) {
>   appearance: base-select;
> }
> ```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
