### PR TITLE
Add spaces around | in SVG attribute syntax

### DIFF
--- a/files/en-us/web/svg/reference/attribute/keypoints/index.md
+++ b/files/en-us/web/svg/reference/attribute/keypoints/index.md
@@ -60,7 +60,7 @@ svg {
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{cssxref("number")}} [; {{cssxref("number")}}]* ;?</td>
+      <td>{{cssxref("number")}} [; {{cssxref("number")}} ]* ;?</td>
     </tr>
     <tr>
       <th scope="row">Default value</th>

--- a/files/en-us/web/svg/reference/attribute/stroke-linejoin/index.md
+++ b/files/en-us/web/svg/reference/attribute/stroke-linejoin/index.md
@@ -116,7 +116,7 @@ svg {
     <tr>
       <th scope="row">Value</th>
       <td>
-        <code>arcs</code> | <code>bevel</code> |<code>miter</code> |
+        <code>arcs</code> | <code>bevel</code> | <code>miter</code> |
         <code>miter-clip</code> | <code>round</code>
       </td>
     </tr>

--- a/files/en-us/web/svg/reference/element/a/index.md
+++ b/files/en-us/web/svg/reference/element/a/index.md
@@ -81,13 +81,13 @@ svg|a:active {
     _Value type_: **[\<list-of-URLs>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: _none_; _Animatable_: **no**
 - [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy)
   - : Which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the {{Glossary("URL")}}.
-    _Value type_: `no-referrer`|`no-referrer-when-downgrade`|`same-origin`|`origin`|`strict-origin`|`origin-when-cross-origin`|`strict-origin-when-cross-origin`|`unsafe-url` ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: `no-referrer` | `no-referrer-when-downgrade` | `same-origin` | `origin` | `strict-origin` | `origin-when-cross-origin` | `strict-origin-when-cross-origin` | `unsafe-url` ; _Default value_: _none_; _Animatable_: **no**
 - [`rel`](/en-US/docs/Web/HTML/Reference/Elements/a#rel)
   - : The relationship of the target object to the link object.
     _Value type_: **[\<list-of-Link-Types>](/en-US/docs/Web/HTML/Reference/Attributes/rel)** ; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("target")}}
   - : Where to display the linked {{Glossary("URL")}}.
-    _Value type_: `_self`|`_parent`|`_top`|`_blank`|**\<XML-Name>** ; _Default value_: `_self`; _Animatable_: **yes**
+    _Value type_: `_self` | `_parent` | `_top` | `_blank` | **\<XML-Name>** ; _Default value_: `_self`; _Animatable_: **yes**
 - [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type)
   - : A {{Glossary("MIME type")}} for the linked URL.
     _Value type_: **\<string>** ; _Default value_: _none_; _Animatable_: **no**

--- a/files/en-us/web/svg/reference/element/a/index.md
+++ b/files/en-us/web/svg/reference/element/a/index.md
@@ -69,31 +69,31 @@ svg|a:active {
 
 - [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download)
   - : Instructs browsers to download a {{Glossary("URL")}} instead of navigating to it, so the user will be prompted to save it as a local file.
-    _Value type_: **\<string>** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("href")}}
   - : The {{Glossary("URL")}} or URL fragment the hyperlink points to.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **yes**
 - [`hreflang`](/en-US/docs/Web/HTML/Reference/Elements/a#hreflang)
   - : The human language of the URL or URL fragment that the hyperlink points to.
-    _Value type_: **\<string>** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
 - [`ping`](/en-US/docs/Web/HTML/Reference/Elements/a#ping) {{experimental_inline}}
   - : A space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking. For a more widely-supported feature addressing the same use cases, see {{domxref("Navigator.sendBeacon()")}}.
-    _Value type_: **[\<list-of-URLs>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **[\<list-of-URLs>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: _none_; _Animatable_: **no**
 - [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy)
   - : Which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the {{Glossary("URL")}}.
-    _Value type_: `no-referrer` | `no-referrer-when-downgrade` | `same-origin` | `origin` | `strict-origin` | `origin-when-cross-origin` | `strict-origin-when-cross-origin` | `unsafe-url` ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: `no-referrer` | `no-referrer-when-downgrade` | `same-origin` | `origin` | `strict-origin` | `origin-when-cross-origin` | `strict-origin-when-cross-origin` | `unsafe-url`; _Default value_: _none_; _Animatable_: **no**
 - [`rel`](/en-US/docs/Web/HTML/Reference/Elements/a#rel)
   - : The relationship of the target object to the link object.
-    _Value type_: **[\<list-of-Link-Types>](/en-US/docs/Web/HTML/Reference/Attributes/rel)** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **[\<list-of-Link-Types>](/en-US/docs/Web/HTML/Reference/Attributes/rel)**; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("target")}}
   - : Where to display the linked {{Glossary("URL")}}.
-    _Value type_: `_self` | `_parent` | `_top` | `_blank` | **\<XML-Name>** ; _Default value_: `_self`; _Animatable_: **yes**
+    _Value type_: `_self` | `_parent` | `_top` | `_blank` | **\<XML-Name>**; _Default value_: `_self`; _Animatable_: **yes**
 - [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type)
   - : A {{Glossary("MIME type")}} for the linked URL.
-    _Value type_: **\<string>** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : The URL or URL fragment that the hyperlink points to. May be required for backwards compatibility for older browsers.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/animatemotion/index.md
+++ b/files/en-us/web/svg/reference/element/animatemotion/index.md
@@ -56,7 +56,7 @@ svg {
     _Value type_: **\<string>**; _Default value_: none; _Animatable_: **no**
 - {{SVGAttr("rotate")}}
   - : This attribute defines a rotation applied to the element animated along a path, usually to make it pointing in the direction of the animation.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)|`auto`|`auto-reverse`; _Default value_: `0`; _Animatable_: **no**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) | `auto` | `auto-reverse`; _Default value_: `0`; _Animatable_: **no**
 
 > [!NOTE]
 > For `<animateMotion>`, the default value for the {{SVGAttr("calcMode")}} attribute is `paced`.

--- a/files/en-us/web/svg/reference/element/circle/index.md
+++ b/files/en-us/web/svg/reference/element/circle/index.md
@@ -30,16 +30,16 @@ svg {
 
 - {{SVGAttr("cx")}}
   - : The x-axis coordinate of the center of the circle.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)**; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("cy")}}
   - : The y-axis coordinate of the center of the circle.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)**; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("r")}}
   - : The radius of the circle. A value lower or equal to zero disables rendering of the circle.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)**; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : The total length for the circle's circumference, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2, `cx`, `cy`, and `r` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.

