### PR TITLE
doc: add explanation for multiple `Transfer-Encoding` values

### DIFF
--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -14,11 +14,9 @@ The HTTP **`Transfer-Encoding`** {{glossary("request header", "request")}} and {
 Each segment of a multi-node connection can use different `Transfer-Encoding` values.
 If you want to compress data over the whole connection, use the end-to-end {{HTTPHeader("Content-Encoding")}} header instead.
 
-When present in a message it indicates the encodings applied to the message body.
-While multiple encodings may be specified, and the client must support the `chunked` directive, in practice this header is rarely used in requests (and if used, only with `chunked`).
+In practice this header is rarely used, and in those cases it is almost always used with `chunked`.
 
-When present on a response it indicates the compression used on the message, and/or whether the message has been chunked.
-Note that if the message is chunked, this must be applied last, after any other compression.
+That said, the specification indicates that when present in a message it indicates the compression used on the message in that hop, and/or whether the message has been chunked.
 For example, `Transfer-Encoding: gzip, chunked` indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body.
 
 The header is optional in responses to a {{HTTPMethod("HEAD")}} request as these messages have no body and, therefore, no transfer encoding.

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -21,7 +21,7 @@ When present on a response it indicates the compression used on the message, and
 Note that if the message is chunked, this must be applied last, after any other compression.
 For example, `Transfer-Encoding: gzip, chunked` indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body.
 
-The response to a {{HTTPMethod("HEAD")}} request has no body and no transfer encoding, so the header is optional.
+The header is optional in responses to a {{HTTPMethod("HEAD")}} request as these messages have no body and, therefore, no transfer encoding.
 When present it indicates the value that would have applied to the corresponding response to a {{HTTPMethod("GET")}} message, if that `GET` request did not include a preferred `Transfer-Encoding`.
 
 > [!WARNING]

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -14,8 +14,8 @@ The HTTP **`Transfer-Encoding`** {{glossary("request header", "request")}} and {
 Each segment of a multi-node connection can use different `Transfer-Encoding` values.
 If you want to compress data over the whole connection, use the end-to-end {{HTTPHeader("Content-Encoding")}} header instead.
 
-When present in a request it indicates the encodings supported by the client.
-Multiple encodings may be specified, and the client must support the `chunked` directive.
+When present in a request it indicates the encodings applied to the request body.
+While multiple encodings may be specified, and the client must support the `chunked` directive, in practice this header is rarely used in requests (and if used, only with `chunked`).
 
 When present on a response it indicates the compression used on the message, and/or whether the message has been chunked.
 Note that if the message is chunked, this must be applied last, after any other compression.

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -45,6 +45,7 @@ Transfer-Encoding: deflate
 Transfer-Encoding: gzip
 
 // Several values can be listed, separated by a comma
+// This indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body
 Transfer-Encoding: gzip, chunked
 ```
 

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -14,7 +14,7 @@ The HTTP **`Transfer-Encoding`** {{glossary("request header", "request")}} and {
 Each segment of a multi-node connection can use different `Transfer-Encoding` values.
 If you want to compress data over the whole connection, use the end-to-end {{HTTPHeader("Content-Encoding")}} header instead.
 
-When present in a request it indicates the encodings applied to the request body.
+When present in a message it indicates the encodings applied to the message body.
 While multiple encodings may be specified, and the client must support the `chunked` directive, in practice this header is rarely used in requests (and if used, only with `chunked`).
 
 When present on a response it indicates the compression used on the message, and/or whether the message has been chunked.

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -14,7 +14,16 @@ The HTTP **`Transfer-Encoding`** {{glossary("request header", "request")}} and {
 Each segment of a multi-node connection can use different `Transfer-Encoding` values.
 If you want to compress data over the whole connection, use the end-to-end {{HTTPHeader("Content-Encoding")}} header instead.
 
-When present on a response to a {{HTTPMethod("HEAD")}} request that has no body, it indicates the value that would have applied to the corresponding {{HTTPMethod("GET")}} message.
+When present in a request it indicates the encodings supported by the client.
+Multiple encodings may be specified, and the client must support the `chunked` directive.
+
+When present on a response it indicates the compression used on the message, and/or whether the message has been chunked.
+Note that if the message is chunked, this must be applied last, after any other compression. 
+For example, `Transfer-Encoding: gzip, chunked` indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body.
+While multiple compression options may be specified in theory, there is no practical value in applying more than one compression.
+
+The response to a {{HTTPMethod("HEAD")}} request has no body and no transfer encoding, so the header is optional.
+When present it indicates the value that would have applied to the corresponding response to a {{HTTPMethod("GET")}} message, if that `GET` request did not include a preferred `Transfer-Encoding`.
 
 > [!WARNING]
 > HTTP/2 disallows all uses of the `Transfer-Encoding` header other than the HTTP/2 specific value `"trailers"`.
@@ -45,7 +54,6 @@ Transfer-Encoding: deflate
 Transfer-Encoding: gzip
 
 // Several values can be listed, separated by a comma
-// This indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body
 Transfer-Encoding: gzip, chunked
 ```
 

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -18,7 +18,7 @@ When present in a request it indicates the encodings supported by the client.
 Multiple encodings may be specified, and the client must support the `chunked` directive.
 
 When present on a response it indicates the compression used on the message, and/or whether the message has been chunked.
-Note that if the message is chunked, this must be applied last, after any other compression. 
+Note that if the message is chunked, this must be applied last, after any other compression.
 For example, `Transfer-Encoding: gzip, chunked` indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body.
 While multiple compression options may be specified in theory, there is no practical value in applying more than one compression.
 

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -20,7 +20,6 @@ While multiple encodings may be specified, and the client must support the `chun
 When present on a response it indicates the compression used on the message, and/or whether the message has been chunked.
 Note that if the message is chunked, this must be applied last, after any other compression.
 For example, `Transfer-Encoding: gzip, chunked` indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body.
-While multiple compression options may be specified in theory, there is no practical value in applying more than one compression.
 
 The response to a {{HTTPMethod("HEAD")}} request has no body and no transfer encoding, so the header is optional.
 When present it indicates the value that would have applied to the corresponding response to a {{HTTPMethod("GET")}} message, if that `GET` request did not include a preferred `Transfer-Encoding`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Currently, the MDN document doesn't explain the meaning of multiple values of `Transfer-Encoding`.

### Additional details

https://datatracker.ietf.org/doc/html/rfc9112#section-6.1-6

```
For example,

Transfer-Encoding: gzip, chunked

indicates that the content has been compressed using the gzip coding and then chunked using the chunked coding while forming the message body.
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
