### PR TITLE
Correct the grammar rules for !important flag in declarations

### DIFF
--- a/files/en-us/web/css/important/index.md
+++ b/files/en-us/web/css/important/index.md
@@ -18,7 +18,7 @@ selector {
 }
 ```
 
-The `!important` comes after the value of the property value pair declaration, preceded by at least one space. The important flag must be the last token in the declaration. In other words, there can be white space and comments between the flag and the declaration's ending semicolon, but nothing else.
+The `!important` comes after the value of the property value pair declaration, preceded by zero or more spaces. The important flag must be the last token in the declaration. In other words, there can be white space and comments between the flag and the declaration's ending semicolon, but nothing else.
 
 ## Impact on the cascade
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The CSS Syntax Module Level 3 specification describes the syntax for a valid property-value declaration, and the diagram does not specify needing a white-space to precede the `!important` flag.

<!-- ✍️ Summarize your changes in one or two sentences -->
- This PR changes the rule regarding leading white-space for `!important` declarations (emphasis not in changes) to be consistent with the spec as follows:
> The `!important` comes after the value of the property value pair declaration, preceded by **at least one space.**

to

> The `!important` comes after the value of the property value pair declaration, preceded by **zero or more spaces.**

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The change is made to be in-line with the the grammar rules that the CSS spec describes.
It will help readers get clarification in the event they miss out on a space between the property value and `!important` and refer to the docs to know the correct behaviour reliably.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[CSS Syntax Module Level 3 Declaration Diagram](<https://www.w3.org/TR/css-syntax-3/#declaration-diagram>)

[Minimal reproducible example on codepen](<https://codepen.io/ginned/pen/yyyBaoW>)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
