### PR TITLE
Update the styling of a star mask example

### DIFF
--- a/files/en-us/web/css/mask-image/index.md
+++ b/files/en-us/web/css/mask-image/index.md
@@ -139,6 +139,8 @@ We use `mask-star.svg` as a mask image on our first image:
 ```css
 img:first-of-type {
   mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-size: 25%;
+  max-width: 50%;
 }
 ```
 


### PR DESCRIPTION
### Description

The preview of the Star Mask example was missing some styles to display properly. I’ve added a few adjustments to ensure the star pattern fits the image correctly without being cut off.

![image](https://github.com/user-attachments/assets/b4fbc14e-4836-4f6e-ac46-5185ef729d66)


### Motivation

To make the information easier to understand.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
