### PR TITLE
Content script load order clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -321,7 +321,7 @@ For example, in this key specification:
 "content_scripts": [
     {
     "matches": ["*://*.mozilla.org/*"],
-    "js": ["my-content-script.js"],
+    "js": ["jquery.js", "my-content-script.js"],
     "run_at": "document_idle"
   },
   {
@@ -332,7 +332,7 @@ For example, in this key specification:
   },
   {
     "matches": ["*://*.mozilla.org/*"],
-    "js": ["jquery.js"],
+    "js": ["run-first.js"],
     "run_at": "document_start"
   }
 ]

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -308,12 +308,11 @@ This table details all the keys you can include.
 
 ## Load order
 
-Files declared in `content_scripts` are injected into web pages in a defined order. When a webpage loads, matching key objects are processed in this order:
+Registered objects in `content_scripts` are injected into matching web pages at the time specified by `run_at` (first `document_start`, then`document_end`, and finally `document_idle`):
 
-- in accordance with the `run_at` directive, then for each object with the same directive:
-  - in the order of each object in the key array, then for each object:
-    - CSS in the order items are specified in the object's `css` property, then,
-    - JavaScript in the order items are specified in the object's `js` property.
+- In the order specified in the `content_scripts` array, for each object with a matching `run_at` value, then:
+  - CSS is applied in the order specified in its `css` array.
+  - JavaScript code is executed in the order specified in its `js` array.
 
 For example, in this key specification:
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -100,7 +100,7 @@ This table details all the keys you can include.
       <td>
         <p>
           An array of paths, relative to <code>manifest.json</code>, referencing
-          CSS files to inject into matching pages. For information on the order 
+          CSS files to inject into matching pages. For information on the order
           in which files are injected, see a <a href="#load_order">Load order</a>.
         </p>
         </p>
@@ -153,7 +153,7 @@ This table details all the keys you can include.
       <td>
         <p>
           An array of paths, relative to <code>manifest.json</code>, referencing
-          JavaScript files to inject into matching pages. For information on the 
+          JavaScript files to inject into matching pages. For information on the
           order in which files are injected, see a <a href="#load_order">Load order</a>.
         </p>
       </td>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -340,8 +340,9 @@ For example, in this key specification:
 
 The files are loaded like this when a mozilla.org domain opens:
 
-- `"jquery.js"` - because it's requested to run at `"document_start"`.
-- `"my-content-script.js"` - because it's in the first array requesting run at `"document_idle"`.
+- `"run-first.js"` - because it's requested to run at `"document_start"`.
+- `"jquery.js"` - because it's in the first array requesting run at `"document_idle"`.
+- `"my-content-script.js"` - because it's the second item in the first array requesting run at `"document_idle"`.
 - `"my-css.css"` - because an object's CSS is loaded before its JavaScript.
 - `"another-content-script.js"` - because it's the first item in the `js` property.
 - `"yet-another-content-script.js"`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -308,9 +308,9 @@ This table details all the keys you can include.
 
 ## Load order
 
-When a webpage load loads, matching key objects are processed in this order:
+Files declared in `content_scripts` are injected into web pages in a defined order. When a webpage loads, matching key objects are processed in this order:
 
-- in accordance with the `run_at` directive (`"document_start"` then `"document_end"` then `"document_idle"`). For each object with the same directive:
+- in accordance with the `run_at` directive, then for each object with the same directive:
   - in the order of each object in the key array, then for each object:
     - CSS in the order items are specified in the object's `css` property, then,
     - JavaScript in the order items are specified in the object's `js` property.

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -37,15 +37,15 @@ browser-compat: webextensions.manifest.content_scripts
   </tbody>
 </table>
 
-Instructs the browser to load [content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) into web pages whose URL matches a given pattern.
+Instructs the browser to load [content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) into web pages whose URL matches a pattern.
 
 This key is an array. Each item is an object which:
 
