### PR TITLE
FF139 ExprFeat: Escape < and > in attributes when serialize HTML

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1110,10 +1110,10 @@ The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developer
 
 ### Escape < and > in attributes when serializing HTML
 
-This replaces the `<` and `>` characters with `&lt;` and `&gt;` (respectively) in attributes when serializing HTML.
+Firefox replaces the `<` and `>` characters with `&lt;` and `&gt;` (respectively) in attributes when serializing HTML.
 This prevents certain exploits where HTML is serialized and then injected back into the DOM.
 The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}.
-([Firefox bug 1941347](https://bugzil.la/1941347))
+([Firefox bug 1941347](https://bugzil.la/1941347)).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1108,6 +1108,49 @@ The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developer
   </tbody>
 </table>
 
+### Escape < and > in attributes when serializing HTML
+
+This replaces the `<` and `>` characters with `&lt;` and `&gt;` (respectively) in attributes when serializing HTML.
+This prevents certain exploits where HTML is serialized and then injected back into the DOM.
+The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}.
+([Firefox bug 1941347](https://bugzil.la/1941347))
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>139</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>139</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>139</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>139</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.security.html_serialization_escape_lt_gt</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Removal of MutationEvent
 
 {{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`, `DOMAttrModified`) are on the path for removal, and have been disabled on nightly.


### PR DESCRIPTION
FF139 escapes `<` as `&lt;` and `>` as `&gt;` in attribute values when HTML is serialized (i.e. when reading [Element.innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML), [Element.outerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML), [Element.getHTML()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getHTML), [ShadowRoot.innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/innerHTML), , [ShadowRoot.getHTML()](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/getHTML).

This is the experimental features update. 

Related docs can be tracked in #39309