### PR TITLE
Add content covering the limitations of <selectedcontent>

### DIFF
--- a/files/en-us/web/html/reference/elements/selectedcontent/index.md
+++ b/files/en-us/web/html/reference/elements/selectedcontent/index.md
@@ -39,7 +39,7 @@ When creating a [Customizable select element](/en-US/docs/Learn_web_development/
 Any subsequent `<select>` content will be included in the drop-down picker.
 
 Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected `<option>`, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}.
-Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element and must be manually updated by the developer.
+Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element, and must be manually updated by the developer.
 
 > [!NOTE]
 > The `<selectedcontent>` element's built-in synchronization features that make it ideal for websites built with minimal or no JavaScript. However, its use is not required when building customizable selects. Developers using JavaScript frameworks may prefer to use the UI synchronization features provided by their framework instead of using `<selectedcontent>`.

--- a/files/en-us/web/html/reference/elements/selectedcontent/index.md
+++ b/files/en-us/web/html/reference/elements/selectedcontent/index.md
@@ -38,7 +38,8 @@ When creating a [Customizable select element](/en-US/docs/Learn_web_development/
 
 Any subsequent `<select>` content will be included in the drop-down picker.
 
-Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected `<option>`, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}. Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element and must be manually updated by the developer.
+Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected `<option>`, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}.
+Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element and must be manually updated by the developer.
 
 > [!NOTE]
 > The `<selectedcontent>` element's built-in synchronization features that make it ideal for websites built with minimal or no JavaScript. However, its use is not required when building customizable selects. Developers using JavaScript frameworks may prefer to use the UI synchronization features provided by their framework instead of using `<selectedcontent>`.

--- a/files/en-us/web/html/reference/elements/selectedcontent/index.md
+++ b/files/en-us/web/html/reference/elements/selectedcontent/index.md
@@ -38,7 +38,10 @@ When creating a [Customizable select element](/en-US/docs/Learn_web_development/
 
 Any subsequent `<select>` content will be included in the drop-down picker.
 
-Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected <code>option</code>, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}.
+Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected <code>option</code>, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}. Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element and must be manually updated by the developer.
+
+> [!NOTE]
+> The `<selectedcontent>` element's built-in synchronization features that make it ideal for websites built with minimal or no JavaScript. However, its use is not required when building customizable selects. Developers using JavaScript frameworks may prefer to use the UI synchronization features provided by their framework instead of using `<selectedcontent>`.
 
 ## Styling with CSS
 

--- a/files/en-us/web/html/reference/elements/selectedcontent/index.md
+++ b/files/en-us/web/html/reference/elements/selectedcontent/index.md
@@ -38,7 +38,7 @@ When creating a [Customizable select element](/en-US/docs/Learn_web_development/
 
 Any subsequent `<select>` content will be included in the drop-down picker.
 
-Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected <code>option</code>, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}. Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element and must be manually updated by the developer.
+Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected `<option>`, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}. Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element and must be manually updated by the developer.
 
 > [!NOTE]
 > The `<selectedcontent>` element's built-in synchronization features that make it ideal for websites built with minimal or no JavaScript. However, its use is not required when building customizable selects. Developers using JavaScript frameworks may prefer to use the UI synchronization features provided by their framework instead of using `<selectedcontent>`.

--- a/files/en-us/web/html/reference/elements/selectedcontent/index.md
+++ b/files/en-us/web/html/reference/elements/selectedcontent/index.md
@@ -41,8 +41,8 @@ Any subsequent `<select>` content will be included in the drop-down picker.
 Whenever the `<select>` element's selected `<option>` switches from one option to another, the `<selectedcontent>` element's content is removed and replaced by a new cloned copy of the DOM structure of the newly selected `<option>`, which is created using {{domxref("Node.cloneNode", "cloneNode()")}}.
 Dynamic modifications to the selected `<option>` element's content made after the `<select>` element has been created are not automatically cloned to the `<selectedcontent>` element, and must be manually updated by the developer.
 
-> [!NOTE]
-> The `<selectedcontent>` element's built-in synchronization features that make it ideal for websites built with minimal or no JavaScript. However, its use is not required when building customizable selects. Developers using JavaScript frameworks may prefer to use the UI synchronization features provided by their framework instead of using `<selectedcontent>`.
+> [!WARNING]
+> In particular, this may cause issues with sites that use popular front-end JavaScript frameworks where {{htmlelement("option")}} elements are dynamically updated after creation, as these updates will not be cloned to the `<selectedcontent>` element.
 
 ## Styling with CSS
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR updates the `<selectedcontent>` reference document to:
1. Include more details about the limitations of <selectedcontent> cloning, and
2. Add a note emphasizing that sites built using JavaScript frameworks may prefer not to use `<selectedcontent>` and instead rely on the framework's existing UI synchronization feature.

### Motivation

After seeing [this Angular bug](https://github.com/angular/angular/issues/60636) related to `<selectedcontent>` as well as testing the behavior of `<selectedcontent>` in several other frameworks and discovering issues, I believe it's important to update the MDN docs to clarify both the use cases for `<selectedcontent>` as well as its limitations. This should help ensure developers aren't confused by issues they run into when trying to use this new element.

FYI, I've discussed this recommendation with folks on the Chrome team working on the customizable `<select>` feature, and they're comfortable with this recommendation.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
