### PR TITLE
Bug-1792685 Content scripts and styles guaranteed execution order release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -58,6 +58,7 @@ This article provides information about the changes in Firefox 139 that affect d
 ## Changes for add-on developers
 
 - Localized extensions now cascade through locale subtags to find translations before reverting to the extension's default language. Previously, the extension used the extension default if a translation couldn't be found for a language with subtags. See [Localized string selection](/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization#localized_string_selection) in the Internationalization article for more details of the new behavior. ([Firefox bug 1381580](https://bugzil.la/1381580))
+- Content scripts and styles are now guaranteed to execute in the order of registration (i.e., their order in the [`content_scripts` manifest key array](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts)). Previously, the order was only guaranteed for scripts within the same `js` array. ([Firefox bug 1792685](https://bugzil.la/1792685))
 
 ### Removals
 


### PR DESCRIPTION
### Description

Provide a release note for the change made in [Bug 1792685](https://bugzilla.mozilla.org/show_bug.cgi?id=1792685) Ensure that all document_start resources have finished loading before starting document_end scripts



<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
