### PR TITLE
chore(css): Convert jsfiddles to live samples

### DIFF
--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -60,7 +60,7 @@ The `:fullscreen` pseudo-class is used to override the [`background-color`](/en-
 The following JavaScript provides an event handler function that toggles fullscreen when the `<button>` is clicked.
 
 ```js
-document.querySelector(".toggle").addEventListener("click", function (event) {
+document.querySelector(".toggle").addEventListener("click", (event) => {
   if (document.fullscreenElement) {
     // If there is a fullscreen element, exit full screen.
     document.exitFullscreen();

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -23,13 +23,13 @@ The `:fullscreen` pseudo-class lets you configure your stylesheets to automatica
 
 ## Examples
 
-### Styling a Fullscreen Element
+### Styling a fullscreen element
 
 This example applies a different background color to a {{htmlelement("div")}} element, depending on whether or not it is in fullscreen mode. It includes a {{htmlelement("button")}} to toggle fullscreen on and off.
 
 ```html
 <div class="element">
-  <h1>MDN :fullscreen pseudo-class demo</h1>
+  <h1>MDN <code>:fullscreen</code> pseudo-class demo</h1>
 
   <p>
     This demo uses the <code>:fullscreen</code> pseudo-class to automatically
@@ -71,9 +71,18 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 });
 ```
 
-#### Demo
+```css hidden
+.element {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: sans-serif;
+  padding: 1.2em;
+}
+```
 
-[See the example live](https://jsfiddle.net/yookoala/oLc1uws0/).
+{{embedlivesample("", "", "300")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -29,7 +29,7 @@ This example applies a different background color to a {{htmlelement("div")}} el
 
 ```html
 <div class="element">
-  <h1>MDN <code>:fullscreen</code> pseudo-class demo</h1>
+  <h1><code>:fullscreen</code> pseudo-class demo</h1>
 
   <p>
     This demo uses the <code>:fullscreen</code> pseudo-class to automatically

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -82,7 +82,7 @@ document.querySelector(".toggle").addEventListener("click", (event) => {
 }
 ```
 
-{{embedlivesample("", "", "300")}}
+{{EmbedLiveSample("Styling a fullscreen element", "", "300", "", "", "", "fullscreen")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/border-radius/index.md
+++ b/files/en-us/web/css/border-radius/index.md
@@ -328,7 +328,7 @@ pre#example-7 {
 }
 ```
 
-{{EmbedLiveSample("Examples", "200", "900")}}
+{{EmbedLiveSample("Comparing border styles", "", "900")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/border-radius/index.md
+++ b/files/en-us/web/css/border-radius/index.md
@@ -232,6 +232,11 @@ border-bottom-left-radius: 3px 4px;
 
 ## Examples
 
+### Comparing border styles
+
+The following example has seven {{htmlelement("pre")}} elements, each of which demonstrates combinations of `border` and `border-radius` styles.
+The styles applied to each `<pre>` element are included as the element's contents, so you can see the CSS declarations necessary to create the associated border style:
+
 ```html hidden
 <pre id="example-1">
   border: solid 10px;
@@ -279,7 +284,7 @@ pre {
   margin: 20px;
   padding: 20px;
   width: 80%;
-  height: 80px;
+  height: 50px;
 }
 
 pre#example-1 {
@@ -323,15 +328,7 @@ pre#example-7 {
 }
 ```
 
-{{EmbedLiveSample("Examples", "200", "1150")}}
-
-### Live Samples
-
-- Sample 1 : <https://jsfiddle.net/Tripad/qnGKj/2/>
-- Sample 2 : <https://jsfiddle.net/Tripad/qnGKj/3/>
-- Sample 3 : <https://jsfiddle.net/Tripad/qnGKj/4/>
-- Sample 4 : <https://jsfiddle.net/Tripad/qnGKj/5/>
-- Sample 5 : <https://jsfiddle.net/Tripad/qnGKj/6/>
+{{EmbedLiveSample("Examples", "200", "900")}}
 
 ## Specifications
 


### PR DESCRIPTION
### Description

These are already essentially on the page as code blocks, but we have links to jsfiddle instead of showing the results directly.

### Related issues and pull requests

Follow-up from:

- [x] https://github.com/mdn/content/pull/32258