### PR TITLE
Release notes for Bug-1381580 multiple locales fallbacks

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -57,7 +57,7 @@ This article provides information about the changes in Firefox 139 that affect d
 
 ## Changes for add-on developers
 
-- Localized extensions now cascade through locale subtags to find translations before reverting to the extension's default language. Previously, the extension used the extension default if a translation couldn't be found for a language with subtags (such as `en-GB` or `zh-Hans-CN`). Take an extension with the default of Spanish (`es`) and a translation for English (`en`) installed by a user who has chosen British English (`en-GB`) as their browser locale. Previously, the user was served the default (Spanish) translation. After this change, the user is served the English (`en`) translation. ([Firefox bug 1381580](https://bugzil.la/1381580))
+- Localized extensions now cascade through locale subtags to find translations before reverting to the extension's default language. Previously, the extension used the extension default if a translation couldn't be found for a language with subtags. See [Localized string selection](/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization#localized_string_selection) in the Internationalization article for more details of the new behavior. ([Firefox bug 1381580](https://bugzil.la/1381580))
 
 ### Removals
 

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -57,6 +57,8 @@ This article provides information about the changes in Firefox 139 that affect d
 
 ## Changes for add-on developers
 
+- Localized extensions now cascade through locale subtags to find translations before reverting to the extension's default language. Previously, the extension used the extension default if a translation couldn't be found for a language with subtags (such as `en-GB` or `zh-Hans-CN`). Take an extension with the default of Spanish (`es`) and a translation for English (`en`) installed by a user who has chosen British English (`en-GB`) as their browser locale. Previously, the user was served the default (Spanish) translation. After this change, the user is served the English (`en`) translation. ([Firefox bug 1381580](https://bugzil.la/1381580))
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
### Description

Provides a release note for [Bug 1381580](https://bugzilla.mozilla.org/show_bug.cgi?id=1381580) "Support multiple fallback locales in i18n API". This change amended the way that localized extensions identified a translation string by cascading through region, language, and then extension default.

Content changes in https://github.com/mdn/content/pull/39013