--- a/files/en-us/web/svg/reference/element/circle/index.md
+++ b/files/en-us/web/svg/reference/element/circle/index.md
@@ -30,13 +30,13 @@ svg {
 
 - {{SVGAttr("cx")}}
   - : The x-axis coordinate of the center of the circle.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**|**[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("cy")}}
   - : The y-axis coordinate of the center of the circle.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**|**[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("r")}}
   - : The radius of the circle. A value lower or equal to zero disables rendering of the circle.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**|**[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** | **[\<percentage>](/en-US/docs/Web/SVG/Guides/Content_type#percentage)** ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : The total length for the circle's circumference, in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/clippath/index.md
+++ b/files/en-us/web/svg/reference/element/clippath/index.md
@@ -71,7 +71,7 @@ By default, {{cssxref("pointer-events")}} are not dispatched on clipped regions.
 
 - {{SVGAttr("clipPathUnits")}}
   - : Defines the coordinate system for the contents of the `<clipPath>` element.
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/clippath/index.md
+++ b/files/en-us/web/svg/reference/element/clippath/index.md
@@ -71,7 +71,7 @@ By default, {{cssxref("pointer-events")}} are not dispatched on clipped regions.
 
 - {{SVGAttr("clipPathUnits")}}
   - : Defines the coordinate system for the contents of the `<clipPath>` element.
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/ellipse/index.md
+++ b/files/en-us/web/svg/reference/element/ellipse/index.md
@@ -33,16 +33,16 @@ svg {
 
 - {{SVGAttr("cx")}}
   - : The x position of the center of the ellipse.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("cy")}}
   - : The y position of the center of the ellipse.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("rx")}}
   - : The radius of the ellipse on the x axis.
-    _Value type_: `auto`|[**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("ry")}}
   - : The radius of the ellipse on the y axis.
-    _Value type_: `auto`|[**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : This attribute lets specify the total length for the path, in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/ellipse/index.md
+++ b/files/en-us/web/svg/reference/element/ellipse/index.md
@@ -33,19 +33,19 @@ svg {
 
 - {{SVGAttr("cx")}}
   - : The x position of the center of the ellipse.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("cy")}}
   - : The y position of the center of the ellipse.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("rx")}}
   - : The radius of the ellipse on the x axis.
-    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("ry")}}
   - : The radius of the ellipse on the y axis.
-    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : This attribute lets specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2 `cx`, `cy`, `rx` and `ry` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.

--- a/files/en-us/web/svg/reference/element/foreignobject/index.md
+++ b/files/en-us/web/svg/reference/element/foreignobject/index.md
@@ -53,16 +53,16 @@ svg {
 
 - {{SVGAttr("height")}}
   - : The height of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The width of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : The x coordinate of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.

--- a/files/en-us/web/svg/reference/element/foreignobject/index.md
+++ b/files/en-us/web/svg/reference/element/foreignobject/index.md
@@ -53,16 +53,16 @@ svg {
 
 - {{SVGAttr("height")}}
   - : The height of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The width of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : The x coordinate of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.

--- a/files/en-us/web/svg/reference/element/image/index.md
+++ b/files/en-us/web/svg/reference/element/image/index.md
@@ -23,22 +23,22 @@ SVG files displayed with `<image>` are [treated as an image](/en-US/docs/Web/SVG
 
 - {{SVGAttr("x")}}
   - : Positions the image horizontally from the origin.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : Positions the image vertically from the origin.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The width the image renders at. Unlike HTML's `<img>`, this attribute is required.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("height")}}
   - : The height the image renders at. Unlike HTML's `<img>`, this attribute is required.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : Points at a URL for the image file.
     _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("preserveAspectRatio")}}
   - : Controls how the image is scaled.
-    _Value type_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("crossorigin")}}
   - : Defines the value of the credentials flag for CORS requests.
     _Value type_: [ anonymous | use-credentials ]? ; _Default value_: None; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/image/index.md
