### PR TITLE
Use reduce() method to get the total size of Uint8Arrays

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -229,10 +229,7 @@ function listener(details) {
   };
 
   filter.onstop = (event) => {
-    let combinedLength = 0;
-    for (const buffer of data) {
-      combinedLength += buffer.length;
-    }
+    const combinedLength = data.reduce((acc, buffer) => acc + buffer.length, 0);
     const combinedArray = new Uint8Array(combinedLength);
     let writeOffset = 0;
     for (const buffer of data) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Use reduce() method to get the total size of Uint8Arrays instead of using `for...of` loop.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Replace 4 lines of code with 1 line.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
