### PR TITLE
Remove reference to ImageData in ImageBitmap docs.

### DIFF
--- a/files/en-us/web/api/imagebitmap/index.md
+++ b/files/en-us/web/api/imagebitmap/index.md
@@ -14,9 +14,9 @@ The **`ImageBitmap`** interface represents a bitmap image which can be drawn to 
 ## Instance properties
 
 - {{domxref("ImageBitmap.height")}} {{ReadOnlyInline}}
-  - : An `unsigned long` representing the height, in CSS pixels, of the `ImageData`.
+  - : An `unsigned long` representing the height, in CSS pixels, of the `ImageBitmap`.
 - {{domxref("ImageBitmap.width")}} {{ReadOnlyInline}}
-  - : An `unsigned long` representing the width, in CSS pixels, of the `ImageData`.
+  - : An `unsigned long` representing the width, in CSS pixels, of the `ImageBitmap`.
 
 ## Instance methods
 


### PR DESCRIPTION
### Description

I was looking up the docs for ImageBitmap and stumbled upon the fact that height and width refer to ImageData instead of ImageBitmap.

### Motivation

See above.

### Additional details

Simple typo fix.

### Related issues and pull requests

N/A