-- **must** contain a key named **`matches`**, which specifies the URL patterns to be matched in order for the scripts to be loaded;
-- **may** contain keys named **`js`** and **`css`**, which list scripts and/or stylesheets to be loaded into matching pages; and
-- **may** contain a number of other properties that control finer aspects of how and when content scripts are loaded.
+- **must** contain a key named **`matches`**, which specifies the URL patterns to be matched for the scripts to be loaded;
+- **may** contain keys named **`js`** and **`css`**, which list scripts and stylesheets to be loaded into matching pages; and
+- **may** contain a number of other properties that control aspects of how and when content scripts are loaded.
 
-Details of all the keys you can include are given in the table below.
+This table details all the keys you can include.
 
 <table class="fullwidth-table standard-table">
   <thead>
@@ -100,12 +100,9 @@ Details of all the keys you can include are given in the table below.
       <td>
         <p>
           An array of paths, relative to <code>manifest.json</code>, referencing
-          CSS files that will be injected into matching pages.
+          CSS files to inject into matching pages. For information on the order 
+          in which files are injected, see a <a href="#load_order">Load order</a>.
         </p>
-        <p>
-          Files are injected in the order given, and at the time specified by
-          <code><a href="#run_at">run_at</a></code
-          >.
         </p>
         <div class="notecard note">
           <p>
@@ -156,23 +153,8 @@ Details of all the keys you can include are given in the table below.
       <td>
         <p>
           An array of paths, relative to <code>manifest.json</code>, referencing
-          JavaScript files that will be injected into matching pages.
-        </p>
-        <p>
-          Files are injected in the order given. This means that, for example,
-          if you include jQuery here followed by another content script, like
-          this:
-        </p>
-        <pre class="brush: json">
-"js": ["jquery.js", "my-content-script.js"]</pre
-        >
-        <p>Then, <code>"my-content-script.js"</code> can use jQuery.</p>
-        <p>
-          The files are injected after any files in
-          <code><a href="#css">css</a></code
-          >, and at the time specified by
-          <code><a href="#run_at">run_at</a></code
-          >.
+          JavaScript files to inject into matching pages. For information on the 
+          order in which files are injected, see a <a href="#load_order">Load order</a>.
         </p>
       </td>
     </tr>
@@ -323,6 +305,46 @@ Details of all the keys you can include are given in the table below.
     </tr>
   </tbody>
 </table>
+
+## Load order
+
+When a webpage load loads, matching key objects are processed in this order:
+
+- in accordance with the `run_at` directive (`"document_start"` then `"document_end"` then `"document_idle"`). For each object with the same directive:
+  - in the order of each object in the key array, then for each object:
+    - CSS in the order items are specified in the object's `css` property, then,
+    - JavaScript in the order items are specified in the object's `js` property.
+
+For example, in this key specification:
+
+```json
+"content_scripts": [
+    {
+    "matches": ["*://*.mozilla.org/*"],
+    "js": ["my-content-script.js"],
+    "run_at": "document_idle"
+  },
+  {
+    "matches": ["*://*.mozilla.org/*"],
+    "css": ["my-css.css"],
+    "js": ["another-content-script.js", "yet-another-content-script.js"],
+    "run_at": "document_idle"
+  },
+  {
+    "matches": ["*://*.mozilla.org/*"],
+    "js": ["jquery.js"],
+    "run_at": "document_start"
+  }
+]
+```
+
+The files are loaded like this when a mozilla.org domain opens:
+
+- `"jquery.js"` - because it's requested to run at `"document_start"`.
+- `"my-content-script.js"` - because it's in the first array requesting run at `"document_idle"`.
+- `"my-css.css"` - because an object's CSS is loaded before its JavaScript.
+- `"another-content-script.js"` - because it's the first item in the `js` property.
+- `"yet-another-content-script.js"`
 
 ## Matching URL patterns
 


### PR DESCRIPTION
### Description

As a follow-up to [Bug-1792685 Content scripts and styles guaranteed execution order release note ](https://github.com/mdn/content/pull/39245#top) #39245, add details of the load order of items specified in the `content_scripts` manifest key.

