### PR TITLE
fix fields description in webRequest CertificateInfo

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
@@ -28,7 +28,7 @@ Values of this type are objects. They contain the following properties:
   - : `Boolean`. `true` if the certificate is one of the trust roots installed in the browser, `false` otherwise.
 - `issuer`
 
-  - : `String`. The Distinguished Name of the entity that issued the certificate, formatted as a comma-separated list of Relative Distinguished Names (RDNs), each of the form "type=value".
+  - : `String`. The Distinguished Name of the entity that issued the certificate, formatted as a comma-separated list of Relative Distinguished Names, each of the form "type=value".
 
     For example: "CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US".
 
@@ -38,7 +38,7 @@ Values of this type are objects. They contain the following properties:
   - : `String`. The certificate's [serial number](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2).
 - `subject`
 
-  - : `String`. The Distinguished Name of the entity to which the certificate was issued, formatted as a comma-separated list of Relative Distinguished Names (RDNs), each of the form "type=value".
+  - : `String`. The Distinguished Name of the entity to which the certificate was issued, formatted as a comma-separated list of Relative Distinguished Names, each of the form "type=value".
 
     For example: "CN=\*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US".
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
@@ -28,7 +28,7 @@ Values of this type are objects. They contain the following properties:
   - : `Boolean`. `true` if the certificate is one of the trust roots installed in the browser, `false` otherwise.
 - `issuer`
 
-  - : `String`. Name of the organization that issued this certificate, represented as a Distinguished Name and formatted as a comma-separated list of Relative Distinguished Names, each of the form "type=value".
+  - : `String`. The Distinguished Name of the entity that issued the certificate, formatted as a comma-separated list of Relative Distinguished Names (RDNs), each of the form "type=value".
 
     For example: "CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US".
 
@@ -38,7 +38,7 @@ Values of this type are objects. They contain the following properties:
   - : `String`. The certificate's [serial number](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2).
 - `subject`
 
-  - : `String`. Name of the organization that issued this certificate, represented as a Distinguished Name and formatted as a comma-separated list of Relative Distinguished Names, each of the form "type=value".
+  - : `String`. The Distinguished Name of the entity to which the certificate was issued, formatted as a comma-separated list of Relative Distinguished Names (RDNs), each of the form "type=value".
 
     For example: "CN=\*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US".
 


### PR DESCRIPTION
the fields `subject` and `issuer` have the exact same description at the moment, and may be considered to be a typo when writing this documentation.

`subject` should refer to the certificate one obtain, and `issuer` should refer to the one who issue that certificate

in addition, I found that this may be one of the few places that mention `Certificate`, and we may link this document to Glossary `Digital Certificate` and update descriptions of it? (though in fact I have few ideas on how to update that glossary entry)