### PR TITLE
Clarify the type description in pseudo-class

### DIFF
--- a/files/en-us/web/css/_colon_first-of-type/index.md
+++ b/files/en-us/web/css/_colon_first-of-type/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.first-of-type
 
 {{CSSRef}}
 
-The **`:first-of-type`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents the first element of its type among a group of sibling elements.
+The **`:first-of-type`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents the first element of its type (tag name) among a group of sibling elements.
 
 {{InteractiveExample("CSS Demo: :first-of-type", "tabbed-shorter")}}
 

--- a/files/en-us/web/css/_colon_last-of-type/index.md
+++ b/files/en-us/web/css/_colon_last-of-type/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.last-of-type
 
 {{CSSRef}}
 
-The **`:last-of-type`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents the last element of its type among a group of sibling elements.
+The **`:last-of-type`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents the last element of its type (tag name) among a group of sibling elements.
 
 {{InteractiveExample("CSS Demo: :last-of-type", "tabbed-shorter")}}
 

--- a/files/en-us/web/css/_colon_only-of-type/index.md
+++ b/files/en-us/web/css/_colon_only-of-type/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.only-of-type
 
 {{CSSRef}}
 
-The **`:only-of-type`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element that has no siblings of the same type.
+The **`:only-of-type`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element that has no siblings of the same type (tag name).
 
 {{InteractiveExample("CSS Demo: :only-of-type", "tabbed-shorter")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Makes minor revisions to the descriptions of a few of the type pseudo selectors.

The idea come from [:nth-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type)

### Motivation

Clarify the `type` definition.
There may be ambiguity in understanding the `type`.

Such as the example below, `li.x:last-of-type` will not match with expected (the second item).

```html
<ul>
  <li class="x">1</li>
  <li class="x">2</li>
  <li>3</li>
  <li>4</li>
</ul>
```

### Additional details

This is my first PR in GitHub.
Please leave comments if there are any mistakes by me.

Thanks.
