### PR TITLE
ElementInternals.aria* examples

### DIFF
--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -33,7 +33,6 @@ class MyCustomElement extends HTMLElement {
     this.internals_ = this.attachInternals();
     this.internals_.ariaAtomic = "true";
   }
-  // …
 }
 ```
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -31,7 +31,14 @@ class MyCustomElement extends HTMLElement {
   constructor() {
     super();
     this.internals_ = this.attachInternals();
-    this.internals_.ariaAtomic = "true";
+    class CustomEl extends HTMLElement {
+      constructor() {
+        super();
+        this.internals_ = this.attachInternals();
+        this.internals_.ariaAtomic = "true";
+      }
+      // …
+    }
   }
 }
 ```

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -31,15 +31,9 @@ class MyCustomElement extends HTMLElement {
   constructor() {
     super();
     this.internals_ = this.attachInternals();
-    class CustomEl extends HTMLElement {
-      constructor() {
-        super();
-        this.internals_ = this.attachInternals();
-        this.internals_.ariaAtomic = "true";
-      }
-      // …
-    }
+    this.internals_.ariaAtomic = "true";
   }
+  // …
 }
 ```
 

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -31,7 +31,14 @@ A string with one of the following values:
 In this example the value of `ariaAutoComplete` is set to "inline".
 
 ```js
-this.internals_.ariaAutoComplete = "inline";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaAutoComplete = "inline";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaBusy` is set to "true".
 
 ```js
-this.internals_.ariaBusy = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaBusy = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -31,7 +31,14 @@ A string with one of the following values:
 In this example the value of `ariaChecked` is set to "true".
 
 ```js
-this.internals_.ariaChecked = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaChecked = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -22,7 +22,14 @@ A string.
 In this example the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-colcount) attribute is set to "3".
 
 ```js
-this.internals_.ariaColCount = "3";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaColCount = "3";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -22,7 +22,14 @@ A string which contains an integer.
 In this example the value of `ariaColIndex` is set to "2".
 
 ```js
-this.internals_.ariaColIndex = "2";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaColIndex = "2";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -21,7 +21,14 @@ A string.
 In this example the value of `ariaColIndexText` is set to "Column name".
 
 ```js
-this.internals_.ariaColIndexText = "Column name";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaColIndexText = "Column name";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -22,7 +22,14 @@ A string which contains an integer.
 In this example the value of `ariaColspan` is set to "2".
 
 ```js
-this.internals_.ariaColspan = "2";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaColspan = "2";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -37,7 +37,14 @@ A string with one of the following values:
 In this example the value of `ariaCurrent` is set to "page".
 
 ```js
-this.internals_.ariaCurrent = "page";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaCurrent = "page";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -22,7 +22,14 @@ A string.
 In this example the value of `ariaDescription` is set to "A description of this widget".
 
 ```js
-this.internals_.ariaDescription = "A description of this widget";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaDescription = "A description of this widget";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaDisabled` is set to "true".
 
 ```js
-this.internals_.ariaDisabled = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaDisabled = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -29,7 +29,21 @@ A string with one of the following values:
 In this example the value of `ariaExpanded` is set to "true".
 
 ```js
-this.internals_.ariaExpanded = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    class CustomControl extends HTMLElement {
+      constructor() {
+        super();
+        this.internals_ = this.attachInternals();
+        this.internals_.ariaInvalid = "false";
+      }
+      // …
+    }
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -33,14 +33,7 @@ class CustomControl extends HTMLElement {
   constructor() {
     super();
     this.internals_ = this.attachInternals();
-    class CustomControl extends HTMLElement {
-      constructor() {
-        super();
-        this.internals_ = this.attachInternals();
-        this.internals_.ariaInvalid = "false";
-      }
-      // …
-    }
+    this.internals_.ariaInvalid = "true";
   }
   // …
 }

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -37,7 +37,14 @@ A string with one of the following values:
 In this example the value of `ariaHasPopup` is set to "true".
 
 ```js
-this.internals_.ariaHasPopup = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaHasPopup = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariahidden/index.md
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.md
@@ -29,7 +29,14 @@ A string with one of the following values:
 In this example the value of `ariaHidden` is set to "true".
 
 ```js
-this.internals_.ariaHidden = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaHidden = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -22,7 +22,14 @@ A string.
 In this example the value of `ariaLabel` is set to "close".
 
 ```js
-this.internals_.ariaLabel = "close";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaLabel = "close";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -22,7 +22,14 @@ A string containing an integer.
 In this example the value of `ariaLevel` is set to "1".
 
 ```js
