### PR TITLE
Fix typo: Add missing quote

### DIFF
--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -543,7 +543,7 @@ When you put both bulbs in their proper place, you'll notice that they are relat
 
 ## See also
 
-- {{glossary("Inset properties)}}
+- {{glossary("Inset properties")}}
 - [Learn CSS: Positioning](/en-US/docs/Learn_web_development/Core/CSS_layout/Positioning)
 - [Inset properties for positioned layout](/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Floating_and_positioning#example_inset_properties_for_positioned_layout)
 - [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) modules


### PR DESCRIPTION


### Description

Adds the missing quote in the `glossary` macro

### Motivation

To correctly render the glossary link


