### PR TITLE
background-clip: Fix interactive example

### DIFF
--- a/files/en-us/web/css/background-clip/index.md
+++ b/files/en-us/web/css/background-clip/index.md
@@ -26,6 +26,7 @@ background-clip: content-box;
 ```css interactive-example-choice
 background-clip: text;
 color: transparent;
+text-shadow: none;
 ```
 
 ```html interactive-example
@@ -37,7 +38,7 @@ color: transparent;
 ```css interactive-example
 #example-element {
   background-image: url("/shared-assets/images/examples/leopard.jpg");
-  color: #d73611;
+  color: white;
   text-shadow: 2px 2px black;
   padding: 20px;
   border: 10px dashed #333;


### PR DESCRIPTION
all browsers now support the `text` example, so a a shadow is not longer needed behind the transparent text.
changed the text and shadow color to black and white to improve contrast on the dark image, and removed the no-longer required and breaking shadow when clipping to text.

Fixes https://github.com/mdn/content/issues/38596