### PR TITLE
Add `Float16Array` to unsupported types for `crypto.getRandomValues()`

### DIFF
--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -28,7 +28,7 @@ getRandomValues(typedArray)
   - : An integer-based {{jsxref("TypedArray")}}, that is one of: {{jsxref("Int8Array")}}, {{jsxref("Uint8Array")}},
     {{jsxref("Uint8ClampedArray")}}, {{jsxref("Int16Array")}}, {{jsxref("Uint16Array")}},
     {{jsxref("Int32Array")}}, {{jsxref("Uint32Array")}}, {{jsxref("BigInt64Array")}},
-    {{jsxref("BigUint64Array")}} (but **not** `Float32Array` nor `Float64Array`).
+    {{jsxref("BigUint64Array")}} (but **not** `Float16Array`, `Float32Array` nor `Float64Array`).
     All elements in the array will be overwritten with random numbers.
 
 ### Return value


### PR DESCRIPTION
The new [`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) is one more exception for the [Crypto: `getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) method per [specs](https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues).