### PR TITLE
Ff139 unship (before/after)scriptexecute in nightly

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -79,7 +79,7 @@ These features are newly shipped in Firefox 139 but are disabled by default. To 
 - **Support for escaping `<` and `>` in attributes when serializing HTML**: `dom.security.html_serialization_escape_lt_gt`.
   Firefox now replaces the `<` and `>` characters with `&lt;` and `&gt;`, respectively, in attributes when serializing HTML. This helps prevent certain exploits where HTML is serialized and then injected back into the DOM.
   The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347)).
-- **Disable non-standard `beforescriptexecute` and `afterscriptexecute`** `dom.events.script_execute.enabled`.
+- **Disable non-standard `beforescriptexecute` and `afterscriptexecute`**: `dom.events.script_execute.enabled`.
   The events have been disabled on Nightly only, allowing browser testing prior to their removal.
   The affected events are: [`beforescriptexecute`](/en-US/docs/Web/API/Document/beforescriptexecute_event) and [`afterscriptexecute`](/en-US/docs/Web/API/Document/afterscriptexecute_event) on the {{domxref("Document")}} interface, and [`afterscriptexecute`](/en-US/docs/Web/API/Element/afterscriptexecute_event) and [`beforescriptexecute`](/en-US/docs/Web/API/Element/beforescriptexecute_event) on the {{domxref("Element")}} interface. ([Firefox bug 1954685](https://bugzil.la/1954685)).
 

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -75,6 +75,9 @@ These features are newly shipped in Firefox 139 but are disabled by default. To 
 - **Support for escaping `<` and `>` in attributes when serializing HTML**: `dom.security.html_serialization_escape_lt_gt`.
   Firefox now replaces the `<` and `>` characters with `&lt;` and `&gt;`, respectively, in attributes when serializing HTML. This helps prevent certain exploits where HTML is serialized and then injected back into the DOM.
   The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347)).
+- **Disable non-standard `beforescriptexecute` and `afterscriptexecute`** `dom.events.script_execute.enabled`.
+  The events have been disabled on Nightly only, allowing browser testing prior to their removal.
+  The affected events are: [`beforescriptexecute`](/en-US/docs/Web/API/Document/beforescriptexecute_event) and [`afterscriptexecute`](/en-US/docs/Web/API/Document/afterscriptexecute_event) on the {{domxref("Document")}} interface, and [`afterscriptexecute`](/en-US/docs/Web/API/Element/afterscriptexecute_event) and [`beforescriptexecute`](/en-US/docs/Web/API/Element/beforescriptexecute_event) on the {{domxref("Element")}} interface. ([Firefox bug 1954685](https://bugzil.la/1954685)).
 
 ## Older versions
 


### PR DESCRIPTION
FF139 stops sending events [`Document`: `beforescriptexecute`](https://developer.mozilla.org/en-US/docs/Web/API/Document/beforescriptexecute_event), [`Document`: `afterscriptexecute`](https://developer.mozilla.org/en-US/docs/Web/API/Document/afterscriptexecute_event), [`Element`: `afterscriptexecute`](https://developer.mozilla.org/en-US/docs/Web/API/Element/afterscriptexecute_event), [`Element`: `beforescriptexecute`](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforescriptexecute_event) - on a pref `dom.events.script_execute.enabled` which is set false on nightly, but is true on release - in https://bugzilla.mozilla.org/show_bug.cgi?id=1954685

This isn't actually unshipped - its an experimental feature test. So have added it to that section.

Related docs can be tracked in #39304