### PR TITLE
Fix: image loading race condition in canvas pattern code

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -691,13 +691,13 @@ function draw() {
 
   // create new image object to use as pattern
   const img = new Image();
-  img.src = "canvas_create_pattern.png";
   img.onload = () => {
     // create pattern
     const pattern = ctx.createPattern(img, "repeat");
     ctx.fillStyle = pattern;
     ctx.fillRect(0, 0, 150, 150);
   };
+  img.src = "canvas_create_pattern.png";
 }
 ```
 


### PR DESCRIPTION
- Reordered img.onload handler to be set before img.src
- Prevents potential missed events when images load from cache

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
