### PR TITLE
CSS `mask` property

### DIFF
--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -57,6 +57,29 @@ mask: revert-layer;
 mask: unset;
 ```
 
+### Values
+
+- `<mask-layer>`
+
+  - : One or more comma-separated mask layers, consisting of the following components:
+
+    - `<mask-reference>`
+      - : Sets the mask image source. See {{cssxref("mask-image")}}.
+    - `<masking-mode>`
+      - : Sets the masking mode of the mask image. See {{cssxref("mask-mode")}}.
+    - `<position>`
+      - : Sets the position of the mask image. See {{cssxref("mask-position")}}.
+    - `<bg-size>`
+      - : Sets the size of the mask image. See {{cssxref("mask-size")}}.
+    - `<repeat-style>`
+      - : Sets the repetition of the mask image. See {{cssxref("mask-repeat")}}.
+    - `<geometry-box>`
+      - : If only one `<geometry-box>` value is given, it sets both {{cssxref("mask-origin")}} and {{cssxref("mask-clip")}}. If two `<geometry-box>` values are present, then the first sets {{cssxref("mask-origin")}} and the second sets {{cssxref("mask-clip")}}.
+    - `<geometry-box> | no-clip`
+      - : Sets the area affected by the mask image. See {{cssxref("mask-clip")}}.
+    - `<compositing-operator>`
+      - : Sets the compositing operation used on the current mask layer. See {{cssxref("mask-composite")}}.
+
 ## Description
 
 The `mask` property hides part or all of the element it is applied to. Which parts are hidden, visible, or partially rendered depends on the opacity of the mask at that pixel. The sections masked by opaque parts of the mask are completely hidden, whereas transparent sections of the mask render the element visible.
@@ -90,29 +113,6 @@ mask-border-width: auto;
 ```
 
 For this reason, the specification recommends using the `mask` shorthand rather than the individual component properties to override any masks set earlier in the cascade. This ensures that `mask-border` has also been reset.
-
-### Values
-
-- `<mask-layer>`
-
-  - : One or more comma-separated mask layers, consisting of the following components:
-
-    - `<mask-reference>`
-      - : Sets the mask image source. See {{cssxref("mask-image")}}.
-    - `<masking-mode>`
-      - : Sets the masking mode of the mask image. See {{cssxref("mask-mode")}}.
-    - `<position>`
-      - : Sets the position of the mask image. See {{cssxref("mask-position")}}.
-    - `<bg-size>`
-      - : Sets the size of the mask image. See {{cssxref("mask-size")}}.
-    - `<repeat-style>`
-      - : Sets the repetition of the mask image. See {{cssxref("mask-repeat")}}.
-    - `<geometry-box>`
-      - : If only one `<geometry-box>` value is given, it sets both {{cssxref("mask-origin")}} and {{cssxref("mask-clip")}}. If two `<geometry-box>` values are present, then the first sets {{cssxref("mask-origin")}} and the second sets {{cssxref("mask-clip")}}.
-    - `<geometry-box> | no-clip`
-      - : Sets the area affected by the mask image. See {{cssxref("mask-clip")}}.
-    - `<compositing-operator>`
-      - : Sets the compositing operation used on the current mask layer. See {{cssxref("mask-composite")}}.
 
 ## Formal definition
 

--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.mask
 
 {{CSSRef}}
 
