### PR TITLE
Add warning against using element IDs as global properties.

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/class/index.md
+++ b/files/en-us/web/html/reference/global_attributes/class/index.md
@@ -37,19 +37,19 @@ The **`class`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attribu
 }
 ```
 
-## Description
-
-Classes allow CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the {{domxref("document.getElementsByClassName()")}}.
-
-Though the specification doesn't put requirements on the name of classes, web developers are encouraged to use names that describe the semantic purpose of the element, rather than the presentation of the element. For example, _attribute_ to describe an attribute rather than _italics_, although an element of this class may be presented by _italics_. Semantic names remain logical even if the presentation of the page changes.
-
-### Syntax
+## Syntax
 
 The `class` attribute is a list of class values separated by [ASCII whitespace](/en-US/docs/Glossary/Whitespace#in_html).
 
 Each class value may contain any Unicode characters (except, of course, ASCII whitespace). However, when used in CSS selectors, either from JavaScript using APIs like {{domxref("Document.querySelector()")}} or in CSS stylesheets, class attribute values must be valid [CSS identifiers](/en-US/docs/Web/CSS/ident). This means that if a class attribute value is not a valid CSS identifier (for example, `my?class` or `1234`) then it must be escaped before being used in a selector, either using the {{domxref("CSS.escape_static", "CSS.escape()")}} method or [manually](/en-US/docs/Web/CSS/ident#escaping_characters).
 
 For this reason, it's recommended that developers choose values for class attributes that are valid CSS identifiers that don't require escaping.
+
+## Description
+
+Classes allow CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the {{domxref("document.getElementsByClassName()")}}.
+
+Though the specification doesn't put requirements on the name of classes, web developers are encouraged to use names that describe the semantic purpose of the element, rather than the presentation of the element. For example, _attribute_ to describe an attribute rather than _italics_, although an element of this class may be presented by _italics_. Semantic names remain logical even if the presentation of the page changes.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -49,7 +49,7 @@ const content = window.preamble.textContent;
 ```
 
 > [!WARNING]
-> While elements with `id` attributes are treated as global properties on the `window` object, depending on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some browser existing or future APIs. Use `document.getElementById()` or `document.querySelector()` instead.
+> Relying on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some existing or future APIs in the browser. For example, if browsers add a new global property called `preamble`, then the same code will no longer be able to access the HTML element. Use `document.getElementById()` or `document.querySelector()` instead.
 >
 > For example, if we had an element with an `id="performance"`, the following code would've worked before the introduction of Performance in modern browsers:
 >

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -48,6 +48,20 @@ You could access the paragraph element in JavaScript using code like:
 const content = window.preamble.textContent;
 ```
 
+> [!WARNING]
+> While elements with `id` attributes are treated as global properties on the `window` object, depending on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some browser features or future APIs. Use `document.getElementById()` or `document.querySelector()` instead.
+>
+> For example, if we had an element with an `id="performance"`, the following code would've worked before the introduction of Performance in modern browsers:
+>
+> ```html
+> <h3 id="performance"></h3>
+>
+> <script>
+>     performance.innerHTML = "Well Done!";
+>     performance.style.backgroundColor = "green";
+> </script>
+> ```
+
 ### Syntax
 
 An ID attribute's value must not contain [ASCII whitespace](/en-US/docs/Glossary/Whitespace#in_html) characters. Browsers treat non-conforming IDs that contain whitespace as if the whitespace is part of the ID. In contrast to the [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) attribute, which allows space-separated values, elements can only have one single ID value.

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -49,18 +49,7 @@ const content = window.preamble.textContent;
 ```
 
 > [!WARNING]
