### PR TITLE
fix(htmlsidebar): Make top-level items links

### DIFF
--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -29,6 +29,7 @@ sidebar:
     path: /Web/HTML/Reference/Attributes
     title: Attributes
     details: closed
+    code: true
   - type: listSubPages
     path: /Web/HTML/Reference/Global_attributes
     title: Global_attributes

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -17,21 +17,25 @@ sidebar:
     title: Reference
   - type: listSubPages
     path: /Web/HTML/Reference/Elements
+    link: /Web/HTML/Reference/Elements
     title: HTML_Elements
     details: closed
     code: true
   - type: listSubPages
     path: /Web/HTML/Reference/Elements/input
+    link: /Web/HTML/Reference/Elements/input
     title: Input_types
     details: closed
     code: true
   - type: listSubPages
     path: /Web/HTML/Reference/Attributes
+    link: /Web/HTML/Reference/Attributes
     title: Attributes
     details: closed
     code: true
   - type: listSubPages
     path: /Web/HTML/Reference/Global_attributes
+    link: /Web/HTML/Reference/Global_attributes
     title: Global_attributes
     details: closed
     code: true

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -23,7 +23,6 @@ sidebar:
     code: true
   - type: listSubPages
     path: /Web/HTML/Reference/Elements/input
-    link: /Web/HTML/Reference/Elements/input
     title: Input_types
     details: closed
     code: true


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is is follow-up to https://github.com/mdn/content/pull/39055.

- Added the `link` key so that the landing pages for those items can be reached from the sidebar
- `code` for Attributes subpages somehow got missed in the previous iteration

### Motivation

Make content reachable from side-bar