### PR TITLE
Documentation for `tab.group`, `tab.ungroup`, and additions of `groupId`

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -24,10 +24,12 @@ let grouping = browser.tabs.group(
 
 ### Parameters
 
-
 - `options`
+
   - : An object containing details about the tab grouping.
+
     - `createProperties`
+
       - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
         - `windowId`
@@ -47,7 +49,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 Add a tab to an existing group, for example, the group of the current tab:
 
 ```js
-let [ oldTab ] = await browser.tabs.query({
+let [oldTab] = await browser.tabs.query({
   active: true,
   lastFocusedWindow: true,
 });

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -29,6 +29,7 @@ let grouping = browser.tabs.group(
   - : An object containing details about the tab grouping.
 
     - `createProperties` {{optional_inline}}
+
       - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
         - `windowId`
@@ -86,7 +87,7 @@ if (browser.tabs.group) {
   } else {
     // oldTab isn't in a group
     // Although a new tab positioned next to an ungrouped tab is
-    // already ungrouped, we call ungroup() in case this example is 
+    // already ungrouped, we call ungroup() in case this example is
     // adopted for use with tabs that aren't adjacent. When oldTab
     // is not in a tab group, the only way to ensure that newTab isn't
     // in a tab group is by using ungroup().

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -46,19 +46,17 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ## Examples
 
-Create two new tabs and put them in a new group.
+Create two tabs and put them in a new group, then create another tab and add it to the group.
 
 ```js
+//Create two tabs and put them in a new group.
 const tab1 = await browser.tabs.create({});
 const tab2 = await browser.tabs.create({});
 const groupId = await browser.tabs.group({
   tabIds: [tab1.id, tab2.id],
 });
-```
 
-Create a new tab and add it to an existing group.
-
-```js
+//Create another tab and add it to the group.
 const tab3 = await browser.tabs.create({});
 await browser.tabs.group({
   tabIds: tab3.id,

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -1,0 +1,75 @@
+---
+title: tabs.group()
+slug: Mozilla/Add-ons/WebExtensions/API/tabs/group
+page-type: webextension-api-function
+browser-compat: webextensions.api.tabs.group
+---
+
+{{AddonSidebar}}
+
+Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group.
+
+## Syntax
+
+```js-nolint
+let grouping = browser.tabs.group(
+  createProperties,    // object
+  groupId,             // integer
+  tabIds               // array
+)
+```
+
+### Parameters
+
+- `createProperties`
+  - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
+
+    - `windowId`
+      - : `integer`. The window of the new group. Defaults to the current window.
+
+- `groupId`
+  - : `integer`. The ID of the group to add the tabs to. If not specified, a new group is created.
+- `tabIds`
+  - : `array`. The tab ID or list of tab IDs to add to the group.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an integer containing the `groupId` of the tab group the tabs were added to. If the `groupId` is not found or some other error occurs, the promise is rejected with an error message.
+
+## Examples
+
+Add two tab to a new tab group:
+
+```js
+function onAdded(groupInfo) {
+  console.log(`New group ID: ${groupInfo.groupId}`);
+}
+
+function onError(error) {
+  console.log(`Error: ${error}`);
+}
+
+let adding = browser.tabs.group( { tabIds: [2, 13] } );
+adding.then(onAdded, onError);
+```
+
+Add a tab to an existing group:
+
+```js
+function onAdded() {
+  console.log(Tab added to group);
+}
+
+function onError(error) {
+  console.log(`Error: ${error}`);
+}
+
+let adding = browser.tabs.group( { groupId: 3, tabIds: [2]} );
+adding.then(onAdded, onError);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -9,32 +9,39 @@ browser-compat: webextensions.api.tabs.group
 
 Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group.
 
+As part of grouping, tabs may be moved to ensure that the tabs in the new group are adjacent to each other.
+
+If tabs were part of a tab group before re-grouping, and that previous tab group becomes empty, that previous tab is removed.
+
+If any of the tabs are pinned, they are unpinned before grouping.
+
+Note: the `tabs.group()` method is not the only way to group tabs; a tab may join an existing tab group by calling {{WebExtAPIRef("tabs.move")}} with an `index` between tabs that are part of an existing tab group.
+
 ## Syntax
 
 ```js-nolint
 let grouping = browser.tabs.group(
-  createProperties,    // object
-  groupId,             // integer
-  tabIds               // array
+  options    // object
 )
 ```
 
 ### Parameters
 
 - `createProperties`
+
   - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
     - `windowId`
-      - : `integer`. The window of the new group. Defaults to the current window.
+      - : `integer`. The window of the new group. Defaults to the [current window](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent).
 
 - `groupId`
   - : `integer`. The ID of the group to add the tabs to. If not specified, a new group is created.
 - `tabIds`
-  - : `array`. The tab ID or list of tab IDs to add to the group.
+  - : `integer` or `array` of `integer`. The tab ID or list of tab IDs to add to the group. Must contain at least one tab ID.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an integer containing the `groupId` of the tab group the tabs were added to. If the `groupId` is not found or some other error occurs, the promise is rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an integer containing the `groupId` of the tab group the tabs were added to. If the `groupId` is not found, any of the `tabIds` is invalid, the `windowId` is invalid, or some other error occurs, the promise is rejected with an error message. When a validation error occurs, the tabs are not modified.
 
 ## Examples
 
@@ -53,19 +60,25 @@ let adding = browser.tabs.group( { tabIds: [2, 13] } );
 adding.then(onAdded, onError);
 ```
 
-Add a tab to an existing group:
+Add a tab to an existing group, for example the group of the current tab:
 
 ```js
-function onAdded() {
-  console.log(Tab added to group);
-}
+let [ oldTab ] = await browser.tabs.query({
+  active: true,
+  lastFocusedWindow: true,
+});
 
-function onError(error) {
-  console.log(`Error: ${error}`);
+let newTab = await browser.tabs.create({
+  url: "https://example.com/",
+  index: oldTab.index + 1,
+});
+if (browser.tabs.group) {
+  if (oldTab.groupId !== -1) {
+    await browser.tabs.group({ groupId: oldTab.groupId, tabIds: [newTab.id] });
+  } else {
+    await browser.tabs.ungroup(newTab.id);
+  }
 }
-
-let adding = browser.tabs.group( { groupId: 3, tabIds: [2]} );
-adding.then(onAdded, onError);
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -32,7 +32,7 @@ let grouping = browser.tabs.group(
 
       - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
-        - `windowId`
+        - `windowId` {{optional_inline}}
           - : `integer`. The window of the new group. Defaults to the [current window](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent).
 
     - `groupId` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -7,15 +7,12 @@ browser-compat: webextensions.api.tabs.group
 
 {{AddonSidebar}}
 
-Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group.
+Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. Any pinned tabs are unpinned before grouping. Tabs are moved so that tabs in a group are adjacent.
 
-As part of grouping, tabs may be moved to ensure that the tabs in the new group are adjacent to each other.
+If a call moves tabs out of tab groups and any of those tab groups become empty, the empty tab groups are removed.
 
-If tabs were part of a tab group before re-grouping, and that previous tab group becomes empty, that previous tab is removed.
-
-If any of the tabs are pinned, they are unpinned before grouping.
-
-Note: the `tabs.group()` method is not the only way to group tabs; a tab may join an existing tab group by calling {{WebExtAPIRef("tabs.move")}} with an `index` between tabs that are part of an existing tab group.
+> [!NOTE]
+> The `tabs.group()` method is not the only way to group tabs. A tab joins a tab group when {{WebExtAPIRef("tabs.move")}} places it between tabs that are part of a tab group.
 
 ## Syntax
 
@@ -27,40 +24,27 @@ let grouping = browser.tabs.group(
 
 ### Parameters
 
-- `createProperties`
 
-  - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
+- `options`
+  - : An object containing details about the tab grouping.
+    - `createProperties`
+      - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
-    - `windowId`
-      - : `integer`. The window of the new group. Defaults to the [current window](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent).
+        - `windowId`
+          - : `integer`. The window of the new group. Defaults to the [current window](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent).
 
-- `groupId`
-  - : `integer`. The ID of the group to add the tabs to. If not specified, a new group is created.
-- `tabIds`
-  - : `integer` or `array` of `integer`. The tab ID or list of tab IDs to add to the group. Must contain at least one tab ID.
+    - `groupId`
+      - : `integer`. The ID of the group to add the tabs to. If not specified, a new group is created.
+    - `tabIds`
+      - : `integer` or `array` of `integer`. The tab ID or list of tab IDs to add to the group. Must contain at least one tab ID.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an integer containing the `groupId` of the tab group the tabs were added to. If the `groupId` is not found, any of the `tabIds` is invalid, the `windowId` is invalid, or some other error occurs, the promise is rejected with an error message. When a validation error occurs, the tabs are not modified.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an integer containing the `groupId` of the tab group the tabs were added to. If the `groupId` is not found, any of the `tabIds` are invalid, the `windowId` is invalid, or some other error occurs, the promise is rejected with an error message. When a validation error occurs, the tabs are not modified.
 
 ## Examples
 
-Add two tab to a new tab group:
-
-```js
-function onAdded(groupInfo) {
-  console.log(`New group ID: ${groupInfo.groupId}`);
-}
-
-function onError(error) {
-  console.log(`Error: ${error}`);
-}
-
-let adding = browser.tabs.group( { tabIds: [2, 13] } );
-adding.then(onAdded, onError);
-```
-
-Add a tab to an existing group, for example the group of the current tab:
+Add a tab to an existing group, for example, the group of the current tab:
 
 ```js
 let [ oldTab ] = await browser.tabs.query({

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -7,12 +7,12 @@ browser-compat: webextensions.api.tabs.group
 
 {{AddonSidebar}}
 
-Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. Any pinned tabs are unpinned before grouping. Tabs are moved so that tabs in a group are adjacent.
+Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. All tabs in a tab group must be adjacent, and tabs are moved if needed. Any pinned tabs are unpinned before grouping.
 
 If a call moves tabs out of tab groups and any of those tab groups become empty, the empty tab groups are removed.
 
 > [!NOTE]
-> The `tabs.group()` method is not the only way to group tabs. A tab joins a tab group when {{WebExtAPIRef("tabs.move")}} places it between tabs that are part of a tab group.
+> The `tabs.group()` method is not the only way to group tabs. A tab also joins a tab group when {{WebExtAPIRef("tabs.move")}} places it between tabs that are part of a tab group.
 
 ## Syntax
 
@@ -27,6 +27,7 @@ let grouping = browser.tabs.group(
 - `options`
 
   - : An object containing details about the tab grouping.
+
     - `createProperties` {{optional_inline}}
       - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
@@ -44,7 +45,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ## Examples
 
-Add a tab to an existing group, for example, the group of the current tab:
+Create a tab and match its grouping to that of the current tab.
 
 ```js
 let [oldTab] = await browser.tabs.query({
@@ -56,10 +57,17 @@ let newTab = await browser.tabs.create({
   url: "https://example.com/",
   index: oldTab.index + 1,
 });
+// Feature detection: tab grouping is a relatively new feature.
+// All tabs are ungrouped if the API does not exist.
 if (browser.tabs.group) {
   if (oldTab.groupId !== -1) {
     await browser.tabs.group({ groupId: oldTab.groupId, tabIds: [newTab.id] });
   } else {
+    // Although a new tab positioned next to an ungrouped tab is
+    // already ungrouped, we call ungroup() in case this example is 
+    // adopted for use with tabs that aren't adjacent. When oldTab
+    // is not in a tab group, the only way to ensure that newTab isn't
+    // in a tab group is by using ungroup().
     await browser.tabs.ungroup(newTab.id);
   }
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -24,16 +24,15 @@ let grouping = browser.tabs.group(
 
 ### Parameters
 
-
 - `options`
   - : An object containing details about the tab grouping.
-    - `createProperties`
+    - `createProperties` {{optional_inline}}
       - : `object`. Configuration details for a new group. Cannot be used if `groupId` is specified.
 
         - `windowId`
           - : `integer`. The window of the new group. Defaults to the [current window](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent).
 
-    - `groupId`
+    - `groupId` {{optional_inline}}
       - : `integer`. The ID of the group to add the tabs to. If not specified, a new group is created.
     - `tabIds`
       - : `integer` or `array` of `integer`. The tab ID or list of tab IDs to add to the group. Must contain at least one tab ID.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -45,6 +45,26 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 ## Examples
 
+Create two new tabs and put them in a new group.
+
+```js
+const tab1 = await browser.tabs.create({});
+const tab2 = await browser.tabs.create({});
+const groupId = await browser.tabs.group({
+  tabIds: [tab1.id, tab2.id],
+});
+```
+
+Create a new tab and add it to an existing group.
+
+```js
+const tab3 = await browser.tabs.create({});
+await browser.tabs.group({
+  tabIds: tab3.id,
+  groupId: groupId,
+});
+```
+
 Create a tab and match its grouping to that of the current tab.
 
 ```js
@@ -61,8 +81,10 @@ let newTab = await browser.tabs.create({
 // All tabs are ungrouped if the API does not exist.
 if (browser.tabs.group) {
   if (oldTab.groupId !== -1) {
+    // oldTab is in a group, add newTab to the same group
     await browser.tabs.group({ groupId: oldTab.groupId, tabIds: [newTab.id] });
   } else {
+    // oldTab isn't in a group
     // Although a new tab positioned next to an ungrouped tab is
     // already ungrouped, we call ungroup() in case this example is 
     // adopted for use with tabs that aren't adjacent. When oldTab

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -87,7 +87,7 @@ Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a s
 - {{WebExtAPIRef("tabs.goBack()")}}
   - : Go back to the previous page, if one is available.
 - {{WebExtAPIRef("tabs.group()")}}
-  - : Adds tabs to a group.
+  - : Adds tabs to a tab group.
 - {{WebExtAPIRef("tabs.hide()")}} {{experimental_inline}}
   - : Hides one or more tabs.
 - {{WebExtAPIRef("tabs.highlight()")}}
@@ -125,7 +125,7 @@ Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a s
 - {{WebExtAPIRef("tabs.toggleReaderMode()")}}
   - : Toggles Reader mode for the specified tab.
 - {{WebExtAPIRef("tabs.ungroup()")}}
-  - : Removes tabs from groups.
+  - : Removes tabs from tab groups.
 - {{WebExtAPIRef("tabs.update()")}}
   - : Navigate the tab to a new URL, or modify other properties of the tab.
 - {{WebExtAPIRef("tabs.warmup()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -86,6 +86,8 @@ Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a s
   - : Go forward to the next page, if one is available.
 - {{WebExtAPIRef("tabs.goBack()")}}
   - : Go back to the previous page, if one is available.
+- {{WebExtAPIRef("tabs.group()")}}
+  - : Adds tabs to a group.
 - {{WebExtAPIRef("tabs.hide()")}} {{experimental_inline}}
   - : Hides one or more tabs.
 - {{WebExtAPIRef("tabs.highlight()")}}
@@ -122,6 +124,8 @@ Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a s
   - : Shows one or more tabs that have been {{WebExtAPIRef("tabs.hide()", "hidden")}}.
 - {{WebExtAPIRef("tabs.toggleReaderMode()")}}
   - : Toggles Reader mode for the specified tab.
+- {{WebExtAPIRef("tabs.ungroup()")}}
+  - : Removes tabs from groups.
 - {{WebExtAPIRef("tabs.update()")}}
   - : Navigate the tab to a new URL, or modify other properties of the tab.
 - {{WebExtAPIRef("tabs.warmup()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -97,8 +97,8 @@ Lists the changes to the state of the tab that is updated. To learn more about t
   - : `boolean`. Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory but is visible in the tab strip. Its content gets reloaded the next time it's activated.
 - `favIconUrl` {{optional_inline}}
   - : `string`. The tab's new favicon URL. Not included when a tab loses its favicon (navigating from a page with a favicon to a page without one). Check `favIconUrl` in [tab](#tab) instead.
-  - `groupId` {{optional_inline}}
-    - : `integer`. The ID of the group the tabs are in or `-1` for ungrouped tabs.
+- `groupId` {{optional_inline}}
+  - : `integer`. The ID of the group the tabs are in or `-1` for ungrouped tabs.
 - `hidden` {{optional_inline}}
   - : `boolean`. True if the tab is {{WebExtAPIRef("tabs.hide()", "hidden")}}.
 - `isArticle` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -97,6 +97,8 @@ Lists the changes to the state of the tab that is updated. To learn more about t
   - : `boolean`. Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory but is visible in the tab strip. Its content gets reloaded the next time it's activated.
 - `favIconUrl` {{optional_inline}}
   - : `string`. The tab's new favicon URL. Not included when a tab loses its favicon (navigating from a page with a favicon to a page without one). Check `favIconUrl` in [tab](#tab) instead.
+  - `groupId` {{optional_inline}}
+    - : `integer`. The ID of the group the tabs are in or `-1` for ungrouped tabs.
 - `hidden` {{optional_inline}}
   - : `boolean`. True if the tab is {{WebExtAPIRef("tabs.hide()", "hidden")}}.
 - `isArticle` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -63,6 +63,7 @@ Events have three functions:
         - "audible"
         - "discarded"
         - "favIconUrl"
+        - "groupId"
         - "hidden"
         - "isArticle"
         - "mutedInfo"

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -39,6 +39,8 @@ let querying = browser.tabs.query(queryInfo)
       - : `boolean`. Whether the tabs are in the current window.
     - `discarded` {{optional_inline}}
       - : `boolean`. Whether the tabs are discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
+    - `groupId` {{optional_inline}}
+      - : `integer`. The ID of the group the tabs are in or `-1` for ungrouped tabs.
     - `hidden` {{optional_inline}}
       - : `boolean`. Whether the tabs are hidden.
     - `highlighted` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -40,7 +40,7 @@ let querying = browser.tabs.query(queryInfo)
     - `discarded` {{optional_inline}}
       - : `boolean`. Whether the tabs are discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
     - `groupId` {{optional_inline}}
-      - : `integer`. The ID of the group the tabs are in or `-1` for ungrouped tabs.
+      - : `integer`. The ID of the tab group the tabs are in or `-1` for ungrouped tabs.
     - `hidden` {{optional_inline}}
       - : `boolean`. Whether the tabs are hidden.
     - `highlighted` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -31,6 +31,8 @@ Values of this type are objects. They contain the following properties:
   - : `boolean`. Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
 - `favIconUrl` {{optional_inline}}
   - : `string`. The URL of the tab's favicon. Only present if the extension has the `"tabs"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). It may also be `undefined` if the page has no favicon, or an empty string if the tab is loading.
+- `groupId` {{optional_inline}}
+  - : `integer`. The ID of the group the tab belongs to. Set to `-1` if the tab doesn't belong to a tab group.
 - `height` {{optional_inline}}
   - : `integer`. The height of the tab in pixels.
 - `hidden`

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -32,7 +32,7 @@ Values of this type are objects. They contain the following properties:
 - `favIconUrl` {{optional_inline}}
   - : `string`. The URL of the tab's favicon. Only present if the extension has the `"tabs"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). It may also be `undefined` if the page has no favicon, or an empty string if the tab is loading.
 - `groupId` {{optional_inline}}
-  - : `integer`. The ID of the group the tab belongs to. Set to `-1` if the tab doesn't belong to a tab group.
+  - : `integer`. The ID of the tab group the tab belongs to. Set to `-1` if the tab doesn't belong to a tab group. See {{WebExtAPIRef("tabs.group")}}.
 - `height` {{optional_inline}}
   - : `integer`. The height of the tab in pixels.
 - `hidden`

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
@@ -1,0 +1,50 @@
+---
+title: tabs.ungroup()
+slug: Mozilla/Add-ons/WebExtensions/API/tabs/ungroup
+page-type: webextension-api-function
+browser-compat: webextensions.api.tabs.ungroup
+---
+
+{{AddonSidebar}}
+
+Removes one or more tabs from their respective groups. If any groups become empty, they are deleted.
+
+## Syntax
+
+```js-nolint
+let ungrouping = browser.tabs.ungroup(
+  tabIds              // array
+)
+```
+
+### Parameters
+
+- `tabIds`
+  - : `array`. The tab ID or list of tab IDs to remove from groups.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
+
+## Examples
+
+Remove two tabs from their tab groups:
+
+```js
+function onRemoved() {
+  console.log(`Tabs removed from groups`);
+}
+
+function onError(error) {
+  console.log(`Error: ${error}`);
+}
+
+let removing = browser.tabs.ungroup( tabIds: [2, 13] );
+removing.then(onRemoved, onError);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
@@ -9,10 +9,10 @@ browser-compat: webextensions.api.tabs.ungroup
 
 Removes one or more tabs from their respective tab groups. If any groups become empty, they are deleted.
 
-If a tab is between other tabs in a tab group before ungrouping, the remaining tabs are moved so they stay adjacent.
+All tabs in a tab group must be adjacent. If necessary, an ungrouped tab is moved before or after the tab group to maintain this requirement.
 
 > [!NOTE]
-> The `tabs.ungroup()` method is not the only way to ungroup tabs. A tab is ungrouped when it's moved by calling {{WebExtAPIRef("tabs.move")}} with an `index` that is outside the tab group.
+> The `tabs.ungroup()` method is not the only way to ungroup tabs. A tab is also ungrouped when it's moved by calling {{WebExtAPIRef("tabs.move")}} with an `index` that is outside a tab group.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
@@ -7,11 +7,12 @@ browser-compat: webextensions.api.tabs.ungroup
 
 {{AddonSidebar}}
 
-Removes one or more tabs from their respective tab groups. If any groups become empty, the empty tab groups are deleted.
+Removes one or more tabs from their respective tab groups. If any groups become empty, they are deleted.
 
-If a tab is between other tabs of the same tab group before ungrouping, the tab may be moved to ensure that the remaining tabs of the group stay adjacent to each other.
+If a tab is between other tabs in a tab group before ungrouping, the remaining tabs are moved so they stay adjacent.
 
-Note: the `tabs.ungroup()` method is not the only way to ungroup tabs; a tab may also be ungrouped when it is moved by calling {{WebExtAPIRef("tabs.move")}} with an `index` away from the tab group.
+> [!NOTE]
+> The `tabs.ungroup()` method is not the only way to ungroup tabs. A tab is ungrouped when it's moved by calling {{WebExtAPIRef("tabs.move")}} with an `index` that is outside the tab group.
 
 ## Syntax
 
@@ -34,7 +35,7 @@ If any of the `tabIds` are invalid, the promise is rejected without modifying th
 
 ## Examples
 
-Remove a tab from their tab group, if any:
+Remove the current tab from its tab group, if any:
 
 ```js
 let tabs = await browser.tabs.query({

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
@@ -7,7 +7,11 @@ browser-compat: webextensions.api.tabs.ungroup
 
 {{AddonSidebar}}
 
-Removes one or more tabs from their respective groups. If any groups become empty, they are deleted.
+Removes one or more tabs from their respective tab groups. If any groups become empty, the empty tab groups are deleted.
+
+If a tab is between other tabs of the same tab group before ungrouping, the tab may be moved to ensure that the remaining tabs of the group stay adjacent to each other.
+
+Note: the `tabs.ungroup()` method is not the only way to ungroup tabs; a tab may also be ungrouped when it is moved by calling {{WebExtAPIRef("tabs.move")}} with an `index` away from the tab group.
 
 ## Syntax
 
@@ -20,27 +24,26 @@ let ungrouping = browser.tabs.ungroup(
 ### Parameters
 
 - `tabIds`
-  - : `array`. The tab ID or list of tab IDs to remove from groups.
+  - : `integer` or `array` of `integer`. The tab ID or list of tab IDs to remove from groups.
 
 ### Return value
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
 
+If any of the `tabIds` are invalid, the promise is rejected without modifying the tabs.
+
 ## Examples
 
-Remove two tabs from their tab groups:
+Remove a tab from their tab group, if any:
 
 ```js
-function onRemoved() {
-  console.log(`Tabs removed from groups`);
-}
+let tabs = await browser.tabs.query({
+  active: true,
+  lastFocusedWindow: true,
+});
 
-function onError(error) {
-  console.log(`Error: ${error}`);
-}
-
-let removing = browser.tabs.ungroup( tabIds: [2, 13] );
-removing.then(onRemoved, onError);
+await browser.tabs.ungroup([tabs[0].id]);
+console.log("Current tab is ungrouped");
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -81,6 +81,11 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 - The `contextualIdentities` permission is now not recognized on Firefox for Android. Previously, it enabled a broken version of the "containers" feature. ([Firefox bug 1659500](https://bugzil.la/1659500))
 - The new Manifest V3 version of the {{WebExtAPIRef("userScripts")}} API is now available on Firefox for Android. ([Firefox bug 1949955](https://bugzil.la/1949955))
 - The {{WebExtAPIRef("alarms.create")}} API now returns a Promise instead of undefined. ([Firefox bug 1869171](https://bugzil.la/1869171))
+- Support added to enable the manipulation of tabs within tab groups, including the addition of:
+  - {{WebExtAPIRef("tabs.group()")}} and {{WebExtAPIRef("tabs.ungroup()")}}. ([Firefox bug 1959714](https://bugzil.la/1959714))
+  - `groupId` to {{WebExtAPIRef("tabs.Tab")}}. ([Firefox bug 1959713](https://bugzil.la/1959713))
+  - `groupId` to {{WebExtAPIRef("tabs.query")}}. ([Firefox bug 1959715](https://bugzil.la/1959715))
+  - `groupId` to {{WebExtAPIRef("tabs.onUpdated")}}. ([Firefox bug 1959716](https://bugzil.la/1959716)
 
 ### Removals
 


### PR DESCRIPTION
### Description

Documentation and release note for `tab.group`, `tab.unGroup`, and additions of `groupId` to `tab.query`, `tab.Tab`, and `tab.onUpdated`.

Addresses the changes implemented in:
- [Bug 1959713](https://bugzilla.mozilla.org/show_bug.cgi?id=1959713) - Implement tabs.Tab.groupId (this bug)
- [Bug 1959715](https://bugzilla.mozilla.org/show_bug.cgi?id=1959715) - Support groupId in tabs.query
- [Bug 1959714](https://bugzilla.mozilla.org/show_bug.cgi?id=1959714) - Implement tabs.group() and tabs.ungroup()
- [Bug 1959716](https://bugzilla.mozilla.org/show_bug.cgi?id=1959716) - Implement groupId in tabs.onUpdated

### Related issues and pull requests

Related BCD changes made in https://github.com/mdn/browser-compat-data/pull/26520