+++ b/files/en-us/web/svg/reference/element/image/index.md
@@ -23,31 +23,31 @@ SVG files displayed with `<image>` are [treated as an image](/en-US/docs/Web/SVG
 
 - {{SVGAttr("x")}}
   - : Positions the image horizontally from the origin.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : Positions the image vertically from the origin.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The width the image renders at. Unlike HTML's `<img>`, this attribute is required.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("height")}}
   - : The height the image renders at. Unlike HTML's `<img>`, this attribute is required.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : Points at a URL for the image file.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("preserveAspectRatio")}}
   - : Controls how the image is scaled.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("crossorigin")}}
   - : Defines the value of the credentials flag for CORS requests.
-    _Value type_: [ anonymous | use-credentials ]? ; _Default value_: None; _Animatable_: **yes**
+    _Value type_: [ `anonymous` | `use-credentials` ]?; _Default value_: None; _Animatable_: **yes**
 - {{SVGAttr("decoding")}}
   - : Provides a hint to the browser as to whether it should perform image decoding synchronously or asynchronously.
-    _Value type_: `async | sync | auto` ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `async | sync | auto`; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}}{{deprecated_inline}}
   - : Points at a URL for the image file.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/line/index.md
+++ b/files/en-us/web/svg/reference/element/line/index.md
@@ -33,16 +33,16 @@ svg {
 
 - {{SVGAttr('x1')}}
   - : Defines the x-axis coordinate of the line starting point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr('x2')}}
   - : Defines the x-axis coordinate of the line ending point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr('y1')}}
   - : Defines the y-axis coordinate of the line starting point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr('y2')}}
   - : Defines the y-axis coordinate of the line ending point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : Defines the total path length in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/line/index.md
+++ b/files/en-us/web/svg/reference/element/line/index.md
@@ -33,19 +33,19 @@ svg {
 
 - {{SVGAttr('x1')}}
   - : Defines the x-axis coordinate of the line starting point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr('x2')}}
   - : Defines the x-axis coordinate of the line ending point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr('y1')}}
   - : Defines the y-axis coordinate of the line starting point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr('y2')}}
   - : Defines the y-axis coordinate of the line ending point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : Defines the total path length in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/lineargradient/index.md
+++ b/files/en-us/web/svg/reference/element/lineargradient/index.md
@@ -41,16 +41,16 @@ svg {
 
 - {{SVGAttr("gradientUnits")}}
   - : This attribute defines the coordinate system for attributes `x1`, `x2`, `y1`, `y2`
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("gradientTransform")}}
   - : This attribute provides additional [transformation](/en-US/docs/Web/SVG/Reference/Attribute/transform) to the gradient coordinate system.
-    _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Guides/Content_type#transform-list) ; _Default value_: _identity transform_; _Animatable_: **yes**
+    _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Guides/Content_type#transform-list); _Default value_: _identity transform_; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : This attribute defines a reference to another `<linearGradient>` element that will be used as a template.
-    _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("spreadMethod")}}
   - : This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.
-    _Value type_: `pad` | `reflect` | `repeat` ; _Default value_: `pad`; _Animatable_: **yes**
+    _Value type_: `pad` | `reflect` | `repeat`; _Default value_: `pad`; _Animatable_: **yes**
 - {{SVGAttr("x1")}}
   - : This attribute defines the x coordinate of the starting point of the vector gradient along which the linear gradient is drawn.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**
@@ -59,7 +59,7 @@ svg {
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `100%`; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : An [\<IRI>](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to another `<linearGradient>` element that will be used as a template.
-    _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Guides/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Guides/Content_type#iri); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("y1")}}
   - : This attribute defines the y coordinate of the starting point of the vector gradient along which the linear gradient is drawn.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/lineargradient/index.md
+++ b/files/en-us/web/svg/reference/element/lineargradient/index.md
@@ -41,7 +41,7 @@ svg {
 
 - {{SVGAttr("gradientUnits")}}
   - : This attribute defines the coordinate system for attributes `x1`, `x2`, `y1`, `y2`
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("gradientTransform")}}
   - : This attribute provides additional [transformation](/en-US/docs/Web/SVG/Reference/Attribute/transform) to the gradient coordinate system.
     _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Guides/Content_type#transform-list) ; _Default value_: _identity transform_; _Animatable_: **yes**
@@ -50,7 +50,7 @@ svg {
     _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("spreadMethod")}}
   - : This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.
-    _Value type_: `pad`|`reflect`|`repeat` ; _Default value_: `pad`; _Animatable_: **yes**
+    _Value type_: `pad` | `reflect` | `repeat` ; _Default value_: `pad`; _Animatable_: **yes**
 - {{SVGAttr("x1")}}
   - : This attribute defines the x coordinate of the starting point of the vector gradient along which the linear gradient is drawn.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/marker/index.md
