### PR TITLE
Add more links to the Wasm sidebar

### DIFF
--- a/files/en-us/webassembly/guides/text_format_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/text_format_to_wasm/index.md
@@ -1,5 +1,5 @@
 ---
-title: Converting WebAssembly text format to Wasm
+title: Converting WebAssembly text format to binary
 slug: WebAssembly/Guides/Text_format_to_Wasm
 page-type: guide
 sidebar: webassemblysidebar

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -133,7 +133,7 @@ l10n:
     Compiling_Rust_to_Wasm: Rust zu WebAssembly kompilieren
     JavaScript_API: WebAssembly-JavaScript-API verwenden
     Text_format: WebAssembly-Textformat verstehen
-    Text_format_to_Wasm: Converting text format to binary
+    Text_format_to_Wasm: Converting WebAssembly text format
     Loading_and_running: WebAssembly-Code laden und ausführen
     Exported_functions: Exportierte WebAssembly-Funktionen
     JavaScript_builtins: JavaScript-Standardobjekte
@@ -146,7 +146,7 @@ l10n:
     Compiling_Rust_to_Wasm: Compiling from Rust to WebAssembly
     JavaScript_API: Using the WebAssembly JavaScript API
     Text_format: Understanding WebAssembly text format
-    Text_format_to_Wasm: Converting text format to binary
+    Text_format_to_Wasm: Converting WebAssembly text format
     Loading_and_running: Loading and running WebAssembly code
     Exported_functions: Exported WebAssembly functions
     JavaScript_builtins: JavaScript builtins
@@ -159,7 +159,7 @@ l10n:
     Compiling_Rust_to_Wasm: Compiler du Rust en WebAssembly
     JavaScript_API: Utiliser l'API JavaScript WebAssembly
     Text_format: Comprendre le format texte WebAssembly
-    Text_format_to_Wasm: Converting text format to binary
+    Text_format_to_Wasm: Converting WebAssembly text format
     Loading_and_running: Chargement et exécution de code WebAssembly
     Exported_functions: Fonctions WebAssembly exportées
     JavaScript_interface: JavaScript interface
@@ -170,7 +170,7 @@ l10n:
     Compiling_Rust_to_Wasm: Rust를 웹어셈블리로 컴파일하기
     JavaScript_API: 웹어셈블리 JavaScript API 사용하기
     Text_format: 웹어셈블리 텍스트 형식 이해하기
-    Text_format_to_Wasm: Converting text format to binary
+    Text_format_to_Wasm: Converting WebAssembly text format
     Loading_and_running: 웹어셈블리 코드 로딩하고 실행하기
     Exported_functions: 내보낸 웹어셈블리(Exported WebAssembly) 함수
     JavaScript_interface: JavaScript 인터페이스
@@ -181,7 +181,7 @@ l10n:
     Compiling_Rust_to_Wasm: Компиляция Rust в WebAssembly
     JavaScript_API: Использование WebAssembly JavaScript API
     Text_format: Описание текстового формата WebAssembly
-    Text_format_to_Wasm: Converting text format to binary
+    Text_format_to_Wasm: Converting WebAssembly text format
     Loading_and_running: Загрузка и запуск кода WebAssembly
     Exported_functions: Экспортируемые функции WebAssembly
     JavaScript_interface: JavaScript interface
@@ -192,7 +192,7 @@ l10n:
     Compiling_Rust_to_Wasm: 将 Rust 编译为 WebAssembly
     JavaScript_API: 使用 WebAssembly JavaScript API
     Text_format: 理解 WebAssembly 文本格式
-    Text_format_to_Wasm: Converting text format to binary
+    Text_format_to_Wasm: Converting WebAssembly text format
     Loading_and_running: 加载和运行 WebAssembly 代码
     Exported_functions: 导出的 WebAssembly 函数
     JavaScript_interface: JavaScript 接口

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -133,7 +133,7 @@ l10n:
     Compiling_Rust_to_Wasm: Rust zu WebAssembly kompilieren
     JavaScript_API: WebAssembly-JavaScript-API verwenden
     Text_format: WebAssembly-Textformat verstehen
