### PR TITLE
Remove experimental flag from Reporting API doc

### DIFF
--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -10,9 +10,6 @@ spec-urls:
   - https://w3c.github.io/webappsec-csp/#cspviolationreportbody
   - https://wicg.github.io/deprecation-reporting/#deprecationreportbody
   - https://wicg.github.io/intervention-reporting/#intervention-report
-browser-compat:
-  - http.headers.Reporting-Endpoints
-  - http.headers.Report-To
 ---
 
 {{DefaultAPISidebar("Reporting API")}}{{AvailableInWorkers}}

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -2,6 +2,9 @@
 title: Reporting API
 slug: Web/API/Reporting_API
 page-type: web-api-overview
+browser-compat:
+  - http.headers.Reporting-Endpoints
+  - http.headers.Report-To
 spec-urls:
   - https://w3c.github.io/reporting/#intro
   - https://w3c.github.io/webappsec-csp/#cspviolationreportbody

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -2,9 +2,7 @@
 title: Reporting API
 slug: Web/API/Reporting_API
 page-type: web-api-overview
-browser-compat:
-  - http.headers.Reporting-Endpoints
-  - http.headers.Report-To
+browser-compat: http.headers.Reporting-Endpoints
 spec-urls:
   - https://w3c.github.io/reporting/#intro
   - https://w3c.github.io/webappsec-csp/#cspviolationreportbody

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -100,8 +100,6 @@ These HTTP response headers define the endpoints where reports are sent.
 - {{HTTPHeader("Reporting-Endpoints")}}
   - : Sets the name and URL of reporting endpoints.
     These endpoints can be used in the `report-to` directive, which may be used with a number of HTTP headers including {{httpheader("Content-Security-Policy")}} and or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
-- {{HTTPHeader("Report-To")}} {{deprecated_inline}}
-  - : Sets the name and URL of reporting endpoint groups, which may be used with a number of HTTP headers including `Content-Security-Policy`.
 
 Report endpoints can be set for the following reports using the `report-to` directive on the corresponding headers:
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -2,16 +2,17 @@
 title: Reporting API
 slug: Web/API/Reporting_API
 page-type: web-api-overview
-status:
-  - experimental
 spec-urls:
   - https://w3c.github.io/reporting/#intro
   - https://w3c.github.io/webappsec-csp/#cspviolationreportbody
   - https://wicg.github.io/deprecation-reporting/#deprecationreportbody
   - https://wicg.github.io/intervention-reporting/#intervention-report
+browser-compat:
+  - http.headers.Reporting-Endpoints
+  - http.headers.Report-To
 ---
 
-{{SeeCompatTable}}{{DefaultAPISidebar("Reporting API")}}{{AvailableInWorkers}}
+{{DefaultAPISidebar("Reporting API")}}{{AvailableInWorkers}}
 
 The Reporting API provides a generic reporting mechanism for web applications to use to make reports available based on various platform features (for example [Content Security Policy](/en-US/docs/Web/HTTP/Guides/CSP), [Permissions-Policy](/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy), or feature deprecation reports) in a consistent manner.
 
@@ -156,9 +157,7 @@ This causes a deprecation report to be generated; because of the event handler w
 
 ## Browser compatibility
 
-The API is supported by Chromium browsers, and by Firefox behind a preference (`dom.reporting.enabled`).
-
-See the specific interfaces for more detailed support information.
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -100,6 +100,8 @@ These HTTP response headers define the endpoints where reports are sent.
 - {{HTTPHeader("Reporting-Endpoints")}}
   - : Sets the name and URL of reporting endpoints.
     These endpoints can be used in the `report-to` directive, which may be used with a number of HTTP headers including {{httpheader("Content-Security-Policy")}} and or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
+- {{HTTPHeader("Report-To")}} {{deprecated_inline}}
+  - : No longer part of the Reporting API but still supported by some browsers. This sets the name and URL of reporting endpoint groups, which may be used with a number of HTTP headers especially for [Network Error Logging](/en-US/docs/Web/HTTP/Guides/Network_Error_Logging) that has not yet been updated to support `Reporting-Endpoints`. Other Reporting API reports should use `Reporting-Endpoints` instead for better future support.
 
 Report endpoints can be set for the following reports using the `report-to` directive on the corresponding headers:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Safari 16.4 now supports this, making two browser engines supporting it and so no longer meeting the definition of Experimental. Firefox also has it behind a flag btw.

This was recently updated in https://github.com/mdn/browser-compat-data/issues/26361 and https://github.com/mdn/browser-compat-data/pull/26380 but it's not linked to BCD here as far as I can tell so doing a manual update in this PR (and also linking it for future reference).

I also removed the reference to the deprecated `Report-To` header since it [is no longer recommended](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Report-To) and not even part of the Spec.

FYI: @yoavweiss 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Correcting data.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://github.com/WebKit/WebKit/pull/3613

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

https://github.com/mdn/browser-compat-data/issues/26361
https://github.com/mdn/browser-compat-data/pull/26380

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