+++ b/files/en-us/web/svg/reference/element/marker/index.md
@@ -167,28 +167,28 @@ svg {
 
 - {{SVGAttr("markerHeight")}}
   - : This attribute defines the height of the marker viewport.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** ; _Default value_: `3`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**; _Default value_: `3`; _Animatable_: **yes**
 - {{SVGAttr("markerUnits")}}
   - : This attribute defines the coordinate system for the attributes `markerWidth`, `markerHeight` and the contents of the `<marker>`.
-    _Value type_: `userSpaceOnUse` | `strokeWidth` ; _Default value_: `strokeWidth`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `strokeWidth`; _Default value_: `strokeWidth`; _Animatable_: **yes**
 - {{SVGAttr("markerWidth")}}
   - : This attribute defines the width of the marker viewport.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** ; _Default value_: `3`; _Animatable_: **yes**
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**; _Default value_: `3`; _Animatable_: **yes**
 - {{SVGAttr("orient")}}
   - : This attribute defines the orientation of the marker relative to the shape it is attached to.
-    _Value type_: `auto` | `auto-start-reverse` | **[\<angle>](/en-US/docs/Web/SVG/Guides/Content_type#angle)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: `auto` | `auto-start-reverse` | **[\<angle>](/en-US/docs/Web/SVG/Guides/Content_type#angle)**; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("refX")}}
   - : This attribute defines the x coordinate for the reference point of the marker.
-    _Value type_: `left` | `center` | `right` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: `left` | `center` | `right` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)**; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("refY")}}
   - : This attribute defines the y coordinate for the reference point of the marker.
-    _Value type_: `top` | `center` | `bottom` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: `top` | `center` | `bottom` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)**; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the current SVG fragment.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/marker/index.md
+++ b/files/en-us/web/svg/reference/element/marker/index.md
@@ -170,22 +170,22 @@ svg {
     _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** ; _Default value_: `3`; _Animatable_: **yes**
 - {{SVGAttr("markerUnits")}}
   - : This attribute defines the coordinate system for the attributes `markerWidth`, `markerHeight` and the contents of the `<marker>`.
-    _Value type_: `userSpaceOnUse`|`strokeWidth` ; _Default value_: `strokeWidth`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `strokeWidth` ; _Default value_: `strokeWidth`; _Animatable_: **yes**
 - {{SVGAttr("markerWidth")}}
   - : This attribute defines the width of the marker viewport.
     _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)** ; _Default value_: `3`; _Animatable_: **yes**
 - {{SVGAttr("orient")}}
   - : This attribute defines the orientation of the marker relative to the shape it is attached to.
-    _Value type_: `auto`|`auto-start-reverse`|**[\<angle>](/en-US/docs/Web/SVG/Guides/Content_type#angle)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: `auto` | `auto-start-reverse` | **[\<angle>](/en-US/docs/Web/SVG/Guides/Content_type#angle)** ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("refX")}}
   - : This attribute defines the x coordinate for the reference point of the marker.
-    _Value type_: `left`|`center`|`right`|**[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: `left` | `center` | `right` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)** ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("refY")}}
   - : This attribute defines the y coordinate for the reference point of the marker.
-    _Value type_: `top`|`center`|`bottom`|**[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)** ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: `top` | `center` | `bottom` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)** ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the current SVG fragment.
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/mask/index.md
+++ b/files/en-us/web/svg/reference/element/mask/index.md
@@ -44,22 +44,22 @@ svg {
 
 - {{SVGAttr("height")}}
   - : This attribute defines the height of the masking area.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `120%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `120%`; _Animatable_: **yes**
 - {{SVGAttr("maskContentUnits")}}
   - : This attribute defines the coordinate system for the contents of the `<mask>`.
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
 - {{SVGAttr("maskUnits")}}
   - : This attribute defines the coordinate system for attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}} and {{SVGAttr("height")}} on the `<mask>`.
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : This attribute defines the x-axis coordinate of the top-left corner of the masking area.
-    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate) ; _Default value_: `-10%`; _Animatable_: **yes**
+    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `-10%`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : This attribute defines the y-axis coordinate of the top-left corner of the masking area.
-    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate) ; _Default value_: `-10%`; _Animatable_: **yes**
+    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `-10%`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : This attribute defines the width of the masking area.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `120%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `120%`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/mask/index.md
+++ b/files/en-us/web/svg/reference/element/mask/index.md
@@ -47,10 +47,10 @@ svg {
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `120%`; _Animatable_: **yes**
 - {{SVGAttr("maskContentUnits")}}
   - : This attribute defines the coordinate system for the contents of the `<mask>`.
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
 - {{SVGAttr("maskUnits")}}
   - : This attribute defines the coordinate system for attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}} and {{SVGAttr("height")}} on the `<mask>`.
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : This attribute defines the x-axis coordinate of the top-left corner of the masking area.
     _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate) ; _Default value_: `-10%`; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/path/index.md
