### PR TITLE
fix: Move lang attributes to bdi elements

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/lang/index.md
+++ b/files/en-us/web/html/reference/global_attributes/lang/index.md
@@ -86,74 +86,74 @@ For example, the language menu on this site (MDN) includes a **`lang`** attribut
     class="dropdown-menu-items right show"
     aria-expanded="true"
     role="menu">
-    <li lang="ca" role="menuitem">
+    <li role="menuitem">
       <a
         href="/ca/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Catalan">
-        <bdi>Català</bdi>
+        <bdi lang="ca">Català</bdi>
       </a>
     </li>
-    <li lang="de" role="menuitem">
+    <li role="menuitem">
       <a
         href="/de/docs/Web/HTML/Reference/Global_attributes/lang"
         title="German">
-        <bdi>Deutsch</bdi>
+        <bdi lang="de">Deutsch</bdi>
       </a>
     </li>
-    <li lang="es" role="menuitem">
+    <li role="menuitem">
       <a
         href="/es/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Spanish">
-        <bdi>Español</bdi>
+        <bdi lang="es">Español</bdi>
       </a>
     </li>
-    <li lang="fr" role="menuitem">
+    <li role="menuitem">
       <a
         href="/fr/docs/Web/HTML/Reference/Global_attributes/lang"
         title="French">
-        <bdi>Français</bdi>
+        <bdi lang="fr">Français</bdi>
       </a>
     </li>
-    <li lang="ja" role="menuitem">
+    <li role="menuitem">
       <a
         href="/ja/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Japanese">
-        <bdi>日本語</bdi>
+        <bdi lang="ja">日本語</bdi>
       </a>
     </li>
-    <li lang="ko" role="menuitem">
+    <li role="menuitem">
       <a
         href="/ko/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Korean">
-        <bdi>한국어</bdi>
+        <bdi lang="ko">한국어</bdi>
       </a>
     </li>
-    <li lang="pt-BR" role="menuitem">
+    <li role="menuitem">
       <a
         href="/pt-BR/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Portuguese (Brazilian)">
-        <bdi>Português (do&nbsp;Brasil)</bdi>
+        <bdi lang="pt-BR">Português (do&nbsp;Brasil)</bdi>
       </a>
     </li>
-    <li lang="ru" role="menuitem">
+    <li role="menuitem">
       <a
         href="/ru/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Russian">
-        <bdi>Русский</bdi>
+        <bdi lang="ru">Русский</bdi>
       </a>
     </li>
-    <li lang="uk" role="menuitem">
+    <li role="menuitem">
       <a
         href="/uk/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Ukrainian">
-        <bdi>Українська</bdi>
+        <bdi lang="uk">Українська</bdi>
       </a>
     </li>
-    <li lang="zh-Hans" role="menuitem">
+    <li role="menuitem">
       <a
         href="/zh-CN/docs/Web/HTML/Reference/Global_attributes/lang"
         title="Chinese (Simplified)">
-        <bdi>中文 (简体)</bdi>
+        <bdi lang="zh-Hans">中文 (简体)</bdi>
       </a>
     </li>
     <li>


### PR DESCRIPTION
### Description
I have corrected the placement of the lang attribute in the language menu example. The lang attribute has been moved from the li element to the bdi element, which actually contains the text in that language.

### Motivation
[Declaring language in HTML](https://www.w3.org/International/questions/qa-html-language-declarations) contains examples of how to handle lang attributes and title attributes when their languages don't match. Following this reference, I updated the code to apply the lang attribute to elements that actually contain text in that language.


### Additional details
[W3C - Declaring language in HTML](https://www.w3.org/International/questions/qa-html-language-declarations#details)

### Related issues and pull requests
Fixes #39252