### PR TITLE
Clarify unexpected bahaviour of using layered `@import` and `@layer` statement together

### DIFF
--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -121,8 +121,8 @@ Another way to create a cascade layer is by using {{cssxref("@import")}}. In thi
 @import "theme.css" layer(utilities);
 ```
 
-> [!IMPORTANT]
-> Using `@layer` to declare the layers order while using layered `@import`s in a same file could result an unexpected bahaviour. `@import` runs sooner and sets its layer before the `@layer` statement and makes its set order ineffective. As the result, the imported layer has the least order among other defined layers in the `@layer` statement. It is a good practice to keep them separated. 
+> [!NOTE]
+> Using `@layer` to declare the layers order while using layered `@import` rules in the same file could result in unexpected behavior. `@import` runs sooner and sets its layer before the `@layer` statement, making the latter's set order ineffective. As a result, the imported layer has the least order among other defined layers in the `@layer` statement. It is a good practice to keep them separated.
 
 ### Nesting layers
 

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -115,7 +115,7 @@ The third way is to create an unnamed layer using a `@layer` block at-rule witho
 
 This creates an _anonymous cascade layer_. This layer functions in the same way as named layers; however, rules cannot be assigned to it later. The order of precedence for anonymous layers is the order in which layers are declared, named or not, and lower than the styles declared outside of a layer.
 
-Another way to create a cascade layer is by using {{cssxref("@import")}}. In this case, the rules would be in the imported stylesheet. Remember that the `@import` at-rule must precede all other types of rules, except `@charset` and `@layer` rules. 
+Another way to create a cascade layer is by using {{cssxref("@import")}}. In this case, the rules would be in the imported stylesheet. Remember that the `@import` at-rule must precede all other types of rules, except `@charset` and `@layer` rules.
 
 ```css
 @import "theme.css" layer(utilities);

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -115,11 +115,14 @@ The third way is to create an unnamed layer using a `@layer` block at-rule witho
 
 This creates an _anonymous cascade layer_. This layer functions in the same way as named layers; however, rules cannot be assigned to it later. The order of precedence for anonymous layers is the order in which layers are declared, named or not, and lower than the styles declared outside of a layer.
 
-Another way to create a cascade layer is by using {{cssxref("@import")}}. In this case, the rules would be in the imported stylesheet. Remember that the `@import` at-rule must precede all other types of rules, except `@charset` and `@layer` rules.
+Another way to create a cascade layer is by using {{cssxref("@import")}}. In this case, the rules would be in the imported stylesheet. Remember that the `@import` at-rule must precede all other types of rules, except `@charset` and `@layer` rules. 
 
 ```css
 @import "theme.css" layer(utilities);
 ```
+
+> [!IMPORTANT]
+> Using `@layer` to declare the layers order while using layered `@import`s in a same file could result an unexpected bahaviour. `@import` runs sooner and sets its layer before the `@layer` statement and makes its set order ineffective. As the result, the imported layer has the least order among other defined layers in the `@layer` statement. It is a good practice to keep them separated. 
 
 ### Nesting layers
 


### PR DESCRIPTION
### Description

The following 
```cs
@layer A, B, C;

@import url('/blob.css') B;
```

will result in `B, A, C` order **NOT** the defined one. 
The reason behind it is that `@import` runs sooner and its layered defined in layers stack. The the `@layer` runs and it predefine the layers in the stack if they are not already defined. 

While CSS doesn't raise any error or warning, this could end up in unexpected behaviour. 

### Motivation

It took me 2 days to understand the issue!

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
