### PR TITLE
Replace interactive-examples assets with shared-assets

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
@@ -133,9 +133,7 @@ The HTML looks like this:
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       Your browser doesn't support HTML video. Here is a
       <a href="rabbit320.mp4">link to the video</a> instead.
@@ -228,9 +226,7 @@ All we're doing here is calling `stopPropagation()` on the event object in the h
 
 <div class="hidden">
   <video>
-    <source
-      src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
-      type="video/webm" />
+    <source src="/shared-assets/videos/flower.webm" type="video/webm" />
     <p>
       Your browser doesn't support HTML video. Here is a
       <a href="rabbit320.mp4">link to the video</a> instead.

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -50,7 +50,7 @@ ctx.font = "16px sans-serif";
 ctx.textAlign = "center";
 
 const img = new Image();
-img.src = "/shared-assets/images/examples/star.png";
+img.src = "/shared-assets/images/examples/big-star.png";
 img.onload = () => {
   const w = img.width,
     h = img.height;

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -50,8 +50,7 @@ ctx.font = "16px sans-serif";
 ctx.textAlign = "center";
 
 const img = new Image();
-img.src =
-  "https://interactive-examples.mdn.mozilla.net/media/examples/star.png";
+img.src = "/shared-assets/images/examples/star.png";
 img.onload = () => {
   const w = img.width,
     h = img.height;

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -40,15 +40,11 @@ Otherwise, this function returns `false`.
 In the following example, we create a new `FontFace` and add it to the `FontFaceSet`:
 
 ```js
-const font = new FontFace(
-  "molot",
-  "url(https://interactive-examples.mdn.mozilla.net/media/fonts/molot.woff2)",
-  {
-    style: "normal",
-    weight: "400",
-    stretch: "condensed",
-  },
-);
+const font = new FontFace("molot", "url(/shared-assets/fonts/molot.woff2)", {
+  style: "normal",
+  weight: "400",
+  stretch: "condensed",
+});
 
 document.fonts.add(font);
 ```

--- a/files/en-us/web/api/htmlimageelement/x/index.md
+++ b/files/en-us/web/api/htmlimageelement/x/index.md
@@ -67,8 +67,7 @@ including their user ID, their full name, and their avatar image.
     <td>12345678</td>
     <td>Johnny Rocket</td>
     <td>
-      <img
-        src="https://interactive-examples.mdn.mozilla.net/media/examples/grapefruit-slice-332-332.jpg" />
+      <img src="/shared-assets/images/examples/grapefruit-slice.jpg" />
     </td>
   </tr>
 </table>

--- a/files/en-us/web/api/htmlmediaelement/loadstart_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadstart_event/index.md
@@ -100,10 +100,7 @@ loadVideo.addEventListener("click", () => {
   } else {
     loadVideo.textContent = "Reset example";
     source = document.createElement("source");
-    source.setAttribute(
-      "src",
-      "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm",
-    );
+    source.setAttribute("src", "/shared-assets/videos/flower.webm");
     source.setAttribute("type", "video/webm");
 
     video.appendChild(source);

--- a/files/en-us/web/api/vttcue/index.md
+++ b/files/en-us/web/api/vttcue/index.md
@@ -59,9 +59,7 @@ _This interface also inherits properties from {{domxref("TextTrackCue")}}._
 The following example adds a new {{domxref("TextTrack")}} to the video, then adds cues using the {{domxref("TextTrack.addCue()")}} method, with a `VTTCue` object as the value.
 
 ```html
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 ### CSS

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -82,9 +82,7 @@ These [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-ele
 The following example adds a new {{domxref("TextTrack")}} to the video, then adds cues using {{domxref("TextTrack.addCue()")}} method calls, with constructed `VTTCue` objects as arguments.
 
 ```html
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 #### CSS
@@ -181,9 +179,7 @@ video {
 ```
 
 ```html
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 #### CSS
@@ -250,9 +246,7 @@ video {
 ```
 
 ```html hidden
-<video
-  controls
-  src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/friday.mp4"></video>
+<video controls src="/shared-assets/videos/friday.mp4"></video>
 ```
 
 #### Styling by tag type

--- a/files/en-us/web/css/border-image-slice/index.md
+++ b/files/en-us/web/css/border-image-slice/index.md
@@ -172,7 +172,7 @@ div > div {
   height: 200px;
   border-width: 30px;
   border-style: solid;
-  border-image: url(https://interactive-examples.mdn.mozilla.net/media/examples/border-diamonds.png);
+  border-image: url(/shared-assets/images/examples/border-diamonds.png);
   border-image-slice: 30;
   border-image-repeat: round;
 }

--- a/files/en-us/web/css/opacity/index.md
+++ b/files/en-us/web/css/opacity/index.md
@@ -178,7 +178,7 @@ In the following example opacity is changed on hover, so the striped background 
 ```html
 <div class="wrapper">
   <img
-    src="//interactive-examples.mdn.mozilla.net/media/dino.svg"
+    src="/shared-assets/images/examples/dino.svg"
     alt="MDN Dino"
     width="128"
     height="146"

--- a/files/en-us/web/html/guides/cheatsheet/index.md
+++ b/files/en-us/web/html/guides/cheatsheet/index.md
@@ -213,7 +213,7 @@ format&#x3C;/code>.</pre
       <td id="audio-example">
         <pre class="brush: html">
 &#x3C;audio controls>
-  &#x3C;source src="https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3" type="audio/mpeg">
+  &#x3C;source src="/shared-assets/audio/t-rex-roar.mp3" type="audio/mpeg">
 &#x3C;/audio>
         </pre>
         {{EmbedLiveSample("audio-example", 100, 80)}}

--- a/files/en-us/web/html/reference/elements/object/index.md
+++ b/files/en-us/web/html/reference/elements/object/index.md
@@ -61,7 +61,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 ```html
 <object
   type="video/webm"
-  data="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+  data="/shared-assets/videos/flower.webm"
   width="600"
   height="140">
   <img src="path/image.jpg" alt="useful image description" />


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replace interactive-examples assets with shared-assets.

### Motivation

We're already replaced interactive-examples, and are deprecating the interactive-examples repo.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
