### PR TITLE
Remove polyfill link for :focus-visible

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -168,4 +168,3 @@ If your code has to work in old browser versions that do not support `:focus-vis
 
 - {{CSSxRef(":focus")}}
 - {{CSSxRef(":focus-within")}}
-- [A polyfill for `:focus-visible`](https://github.com/WICG/focus-visible)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This pr removes the [link to the polyfill for :focus-visible in the "See also" section](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#see_also).

### Motivation

No need for a polyfill because of widely available (baseline) browser support.

### Additional details

[Browser support details for the :focus-visible CSS pseudo-class on Can I use...](https://caniuse.com/css-focus-visible)

### Related issues and pull requests

I hope it's fine to make a small pr without an issue :)


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