+++ b/files/en-us/web/svg/reference/element/path/index.md
@@ -35,10 +35,10 @@ svg {
 
 - {{SVGAttr("d")}}
   - : This attribute defines the shape of the path.
-    _Value type_: **\<string>** ; _Default value_: `''`; _Animatable_: **yes**
+    _Value type_: **\<string>**; _Default value_: `''`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : This attribute lets authors specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/pattern/index.md
+++ b/files/en-us/web/svg/reference/element/pattern/index.md
@@ -52,7 +52,7 @@ svg {
 - {{SVGAttr("patternContentUnits")}}
 
   - : This attribute defines the coordinate system for the contents of the `<pattern>`.
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
 
     > [!NOTE]
     > This attribute has no effect if a `viewBox` attribute is specified on the `<pattern>` element.
@@ -62,10 +62,10 @@ svg {
     _Value type_: **[\<transform-list>](/en-US/docs/Web/SVG/Guides/Content_type#transform-list)**; _Default value_: _identity transform_; _Animatable_: **yes**
 - {{SVGAttr("patternUnits")}}
   - : This attribute defines the coordinate system for attributes `x`, `y`, `width`, and `height`.
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the SVG fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the pattern fragment.
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/pattern/index.md
+++ b/files/en-us/web/svg/reference/element/pattern/index.md
@@ -65,16 +65,16 @@ svg {
     _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the SVG fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the pattern fragment.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : This attribute determines the width of the pattern tile.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : This attribute determines the x coordinate shift of the pattern tile.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
   - : This attribute references a template pattern that provides default values for the `<pattern>` attributes.
@@ -85,7 +85,7 @@ svg {
 
 - {{SVGAttr("y")}}
   - : This attribute determines the y coordinate shift of the pattern tile.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/polygon/index.md
+++ b/files/en-us/web/svg/reference/element/polygon/index.md
@@ -36,10 +36,10 @@ svg {
 
 - {{SVGAttr('points')}}
   - : This attribute defines the list of points (pairs of `x,y` absolute coordinates) required to draw the polygon.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+ ; _Default value_: `""`; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+; _Default value_: `""`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : This attribute lets specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/polyline/index.md
+++ b/files/en-us/web/svg/reference/element/polyline/index.md
@@ -34,10 +34,10 @@ svg {
 
 - {{SVGAttr('points')}}
   - : This attribute defines the list of points (pairs of x,y absolute coordinates) required to draw the polyline
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+ ; _Default value_: `""`; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+; _Default value_: `""`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : This attribute lets specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/radialgradient/index.md
+++ b/files/en-us/web/svg/reference/element/radialgradient/index.md
@@ -44,37 +44,37 @@ svg {
 
 - {{SVGAttr("cx")}}
   - : This attribute defines the x coordinate of the end circle of the radial gradient.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `50%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `50%`; _Animatable_: **yes**
 - {{SVGAttr("cy")}}
   - : This attribute defines the y coordinate of the end circle of the radial gradient.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `50%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `50%`; _Animatable_: **yes**
 - {{SVGAttr("fr")}}
   - : This attribute defines the radius of the start circle of the radial gradient. The gradient will be drawn such that the 0% {{SVGElement('stop','gradient stop')}} is mapped to the perimeter of the start circle.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `0%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**
 - {{SVGAttr("fx")}}
   - : This attribute defines the x coordinate of the start circle of the radial gradient.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: Same as `cx`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: Same as `cx`; _Animatable_: **yes**
 - {{SVGAttr("fy")}}
   - : This attribute defines the y coordinate of the start circle of the radial gradient.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: Same as `cy`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: Same as `cy`; _Animatable_: **yes**
 - {{SVGAttr("gradientUnits")}}
   - : This attribute defines the coordinate system for attributes `cx`, `cy`, `r`, `fx`, `fy`, `fr`
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("gradientTransform")}}
   - : This attribute provides additional [transformation](/en-US/docs/Web/SVG/Reference/Attribute/transform) to the gradient coordinate system.
-    _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Guides/Content_type#transform-list) ; _Default value_: _identity transform_; _Animatable_: **yes**
+    _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Guides/Content_type#transform-list); _Default value_: _identity transform_; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : This attribute defines a reference to another `<radialGradient>` element that will be used as a template.
-    _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("r")}}
   - : This attribute defines the radius of the end circle of the radial gradient. The gradient will be drawn such that the 100% {{SVGElement('stop','gradient stop')}} is mapped to the perimeter of the end circle.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `50%`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `50%`; _Animatable_: **yes**
 - {{SVGAttr("spreadMethod")}}
   - : This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.
-    _Value type_: `pad` | `reflect` | `repeat` ; _Default value_: `pad`; _Animatable_: **yes**
+    _Value type_: `pad` | `reflect` | `repeat`; _Default value_: `pad`; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : An [\<IRI>](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to another `<radialGradient>` element that will be used as a template.
-    _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Guides/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Guides/Content_type#iri); _Default value_: none; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/radialgradient/index.md
+++ b/files/en-us/web/svg/reference/element/radialgradient/index.md
@@ -59,7 +59,7 @@ svg {
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: Same as `cy`; _Animatable_: **yes**
 - {{SVGAttr("gradientUnits")}}
   - : This attribute defines the coordinate system for attributes `cx`, `cy`, `r`, `fx`, `fy`, `fr`
-    _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox` ; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
 - {{SVGAttr("gradientTransform")}}
   - : This attribute provides additional [transformation](/en-US/docs/Web/SVG/Reference/Attribute/transform) to the gradient coordinate system.
     _Value type_: [**\<transform-list>**](/en-US/docs/Web/SVG/Guides/Content_type#transform-list) ; _Default value_: _identity transform_; _Animatable_: **yes**
@@ -71,7 +71,7 @@ svg {
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `50%`; _Animatable_: **yes**
 - {{SVGAttr("spreadMethod")}}
   - : This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.
-    _Value type_: `pad`|`reflect`|`repeat` ; _Default value_: `pad`; _Animatable_: **yes**
+    _Value type_: `pad` | `reflect` | `repeat` ; _Default value_: `pad`; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : An [\<IRI>](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to another `<radialGradient>` element that will be used as a template.
     _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Guides/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/rect/index.md
+++ b/files/en-us/web/svg/reference/element/rect/index.md
@@ -34,25 +34,25 @@ svg {
 
 - {{SVGAttr("x")}}
   - : The x coordinate of the rect.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the rect.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The width of the rect.
-    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("height")}}
   - : The height of the rect.
-    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("rx")}}
   - : The horizontal corner radius of the rect. Defaults to `ry` if it is specified.
-    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("ry")}}
   - : The vertical corner radius of the rect. Defaults to `rx` if it is specified.
-    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : The total length of the rectangle's perimeter, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, `height`, `rx` and `ry` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.

--- a/files/en-us/web/svg/reference/element/rect/index.md
+++ b/files/en-us/web/svg/reference/element/rect/index.md
@@ -34,22 +34,22 @@ svg {
 
 - {{SVGAttr("x")}}
   - : The x coordinate of the rect.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the rect.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The width of the rect.
-    _Value type_: `auto`|[**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("height")}}
   - : The height of the rect.
-    _Value type_: `auto`|[**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("rx")}}
   - : The horizontal corner radius of the rect. Defaults to `ry` if it is specified.
-    _Value type_: `auto`|[**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("ry")}}
   - : The vertical corner radius of the rect. Defaults to `rx` if it is specified.
-    _Value type_: `auto`|[**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: `auto` | [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("pathLength")}}
   - : The total length of the rectangle's perimeter, in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/script/index.md
+++ b/files/en-us/web/svg/reference/element/script/index.md
@@ -57,13 +57,13 @@ Click the circle to change colors.
     _Value type_: [**[ anonymous | use-credentials ]?**](/en-US/docs/Web/CSS/string); _Default value_: `?`; _Animatable_: **yes**
 - {{SVGAttr("href")}}
   - : The {{Glossary("URL")}} to the script to load.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
 - {{SVGAttr("type")}}
   - : This attribute defines type of the script language to use.
     _Value type_: [**`<media-type>`**](/en-US/docs/Glossary/MIME_type); _Default value_: `application/ecmascript`; _Animatable_: **no**
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : The {{Glossary("URL")}} to the script to load.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)** ; _Default value_: _none_; _Animatable_: **no**
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/stop/index.md
+++ b/files/en-us/web/svg/reference/element/stop/index.md
@@ -41,7 +41,7 @@ svg {
 
 - {{SVGAttr("offset")}}
   - : This attribute defines where the gradient stop is placed along the gradient vector.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("stop-color")}}
   - : This attribute defines the color of the gradient stop. It can be used as a CSS property.
     _Value type_: [**\<color>**](/en-US/docs/Web/SVG/Guides/Content_type#color); _Default value_: `black`; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/svg/index.md
+++ b/files/en-us/web/svg/reference/element/svg/index.md
@@ -93,28 +93,28 @@ To change the iframe's dimensions try resizing the dotted red border from bottom
 
 - {{SVGAttr("baseProfile")}} {{deprecated_inline}}
   - : The minimum SVG language profile that the document requires.
-    _Value type_: **\<string>** ; _Default value_: none; _Animatable_: **no**
+    _Value type_: **\<string>**; _Default value_: none; _Animatable_: **no**
 - {{SVGAttr("height")}}
   - : The displayed height of the rectangular viewport. (Not the height of its coordinate system.)
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : How the `svg` fragment must be deformed if it is displayed with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("version")}} {{deprecated_inline}}
   - : Which version of SVG is used for the inner content of the element.
-    _Value type_: **[\<number>](/en-US/docs/Web/SVG/Guides/Content_type#number)** ; _Default value_: none; _Animatable_: **no**
+    _Value type_: **[\<number>](/en-US/docs/Web/SVG/Guides/Content_type#number)**; _Default value_: none; _Animatable_: **no**
 - {{SVGAttr("viewBox")}}
   - : The SVG viewport coordinates for the current SVG fragment.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The displayed width of the rectangular viewport. (Not the width of its coordinate system.)
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : The displayed x coordinate of the svg container. No effect on outermost `svg` elements.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The displayed y coordinate of the svg container. No effect on outermost `svg` elements.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning these attributes can also be used as CSS properties.

--- a/files/en-us/web/svg/reference/element/svg/index.md
+++ b/files/en-us/web/svg/reference/element/svg/index.md
@@ -96,10 +96,10 @@ To change the iframe's dimensions try resizing the dotted red border from bottom
     _Value type_: **\<string>** ; _Default value_: none; _Animatable_: **no**
 - {{SVGAttr("height")}}
   - : The displayed height of the rectangular viewport. (Not the height of its coordinate system.)
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : How the `svg` fragment must be deformed if it is displayed with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("version")}} {{deprecated_inline}}
   - : Which version of SVG is used for the inner content of the element.
     _Value type_: **[\<number>](/en-US/docs/Web/SVG/Guides/Content_type#number)** ; _Default value_: none; _Animatable_: **no**
@@ -108,13 +108,13 @@ To change the iframe's dimensions try resizing the dotted red border from bottom
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : The displayed width of the rectangular viewport. (Not the width of its coordinate system.)
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : The displayed x coordinate of the svg container. No effect on outermost `svg` elements.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The displayed y coordinate of the svg container. No effect on outermost `svg` elements.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning these attributes can also be used as CSS properties.

--- a/files/en-us/web/svg/reference/element/symbol/index.md
+++ b/files/en-us/web/svg/reference/element/symbol/index.md
@@ -48,28 +48,28 @@ svg {
 
 - {{SVGAttr("height")}}
   - : This attribute determines the height of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("refX")}}
   - : This attribute determines the x coordinate of the reference point of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|`left`|`center`|`right` ; _Default value_: None; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `left` | `center` | `right` ; _Default value_: None; _Animatable_: **yes**
 - {{SVGAttr("refY")}}
   - : This attribute determines the y coordinate of the reference point of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|`top`|`center`|`bottom` ; _Default value_: None; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `top` | `center` | `bottom` ; _Default value_: None; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the current symbol.
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : This attribute determines the width of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : This attribute determines the x coordinate of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : This attribute determines the y coordinate of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/symbol/index.md
+++ b/files/en-us/web/svg/reference/element/symbol/index.md
@@ -48,28 +48,28 @@ svg {
 
 - {{SVGAttr("height")}}
   - : This attribute determines the height of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("refX")}}
   - : This attribute determines the x coordinate of the reference point of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `left` | `center` | `right` ; _Default value_: None; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `left` | `center` | `right`; _Default value_: None; _Animatable_: **yes**
 - {{SVGAttr("refY")}}
   - : This attribute determines the y coordinate of the reference point of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `top` | `center` | `bottom` ; _Default value_: None; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `top` | `center` | `bottom`; _Default value_: None; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the current symbol.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("width")}}
   - : This attribute determines the width of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `auto`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
 - {{SVGAttr("x")}}
   - : This attribute determines the x coordinate of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : This attribute determines the y coordinate of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/text/index.md
