### PR TITLE
FF139 ExprFeat: Prioritized Scheduler API in nightly

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1889,7 +1889,7 @@ See [Firefox bug 1697647](https://bugzil.la/1697647) for more details.
 
 ### Prioritized Task Scheduling API
 
-The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.
+The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third-party libraries and frameworks.
 Support for most of the API was added behind a preference in Firefox version 101.
 Firefox version 139 adds support for support for {{domxref("scheduler.yield()")}} and enables the API in the Nightly release.
 ([Firefox bug 1734997](https://bugzil.la/1734997) and [Firefox bug 1920115](https://bugzil.la/1920115)),

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1889,10 +1889,10 @@ See [Firefox bug 1697647](https://bugzil.la/1697647) for more details.
 
 ### Prioritized Task Scheduling API
 
-The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks. ([Firefox bug 1734997](https://bugzil.la/1734997))
-
-This feature was enabled on Firefox Nightly in Firefox 101.
-Support in Firefox Nightly 135 has been temporarily disabled in order to avoid [breakage in-the-wild](https://bugzil.la/1937232).
+The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.
+Support for most of the API was added behind a preference in Firefox version 101.
+Firefox version 139 adds support for support for {{domxref("scheduler.yield()")}} and enables the API in the Nightly release.
+([Firefox bug 1734997](https://bugzil.la/1734997) and [Firefox bug 1920115](https://bugzil.la/1920115)),
 
 <table>
   <thead>
@@ -1905,8 +1905,8 @@ Support in Firefox Nightly 135 has been temporarily disabled in order to avoid [
   <tbody>
     <tr>
       <th>Nightly</th>
-      <td>101</td>
-      <td>No</td>
+      <td>139</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Developer Edition</th>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1891,8 +1891,8 @@ See [Firefox bug 1697647](https://bugzil.la/1697647) for more details.
 
 The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third-party libraries and frameworks.
 Support for most of the API was added behind a preference in Firefox version 101.
-Firefox version 139 adds support for support for {{domxref("scheduler.yield()")}} and enables the API in the Nightly release.
-([Firefox bug 1734997](https://bugzil.la/1734997) and [Firefox bug 1920115](https://bugzil.la/1920115)),
+Firefox version 139 adds support for {{domxref("scheduler.yield()")}} and enables the API in the Nightly release.
+([Firefox bug 1734997](https://bugzil.la/1734997) and [Firefox bug 1920115](https://bugzil.la/1920115)).
 
 <table>
   <thead>


### PR DESCRIPTION
FF139 enables the Prioritized Scheduling API in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1958943 (sets `dom.enable_web_task_scheduling` to `true`, and also adds support for the `scheduler.yield()` method in https://bugzilla.mozilla.org/show_bug.cgi?id=1920115

This updates the experimental features doc.

Related docs work can be tracked in #39310