### PR TITLE
Bug-1550032 addition of unspecified to webextension.api.cookie.SameSiteStatus release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -57,6 +57,8 @@ This article provides information about the changes in Firefox 140 that affect d
 
 ## Changes for add-on developers
 
+- Support added for `unspecified` in {{WebExtAPIRef("cookies.SameSiteStatus")}}. In addition, `unspecified` is now the default value for `sameSite` in {{WebExtAPIRef("cookies.set()")}}. ([Firefox bug 1550032](https://bugzil.la/1550032))
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
### Descripton

Provides a release note for [Bug 1550032](https://bugzilla.mozilla.org/show_bug.cgi?id=1550032) Change cookie API to explicitly support sameSite=none. 

#### Related issues

- MDN documentation changes made in https://github.com/mdn/content/pull/39512.
- Release note update made in https://github.com/mdn/browser-compat-data/pull/26795.
