### PR TITLE
Set Vary header in the Fetch metadata example

### DIFF
--- a/files/en-us/web/security/attacks/xs-leaks/index.md
+++ b/files/en-us/web/security/attacks/xs-leaks/index.md
@@ -186,6 +186,7 @@ function isAllowed(req) {
 app.get("/admin", (req, res) => {
   if (isAllowed(req)) {
     // Respond with the admin page if the user is admin
+    res.setHeader("Vary", "sec-fetch-site, sec-fetch-mode");
     getAdminPage(req, res);
   } else {
     res.status(404).send("Not found.");
@@ -194,6 +195,8 @@ app.get("/admin", (req, res) => {
 ```
 
 Since the attacker's request is cross-site and is not a navigation, then this server always returns an error for it, whether the user is signed in or not.
+
+Note that we also send the {{httpheader("Vary")}} response header. This ensures that if the response is cached, the cached response will only be given to requests with the same fetch metadata header values.
 
 A policy like this is called a _Resource Isolation Policy_. To learn much more about implementing isolation policies with Fetch metadata, see [Protect your resources from web attacks with Fetch Metadata](https://web.dev/articles/fetch-metadata) and [Isolation Policies](https://xsleaks.dev/docs/defenses/isolation-policies/).
 

--- a/files/en-us/web/security/attacks/xs-leaks/index.md
+++ b/files/en-us/web/security/attacks/xs-leaks/index.md
@@ -196,7 +196,7 @@ app.get("/admin", (req, res) => {
 
 Since the attacker's request is cross-site and is not a navigation, then this server always returns an error for it, whether the user is signed in or not.
 
-Note that we also send the {{httpheader("Vary")}} response header. This ensures that if the response is cached, the cached response will only be given to requests with the same fetch metadata header values.
+Note that we also send the {{httpheader("Vary")}} response header. This ensures that if the response is cached, the cached response will only be given to requests with the same values for the Fetch metadata headers we are using.
 
 A policy like this is called a _Resource Isolation Policy_. To learn much more about implementing isolation policies with Fetch metadata, see [Protect your resources from web attacks with Fetch Metadata](https://web.dev/articles/fetch-metadata) and [Isolation Policies](https://xsleaks.dev/docs/defenses/isolation-policies/).
 

--- a/files/en-us/web/security/attacks/xs-leaks/index.md
+++ b/files/en-us/web/security/attacks/xs-leaks/index.md
@@ -184,9 +184,9 @@ function isAllowed(req) {
 }
 
 app.get("/admin", (req, res) => {
+  res.setHeader("Vary", "sec-fetch-site, sec-fetch-mode");
   if (isAllowed(req)) {
     // Respond with the admin page if the user is admin
-    res.setHeader("Vary", "sec-fetch-site, sec-fetch-mode");
     getAdminPage(req, res);
   } else {
     res.status(404).send("Not found.");


### PR DESCRIPTION
Set the `Vary` header in the response, in the fetch metadata example, as reported in https://front-end.social/@openwebdocs/114506561385552270.

We probably ought to have a proper guide to fetch metadata on MDN.

@jub0bs , thank you for finding this! Would you like to review?