### PR TITLE
Fix incorrect example output for Reflect.deleteProperty() on arrays

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
@@ -25,7 +25,7 @@ const array1 = [1, 2, 3, 4, 5];
 Reflect.deleteProperty(array1, "3");
 
 console.log(array1);
-// Expected output: Array [1, 2, 3, undefined, 5]
+// Expected output: Array [1, 2, 3, <1 empty slot>, 5]
 ```
 
 ## Syntax
@@ -73,7 +73,7 @@ console.log(obj); // { y: 2 }
 
 const arr = [1, 2, 3, 4, 5];
 Reflect.deleteProperty(arr, "3"); // true
-console.log(arr); // [1, 2, 3, undefined, 5]
+console.log(arr); // [1, 2, 3, <1 empty slot>, 5]
 
 // Returns true if no such property exists
 Reflect.deleteProperty({}, "foo"); // true


### PR DESCRIPTION
This PR corrects the incorrect example output for Reflect.deleteProperty() when used to remove an array element.

### Related issues and pr
 https://github.com/mdn/yari/issues/12943

https://github.com/mdn/yari/pull/12944
