### PR TITLE
fix: Firefox user-agent string reference

### DIFF
--- a/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
@@ -55,10 +55,14 @@ The preferred way to target content to a device form factor is to use CSS Media 
 
 Windows user agents have the following variations, where _x.y_ is the Windows NT version (for instance, Windows NT 6.1).
 
-| Windows version                  | Gecko user agent string                                                           |
-| -------------------------------- | --------------------------------------------------------------------------------- |
-| Windows NT on x86 or aarch64 CPU | Mozilla/5.0 (Windows NT _x_._y_; rv:10.0) Gecko/20100101 Firefox/10.0             |
-| Windows NT on x64 CPU            | Mozilla/5.0 (Windows NT _x_._y_; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0 |
+| Windows version       | Gecko user agent string                                                           |
+| --------------------- | --------------------------------------------------------------------------------- |
+| Windows NT on x86 CPU | Mozilla/5.0 (Windows NT _x_._y_; rv:10.0) Gecko/20100101 Firefox/10.0             |
+| Windows NT on x64 CPU | Mozilla/5.0 (Windows NT _x_._y_; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0 |
+
+> [!NOTE]
+> For aarch64 CPU, It reported as x86 on Windows 10 (since it doesn't support x64 emulation), and reported as x86_64 on Windows 11.
+> See [Bugzilla #1763310](https://bugzil.la/show_bug.cgi?id=1763310)
 
 ## macOS
 
@@ -77,6 +81,10 @@ Linux is a more diverse platform. Your distribution of Linux might include an ex
 | --------------------------- | -------------------------------------------------------------------- |
 | Linux desktop on i686 CPU   | Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0   |
 | Linux desktop on x86_64 CPU | Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0 |
+
+> [!NOTE]
+> In Firefox 127.0 and later, 32-bit x86 will now be reported as x86_64 in Firefox's User-Agent string and `navigator.platform` and `navigator.oscpu` Web APIs
+> See [Firefox 127.0 Release Notes](https://www.mozilla.org/en-US/firefox/127.0/releasenotes/)
 
 ## Firefox for Android
 

--- a/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
@@ -83,8 +83,7 @@ Linux is a more diverse platform. Your distribution of Linux might include an ex
 | Linux desktop on x86_64 CPU | Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0 |
 
 > [!NOTE]
-> In Firefox 127.0 and later, 32-bit x86 will now be reported as x86_64 in Firefox's User-Agent string and `navigator.platform` and `navigator.oscpu` Web APIs
-> See [Firefox 127.0 Release Notes](https://www.mozilla.org/en-US/firefox/127.0/releasenotes/)
+> In Firefox 127.0 and later, 32-bit x86 will now be reported as x86_64 in Firefox's User-Agent string,{{domxref("navigator.platform")}}, and {{domxref("navigator.oscpu")}} (see [Firefox 127.0 Release Notes](https://www.mozilla.org/en-US/firefox/127.0/releasenotes/)).
 
 ## Firefox for Android
 

--- a/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
@@ -61,8 +61,8 @@ Windows user agents have the following variations, where _x.y_ is the Windows NT
 | Windows NT on x64 CPU | Mozilla/5.0 (Windows NT _x_._y_; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0 |
 
 > [!NOTE]
-> An aarch64 CPU is reported as x86_64 on Windows 11 and x86 on Windows 10 (since it doesn't support x64 emulation).
-> See [Bugzilla #1763310](https://bugzil.la/1763310)
+> An aarch64 CPU is reported as x86_64 on Windows 11, and x86 on Windows 10 (since it doesn't support x64 emulation).
+> See [Bugzilla #1763310](https://bugzil.la/1763310).
 
 ## macOS
 

--- a/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
@@ -61,7 +61,7 @@ Windows user agents have the following variations, where _x.y_ is the Windows NT
 | Windows NT on x64 CPU | Mozilla/5.0 (Windows NT _x_._y_; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0 |
 
 > [!NOTE]
-> For aarch64 CPU, It reported as x86 on Windows 10 (since it doesn't support x64 emulation), and reported as x86_64 on Windows 11.
+> An aarch64 CPU is reported as x86_64 on Windows 11 and x86 on Windows 10 (since it doesn't support x64 emulation).
 > See [Bugzilla #1763310](https://bugzil.la/1763310)
 
 ## macOS

--- a/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/reference/headers/user-agent/firefox/index.md
@@ -62,7 +62,7 @@ Windows user agents have the following variations, where _x.y_ is the Windows NT
 
 > [!NOTE]
 > For aarch64 CPU, It reported as x86 on Windows 10 (since it doesn't support x64 emulation), and reported as x86_64 on Windows 11.
-> See [Bugzilla #1763310](https://bugzil.la/show_bug.cgi?id=1763310)
+> See [Bugzilla #1763310](https://bugzil.la/1763310)
 
 ## macOS
 


### PR DESCRIPTION
### Description

Since Firefox 127.0 released, Linux x86 was reported as x86_64, add note for it.
Add note for windows aarch64 cpu and remove outdated reference.

### Motivation

Current Firefox User-Agent string reference was outdated
It will mislead people (especially when they don't have the actual device)
> See [here](https://github.com/git-for-windows/git-for-windows.github.io/pull/61#issuecomment-2834747366)

### Additional details

- [Firefox 127.0 Release Notes](https://www.mozilla.org/en-US/firefox/127.0/releasenotes/)
- [Bugzilla #1763310](https://bugzilla.mozilla.org/show_bug.cgi?id=1763310)

### Related issues and pull requests

None