### PR TITLE
Minor edits to the "Third-party cookies" section

### DIFF
--- a/files/en-us/web/http/guides/cors/index.md
+++ b/files/en-us/web/http/guides/cors/index.md
@@ -360,7 +360,12 @@ Also note that any `Set-Cookie` response header in a response would not set a co
 
 Note that cookies set in CORS responses are subject to normal third-party cookie policies. In the example above, the page is loaded from `foo.example` but the `Set-Cookie` header in the response is sent by `bar.other`, and would thus not be saved if the user's browser is configured to reject all third-party cookies.
 
-Third-party cookie policies (e.g., the [SameSite](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute) may suppress certain cookies from being sent to the server. The enforced cookie policy may therefore nullify the capability described in this chapter, effectively preventing you from making credentialed requests whatsoever.
+Cookies set in CORS requests and responses are subject to normal third-party cookie policies.
+
+Third-party cookie policies may prevent third party cookies being sent in requests, effectively stopping a site from making credentialed requests even if permitted by the third party server (using `Access-Control-Allow-Credentials`).
+The default policy differs between browsers, but may be set using the [SameSite](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute.
+
+Even if credentialed requests are allowed, a browser may be configured to reject all third-party cookies in responses.
 
 ## The HTTP response headers
 

--- a/files/en-us/web/http/guides/cors/index.md
+++ b/files/en-us/web/http/guides/cors/index.md
@@ -360,9 +360,7 @@ Also note that any `Set-Cookie` response header in a response would not set a co
 
 Note that cookies set in CORS responses are subject to normal third-party cookie policies. In the example above, the page is loaded from `foo.example` but the `Set-Cookie` header in the response is sent by `bar.other`, and would thus not be saved if the user's browser is configured to reject all third-party cookies.
 
-Cookie in the request may also be suppressed in normal third-party cookie policies. The enforced cookie policy may therefore nullify the capability described in this chapter, effectively preventing you from making credentialed requests whatsoever.
-
-Cookie policy around the [SameSite](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute would apply.
+Third-party cookie policies (e.g., the [SameSite](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute) may suppress certain cookies from being sent to the server. The enforced cookie policy may therefore nullify the capability described in this chapter, effectively preventing you from making credentialed requests whatsoever.
 
 ## The HTTP response headers
 


### PR DESCRIPTION
- I think there was some issues with pluralization of the word "Cookie" at the end of this section, so I attempted to reword it.
- I ended up changing more than I originally intended
- I did not intend to change any of the original meaning. If I did, that was a mistake on my part.