-    Text_format_to_Wasm: Converting WebAssembly text format to binary
+    Text_format_to_Wasm: Converting text format to binary
     Loading_and_running: WebAssembly-Code laden und ausführen
     Exported_functions: Exportierte WebAssembly-Funktionen
     JavaScript_builtins: JavaScript-Standardobjekte
@@ -146,7 +146,7 @@ l10n:
     Compiling_Rust_to_Wasm: Compiling from Rust to WebAssembly
     JavaScript_API: Using the WebAssembly JavaScript API
     Text_format: Understanding WebAssembly text format
-    Text_format_to_Wasm: Converting WebAssembly text format to binary
+    Text_format_to_Wasm: Converting text format to binary
     Loading_and_running: Loading and running WebAssembly code
     Exported_functions: Exported WebAssembly functions
     JavaScript_builtins: JavaScript builtins
@@ -159,7 +159,7 @@ l10n:
     Compiling_Rust_to_Wasm: Compiler du Rust en WebAssembly
     JavaScript_API: Utiliser l'API JavaScript WebAssembly
     Text_format: Comprendre le format texte WebAssembly
-    Text_format_to_Wasm: Converting WebAssembly text format to binary
+    Text_format_to_Wasm: Converting text format to binary
     Loading_and_running: Chargement et exécution de code WebAssembly
     Exported_functions: Fonctions WebAssembly exportées
     JavaScript_interface: JavaScript interface
@@ -170,7 +170,7 @@ l10n:
     Compiling_Rust_to_Wasm: Rust를 웹어셈블리로 컴파일하기
     JavaScript_API: 웹어셈블리 JavaScript API 사용하기
     Text_format: 웹어셈블리 텍스트 형식 이해하기
-    Text_format_to_Wasm: Converting WebAssembly text format to binary
+    Text_format_to_Wasm: Converting text format to binary
     Loading_and_running: 웹어셈블리 코드 로딩하고 실행하기
     Exported_functions: 내보낸 웹어셈블리(Exported WebAssembly) 함수
     JavaScript_interface: JavaScript 인터페이스
@@ -181,7 +181,7 @@ l10n:
     Compiling_Rust_to_Wasm: Компиляция Rust в WebAssembly
     JavaScript_API: Использование WebAssembly JavaScript API
     Text_format: Описание текстового формата WebAssembly
-    Text_format_to_Wasm: Converting WebAssembly text format to binary
+    Text_format_to_Wasm: Converting text format to binary
     Loading_and_running: Загрузка и запуск кода WebAssembly
     Exported_functions: Экспортируемые функции WebAssembly
     JavaScript_interface: JavaScript interface
@@ -192,7 +192,7 @@ l10n:
     Compiling_Rust_to_Wasm: 将 Rust 编译为 WebAssembly
     JavaScript_API: 使用 WebAssembly JavaScript API
     Text_format: 理解 WebAssembly 文本格式
-    Text_format_to_Wasm: Converting WebAssembly text format to binary
+    Text_format_to_Wasm: Converting text format to binary
     Loading_and_running: 加载和运行 WebAssembly 代码
     Exported_functions: 导出的 WebAssembly 函数
     JavaScript_interface: JavaScript 接口

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -4,58 +4,132 @@ sidebar:
   - type: section
     link: /WebAssembly
     title: WebAssembly
