### PR TITLE
Improve MediaKeySession.generateRequest() details (parameters, exceptions)

### DIFF
--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -24,7 +24,11 @@ generateRequest(initDataType, initData)
     - `"keyids"`: The `initData` parameter uses the [`"keyids"`](https://www.w3.org/TR/eme-initdata-keyids/) format.
     - `"webm"`: The `initData` parameter uses the [`"webm"`](https://www.w3.org/TR/eme-initdata-webm/) format.
 - `initData`
-  - : A `BufferSource` (e.g, {{jsxref("ArrayBuffer")}} , {{jsxref("TypedArray")}} or {{jsxref("DataView")}}) that contains the initialization data. This parameter is mandatory and cannot be an empty array.
+  - : Initialization data for the request, in the format specified by `initDataType`. It is an instance of any of the following types:
+
+    - {{jsxref("ArrayBuffer")}}
+    - {{jsxref("DataView")}}
+    - {{jsxref("TypedArray")}}
 
 ### Return value
 

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -36,7 +36,7 @@ A {{jsxref('Promise')}}.
 - {{domxref("DOMException")}} `QuotaExceededError`
   - : Raised if the operation fails due to a lack of resources on the user agent or CDM.
 - {{domxref("DOMException")}} `InvalidStateError`
-  - : Raised if the `MediaKeySession` object is in a `closing` or `closed` state, or if it has already been initialized. 
+  - : Raised if the `MediaKeySession` object is in a `closing` or `closed` state, or if it has already been initialized.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -39,7 +39,7 @@ A {{jsxref('Promise')}}.
 - {{jsxref("TypeError")}}
   - : Raised if `initDataType` is an empty string, if `initData` is an empty array, or if the provided `initData` is not valid according to the specified `initDataType`.
 - {{domxref("DOMException")}} `NotSupportedError`
-  - : Raised if the Key System implementation associated with the `MediaKeySession` object does not support the provided `initDataType`, if the sanitized initialization data is empty, or if the sanitized initialization data is not supported by the Content Decryption Module (CDM).
+  - : Raised if the Key System implementation associated with the `MediaKeySession` object does not support the provided `initDataType`, if the sanitized initialization data is empty, or if the sanitized initialization data is not supported by the content decryption module (CDM).
 - {{domxref("DOMException")}} `QuotaExceededError`
   - : Raised if the operation fails due to a lack of resources on the user agent or CDM.
 - {{domxref("DOMException")}} `InvalidStateError`

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -24,6 +24,7 @@ generateRequest(initDataType, initData)
     - `"keyids"`: The `initData` parameter uses the [`"keyids"`](https://www.w3.org/TR/eme-initdata-keyids/) format.
     - `"webm"`: The `initData` parameter uses the [`"webm"`](https://www.w3.org/TR/eme-initdata-webm/) format.
 - `initData`
+
   - : Initialization data for the request, in the format specified by `initDataType`. It is an instance of any of the following types:
 
     - {{jsxref("ArrayBuffer")}}

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -19,7 +19,10 @@ generateRequest(initDataType, initData)
 ### Parameters
 
 - `initDataType`
-  - : A `string` that specifies the type of the `initData`. This parameter is mandatory and cannot be an empty string.
+  - : A string that specifies the format of the `initData` parameter. This must be one of the following values:
+    - `"cenc"`: The `initData` parameter uses the [`"cenc"`](https://www.w3.org/TR/eme-initdata-cenc/) format.
+    - `"keyids"`: The `initData` parameter uses the [`"keyids"`](https://www.w3.org/TR/eme-initdata-keyids/) format.
+    - `"webm"`: The `initData` parameter uses the [`"webm"`](https://www.w3.org/TR/eme-initdata-webm/) format.
 - `initData`
   - : A `BufferSource` (e.g, {{jsxref("ArrayBuffer")}} , {{jsxref("TypedArray")}} or {{jsxref("DataView")}}) that contains the initialization data. This parameter is mandatory and cannot be an empty array.
 

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -8,21 +8,35 @@ browser-compat: api.MediaKeySession.generateRequest
 
 {{APIRef("Encrypted Media Extensions")}}{{SecureContext_Header}}
 
-The `generateRequest()` method of the {{domxref('MediaKeySession')}} interface returns a {{jsxref('Promise')}} after generating a media request based on initialization data.
+The `generateRequest()` method of the {{domxref('MediaKeySession')}} interface returns a {{jsxref('Promise')}} after generating a licence request based on initialization data.
 
 ## Syntax
 
 ```js-nolint
-generateRequest()
+generateRequest(initDataType, initData)
 ```
 
 ### Parameters
 
-None.
+- `initDataType`
+  - : A `string` that specifies the type of the `initData`. This parameter is mandatory and cannot be an empty string.
+- `initData`
+  - : A `BufferSource` (e.g, {{jsxref("ArrayBuffer")}} , {{jsxref("TypedArray")}} or {{jsxref("DataView")}}) that contains the initialization data. This parameter is mandatory and cannot be an empty array.
 
 ### Return value
 
 A {{jsxref('Promise')}}.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Raised if `initDataType` is an empty string, if `initData` is an empty array, or if the provided `initData` is not valid according to the specified `initDataType`.
+- {{domxref("DOMException")}} `NotSupportedError`
+  - : Raised if the Key System implementation associated with the `MediaKeySession` object does not support the provided `initDataType`, if the sanitized initialization data is empty, or if the sanitized initialization data is not supported by the Content Decryption Module (CDM).
+- {{domxref("DOMException")}} `QuotaExceededError`
+  - : Raised if the operation fails due to a lack of resources on the user agent or CDM.
+- {{domxref("DOMException")}} `InvalidStateError`
+  - : Raised if the `MediaKeySession` object is in a `closing` or `closed` state, or if it has already been initialized. 
 
 ## Specifications
 

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MediaKeySession.generateRequest
 
 {{APIRef("Encrypted Media Extensions")}}{{SecureContext_Header}}
 
-The `generateRequest()` method of the {{domxref('MediaKeySession')}} interface returns a {{jsxref('Promise')}} after generating a licence request based on initialization data.
+The `generateRequest()` method of the {{domxref('MediaKeySession')}} interface returns a {{jsxref('Promise')}} after generating a license request based on initialization data.
 
 ## Syntax
 

--- a/files/en-us/web/api/mediakeysession/index.md
+++ b/files/en-us/web/api/mediakeysession/index.md
@@ -34,7 +34,7 @@ The **`MediaKeySession`** interface of the [Encrypted Media Extensions API](/en-
 - {{domxref("MediaKeySession.close()")}}
   - : Returns a {{jsxref("Promise")}} after notifying the current media session is no longer needed and that the CDM should release any resources associated with this object and close it.
 - {{domxref("MediaKeySession.generateRequest()")}}
-  - : Returns a {{jsxref("Promise")}} after generating a media request based on initialization data.
+  - : Returns a {{jsxref("Promise")}} after generating a licence request based on initialization data.
 - {{domxref("MediaKeySession.load()")}}
   - : Returns a {{jsxref("Promise")}} that resolves to a boolean value after loading data for a specified session object.
 - {{domxref("MediaKeySession.remove()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR updates the description, parameters, and exceptions for the [ `generateRequest()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySession/generateRequest) method of the `MediaKeySession` interface to align more closely with the [W3C specification](https://w3c.github.io/encrypted-media/).

Key changes include:
- Clarifying that the method generates a "license request" (rather than a general "media request").
- Providing a more detailed description of the `initDataType` and `initData` parameters, including their expected types (`DOMString` and `BufferSource`) and constraints (mandatory, non-empty).
- Explicitly listing the specific `DOMException` types that can be thrown, in addition to `TypeError`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

All the changes/additions are based on [this section](https://w3c.github.io/encrypted-media/#dom-mediakeysession-generaterequest) of the spec.

### Related issues and pull requests

Fixes #39341
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
