### PR TITLE
FF139 Relnote - Escape < and > in attributes when serializing HTML

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -68,6 +68,10 @@ This article provides information about the changes in Firefox 139 that affect d
 
 These features are newly shipped in Firefox 139 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **Escape `<` and `>` in attributes when serializing HTML** `dom.security.html_serialization_escape_lt_gt`.
+  The browser replaces the `<` and `>` characters with `&lt;` and `&gt;` (respectively) in attributes when serializing HTML, which prevents certain exploits where HTML is serialized and then injected back into the DOM.
+  The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347))
+
 ## Older versions
 
 {{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -68,9 +68,9 @@ This article provides information about the changes in Firefox 139 that affect d
 
 These features are newly shipped in Firefox 139 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
-- **Escape `<` and `>` in attributes when serializing HTML** `dom.security.html_serialization_escape_lt_gt`.
-  The browser replaces the `<` and `>` characters with `&lt;` and `&gt;` (respectively) in attributes when serializing HTML, which prevents certain exploits where HTML is serialized and then injected back into the DOM.
-  The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347))
+- **Support for escaping `<` and `>` in attributes when serializing HTML**: `dom.security.html_serialization_escape_lt_gt`.
+  Firefox now replaces the `<` and `>` characters with `&lt;` and `&gt;`, respectively, in attributes when serializing HTML. This helps prevent certain exploits where HTML is serialized and then injected back into the DOM.
+  The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347)).
 
 ## Older versions
 


### PR DESCRIPTION
FF139 escapes `<` as `&lt;` and `>` as `&gt;` in attribute values when HTML is serialized (i.e. when reading [Element.innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML), [Element.outerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML), [Element.getHTML()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getHTML), [ShadowRoot.innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/innerHTML), , [ShadowRoot.getHTML()](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/getHTML).

This is the release note update. 

Related docs can be tracked in #39309