-The **`mask`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties) hides an element (partially or fully) by masking or clipping the image at specific points. It is a shorthand for all the [`mask-*`](#constituent-properties) properties. The property accepts one or more comma-separated values, where each value corresponds to a [`<mask-layer>`](#mask-layer).
+The **`mask`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties) hides an element (partially or fully) by masking or clipping a specified area of the image. It is a shorthand for all the [`mask-*`](#constituent-properties) properties. The property accepts one or more comma-separated values, where each value corresponds to a [`<mask-layer>`](#mask-layer).
 
 ## Constituent properties
 
@@ -23,13 +23,13 @@ This property is a shorthand for the following CSS properties:
 - {{cssxref("mask-size")}}
 
 > [!NOTE]
-> As the `mask` shorthand resets all the component properties as well as the {{cssxref("mask-border")}} properties to their initial values, the specification authors recommend using the `mask` shorthand rather than the individual component properties to override any mask settings earlier in the cascade. This ensures that `mask-border` is also reset, allowing the new styles to take effect.
+> As the `mask` shorthand resets all the component properties as well as the {{cssxref("mask-border")}} properties to their initial values, the specification authors recommend using the `mask` shorthand rather than the individual component properties to override any mask values set earlier in the cascade. This ensures that `mask-border` is also reset, allowing the new styles to take effect.
 
 ## Description
 
-The `mask` property is used to hide part or all of the element on which it is applied. The parts that are hidden, visible, or partially rendered depend on the opacity of the mask at that pixel. The sections masked by opaque parts of the mask are completely hidden. Where the mask is fully transparent the element is visible.
+The `mask` property hides part or all of the element it is applied to. Which parts are hidden, visible, or partially rendered depends on the opacity of the mask at that pixel. The sections masked by opaque parts of the mask are completely hidden, whereas transparent sections of the mask render the element visible.
 
-While not all constituent properties need to be declared, any values that are omitted default to their initial values, which are:
+While not all constituent mask properties need to be declared, any values that are omitted default to their initial values, which are:
 
 ```css
 mask-image: none;
@@ -42,9 +42,9 @@ mask-clip: border-box;
 mask-composite: add;
 ```
 
-The order of some properties matter. Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm), this value is used for both the `mask-origin` and `mask-clip` properties. Where order is important is if there are two `<geometry-box>` values present; in this case, the first is the `mask-origin` value while the second is the `mask-clip` value.
+The order of some properties matters. Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property, as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm specified), this value is used for both the `mask-origin` and `mask-clip` properties. The order is important if there are two `<geometry-box>` values present; in this case, the first is the `mask-origin` value while the second is the `mask-clip` value.
 
-As the `mask` shorthand resets all the `mask-border-*` properties to their `initial` value, declare these properties, or the {{cssxref("mask-border")}} shorthand after any `mask` declarations. Using `mask` behaves as if you also set the following in your declaration block:
+As the `mask` shorthand resets all the `mask-border-*` properties to their `initial` value, you should declare these properties — or the {{cssxref("mask-border")}} shorthand — after any `mask` declarations. When setting `mask` in your declaration block, you also implicitly set the following:
 
 ```css
 mask-border-source: none;
@@ -55,7 +55,7 @@ mask-border-slice: 0;
 mask-border-width: auto;
 ```
 
-For this reason, the specification recommends using the `mask` shorthand rather than the individual component properties to override any masks set earlier in the cascade to ensure that `mask-border` has also been reset.
+For this reason, the specification recommends using the `mask` shorthand rather than the individual component properties to override any masks set earlier in the cascade. This ensures that `mask-border` has also been reset.
 
 ## Syntax
 
@@ -65,13 +65,13 @@ mask: none;
 
 /* Image values */
 mask: url(mask.png); /* Raster image used as mask */
