### PR TITLE
Add `hev1.*`/`hvc1.*`/`avc1.*`/`avc3.*`/`av01.*` mp4 mimetypes for MediaRecorder

### DIFF
--- a/files/en-us/web/api/mediarecorder/istypesupported_static/index.md
+++ b/files/en-us/web/api/mediarecorder/istypesupported_static/index.md
@@ -38,12 +38,22 @@ const types = [
   "video/webm;codecs=h264",
   "audio/webm;codecs=opus",
   "video/mp4",
+  "video/mp4;codecs=avc1.64003E,mp4a.40.2",
+  "video/mp4;codecs=avc1.64003E,opus",
+  "video/mp4;codecs=avc3.64003E,mp4a.40.2",
+  "video/mp4;codecs=avc3.64003E,opus",
+  "video/mp4;codecs=hvc1.1.6.L186.B0,mp4a.40.2",
+  "video/mp4;codecs=hvc1.1.6.L186.B0,opus",
+  "video/mp4;codecs=hev1.1.6.L186.B0,mp4a.40.2",
+  "video/mp4;codecs=hev1.1.6.L186.B0,opus",
+  "video/mp4;codecs=av01.0.19M.08,mp4a.40.2",
+  "video/mp4;codecs=av01.0.19M.08,opus",
 ];
 
 for (const type of types) {
   console.log(
     `Is ${type} supported? ${
-      MediaRecorder.isTypeSupported(type) ? "Maybe!" : "Nope :("
+      MediaRecorder.isTypeSupported(type) ? "Yes!" : "Nope :("
     }`,
   );
 }


### PR DESCRIPTION
### Description

The `hev1.*`/`hvc1.*`/`avc3.*` mimetypes are newly supported by Chrome 136. Refer to:
https://chromestatus.com/feature/6375884229181440. and `avc1.*`/`av01.*` mimetypes 
have  already been supported by Chrome/Edge 126 and later versions.

The `hvc1.*/av01.*` mimetypes are newly supported by Safari 18.4. Refer to:
https://webkit.org/blog/16574/webkit-features-in-safari-18-4/ . and `avc1.*`
mimetypes have been supported by Safari since an early version.

