### PR TITLE
clip-path update

### DIFF
--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -399,8 +399,6 @@ function log(text) {
 
 Select different options to change the `clip-path` value. To clip a background to text, use the {{cssxref("background-clip")}} property.
 
-### Shape path() and shape() functions
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -251,7 +251,7 @@ div {
 
 {{EmbedLiveSample("shapes3", "", "280")}}
 
-The visibility, or at least partial visibility, of the four border sides in the clip path example defined by the `shape()` function exists because the percentage values have allowed the path to grow with the element. In the `path()` version, the element grew but not the shape. As a result, the top and left borders are partially visible while the right and bottom borders are clipped out.
+The visibility, or at least partial visibility, of the four border sides in the clip path example defined by the `shape()` function is due to the percentage values allowing the path to grow with the element. In the `path()` version, the element grew, but not the shape. As a result, the top and left borders are partially visible while the right and bottom borders are clipped out.
 
 ### SVG as clip source
 

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -220,7 +220,9 @@ For the first triangle, we didn't specify a reference box, defaulting to `border
 
 ### Shape() versus path() functions
 
-The previous example can also be created with the {{cssxref("basic-shape/shape","shape()")}}` and {{cssxref("basic-shape/path","path()")}} functions.
+Expanding on the previous example, we create the same shape with different `<basic-shape>` values, demonstrate how the {{cssxref("basic-shape/shape","shape()")}}`and {{cssxref("basic-shape/path","path()")}} functions can also be used to create clipping paths, with`shape()` being a more flexible solution.
+
+We use `path()` to define the first element's clipping path, and `shape()` for the second to create a triangle, both using the default `border-box` as their references box:
 
 ```css live-sample___shapes2 live-sample___shapes3
 div {
@@ -234,7 +236,9 @@ div:last-of-type {
 
 {{EmbedLiveSample("shapes2", "", "230")}}
 
-Because the `shape()` function allows using {{cssxref("percentage")}} values, and even {{cssxref("--*", "custom properties")}}, it is more robust. Here we change the size of the underlying element. The path defined with the `shape()` function grows with the element.
+Because the `shape()` function allows using {{cssxref("percentage")}} values (and {{cssxref("--*", "custom properties")}} too), it is more robust.
+
+Expanding on the previous result, the only change we make here is an increase the size of the underlying element:
 
 ```css live-sample___shapes3
 div {
@@ -245,7 +249,7 @@ div {
 
 {{EmbedLiveSample("shapes3", "", "280")}}
 
-You'll note by the visibility or at least partial visibility of the border's four sides in the clip path example defined by the `shape()` example, as the path has grown with the element. The `path()` version is clipped at 200px, with only the top and left borders being partially visible; the right and bottom borders are clipped out.
+The path defined with the `shape()` function grew with the element. You'll note by the visibility or at least partial visibility of the four border sides in the clip path example defined by the `shape()` function; by using percentages, the path grew with the element. In the `path()` version, the top and left borders being partially visible while the right and bottom borders are clipped out.
 
 ### SVG as clip source
 
@@ -411,5 +415,6 @@ Select different options to change the `clip-path` value. To clip a background t
 - {{CSSxRef("mask")}}
 - {{CSSxRef("filter")}}
 - {{cssxref("background-clip")}}
+- [CSS masking](/en-US/docs/Web/CSS/CSS_masking) module
 - SVG {{SVGAttr("clip-path")}} attribute
 - [Applying SVG effects to HTML content](/en-US/docs/Web/SVG/Guides/Applying_SVG_effects_to_HTML_content)

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -234,6 +234,8 @@ div:last-of-type {
 }
 ```
 
+As a result, the path defined with the shape() function grows with the element, whereas the path() version does not:
+
 {{EmbedLiveSample("shapes2", "", "230")}}
 
 Because the `shape()` function allows using {{cssxref("percentage")}} values (and {{cssxref("--*", "custom properties")}} too), it is more robust.
@@ -249,7 +251,7 @@ div {
 
 {{EmbedLiveSample("shapes3", "", "280")}}
 
-The path defined with the `shape()` function grew with the element. You'll note by the visibility or at least partial visibility of the four border sides in the clip path example defined by the `shape()` function; by using percentages, the path grew with the element. In the `path()` version, the top and left borders being partially visible while the right and bottom borders are clipped out.
+The visibility, or at least partial visibility, of the four border sides in the clip path example defined by the `shape()` function exists because the percentage values have allowed the path to grow with the element. In the `path()` version, the element grew but not the shape. As a result, the top and left borders are partially visible while the right and bottom borders are clipped out.
 
 ### SVG as clip source
 
@@ -335,11 +337,13 @@ This example demonstrates the various values of the `clip-path` property clippin
 The HTML includes an `<img>` that will be clipped, a star-shaped `<clipPath>`, and a {{htmlelement("select")}} element to choose a `clip-path` property value from.
 
 ```html
-<img id="clipped" src="mdn.svg" alt="MDN logo" />
+<img id="clipped"
+  src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
+  alt="Pride flag" />
 <svg height="0" width="0">
   <defs>
     <clipPath id="star">
-      <path d="M50,0 21,90 98,35 2,35 79,90z">
+      <path d="M100,0 42,180 196,70 4,70 158,180z">
     </clipPath>
   </defs>
 </svg>
@@ -379,9 +383,9 @@ When you select a new option from the `<select>` menu, an event handler updates 
 ```js
 const clipPathSelect = document.getElementById("clipPath");
 clipPathSelect.addEventListener("change", (evt) => {
-  const x = evt.target.value;
-  document.getElementById("clipped").style.clipPath = x;
-  log(`clip-path: ${x};`);
+  const path = evt.target.value;
+  document.getElementById("clipped").style.clipPath = path;
+  log(`clip-path: ${path};`);
 });
 ```
 

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -174,481 +174,137 @@ The `clip-path` property is specified as one or a combination of the values list
 
 ## Examples
 
-### Comparison of HTML and SVG
+### Shapes and geometry boxes
 
-```html hidden
-<svg class="defs">
+In this example, a triangle is created by defining a `polygon()` as the clip path on an element with a solid colored background with large {{cssxref("border")}}. The second element has a `<>:
+
+#### HTML
+
+```html
+<div></div>
+<div></div>
+```
+
+#### CSS
+
+```css hidden
+body {
+  display: flex;
+  gap: 20px;
+  flex-flow: row wrap;
+}
+```
+
+```css
+div {
+  height: 200px;
+  width: 200px;
+  background-color: rebeccapurple;
+  border: 20px solid;
+
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+}
+
+div:last-of-type {
+  clip-path: content-box polygon(50% 0, 100% 100%, 0 100%);
+}
+```
+
+#### Results
+
+{{EmbedLiveSample("Basic1", "", "230")}}
+
+For the first triangle, we didn't specify a reference box, defaulting to `border-box` being used as the reference box, with the 0% and 100% being the outside edge of the border. In the second example, we set the `<geometry-box>` to `content-box`, meaning the reference box for the basic shape is the outer edge of the content area, which is inside the padding box. In our padding-less example, this is the inner edge of the border.
+
+### SVG as clip source
+
+In this example, we define SVG {{svgElement("clipPath")}} elements to use as a `clip-path` source.
+
+#### HTML
+
+We include two {{htmlElement("div")}} elements that we will style along with an SVG element with two `<clipPath>` elements; one containing four {{svgElement("rect")}} elements that together define window panes, leaving a cross of blank space in the middle, and the other containing two crossing `<rect>` elements.
+
+```html
+<svg height="0" width="0">
   <defs>
-    <clipPath id="myPath" clipPathUnits="objectBoundingBox">
-      <path
-        d="M0.5,1 C0.5,1,0,0.7,0,0.3 A0.25,0.25,1,1,1,0.5,0.3 A0.25,0.25,1,1,1,1,0.3 C1,0.7,0.5,1,0.5,1 Z" />
+    <clipPath id="window">
+      <rect y="0" x="0" width="80" height="80" />
+      <rect y="0" x="120" width="80" height="80" />
+      <rect y="120" x="0" width="80" height="80" />
+      <rect y="120" x="120" width="80" height="80" />
+    </clipPath>
+    <clipPath id="cross">
+      <rect y="0" x="80" width="40" height="200" />
+      <rect y="80" x="0" width="200" height="40" />
     </clipPath>
   </defs>
 </svg>
 
-<div class="grid">
-  <div class="col">
-    <div class="note">clip-path: none</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="none">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="none">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">
-      clip-path: url(#myPath)<br /><br />
-      Assuming the following clipPath definition:
-      <pre>
-&lt;svg&gt;
-  &lt;clipPath id="myPath" clipPathUnits="objectBoundingBox"&gt;
-    &lt;path d="M0.5,1
-      C 0.5,1,0,0.7,0,0.3
-      A 0.25,0.25,1,1,1,0.5,0.3
-      A 0.25,0.25,1,1,1,1,0.3
-      C 1,0.7,0.5,1,0.5,1 Z" /&gt;
-  &lt;/clipPath&gt;
-&lt;/svg&gt;</pre
-      >
-    </div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="svg">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="svg">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">
-      clip-path: path('M15,45 A30,30,0,0,1,75,45 A30,30,0,0,1,135,45
-      Q135,90,75,130 Q15,90,15,45 Z')
-    </div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="svg2">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="svg2">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: circle(25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape1">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape1">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape2">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape2">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: fill-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape3">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape3">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: stroke-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape4">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape4">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: view-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape5">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape5">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: margin-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape6">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape6">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: border-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape7">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape7">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: padding-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape8">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape8">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div class="note">clip-path: content-box circle(25% at 25% 25%)</div>
-    <div class="row">
-      <div class="cell">
-        <span>HTML</span>
-        <div class="container">
-          <p class="shape9">I LOVE<br /><em>clipping</em></p>
-        </div>
-      </div>
-      <div class="cell">
-        <span>SVG</span>
-        <div class="container view-box">
-          <svg viewBox="0 0 192 192">
-            <g class="shape9">
-              <rect x="24" y="24" width="144" height="144" />
-              <text x="96" y="91">I LOVE</text>
-              <text x="96" y="109" class="em">clipping</text>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<div class="window">Window</div>
+<div class="cross">Cross</div>
 ```
+
+#### CSS
+
+We use flexible layout to allow our elements to sit side-by-side with a gap between if they fit. We define a {{cssxref("gradient/conic-gradient", "conic-gradient()")}} background image on both `<div>` elements, providing an interesting visual to clip, along with a border.
 
 ```css
-html,
 body {
-  height: 100%;
-  box-sizing: border-box;
-  background: #eee;
-}
-
-.grid {
-  width: 100%;
-  height: 100%;
   display: flex;
-  font: 1em monospace;
+  gap: 20px;
+  flex-flow: row wrap;
+  font: 2em sans-serif;
 }
 
-.row {
-  display: flex;
-  flex: 1 auto;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-
-.col {
-  flex: 1 auto;
-}
-
-.cell {
-  margin: 0.5em;
-  padding: 0.5em;
-  background-color: #fff;
-  overflow: hidden;
-  text-align: center;
-  flex: 1;
-}
-
-.note {
-  background: #fff3d4;
-  padding: 1em;
-  margin: 0.5em 0.5em 0;
-  font: 0.8em sans-serif;
-  text-align: left;
-  white-space: nowrap;
-}
-
-.note + .row .cell {
-  margin-top: 0;
-}
-
-.container {
-  display: inline-block;
-  border: 1px dotted grey;
-  position: relative;
-}
-
-.container::before {
-  content: "margin";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  font: italic 0.6em sans-serif;
-}
-
-.view-box {
-  box-shadow:
-    1rem 1rem 0 #efefef inset,
-    -1rem -1rem 0 #efefef inset;
-}
-
-.container.view-box::after {
-  content: "view-box";
-  position: absolute;
-  left: 1.1rem;
-  top: 1.1rem;
-  font: italic 0.6em sans-serif;
-}
-
-.cell span {
-  display: block;
-  margin-bottom: 0.5em;
-}
-
-p {
-  font-family: sans-serif;
-  background: #000;
-  color: pink;
-  margin: 2em;
-  padding: 3em 1em;
-  border: 1em solid pink;
-  width: 6em;
-}
-
-.none {
-  clip-path: none;
-}
-.svg {
-  clip-path: url(#myPath);
-}
-.svg2 {
-  clip-path: path(
-    "M15,45 A30,30,0,0,1,75,45 A30,30,0,0,1,135,45 Q135,90,75,130 Q15,90,15,45 Z"
+div {
+  width: 200px;
+  height: 200px;
+  background-image: conic-gradient(
+    at center,
+    rebeccapurple,
+    green,
+    lightblue,
+    rebeccapurple
   );
-}
-.shape1 {
-  clip-path: circle(25%);
-}
-.shape2 {
-  clip-path: circle(25% at 25% 25%);
-}
-.shape3 {
-  clip-path: fill-box circle(25% at 25% 25%);
-}
-.shape4 {
-  clip-path: stroke-box circle(25% at 25% 25%);
-}
-.shape5 {
-  clip-path: view-box circle(25% at 25% 25%);
-}
-.shape6 {
-  clip-path: margin-box circle(25% at 25% 25%);
-}
-.shape7 {
-  clip-path: border-box circle(25% at 25% 25%);
-}
-.shape8 {
-  clip-path: padding-box circle(25% at 25% 25%);
-}
-.shape9 {
-  clip-path: content-box circle(25% at 25% 25%);
-}
 
-.defs {
-  width: 0;
-  height: 0;
-  margin: 0;
-}
-
-pre {
-  margin-bottom: 0;
-}
-
-svg {
-  margin: 1em;
-  font-family: sans-serif;
-  width: 192px;
-  height: 192px;
-}
-
-svg rect {
-  stroke: pink;
-  stroke-width: 16px;
-}
-
-svg text {
-  fill: pink;
-  text-anchor: middle;
-}
-
-svg text.em {
-  font-style: italic;
+  border: 5px solid;
+  box-sizing: border-box;
 }
 ```
 
-{{EmbedLiveSample("Comparison_of_HTML_and_SVG", "100%", "800px")}}
+We then set the `id` of the `<clipPath>` as the `<clip-source>`. We included a {{cssxref("align-content")}} on the `cross` example, centering the text vertically, as otherwise the text would be clipped, as is happening in the `window` example.
 
-### Complete example
+```css
+.window {
+  clip-path: url(#window);
+}
+
+.cross {
+  clip-path: url(#cross);
+  align-content: center;
+}
+```
+
+#### Results
+
+{{EmbedLiveSample("SVG as clip source", "", "230")}}
+
+The element, including the border and text, is clipped, with only the parts overlapping the `<clipPath>` being drawn to the page.
+
+### The various value types
+
+This example demonstrates the various values of the `clip-path` property.
 
 #### HTML
+
+The HTML includes an image and a `<clipPath>` in the shape of a star. We also included a {{htmlelement("select")}} element which provides various optional values for the `clip-path` property.
 
 ```html
 <img id="clipped" src="mdn.svg" alt="MDN logo" />
 <svg height="0" width="0">
   <defs>
-    <clipPath id="cross">
-      <rect y="110" x="137" width="90" height="90" />
-      <rect x="0" y="110" width="90" height="90" />
-      <rect x="137" y="0" width="90" height="90" />
-      <rect x="0" y="0" width="90" height="90" />
+    <clipPath id="star">
+      <path d="M50,0 21,90 98,35 2,35 79,90z">
     </clipPath>
   </defs>
 </svg>
@@ -656,9 +312,9 @@ svg text.em {
 <select id="clipPath">
   <option value="none">none</option>
   <option value="circle(100px at 110px 100px)">circle</option>
-  <option value="url(#cross)" selected>cross</option>
+  <option value="url(#star)" selected>star</option>
   <option value="inset(20px round 20px)">inset</option>
-  <option value="rect(10px 10px 180px 220px round 20px)">rect</option>
+  <option value="rect(20px 150px 200px 20px round 10%)">rect</option>
   <option value="xywh(0 20% 90% 67% round 0 0 5% 5px)">xywh</option>
   <option value="path('M 0 200 L 0,110 A 110,90 0,0,1 240,100 L 200 340 z')">
     path
@@ -666,25 +322,47 @@ svg text.em {
 </select>
 ```
 
+```html hidden
+<pre id="log"></pre>
+```
+
 #### CSS
+
+The initial rendering includes the star as the `clip-path` source.
 
 ```css
 #clipped {
   margin-bottom: 20px;
-  clip-path: url(#cross);
+  clip-path: url(#star);
 }
 ```
 
-```js hidden
+#### JavaScript
+
+When you select a new option, an event handler updates the value of the `clip-path`.
+
+```js
 const clipPathSelect = document.getElementById("clipPath");
 clipPathSelect.addEventListener("change", (evt) => {
-  document.getElementById("clipped").style.clipPath = evt.target.value;
+  const x = evt.target.value;
+  document.getElementById("clipped").style.clipPath = x;
+  log(`clip-path: ${x};`);
 });
+```
+
+```js hidden
+function log(text) {
+  const logElement = document.querySelector("#log");
+  logElement.innerText = `${text}`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
 ```
 
 #### Result
 
-{{EmbedLiveSample("Complete_example", 230, 250)}}
+{{EmbedLiveSample("Complete_example", 230, 280)}}
+
+Select different options to change the `clip-path` value. To clip a background to text, use the {{cssxref("background-clip")}} property.
 
 ## Specifications
 
@@ -699,6 +377,6 @@ clipPathSelect.addEventListener("change", (evt) => {
 - {{CSSxRef("clip-rule")}}
 - {{CSSxRef("mask")}}
 - {{CSSxRef("filter")}}
+- {{cssxref("background-clip")}}
 - SVG {{SVGAttr("clip-path")}} attribute
-- [Shapes in clipping and masking – and how to use them](https://hacks.mozilla.org/2017/06/css-shapes-clipping-and-masking/)
 - [Applying SVG effects to HTML content](/en-US/docs/Web/SVG/Guides/Applying_SVG_effects_to_HTML_content)

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -401,7 +401,10 @@ function log(text) {
 
 {{EmbedLiveSample("Complete_example", 230, 300)}}
 
-Select different options to change the `clip-path` value. To clip a background to text, use the {{cssxref("background-clip")}} property.
+Select different options to change the `clip-path` value. 
+
+> [!NOTE]
+> While it is possible to define a path of text, if you want to clip a background image to text rather than a shape, see the {{cssxref("background-clip")}} property.
 
 ## Specifications
 

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -401,7 +401,7 @@ function log(text) {
 
 {{EmbedLiveSample("Complete_example", 230, 300)}}
 
-Select different options to change the `clip-path` value. 
+Select different options to change the `clip-path` value.
 
 > [!NOTE]
 > While it is possible to define a path of text, if you want to clip a background image to text rather than a shape, see the {{cssxref("background-clip")}} property.

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -177,7 +177,7 @@ The `clip-path` property is specified as one or a combination of the values list
 
 ### Shapes and geometry boxes
 
-In this example, a triangle is created by defining a `polygon()` as the clip path on an element with a solid colored background with large {{cssxref("border")}}. The second element has a `<>:
+In this example, two triangles are created by defining a `polygon()` as the clip path on {{htmlelement("div")}} elements. Each one has a solid colored background and a thick {{cssxref("border")}}. The second `<div>` element has its reference box set to `content-box`:
 
 #### HTML
 
@@ -216,13 +216,13 @@ div:last-of-type {
 
 {{EmbedLiveSample("shapes1", "", "230")}}
 
-For the first triangle, we didn't specify a reference box, defaulting to `border-box` being used as the reference box, with the 0% and 100% being the outside edge of the border. In the second example, we set the `<geometry-box>` to `content-box`, meaning the reference box for the basic shape is the outer edge of the content area, which is inside the padding box. In our padding-less example, this is the inner edge of the border.
+For the first triangle, we didn't specify a reference box; it therefore defaults to `border-box`, with the 0% and 100% positions located on the outside edge of the border. In the second example, we set the `<geometry-box>` to `content-box`, meaning the reference box for the basic shape is the outer edge of the content area, which is inside the padding box. Because our example has no `padding`, this is the inner edge of the border.
 
-### Shape() versus path() functions
+### `shape()` versus `path()` functions
 
-Expanding on the previous example, we create the same shape with different `<basic-shape>` values, demonstrate how the {{cssxref("basic-shape/shape","shape()")}}`and {{cssxref("basic-shape/path","path()")}} functions can also be used to create clipping paths, with`shape()` being a more flexible solution.
+Expanding on the previous example, we create the same triangle with different `<basic-shape>` values, demonstrating how the {{cssxref("basic-shape/shape", "shape()")}} and {{cssxref("basic-shape/path", "path()")}} functions can also be used to create clipping paths, with `shape()` being a more flexible solution.
 
-We use `path()` to define the first element's clipping path, and `shape()` for the second to create a triangle, both using the default `border-box` as their references box:
+We use `path()` to define the first element's clipping path, and `shape()` for the second, both using the default `border-box` as their reference box:
 
 ```css live-sample___shapes2 live-sample___shapes3
 div {
@@ -238,7 +238,7 @@ div:last-of-type {
 
 Because the `shape()` function allows using {{cssxref("percentage")}} values (and {{cssxref("--*", "custom properties")}} too), it is more robust.
 
-Expanding on the previous result, the only change we make here is an increase the size of the underlying element:
+We'll demonstrate this by increasing the size of the underlying element:
 
 ```css live-sample___shapes3
 div {
@@ -257,7 +257,7 @@ In this example, we define SVG {{svgElement("clipPath")}} elements to use as a `
 
 #### HTML
 
-We include two {{htmlElement("div")}} elements that we will style along with an SVG element with two `<clipPath>` elements; one containing four {{svgElement("rect")}} elements that together define window panes, leaving a cross of blank space in the middle, and the other containing two crossing `<rect>` elements.
+We include two {{htmlElement("div")}} elements and an `<svg> element containing two `<clipPath>` elements. One `<clipPath>` contains four {{svgElement("rect")}} elements that together define window panes, leaving a cross of blank space in the middle, and the other contains two crossing `<rect>` elements.
 
 ```html
 <svg height="0" width="0">
@@ -281,7 +281,7 @@ We include two {{htmlElement("div")}} elements that we will style along with an 
 
 #### CSS
 
-We use flexible layout to allow our elements to sit side-by-side with a gap between if they fit. We define a {{cssxref("gradient/conic-gradient", "conic-gradient()")}} background image on both `<div>` elements, providing an interesting visual to clip, along with a border.
+We use [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to allow our elements to sit side-by-side with a gap between them, if there is space available. We define a {{cssxref("gradient/conic-gradient", "conic-gradient()")}} background image on both `<div>` elements, providing an interesting visual to clip, along with a {{cssxref("border")}}.
 
 ```css
 body {
@@ -307,7 +307,7 @@ div {
 }
 ```
 
-We then set the `id` of the `<clipPath>` as the `<clip-source>`. We included a {{cssxref("align-content")}} on the `cross` example, centering the text vertically, as otherwise the text would be clipped, as is happening in the `window` example.
+We then set the `id` of the `<clipPath>` as the `<clip-source>`. We center the text in the `cross` example vertically using {{cssxref("align-content")}}, as otherwise the text would be clipped, as is happening in the `window` example.
 
 ```css
 .window {
@@ -324,7 +324,7 @@ We then set the `id` of the `<clipPath>` as the `<clip-source>`. We included a {
 
 {{EmbedLiveSample("SVG as clip source", "", "230")}}
 
-The element, including the border and text, is clipped, with only the parts overlapping the `<clipPath>` being drawn to the page.
+The elements, including their border and text, are clipped, with only the parts overlapping the `<clipPath>` elements being drawn to the page.
 
 ### The various value types
 
@@ -332,7 +332,7 @@ This example demonstrates the various values of the `clip-path` property clippin
 
 #### HTML
 
-The HTML includes an image and a `<clipPath>` in the shape of a star. We also included a {{htmlelement("select")}} element which provides various optional values for the `clip-path` property.
+The HTML includes an `<img>` that will be clipped, a star-shaped `<clipPath>`, and a {{htmlelement("select")}} element to choose a `clip-path` property value from.
 
 ```html
 <img id="clipped" src="mdn.svg" alt="MDN logo" />
@@ -374,7 +374,7 @@ The initial rendering includes the star as the `clip-path` source.
 
 #### JavaScript
 
-When you select a new option, an event handler updates the value of the `clip-path`.
+When you select a new option from the `<select>` menu, an event handler updates the value of the `clip-path` set on the `<img>`.
 
 ```js
 const clipPathSelect = document.getElementById("clipPath");
@@ -395,7 +395,7 @@ function log(text) {
 
 #### Result
 
-{{EmbedLiveSample("Complete_example", 230, 280)}}
+{{EmbedLiveSample("Complete_example", 230, 300)}}
 
 Select different options to change the `clip-path` value. To clip a background to text, use the {{cssxref("background-clip")}} property.
 

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -257,7 +257,7 @@ In this example, we define SVG {{svgElement("clipPath")}} elements to use as a `
 
 #### HTML
 
-We include two {{htmlElement("div")}} elements and an `<svg> element containing two `<clipPath>` elements. One `<clipPath>` contains four {{svgElement("rect")}} elements that together define window panes, leaving a cross of blank space in the middle, and the other contains two crossing `<rect>` elements.
+We include two {{htmlElement("div")}} elements and an `<svg>` element containing two `<clipPath>` elements. One `<clipPath>` contains four {{svgElement("rect")}} elements that together define window panes, leaving a cross of blank space in the middle, and the other contains two crossing `<rect>` elements.
 
 ```html
 <svg height="0" width="0">

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -99,6 +99,7 @@ clip-path: path(
   "M0.5,1 C0.5,1,0,0.7,0,0.3 A0.25,0.25,1,1,1,0.5,0.3 A0.25,0.25,1,1,1,1,0.3 C1,0.7,0.5,1,0.5,1 Z"
 );
 clip-path: rect(5px 5px 160px 145px round 20%);
+clip-path: shape(from 0% 0%, line to 100% 0%, line to 50% 100%, close);
 clip-path: xywh(0 5px 100% 75% round 15% 0);
 
 /* Box and shape values combined */
@@ -180,14 +181,14 @@ In this example, a triangle is created by defining a `polygon()` as the clip pat
 
 #### HTML
 
-```html
+```html live-sample___shapes1 live-sample___shapes2 live-sample___shapes3
 <div></div>
 <div></div>
 ```
 
 #### CSS
 
-```css hidden
+```css hidden live-sample___shapes1 live-sample___shapes2 live-sample___shapes3
 body {
   display: flex;
   gap: 20px;
@@ -195,12 +196,13 @@ body {
 }
 ```
 
-```css
+```css live-sample___shapes1 live-sample___shapes2 live-sample___shapes3
 div {
   height: 200px;
   width: 200px;
+  box-sizing: border-box;
   background-color: rebeccapurple;
-  border: 20px solid;
+  border: 20px solid magenta;
 
   clip-path: polygon(50% 0, 100% 100%, 0 100%);
 }
@@ -212,9 +214,38 @@ div:last-of-type {
 
 #### Results
 
-{{EmbedLiveSample("Basic1", "", "230")}}
+{{EmbedLiveSample("shapes1", "", "230")}}
 
 For the first triangle, we didn't specify a reference box, defaulting to `border-box` being used as the reference box, with the 0% and 100% being the outside edge of the border. In the second example, we set the `<geometry-box>` to `content-box`, meaning the reference box for the basic shape is the outer edge of the content area, which is inside the padding box. In our padding-less example, this is the inner edge of the border.
+
+### Shape() versus path() functions
+
+The previous example can also be created with the {{cssxref("basic-shape/shape","shape()")}}` and {{cssxref("basic-shape/path","path()")}} functions.
+
+```css live-sample___shapes2 live-sample___shapes3
+div {
+  clip-path: path("M100 0 L200 200 L0 200 Z");
+}
+
+div:last-of-type {
+  clip-path: shape(from 50% 0, line to 100% 100%, line to 0 100%, close);
+}
+```
+
+{{EmbedLiveSample("shapes2", "", "230")}}
+
+Because the `shape()` function allows using {{cssxref("percentage")}} values, and even {{cssxref("--*", "custom properties")}}, it is more robust. Here we change the size of the underlying element. The path defined with the `shape()` function grows with the element.
+
+```css live-sample___shapes3
+div {
+  width: 250px;
+  height: 250px;
+}
+```
+
+{{EmbedLiveSample("shapes3", "", "280")}}
+
+You'll note by the visibility or at least partial visibility of the border's four sides in the clip path example defined by the `shape()` example, as the path has grown with the element. The `path()` version is clipped at 200px, with only the top and left borders being partially visible; the right and bottom borders are clipped out.
 
 ### SVG as clip source
 
@@ -293,7 +324,7 @@ The element, including the border and text, is clipped, with only the parts over
 
 ### The various value types
 
-This example demonstrates the various values of the `clip-path` property.
+This example demonstrates the various values of the `clip-path` property clipping an HTML {{htmlelement("img")}}.
 
 #### HTML
 
@@ -363,6 +394,8 @@ function log(text) {
 {{EmbedLiveSample("Complete_example", 230, 280)}}
 
 Select different options to change the `clip-path` value. To clip a background to text, use the {{cssxref("background-clip")}} property.
+
+### Shape path() and shape() functions
 
 ## Specifications
 


### PR DESCRIPTION
moving the examples, which are the fully drawn owl, to a guide, and making the examples way more basic.,
committing this before the whole project is complete because this is turning into a huge project, and the rect() example in the drop down is broken.

will add the new guide and module in when the guide is complete.

part of https://github.com/openwebdocs/project/issues/224 and https://github.com/mdn/content/pull/39151