### PR TITLE
Update Firefox 138 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -72,9 +72,18 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 
 #### General
 
+- All remote protocols now force the preferences required to properly pipe logs to stdout ([Firefox bug 1947740](https://bugzilla.mozilla.org/show_bug.cgi?id=1947740)).
+- A new Firefox argument, `--remote-enable-system-access`, was added to enable sensitive features, such as interacting with Browsing Contexts in the parent process (e.g., Browser UI) or using privileged APIs in content processes ([Firefox bug 1944565](https://bugzilla.mozilla.org/show_bug.cgi?id=1944565)).
+
 #### WebDriver BiDi
 
+- The `webExtension.install` command now installs web extensions as temporary extensions by default. This allows the command to be used with unsigned extensions. A new Firefox-specific parameter, `moz:permanent`, has been added to force installation as a regular extension instead ([Firefox bug 1947678](https://bugzilla.mozilla.org/show_bug.cgi?id=1947678)).
+- The `browsingContext.setViewport` command now supports a `userContexts` parameter, which must be an array of user context (Firefox container) ids. When provided, the viewport configuration will be applied to all Browsing Contexts belonging to those user contexts, as well as any future contexts created within them. This parameter cannot be used together with the existing `context` parameter ([Firefox bug 1940952](https://bugzilla.mozilla.org/show_bug.cgi?id=1940952)).
+- The `browsingContext.Info` now includes a `clientWindow` property corresponding to the ID of the window owning the Browsing Context. This type is typically returned by `browsingContext.getTree` or included in the payload of events such as `browsingContext.contextCreated` ([Firefox bug 1920952](https://bugzilla.mozilla.org/show_bug.cgi?id=1920952)).
+
 #### Marionette
+
+- Switching to the `chrome` (parent process) context with Marionette now requires using the `--remote-enable-system-access` command-line flag when starting Firefox ([Firefox bug 1710425](https://bugzilla.mozilla.org/show_bug.cgi?id=1710425)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -72,14 +72,14 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 
 #### General
 
-- All remote protocols now force the preferences required to properly pipe logs to stdout ([Firefox bug 1947740](https://bugzilla.mozilla.org/show_bug.cgi?id=1947740)).
-- A new Firefox argument, `--remote-enable-system-access`, was added to enable sensitive features, such as interacting with Browsing Contexts in the parent process (e.g., Browser UI) or using privileged APIs in content processes ([Firefox bug 1944565](https://bugzilla.mozilla.org/show_bug.cgi?id=1944565)).
+- All remote protocols now enable the preferences required to properly pipe logs to stdout ([Firefox bug 1947740](https://bugzilla.mozilla.org/show_bug.cgi?id=1947740)).
+- A new Firefox argument, `--remote-enable-system-access`, was added to enable sensitive features, such as interacting with Browsing Contexts in the parent process (e.g., Browser UI) or using privileged APIs in content processes. This will be used for WebDriver BiDi features in the next releases, and can already be used with Marionette (see the Marionette section below) ([Firefox bug 1944565](https://bugzilla.mozilla.org/show_bug.cgi?id=1944565)).
 
 #### WebDriver BiDi
 
-- The `webExtension.install` command now installs web extensions as temporary extensions by default. This allows the command to be used with unsigned extensions. A new Firefox-specific parameter, `moz:permanent`, has been added to force installation as a regular extension instead ([Firefox bug 1947678](https://bugzilla.mozilla.org/show_bug.cgi?id=1947678)).
+- The `webExtension.install` command now installs web extensions temporarily by default, allowing it to be used with unsigned extensions - either as an XPI file or as an unpacked folder. A new Firefox-specific parameter, `moz:permanent`, has been added to force installation as a regular extension instead ([Firefox bug 1947678](https://bugzilla.mozilla.org/show_bug.cgi?id=1947678)).
 - The `browsingContext.setViewport` command now supports a `userContexts` parameter, which must be an array of user context (Firefox container) ids. When provided, the viewport configuration will be applied to all Browsing Contexts belonging to those user contexts, as well as any future contexts created within them. This parameter cannot be used together with the existing `context` parameter ([Firefox bug 1940952](https://bugzilla.mozilla.org/show_bug.cgi?id=1940952)).
-- The `browsingContext.Info` now includes a `clientWindow` property corresponding to the ID of the window owning the Browsing Context. This type is typically returned by `browsingContext.getTree` or included in the payload of events such as `browsingContext.contextCreated` ([Firefox bug 1920952](https://bugzilla.mozilla.org/show_bug.cgi?id=1920952)).
+- The `browsingContext.Info` type now includes a `clientWindow` property corresponding to the ID of the window owning the Browsing Context. It is typically returned by `browsingContext.getTree` or included in the payload of events such as `browsingContext.contextCreated` ([Firefox bug 1920952](https://bugzilla.mozilla.org/show_bug.cgi?id=1920952)).
 
 #### Marionette
 


### PR DESCRIPTION
Release notes update based on the following list of [relnote worthy bugs](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox137&query_format=advanced&o1=equals&f1=cf_status_firefox138&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=17522701).