-this.internals_.ariaLevel = "1";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaLevel = "1";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/arialive/index.md
+++ b/files/en-us/web/api/elementinternals/arialive/index.md
@@ -29,7 +29,14 @@ A string with one of the following values:
 In this example the value of `ariaLive` is set to "assertive".
 
 ```js
-this.internals_.ariaLive = "assertive";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaLive = "assertive";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaModal` is set to "true".
 
 ```js
-this.internals_.ariaModal = "true";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaModal = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaMultiLine` is set to "true".
 
 ```js
-this.internals_.ariaMultiLine = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaMultiLine = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaMultiSelectable` is set to "true".
 
 ```js
-this.internals_.ariaMultiSelectable = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaMultiSelectable = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.md
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.md
@@ -29,7 +29,14 @@ A string with one of the following values:
 In this example the value of `ariaOrientation` is set to "vertical".
 
 ```js
-this.internals_.ariaOrientation = "vertical";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaOrientation = "vertical";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -22,7 +22,14 @@ A string.
 In this example the value of `ariaPlaceholder` is set to "12345".
 
 ```js
-this.internals_.ariaPlaceholder = "12345";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaPlaceholder = "12345";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -22,7 +22,14 @@ A string containing an integer.
 In this example the value of `ariaPosInSet` is set to "2".
 
 ```js
-this.internals_.ariaPosInSet = "2";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaPosInSet = "2";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -31,7 +31,14 @@ A string with one of the following values:
 In this example the value of `ariaPressed` is set to "true".
 
 ```js
-this.internals_.ariaPressed = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaPressed = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaReadOnly` is set to "true".
 
 ```js
-this.internals_.ariaReadonly = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaReadonly = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -33,7 +33,14 @@ A string containing one or more of the following values, space separated:
 In this example the value of `ariaRelevant` is set to "all".
 
 ```js
-this.internals_.ariaRelevant = "all";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRelevant = "all";
+  }
+  // …
+}
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -27,7 +27,14 @@ A string with one of the following values:
 In this example the value of `ariaRequired` is set to "true".
 
 ```js
-this.internals_.ariaRequired = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRequired = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -22,7 +22,14 @@ A string.
 In this example the value of `ariaRoleDescription` is set to "My custom widget".
 
 ```js
-this.internals_.ariaRoleDescription = "My custom widget";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRoleDescription = "My custom widget";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -22,7 +22,14 @@ A string which contains an integer.
 In this example the value of `ariaRowCount` is set to "100".
 
 ```js
-this.internals_.ariaRowCount = "100";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRowCount = "100";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -22,7 +22,14 @@ A string which contains an integer.
 In this example the value of `ariaRowIndex` is set to "1".
 
 ```js
-this.internals_.ariaRowIndex = "1";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRowIndex = "1";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -21,7 +21,14 @@ A string.
 In this example the value of `ariaRowIndexText` is set to "Heading row".
 
 ```js
-this.internals_.ariaRowIndexText = "Heading row";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRowIndexText = "Heading row";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -22,7 +22,14 @@ A string which contains an integer.
 In this example the value of `ariaRowSpan` is set to "2".
 
 ```js
-this.internals_.ariaRowSpan = "2";
+class CustomEl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaRowSpan = "2";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -29,7 +29,14 @@ A string with one of the following values:
 In this example the value of `ariaSelected` is set to "true".
 
 ```js
-this.internals_.ariaSelected = "true";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaSelected = "true";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -22,7 +22,14 @@ A string containing an integer.
 In this example the value of `ariaSetSize` is set to "4".
 
 ```js
-this.internals_.ariaSetSize = "4";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaSetSize = "4";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -31,7 +31,14 @@ A string with one of the following values:
 In this example the value of `ariaSort` is set to "ascending".
 
 ```js
-this.internals_.ariaSort = "ascending";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaSort = "ascending";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.md
@@ -22,7 +22,14 @@ A string which contains a number.
 In this example the value of `ariaValueMax` is set to "20".
 
 ```js
-this.internals_.ariaValueMax = "20";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaValueMax = "20";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.md
@@ -22,7 +22,14 @@ A string which contains a number.
 In this example the value of `ariaValueMin` is set to "10".
 
 ```js
-this.internals_.ariaValueMin = "10";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaValueMin = "10";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.md
@@ -22,7 +22,14 @@ A string which contains a number.
 In this example the value of `ariaValueNow` is set to "1".
 
 ```js
-this.internals_.ariaValueNow = "1";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaValueNow = "1";
+  }
+  // …
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.md
@@ -22,7 +22,14 @@ A string.
 In this example the value of `ariaValueText` is set to "Sunday".
 
 ```js
-this.internals_.ariaValueText = "Sunday";
+class CustomControl extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.ariaValueText = "Sunday";
+  }
+  // …
+}
 ```
 
 ## Specifications


### PR DESCRIPTION
The examples in elementInternals for ARIA does not define a variable used. This makes the examples a little bit better. (Not perfect, but hopefully a definite improvement)

addresses some of https://github.com/mdn/content/issues/36508