### PR TITLE
Restore missing reference to column tracks in grid-template-columns example

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -98,7 +98,7 @@ Grid tracks are defined in the [explicit grid](#implicit_and_explicit_grids) by 
 
 ### Basic example
 
-We can add to our earlier example by adding the `grid-template-columns` property, then defining the size of the column tracks.
+We can add column tracks to our earlier example by adding the `grid-template-columns` property, then defining the size of the column tracks.
 
 We have now created a grid with three 200-pixel-wide column tracks. The child items will be laid out on this grid one in each grid cell.
 


### PR DESCRIPTION
### Description

Corrected a vague sentence by restoring the omitted reference to “column tracks” in the explanation of `grid-template-columns`.

### Motivation

The original sentence did not clearly specify what was being added to the example. By explicitly stating “column tracks,” the explanation becomes more precise and informative, improving clarity for readers learning CSS Grid.

### Additional details

N/A

### Related issues and pull requests

N/A