-  - title: Guides
-    details: open
-    children:
-      - link: /WebAssembly/Guides/Concepts
-        title: WebAssembly_concepts
-      - link: /WebAssembly/Guides/C_to_Wasm
-        title: Compiling_to_Wasm
-      - link: /WebAssembly/Guides/Rust_to_Wasm
-        title: Compiling_Rust_to_Wasm
-      - link: /WebAssembly/Guides/Using_the_JavaScript_API
-        title: JavaScript_API
-      - link: /WebAssembly/Guides/Understanding_the_text_format
-        title: Text_format
-      - link: /WebAssembly/Guides/Text_format_to_Wasm
-        title: Text_format_to_Wasm
-      - link: /WebAssembly/Guides/Loading_and_running
-        title: Loading_and_running
-      - link: /WebAssembly/Guides/Exported_functions
-        title: Exported_functions
-      - link: /WebAssembly/Guides/JavaScript_builtins
-        title: JavaScript_builtins
-      - link: /WebAssembly/Guides/Imported_string_constants
-        title: Imported_string_constants
+  - type: section
+    link: /WebAssembly/Guides
+    title: Guides
+  - link: /WebAssembly/Guides/Concepts
+    title: WebAssembly_concepts
+  - link: /WebAssembly/Guides/C_to_Wasm
+    title: Compiling_to_Wasm
+  - link: /WebAssembly/Guides/Existing_C_to_Wasm
+    title: Existing_C_to_Wasm
+  - link: /WebAssembly/Guides/Rust_to_Wasm
+    title: Compiling_Rust_to_Wasm
+  - link: /WebAssembly/Guides/Using_the_JavaScript_API
+    title: JavaScript_API
+  - link: /WebAssembly/Guides/Understanding_the_text_format
+    title: Text_format
+  - link: /WebAssembly/Guides/Text_format_to_Wasm
+    title: Text_format_to_Wasm
+  - link: /WebAssembly/Guides/Loading_and_running
+    title: Loading_and_running
+  - link: /WebAssembly/Guides/Exported_functions
+    title: Exported_functions
+  - link: /WebAssembly/Guides/JavaScript_builtins
+    title: JavaScript_builtins
+  - link: /WebAssembly/Guides/Imported_string_constants
+    title: Imported_string_constants
+  - type: section
+    link: /WebAssembly/Reference
+    title: Reference
   - title: JavaScript_interface
     details: open
     children:
-      - link: /WebAssembly/Reference/JavaScript_interface
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface
+        tags: webassembly-function
+        link: /WebAssembly/Reference/JavaScript_interface
+        title: <code>WebAssembly</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Module
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Module
+        link: /WebAssembly/Reference/JavaScript_interface/Module
+        title: <code>WebAssembly.Module</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Global
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Global
+        link: /WebAssembly/Reference/JavaScript_interface/Global
+        title: <code>WebAssembly.Global</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Instance
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Instance
+        link: /WebAssembly/Reference/JavaScript_interface/Instance
+        title: <code>WebAssembly.Instance</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Memory
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Memory
+        link: /WebAssembly/Reference/JavaScript_interface/Memory
+        title: <code>WebAssembly.Memory</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Table
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Table
+        link: /WebAssembly/Reference/JavaScript_interface/Table
+        title: <code>WebAssembly.Table</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Tag
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Tag
+        link: /WebAssembly/Reference/JavaScript_interface/Tag
+        title: <code>WebAssembly.Tag</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/Exception
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/Exception
+        link: /WebAssembly/Reference/JavaScript_interface/Exception
+        title: <code>WebAssembly.Exception</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/CompileError
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/CompileError
+        link: /WebAssembly/Reference/JavaScript_interface/CompileError
+        title: <code>WebAssembly.CompileError</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/LinkError
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/LinkError
+        link: /WebAssembly/Reference/JavaScript_interface/LinkError
+        title: <code>WebAssembly.LinkError</code>
+        details: closed
         code: true
-      - link: /WebAssembly/Reference/JavaScript_interface/RuntimeError
+      - type: listSubPages
+        path: /WebAssembly/Reference/JavaScript_interface/RuntimeError
+        link: /WebAssembly/Reference/JavaScript_interface/RuntimeError
+        title: <code>WebAssembly.RuntimeError</code>
+        details: closed
         code: true
+  - title: Instructions
+    details: open
+    children:
+      - type: listSubPages
+        path: /en-US/docs/WebAssembly/Reference/Control_flow
+        link: /en-US/docs/WebAssembly/Reference/Control_flow
+        title: Control flow
+        details: closed
+      - type: listSubPages
+        path: /en-US/docs/WebAssembly/Reference/Memory
+        link: /en-US/docs/WebAssembly/Reference/Memory
+        title: Memory
+        details: closed
+      - type: listSubPages
+        path: /en-US/docs/WebAssembly/Reference/Numeric
+        link: /en-US/docs/WebAssembly/Reference/Numeric
+        title: Numeric
+        details: closed
+      - type: listSubPages
+        path: /en-US/docs/WebAssembly/Reference/Variables
+        link: /en-US/docs/WebAssembly/Reference/Variables
+        title: Variables
+        details: closed
 l10n:
   de:
     WebAssembly_concepts: WebAssembly-Konzepte
     Compiling_to_Wasm: C/C++ zu WebAssembly kompilieren
