### PR TITLE
Content script persistence over update

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -29,6 +29,8 @@ Values of this type are objects. They contain these properties:
   - : `boolean`. Whether code is injected into `about:`, `data:`, and `blob:` pages when their origin matches the pattern in `matches`, even if the document origin is opaque (due to the use of CSP or iframe sandbox). Match patterns in `matches` must specify a wildcard path glob. Defaults to `false`.
 - `persistAcrossSessions` {{optional_inline}}
   - : `boolean`. Specifies if this content script persists across browser restarts and updates and extension restarts. Defaults to `true`.
+    > [!NOTE]
+    > When an extension updates, content scripts are cleared. To restore scripts, add code to the extension's {{WebExtAPIRef("runtime.onInstalled")}} event handler that responds to the `"update"` reason.
 - `runAt` {{optional_inline}}
   - : {{WebExtAPIRef("extensionTypes.RunAt")}}. Specifies when JavaScript files are injected into the web page. The default value is `document_idle`. In Firefox, `runAt` also affects the point where the CSS is inserted. In Chrome, `runAt` does not affect the CSS insertion point.
 - `world` {{optional_inline}}


### PR DESCRIPTION
### Description

Adds a note to explain that content scripts are unregistered when an extension is updated, with an explanation of how the scripts can be restored. 

### Related issues and pull requests

Fixes #38690