### PR TITLE
Align `getCapabilities()` documentation with JavaScript runtime behavior

### DIFF
--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -22,41 +22,7 @@ None.
 
 ### Return value
 
-A `MediaTrackCapabilities` object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties, containing the following members:
-
-- `deviceId`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the device ID.
-- `groupId`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing a group ID.
-- `autoGainControl`
-  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do auto gain control.
-    If the feature can be controlled by a script the source will report both true and false as possible values.
-- `channelCount`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the channel count or range of channel counts.
-- `echoCancellation`
-  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do echo cancellation.
-    If the feature can be controlled by a script the source will report both true and false as possible values.
-- `latency`
-  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the latency or range of latencies.
-- `noiseSuppression`
-  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do noise suppression.
-    If the feature can be controlled by a script the source will report both true and false as possible values.
-- `sampleRate`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the sample rate or range of sample rates.
-- `sampleSize`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the sample size or range of sample sizes.
-- `aspectRatio`
-  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the video {{glossary("aspect ratio")}} (width in pixels divided by height in pixels) or range of aspect ratios.
-- `facingMode`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the camera facing mode. A camera may report multiple facings, for example "left" and "user".
-- `frameRate`
-  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the frame rate or range of frame rates which are acceptable.
-- `height`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the video height or range of heights in pixels.
-- `width`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the video width or range of widths in pixels.
-- `resizeMode`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the mode or an array of modes the UA can use to derive the resolution of the video track.
+A `MediaTrackCapabilities` object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties. It is required to return identical information as returned by calling `getCapabilities()` on the first {{domxref("MediaStreamTrack")}} of the same `kind` as this device (video or audio) in the `MediaStream` returned by `getUserMedia({ deviceId: deviceInfo.deviceId })`. See {{domxref("MediaStreamTrack.getCapabilities()")}} for a list of commonly supported properties and their types.
 
 > [!NOTE]
 > If the user has not granted permission to access the input device an empty object will be returned.

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -71,24 +71,16 @@ If `device` is an `InputDeviceInfo` object, then `getCapabilities()` will return
 // Get permission to access audio or video devices
 navigator.mediaDevices
   .getUserMedia({ audio: true, video: true })