+    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
     Compiling_Rust_to_Wasm: Rust zu WebAssembly kompilieren
     JavaScript_API: WebAssembly-JavaScript-API verwenden
     Text_format: WebAssembly-Textformat verstehen
@@ -68,6 +142,7 @@ l10n:
   en-US:
     WebAssembly_concepts: WebAssembly concepts
     Compiling_to_Wasm: Compiling from C/C++ to WebAssembly
+    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
     Compiling_Rust_to_Wasm: Compiling from Rust to WebAssembly
     JavaScript_API: Using the WebAssembly JavaScript API
     Text_format: Understanding WebAssembly text format
@@ -80,6 +155,7 @@ l10n:
   fr:
     WebAssembly_concepts: Concepts WebAssembly
     Compiling_to_Wasm: Compiler du C/C++ en WebAssembly
+    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
     Compiling_Rust_to_Wasm: Compiler du Rust en WebAssembly
     JavaScript_API: Utiliser l'API JavaScript WebAssembly
     Text_format: Comprendre le format texte WebAssembly
@@ -90,6 +166,7 @@ l10n:
   ko:
     WebAssembly_concepts: 웹어셈블리의 개념
     Compiling_to_Wasm: C/C++ 모듈을 웹어셈블리로 컴파일하기
+    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
     Compiling_Rust_to_Wasm: Rust를 웹어셈블리로 컴파일하기
     JavaScript_API: 웹어셈블리 JavaScript API 사용하기
     Text_format: 웹어셈블리 텍스트 형식 이해하기
@@ -100,6 +177,7 @@ l10n:
   ru:
     WebAssembly_concepts: Основы WebAssembly
     Compiling_to_Wasm: Компиляция кода C/C++ в WebAssembly
+    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
     Compiling_Rust_to_Wasm: Компиляция Rust в WebAssembly
     JavaScript_API: Использование WebAssembly JavaScript API
     Text_format: Описание текстового формата WebAssembly
@@ -110,6 +188,7 @@ l10n:
   zh-CN:
     WebAssembly_concepts: WebAssembly 概念
     Compiling_to_Wasm: 将 C/C++ 编译为 WebAssembly
+    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
     Compiling_Rust_to_Wasm: 将 Rust 编译为 WebAssembly
     JavaScript_API: 使用 WebAssembly JavaScript API
     Text_format: 理解 WebAssembly 文本格式

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -106,23 +106,23 @@ sidebar:
     details: open
     children:
       - type: listSubPages
-        path: /en-US/docs/WebAssembly/Reference/Control_flow
-        link: /en-US/docs/WebAssembly/Reference/Control_flow
+        path: /WebAssembly/Reference/Control_flow
+        link: /WebAssembly/Reference/Control_flow
         title: Control flow
         details: closed
       - type: listSubPages
-        path: /en-US/docs/WebAssembly/Reference/Memory
-        link: /en-US/docs/WebAssembly/Reference/Memory
+        path: /WebAssembly/Reference/Memory
+        link: /WebAssembly/Reference/Memory
         title: Memory
         details: closed
       - type: listSubPages
-        path: /en-US/docs/WebAssembly/Reference/Numeric
-        link: /en-US/docs/WebAssembly/Reference/Numeric
+        path: /WebAssembly/Reference/Numeric
+        link: /WebAssembly/Reference/Numeric
         title: Numeric
         details: closed
       - type: listSubPages
-        path: /en-US/docs/WebAssembly/Reference/Variables
-        link: /en-US/docs/WebAssembly/Reference/Variables
+        path: /WebAssembly/Reference/Variables
+        link: /WebAssembly/Reference/Variables
         title: Variables
         details: closed
 l10n:

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -133,7 +133,7 @@ l10n:
     Compiling_Rust_to_Wasm: Rust zu WebAssembly kompilieren
     JavaScript_API: WebAssembly-JavaScript-API verwenden
     Text_format: WebAssembly-Textformat verstehen
