### PR TITLE
Fix CSS syntax errors

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/combinators/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/combinators/index.md
@@ -65,7 +65,9 @@ In the example below, we are matching only the `<p>` element which is inside an 
 The **child combinator** (`>`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the direct children of elements matched by the first. Descendant elements further down the hierarchy don't match. For example, to select only `<p>` elements that are direct children of `<article>` elements:
 
 ```css
-article > p
+article > p {
+  /* … */
+}
 ```
 
 In this next example, we have an ordered list ({{htmlelement("ol")}}) nested inside an unordered list ({{htmlelement("ul")}}). The child combinator selects only those `<li>` elements which are direct children of a `<ul>`, and styles them with a top border.
@@ -98,7 +100,9 @@ ul > li {
 The **next-sibling combinator** (`+`) is placed between two CSS selectors. It matches only those elements matched by the second selector that come right after the element matched by the first selector. For example, to select all `<img>` elements that are immediately preceded by a `<p>` element:
 
 ```css
-p + img
+p + img {
+  /* … */
+}
 ```
 
 A common use case is to do something with a paragraph that follows a heading, as in the example below. In that example, we are looking for any paragraph which shares a parent element with an `<h1>`, and immediately follows that `<h1>`.
@@ -141,7 +145,9 @@ h1 + p {
 If you want to select siblings of an element even if they are not directly adjacent, then you can use the **subsequent-sibling combinator** (`~`). To select all `<img>` elements that come _anywhere_ after `<p>` elements, we'd do this:
 
 ```css
-p ~ img
+p ~ img {
+  /* … */
+}
 ```
 
 In the example below we are selecting all `<p>` elements that come after the `<h1>`, and even though there is a `<div>` in the document as well, the `<p>` that comes after it is selected.

--- a/files/en-us/learn_web_development/extensions/testing/html_and_css/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/html_and_css/index.md
@@ -212,7 +212,9 @@ For example, in the Firefox dev tools, you get this kind of output at the bottom
 If for example you were trying to use this selector, you'd be able to see that it wouldn't select the input element as desired:
 
 ```css
-form > #date
+form > #date {
+  /* … */
+}
 ```
 
 (The `date` form input isn't a direct child of the `<form>`; you'd be better off using a general descendant selector instead of a child selector).

--- a/files/en-us/web/accessibility/guides/colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/guides/colors_and_luminance/index.md
@@ -87,12 +87,12 @@ color: lab(60 93.56 -60.5);
 color: lab(60 93.56 -60.5 / 1);
 
 /* representation in the CIELAB color spaces */
-oklch(0.7 0.32 328.37);
-oklch(0.7 0.32 328.37 / 1);
+color: oklch(0.7 0.32 328.37);
+color: oklch(0.7 0.32 328.37 / 1);
 
 /* color() function in the XYZ color space */
-color(xyz-d65 0.59 0.28 0.96);
-color(xyz-d65 0.59 0.28 0.96 / 1);
+color: color(xyz-d65 0.59 0.28 0.96);
+color: color(xyz-d65 0.59 0.28 0.96 / 1);
 ```
 
 The first example uses one of the defined [named colors](/en-US/docs/Web/CSS/named-color).

--- a/files/en-us/web/api/cssstylevalue/parse_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse_static/index.md
@@ -43,7 +43,7 @@ const css = CSSStyleValue.parse(
 );
 ```
 
-```css
+```plain
 CSSTransformValue {0: CSSTranslate, 1: CSSScale, length: 2, is2D: false}
 ```
 

--- a/files/en-us/web/css/@container/index.md
+++ b/files/en-us/web/css/@container/index.md
@@ -146,9 +146,15 @@ The `<container-condition>` queries include [size](#size_container_descriptors) 
 The `<container-condition>` can include one or more boolean size queries, each within a set of parentheses. A size query includes a size descriptor, a value, and — depending on the descriptor — a comparison operator. The syntax for including multiple conditions is the same as for [`@media`](/en-US/docs/Web/CSS/@media) size feature queries.
 
 ```css
-@container (min-width: 400px) { ... }
-@container (orientation: landscape) and (width > 400px) { ... }
-@container (15em <= block-size <= 30em) { ... }
+@container (min-width: 400px) {
+  /* … */
+}
+@container (orientation: landscape) and (width > 400px) {
+  /* … */
+}
+@container (15em <= block-size <= 30em) {
+  /* … */
+}
 ```
 
 - `aspect-ratio`
@@ -179,9 +185,15 @@ The `<container-condition>` can include one or more boolean size queries, each w
 Scroll-state container descriptors are specified inside the `<container-condition>` within a set of parentheses following the `scroll-state` keyword, for example:
 
 ```css
-@container scroll-state(scrollable: top) { ... }
-@container scroll-state(stuck: inline-end) { ... }
-@container scroll-state(snapped: both) { ... }
+@container scroll-state(scrollable: top) {
+  /* … */
+}
+@container scroll-state(stuck: inline-end) {
+  /* … */
+}
+@container scroll-state(snapped: both) {
+  /* … */
+}
 ```
 
 Supported keywords for scroll-state container descriptors include physical and {{glossary("flow relative values")}}
@@ -222,7 +234,9 @@ Supported keywords for scroll-state container descriptors include physical and {
     To evaluate whether a container is scrollable, without being concerned about the direction, use the `none` value with the `not` operator:
 
     ```css
-    @container not scroll-state(scrollable: none) { ... }
+    @container not scroll-state(scrollable: none) {
+      /* … */
+    }
     ```
 
 - `snapped`
@@ -249,7 +263,9 @@ Supported keywords for scroll-state container descriptors include physical and {
     To evaluate whether a container is a snap target, without being concerned about the direction, use the `none` value with the `not` operator:
 
     ```css
-    @container not scroll-state(snapped: none) { ... }
+    @container not scroll-state(snapped: none) {
+      /* … */
+    }
     ```
 
 - `stuck`
@@ -280,19 +296,25 @@ Supported keywords for scroll-state container descriptors include physical and {
     It is possible for two values from opposite axes to match at the same time:
 
     ```css
-    @container scroll-state((stuck: top) and (stuck: left)) { ... }
+    @container scroll-state((stuck: top) and (stuck: left)) {
+      /* … */
+    }
     ```
 
     However, two values from opposite edges will never match at the same time:
 
     ```css
-    @container scroll-state((stuck: left) and (stuck: right)) { ... }
+    @container scroll-state((stuck: left) and (stuck: right)) {
+      /* … */
+    }
     ```
 
     To evaluate whether a container is stuck, without being concerned about the direction, use the `none` value with the `not` operator:
 
     ```css
-    @container not scroll-state(stuck: none) { ... }
+    @container not scroll-state(stuck: none) {
+      /* … */
+    }
     ```
 
 ## Formal syntax

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -19,7 +19,7 @@ The `@scope` at-rule contains one or more rulesets (termed **scoped style rules*
 
    ```css
    @scope (scope root) to (scope limit) {
-     rulesets
+     /* … */
    }
    ```
 
@@ -136,11 +136,17 @@ The three rules in the following block are all equivalent in what they select:
 
 ```css
 @scope (.feature) {
-  img { ... }
+  img {
+    /* … */
+  }
 
-  :scope img { ... }
+  :scope img {
+    /* … */
+  }
 
-  & img { ... }
+  & img {
+    /* … */
+  }
 }
 ```
 
@@ -150,14 +156,18 @@ The three rules in the following block are all equivalent in what they select:
 
   ```css
   /* figure is only a limit when it is a direct child of the :scope */
-  @scope (.article-body) to (:scope > figure) { ... }
+  @scope (.article-body) to (:scope > figure) {
+    /* … */
+  }
   ```
 
 - A scope limit can reference elements outside the scope root using `:scope`. For example:
 
   ```css
   /* figure is only a limit when the :scope is inside .feature */
-  @scope (.article-body) to (.feature :scope figure) { ... }
+  @scope (.article-body) to (.feature :scope figure) {
+    /* … */
+  }
   ```
 
 - Scoped style rules can't escape the subtree. Selections like `:scope + p` are invalid because that selection would be outside the subtree.
@@ -180,7 +190,9 @@ Including a ruleset inside a `@scope` block does not affect the specificity of i
 ```css
 @scope (.article-body) {
   /* img has a specificity of 0-0-1, as expected */
-  img { ... }
+  img {
+    /* … */
+  }
 }
 ```
 
@@ -189,7 +201,9 @@ However, if you decide to explicitly prepend the `:scope` pseudo-class to your s
 ```css
 @scope (.article-body) {
   /* :scope img has a specificity of 0-1-0 + 0-0-1 = 0-1-1 */
-  :scope img { ... }
+  :scope img {
+    /* … */
+  }
 }
 ```
 
@@ -197,7 +211,9 @@ When using the `&` selector inside a `@scope` block, `&` represents the scope ro
 
 ```css
 @scope (figure, #primary) {
-  & img { ... }
+  & img {
+    /* … */
+  }
 }
 ```
 
@@ -210,10 +226,14 @@ When using the `&` selector inside a `@scope` block, `&` represents the scope ro
 ```css
 @scope (.feature) {
   /* Selects a .feature inside the matched root .feature */
-  & & { ... }
+  & & {
+    /* … */
+  }
 
   /* Doesn't work */
-  :scope :scope { ... }
+  :scope :scope {
+    /* … */
+  }
 }
 ```
 

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -17,7 +17,7 @@ The `@starting-style` at rule can be used in two ways:
 
    ```css
    @starting-style {
-     rulesets
+     /* rulesets */
    }
    ```
 
@@ -28,7 +28,7 @@ The `@starting-style` at rule can be used in two ways:
      /* ... */
 
      @starting-style {
-       declarations
+       /* declarations */
      }
    }
    ```

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -24,7 +24,8 @@ The `@starting-style` at rule can be used in two ways:
 2. Nested within an existing ruleset, in which case it contains one or more declarations defining starting property values for the elements already selected by that ruleset:
 
    ```css
-   selector { /* existing ruleset */
+   selector {
+     /* existing ruleset */
      /* ... */
 
      @starting-style {

--- a/files/en-us/web/css/_colon_nth-last-child/index.md
+++ b/files/en-us/web/css/_colon_nth-last-child/index.md
@@ -82,7 +82,8 @@ By passing a selector argument, we can select the **nth-last** element that matc
 > This is different from moving the selector outside of the function, like:
 
 ```css
-li.important: nth-last-child(-n + 3);
+li.important:nth-last-child(-n + 3) {
+}
 ```
 
 This selector applies a style to list items if they are also within the last three children.

--- a/files/en-us/web/css/animation-range-start/index.md
+++ b/files/en-us/web/css/animation-range-start/index.md
@@ -147,7 +147,7 @@ Last, an animation is specified on the element that animates its opacity and sca
   }
 
   to {
-    opacity: 1,
+    opacity: 1;
     transform: scaleX(1);
   }
 }

--- a/files/en-us/web/css/animation-range/index.md
+++ b/files/en-us/web/css/animation-range/index.md
@@ -204,7 +204,7 @@ Last, an animation is specified on the element that animates its opacity and sca
   }
 
   to {
-    opacity: 1,
+    opacity: 1;
     transform: scaleX(1);
   }
 }

--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -30,13 +30,17 @@ li.spacious.elegant {
 ## Syntax
 
 ```css
-.class_name { style properties }
+.class_name {
+  /* … */
+}
 ```
 
 Note that this is equivalent to the following [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors):
 
 ```css
-[class~=class_name] { style properties }
+[class~="class_name"] {
+  /* … */
+}
 ```
 
 The `class_name` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident). HTML `class` attributes which are not valid CSS identifiers must be [escaped](/en-US/docs/Web/CSS/ident#escaping_characters) before they can be used in class selectors.

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -116,22 +116,22 @@ The `exp()` function can be useful for strategies like CSS modular scale, which 
 
 ```css
 h1 {
-  font-size: calc(1rem * exp(1.25)); // 3.4903429574618414rem
+  font-size: calc(1rem * exp(1.25)); /* 3.4903429574618414rem */
 }
 h2 {
-  font-size: calc(1rem * exp(1)); // 2.718281828459045rem
+  font-size: calc(1rem * exp(1)); /* 2.718281828459045rem */
 }
 h3 {
-  font-size: calc(1rem * exp(0.75)); // 2.117000016612675rem
+  font-size: calc(1rem * exp(0.75)); /* 2.117000016612675rem */
 }
 h4 {
-  font-size: calc(1rem * exp(0.5)); // 1.6487212707001282rem
+  font-size: calc(1rem * exp(0.5)); /* 1.6487212707001282rem */
 }
 h5 {
-  font-size: calc(1rem * exp(0.25)); // 1.2840254166877414rem
+  font-size: calc(1rem * exp(0.25)); /* 1.2840254166877414rem */
 }
 h6 {
-  font-size: calc(1rem * exp(0)); // 1rem
+  font-size: calc(1rem * exp(0)); /* 1rem */
 }
 ```
 

--- a/files/en-us/web/css/id_selectors/index.md
+++ b/files/en-us/web/css/id_selectors/index.md
@@ -19,13 +19,17 @@ The CSS **ID selector** matches an element based on the value of the element's [
 ## Syntax
 
 ```css
-#id_value { style properties }
+#id_value {
+  /* … */
+}
 ```
 
 Note that syntactically (but not specificity-wise), this is equivalent to the following [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors):
 
 ```css
-[id=id_value] { style properties }
+[id="id_value"] {
+  /* … */
+}
 ```
 
 The `id_value` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident). HTML `id` attributes which are not valid CSS identifiers must be [escaped](/en-US/docs/Web/CSS/ident#escaping_characters) before they can be used in ID selectors.

--- a/files/en-us/web/css/image/image/index.md
+++ b/files/en-us/web/css/image/image/index.md
@@ -58,7 +58,7 @@ The background image of the element will be the portion of the image _myImage.we
 
 The `#xywh=#,#,#,#` media fragment syntax takes four comma separated numeric values. The first two represent the X and Y coordinates for the starting point of the box that will be created. The third value is the width of the box, and the last value is the height. By default, these are pixel values. The [spacial dimension definition in the media specification](https://www.w3.org/TR/media-frags/#naming-space) indicates that percentages will be supported as well:
 
-```css
+```plain
 xywh=160,120,320,240        /* results in a 320x240 image at x=160 and y=120 */
 xywh=pixel:160,120,320,240  /* results in a 320x240 image at x=160 and y=120 */
 xywh=percent:25,25,50,50    /* results in a 50%x50% image at x=25% and y=25% */

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -269,6 +269,7 @@ body {
   80%, 100% {
     offset-distance: 100%;
   }
+}
 ```
 
 ```html hidden

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -226,10 +226,10 @@ body {
 }
 
 .container {
-   transform-style: preserve-3d;
-   width: 150px;
-   height: 100px;
-   border: 2px dotted green;
+  transform-style: preserve-3d;
+  width: 150px;
+  height: 100px;
+  border: 2px dotted green;
 }
 
 .shape {
@@ -263,10 +263,12 @@ body {
 }
 
 @keyframes move {
-  0%, 20% {
+  0%,
+  20% {
     offset-distance: 0%;
   }
-  80%, 100% {
+  80%,
+  100% {
     offset-distance: 100%;
   }
 }

--- a/files/en-us/web/css/view-timeline-axis/index.md
+++ b/files/en-us/web/css/view-timeline-axis/index.md
@@ -154,7 +154,7 @@ p {
   }
 
   to {
-    opacity: 1,
+    opacity: 1;
     transform: scaleX(1);
   }
 }

--- a/files/en-us/web/css/view-timeline-inset/index.md
+++ b/files/en-us/web/css/view-timeline-inset/index.md
@@ -157,7 +157,7 @@ Last, an animation is specified on the element that animates its opacity and sca
   }
 
   to {
-    opacity: 1,
+    opacity: 1;
     transform: scaleX(1);
   }
 }

--- a/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
@@ -131,7 +131,7 @@ h2 {
   width: 100%;
   .wrapper {
     flex: 1 1;
-    margin: 0
+    margin: 0;
     padding: 0;
   }
   h3 {


### PR DESCRIPTION
### Description

Remove the extra whitespace and replace the semicolon(`;`) with braces(`{}`).