### PR TITLE
HTMLDialogElement.requestClose() - tweak example

### DIFF
--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -45,7 +45,7 @@ Once open you can click the **X** button to request to close the dialog (via the
 <!-- Simple pop-up dialog box, containing a form -->
 <dialog id="favDialog">
   <form method="dialog">
-    <button id="close" aria-label="close" formnovalidate>X</button>
+    <button type="button" id="close" aria-label="close" formnovalidate>X</button>
     <section>
       <p>
         <label for="favAnimal">Favorite animal:</label>

--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -34,6 +34,8 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
+### Dialog with
+
 The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form, via the `showModal()` method.
 From there you can click the **X** button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the **Confirm** button.
 
@@ -81,12 +83,15 @@ closeButton.addEventListener("click", () => {
 });
 
 function dialogShouldNotClose() {
-  // Add logic to decide whether to prevent the dialog from closing
+  // Add logic to decide whether to allow the dialog to close.
+  // Closing prevented by default
+  return true;
 }
 
 dialog.addEventListener("cancel", (event) => {
   if (!event.cancelable) return;
   if (dialogShouldNotClose()) {
+    console.log("Closing prevented");
     event.preventDefault();
   }
 });

--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -11,8 +11,10 @@ browser-compat: api.HTMLDialogElement.requestClose
 The **`requestClose()`** method of the {{domxref("HTMLDialogElement")}} interface requests to close the {{htmlelement("dialog")}}.
 An optional string may be passed as an argument, updating the `returnValue` of the dialog.
 
-This method differs from the `HTMLDialogElement.close()` method by firing a `cancel` event before firing the `close` event. This allows
-authors to prevent the dialog from closing. This method exposes the same behavior as the dialog's internal close watcher.
+This method differs from the {{domxref("HTMLDialogElement.close()")}} method in that it fires a `cancel` event before firing the `close` event.
+Authors can call {{domxref("Event.preventDefault()")}} in the handler for the `cancel` event to prevent the dialog from closing.
+
+This method exposes the same behavior as the dialog's internal close watcher.
 
 ## Syntax
 
@@ -33,7 +35,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form, via the `showModal()` method.
-From there you can click the _X_ button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the submit button.
+From there you can click the **X** button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the **Confirm** button.
 
 ```html
 <!-- Simple pop-up dialog box, containing a form -->
@@ -61,33 +63,33 @@ From there you can click the _X_ button to request to close the dialog (via the 
 <menu>
   <button id="updateDetails">Update details</button>
 </menu>
+```
 
-<script>
-  (() => {
-    const updateButton = document.getElementById("updateDetails");
-    const closeButton = document.getElementById("close");
-    const dialog = document.getElementById("favDialog");
+```js
+const updateButton = document.getElementById("updateDetails");
+const closeButton = document.getElementById("close");
+const dialog = document.getElementById("favDialog");
 
-    // Update button opens a modal dialog
-    updateButton.addEventListener("click", () => {
-      dialog.showModal();
-    });
+// Update button opens a modal dialog
+updateButton.addEventListener("click", () => {
+  dialog.showModal();
+});
 
-    // Form close button requests to close the dialog box
-    closeButton.addEventListener("click", () => {
-      dialog.requestClose("animalNotChosen");
-    });
+// Form close button requests to close the dialog box
+closeButton.addEventListener("click", () => {
+  dialog.requestClose("animalNotChosen");
+});
 
-    function dialogShouldNotClose() {
-      // Add logic to decide whether to prevent the dialog from closing
-    }
+function dialogShouldNotClose() {
+  // Add logic to decide whether to prevent the dialog from closing
+}
 
-    dialog.addEventListener("cancel", (event) => {
-      if (!event.cancelable) return;
-      if (dialogShouldNotClose()) event.preventDefault();
-    });
-  })();
-</script>
+dialog.addEventListener("cancel", (event) => {
+  if (!event.cancelable) return;
+  if (dialogShouldNotClose()) {
+    event.preventDefault();
+  }
+});
 ```
 
 If the "X" button was of `type="submit"`, the dialog would have closed without requiring JavaScript.

--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -34,10 +34,12 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-### Dialog with
+### Using requestClose()
 
 The following example shows a simple button that, when clicked, opens a {{htmlelement("dialog")}} containing a form, via the `showModal()` method.
-From there you can click the **X** button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the **Confirm** button.
+Once open you can click the **X** button to request to close the dialog (via the `HTMLDialogElement.requestClose()` method), or submit the form via the **Confirm** button.
+
+#### HTML
 
 ```html
 <!-- Simple pop-up dialog box, containing a form -->
@@ -66,6 +68,8 @@ From there you can click the **X** button to request to close the dialog (via th
   <button id="updateDetails">Update details</button>
 </menu>
 ```
+
+#### JavaScript
 
 ```js
 const updateButton = document.getElementById("updateDetails");
@@ -100,7 +104,7 @@ dialog.addEventListener("cancel", (event) => {
 If the "X" button was of `type="submit"`, the dialog would have closed without requiring JavaScript.
 A form submission closes the `<dialog>` it is nested within if the [form's method is `dialog`](/en-US/docs/Web/HTML/Reference/Elements/form#method), so no "close" button is required.
 
-### Result
+#### Result
 
 {{ EmbedLiveSample('Examples', '100%', '200px') }}
 

--- a/files/en-us/web/api/htmldialogelement/requestclose/index.md
+++ b/files/en-us/web/api/htmldialogelement/requestclose/index.md
@@ -45,7 +45,9 @@ Once open you can click the **X** button to request to close the dialog (via the
 <!-- Simple pop-up dialog box, containing a form -->
 <dialog id="favDialog">
   <form method="dialog">
-    <button type="button" id="close" aria-label="close" formnovalidate>X</button>
+    <button type="button" id="close" aria-label="close" formnovalidate>
+      X
+    </button>
     <section>
       <p>
         <label for="favAnimal">Favorite animal:</label>


### PR DESCRIPTION
FF139 adds support for [`HTMLDialogElement.requestClose()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/requestClose).

This is a relatively minor update to split the example into separate HTML and javascript parts as per "standard way of doing examples.
I also set it to not close by default - otherwise this doesn't prove much over the close() method.
The attempt to close is logged in console.

Related docs work can be tracked in #39307