### PR TITLE
Remove erroneous line numbers from link to voice-change-o-matic

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -34,7 +34,7 @@ A {{domxref("WaveShaperNode")}}.
 ## Examples
 
 The following example shows basic usage of an AudioContext to create a wave shaper node.
-For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
+For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js) for relevant code).
 
 > [!NOTE]
 > Sigmoid functions are commonly used for distortion curves


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the example section for the wave shaper node, I'm updating the existing link to the sample source code for the Voice-Change-O-Matic to remove the line numbers, as the code within the highlighted lines pertains to the visualization function, not the wave distortion relevant to this page. I'm generalizing the link to the entire file rather than specific lines as there are 3 different sections of the file that contain relevant code for the wave shaper (lines 23-44, 69-84, and 185-216).

### Motivation

Fixing a link that currently points to the wrong section of the sample source code file to avoid confusion for readers

### Additional details

If you think it'd be better to include links to all 3 relevant sections of the code (ie lines 23-44, 69-84, and 185-216) I could do that instead--removing the line numbers altogether just seemed a little cleaner/less likely to require future changes if the linked source code file gets updated or something.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
