### PR TITLE
Remove experimental status for `selectionchange` event on <input> and <textarea> elements

### DIFF
--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.md
@@ -3,12 +3,10 @@ title: "HTMLInputElement: selectionchange event"
 short-title: selectionchange
 slug: Web/API/HTMLInputElement/selectionchange_event
 page-type: web-api-event
-status:
-  - experimental
 browser-compat: api.HTMLInputElement.selectionchange_event
 ---
 
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) is fired when the text selection within an {{HTMLElement("input")}} element is changed.
 This includes both changes in the selected range of characters, or if the caret moves.

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.md
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.md
@@ -3,12 +3,10 @@ title: "HTMLTextAreaElement: selectionchange event"
 short-title: selectionchange
 slug: Web/API/HTMLTextAreaElement/selectionchange_event
 page-type: web-api-event
-status:
-  - experimental
 browser-compat: api.HTMLTextAreaElement.selectionchange_event
 ---
 
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) is fired when the text selection within an {{HTMLElement("textarea")}} element is changed.
 This includes both changes in the selected range of characters, or if the caret moves.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The selectionchange event of input and textarea elements is now supported in both Chrome and Safari (as well as Firefox, which was already supporting it for a while). It should no longer be marked as experimental.

Attention: I am a first time contributor. If there are any other places where this needs to be updated (e.g. for the navigation, where an experimental icon is shown or for the Baseline newly available banner), please let me know.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I've helped update the browser compatibility data and now I would like to help removing the experimental status from the MDN page.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
This change allows developers to know they can use the selectionchange event in future web applications.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
See
Description | Link
-------------|-----
Related Issue | https://github.com/mdn/browser-compat-data/issues/25672
Related PR | https://github.com/mdn/browser-compat-data/pull/26681
Webkit bug tracker | https://bugs.webkit.org/show_bug.cgi?id=271033
Chrome bug tracker | https://issues.chromium.org/issues/40840956
Automated test cases | https://wpt.fyi/results/selection/textcontrols/selectionchange.html?label=experimental&label=master&aligned
JSFiddle by @caugner | https://jsfiddle.net/jx6gakhb/

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
