### PR TITLE
fix: Remove "Initial" log from promise example output

### DIFF
--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -313,7 +313,6 @@ doSomething()
 This will output the following text:
 
 ```plain
-Initial
 Do that
 Do this, no matter what happened before
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR removes "Initial" from the example output in the promise chaining section to better reflect the current code and maintain clarity.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The example output included 'Initial', but the current code no longer logs it.
I considered adding console.log('Initial'), but decided to remove it from the output instead, since:

- The example focuses on chaining after a .catch(), not synchronous logs.
- Adding 'Initial' back could distract from the promise flow being demonstrated.

This change keeps the output aligned with the current code and its intent.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Attaching previous update made in [#29746](https://github.com/mdn/content/pull/29746), where the console.log('Initial') statement was removed from the code example.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
