### PR TITLE
Update Insertable Streams for MediaStreamTrack API to spec

### DIFF
--- a/files/en-us/web/api/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/index.md
@@ -10,6 +10,9 @@ browser-compat: api.MediaStreamTrackGenerator
 
 {{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
+> [!NOTE]
+> Consider using {{domxref("VideoTrackGenerator")}} instead.
+
 The **`MediaStreamTrackGenerator`** interface of the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API) creates a {{domxref("WritableStream")}} that acts as a {{domxref("MediaStreamTrack")}} source.
 The object consumes a stream of media frames as input, which can be audio or video frames.
 
@@ -53,6 +56,10 @@ trackProcessor.readable
   .pipeThrough(transformer)
   .pipeTo(trackGenerator.writable);
 ```
+
+## See also
+
+- {{domxref("VideoTrackGenerator")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
@@ -21,7 +21,7 @@ new MediaStreamTrackGenerator(options)
 
 ### Parameters
 
-- `options`
+- `options` {{Experimental_Inline}} {{Non-standard_Inline}}
   - : An object containing the property `kind`, which is one of the following strings:
     - `"audio"`
       - : Specifies that the stream accepts {{domxref("AudioTrack")}} objects.

--- a/files/en-us/web/api/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/index.md
@@ -2,47 +2,64 @@
 title: MediaStreamTrackProcessor
 slug: Web/API/MediaStreamTrackProcessor
 page-type: web-api-interface
+status:
+  - experimental
 browser-compat: api.MediaStreamTrackProcessor
 ---
 
-{{APIRef("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
 
-The **`MediaStreamTrackProcessor`** interface of the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API) consumes a {{domxref("MediaStreamTrack")}} object's source and generates a stream of media frames.
+> [!WARNING]
+> Browsers differ on which global context they expose this interface in (e.g., only window in some browsers and only dedicated worker in others), making them incompatible. Keep this in mind when comparing support.
+
+The **`MediaStreamTrackProcessor`** interface of the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API) consumes a video {{domxref("MediaStreamTrack")}} object's source and generates a stream of {{domxref("VideoFrame")}}s.
+
+This interface is only available in {{domxref("Worker","dedicated workers")}} (except as noted).
 
 ## Constructor
 
-- {{domxref("MediaStreamTrackProcessor.MediaStreamTrackProcessor", "MediaStreamTrackProcessor()")}}
+- {{domxref("MediaStreamTrackProcessor.MediaStreamTrackProcessor", "MediaStreamTrackProcessor()")}} {{Experimental_Inline}}
+
   - : Creates a new `MediaStreamTrackProcessor` object.
+
+- {{domxref("MediaStreamTrackProcessor.MediaStreamTrackProcessor", "window.MediaStreamTrackProcessor()")}} {{Experimental_Inline}} {{Non-standard_Inline}}
+  - : Creates a new `MediaStreamTrackProcessor` object on the {{Glossary("main thread")}} that can process both video and audio.
 
 ## Instance properties
 
-- {{domxref("MediaStreamTrackProcessor.readable")}}
+- {{domxref("MediaStreamTrackProcessor.readable")}} {{Experimental_Inline}}
   - : Returns a {{domxref("ReadableStream")}}.
 
 ## Examples
 
-The following example is from the article [Insertable streams for MediaStreamTrack](https://developer.chrome.com/docs/capabilities/web-apis/mediastreamtrack-insertable-media-processing), and demonstrates a barcode scanner application, which transforms the stream accessed via {{domxref("MediaStreamTrackProcessor.readable")}} by highlighting the barcode.
+The following example is from the article [Unbundling MediaStreamTrackProcessor and VideoTrackGenerator](https://blog.mozilla.org/webrtc/unbundling-mediastreamtrackprocessor-and-videotrackgenerator/). It [transfers](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) a camera {{domxref("MediaStreamTrack")}} to a worker for processing. The worker creates a pipeline that applies a sepia tone filter to the video frames and mirrors them. The pipeline culminates in a {{domxref("VideoTrackGenerator")}} whose {{domxref("MediaStreamTrack")}} is transferred back and played. The media now flows in real time through the transform off the {{Glossary("main thread")}}.
 
 ```js
-const stream = await getUserMedia({ video: true });
-const videoTrack = stream.getVideoTracks()[0];
-
-const trackProcessor = new MediaStreamTrackProcessor({ track: videoTrack });
-const trackGenerator = new MediaStreamTrackGenerator({ kind: "video" });
-
-const transformer = new TransformStream({
-  async transform(videoFrame, controller) {
-    const barcodes = await detectBarcodes(videoFrame);
-    const newFrame = highlightBarcodes(videoFrame, barcodes);
-    videoFrame.close();
-    controller.enqueue(newFrame);
-  },
-});
-
-trackProcessor.readable
-  .pipeThrough(transformer)
-  .pipeTo(trackGenerator.writable);
+const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+const [track] = stream.getVideoTracks();
+const worker = new Worker("worker.js");
+worker.postMessage({ track }, [track]);
+const { data } = await new Promise((r) => (worker.onmessage = r));
+video.srcObject = new MediaStream([data.track]);
 ```
+
+worker.js:
+
+```js
+onmessage = async ({ data: { track } }) => {
+  const vtg = new VideoTrackGenerator();
+  self.postMessage({ track: vtg.track }, [vtg.track]);
+  const { readable } = new MediaStreamTrackProcessor({ track });
+  await readable
+    .pipeThrough(new TransformStream({ transform }))
+    .pipeTo(vtg.writable);
+};
+```
+
+## See also
+
+- {{domxref("VideoTrackGenerator")}}
+- The older article [Insertable streams for MediaStreamTrack](https://developer.chrome.com/docs/capabilities/web-apis/mediastreamtrack-insertable-media-processing) was written before the API was restricted to workers and video (beware its use of the non-standard version of {{domxref("MediaStreamTrackProcessor")}} which blocks on the {{Glossary("main thread")}})
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
@@ -3,12 +3,14 @@ title: "MediaStreamTrackProcessor: MediaStreamTrackProcessor() constructor"
 short-title: MediaStreamTrackProcessor()
 slug: Web/API/MediaStreamTrackProcessor/MediaStreamTrackProcessor
 page-type: web-api-constructor
+status:
+  - experimental
 browser-compat: api.MediaStreamTrackProcessor.MediaStreamTrackProcessor
 ---
 
-{{APIRef("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
 
-The **`MediaStreamTrackProcessor()`** constructor creates a new {{domxref("MediaStreamTrackProcessor")}} object which consumes a {{domxref("MediaStreamTrack")}} object's source and generates a stream of media frames.
+The **`MediaStreamTrackProcessor()`** constructor creates a new {{domxref("MediaStreamTrackProcessor")}} object which consumes a video {{domxref("MediaStreamTrack")}} object's source and generates a stream of {{domxref("VideoFrame")}}s.
 
 ## Syntax
 

--- a/files/en-us/web/api/mediastreamtrackprocessor/readable/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/readable/index.md
@@ -3,12 +3,14 @@ title: "MediaStreamTrackProcessor: readable property"
 short-title: readable
 slug: Web/API/MediaStreamTrackProcessor/readable
 page-type: web-api-instance-property
+status:
+  - experimental
 browser-compat: api.MediaStreamTrackProcessor.readable
 ---
 
-{{APIRef("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
 
-The **`readable`** property of the {{domxref("MediaStreamTrackProcessor")}} interface returns a {{domxref("ReadableStream")}}.
+The **`readable`** property of the {{domxref("MediaStreamTrackProcessor")}} interface returns a {{domxref("ReadableStream")}} of {{domxref("VideoFrame")}}s.
 
 ## Value
 
@@ -16,18 +18,7 @@ A {{domxref("ReadableStream")}}.
 
 ## Examples
 
-In the following example video frames from the {{domxref("ReadableStream")}} are transformed.
-
-```js
-const trackProcessor = new MediaStreamTrackProcessor({ track: videoTrack });
-const trackGenerator = new MediaStreamTrackGenerator({ kind: "video" });
-
-/* */
-
-trackProcessor.readable
-  .pipeThrough(transformer)
-  .pipeTo(trackGenerator.writable);
-```
+See the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API#examples) for an example.
 
 ## Specifications
 

--- a/files/en-us/web/api/videotrackgenerator/index.md
+++ b/files/en-us/web/api/videotrackgenerator/index.md
@@ -1,0 +1,66 @@
+---
+title: VideoTrackGenerator
+slug: Web/API/VideoTrackGenerator
+page-type: web-api-interface
+status:
+  - experimental
+browser-compat: api.VideoTrackGenerator
+---
+
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
+
+The **`VideoTrackGenerator`** interface of the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API) has a {{domxref("WritableStream")}} property that acts as a {{domxref("MediaStreamTrack")}} source, by consuming a stream of {{domxref("VideoFrame")}}s as input.
+
+This interface is only available in {{domxref("Worker","dedicated workers")}}.
+
+## Constructor
+
+- {{domxref("VideoTrackGenerator.VideoTrackGenerator", "VideoTrackGenerator()")}} {{Experimental_Inline}}
+  - : Creates a new `VideoTrackGenerator` object which accepts {{domxref("VideoFrame")}} objects.
+
+## Instance properties
+
+- {{domxref("VideoTrackGenerator.track")}} {{Experimental_Inline}}
+
+  - : The output {{domxref("MediaStreamTrack")}}.
+
+- {{domxref("VideoTrackGenerator.writable")}} {{Experimental_Inline}}
+  - : The input {{domxref("WritableStream")}}.
+
+## Examples
+
+The following example is from the article [Unbundling MediaStreamTrackProcessor and VideoTrackGenerator](https://blog.mozilla.org/webrtc/unbundling-mediastreamtrackprocessor-and-videotrackgenerator/). It [transfers](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) a camera {{domxref("MediaStreamTrack")}} to a worker for processing. The worker creates a pipeline that applies a sepia tone filter to the video frames and mirrors them. The pipeline culminates in a {{domxref("VideoTrackGenerator")}} whose {{domxref("MediaStreamTrack")}} is transferred back and played. The media now flows in real time through the transform off the {{Glossary("main thread")}}.
+
+```js
+const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+const [track] = stream.getVideoTracks();
+const worker = new Worker("worker.js");
+worker.postMessage({ track }, [track]);
+const { data } = await new Promise((r) => (worker.onmessage = r));
+video.srcObject = new MediaStream([data.track]);
+```
+
+worker.js:
+
+```js
+onmessage = async ({ data: { track } }) => {
+  const vtg = new VideoTrackGenerator();
+  self.postMessage({ track: vtg.track }, [vtg.track]);
+  const { readable } = new MediaStreamTrackProcessor({ track });
+  await readable
+    .pipeThrough(new TransformStream({ transform }))
+    .pipeTo(vtg.writable);
+};
+```
+
+## See also
+
+- {{domxref("MediaStreamTrackProcessor")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videotrackgenerator/index.md
+++ b/files/en-us/web/api/videotrackgenerator/index.md
@@ -20,6 +20,10 @@ This interface is only available in {{domxref("Worker","dedicated workers")}}.
 
 ## Instance properties
 
+- {{domxref("VideoTrackGenerator.muted")}} {{Experimental_Inline}}
+
+  - : A Boolean property to temporarily halt or resume the generation of video frames in the output track.
+
 - {{domxref("VideoTrackGenerator.track")}} {{Experimental_Inline}}
 
   - : The output {{domxref("MediaStreamTrack")}}.

--- a/files/en-us/web/api/videotrackgenerator/muted/index.md
+++ b/files/en-us/web/api/videotrackgenerator/muted/index.md
@@ -1,0 +1,39 @@
+---
+title: "VideoTrackGenerator: muted property"
+short-title: muted
+slug: Web/API/VideoTrackGenerator/muted
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.VideoTrackGenerator.muted
+---
+
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
+
+The **`muted`** Boolean property of the {{domxref("VideoTrackGenerator")}} interface can be used to temporarily halt or resume the generation of video frames in the output track.
+
+## Value
+
+A boolean.
+
+## Examples
+
+To pause production of video frames:
+
+```js
+videoTrackGenerator.muted = true;
+```
+
+To resume production of video frames:
+
+```js
+videoTrackGenerator.muted = false;
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videotrackgenerator/track/index.md
+++ b/files/en-us/web/api/videotrackgenerator/track/index.md
@@ -1,0 +1,29 @@
+---
+title: "VideoTrackGenerator: track property"
+short-title: track
+slug: Web/API/VideoTrackGenerator/track
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.VideoTrackGenerator.track
+---
+
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
+
+The **`track`** property of the {{domxref("VideoTrackGenerator")}} interface returns a {{domxref("WritableStream")}}. This allows the writing of media frames to the `VideoTrackGenerator`. The frames will be audio or video. The type is dictated by the kind of `VideoTrackGenerator` that was created.
+
+## Value
+
+A {{domxref("WritableStream")}}.
+
+## Examples
+
+See the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API#examples) for an example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videotrackgenerator/track/index.md
+++ b/files/en-us/web/api/videotrackgenerator/track/index.md
@@ -10,11 +10,11 @@ browser-compat: api.VideoTrackGenerator.track
 
 {{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
 
-The **`track`** property of the {{domxref("VideoTrackGenerator")}} interface returns a {{domxref("WritableStream")}}. This allows the writing of media frames to the `VideoTrackGenerator`. The frames will be audio or video. The type is dictated by the kind of `VideoTrackGenerator` that was created.
+The **`track`** property of the {{domxref("VideoTrackGenerator")}} interface returns a {{domxref("MediaStreamTrack")}}. {{domxref("VideoFrame")}}s written to {{domxref("VideoTrackGenerator.writable")}} will be generated in this track.
 
 ## Value
 
-A {{domxref("WritableStream")}}.
+A video {{domxref("MediaStreamTrack")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/videotrackgenerator/videotrackgenerator/index.md
+++ b/files/en-us/web/api/videotrackgenerator/videotrackgenerator/index.md
@@ -1,0 +1,39 @@
+---
+title: "VideoTrackGenerator: VideoTrackGenerator() constructor"
+short-title: VideoTrackGenerator()
+slug: Web/API/VideoTrackGenerator/VideoTrackGenerator
+page-type: web-api-constructor
+status:
+  - experimental
+browser-compat: api.VideoTrackGenerator.VideoTrackGenerator
+---
+
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
+
+The **`VideoTrackGenerator()`** constructor creates a new {{domxref("VideoTrackGenerator")}} object which consumes a stream of media frames and exposes a {{domxref("MediaStreamTrack")}}.
+
+## Syntax
+
+```js-nolint
+new VideoTrackGenerator()
+```
+
+## Examples
+
+In the following example a new video `VideoTrackGenerator` is created.
+
+```js
+const trackGenerator = new VideoTrackGenerator();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Insertable streams for MediaStreamTrack](https://developer.chrome.com/docs/capabilities/web-apis/mediastreamtrack-insertable-media-processing)

--- a/files/en-us/web/api/videotrackgenerator/writable/index.md
+++ b/files/en-us/web/api/videotrackgenerator/writable/index.md
@@ -1,0 +1,29 @@
+---
+title: "VideoTrackGenerator: writable property"
+short-title: writable
+slug: Web/API/VideoTrackGenerator/writable
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.VideoTrackGenerator.writable
+---
+
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
+
+The **`writable`** property of the {{domxref("VideoTrackGenerator")}} interface returns a {{domxref("WritableStream")}}. This allows the writing of media frames to the `VideoTrackGenerator`. The frames will be audio or video. The type is dictated by the kind of `VideoTrackGenerator` that was created.
+
+## Value
+
+A {{domxref("WritableStream")}}.
+
+## Examples
+
+See the [Insertable Streams for MediaStreamTrack API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API#examples) for an example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videotrackgenerator/writable/index.md
+++ b/files/en-us/web/api/videotrackgenerator/writable/index.md
@@ -10,11 +10,11 @@ browser-compat: api.VideoTrackGenerator.writable
 
 {{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
 
-The **`writable`** property of the {{domxref("VideoTrackGenerator")}} interface returns a {{domxref("WritableStream")}}. This allows the writing of media frames to the `VideoTrackGenerator`. The frames will be audio or video. The type is dictated by the kind of `VideoTrackGenerator` that was created.
+The **`writable`** property of the {{domxref("VideoTrackGenerator")}} interface returns a {{domxref("WritableStream")}}. This allows the writing of {{domxref("VideoFrame")}}s to the {{domxref("VideoTrackGenerator.track")}}.
 
 ## Value
 
-A {{domxref("WritableStream")}}.
+A {{domxref("WritableStream")}} of {{domxref("VideoFrame")}}s.
 
 ## Examples
 

--- a/files/en-us/web/api/web_workers_api/transferable_objects/index.md
+++ b/files/en-us/web/api/web_workers_api/transferable_objects/index.md
@@ -91,6 +91,7 @@ Some of the items that various specifications indicate can be _transferred_ are 
 - {{domxref("RTCDataChannel")}}
 - {{domxref("MediaSourceHandle")}}
 - {{domxref("MIDIAccess")}}
+- {{domxref("MediaStreamTrack")}}
 
 > [!NOTE]
 > Transferable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Transferable]`.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -951,7 +951,11 @@
     "Insertable Streams for MediaStreamTrack API": {
       "overview": ["Insertable Streams for MediaStreamTrack API"],
       "guides": [],
-      "interfaces": ["MediaStreamTrackGenerator", "MediaStreamTrackProcessor"],
+      "interfaces": [
+        "MediaStreamTrackGenerator",
+        "MediaStreamTrackProcessor",
+        "VideoTrackGenerator"
+      ],
       "methods": [],
       "properties": [],
       "events": []


### PR DESCRIPTION
### Description
- Update the [Insertable Streams for MediaStreamTrack API](https://developer.mozilla.org/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API) and related interfaces to spec
- ~Mark [MediaStreamTrackProcessor](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackProcessor) as experimental due to the~ [edit: adds a warning about] two implementations being incompatible
- Call-outs to nonstandard browser differences

### Motivation

The old articles were incorrectly mixing examples and browser support data between the two incompatible implementations. Clear up confusion around what is standard and differences that have shipped.

### Additional details

- Spec: https://w3c.github.io/mediacapture-transform/

### Related issues and pull requests

I plan to update browser data next, using annotations to highlight who supports what 