### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -90,7 +90,7 @@ The following table shows the state of `result` after running this script:
 | `index`   | `4`                                                                |
 | `indices` | `[[4, 25], [10, 15], [20, 25]]`<br />`groups: { color: [10, 15 ]}` |
 | `input`   | `"The Quick Brown Fox Jumps Over The Lazy Dog"`                    |
-| `groups`  | `{ color: "brown" }`                                               |
+| `groups`  | `{ color: "Brown" }`                                               |
 
 In addition, `re.lastIndex` will be set to `25`, due to this regex being global.
 


### PR DESCRIPTION
I tested the example code in Google Chrome.  The `groups` actually returns `{ color: "Brown" }` with an uppercase `B` since the `input` is `The Quick Brown Fox Jumps Over The Lazy Dog`.  The docs currently show `brown` with a lowercase `b`.

### Description
Typo in `brown`.  Should be `Brown` given the `input` string.

### Motivation
The example code should be accurate.

### Additional details
None

### Related issues and pull requests
None