### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -96,7 +96,7 @@ The following terms are used when talking about the functionality of proxies.
 - [handler](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy#handler_functions)
   - : The object passed as the second argument to the `Proxy` constructor. It contains the traps which define the behavior of the proxy.
 - trap
-  - : The function that define the behavior for the corresponding [object internal method](#object_internal_methods). (This is analogous to the concept of _traps_ in operating systems.)
+  - : The function that defines the behavior for the corresponding [object internal method](#object_internal_methods). (This is analogous to the concept of _traps_ in operating systems.)
 - target
   - : Object which the proxy virtualizes. It is often used as storage backend for the proxy. Invariants (semantics that remain unchanged) regarding object non-extensibility or non-configurable properties are verified against the target.
 - invariants


### PR DESCRIPTION
### Description

Fixes a typo in the definition of a trap on the Proxy reference page ("define" -> "defines").

### Motivation

### Additional details

### Related issues and pull requests