-    Text_format_to_Wasm: WebAssembly-Textformat in Wasm umwandeln
+    Text_format_to_Wasm: Converting WebAssembly text format to binary
     Loading_and_running: WebAssembly-Code laden und ausführen
     Exported_functions: Exportierte WebAssembly-Funktionen
     JavaScript_builtins: JavaScript-Standardobjekte
@@ -146,7 +146,7 @@ l10n:
     Compiling_Rust_to_Wasm: Compiling from Rust to WebAssembly
     JavaScript_API: Using the WebAssembly JavaScript API
     Text_format: Understanding WebAssembly text format
-    Text_format_to_Wasm: Converting WebAssembly text format to Wasm
+    Text_format_to_Wasm: Converting WebAssembly text format to binary
     Loading_and_running: Loading and running WebAssembly code
     Exported_functions: Exported WebAssembly functions
     JavaScript_builtins: JavaScript builtins
@@ -159,7 +159,7 @@ l10n:
     Compiling_Rust_to_Wasm: Compiler du Rust en WebAssembly
     JavaScript_API: Utiliser l'API JavaScript WebAssembly
     Text_format: Comprendre le format texte WebAssembly
-    Text_format_to_Wasm: Convertir du format texte WebAssembly en Wasm
+    Text_format_to_Wasm: Converting WebAssembly text format to binary
     Loading_and_running: Chargement et exécution de code WebAssembly
     Exported_functions: Fonctions WebAssembly exportées
     JavaScript_interface: JavaScript interface
@@ -170,7 +170,7 @@ l10n:
     Compiling_Rust_to_Wasm: Rust를 웹어셈블리로 컴파일하기
     JavaScript_API: 웹어셈블리 JavaScript API 사용하기
     Text_format: 웹어셈블리 텍스트 형식 이해하기
-    Text_format_to_Wasm: 웹어셈블리 기반 텍스트를 Wasm 형식으로 변환하기
+    Text_format_to_Wasm: Converting WebAssembly text format to binary
     Loading_and_running: 웹어셈블리 코드 로딩하고 실행하기
     Exported_functions: 내보낸 웹어셈블리(Exported WebAssembly) 함수
     JavaScript_interface: JavaScript 인터페이스
@@ -181,7 +181,7 @@ l10n:
     Compiling_Rust_to_Wasm: Компиляция Rust в WebAssembly
     JavaScript_API: Использование WebAssembly JavaScript API
     Text_format: Описание текстового формата WebAssembly
-    Text_format_to_Wasm: Перевод из текстового формата WebAssembly в Wasm
+    Text_format_to_Wasm: Converting WebAssembly text format to binary
     Loading_and_running: Загрузка и запуск кода WebAssembly
     Exported_functions: Экспортируемые функции WebAssembly
     JavaScript_interface: JavaScript interface
@@ -192,7 +192,7 @@ l10n:
     Compiling_Rust_to_Wasm: 将 Rust 编译为 WebAssembly
     JavaScript_API: 使用 WebAssembly JavaScript API
     Text_format: 理解 WebAssembly 文本格式
-    Text_format_to_Wasm: 将 WebAssembly 文本格式转换为 Wasm
+    Text_format_to_Wasm: Converting WebAssembly text format to binary
     Loading_and_running: 加载和运行 WebAssembly 代码
     Exported_functions: 导出的 WebAssembly 函数
     JavaScript_interface: JavaScript 接口

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -33,7 +33,7 @@ sidebar:
     link: /WebAssembly/Reference
     title: Reference
   - title: JavaScript_interface
-    details: open
+    details: closed
     children:
       - type: listSubPages
         path: /WebAssembly/Reference/JavaScript_interface
@@ -103,7 +103,7 @@ sidebar:
         details: closed
         code: true
   - title: Instructions
-    details: open
+    details: closed
     children:
       - type: listSubPages
         path: /WebAssembly/Reference/Control_flow


### PR DESCRIPTION
A lot of pages are not reachable from the sidebar, making the Wasm docs extremely hard to navigate. This adds pretty much everything to the sidebar.