### PR TITLE
Docs: Clarify setListener source in insertAdjacentElement example

### DIFF
--- a/files/en-us/web/api/element/insertadjacentelement/index.md
+++ b/files/en-us/web/api/element/insertadjacentelement/index.md
@@ -75,7 +75,7 @@ beforeBtn.addEventListener("click", () => {
   if (activeElem) {
     activeElem.insertAdjacentElement("beforebegin", tempDiv);
   }
-  setListener(tempDiv);
+  setListener(tempDiv); // Definition in the linked GitHub demo
 });
 
 afterBtn.addEventListener("click", () => {
@@ -84,7 +84,7 @@ afterBtn.addEventListener("click", () => {
   if (activeElem) {
     activeElem.insertAdjacentElement("afterend", tempDiv);
   }
-  setListener(tempDiv);
+  setListener(tempDiv); // Definition in the linked GitHub demo
 });
 ```
 


### PR DESCRIPTION
The `setListener(tempDiv);` calls in the static JavaScript examples for `Element.insertAdjacentElement()` could be confusing as the `setListener` function is not defined within the MDN page's visible snippets.

Its definition is located in the full interactive demo hosted on GitHub, which is linked from the "Examples" section.

This commit adds an inline comment, such as:
`// Definition in the linked GitHub demo`
next to these calls. This provides immediate context for readers, improving the standalone clarity of the code snippets on the MDN page without requiring them to navigate away to understand the `setListener` reference.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
