### PR TITLE
Updates to the HTMLDialogElement.returnValue example

### DIFF
--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -75,7 +75,7 @@ dialog.addEventListener("close", () => {
 
 Try clicking "Review ToS", then choosing the "Accept" or "Decline" buttons in the dialog, or dismissing the dialog by pressing the <kbd>Esc</kbd> key, and observe the different status updates.
 
-{{ EmbedLiveSample('Examples', '100%', '200px') }}
+{{ EmbedLiveSample('Checking the return value', '100%', '200px') }}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -18,60 +18,62 @@ Defaults to an empty string (`""`).
 
 ## Examples
 
-The following example displays a button to open a dialog containing a Terms of Service prompt via the `showModal()` method.
-The script handles the user's input by assigning the `returnValue` when the Accept or Decline button is clicked.
-The "Decline" button sets the `returnValue` to "declined", while the "Accept" button sets it to "accepted". Additionally, closing the dialog (e.g., using the close event) updates the status text with the dialog's `returnValue`.
-Closing the dialog with the <kbd>Esc</kbd> key does not set the `returnValue`.
+### Checking the return value
+
+The following example displays a button to open a dialog. The dialog asks the user if they want to accept a Terms of Service prompt.
+
+The dialog contains "Accept" or "Decline" buttons: when the user clicks one of the buttons, the button's click handler closes the dialog, passing their choice into the {{domxref("HTMLDialogElement.close()", "close()")}} function. This assigns the choice to the dialog's `returnValue` property.
+
+In the dialog's {{domxref("HTMLDialogElement.close_event", "close")}} event handler, the example updates the main page's status text to record the `returnValue`.
+
+If the user dismisses the dialog without clicking a button (for example, by pressing the <kbd>Esc</kbd> key), then the return value is not set.
+
+#### HTML
 
 ```html
-<!-- Simple pop-up dialog box -->
 <dialog id="termsDialog">
-  <p>Do you agree to the Terms of Service(link)?</p>
+  <p>Do you agree to the Terms of Service (link)?</p>
   <button id="declineButton" value="declined">Decline</button>
   <button id="acceptButton" value="accepted">Accept</button>
 </dialog>
 <p>
-  <button id="openDialog">Review ToS</button>
+  <button id="openDialogButton">Review ToS</button>
 </p>
 <p id="statusText"></p>
-
-<script>
-  const dialog = document.getElementById("termsDialog");
-  const openDialog = document.getElementById("openDialog");
-  const statusText = document.getElementById("statusText");
-  const declineButton = document.getElementById("declineButton");
-  const acceptButton = document.getElementById("acceptButton");
-
-  function handleUserInput(returnValue) {
-    if (returnValue === "") {
-      statusText.innerText = "There was no return value";
-    } else {
-      statusText.innerText = "Return value: " + returnValue;
-    }
-  }
-
-  openDialog.addEventListener("click", () => {
-    dialog.showModal();
-    handleUserInput(dialog.returnValue);
-  });
-
-  declineButton.addEventListener("click", closeDialog);
-  acceptButton.addEventListener("click", closeDialog);
-
-  function closeDialog(event) {
-    const button = event.target;
-    const returnValue = button.value;
-    dialog.close(returnValue);
-    handleUserInput(dialog.returnValue);
-  }
-
-  dialog.addEventListener("close", () => {
-    handleUserInput(dialog.returnValue);
-  });
-</script>
 ```
 
-### Result
+#### JavaScript
+
+```js
+const dialog = document.getElementById("termsDialog");
+const statusText = document.getElementById("statusText");
+
+const openDialogButton = document.getElementById("openDialogButton");
+const declineButton = document.getElementById("declineButton");
+const acceptButton = document.getElementById("acceptButton");
+
+openDialogButton.addEventListener("click", () => {
+  dialog.showModal();
+});
+
+declineButton.addEventListener("click", closeDialog);
+acceptButton.addEventListener("click", closeDialog);
+
+function closeDialog(event) {
+  const button = event.target;
+  dialog.close(button.value);
+}
+
+dialog.addEventListener("close", () => {
+  statusText.innerText = dialog.returnValue
+    ? `Return value: ${dialog.returnValue}`
+    : "There was no return value";
+});
+```
+
+#### Result
+
+Try clicking "Review ToS", then choosing the "Accept" or "Decline" buttons in the dialog, or dismissing the dialog by pressing the <kbd>Esc</kbd> key, and observe the different status updates.
 
 {{ EmbedLiveSample('Examples', '100%', '200px') }}
 


### PR DESCRIPTION
This makes some updates to the example for https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue.

It's mostly motivated by some of the issues discussed in https://github.com/mdn/content/pull/39336. I also made a few other changes though:

- updated the description for clarity
- separated HTML and JavaScript
- added subheadings
- some minor code updates, like using the ternary operator and template strings, and more consistent naming.