### PR TITLE
Editorial review: Document <dialog> closeby attribute

### DIFF
--- a/files/en-us/web/api/htmldialogelement/closedby/index.md
+++ b/files/en-us/web/api/htmldialogelement/closedby/index.md
@@ -15,20 +15,28 @@ The **`closedBy`** property of the
 
 A string; possible values are:
 
-- `none`
+- `any`
 
-  - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a close {{htmlelement("button")}} (for example with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}}) or a {{htmlelement("form")}} submission.
+  - : The `<dialog>` element can be closed by:
+
+    - Clicking or tapping outside the `<dialog>`.
+    - Relevant platform-specific user actions such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+    - Developer-specified mechanisms such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission.
+
+    This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
 
 - `closerequest`
 
-  - : The `<dialog>` element can be closed via relevant platform-specific user actions, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+  - : The `<dialog>` element can be closed via relevant platform-specific user actions or developer-specified mechanisms.
 
-- `any`
+- `none`
 
-  - : The `<dialog>` element can be closed via relevant platform-specific user actions, or by clicking or tapping outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+  - : The `<dialog>` element can only be closed via developer-specified mechanisms.
 
-> [!NOTE]
-> If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `"closerequest"` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `"none"` if it was not.
+If the `<dialog>` element does not have a valid `closedby` value specified, then
+
+- if it was opened using {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, it behaves as if the value was `"closerequest"`
+- otherwise, it behaves as if the value was `"none"`.
 
 ## Examples
 

--- a/files/en-us/web/api/htmldialogelement/closedby/index.md
+++ b/files/en-us/web/api/htmldialogelement/closedby/index.md
@@ -1,0 +1,51 @@
+---
+title: "HTMLDialogElement: closedBy property"
+short-title: closedBy
+slug: Web/API/HTMLDialogElement/closedBy
+page-type: web-api-instance-property
+browser-compat: api.HTMLDialogElement.closedBy
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`closedBy`** property of the
+{{domxref("HTMLDialogElement")}} interface indicates the types of user actions that can be used to close it.
+
+## Value
+
+A string; possible values are:
+
+- `none`
+
+  - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a JavaScript-powered "Close" {{htmlelement("button")}} or a {{htmlelement("form")}} submission.
+
+- `closerequest`
+
+  - : The `<dialog>` element can be closed via relevant platform-specific close requests, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+
+- `any`
+
+  - : The `<dialog>` element can be closed via relevant platform-specific close requests, or by pressing outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+
+> [!NOTE]
+> If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `closerequest` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `none` if it was not.
+
+## Examples
+
+```js
+const dialogElem = document.querySelector("dialog");
+
+dialogElem.closedBy;
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{ HTMLElement("dialog") }}

--- a/files/en-us/web/api/htmldialogelement/closedby/index.md
+++ b/files/en-us/web/api/htmldialogelement/closedby/index.md
@@ -16,37 +16,15 @@ The **`closedBy`** property of the
 A string; possible values are:
 
 - `any`
-
-  - : The `<dialog>` element can be closed by:
-
-    - Clicking or tapping outside the `<dialog>`.
-    - Relevant platform-specific user actions such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
-    - Developer-specified mechanisms such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission.
-
-    This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
-
+  - : The dialog can be dismissed with a light dismiss user action, a platform-specific user action, or a developer-specified mechanism.
 - `closerequest`
-
-  - : The `<dialog>` element can be closed via relevant platform-specific user actions or developer-specified mechanisms.
-
+  - : The dialog can be dismissed with a platform-specific user action or a developer-specified mechanism.
 - `none`
-
-  - : The `<dialog>` element can only be closed via developer-specified mechanisms.
-
-If the `<dialog>` element does not have a valid `closedby` value specified, then
-
-- if it was opened using {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, it behaves as if the value was `"closerequest"`
-- otherwise, it behaves as if the value was `"none"`.
+  - : The dialog can only be dismissed with a developer-specified mechanism.
 
 ## Examples
 
 ### Basic `closedBy` usage
-
-In this example, we'll declare a `<dialog>` element, then access its `closedby` attribute value via JavaScript.
-
-#### HTML
-
-We first declare an open `<dialog>` element with a `closedby` value of `any`:
 
 ```html
 <dialog open closedby="any">
@@ -57,10 +35,6 @@ We first declare an open `<dialog>` element with a `closedby` value of `any`:
   </p>
 </dialog>
 ```
-
-#### JavaScript
-
-We then grab a reference to the `<dialog>` element in JavaScript and log its `closedby` value to the console, accessing it via the `closedBy` property:
 
 ```js
 const dialogElem = document.querySelector("dialog");

--- a/files/en-us/web/api/htmldialogelement/closedby/index.md
+++ b/files/en-us/web/api/htmldialogelement/closedby/index.md
@@ -9,7 +9,7 @@ browser-compat: api.HTMLDialogElement.closedBy
 {{ APIRef("HTML DOM") }}
 
 The **`closedBy`** property of the
-{{domxref("HTMLDialogElement")}} interface indicates the types of user actions that can be used to close it.
+{{domxref("HTMLDialogElement")}} interface indicates the types of user actions that can be used to close the associated {{htmlelement("dialog")}} element. It sets or returns the dialog's [`closedby`](/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute value.
 
 ## Value
 
@@ -17,25 +17,48 @@ A string; possible values are:
 
 - `none`
 
-  - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a JavaScript-powered "Close" {{htmlelement("button")}} or a {{htmlelement("form")}} submission.
+  - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a close {{htmlelement("button")}} (for example with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}}) or a {{htmlelement("form")}} submission.
 
 - `closerequest`
 
