### PR TITLE
Fix plaindate.compare return value explanation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/compare/index.md
@@ -31,7 +31,7 @@ Temporal.Duration.compare(duration1, duration2, options)
 
 ### Return value
 
-Returns `-1` if `duration1` is shorter than `duration2`, `0` if they are equal, and `1` if `duration1` is longer.
+Returns `-1` if `duration1` is shorter than `duration2`, `0` if they are equal, and `1` if `duration1` is longer than `duration2`.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/instant/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/instant/compare/index.md
@@ -26,7 +26,7 @@ Temporal.Instant.compare(instant1, instant2)
 
 ### Return value
 
-Returns `-1` if `instant1` comes before `instant2`, `0` if they are the same, and `1` if `instant1` comes after.
+Returns `-1` if `instant1` comes before `instant2`, `0` if they are the same, and `1` if `instant1` comes after `instant2`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/compare/index.md
@@ -26,7 +26,7 @@ Temporal.PlainDate.compare(date1, date2)
 
 ### Return value
 
-Returns `-1` if `date1` comes before `date2`, `0` if they are the same, and `1` if `date2` comes after. They are compared by their underlying date values, ignoring their calendars.
+Returns `-1` if `date1` comes before `date2`, `0` if they are the same, and `1` if `date1` comes after `date2`. They are compared by their underlying date values, ignoring their calendars.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/compare/index.md
@@ -26,7 +26,7 @@ Temporal.PlainDateTime.compare(dateTime1, dateTime2)
 
 ### Return value
 
-Returns `-1` if `dateTime1` comes before `dateTime2`, `0` if they are the same, and `1` if `dateTime2` comes after. They are compared by their underlying date and time values, ignoring their calendars.
+Returns `-1` if `dateTime1` comes before `dateTime2`, `0` if they are the same, and `1` if `dateTime1` comes after `dateTime2`. They are compared by their underlying date and time values, ignoring their calendars.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/compare/index.md
@@ -26,7 +26,7 @@ Temporal.PlainTime.compare(time1, time2)
 
 ### Return value
 
-Returns `-1` if `time1` comes before `time2`, `0` if they are the same, and `1` if `time2` comes after.
+Returns `-1` if `time1` comes before `time2`, `0` if they are the same, and `1` if `time1` comes after `time2`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/compare/index.md
@@ -28,7 +28,7 @@ Temporal.PlainYearMonth.compare(yearMonth1, yearMonth2)
 
 ### Return value
 
-Returns `-1` if `yearMonth1` comes before `yearMonth2`, `0` if they are the same, and `1` if `yearMonth2` comes after. They are compared by their underlying date values (usually the first day of the month), ignoring their calendars.
+Returns `-1` if `yearMonth1` comes before `yearMonth2`, `0` if they are the same, and `1` if `yearMonth1` comes after `yearMonth2`. They are compared by their underlying date values (usually the first day of the month), ignoring their calendars.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/compare/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/compare/index.md
@@ -26,7 +26,7 @@ Temporal.ZonedDateTime.compare(dateTime1, dateTime2)
 
 ### Return value
 
-Returns `-1` if `dateTime1` comes before `dateTime2`, `0` if they are the same, and `1` if `dateTime2` comes after. They are compared by their underlying instant values, ignoring their calendars or time zones.
+Returns `-1` if `dateTime1` comes before `dateTime2`, `0` if they are the same, and `1` if `dateTime1` comes after `dateTime2`. They are compared by their underlying instant values, ignoring their calendars or time zones.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description & Motivation

There's a typo/error in the explanation of the return value of Temporal.PlainDate.compare(), as it reads currently it repeats the first set of conditions.

