### PR TITLE
Fix GFM alert syntax, add markdownlint check

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -273,7 +273,7 @@
         "name": "bad-gfm-alert",
         "message": "Use the correct GFM syntax: `> [!NOTE]`",
         // TODO this should use the modifier syntax; until it has better Node support
-        "searchPattern": "/^ *> !?\\[!?((?!NOTE)[Nn][Oo][Tt][Ee]|(?!WARNING)[Ww][Aa][Rr][Nn][Ii][Nn][Gg]|(?!CALLOUT)[Cc][Aa][Ll][Ll][Oo][Uu][Tt])\\]\\n|^ *> (?!\\[!)!?\\[!?(NOTE|WARNING|CALLOUT)\\]\\n/gm",
+        "searchPattern": "/^ *> !?\\[!?((?!NOTE)[Nn][Oo][Tt][Ee]|(?!WARNING)[Ww][Aa][Rr][Nn][Ii][Nn][Gg]|(?!CALLOUT)[Cc][Aa][Ll][Ll][Oo][Uu][Tt])\\]\\n|^ *> (?!\\[!)!?\\[!?(NOTE|WARNING|CALLOUT)\\]\\n|^ *> \\[!(NOTE|WARNING|CALLOUT)\\](?!\\n)/gm",
         "searchScope": "text",
       },
       {

--- a/files/en-us/learn_web_development/extensions/security_privacy/index.md
+++ b/files/en-us/learn_web_development/extensions/security_privacy/index.md
@@ -93,7 +93,7 @@ Learning outcomes:
 
 - Understand how to comply with such laws, in terms of practical implementation.
 
-> [!NOTE]:
+> [!NOTE]
 > Conforming to the above criteria does not require students to become legal experts in privacy laws, but they should understand the implications of these laws, and how that affects their work.
 
 ## Resources

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/headerinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/headerinfo/index.md
@@ -15,7 +15,8 @@ When used in the condition responseHeaders, the rule matches if the request matc
 
 Each object describes one header to match or exclude. To check multiple headers, multiple objects can be specified in these arrays, or across multiple rules.
 
-> [!NOTE] Matching by headers is a relatively new feature. Make sure to feature-detect its availability before relying on it. While some browsers ignore the complete rule when an unrecognized condition is present, Chrome 121 until 127 applied the whole rule while ignoring the `responseHeaders` condition. This could result in matching more requests than intended, see [Chromium issue 347186592](https://crbug.com/347186592).
+> [!NOTE]
+> Matching by headers is a relatively new feature. Make sure to feature-detect its availability before relying on it. While some browsers ignore the complete rule when an unrecognized condition is present, Chrome 121 until 127 applied the whole rule while ignoring the `responseHeaders` condition. This could result in matching more requests than intended, see [Chromium issue 347186592](https://crbug.com/347186592).
 
 ## Type
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1070,7 +1070,7 @@ This subset of the API has been implemented:
 
 ### HTML Sanitizer API
 
-The {{domxref('HTML Sanitizer API')}} allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document's DOM.
+The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document's DOM.
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -125,7 +125,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **HTML Sanitizer API**: `dom.security.sanitizer.enabled`
 
-  The {{domxref('HTML Sanitizer API')}} allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document's DOM. ([Firefox bug 1950605](https://bugzil.la/1950605)), ([Firefox bug 1952250](https://bugzil.la/1952250)).
+  The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document's DOM. ([Firefox bug 1950605](https://bugzil.la/1950605)), ([Firefox bug 1952250](https://bugzil.la/1952250)).
 
 ## Older versions
 

--- a/files/en-us/web/api/cspviolationreportbody/sample/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sample/index.md
@@ -16,7 +16,8 @@ If not populated it is the empty string `""`.
 Note that this is only populated when attempting to load _inline_ scripts, event handlers, or styles that violate CSP [`script-src*`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src) and [`style-src*`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src) rules — external resources that violate the CSP will not generate a sample.
 In addition, a sample is only included if the `Content-Security-Policy` directive that was violated also contains the [`'report-sample'`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#report-sample) keyword.
 
-> [!NOTE] Violation reports should be considered attacker-controlled data.
+> [!NOTE]
+> Violation reports should be considered attacker-controlled data.
 > The content of this field _in particular_ should be sanitized before storing or rendering.
 
 ## Value

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
@@ -13,7 +13,8 @@ The **`sample`** read-only property of the {{domxref("SecurityPolicyViolationEve
 This is only [`script-src*`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src) and [`style-src*`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src) violations, when the corresponding `Content-Security-Policy` directive contains the [`'report-sample'`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#report-sample) keyword.
 In addition, this will only be populated if the resource is an inline script, event handler, or style — external resources causing a violation will not generate a sample.
 
-> [!NOTE] Violation reports should be considered attacker-controlled data.
+> [!NOTE]
+> Violation reports should be considered attacker-controlled data.
 > The content of this field should be sanitized before storing or rendering.
 
 ## Value

--- a/files/en-us/web/http/reference/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/report-uri/index.md
@@ -55,7 +55,8 @@ Content-Security-Policy: report-uri <uri> <uri>;
 
 The report JSON object is sent via an HTTP `POST` operation with a {{HTTPHeader("Content-Type")}} of `application/csp-report`.
 
-> [!NOTE] Violation reports should be considered attacker-controlled data.
+> [!NOTE]
+> Violation reports should be considered attacker-controlled data.
 > The content should be properly sanitized before storing or rendering.
 > This is particularly true of the [script-sample](#script-sample) property, if supplied.
 


### PR DESCRIPTION
Without a line break after `[!NOTE]`, it's rendered weirdly without spaces around HTML tags.