### PR TITLE
Add link to the specific `@import layer()` page

### DIFF
--- a/files/en-us/web/css/css_syntax/at-rule_functions/index.md
+++ b/files/en-us/web/css/css_syntax/at-rule_functions/index.md
@@ -27,7 +27,7 @@ The {{CSSxRef("@import")}} at-rule is used to import styles from other styleshee
   - : Imports a stylesheet file from the specified URL.
 - {{CSSxRef("@import", "@import supports()")}}
   - : Imports a stylesheet file based on browser support.
-- {{CSSxRef("@import", "@import layer()")}}
+- [`@import layer()`](/en-US/docs/Web/CSS/@import/layer_function)
   - : Imports a stylesheet file into the specified cascade layer.
 
 ## @supports functions


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

We have a page for documenting the `@import layer()` function at [`layer()`](https://developer.mozilla.org/en-US/docs/Web/CSS/@import/layer_function), but we don't link to it on the [CSS at-rule functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions) page.

This PR replaces the link to surface the nested `@import` page.