-  .then((stream) => {
-    console.log("Media stream started:", stream);
-
-    // Enumerate media devices
-    navigator.mediaDevices
-      .enumerateDevices()
-      .then((devices) => {
-        devices.forEach((device) => {
-          if (typeof device.getCapabilities === "function") {
-            console.log("Capabilities:", device.getCapabilities());
-          } else {
-            console.log("Device does not support getCapabilities:", device);
-          }
-        });
-      })
-      .catch((enumerateError) => {
-        console.error("Error enumerating devices:", enumerateError);
-      });
+  // Enumerate media devices
+  .then(() => navigator.mediaDevices.enumerateDevices())
+  .then((devices) => {
+    devices.forEach((device) => {
+      if (typeof device.getCapabilities === "function") {
+        console.log("Capabilities:", device.getCapabilities()); // A MediaTrackCapabilities object.
+      } else {
+        console.log("Device does not support getCapabilities:", device);
+      }
+    });
   })
   .catch((mediaError) => {
     console.error("Error accessing media devices:", mediaError);

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -74,7 +74,8 @@ navigator.mediaDevices.getUserMedia({ audio: true, video: true })
     console.log("Media stream started:", stream);
 
     // Enumerate media devices
-    navigator.mediaDevices.enumerateDevices()
+    navigator.mediaDevices
+      .enumerateDevices()
       .then((devices) => {
         devices.forEach((device) => {
           if (typeof device.getCapabilities === "function") {

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -69,13 +69,28 @@ If `device` is an `InputDeviceInfo` object, then `getCapabilities()` will return
 
 ```js
 // Get permission to access audio or video devices
-navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+  .then((stream) => {
+    console.log("Media stream started:", stream);
 
-navigator.mediaDevices.enumerateDevices().then((devices) => {
-  devices.forEach((device) => {
-    console.log(device.getCapabilities()); // a MediaTrackCapabilities object.
+    // Enumerate media devices
+    navigator.mediaDevices.enumerateDevices()
+      .then((devices) => {
+        devices.forEach((device) => {
+          if (typeof device.getCapabilities === "function") {
+            console.log("Capabilities:", device.getCapabilities());
+          } else {
+            console.log("Device does not support getCapabilities:", device);
+          }
+        });
+      })
+      .catch((enumerateError) => {
+        console.error("Error enumerating devices:", enumerateError);
+      });
+  })
+  .catch((mediaError) => {
+    console.error("Error accessing media devices:", mediaError);
   });
-});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -69,7 +69,8 @@ If `device` is an `InputDeviceInfo` object, then `getCapabilities()` will return
 
 ```js
 // Get permission to access audio or video devices
-navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+navigator.mediaDevices
+  .getUserMedia({ audio: true, video: true })
   .then((stream) => {
     console.log("Media stream started:", stream);
 

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -27,41 +27,40 @@ None.
 
 ### Return value
 
-A `MediaTrackCapabilities` object which specifies the accepted value or range of values supported for each of the user agent's constrainable properties. This can contain the following members:
+A `MediaTrackCapabilities` object which specifies the accepted value or range of values supported for each of the user agent's constrainable properties. Note that not every property appears on every track, the available members depend on whether the track is audio or video. This can contain the following members:
 
-- `deviceId`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the device ID.
-- `groupId`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing a group ID.
-- `autoGainControl`
-  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can automatically control the input signal's gain.
-    If the feature can be controlled by a script the source will report both true and false as possible values.
-- `channelCount`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the channel count or channel count range.
-- `echoCancellation`
-  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can provide echo cancellation.
+- `deviceId` (audio and video tracks)
+  - : A string that identifies the capture device.
+- `groupId` (audio and video tracks)
+  - : A string that groups related devices.
+- `autoGainControl` (audio track only)
+  - : A boolean or an array of booleans. If the device supports script-controlled toggling, you may see both `true` and `false`.
+- `channelCount` (audio track only)
+  - : A range object describing the supported number of channels. For example:
+`{ min: 1, max: 2 }`
+- `echoCancellation` (audio track only)
+  - : A boolean or an array of booleans indicating if echo cancellation is supported.
+- `latency` (audio track only)
+  - : Either a fixed numeric value or a range object (with `{ min, max [, step] }`) representing the latency in seconds. This value could be an integer or, in some cases, a floating-point number depending on measurement precision
+- `noiseSuppression` (audio track only)
+  - : A boolean or an array indicating whether noise suppression is available.
     If the feature can be controlled by a script the source will report both `true` and `false` as possible values.
-- `latency`
-  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the latency or latency range.
-- `noiseSuppression`
-  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can provide noise suppression.
-    If the feature can be controlled by a script the source will report both `true` and `false` as possible values.
-- `sampleRate`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the sample rate or sample rate range.
-- `sampleSize`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the sample size or sample size range.
-- `aspectRatio`
-  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the video {{glossary("aspect ratio")}} (width in pixels divided by height in pixels) or aspect ratio range.
-- `facingMode`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the camera facing mode. A camera may report multiple facings, for example "left" and "user".
-- `frameRate`
-  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the frame rate or range of frame rates which are acceptable.
-- `height`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the video height or height range, in pixels.
-- `width`
-  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the video width or width range, in pixels.
-- `resizeMode`
-  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the mode or an array of modes the UA can use to derive the resolution of the video track.
+- `sampleRate` (audio track only)
+  - : A range object indicating the supported audio sample rates (for example: `{ min: 22050, max: 48000 }`).
+- `sampleSize` (audio track only)
+  - : A range object describing the supported audio sample sizes in bits.
+- `aspectRatio` (video track only)
+  - : Either a single number or a range object that represents the ratio (width divided by height) the video device can output.
+- `facingMode` (video track only)
+  - : A string or an array of strings (such as "user", "environment", or even "left"/"right") which indicate the camera orientation. On some devices, more than one facing mode may be reported.
+- `frameRate` (video track only)
+  - : A number (if fixed) or a range object giving the supported frames per second.
+- `height` (video track only)
+  - : A numeric value or range object (with pixel dimensions) representing the video track’s height.
+- `width` (video track only)
+  - : A numeric value or range object (with pixel dimensions) representing the video track’s width in pixels.
+- `resizeMode` (video track only)
+  - : A string or an array of strings that indicates how the user agent may derive the desired resolution (for example, modes like "none" or "crop-and-scale").
 
 ## Examples
 

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -44,7 +44,7 @@ For audio tracks only:
   - : A range object describing the supported number of channels. For example: `{ min: 1, max: 2 }`
 - `echoCancellation`
   - : A boolean or an array of booleans indicating if echo cancellation is supported.
-- `latency` (audio track only)
+- `latency`
   - : Either a fixed numeric value or a range object (with `min`, `max`, and optionally `step`) representing the latency in seconds. This value could be an integer or, in some cases, a floating-point number depending on measurement precision
 - `noiseSuppression`
   - : A boolean or an array indicating whether noise suppression is available. If the feature can be controlled by a script the source will report both `true` and `false` as possible values.

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -58,7 +58,7 @@ A `MediaTrackCapabilities` object which specifies the accepted value or range of
 - `height` (video track only)
   - : A numeric value or range object (with pixel dimensions) representing the video track's height.
 - `width` (video track only)
-  - : A numeric value or range object (with pixel dimensions) representing the video track’s width in pixels.
+  - : A numeric value or range object (with pixel dimensions) representing the video track's width in pixels.
 - `resizeMode` (video track only)
   - : A string or an array of strings that indicates how the user agent may derive the desired resolution (for example, modes like "none" or "crop-and-scale").
 

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -29,37 +29,43 @@ None.
 
 A `MediaTrackCapabilities` object which specifies the accepted value or range of values supported for each of the user agent's constrainable properties. Note that not every property appears on every track, the available members depend on whether the track is audio or video. This can contain the following members:
 
-- `deviceId` (audio and video tracks)
+For both audio and video tracks:
+
+- `deviceId`
   - : A string that identifies the capture device.
-- `groupId` (audio and video tracks)
+- `groupId`
   - : A string that groups related devices.
-- `autoGainControl` (audio track only)
+
+For audio tracks only:
+
+- `autoGainControl`
   - : A boolean or an array of booleans. If the device supports script-controlled toggling, you may see both `true` and `false`.
-- `channelCount` (audio track only)
-  - : A range object describing the supported number of channels. For example:
-    `{ min: 1, max: 2 }`
-- `echoCancellation` (audio track only)
+- `channelCount`
+  - : A range object describing the supported number of channels. For example: `{ min: 1, max: 2 }`
+- `echoCancellation`
   - : A boolean or an array of booleans indicating if echo cancellation is supported.
 - `latency` (audio track only)
-  - : Either a fixed numeric value or a range object (with `{ min, max [, step] }`) representing the latency in seconds. This value could be an integer or, in some cases, a floating-point number depending on measurement precision
-- `noiseSuppression` (audio track only)
-  - : A boolean or an array indicating whether noise suppression is available.
-    If the feature can be controlled by a script the source will report both `true` and `false` as possible values.
-- `sampleRate` (audio track only)
+  - : Either a fixed numeric value or a range object (with `min`, `max`, and optionally `step`) representing the latency in seconds. This value could be an integer or, in some cases, a floating-point number depending on measurement precision
+- `noiseSuppression`
+  - : A boolean or an array indicating whether noise suppression is available. If the feature can be controlled by a script the source will report both `true` and `false` as possible values.
+- `sampleRate`
   - : A range object indicating the supported audio sample rates (for example: `{ min: 22050, max: 48000 }`).
-- `sampleSize` (audio track only)
+- `sampleSize`
   - : A range object describing the supported audio sample sizes in bits.
-- `aspectRatio` (video track only)
+
+For video tracks only:
+
+- `aspectRatio`
   - : Either a single number or a range object that represents the ratio (width divided by height) the video device can output.
-- `facingMode` (video track only)
+- `facingMode`
   - : A string or an array of strings (such as "user", "environment", or even "left"/"right") which indicate the camera orientation. On some devices, more than one facing mode may be reported.
-- `frameRate` (video track only)
+- `frameRate`
   - : A number (if fixed) or a range object giving the supported frames per second.
-- `height` (video track only)
+- `height`
   - : A numeric value or range object (with pixel dimensions) representing the video track's height.
-- `width` (video track only)
+- `width`
   - : A numeric value or range object (with pixel dimensions) representing the video track's width in pixels.
-- `resizeMode` (video track only)
+- `resizeMode`
   - : A string or an array of strings that indicates how the user agent may derive the desired resolution (for example, modes like "none" or "crop-and-scale").
 
 ## Examples

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -56,7 +56,7 @@ A `MediaTrackCapabilities` object which specifies the accepted value or range of
 - `frameRate` (video track only)
   - : A number (if fixed) or a range object giving the supported frames per second.
 - `height` (video track only)
-  - : A numeric value or range object (with pixel dimensions) representing the video track’s height.
+  - : A numeric value or range object (with pixel dimensions) representing the video track's height.
 - `width` (video track only)
   - : A numeric value or range object (with pixel dimensions) representing the video track’s width in pixels.
 - `resizeMode` (video track only)

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -37,7 +37,7 @@ A `MediaTrackCapabilities` object which specifies the accepted value or range of
   - : A boolean or an array of booleans. If the device supports script-controlled toggling, you may see both `true` and `false`.
 - `channelCount` (audio track only)
   - : A range object describing the supported number of channels. For example:
-`{ min: 1, max: 2 }`
+    `{ min: 1, max: 2 }`
 - `echoCancellation` (audio track only)
   - : A boolean or an array of booleans indicating if echo cancellation is supported.
 - `latency` (audio track only)

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -36,37 +36,42 @@ For both audio and video tracks:
 - `groupId`
   - : A string that groups related devices.
 
+> [!NOTE]
+> For historical reasons, these two properties are strings instead of an array of strings like all other capabilities.
+
 For audio tracks only:
 
 - `autoGainControl`
-  - : A boolean or an array of booleans. If the device supports script-controlled toggling, you may see both `true` and `false`.
+  - : An array of booleans. If the source cannot do auto gain control, a single `false` is reported. If auto gain control cannot be turned off, a single `true` is reported. If the script can control the feature, the source reports both `true` and `false`.
 - `channelCount`
-  - : A range object describing the supported number of channels. For example: `{ min: 1, max: 2 }`
+  - : A range object, containing a `min` and a `max` property (both containing a non-negative integer), describing the supported number of channels.
 - `echoCancellation`
-  - : A boolean or an array of booleans indicating if echo cancellation is supported.
+  - : An array of booleans or strings indicating if echo cancellation is supported. If the source cannot do echo cancellation, a single `false` is reported. If the source can do echo cancellation, then the array starts with `true`. If the script can control the feature, then the array starts with `true, false`. Additionally, if the source allows controlling which audio sources will be cancelled, the array also includes the values `"all"` and/or `"remote-only"`.
 - `latency`
-  - : Either a fixed numeric value or a range object (with `min`, `max`, and optionally `step`) representing the latency in seconds. This value could be an integer or, in some cases, a floating-point number depending on measurement precision
+  - : A range object, containing a `min` and a `max` property (both containing a number), describing the expected amount of latency in seconds from when the sound starts to when data becomes available.
 - `noiseSuppression`
-  - : A boolean or an array indicating whether noise suppression is available. If the feature can be controlled by a script the source will report both `true` and `false` as possible values.
+  - : An array of booleans indicating whether noise suppression is available. If the source cannot do noise suppression, a single `false` is reported. If noise suppression cannot be turned off, a single `true` is reported. If the script can control the feature, the source reports both `true` and `false`.
 - `sampleRate`
-  - : A range object indicating the supported audio sample rates (for example: `{ min: 22050, max: 48000 }`).
+  - : A range object, containing a `min` and a `max` property (both containing a non-negative integer), describing the supported audio sample rate range.
 - `sampleSize`
-  - : A range object describing the supported audio sample sizes in bits.
+  - : A range object, containing a `min` and a `max` property (both containing a non-negative integer), describing the supported linear sample size range in bits.
 
 For video tracks only:
 
 - `aspectRatio`
-  - : Either a single number or a range object that represents the ratio (width divided by height) the video device can output.
+  - : A range object, containing a `min` and a `max` property (both containing a number), describing the supported video aspect ratio range (width divided by height).
 - `facingMode`
-  - : A string or an array of strings (such as "user", "environment", or even "left"/"right") which indicate the camera orientation. On some devices, more than one facing mode may be reported.
+  - : An array of strings indicating the camera orientation. See {{domxref("MediaTrackConstraints.facingMode")}} for supported values. On some devices, more than one facing mode may be reported; for example, in a high-end telepresence solution with several cameras facing the user, a camera to the left of the user can report both `"left"` and `"user"`.
 - `frameRate`
-  - : A number (if fixed) or a range object giving the supported frames per second.
+  - : A range object, containing a `min` and a `max` property (both containing a number), describing the supported frames per second range.
 - `height`
-  - : A numeric value or range object (with pixel dimensions) representing the video track's height.
+  - : A range object, containing a `min` and a `max` property (both containing a non-negative integer), describing the supported height range in pixels.
 - `width`
-  - : A numeric value or range object (with pixel dimensions) representing the video track's width in pixels.
+  - : A range object, containing a `min` and a `max` property (both containing a non-negative integer), describing the supported width range in pixels.
 - `resizeMode`
-  - : A string or an array of strings that indicates how the user agent may derive the desired resolution (for example, modes like "none" or "crop-and-scale").
+  - : An array of strings that indicates how the user agent may derive the desired resolution from the camera resolution.See {{domxref("MediaTrackConstraints.resizeMode")}} for supported values. The value `"none"` is always included.
+
+For more information about what each property means, see {{domxref("MediaTrackConstraints")}}.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
As pointed out by [#38249](https://github.com/mdn/content/issues/38249) the objects presented as the properties of the return value of the [`getCapabilities()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities#return_value), method were wrong. I removed that abstraction all together and mapped the properties to the actual runtime behavior developers see in JavaScript. There’s no need to introduce abstract or specialized types like "UDoubleRange" that might make developers think they’re dealing with a built-in, complex data type. This reduces unnecessary cognitive overhead.



### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #38249
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
