### PR TITLE
Update "Django Tutorial Part 2: Creating a skeleton website" page to prevent a bug in "Django Tutorial Part 8: User authentication and permissions" 

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/skeleton_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/skeleton_website/index.md
@@ -139,22 +139,24 @@ In addition we now have:
 
 Now that the application has been created, we have to register it with the project so that it will be included when any tools are run (like adding models to the database for example). Applications are registered by adding them to the `INSTALLED_APPS` list in the project settings.
 
-Open the project settings file, **django-locallibrary-tutorial/locallibrary/settings.py**, and find the definition for the `INSTALLED_APPS` list. Then add a new line at the end of the list, as shown below:
+Open the project settings file, **django-locallibrary-tutorial/locallibrary/settings.py**, and find the definition for the `INSTALLED_APPS` list. Then add a new line at the top of the list, as shown below:
 
 ```bash
 INSTALLED_APPS = [
+    # Add our new application
+    'catalog.apps.CatalogConfig', # This object was created for us in /catalog/apps.py
+
+    # Previous applications
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    # Add our new application
-    'catalog.apps.CatalogConfig', # This object was created for us in /catalog/apps.py
 ]
 ```
 
-The new line specifies the application configuration object (`CatalogConfig`) that was generated for you in **/django-locallibrary-tutorial/catalog/apps.py** when you created the application.
+The new line specifies the application configuration object (`CatalogConfig`) that was generated for you in **/django-locallibrary-tutorial/catalog/apps.py** when you created the application. Pay attention to the fact that you added it to the top of the list : Order of applications matter, and when multiple apps have the same page, the first in the list will be chosen.
 
 > [!NOTE]
 > You'll notice that there are already a lot of other `INSTALLED_APPS` (and `MIDDLEWARE`, further down in the settings file). These enable support for the [Django administration site](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Admin_site) and the functionality it uses (including sessions, authentication, etc.).


### PR DESCRIPTION
Move the catalog as the first line in the installed app to override default behavior

### Description

I moved `'catalog.apps.CatalogConfig',` as the first line of `INSTALLED_APPS` in the setup of the Django skeleton website tutorial, and made the following change in the description just above and below the code section.

### Motivation

When implementing the part 8 of the tutorial, I ran into an issue : the `logged_out.html` page I set up wasn't overriding the default Django page, which meant that when using the log out form in the tutorial, I was sent to the admin console logout page instead of mine.

I found that it was because the order of applications in the settings mattered, so I needed to move my app the top of my list. I hope this change will avoid others the same headache as me ! 

English is not my first language, so my apologies if there are any mistakes in the way I rewrote the description :) 

### Additional details

I found the solution [here](https://stackoverflow.com/questions/35153108/why-is-logged-out-html-not-overriding-in-django-registration), which is coherent with [Django Documentation](https://docs.djangoproject.com/en/5.2/ref/applications/) : 

> At each stage, Django processes all applications in the order of [INSTALLED_APPS](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-INSTALLED_APPS).

### Related issues and pull requests

None that I could find.
