### PR TITLE
Bug-1550032 addition of unspecified to webextension.api.cookie.SameSiteStatus docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -47,7 +47,7 @@ let setting = browser.cookies.set(
     - `path` {{optional_inline}}
       - : A `string` representing the path of the cookie. If omitted, this defaults to the path portion of the URL parameter.
     - `sameSite` {{optional_inline}}
-      - : A {{WebExtAPIRef("cookies.SameSiteStatus")}} value that indicates the SameSite state of the cookie. If omitted, it defaults to 0, 'no_restriction'.
+      - : A {{WebExtAPIRef("cookies.SameSiteStatus")}} value that indicates the SameSite state of the cookie. If omitted, defaults to `unspecified`.
     - `secure` {{optional_inline}}
       - : A `boolean` that specifies whether the cookie is marked as secure (`true`), or not (false). If omitted, it defaults to false.
     - `storeId` {{optional_inline}}


### PR DESCRIPTION
### Description

Provides the updates necessary for [Bug 1550032](https://bugzilla.mozilla.org/show_bug.cgi?id=1550032) Change cookie API to explicitly support sameSite=none. Specifically:

- That `unspecified` is now the default value for `sameSite` in `cookies.set()`.

### Related issues and pull requests

- BCD changes made in https://github.com/mdn/browser-compat-data/pull/26795.
- Release note update made in https://github.com/mdn/content/pull/39513

