### PR TITLE
docs(Fx138-relnote): Move support for `import` from Experimental to main release

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -925,46 +925,6 @@ This includes:
   </tbody>
 </table>
 
-### Import attribute for JSON modules
-
-The [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) declaration now supports importing JSON modules using the [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) attribute.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>138</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>138</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>138</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>138</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>javascript.options.experimental.import_attributes</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## APIs
 
 ### CloseWatcher Interface

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -26,6 +26,7 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 
 - The {{jsxref("Error.captureStackTrace()")}} static method is now supported. This installs stack trace information on a provided object as the {{jsxref("Error.stack")}} property. Its main use case is to install a stack trace on a custom error object that does not derive from the {{jsxref("Error")}} interface. ([Firefox bug 1950508](https://bugzil.la/1950508)).
 - The {{jsxref("Error.isError()")}} static method can now be used to check whether or not an object is an instance of an {{jsxref("Error")}} or a {{domxref("DOMException")}}. This is more reliable than using `instanceof` for the same purpose. ([Firefox bug 1952249](https://bugzil.la/1952249)).
+- The [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) declaration now supports importing JSON modules using the [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) attribute.
 
 #### Removals
 
@@ -134,10 +135,6 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **`PerformanceEventTiming.interactionId`**: `dom.performance.event_timing.enable_interactionid`
 
   {{domxref("PerformanceEventTiming.interactionId")}} can be used to measure latency timing for events triggered by a particular user interaction. ([Firefox bug 1934683](https://bugzil.la/1934683)).
-
-- **Import attribute for JSON modules** (Nightly): `javascript.options.experimental.import_attributes`
-
-  The [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) declaration now supports importing JSON modules using the [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) attribute.
 
 ## Older versions
 


### PR DESCRIPTION
### Description

This is a follow up to https://github.com/mdn/content/pull/39217. The feature is actually going to make it to the stable release. More details are included in the the [BCD PR](https://github.com/mdn/browser-compat-data/pull/26606).

So removing this update from Experimental and moving it to the main release page.

### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/38878


