### PR TITLE
Clarify that privacy sandbox enrollment is currently a Chrome-only thing

### DIFF
--- a/files/en-us/web/privacy/guides/privacy_sandbox/enrollment/index.md
+++ b/files/en-us/web/privacy/guides/privacy_sandbox/enrollment/index.md
@@ -6,7 +6,8 @@ page-type: guide
 sidebar: privacy
 ---
 
-To access certain privacy sandbox features, browsers require developers to complete an **enrollment** process.
+To access certain privacy sandbox features, Google Chrome requires developers to complete an **enrollment** process.
+These features are currently still experimental and only available in Chrome and Chromium-based browsers and may or may not make it into other browsers.
 
 Enrollment provides a mechanism to verify the entities that call privacy sandbox features, and to gather the developer-specific data needed to properly configure and use them. The enrollment process adds an additional layer of protections on top of the structural restrictions enforced within each feature by adding transparency to who is collecting data, and mitigating attempts to misuse features to gather more data than intended.
 
@@ -24,9 +25,7 @@ The following features require enrollment to be usable:
 
 The documentation of each feature includes more details on exactly which sub-features will fail if enrollment is not completed, and how.
 
-## Browser enrollment information
-
-### Chrome
+## Enrollment information
 
 - **Instructions**: [Enroll for the Privacy Sandbox](https://github.com/privacysandbox/attestation/blob/main/how-to-enroll.md).
 - **Testing**: You do not need to enroll to test privacy sandbox features locally. To allow local testing, enable the `chrome://flags/#privacy-sandbox-enrollment-overrides` developer flag.


### PR DESCRIPTION
### Description

This makes some of the wording around the Privacy Sandbox Enrollment more specific to Chrome since these features are currently only available as experimental features in Chrome.
Furthermore, Mozilla is opposed to 4/5 of the listed features, while Apple is opposed to just the Topics API.
They both have yet to give a standards position on the remaining features.

### Motivation

I think it is disingenuous to frame Google's additions to their browser as a general concept for "Browsers" (plural) when other implementers seem to overall take issue with the features at hand.
Framing it that way seems to give too much credibility to something that is still up in the air and with a seemingly undecided future.

### Additional details

https://mozilla.github.io/standards-positions/ includes Mozilla's negative standards position for the [Fenced Frame API](https://developer.mozilla.org/en-US/docs/Web/API/Fenced_frame_API), Protected Audience API, [Shared Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Shared_Storage_API) and [Topics API](https://developer.mozilla.org/en-US/docs/Web/API/Topics_API).
https://webkit.org/standards-positions/#position-111 has Apple's opposition to the [Topics API](https://developer.mozilla.org/en-US/docs/Web/API/Topics_API).

### Related issues and pull requests

Could not find any.
