### PR TITLE
fix(pr-review-companion): set `cache-control: no-store`

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -69,8 +69,10 @@ jobs:
           path: "build"
           destination: "${{ vars.GCP_BUCKET_NAME }}/${{ steps.check.outputs.PREFIX }}"
           resumable: false
-          concurrency: 500
+          headers: |-
+            cache-control: no-store
           parent: false
+          concurrency: 500
           process_gcloudignore: false
 
       - name: Checkout (mdn/content)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `pr-review-companion` workflow to set `cache-control: no-store` on all uploaded files.

### Motivation

This should avoid the caching issues some folks have experienced.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
