### PR TITLE
relnote(Fx138): Add AudioWorklet.port and AudioWorkletGlobalScope.port

### DIFF
--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -53,6 +53,8 @@ Firefox 138 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 - The [Login Status API](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) is now supported when using the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API). It can be used to set and check whether a browser user is logged in to an identity provider.
   This includes support for the {{domxref("NavigatorLogin")}} interface, the {{domxref("navigator.login")}} property, and the {{httpheader("Set-Login")}} HTTP response header.
   ([Firefox bug 1945576](https://bugzil.la/1945576) and [Firefox bug 1945573](https://bugzil.la/1945573)).
+- The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) now supports bidirectional messaging on an {{domxref("AudioWorklet.port")}} and an {{domxref("AudioWorkletGlobalScope.port")}}.
+  This allows for custom, asynchronous communication between code in the main thread and the global scope of an audio worklet, such as receiving control data or global settings. ([Firefox bug 1951240](https://bugzil.la/1951240))
 
 #### DOM
 


### PR DESCRIPTION
### Description

Relnote for associated docs changes. More context in the linked PRs.

- __Spec:__ https://webaudio.github.io/web-audio-api/#dom-audioworklet-port
- __WPT:__ https://wpt.fyi/results/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html?label=experimental&label=master&aligned
- __Bugzilla:__ [1861363](https://bugzilla.mozilla.org/show_bug.cgi?id=1951240)

### Related issues and pull requests

- [x] __Docs:__ https://github.com/mdn/content/pull/39264
- [ ] Parent issue https://github.com/mdn/content/issues/38884
