### PR TITLE
fix typo

### DIFF
--- a/files/en-us/web/http/reference/status/102/index.md
+++ b/files/en-us/web/http/reference/status/102/index.md
@@ -26,7 +26,7 @@ This status code is only sent if the server expects the request to take signific
 
 ## Browser compatibility
 
-This feature is deprecated and browsers will ignore this response header.
+This feature is deprecated and browsers will ignore this response status code.
 
 ## See also
 


### PR DESCRIPTION
### Description

This doc is writing about "response status code", not "response header"

### Related issues and pull requests

Downstream: mdn/translated-content#26765