-> Relying on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some existing or future APIs in the browser. For example, if browsers add a new global property called `preamble`, then the same code will no longer be able to access the HTML element. Use `document.getElementById()` or `document.querySelector()` instead.
->
-> For example, if we had an element with an `id="performance"`, the following code would've worked before the introduction of Performance in modern browsers:
->
-> ```html
-> <h3 id="performance"></h3>
->
-> <script>
->   performance.innerHTML = "Well Done!";
->   performance.style.backgroundColor = "green";
-> </script>
-> ```
+> Relying on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some existing or future APIs in the browser. For example, if browsers introduce a new global property named `preamble`, then the same code will no longer be able to access the HTML element. Use `document.getElementById()` or `document.querySelector()` instead.
 
 ### Syntax
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -32,6 +32,16 @@ The **`id`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes
 }
 ```
 
+## Syntax
+
+An ID attribute's value must not contain [ASCII whitespace](/en-US/docs/Glossary/Whitespace#in_html) characters. Browsers treat non-conforming IDs that contain whitespace as if the whitespace is part of the ID. In contrast to the [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) attribute, which allows space-separated values, elements can only have one single ID value.
+
+Technically, the value for an ID attribute may contain any other Unicode character. However, when used in CSS selectors, either from JavaScript using APIs like {{domxref("Document.querySelector()")}} or in CSS stylesheets, ID attribute values must be valid [CSS identifiers](/en-US/docs/Web/CSS/ident). This means that if an ID attribute value is not a valid CSS identifier (for example, `my?id` or `1234`) then it must be escaped before being used in a selector, either using the {{domxref("CSS.escape_static", "CSS.escape()")}} method or [manually](/en-US/docs/Web/CSS/ident#escaping_characters).
+
+For this reason, it's recommended that developers choose values for ID attributes that are valid CSS identifiers that don't require escaping.
+
+Also, not all valid ID attribute values are valid JavaScript identifiers. For example, `1234` is a valid attribute value but not a valid JavaScript identifier. This means that the value is not a valid variable name, so you can't access the element using code like `window.1234`. However, you can access it using `window["1234"]`.
+
 ## Description
 
 The purpose of the ID attribute is to identify a single element when linking (using a [fragment identifier](/en-US/docs/Web/URI#fragment)), scripting, or styling (with {{glossary("CSS")}}).
@@ -50,16 +60,6 @@ const content = window.preamble.textContent;
 
 > [!WARNING]
 > Relying on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some existing or future APIs in the browser. For example, if browsers introduce a new global property named `preamble`, then the same code will no longer be able to access the HTML element. Use `document.getElementById()` or `document.querySelector()` instead.
-
-### Syntax
-
-An ID attribute's value must not contain [ASCII whitespace](/en-US/docs/Glossary/Whitespace#in_html) characters. Browsers treat non-conforming IDs that contain whitespace as if the whitespace is part of the ID. In contrast to the [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) attribute, which allows space-separated values, elements can only have one single ID value.
-
-Technically, the value for an ID attribute may contain any other Unicode character. However, when used in CSS selectors, either from JavaScript using APIs like {{domxref("Document.querySelector()")}} or in CSS stylesheets, ID attribute values must be valid [CSS identifiers](/en-US/docs/Web/CSS/ident). This means that if an ID attribute value is not a valid CSS identifier (for example, `my?id` or `1234`) then it must be escaped before being used in a selector, either using the {{domxref("CSS.escape_static", "CSS.escape()")}} method or [manually](/en-US/docs/Web/CSS/ident#escaping_characters).
-
-For this reason, it's recommended that developers choose values for ID attributes that are valid CSS identifiers that don't require escaping.
-
-Also, not all valid ID attribute values are valid JavaScript identifiers. For example, `1234` is a valid attribute value but not a valid JavaScript identifier. This means that the value is not a valid variable name, so you can't access the element using code like `window.1234`. However, you can access it using `window["1234"]`.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -57,8 +57,8 @@ const content = window.preamble.textContent;
 > <h3 id="performance"></h3>
 >
 > <script>
->     performance.innerHTML = "Well Done!";
->     performance.style.backgroundColor = "green";
+>   performance.innerHTML = "Well Done!";
+>   performance.style.backgroundColor = "green";
 > </script>
 > ```
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -49,7 +49,7 @@ const content = window.preamble.textContent;
 ```
 
 > [!WARNING]
-> While elements with `id` attributes are treated as global properties on the `window` object, depending on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some browser features or future APIs. Use `document.getElementById()` or `document.querySelector()` instead.
+> While elements with `id` attributes are treated as global properties on the `window` object, depending on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some browser existing or future APIs. Use `document.getElementById()` or `document.querySelector()` instead.
 >
 > For example, if we had an element with an `id="performance"`, the following code would've worked before the introduction of Performance in modern browsers:
 >
@@ -57,8 +57,8 @@ const content = window.preamble.textContent;
 > <h3 id="performance"></h3>
 >
 > <script>
->   performance.innerHTML = "Well Done!";
->   performance.style.backgroundColor = "green";
+>     performance.innerHTML = "Well Done!";
+>     performance.style.backgroundColor = "green";
 > </script>
 > ```
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Add a warning about using element IDs as global properties on `window` object, and recommend best practices for safer DOM access.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Help the readers follow modern standard and best practices when selecting and manipulating element using ID.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None.
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #39339

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
