### PR TITLE
chore: Linking to some MDN pages not linked by parent page

### DIFF
--- a/files/en-us/mdn/community/index.md
+++ b/files/en-us/mdn/community/index.md
@@ -13,23 +13,28 @@ We also provide extensive [learning resources](/en-US/docs/Learn_web_development
   - : This section explains how you can start contributing and the type of contributions we accept.
     Anyone can contribute, and each person who does contribute has an impact on millions of readers.
     Learn how to contribute and drive innovation on the Open Web.
+- [Communication channels](/en-US/docs/MDN/Community/Communication_channels)
+  - : This page lists communication channels used by the MDN team and our community, with hints on which might be best for you.
 - [Our repositories](/en-US/docs/MDN/Community/Our_repositories)
   - : This document describes the GitHub repositories (repos) you may need when contributing to MDN Web Docs.
+- [Translated content](/en-US/docs/MDN/Community/Translated_content)
+  - : MDN Web Docs Localization information, with details about teams, communication channels, and how to get involved.
+- [Open source etiquette](/en-US/docs/MDN/Community/Open_source_etiquette)
+  - : This article gives guidance on how to behave when contributing to MDN and other open source projects, including hints for collaboration and how to handle conflicts.
 - [GitHub Issues](/en-US/docs/MDN/Community/Issues)
   - : Issues are used to track all bugs and work that has a clear actionable outcome.
     This article contains guidelines on opening and working on issues and also covers issue triage and content suggestions.
 - [Pull requests](/en-US/docs/MDN/Community/Pull_requests)
   - : This section covers our guidelines for submitting pull requests and what you should expect from the review process.
+- [GitHub Discussions](/en-US/docs/MDN/Community/Discussions)
+  - : On MDN Web Docs, we encourage our community to start and engage in discussions around topics related to the project.
+    GitHub Discussions are good for gathering feedback on ideas and getting to a consensus on tasks that may have many different approaches.
 - [Roles and teams](/en-US/docs/MDN/Community/Roles_teams)
   - : This section provides an overview of the users and teams that are part of the MDN Web Docs project and details what it means to be part of a team.
-- [Translated content](/en-US/docs/MDN/Community/Translated_content)
-  - : MDN Web Docs Localization information, with details about teams, communication channels, and how to get involved.
-- [Open source etiquette](/en-US/docs/MDN/Community/Open_source_etiquette)
-  - : This article gives guidance on how to behave when contributing to our open source project including rules for contributing, etiquette, and how to handle conflicts.
-- [Communication channels](/en-US/docs/MDN/Community/Communication_channels)
-  - : This page lists communication channels used by the MDN team and our community, with hints on which might be best for you.
 - [Community Participation Guidelines (CPG)](/en-US/docs/MDN/Community/Community_Participation_Guidelines)
   - : This page lists all the Community Participation Guidelines we have that helps us foster a welcoming, inclusive, and safe community. It also covers [How to Report](/en-US/docs/MDN/Community/Community_Participation_Guidelines#reporting_process) a CPG Violation.
+- [MDN Web Docs changelog](/en-US/docs/MDN/Writing_guidelines/Changelog)
+  - : This document records notable changes to MDN content processes and best practices, with information about when and why they changed.
 
 ## Code of conduct
 

--- a/files/en-us/mdn/community/issues/index.md
+++ b/files/en-us/mdn/community/issues/index.md
@@ -24,6 +24,8 @@ Avoid doing the following:
 - Opening lots of issues asking vague questions.
 - Asking questions without trying to solve the problem yourself first.
 
+If you want to suggest new documentation or ways to improve the website, see [Proposing new content or features](/en-US/docs/MDN/Community/Issues/Content_suggestions_feature_proposals).
+
 ## Guidelines for reporting an issue
 
 [Issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) are used to track bugs. An issue must be a single actionable task or a collection of related actionable tasks and must have a clear outcome.

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -6,9 +6,7 @@ sidebar: mdnsidebar
 ---
 
 This page lists many of the general-purpose macros created for use on MDN.
-For additional how-to information on using these macros, see [Using macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros).
-
-See [Other macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Other) for information on macros that are infrequently used, are used only in special contexts, or are deprecated.
+For generic how-to information on using them in MDN content, see [Using macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros).
 
 ## Linking
 
@@ -267,3 +265,4 @@ The following macros are included on all reference pages, but are also supported
 - [Page templates](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types#page_templates)
 - [Page components](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#page_components)
 - [Feature status macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status)
+- [Other macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Other): infrequently used or deprecated macros

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/index.md
@@ -25,6 +25,7 @@ A few notes about macro calls:
 Macros can be as simple as just inserting a larger block of text or swapping in contents from another part of MDN, or as complex as building an entire index of content by searching through parts of the site, styling the output, and adding links.
 
 You can read up on our most commonly used macros on the [Commonly used macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros) page.
+Less common macros are described in the [Other macros](MDN/Writing_guidelines/Page_structures/Macros/Other) documentation.
 
 ## See also
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -57,6 +57,7 @@ Below are examples of the various pages you'll find on MDN along with templates 
 - [API landing pages](#api_landing_page)
 - [API reference page](#api_reference_page)
 - [API reference subpage](#api_reference_subpage)
+- [ARIA reference](#aria_reference_page)
 - [Conceptual pages](#conceptual_page)
 - [CSS feature reference](#css_feature_reference_page)
 - [CSS module landing page](#css_module_landing_page)
@@ -213,6 +214,19 @@ It also provides examples, browser compatibility information, and other importan
 #### Templates
 
 - [HTTP header page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/HTTP_header_page_template)
+
+### ARIA reference page
+
+An **ARIA reference page** describes a [role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) or [attribute](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes) that defines ways to make web content and web applications more accessible to people with disabilities.
+
+#### Examples
+
+- [aria-busy attribute](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy)
+- [application role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role)
+
+#### Templates
+
+- [ARIA page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/ARIA_Page_Template)
 
 ### Conceptual page
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -221,8 +221,8 @@ An **ARIA reference page** describes a [role](/en-US/docs/Web/Accessibility/ARIA
 
 #### Examples
 
-- [aria-busy attribute](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy)
-- [application role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role)
+- [`aria-busy` attribute](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy)
+- [`application` role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/application_role)
 
 #### Templates
 


### PR DESCRIPTION
### Description

Thanks to the warning graph, we can detect pages not linked in parent docs. This PR fixes a few in our writing guidelines.

