### PR TITLE
Correct page title for `Uint8Array.prototype.setFromHex()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/setfromhex/index.md
@@ -1,5 +1,5 @@
 ---
-title: Uint8Array.setFromHex()
+title: Uint8Array.prototype.setFromHex()
 slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/setFromHex
 page-type: javascript-instance-method
 browser-compat: javascript.builtins.Uint8Array.setFromHex


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

It looks like `Uint8Array.prototype.setFromHex()` is correct here instead of `Uint8Array.setFromHex()`. This is an instance method.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

If the title is incorrect, it can be confusing.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

- https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfromhex

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
