### PR TITLE
FF139 Relnote: HTMLDialogElement.requestClose()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -39,6 +39,10 @@ This article provides information about the changes in Firefox 139 that affect d
 
 #### DOM
 
+- The {{domxref("HTMLDialogElement/requestClose", "requestClose()")}} method of the {{domxref("HTMLDialogElement")}} interface is supported.
+  This allows developers to conditionally prevent a dialog from closing by providing a [`cancel` event](/en-US/docs/Web/API/HTMLDialogElement/cancel_event) handler.
+  ([Firefox bug 1960556](https://bugzil.la/1960556)).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -39,7 +39,7 @@ This article provides information about the changes in Firefox 139 that affect d
 
 #### DOM
 
-- The {{domxref("HTMLDialogElement/requestClose", "requestClose()")}} method of the {{domxref("HTMLDialogElement")}} interface is supported.
+- The {{domxref("HTMLDialogElement/requestClose", "requestClose()")}} method of the {{domxref("HTMLDialogElement")}} interface is now supported.
   This allows developers to conditionally prevent a dialog from closing by providing a [`cancel` event](/en-US/docs/Web/API/HTMLDialogElement/cancel_event) handler.
   ([Firefox bug 1960556](https://bugzil.la/1960556)).
 


### PR DESCRIPTION
FF139 Adds support for [`HTMLDialogElement.requestClose()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/requestClose) in https://bugzilla.mozilla.org/show_bug.cgi?id=1960556

This adds the release note.

Related docs work can be tracked in #39307
