### PR TITLE
Document checkbox value

### DIFF
--- a/files/en-us/web/api/htmlinputelement/value/index.md
+++ b/files/en-us/web/api/htmlinputelement/value/index.md
@@ -14,7 +14,7 @@ This property can also be set directly, for example to set a default value based
 
 ## Value
 
-A string containing the value of the {{htmlelement("input")}} element, or the empty string if the input element has no value set, unless the input element has a type of `checkbox` or `radio`, in which case it will be the string `"on"` if it has no value set (although the value can still be manually set to the empty string).
+A string specifying the default value of the {{htmlelement("input")}} element.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlinputelement/value/index.md
+++ b/files/en-us/web/api/htmlinputelement/value/index.md
@@ -14,7 +14,7 @@ This property can also be set directly, for example to set a default value based
 
 ## Value
 
-A string containing the value of the {{htmlelement("input")}} element, or the empty string if the input element has no value set.
+A string containing the value of the {{htmlelement("input")}} element, or the empty string if the input element has no value set, unless the input element has a type of `checkbox` or `radio`, in which case it will be the string `"on"` if it has no value set (although the value can still be manually set to the empty string).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I added documentation for the thing where checkbox and radio elements actually have JavaScript value `"on"` rather than `""` if the value attribute is left off their HTML.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This is how browsers actually work, and the current text is incorrect as far as I can tell.

I'm not sure about this wording, but it seems clear to me that this behavior should be mentioned in _some_ way here, because of how confusing it is when not explicitly mentioned. I think you could make an argument that the current text is technically correct (it feels like a huge stretch), but that doesn't change how relevant it is to describe this behavior here.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
I mean, here's the spec:

https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
