### PR TITLE
docs(Fx138): Add `port` pages for AudioWorklet and AudioWorkletGlobalScope

### DIFF
--- a/files/en-us/web/api/audioworklet/index.md
+++ b/files/en-us/web/api/audioworklet/index.md
@@ -17,7 +17,11 @@ Access the audio context's instance of `AudioWorklet` through the {{domxref("Bas
 
 ## Instance properties
 
-_The `AudioWorklet` interface does not define any properties of its own, but does inherit properties of {{domxref("Worklet")}}._
+_This interface also inherits properties defined on its parent interface, {{domxref("Worklet")}}._
+
+- {{domxref("AudioWorklet.port", "port")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("MessagePort")}} for custom, asynchronous communication between code in the main thread and the global scope of an audio worklet.
+    This allows for custom messages, such as sending and receiving control data or global settings.
 
 ## Instance methods
 

--- a/files/en-us/web/api/audioworklet/port/index.md
+++ b/files/en-us/web/api/audioworklet/port/index.md
@@ -1,0 +1,56 @@
+---
+title: "AudioWorklet: port"
+short-title: port
+slug: Web/API/AudioWorklet/port
+page-type: web-api-instance-property
+browser-compat: api.AudioWorklet.port
+---
+
+{{APIRef("Web Audio API")}}
+
+The **`port`** read-only property of the {{domxref("AudioWorklet")}} interface returns a {{domxref("MessagePort")}} object that can be used to send and receive messages between the main thread and the associated {{domxref("AudioWorkletGlobalScope")}}.
+
+This allows for custom, asynchronous communication between code in the main thread and the global scope of an audio worklet, such as receiving control data or global settings.
+
+## Value
+
+The {{domxref("MessagePort")}} object connecting the `AudioWorklet` and its associated `AudioWorkletGlobalScope`.
+
+## Examples
+
+See [`AudioWorkletNode.port`](/en-US/docs/Web/API/AudioWorkletNode/port#examples) for more examples.
+
+### Using a port for global messages
+
+In the following example, we can use `port.onmessage` to receive data and `port.postMessage` to send data:
+
+```js
+const context = new AudioContext();
+// Load the module that contains worklet code
+await context.audioWorklet.addModule("processor.js");
+
+// Listener for messages from AudioWorkletGlobalScope
+context.audioWorklet.port.onmessage = (event) => {
+  console.log("Message from global worklet:", event.data);
+};
+
+// Set a global config, for example:
+context.audioWorklet.port.postMessage({
+  volume: 0.8,
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioWorkletGlobalScope")}} — the global execution context of an `AudioWorklet`
+- [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
+- [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Using AudioWorklet](/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)

--- a/files/en-us/web/api/audioworkletglobalscope/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/index.md
@@ -25,6 +25,9 @@ _This interface also inherits properties defined on its parent interface, {{domx
   - : Returns a double that represents the ever-increasing context time of the audio block being processed. It is equal to the {{domxref("BaseAudioContext.currentTime", "currentTime")}} property of the {{domxref("BaseAudioContext")}} the worklet belongs to.
 - {{domxref("AudioWorkletGlobalScope.sampleRate", "sampleRate")}} {{ReadOnlyInline}}
   - : Returns a float that represents the sample rate of the associated {{domxref("BaseAudioContext")}}.
+- {{domxref("AudioWorkletGlobalScope.port", "port")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("MessagePort")}} for custom, asynchronous communication between code in the main thread and the global scope of an audio worklet.
+    This allows for custom messages, such as sending and receiving control data or global settings.
 
 ## Instance methods
 

--- a/files/en-us/web/api/audioworkletglobalscope/port/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/port/index.md
@@ -1,0 +1,35 @@
+---
+title: "AudioWorkletGlobalScope: port"
+short-title: port
+slug: Web/API/AudioWorkletGlobalScope/port
+page-type: web-api-instance-property
+spec-urls: https://webaudio.github.io/web-audio-api/#AudioWorkletGlobalScope
+---
+
+{{APIRef("Web Audio API")}}
+
+The **`port`** read-only property of the {{domxref("AudioWorkletGlobalScope")}} interface returns a {{domxref("MessagePort")}} object that can be used to send and receive messages between the main thread and the associated {{domxref("AudioWorklet")}}.
+
+This allows for custom, asynchronous communication between code in the main thread and the global scope of an audio worklet, such as sending control data or global settings.
+
+## Value
+
+The {{domxref("MessagePort")}} object that is connecting the `AudioWorklet` and its associated `AudioWorkletGlobalScope`.
+
+## Examples
+
+See [`AudioWorkletNode.port`](/en-US/docs/Web/API/AudioWorkletNode/port#examples) for examples.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
+- [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Using AudioWorklet](/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)


### PR DESCRIPTION
### Description

Web Audio API v1.1 adds bidirectional messaging on `AudioWorkletGlobalScope` via a `port`. This is shipping in Fx138.

__Additions:__
- `Web/API/AudioWorklet/port` page
- `Web/API/AudioWorkletGlobalScope/port` page

__Changes:__
- list & link to respective `port`s under `AudioWorklet` and `AudioWorkletGlobalScope` props

### Additional details

- __Spec:__ https://webaudio.github.io/web-audio-api/#dom-audioworklet-port
- __WPT:__ https://wpt.fyi/results/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html?label=experimental&label=master&aligned
- __Bugzilla:__ [1861363](https://bugzilla.mozilla.org/show_bug.cgi?id=1951240)

Motivation for adding this to the Web Audio API:

- [x] https://github.com/WebAudio/web-audio-api/issues/2456

__Related issues and pull requests:__

- [ ] Parent issue https://github.com/mdn/content/issues/38884
- [x] BCD: https://github.com/mdn/browser-compat-data/pull/26371

## TODO

- [x] Check if we need a BCD entry for `AudioWorkletGlobalScope.port`