### PR TITLE
docs(Fx138): Add BCD for AudioWorkletGlobalScope port

### DIFF
--- a/files/en-us/web/api/audioworkletglobalscope/port/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/port/index.md
@@ -3,7 +3,7 @@ title: "AudioWorkletGlobalScope: port"
 short-title: port
 slug: Web/API/AudioWorkletGlobalScope/port
 page-type: web-api-instance-property
-spec-urls: https://webaudio.github.io/web-audio-api/#AudioWorkletGlobalScope
+browser-compat: api.AudioWorkletGlobalScope.port
 ---
 
 {{APIRef("Web Audio API")}}


### PR DESCRIPTION
### Description

Adding in missing BCD. Follow-up from https://github.com/mdn/content/pull/39264

### Related issues and pull requests

- [x] https://github.com/mdn/browser-compat-data/pull/26615

Fixes #38884