+++ b/files/en-us/web/svg/reference/element/text/index.md
@@ -54,25 +54,25 @@ svg {
 
 - {{SVGAttr("x")}}
   - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("dx")}}
   - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("dy")}}
   - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("rotate")}}
   - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
     _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("lengthAdjust")}}
   - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
-    _Value type_: `spacing`|`spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
+    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
 - {{SVGAttr("textLength")}}
   - : A width that the text should be scaled to fit.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/text/index.md
+++ b/files/en-us/web/svg/reference/element/text/index.md
@@ -54,25 +54,25 @@ svg {
 
 - {{SVGAttr("x")}}
   - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("dx")}}
   - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("dy")}}
   - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("rotate")}}
   - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
-    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("lengthAdjust")}}
   - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
     _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
 - {{SVGAttr("textLength")}}
   - : A width that the text should be scaled to fit.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/textpath/index.md
+++ b/files/en-us/web/svg/reference/element/textpath/index.md
@@ -45,25 +45,25 @@ svg {
     _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("lengthAdjust")}}
   - : Where length adjustment should be applied to the text: the space between glyphs, or both the space and the glyphs themselves.
-    _Value type_: `spacing`|`spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
+    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
 - {{SVGAttr("method")}}
   - : Which method to render individual glyphs along the path.
