### PR TITLE
Adjust JS guide IA

### DIFF
--- a/files/en-us/web/javascript/guide/index.md
+++ b/files/en-us/web/javascript/guide/index.md
@@ -161,15 +161,6 @@ Overview: [Internationalization](/en-US/docs/Web/JavaScript/Guide/Internationali
 - [Number formatting](/en-US/docs/Web/JavaScript/Guide/Internationalization#number_formatting)
 - [Collation](/en-US/docs/Web/JavaScript/Guide/Internationalization#collation)
 
-## Meta programming
-
-Overview: [Meta programming](/en-US/docs/Web/JavaScript/Guide/Meta_programming)
-
-- [`Proxy`](/en-US/docs/Web/JavaScript/Guide/Meta_programming#proxies)
-- [Handlers and traps](/en-US/docs/Web/JavaScript/Guide/Meta_programming#handlers_and_traps)
-- [Revocable Proxy](/en-US/docs/Web/JavaScript/Guide/Meta_programming#revocable_proxy)
-- [`Reflect`](/en-US/docs/Web/JavaScript/Guide/Meta_programming#reflection)
-
 ## JavaScript modules
 
 Overview: [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules)
@@ -180,5 +171,18 @@ Overview: [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules)
 - [Renaming features](/en-US/docs/Web/JavaScript/Guide/Modules#renaming_imports_and_exports)
 - [Aggregating modules](/en-US/docs/Web/JavaScript/Guide/Modules#aggregating_modules)
 - [Dynamic module loading](/en-US/docs/Web/JavaScript/Guide/Modules#dynamic_module_loading)
+
+## Advanced topics
+
+After you have learned all fundamental features of JavaScript, you can explore some more niche features, or dive deeper into the language's mechanisms and concepts.
+
+- [Language overview](/en-US/docs/Web/JavaScript/Guide/Language_overview)
+- [Data structures](/en-US/docs/Web/JavaScript/Guide/Data_structures)
+- [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Guide/Enumerability_and_ownership_of_properties)
+- [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
+- [Equality comparisons and sameness](/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness)
+- [Closures](/en-US/docs/Web/JavaScript/Guide/Closures)
+- [Meta programming](/en-US/docs/Web/JavaScript/Guide/Meta_programming)
+- [Memory management](/en-US/docs/Web/JavaScript/Guide/Memory_management)
 
 {{Next("Web/JavaScript/Guide/Introduction")}}

--- a/files/en-us/web/javascript/guide/internationalization/index.md
+++ b/files/en-us/web/javascript/guide/internationalization/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Internationalization
 page-type: guide
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Iterators_and_generators", "Web/JavaScript/Guide/Meta_programming")}}
+{{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Iterators_and_generators", "Web/JavaScript/Guide/Modules")}}
 
 The {{jsxref("Intl")}} object is the namespace for the ECMAScript Internationalization API, which provides a wide range of locale- and culture-sensitive data and operations.
 
@@ -844,4 +844,4 @@ setInterval(renderTime, 500);
 
 {{EmbedLiveSample("display_names", "", 300)}}
 
-{{PreviousNext("Web/JavaScript/Guide/Iterators_and_generators", "Web/JavaScript/Guide/Meta_programming")}}
+{{PreviousNext("Web/JavaScript/Guide/Iterators_and_generators", "Web/JavaScript/Guide/Modules")}}

--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Meta_programming
 page-type: guide
 ---
 
-{{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Internationalization", "Web/JavaScript/Guide/Modules")}}
+{{jsSidebar("Advanced")}}
 
 The {{jsxref("Proxy")}} and {{jsxref("Reflect")}} objects allow you to intercept and define custom behavior for fundamental language operations (e.g., property lookup, assignment, enumeration, function invocation, etc.). With the help of these two objects you are able to program at the meta level of JavaScript.
 
@@ -281,5 +281,3 @@ if (Reflect.defineProperty(target, property, attributes)) {
   // failure
 }
 ```
-
-{{PreviousNext("Web/JavaScript/Guide/Internationalization", "Web/JavaScript/Guide/Modules")}}

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Modules
 page-type: guide
 ---
 
-{{jsSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Meta_programming")}}
+{{jsSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Internationalization")}}
 
 This guide gives you all you need to get started with JavaScript module syntax.
 
@@ -1012,4 +1012,4 @@ Here are a few tips that may help you if you are having trouble getting your mod
 - [ES6 in Depth: Modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) on hacks.mozilla.org (2015)
 - [Exploring JS, Ch.16: Modules](https://exploringjs.com/es6/ch_modules.html) by Dr. Axel Rauschmayer
 
-{{Previous("Web/JavaScript/Guide/Meta_programming")}}
+{{Previous("Web/JavaScript/Guide/Internationalization")}}

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -358,6 +358,7 @@ If you are new to JavaScript, start with the [guide](/en-US/docs/Web/JavaScript/
 
 ## Additional reference pages
 
+- [JavaScript technologies overview](/en-US/docs/Web/JavaScript/Reference/JavaScript_technologies_overview)
 - [Execution model](/en-US/docs/Web/JavaScript/Reference/Execution_model)
 - {{jsxref("Lexical_grammar", "Lexical grammar", "", 1)}}
 - [Data types and data structures](/en-US/docs/Web/JavaScript/Guide/Data_structures)

--- a/files/sidebars/jssidebar.yaml
+++ b/files/sidebars/jssidebar.yaml
@@ -53,8 +53,6 @@ sidebar:
         title: Guide_Iterators_generators
       - link: /Web/JavaScript/Guide/Internationalization
         title: Guide_Internationalization
-      - link: /Web/JavaScript/Guide/Meta_programming
-        title: Guide_Meta
       - link: /Web/JavaScript/Guide/Modules
         title: Guide_Modules
   - title: Intermediate
@@ -81,6 +79,8 @@ sidebar:
     children:
       - link: /Web/JavaScript/Guide/Inheritance_and_the_prototype_chain
         title: Inheritance
+      - link: /Web/JavaScript/Guide/Meta_programming
+        title: Guide_Meta
       - link: /Web/JavaScript/Guide/Memory_management
         title: Memory_management
   - type: section


### PR DESCRIPTION
Add missing links to child pages; move "meta programming" to advanced guides