### PR TITLE
Make Element and Attributes list pages reachable in MathML sidebar

### DIFF
--- a/files/sidebars/mathmlref.yaml
+++ b/files/sidebars/mathmlref.yaml
@@ -29,11 +29,13 @@ sidebar:
     title: Reference
   - type: listSubPages
     path: /Web/MathML/Reference/Element
+    link: /Web/MathML/Reference/Element
     title: Elements
     details: closed
     code: true
   - type: listSubPages
     path: /Web/MathML/Reference/Global_attributes
+    link: /Web/MathML/Reference/Global_attributes
     title: Global attributes
     details: closed
     code: true


### PR DESCRIPTION
These two pages are not linked in the sidebar