-  - : The `<dialog>` element can be closed via relevant platform-specific close requests, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+  - : The `<dialog>` element can be closed via relevant platform-specific user actions, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
 
 - `any`
 
-  - : The `<dialog>` element can be closed via relevant platform-specific close requests, or by pressing outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+  - : The `<dialog>` element can be closed via relevant platform-specific user actions, or by clicking or tapping outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
 
 > [!NOTE]
-> If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `closerequest` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `none` if it was not.
+> If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `"closerequest"` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `"none"` if it was not.
 
 ## Examples
+
+### Basic `closedBy` usage
+
+In this example, we'll declare a `<dialog>` element, then access its `closedby` attribute value via JavaScript.
+
+#### HTML
+
+We first declare an open `<dialog>` element with a `closedby` value of `any`:
+
+```html
+<dialog open closedby="any">
+  <h2>My dialog</h2>
+  <p>
+    Closable using the Esc key, or by clicking outside the dialog. "Light
+    dismiss" behavior.
+  </p>
+</dialog>
+```
+
+#### JavaScript
+
+We then grab a reference to the `<dialog>` element in JavaScript and log its `closedby` value to the console, accessing it via the `closedBy` property:
 
 ```js
 const dialogElem = document.querySelector("dialog");
 
-dialogElem.closedBy;
+// Logs "any" to the console
+console.log(dialogElem.closedBy);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -18,6 +18,8 @@ The **`HTMLDialogElement`** interface provides methods to manipulate {{HTMLEleme
 
 _Also inherits properties from its parent interface, {{domxref("HTMLElement")}}._
 
+- {{domxref("HTMLDialogElement.closedBy")}}
+  - : A string that sets or returns the [`closedby`](/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute of the `<dialog>` element, which indicates the types of user actions that can be used to close it.
 - {{domxref("HTMLDialogElement.open")}}
   - : A boolean value reflecting the [`open`](/en-US/docs/Web/HTML/Reference/Elements/dialog#open) HTML attribute, indicating whether the dialog is available for interaction.
 - {{domxref("HTMLDialogElement.returnValue")}}

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLDialogElement`** interface provides methods to manipulate {{HTMLEleme
 _Also inherits properties from its parent interface, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLDialogElement.closedBy")}}
-  - : A string that sets or returns the [`closedby`](/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute of the `<dialog>` element, which indicates the types of user actions that can be used to close it.
+  - : A string that sets or returns the [`closedby`](/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute value of the `<dialog>` element, which indicates the types of user actions that can be used to close it.
 - {{domxref("HTMLDialogElement.open")}}
   - : A boolean value reflecting the [`open`](/en-US/docs/Web/HTML/Reference/Elements/dialog#open) HTML attribute, indicating whether the dialog is available for interaction.
 - {{domxref("HTMLDialogElement.returnValue")}}

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLDialogElement`** interface provides methods to manipulate {{HTMLEleme
 _Also inherits properties from its parent interface, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLDialogElement.closedBy")}}
-  - : A string that sets or returns the [`closedby`](/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute value of the `<dialog>` element, which indicates the types of user actions that can be used to close it.
+  - : A string that sets or returns the [`closedby`](/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby) attribute value of the `<dialog>` element, which indicates the types of user actions that can be used to close the dialog.
 - {{domxref("HTMLDialogElement.open")}}
   - : A boolean value reflecting the [`open`](/en-US/docs/Web/HTML/Reference/Elements/dialog#open) HTML attribute, indicating whether the dialog is available for interaction.
 - {{domxref("HTMLDialogElement.returnValue")}}

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -22,25 +22,20 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
 - `closedby`
 
-  - : Specifies the types of user actions that can be used to close the `<dialog>` element. Possible values are:
+  - : Specifies the types of user actions that can be used to close the `<dialog>` element. This attribute distinguishes three methods by which a dialog might be closed:
+
+    - A _light dismiss user action_, in which the `<dialog>` is closed when the user clicks or taps outside it. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+    - A _platform-specific user action_, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+    - A developer-specified mechanism such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission
+
+    Possible values are:
 
     - `any`
-
-      - : The `<dialog>` element can be closed by:
-
-        - Clicking or tapping outside the `<dialog>`.
-        - Relevant platform-specific user actions such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
-        - Developer-specified mechanisms such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission.
-
-        This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
-
+      - : The dialog can be dismissed using any of the three methods.
     - `closerequest`
-
-      - : The `<dialog>` element can be closed via relevant platform-specific user actions or developer-specified mechanisms.
-
+      - : The dialog can be dismissed with a platform-specific user action or a developer-specified mechanism.
     - `none`
-
-      - : The `<dialog>` element can only be closed via developer-specified mechanisms.
+      - : The dialog can only be dismissed with a developer-specified mechanism.
 
     If the `<dialog>` element does not have a valid `closedby` value specified, then
 

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -26,18 +26,18 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
     - `none`
 
-      - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a JavaScript-powered "Close" {{htmlelement("button")}} or a {{htmlelement("form")}} submission.
+      - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a close {{htmlelement("button")}} (for example with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}}) or a {{htmlelement("form")}} submission.
 
     - `closerequest`
 
-      - : The `<dialog>` element can be closed via relevant platform-specific close requests, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+      - : The `<dialog>` element can be closed via relevant platform-specific user actions, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
 
     - `any`
 
-      - : The `<dialog>` element can be closed via relevant platform-specific close requests, or by pressing outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+      - : The `<dialog>` element can be closed via relevant platform-specific user actions, or by clicking or tapping outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
 
     > [!NOTE]
-    > If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `closerequest` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `none` if it was not.
+    > If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `"closerequest"` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `"none"` if it was not.
 
 - `open`
 
@@ -399,7 +399,7 @@ The rendered result is as follows:
 
 {{EmbedLiveSample("closedby-values", "100%", 300)}}
 
-Try clicking each button to open a dialog. The first one can only be closed by pressing its "Close" button. The second one can also be closed via a device specific close request such as pressing the <kbd>Esc</kbd> key. The third one has full ["light-dismiss" behavior](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), and can additionally be closed by pressing outside the dialog.
+Try clicking each button to open a dialog. The first one can only be closed by clicking its "Close" button. The second one can also be closed via a device specific user action such as pressing the <kbd>Esc</kbd> key. The third one has full ["light-dismiss" behavior](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), and can additionally be closed by clicking or tapping outside the dialog.
 
 ### Animating dialogs
 

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -20,6 +20,25 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 > [!WARNING]
 > The `tabindex` attribute must not be used on the `<dialog>` element. See [usage notes](#usage_notes).
 
+- `closedby`
+
+  - : Specifies the types of user actions that can be used to close the `<dialog>` element. Possible values are:
+
+    - `none`
+
+      - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a JavaScript-powered "Close" {{htmlelement("button")}} or a {{htmlelement("form")}} submission.
+
+    - `closerequest`
+
+      - : The `<dialog>` element can be closed via relevant platform-specific close requests, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+
+    - `any`
+
+      - : The `<dialog>` element can be closed via relevant platform-specific close requests, or by pressing outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+
+    > [!NOTE]
+    > If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `closerequest` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `none` if it was not.
+
 - `open`
 
   - : Indicates that the dialog box is active and is available for interaction. If the `open` attribute is not set, the dialog box will not be visible to the user.
@@ -271,6 +290,116 @@ jsCloseBtn.addEventListener("click", (e) => {
 {{EmbedLiveSample("Closing a dialog with a required form input", "100%", 300)}}
 
 From the output, we see it is impossible to close the dialog using the _Normal close_ button. But the dialog can be closed if we bypass the form validation using the `formnovalidate` attribute on the _Cancel_ button. Programmatically, `dialog.close()` will also close such dialog.
+
+### Comparison of different closedby behaviors
+
+This example demonstrates the difference in behavior between different values of the [`closedby`](#closedby) attribute.
+
+#### HTML
+
+We provide three {{htmlelement("button")}} elements and three {{htmlelement("dialog")}} elements. Each button will be programmed to open a different dialog that demonstrates the behavior one of the three values of the `closedby` attribute — `none`, `closedby`, and `any`. Note that each `<dialog>` element contains a `<button>` element that will be used to close it.
+
+```html live-sample___closedbyvalues
+<p>Choose a <code>&lt;dialog&gt;</code> type to show:</p>
+<div id="controls">
+  <button id="none-btn"><code>closedby="none"</code></button>
+  <button id="closerequest-btn">
+    <code>closedby="closerequest"</code>
+  </button>
+  <button id="any-btn"><code>closedby="any"</code></button>
+</div>
+
+<dialog closedby="none">
+  <h2><code>closedby="none"</code></h2>
+  <p>
+    Only closable using a specific provided mechanism, which in this case is
+    pressing the "Close" button below.
+  </p>
+  <button class="close">Close</button>
+</dialog>
+
+<dialog closedby="closerequest">
+  <h2><code>closedby="closerequest"</code></h2>
+  <p>Closable using the "Close" button or the Esc key.</p>
+  <button class="close">Close</button>
+</dialog>
+
+<dialog closedby="any">
+  <h2><code>closedby="any"</code></h2>
+  <p>
+    Closable using the "Close" button, the Esc key, or by clicking outside the
+    dialog. "Light dismiss" behavior.
+  </p>
+  <button class="close">Close</button>
+</dialog>
+```
+
+```css hidden live-sample___closedbyvalues
+body {
+  font-family: sans-serif;
+}
+
+#controls {
+  display: flex;
+  justify-content: space-around;
+}
+
+dialog {
+  width: 480px;
+  border-radius: 5px;
+  border-color: rgb(0 0 0 / 0.3);
+}
+
+dialog h2 {
+  margin: 0;
+}
+
+dialog p {
+  line-height: 1.4;
+}
+```
+
+#### JavaScript
+
+Here we assign different variables to reference the main control `<button>` elements, the `<dialog>` elements, and the "Close" `<button>` elements inside the dialogs. First we assign a [`click`](/en-US/docs/Web/API/Element/click_event) event listener to each control button using [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener), the event handler function of which opens the associated `<dialog>` element via [`showModal()`](/en-US/docs/Web/API/HTMLDialogElement/showModal). We then loop through the "Close" `<button>` references, assigning each one a `click` event handler function that closes its `<dialog>` element via [`close()`](/en-US/docs/Web/API/HTMLDialogElement/close).
+
+```js live-sample___closedbyvalues
+const noneBtn = document.getElementById("none-btn");
+const closerequestBtn = document.getElementById("closerequest-btn");
+const anyBtn = document.getElementById("any-btn");
+
+const noneDialog = document.querySelector("[closedby='none']");
+const closerequestDialog = document.querySelector("[closedby='closerequest']");
+const anyDialog = document.querySelector("[closedby='any']");
+
+const closeBtns = document.querySelectorAll(".close");
+
+noneBtn.addEventListener("click", () => {
+  noneDialog.showModal();
+});
+
+closerequestBtn.addEventListener("click", () => {
+  closerequestDialog.showModal();
+});
+
+anyBtn.addEventListener("click", () => {
+  anyDialog.showModal();
+});
+
+closeBtns.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    btn.parentElement.close();
+  });
+});
+```
+
+#### Result
+
+The rendered result is as follows:
+
+{{EmbedLiveSample("closedby-values", "100%", 300)}}
+
+Try clicking each button to open a dialog. The first one can only be closed by pressing its "Close" button. The second one can also be closed via a device specific close request such as pressing the <kbd>Esc</kbd> key. The third one has full ["light-dismiss" behavior](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), and can additionally be closed by pressing outside the dialog.
 
 ### Animating dialogs
 

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -24,20 +24,28 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
   - : Specifies the types of user actions that can be used to close the `<dialog>` element. Possible values are:
 
-    - `none`
+    - `any`
 
-      - : No user actions can be used to close the `<dialog>` element, only developer-specified mechanisms such as a close {{htmlelement("button")}} (for example with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}}) or a {{htmlelement("form")}} submission.
+      - : The `<dialog>` element can be closed by:
+
+        - Clicking or tapping outside the `<dialog>`.
+        - Relevant platform-specific user actions such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+        - Developer-specified mechanisms such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission.
+
+        This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
 
     - `closerequest`
 
-      - : The `<dialog>` element can be closed via relevant platform-specific user actions, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
+      - : The `<dialog>` element can be closed via relevant platform-specific user actions or developer-specified mechanisms.
 
-    - `any`
+    - `none`
 
-      - : The `<dialog>` element can be closed via relevant platform-specific user actions, or by clicking or tapping outside the `<dialog>`. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
+      - : The `<dialog>` element can only be closed via developer-specified mechanisms.
 
-    > [!NOTE]
-    > If the `<dialog>` element does not have a `closedby` value specified, or it is specified with an invalid value, it behaves as if the value was `"closerequest"` if the `<dialog>` was shown via {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, or `"none"` if it was not.
+    If the `<dialog>` element does not have a valid `closedby` value specified, then
+
+    - if it was opened using {{domxref("HTMLDialogElement.showModal()", "showModal()")}}, it behaves as if the value was `"closerequest"`
+    - otherwise, it behaves as if the value was `"none"`.
 
 - `open`
 
@@ -297,7 +305,7 @@ This example demonstrates the difference in behavior between different values of
 
 #### HTML
 
-We provide three {{htmlelement("button")}} elements and three {{htmlelement("dialog")}} elements. Each button will be programmed to open a different dialog that demonstrates the behavior one of the three values of the `closedby` attribute — `none`, `closedby`, and `any`. Note that each `<dialog>` element contains a `<button>` element that will be used to close it.
+We provide three {{htmlelement("button")}} elements and three `<dialog>` elements. Each button will be programmed to open a different dialog that demonstrates the behavior of one of the three values of the `closedby` attribute — `none`, `closerequest`, and `any`. Note that each `<dialog>` element contains a `<button>` element that will be used to close it.
 
 ```html live-sample___closedbyvalues
 <p>Choose a <code>&lt;dialog&gt;</code> type to show:</p>