-    _Value type_: `align`|`stretch` ; _Default value_: `align`; _Animatable_: **yes**
+    _Value type_: `align` | `stretch` ; _Default value_: `align`; _Animatable_: **yes**
 - {{SVGAttr("path")}} {{Experimental_Inline}}
   - : The path on which the text should be rendered.
     _Value type_: [**\<path_data>**](/en-US/docs/Web/SVG/Reference/Attribute/path#path-data) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("side")}} {{Experimental_Inline}}
   - : Which side of the path the text should be rendered.
-    _Value type_: `left`|`right` ; _Default value_: `left`; _Animatable_: **yes**
+    _Value type_: `left` | `right` ; _Default value_: `left`; _Animatable_: **yes**
 - {{SVGAttr("spacing")}}
   - : How space between glyphs should be handled.
-    _Value type_: `auto`|`exact` ; _Default value_: `exact`; _Animatable_: **yes**
+    _Value type_: `auto` | `exact` ; _Default value_: `exact`; _Animatable_: **yes**
 - {{SVGAttr("startOffset")}}
   - : How far the beginning of the text should be offset from the beginning of the path.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("textLength")}}
   - : The width of the space into which the text will render.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _auto_; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _auto_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/textpath/index.md
+++ b/files/en-us/web/svg/reference/element/textpath/index.md
@@ -42,28 +42,28 @@ svg {
 
 - {{SVGAttr("href")}}
   - : The URL to the path or basic shape on which to render the text. If the `path` attribute is set, `href` has no effect.
-    _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<URL>**](/en-US/docs/Web/SVG/Guides/Content_type#url); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("lengthAdjust")}}
   - : Where length adjustment should be applied to the text: the space between glyphs, or both the space and the glyphs themselves.
     _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
 - {{SVGAttr("method")}}
   - : Which method to render individual glyphs along the path.
-    _Value type_: `align` | `stretch` ; _Default value_: `align`; _Animatable_: **yes**
+    _Value type_: `align` | `stretch`; _Default value_: `align`; _Animatable_: **yes**
 - {{SVGAttr("path")}} {{Experimental_Inline}}
   - : The path on which the text should be rendered.
-    _Value type_: [**\<path_data>**](/en-US/docs/Web/SVG/Reference/Attribute/path#path-data) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<path_data>**](/en-US/docs/Web/SVG/Reference/Attribute/path#path-data); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("side")}} {{Experimental_Inline}}
   - : Which side of the path the text should be rendered.
-    _Value type_: `left` | `right` ; _Default value_: `left`; _Animatable_: **yes**
+    _Value type_: `left` | `right`; _Default value_: `left`; _Animatable_: **yes**
 - {{SVGAttr("spacing")}}
   - : How space between glyphs should be handled.
-    _Value type_: `auto` | `exact` ; _Default value_: `exact`; _Animatable_: **yes**
+    _Value type_: `auto` | `exact`; _Default value_: `exact`; _Animatable_: **yes**
 - {{SVGAttr("startOffset")}}
   - : How far the beginning of the text should be offset from the beginning of the path.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("textLength")}}
   - : The width of the space into which the text will render.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) ; _Default value_: _auto_; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _auto_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/tspan/index.md