-mask: url(masks.svg#star); /* Element with an SVG used as mask */
+mask: url(masks.svg#star); /* SVG used as mask */
 
 /* Combined values */
 mask: url(masks.svg#star) luminance; /* Luminance mask */
 mask: url(masks.svg#star) 40px 20px; /* Mask positioned 40px from the top and 20px from the left */
 mask: url(masks.svg#star) 0 0/50px 50px; /* Mask with a width and height of 50px */
-mask: url(masks.svg#star) repeat-x; /* Horizontally repeated mask */
+mask: url(masks.svg#star) repeat-x; /* Horizontally-repeated mask */
 mask: url(masks.svg#star) stroke-box; /* Mask extends to the inside edge of the stroke box */
 mask: url(masks.svg#star) exclude; /* Mask combined with background using non-overlapping parts */
 
@@ -93,7 +93,7 @@ mask: unset;
 
 - `<mask-layer>`
 
-  - : One or more comma separated mask layers, consisting of the following components:
+  - : One or more comma-separated mask layers, consisting of the following components:
 
     - `<mask-reference>`
       - : Sets the mask image source. See {{cssxref("mask-image")}}.
@@ -108,7 +108,7 @@ mask: unset;
     - `<geometry-box>`
       - : If only one `<geometry-box>` value is given, it sets both {{cssxref("mask-origin")}} and {{cssxref("mask-clip")}}. If two `<geometry-box>` values are present, then the first sets {{cssxref("mask-origin")}} and the second sets {{cssxref("mask-clip")}}.
     - `<geometry-box> | no-clip`
-      - : Sets the area that is affected by the mask image. See {{cssxref("mask-clip")}}.
+      - : Sets the area affected by the mask image. See {{cssxref("mask-clip")}}.
     - `<compositing-operator>`
       - : Sets the compositing operation used on the current mask layer. See {{cssxref("mask-composite")}}.
 
@@ -124,7 +124,7 @@ mask: unset;
 
 ### Masking an image
 
-In this example, an image is masked using a CSS generated repeating conic gradient as a mask source. We'll also show the gradient as a background image for comparison.
+In this example, an image is masked using a CSS-generated repeating conic gradient as a mask source. We'll also show the gradient as a background image for comparison.
 
 #### HTML
 
@@ -152,7 +152,7 @@ div {
 }
 ```
 
-We then apply a mask to the `<img>`. The `mask-image` is generated using a {{cssxref("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}} function. We define it to be a `100px` by `100px` gradient which repeats starting at the top and left corner of the image's `content-box`. We include two `<geometry-box>` values; the first sets `mask-origin` and the second defines the `mask-clip` property value. The gradient goes from transparent to solid `lightgreen`. We used `lightgreen` to demonstrate that it isn't the color of the mask that is important, but rather it's transparency.
+We then apply a mask to the `<img>`. The `mask-image` is generated using a {{cssxref("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}} function. We define it to be a `100px` by `100px` gradient, which repeats starting at the top and left corner of the image's `content-box`. We include two `<geometry-box>` values; the first sets the `mask-origin` and the second defines the `mask-clip` property value. The gradient goes from transparent to solid `lightgreen`. We used `lightgreen` to demonstrate that it isn't the color of the mask that is important, but rather its transparency.
 
 ```css
 img {
@@ -165,7 +165,7 @@ img {
 }
 ```
 
-Finally, we use the same value for the `<div>`'s {{cssxref("background")}} shorthand, property as we used fpr the `mask`.
+Finally, we use the same value for the `<div>`'s {{cssxref("background")}} shorthand property as we used for the `mask`.
 
 ```css
 div {

--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -7,23 +7,55 @@ browser-compat: css.properties.mask
 
 {{CSSRef}}
 
-The **`mask`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties) hides an element (partially or fully) by masking or clipping the image at specific points.
-
-> [!NOTE]
-> As well as the properties listed below, the `mask` shorthand also resets {{cssxref("mask-border")}} to its initial value. It is therefore recommended to use the `mask` shorthand rather than other shorthands or the individual properties to override any mask settings earlier in the cascade. This will ensure that `mask-border` has also been reset to allow the new styles to take effect.
+The **`mask`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties) hides an element (partially or fully) by masking or clipping the image at specific points. It is a shorthand for all the [`mask-*`](#constituent-properties) properties. The property accepts one or more comma-separated values, where each value corresponds to a [`<mask-layer>`](#mask-layer).
 
 ## Constituent properties
 
 This property is a shorthand for the following CSS properties:
 
-- [`mask-clip`](/en-US/docs/Web/CSS/mask-clip)
-- [`mask-composite`](/en-US/docs/Web/CSS/mask-composite)
-- [`mask-image`](/en-US/docs/Web/CSS/mask-image)
-- [`mask-mode`](/en-US/docs/Web/CSS/mask-mode)
-- [`mask-origin`](/en-US/docs/Web/CSS/mask-origin)
-- [`mask-position`](/en-US/docs/Web/CSS/mask-position)
-- [`mask-repeat`](/en-US/docs/Web/CSS/mask-repeat)
-- [`mask-size`](/en-US/docs/Web/CSS/mask-size)
+- {{cssxref("mask-clip")}}
+- {{cssxref("mask-composite")}}
+- {{cssxref("mask-image")}}
+- {{cssxref("mask-mode")}}
+- {{cssxref("mask-origin")}}
+- {{cssxref("mask-position")}}
+- {{cssxref("mask-repeat")}}
+- {{cssxref("mask-size")}}
+
+> [!NOTE]
+> As the `mask` shorthand resets all the component properties as well as the {{cssxref("mask-border")}} properties to their initial values, the specification authors recommend using the `mask` shorthand rather than the individual component properties to override any mask settings earlier in the cascade. This ensures that `mask-border` is also reset, allowing the new styles to take effect.
+
+## Description
+
+The `mask` property is used to hide part or all of the element on which it is applied. The parts that are hidden, visible, or partially rendered depend on the opacity of the mask at that pixel. The sections masked by opaque parts of the mask are completely hidden. Where the mask is fully transparent the element is visible.
+
+While not all constituent properties need to be declared, any values that are omitted default to their initial values, which are:
+
+```css
+mask-image: none;
+mask-mode: match-source;
+mask-position: 0% 0%;
+mask-size: auto;
+mask-repeat: repeat;
+mask-origin: border-box;
+mask-clip: border-box;
+mask-composite: add;
+```
+
+The order of some properties matter. Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm), this value is used for both the `mask-origin` and `mask-clip` properties. Where order is important is if there are two `<geometry-box>` values present; in this case, the first is the `mask-origin` value while the second is the `mask-clip` value.
+
+As the `mask` shorthand resets all the `mask-border-*` properties to their `initial` value, declare these properties, or the {{cssxref("mask-border")}} shorthand after any `mask` declarations. Using `mask` behaves as if you also set the following in your declaration block:
+
+```css
+mask-border-source: none;
+mask-border-mode: alpha;
+mask-border-outset: 0;
+mask-border-repeat: stretch;
+mask-border-slice: 0;
+mask-border-width: auto;
+```
+
+For this reason, the specification recommends using the `mask` shorthand rather than the individual component properties to override any masks set earlier in the cascade to ensure that `mask-border` has also been reset.
 
 ## Syntax
 
@@ -32,16 +64,22 @@ This property is a shorthand for the following CSS properties:
 mask: none;
 
 /* Image values */
-mask: url(mask.png); /* Pixel image used as mask */
-mask: url(masks.svg#star); /* Element within SVG graphic used as mask */
+mask: url(mask.png); /* Raster image used as mask */
+mask: url(masks.svg#star); /* Element with an SVG used as mask */
 
 /* Combined values */
-mask: url(masks.svg#star) luminance; /* Element within SVG graphic used as luminance mask */
-mask: url(masks.svg#star) 40px 20px; /* Element within SVG graphic used as mask positioned 40px from the top and 20px from the left */
-mask: url(masks.svg#star) 0 0/50px 50px; /* Element within SVG graphic used as mask with a width and height of 50px */
-mask: url(masks.svg#star) repeat-x; /* Element within SVG graphic used as horizontally repeated mask */
-mask: url(masks.svg#star) stroke-box; /* Element within SVG graphic used as mask extending to the box enclosed by the stroke */
-mask: url(masks.svg#star) exclude; /* Element within SVG graphic used as mask and combined with background using non-overlapping parts */
+mask: url(masks.svg#star) luminance; /* Luminance mask */
+mask: url(masks.svg#star) 40px 20px; /* Mask positioned 40px from the top and 20px from the left */
+mask: url(masks.svg#star) 0 0/50px 50px; /* Mask with a width and height of 50px */
+mask: url(masks.svg#star) repeat-x; /* Horizontally repeated mask */
+mask: url(masks.svg#star) stroke-box; /* Mask extends to the inside edge of the stroke box */
+mask: url(masks.svg#star) exclude; /* Mask combined with background using non-overlapping parts */
+
+/* Multiple masks */
+mask:
+  url(masks.svg#star) left / 16px repeat-y,
+  /* 16px-wide mask on the left side */ url(masks.svg#circle) right / 16px
+    repeat-y; /* 16px-wide mask against right side */
 
 /* Global values */
 mask: inherit;
@@ -49,32 +87,30 @@ mask: initial;
 mask: revert;
 mask: revert-layer;
 mask: unset;
-
-/* Multiple masks */
-mask:
-  url(masks.svg#star) left / 16px repeat-y,
-  /* Element within SVG graphic is used as a mask on the left-hand side with a width of 16px */
-    url(masks.svg#circle) right / 16px repeat-y; /* Element within SVG graphic is used as a mask on the right-hand side with a width of 16px */
 ```
 
 ### Values
 
-- `<mask-reference>`
-  - : Sets the mask image source. See {{cssxref("mask-image")}}.
-- `<masking-mode>`
-  - : Sets the masking mode of the mask image. See {{cssxref("mask-mode")}}.
-- `<position>`
-  - : Sets the position of the mask image. See {{cssxref("mask-position")}}.
-- `<bg-size>`
-  - : Sets the size of the mask image. See {{cssxref("mask-size")}}.
-- `<repeat-style>`
-  - : Sets the repetition of the mask image. See {{cssxref("mask-repeat")}}.
-- `<geometry-box>`
-  - : If only one `<geometry-box>` value is given, it sets both {{cssxref("mask-origin")}} and {{cssxref("mask-clip")}}. If two `<geometry-box>` values are present, then the first sets {{cssxref("mask-origin")}} and the second sets {{cssxref("mask-clip")}}.
-- `<geometry-box> | no-clip`
-  - : Sets the area that is affected by the mask image. See {{cssxref("mask-clip")}}.
-- `<compositing-operator>`
-  - : Sets the compositing operation used on the current mask layer. See {{cssxref("mask-composite")}}.
+- `<mask-layer>`
+
+  - : One or more comma separated mask layers, consisting of the following components:
+
+    - `<mask-reference>`
+      - : Sets the mask image source. See {{cssxref("mask-image")}}.
+    - `<masking-mode>`
+      - : Sets the masking mode of the mask image. See {{cssxref("mask-mode")}}.
+    - `<position>`
+      - : Sets the position of the mask image. See {{cssxref("mask-position")}}.
+    - `<bg-size>`
+      - : Sets the size of the mask image. See {{cssxref("mask-size")}}.
+    - `<repeat-style>`
+      - : Sets the repetition of the mask image. See {{cssxref("mask-repeat")}}.
+    - `<geometry-box>`
+      - : If only one `<geometry-box>` value is given, it sets both {{cssxref("mask-origin")}} and {{cssxref("mask-clip")}}. If two `<geometry-box>` values are present, then the first sets {{cssxref("mask-origin")}} and the second sets {{cssxref("mask-clip")}}.
+    - `<geometry-box> | no-clip`
+      - : Sets the area that is affected by the mask image. See {{cssxref("mask-clip")}}.
+    - `<compositing-operator>`
+      - : Sets the compositing operation used on the current mask layer. See {{cssxref("mask-composite")}}.
 
 ## Formal definition
 
@@ -88,15 +124,63 @@ mask:
 
 ### Masking an image
 
-```css
-.target {
-  mask: url(#c1) luminance;
-}
+In this example, an image is masked using a CSS generated repeating conic gradient as a mask source. We'll also show the gradient as a background image for comparison.
 
-.another-target {
-  mask: url(resources.svg#c1) 50px 30px/10px 10px repeat-x exclude;
+#### HTML
+
+We include an {{htmlelement("img")}} and an empty {{htmlelement("div")}} element.
+
+```html
+<img
+  src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
+  alt="Pride flag" />
+<div></div>
+```
+
+#### CSS
+
+We set the same {{cssxref("border")}}, {{cssxref("padding")}}, and sizing on both the `<img>` and `<div>`.
+
+```css
+img,
+div {
+  border: 20px dashed rebeccapurple;
+  box-sizing: content-box;
+  padding: 20px;
+  height: 220px;
+  width: 220px;
 }
 ```
+
+We then apply a mask to the `<img>`. The `mask-image` is generated using a {{cssxref("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}} function. We define it to be a `100px` by `100px` gradient which repeats starting at the top and left corner of the image's `content-box`. We include two `<geometry-box>` values; the first sets `mask-origin` and the second defines the `mask-clip` property value. The gradient goes from transparent to solid `lightgreen`. We used `lightgreen` to demonstrate that it isn't the color of the mask that is important, but rather it's transparency.
+
+```css
+img {
+  mask: repeating-radial-gradient(
+      circle,
+      transparent 0 5px,
+      lightgreen 15px 20px
+    )
+    content-box border-box 0% 0% / 100px 100px repeat;
+}
+```
+
+Finally, we use the same value for the `<div>`'s {{cssxref("background")}} shorthand, property as we used fpr the `mask`.
+
+```css
+div {
+  background: repeating-radial-gradient(
+      circle,
+      transparent 0 5px,
+      lightgreen 15px 20px
+    )
+    content-box border-box 0% 0% / 100px 100px repeat;
+}
+```
+
+#### Results
+
+{{EmbedLiveSample("Masking an image", "", "630")}}
 
 ## Specifications
 
@@ -110,6 +194,6 @@ mask:
 
 - {{CSSxRef("clip-path")}}
 - {{CSSxRef("filter")}}
+- [CSS masking](/en-US/docs/Web/CSS/CSS_masking) module
 - SVG {{SVGAttr("mask")}} attribute
-- [CSS Shapes, clipping and masking – and how to use them](https://hacks.mozilla.org/2017/06/css-shapes-clipping-and-masking/)
 - [Applying SVG effects to HTML content](/en-US/docs/Web/SVG/Guides/Applying_SVG_effects_to_HTML_content)

--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -25,38 +25,6 @@ This property is a shorthand for the following CSS properties:
 > [!NOTE]
 > As the `mask` shorthand resets all the component properties as well as the {{cssxref("mask-border")}} properties to their initial values, the specification authors recommend using the `mask` shorthand rather than the individual component properties to override any mask values set earlier in the cascade. This ensures that `mask-border` is also reset, allowing the new styles to take effect.
 
-## Description
-
-The `mask` property hides part or all of the element it is applied to. Which parts are hidden, visible, or partially rendered depends on the opacity of the mask at that pixel. The sections masked by opaque parts of the mask are completely hidden, whereas transparent sections of the mask render the element visible.
-
-While not all constituent mask properties need to be declared, any values that are omitted default to their initial values, which are:
-
-```css
-mask-image: none;
-mask-mode: match-source;
-mask-position: 0% 0%;
-mask-size: auto;
-mask-repeat: repeat;
-mask-origin: border-box;
-mask-clip: border-box;
-mask-composite: add;
-```
-
-The order of some properties matters. Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property, as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm specified), this value is used for both the `mask-origin` and `mask-clip` properties. The order is important if there are two `<geometry-box>` values present; in this case, the first is the `mask-origin` value while the second is the `mask-clip` value.
-
-As the `mask` shorthand resets all the `mask-border-*` properties to their `initial` value, you should declare these properties — or the {{cssxref("mask-border")}} shorthand — after any `mask` declarations. When setting `mask` in your declaration block, you also implicitly set the following:
-
-```css
-mask-border-source: none;
-mask-border-mode: alpha;
-mask-border-outset: 0;
-mask-border-repeat: stretch;
-mask-border-slice: 0;
-mask-border-width: auto;
-```
-
-For this reason, the specification recommends using the `mask` shorthand rather than the individual component properties to override any masks set earlier in the cascade. This ensures that `mask-border` has also been reset.
-
 ## Syntax
 
 ```css
@@ -88,6 +56,38 @@ mask: revert;
 mask: revert-layer;
 mask: unset;
 ```
+
+## Description
+
+The `mask` property hides part or all of the element it is applied to. Which parts are hidden, visible, or partially rendered depends on the opacity of the mask at that pixel. The sections masked by opaque parts of the mask are completely hidden, whereas transparent sections of the mask render the element visible.
+
+While not all constituent mask properties need to be declared, any values that are omitted default to their initial values, which are:
+
+```css
+mask-image: none;
+mask-mode: match-source;
+mask-position: 0% 0%;
+mask-size: auto;
+mask-repeat: repeat;
+mask-origin: border-box;
+mask-clip: border-box;
+mask-composite: add;
+```
+
+The order of some properties matters. Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property, as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm specified), this value is used for both the `mask-origin` and `mask-clip` properties. The order is important if there are two `<geometry-box>` values present; in this case, the first is the `mask-origin` value while the second is the `mask-clip` value.
+
+As the `mask` shorthand resets all the `mask-border-*` properties to their `initial` value, you should declare these properties — or the {{cssxref("mask-border")}} shorthand — after any `mask` declarations. When setting `mask` in your declaration block, you also implicitly set the following:
+
+```css
+mask-border-source: none;
+mask-border-mode: alpha;
+mask-border-outset: 0;
+mask-border-repeat: stretch;
+mask-border-slice: 0;
+mask-border-width: auto;
+```
+
+For this reason, the specification recommends using the `mask` shorthand rather than the individual component properties to override any masks set earlier in the cascade. This ensures that `mask-border` has also been reset.
 
 ### Values
 

--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -74,7 +74,9 @@ mask-clip: border-box;
 mask-composite: add;
 ```
 
-The order of some properties matters. Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property, as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm specified), this value is used for both the `mask-origin` and `mask-clip` properties. The order is important if there are two `<geometry-box>` values present; in this case, the first is the `mask-origin` value while the second is the `mask-clip` value.
+Within each `<mask-layer>`, the `mask-size` component must go after the `mask-position` value, with a forward slash (`/`) separating the two.
+
+If there are two `<geometry-box>` values present, the first is the `mask-origin` value, while the second is the `mask-clip` value. If one `<geometry-box>` value and the `no-clip` keyword are present, the `<geometry-box>` is the value of the `mask-origin` property, as the `no-clip` is only valid for the `mask-clip` property. In this case, the order of the two values doesn't matter. If only one `<geometry-box>` value is present (with no `no-clip` keyterm specified), this value is used for both the `mask-origin` and `mask-clip` properties.
 
 As the `mask` shorthand resets all the `mask-border-*` properties to their `initial` value, you should declare these properties — or the {{cssxref("mask-border")}} shorthand — after any `mask` declarations. When setting `mask` in your declaration block, you also implicitly set the following:
 


### PR DESCRIPTION
* rewrote intro
* added a description
* added an example
* the value is a comma-separated list of `<mask-layer>`s, so made the value section reflect this.
* updated the see also (will add the guide when the guide is complete)
* made the commenting in the syntax section shorter (i am ok with deleting them altogether if the reviewer is)

part of https://github.com/openwebdocs/project/issues/224 and https://github.com/mdn/content/pull/39151