@@ -399,7 +407,7 @@ The rendered result is as follows:
 
 {{EmbedLiveSample("closedby-values", "100%", 300)}}
 
-Try clicking each button to open a dialog. The first one can only be closed by clicking its "Close" button. The second one can also be closed via a device specific user action such as pressing the <kbd>Esc</kbd> key. The third one has full ["light-dismiss" behavior](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), and can additionally be closed by clicking or tapping outside the dialog.
+Try clicking each button to open a dialog. The first one can only be closed by clicking its "Close" button. The second one can also be closed via a device-specific user action such as pressing the <kbd>Esc</kbd> key. The third one has full ["light-dismiss" behavior](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), so it can also be closed by clicking or tapping outside the dialog.
 
 ### Animating dialogs
 

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -26,7 +26,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
     - A _light dismiss user action_, in which the `<dialog>` is closed when the user clicks or taps outside it. This is equivalent to the ["light dismiss" behavior of "auto" state popovers](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss).
     - A _platform-specific user action_, such as pressing the <kbd>Esc</kbd> key on desktop platforms, or a "back" or "dismiss" gesture on mobile platforms.
-    - A developer-specified mechanism such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission
+    - A developer-specified mechanism such as a {{htmlelement("button")}} with a [`click`](/en-US/docs/Web/API/Element/click_event) handler that invokes {{domxref("HTMLDialogElement.close()")}} or a {{htmlelement("form")}} submission.
 
     Possible values are:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 134 supports the `closedby` attribute of the `<dialog>` element: see https://chromestatus.com/feature/5097714453577728.

This PR documents the new attribute, plus the equivalent DOM property.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
