### PR TITLE
Replace OGV video example with shared-assets WebM video

### DIFF
--- a/files/en-us/web/html/guides/cheatsheet/index.md
+++ b/files/en-us/web/html/guides/cheatsheet/index.md
@@ -225,8 +225,8 @@ format&#x3C;/code>.</pre
       <td id="video-example">
         <pre class="brush: html">
 &#x3C;video controls width="250"
-  src="https://archive.org/download/ElephantsDream/ed_hd.ogv" >
-  &#x3C;a href="https://archive.org/download/ElephantsDream/ed_hd.ogv">Download OGV video&#x3C;/a>
+  src="/shared-assets/videos/flower.webm" >
+  &#x3C;a href="/shared-assets/videos/flower.webm">Download WebM video&#x3C;/a>
 &#x3C;/video></pre
         >
         {{EmbedLiveSample("video-example", 100, 200)}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replace the OGV video example in the cheatsheet with the shared-assets WebM video.

### Motivation

The existing OGV source doesn’t show video in Firefox or Chrome. Switching to `/shared-assets/videos/flower.webm` ensures cross-browser playback and keeps our assets up-to-date.

### Additional details

- Tested locally via `yarn start` on Firefox 138.0.1 and Chrome 136.0.7103.93 (Windows 11 Pro).
- No CSS or JS changes other than the `<video>` source URL.

### Related issues and pull requests

Fixes #39415

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