+++ b/files/en-us/web/svg/reference/element/tspan/index.md
@@ -47,25 +47,25 @@ svg {
 
 - {{SVGAttr("x")}}
   - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("dx")}}
   - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("dy")}}
   - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("rotate")}}
   - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
-    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts) ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("lengthAdjust")}}
   - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
     _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
 - {{SVGAttr("textLength")}}
   - : A width that the text should be scaled to fit.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/tspan/index.md
+++ b/files/en-us/web/svg/reference/element/tspan/index.md
@@ -47,25 +47,25 @@ svg {
 
 - {{SVGAttr("x")}}
   - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("dx")}}
   - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("dy")}}
   - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)) ; _Default value_: _none_; _Animatable_: **yes**
 - {{SVGAttr("rotate")}}
   - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
     _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts) ; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("lengthAdjust")}}
   - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
-    _Value type_: `spacing`|`spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
+    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
 - {{SVGAttr("textLength")}}
   - : A width that the text should be scaled to fit.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -35,17 +35,17 @@ svg {
 ## Attributes
 
 - {{SVGAttr("href")}}
-  - : The URL to an element/fragment that needs to be duplicated. See [Usage notes](#usage_notes) for details on common pitfalls.<br/> _Value type_: [**`<URL>`**](/en-US/docs/Web/SVG/Guides/Content_type#url) ; _Default value_: none; _Animatable_: **yes**
+  - : The URL to an element/fragment that needs to be duplicated. See [Usage notes](#usage_notes) for details on common pitfalls.<br/> _Value type_: [**`<URL>`**](/en-US/docs/Web/SVG/Guides/Content_type#url); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{Deprecated_Inline}}
-  - : An [`<IRI>`](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to an element/fragment that needs to be duplicated. If both {{SVGAttr("href")}} and {{SVGAttr("xlink:href")}} are present, the value given by {{SVGAttr("href")}} is used.<br/> _Value type_: [**`<IRI>`**](/en-US/docs/Web/SVG/Guides/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
+  - : An [`<IRI>`](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to an element/fragment that needs to be duplicated. If both {{SVGAttr("href")}} and {{SVGAttr("xlink:href")}} are present, the value given by {{SVGAttr("href")}} is used.<br/> _Value type_: [**`<IRI>`**](/en-US/docs/Web/SVG/Guides/Content_type#iri); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("x")}}
-  - : The x coordinate of an additional final offset transformation applied to the `<use>` element.<br/> _Value type_: [**`<coordinate>`**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate) ; _Default value_: `0`; _Animatable_: **yes**
+  - : The x coordinate of an additional final offset transformation applied to the `<use>` element.<br/> _Value type_: [**`<coordinate>`**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
-  - : The y coordinate of an additional final offset transformation applied to the `<use>` element.<br/> _Value type_: [**`<coordinate>`**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate) ; _Default value_: `0`; _Animatable_: **yes**
+  - : The y coordinate of an additional final offset transformation applied to the `<use>` element.<br/> _Value type_: [**`<coordinate>`**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
-  - : The width of the use element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `0`; _Animatable_: **yes**
+  - : The width of the use element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("height")}}
-  - : The height of the use element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length) ; _Default value_: `0`; _Animatable_: **yes**
+  - : The height of the use element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 
 > **Note:** `width`, and `height` have no effect on `use` elements, unless the element referenced has a [viewBox](/en-US/docs/Web/SVG/Reference/Attribute/viewBox) - i.e., they only have an effect when `use` refers to a `svg` or `symbol` element.
 

--- a/files/en-us/web/svg/reference/element/view/index.md
+++ b/files/en-us/web/svg/reference/element/view/index.md
@@ -16,7 +16,7 @@ The **`<view>`** [SVG](/en-US/docs/Web/SVG) element defines a particular view of
 
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the SVG fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none`| `xMinYMin`| `xMidYMin`| `xMaxYMin`| `xMinYMid`| `xMidYMid`| `xMaxYMid`| `xMinYMax`| `xMidYMax`| `xMaxYMax`) (`meet`|`slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the pattern fragment.
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**

--- a/files/en-us/web/svg/reference/element/view/index.md
+++ b/files/en-us/web/svg/reference/element/view/index.md
@@ -16,13 +16,13 @@ The **`<view>`** [SVG](/en-US/docs/Web/SVG) element defines a particular view of
 
 - {{SVGAttr("preserveAspectRatio")}}
   - : This attribute defines how the SVG fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)? ; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the pattern fragment.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("zoomAndPan")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : This attribute specifies whether the SVG document can be magnified and panned.
-    _Value type_: **disable | magnify** ; _Default value_: magnify; _Animatable_: **no**
+    _Value type_: **disable | magnify**; _Default value_: magnify; _Animatable_: **no**
 
 ## Example
 


### PR DESCRIPTION
Makes the text slightly easier to read