### PR TITLE
Adding @starting-style to CSS nesting at-rules

### DIFF
--- a/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
@@ -15,6 +15,7 @@ Any [at-rule](/en-US/docs/Web/CSS/CSS_syntax/At-rule) whose body contains style 
 - {{cssxref('@layer')}}
 - {{cssxref('@scope')}}
 - {{cssxref('@container')}}
+- {{cssxref('@starting-style')}}
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Adding @starting-style to the list of "at-rules that can be nested"

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

On the item 2 of the [Syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style#syntax) section of @starting-style, it says the can be nested within an existing ruleset.
