### PR TITLE
Change CPP to other languages where appropriate

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -110,6 +110,7 @@
       "apacheconf",
       "bash",
       "batch",
+      "c",
       "cpp",
       "cs",
       "css",

--- a/files/en-us/web/api/ext_shader_texture_lod/index.md
+++ b/files/en-us/web/api/ext_shader_texture_lod/index.md
@@ -19,7 +19,7 @@ WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExt
 
 The following new functions can be used in GLSL shader code, if this extension is enabled:
 
-```cpp
+```c
 vec4 texture2DLodEXT(sampler2D sampler, vec2 coord, float lod)
 vec4 texture2DProjLodEXT(sampler2D sampler, vec3 coord, float lod)
 vec4 texture2DProjLodEXT(sampler2D sampler, vec4 coord, float lod)

--- a/files/en-us/web/api/oes_standard_derivatives/index.md
+++ b/files/en-us/web/api/oes_standard_derivatives/index.md
@@ -26,7 +26,7 @@ This extension exposes one new constant, which can be used in the {{domxref("Web
 
 The following new functions can be used in GLSL shader code, if this extension is enabled:
 
-```cpp
+```c
 genType dFdx(genType p)
 genType dFdy(genType p)
 genType fwidth(genType p)

--- a/files/en-us/web/api/ovr_multiview2/index.md
+++ b/files/en-us/web/api/ovr_multiview2/index.md
@@ -85,7 +85,7 @@ gl.drawElements(/* … */); // draw will be broadcasted to the layers of colorTe
 
 Shader code
 
-```cpp
+```glsl
 #version 300 es
 #extension GL_OVR_multiview2 : require
 precision mediump float;

--- a/files/en-us/web/api/webgl_api/data/index.md
+++ b/files/en-us/web/api/webgl_api/data/index.md
@@ -46,8 +46,7 @@ gl.vertexAttribPointer(vColor, 4, gl.FLOAT, false, 0, 0);
 gl.enableVertexAttribArray(vColor);
 ```
 
-```cpp
-//glsl
+```glsl
 attribute  vec4 vColor;
 
 void main()

--- a/files/en-us/web/javascript/guide/typed_arrays/index.md
+++ b/files/en-us/web/javascript/guide/typed_arrays/index.md
@@ -248,11 +248,11 @@ By combining a single buffer with multiple views of different types, starting at
 
 Consider this C structure:
 
-```cpp
+```c
 struct someStruct {
-  unsigned long id;
-  char username[16];
-  float amountDue;
+    unsigned long id;
+    char username[16];
+    float amountDue;
 };
 ```
 

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1210,7 +1210,7 @@ Each image consists of 2 to 4 `#define` directives, providing the width and heig
 The image must be a multiple of 8 pixels wide.
 For example, the following code represents an XBM image which is 8 pixels by 8 pixels, with those pixels in a black-and-white checkerboard pattern:
 
-```cpp
+```c
 #define square8_width 8
 #define square8_height 8
 static unsigned char square8_bits[] = {

--- a/files/en-us/web/webdriver/reference/commands/closewindow/index.md
+++ b/files/en-us/web/webdriver/reference/commands/closewindow/index.md
@@ -45,7 +45,7 @@ session.switch_to.window(original_window)
 
 C#:
 
-```cpp
+```cs
 using OpenQA.Selenium.Firefox;
 
 namespace MDNWebDriverExamples

--- a/files/en-us/web/webdriver/reference/commands/getwindowhandles/index.md
+++ b/files/en-us/web/webdriver/reference/commands/getwindowhandles/index.md
@@ -30,7 +30,7 @@ In order to determine whether or not a particular interaction with the browser o
 
 C#:
 
-```cpp
+```cs
 using System.Collections.ObjectModel;
 using OpenQA.Selenium.Firefox;
 

--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -30,7 +30,7 @@ This is the simplest case we'll look at, whereby you get emscripten to generate 
 
 1. First we need an example to compile. Take a copy of the following simple C example, and save it in a file called `hello.c` in a new directory on your local drive:
 
-   ```cpp
+   ```c
    #include <stdio.h>
 
    int main() {
@@ -71,7 +71,7 @@ Sometimes you will want to use a custom HTML template. Let's look at how we can 
 
 1. First of all, save the following C code in a file called `hello2.c`, in a new directory:
 
-   ```cpp
+   ```c
    #include <stdio.h>
 
    int main() {
@@ -106,7 +106,7 @@ If you want to call a function defined in your C code from JavaScript, you can u
 
 1. To start with, save the following code as `hello3.c` in a new directory:
 
-   ```cpp
+   ```c
    #include <stdio.h>
    #include <emscripten/emscripten.h>
 

--- a/files/en-us/webassembly/guides/existing_c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/existing_c_to_wasm/index.md
@@ -17,13 +17,13 @@ git clone https://github.com/webmproject/libwebp
 
 To start off simple, expose `WebPGetEncoderVersion()` from `encode.h` to JavaScript by writing a C file called `webp.c`:
 
-```cpp
+```c
 #include "emscripten.h"
 #include "src/webp/encode.h"
 
 EMSCRIPTEN_KEEPALIVE
 int version() {
-  return WebPGetEncoderVersion();
+    return WebPGetEncoderVersion();
 }
 ```
 
@@ -87,17 +87,17 @@ async function loadImage(src) {
 
 Now it's "only" a matter of copying the data from JavaScript into Wasm. For that, you need to expose two additional functions — one that allocates memory for the image inside Wasm and one that frees it up again:
 
-```cpp
+```c
 #include <stdlib.h> // required for malloc definition
 
 EMSCRIPTEN_KEEPALIVE
 uint8_t* create_buffer(int width, int height) {
-  return malloc(width * height * 4 * sizeof(uint8_t));
+    return malloc(width * height * 4 * sizeof(uint8_t));
 }
 
 EMSCRIPTEN_KEEPALIVE
 void destroy_buffer(uint8_t* p) {
-  free(p);
+    free(p);
 }
 ```
 
@@ -127,17 +127,17 @@ The image is now available in Wasm. It is time to call the WebP encoder to do it
 
 The result of the encoding operation is an output buffer and its length. Because functions in C can't have arrays as return types (unless you allocate memory dynamically), this example resorts to a static global array. This may not be clean C. In fact, it relies on Wasm pointers being 32 bits wide. But this is a fair shortcut for keeping things simple:
 
-```cpp
+```c
 int result[2];
 EMSCRIPTEN_KEEPALIVE
 void encode(uint8_t* img_in, int width, int height, float quality) {
-  uint8_t* img_out;
-  size_t size;
+    uint8_t* img_out;
+    size_t size;
 
-  size = WebPEncodeRGBA(img_in, width, height, width * 4, quality, &img_out);
+    size = WebPEncodeRGBA(img_in, width, height, width * 4, quality, &img_out);
 
-  result[0] = (int)img_out;
-  result[1] = size;
+    result[0] = (int)img_out;
+    result[1] = size;
 }
 
 EMSCRIPTEN_KEEPALIVE


### PR DESCRIPTION
Most of the code blocks marked as "CPP" are not real C++, but other C-like languages. This PR makes them more technically precise so readers know what kind of file to copy the code into.