### PR TITLE
Fix invalid code syntax

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/ember_conditional_footer/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/ember_conditional_footer/index.md
@@ -72,8 +72,12 @@ To get the footer working, we need to implement the following three areas of fun
    In `todo-data.js`, add the following getter underneath the existing `all()` getter to define what the incomplete todos actually are:
 
    ```ts
-   get incomplete() {
-     return this.todos.filter((todo) => !todo.isCompleted);
+   export default class TodoDataService extends Service {
+     // …
+     get incomplete() {
+       return this.todos.filter((todo) => !todo.isCompleted);
+     }
+     // …
    }
    ```
 
@@ -82,9 +86,13 @@ To get the footer working, we need to implement the following three areas of fun
 4. Next, add the following action underneath the existing `add(text)` action:
 
    ```ts
-   @action
-   clearCompleted() {
-     this.todos = this.incomplete;
+   export default class TodoDataService extends Service {
+     // …
+     @action
+     clearCompleted() {
+       this.todos = this.incomplete;
+     }
+     // …
    }
    ```
 
@@ -146,11 +154,15 @@ with the following:
 
 This will give us an error, however — in Ember, these simple if statements can currently only test for a truthy/falsy value, not a more complex expression such as a comparison. To fix this, we'll have to add a getter to `todo-data.js` to return the result of `this.incomplete.length === 1`, and then call that in our template.
 
-Add the following new getter to `todo-data.js`, just below the existing getters. Note that here we need `this.incomplete.length`, not `this.todos.incomplete.length`, because we are doing this inside the service, where the `incomplete()` getter is available directly (in the template, the contents of the service has been made available as `todos` via the `@service('todo-data') todos;` line inside the footer class, hence it being `this.todos.incomplete.length` there).
+Add the following new getter to `todo-data.js`, just below the existing getters. Note that here we need `this.incomplete.length`, not `this.todos.incomplete.length`, because we are doing this inside the service, where the `incomplete()` getter is available directly (in the template, the contents of the service has been made available as `todos` via the `@service("todo-data") todos;` line inside the footer class, hence it being `this.todos.incomplete.length` there).
 
 ```ts
-get todoCountIsOne() {
-  return this.incomplete.length === 1;
+export default class TodoDataService extends Service {
+  // …
+  get todoCountIsOne() {
+    return this.incomplete.length === 1;
+  }
+  // …
 }
 ```
 
@@ -195,9 +207,13 @@ As with the other components, we need a class to access the service.
 3. Next, go back again to our `todo-data.js` service file and add the following action just below the previous ones, which will allow us to toggle a completion state for each todo:
 
    ```ts
-   @action
-   toggleCompletion(todo) {
-     todo.isCompleted = !todo.isCompleted;
+   export default class TodoDataService extends Service {
+     // …
+     @action
+     toggleCompletion(todo) {
+       todo.isCompleted = !todo.isCompleted;
+     }
+     // …
    }
    ```
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/ember_interactivity_events_state/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/ember_interactivity_events_state/index.md
@@ -208,7 +208,10 @@ import { inject as service } from "@ember/service";
 With this import in place, we can now make the `todo-data` service available inside the `HeaderComponent` class via the `todos` object, using the `@service` decorator. Add the following line just below the opening `export…` line:
 
 ```js
-@service('todo-data') todos;
+export default class HeaderComponent extends Component {
+  @service("todo-data") todos;
+  // …
+}
 ```
 
 Now the placeholder `alert(text);` line can be replaced with a call to our new `add()` function. Replace it with the following:
@@ -249,8 +252,13 @@ One issue here is that our service is called `todos`, but the list of todos is a
 To do this, go back to your `todo-data.js` file and add the following below the `@tracked todos = [];` line:
 
 ```js
-get all() {
-  return this.todos;
+export default class TodoDataService extends Service {
+  @tracked todos = [];
+
+  get all() {
+    return this.todos;
+  }
+  // …
 }
 ```
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/ember_routing/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/ember_routing/index.md
@@ -119,8 +119,12 @@ But now we need a way to differentiate between each of these routes, so that the
 First of all, return once more to our `todo-data.js` file. It already contains a getter that returns all todos, and a getter that returns incomplete todos. The getter we are missing is one to return just the completed todos. Add the following below the existing getters:
 
 ```js
-get completed() {
-  return this.todos.filter((todo) => todo.isCompleted);
+export default class TodoDataService extends Service {
+  // …
+  get completed() {
+    return this.todos.filter((todo) => todo.isCompleted);
+  }
+  // …
 }
 ```
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_components/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_components/index.md
@@ -122,9 +122,14 @@ In order to track the names of tasks we want to complete, we should ensure that 
 In `App.jsx`, give each `<Todo />` a name prop. Let's use the names of our tasks that we had before:
 
 ```jsx
-<Todo name="Eat" />
-<Todo name="Sleep" />
-<Todo name="Repeat" />
+<ul
+  role="list"
+  className="todo-list stack-large stack-exception"
+  aria-labelledby="list-heading">
+  <Todo name="Eat" />
+  <Todo name="Sleep" />
+  <Todo name="Repeat" />
+</ul>
 ```
 
 When your browser refreshes, you will see… the exact same thing as before. We gave our `<Todo />` some props, but we aren't using them yet. Let's go back to `Todo.jsx` and remedy that.
@@ -169,9 +174,14 @@ _Now_ your browser should show three unique tasks. Another problem remains thoug
 In our original static list, only `Eat` was checked. Once again, we want to reuse _most_ of the UI that makes up a `<Todo />` component, but change one thing. That's a good job for another prop! Give your first `<Todo />` call a boolean prop of `completed`, and leave the other two as they are.
 
 ```jsx
-<Todo name="Eat" completed />
-<Todo name="Sleep" />
-<Todo name="Repeat" />
+<ul
+  role="list"
+  className="todo-list stack-large stack-exception"
+  aria-labelledby="list-heading">
+  <Todo name="Eat" completed />
+  <Todo name="Sleep" />
+  <Todo name="Repeat" />
+</ul>
 ```
 
 As before, we must go back to `Todo.jsx` to actually use these props. Change the `defaultChecked` attribute on the `<input />` so that its value is equal to the `completed` prop. Once you're done, the Todo component's `<input />` element will read like this:
@@ -198,9 +208,14 @@ The second problem is affecting our app right now. If you click on the word "Sle
 We had unique `id` attributes before we created the `<Todo />` component. Let's bring them back, following the format of `todo-i`, where `i` gets larger by one every time. Update the `Todo` component instances inside `App.jsx` to add in `id` props, as follows:
 
 ```jsx
-<Todo name="Eat" id="todo-0" completed />
-<Todo name="Sleep" id="todo-1" />
-<Todo name="Repeat" id="todo-2" />
+<ul
+  role="list"
+  className="todo-list stack-large stack-exception"
+  aria-labelledby="list-heading">
+  <Todo name="Eat" id="todo-0" completed />
+  <Todo name="Sleep" id="todo-1" />
+  <Todo name="Repeat" id="todo-2" />
+</ul>
 ```
 
 > [!NOTE]

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -423,7 +423,7 @@ The curly braces around `subject` are another feature of JSX's syntax. The curly
 <h1>Hello, {2 + 2}!</h1>
 ```
 
-Even comments in JSX are written inside curly braces! This is because comments, too, are technically JavaScript expressions. The `/* block comment syntax */` is necessary for your program to know where the comment starts and ends.
+Even comments in JSX are written inside curly braces! This is because curly braces can contain a single JavaScript expression, and comments are valid as part of a JavaScript expression (and get ignored). You can use both `/* block comment syntax */` and `// line comment syntax` (with a trailing new line) inside curly braces.
 
 ### Component props
 
@@ -445,7 +445,11 @@ Back in `App.jsx`, let's revisit the `App()` function. Change the signature of `
 function App(props) {
   console.log(props);
   return (
-    // code omitted for brevity
+    <>
+      {
+        // code omitted for brevity
+      }
+    </>
   );
 }
 ```

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
@@ -80,6 +80,8 @@ To use this function, add an `onSubmit` attribute to the [`<form>`](/en-US/docs/
 
 ```jsx
 <form onSubmit={handleSubmit}>
+  {/* … */}
+</fom>
 ```
 
 Now if you head back to your browser and click on the "Add" button, your browser will show you an alert dialog with the words "Hello, world!" — or whatever you chose to write there.

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
@@ -81,7 +81,7 @@ To use this function, add an `onSubmit` attribute to the [`<form>`](/en-US/docs/
 ```jsx
 <form onSubmit={handleSubmit}>
   {/* … */}
-</fom>
+</form>
 ```
 
 Now if you head back to your browser and click on the "Add" button, your browser will show you an alert dialog with the words "Hello, world!" — or whatever you chose to write there.

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_events_state/index.md
@@ -79,9 +79,7 @@ function handleSubmit(event) {
 To use this function, add an `onSubmit` attribute to the [`<form>`](/en-US/docs/Web/HTML/Reference/Elements/form) element, and set its value to the `handleSubmit` function:
 
 ```jsx
-<form onSubmit={handleSubmit}>
-  {/* … */}
-</form>
+<form onSubmit={handleSubmit}>{/* … */}</form>
 ```
 
 Now if you head back to your browser and click on the "Add" button, your browser will show you an alert dialog with the words "Hello, world!" — or whatever you chose to write there.

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_filtering_conditional_rendering/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_interactivity_filtering_conditional_rendering/index.md
@@ -234,6 +234,8 @@ Bind this function to the form's `submit` event by adding the following `onSubmi
 
 ```jsx
 <form className="stack-small" onSubmit={handleSubmit}>
+  {/* … */}
+</form>
 ```
 
 You should now be able to edit a task in your browser. At this point, your `Todo.jsx` file should look like this:
@@ -386,15 +388,17 @@ const filterList = FILTER_NAMES.map((name) => (
 Now we'll replace the three repeated `<FilterButton />`s in `App.jsx` with this `filterList`. Replace the following:
 
 ```jsx
-<FilterButton />
-<FilterButton />
-<FilterButton />
+<div className="filters btn-group stack-exception">
+  <FilterButton />
+  <FilterButton />
+  <FilterButton />
+</div>
 ```
 
 With this:
 
-```jsx-nolint
-{filterList}
+```jsx
+<div className="filters btn-group stack-exception">{filterList}</div>
 ```
 
 This won't work yet. We've got a bit more work to do first.

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_todo_list_beginning/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_todo_list_beginning/index.md
@@ -227,10 +227,12 @@ The `aria-labelledby` attribute tells assistive technologies that we're treating
 Finally, the labels and inputs in our list items have some attributes unique to JSX:
 
 ```jsx
-<input id="todo-0" type="checkbox" defaultChecked />
-<label className="todo-label" htmlFor="todo-0">
-  Eat
-</label>
+<div className="c-cb">
+  <input id="todo-0" type="checkbox" defaultChecked />
+  <label className="todo-label" htmlFor="todo-0">
+    Eat
+  </label>
+</div>
 ```
 
 The `defaultChecked` attribute in the `<input />` tag tells React to check this checkbox initially. If we were to use `checked`, as we would in regular HTML, React would log some warnings into our browser console relating to handling events on the checkbox, which we want to avoid. Don't worry too much about this for now — we will cover this later on when we get to using events.

--- a/files/en-us/learn_web_development/core/frameworks_libraries/vue_methods_events_models/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/vue_methods_events_models/index.md
@@ -85,9 +85,14 @@ We now have an app that displays a list of to-do items. However, we can't update
 5. You also need to register the new component in your `App` component — update the `components` property of the component object so that it looks like this:
 
    ```js
-   components: {
-     ToDoItem, ToDoForm,
-   }
+   export default {
+     // …
+     components: {
+       ToDoItem,
+       ToDoForm,
+     },
+     // …
+   };
    ```
 
 6. Finally for this section, render your `ToDoForm` component inside your app by adding the `<to-do-form />` element inside your `App`'s `<template>`, like so:
@@ -210,11 +215,13 @@ The first thing we need is a `data` property in our form to track the value of t
    Update your `onSubmit()` method to look like this:
 
    ```js
-   methods: {
-     onSubmit() {
-       console.log('Label value: ', this.label);
-     }
-   },
+   export default {
+     methods: {
+       onSubmit() {
+         console.log("Label value: ", this.label);
+       },
+     },
+   };
    ```
 
 4. Now go back to your running app, add some text to the `<input>` field, and click the "Add" button. You should see the value you entered logged to your console, for example:

--- a/files/en-us/learn_web_development/core/scripting/conditionals/index.md
+++ b/files/en-us/learn_web_development/core/scripting/conditionals/index.md
@@ -81,8 +81,8 @@ However, you need to be careful here — in this case, the second block of code 
 As a final point, while not recommended, you may sometimes see `if...else` statements written without the curly braces:
 
 ```js example-bad
-if (condition) /* code to run if condition is true */
-else /* run some other code instead */
+if (condition) doSomething();
+else doSomethingElse();
 ```
 
 This syntax is perfectly valid, but it is much easier to understand the code if you use the curly braces to delimit the blocks of code, and use multiple lines and indentation.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -30,7 +30,7 @@ browser.menus.onShown.addListener(async (info, tab) => {
   lastMenuInstanceId = menuInstanceId;
 
   // Call an async function
-  await /* the function to call */ ;
+  await doSomethingAsync();
 
   // After completing the async operation, check whether the menu is still shown.
   if (menuInstanceId !== lastMenuInstanceId) {

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
@@ -64,11 +64,6 @@ button {
 </script>
 ```
 
-```js hidden
-;(() => {
-  "use strict";
-```
-
 ```js
 window.addEventListener("load", setupWebGL, false);
 let gl;
@@ -148,10 +143,6 @@ function getRenderingContext() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   return gl;
 }
-```
-
-```js hidden
-})();
 ```
 
 The source code of this example is also available on [GitHub](https://github.com/idofilin/webgl-by-example/tree/master/hello-glsl).

--- a/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.md
@@ -69,11 +69,6 @@ button {
 </script>
 ```
 
-```js hidden
-;(() => {
-  "use strict";
-```
-
 ```js
 window.addEventListener("load", setupWebGL, false);
 let gl;
@@ -168,10 +163,6 @@ function getRenderingContext() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   return gl;
 }
-```
-
-```js hidden
-})();
 ```
 
 The source code of this example is also available on [GitHub](https://github.com/idofilin/webgl-by-example/tree/master/hello-vertex-attributes).

--- a/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.md
@@ -47,11 +47,6 @@ button {
 }
 ```
 
-```js hidden
-;(() => {
-  "use strict";
-```
-
 ```js
 window.addEventListener("load", setupAnimation, false);
 let gl;
@@ -164,10 +159,6 @@ function getRenderingContext() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   return gl;
 }
-```
-
-```js hidden
-})();
 ```
 
 The source code of this example is also available on [GitHub](https://github.com/idofilin/webgl-by-example/tree/master/raining-rectangles).

--- a/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.md
@@ -51,11 +51,6 @@ button {
 }
 ```
 
-```js hidden
-;(() => {
-  "use strict";
-```
-
 ```js
 window.addEventListener("load", setupAnimation, false);
 // Variables to hold the WebGL context, and the color and
@@ -146,10 +141,6 @@ function getRenderingContext() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   return gl;
 }
-```
-
-```js hidden
-})();
 ```
 
 The source code of this example is also available on [GitHub](https://github.com/idofilin/webgl-by-example/tree/master/scissor-animation).

--- a/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.md
@@ -72,11 +72,6 @@ button {
 </script>
 ```
 
-```js hidden
-;(() => {
-  "use strict";
-```
-
 ```js
 window.addEventListener("load", setupWebGL, false);
 
@@ -156,10 +151,6 @@ function getRenderingContext() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   return gl;
 }
-```
-
-```js hidden
-})();
 ```
 
 The source code of this example is also available on [GitHub](https://github.com/idofilin/webgl-by-example/tree/master/textures-from-code).

--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -383,10 +383,6 @@ A common practice for tables is to use _zebra-stripes_ which alternates between 
 
 #### HTML
 
-```html-nolint hidden
-<div class="wrapper">
-```
-
 ```html-nolint
 <table class="broken">
   <thead>
@@ -416,14 +412,10 @@ A common practice for tables is to use _zebra-stripes_ which alternates between 
 </table>
 ```
 
-```html hidden
-</div>
-```
-
 #### CSS
 
 ```css hidden
-.wrapper {
+body {
   display: flex;
   justify-content: space-around;
 }

--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -167,46 +167,45 @@ In this example, you can switch between three different {{cssxref("display")}} p
 </section>
 ```
 
-```html-nolint hidden
+```html hidden
 <fieldset class="controls">
-    <legend>Controls</legend>
-    <div class="row">
-      <label for="display">display: </label>
-      <select id="display">
-        <option value="block" selected>block</option>
-        <option value="flex">flex</option>
-        <option value="grid">grid</option>
-      </select>
-    </div>
-    <div class="row">
-      <label for="alignContent">align-content: </label>
-      <select id="alignContent">
-        <option value="normal" selected>normal</option>
-        <option value="start">start</option>
-        <option value="center">center</option>
-        <option value="end">end</option>
-        <option value="flex-start">flex-start</option>
-        <option value="flex-end">flex-end</option>
-        <option value="space-between">space-between</option>
-        <option value="space-around">space-around</option>
-        <option value="space-evenly">space-evenly</option>
-      </select>
-    </div>
-    <p>CSS applied</p>
-    <pre>
+  <legend>Controls</legend>
+  <div class="row">
+    <label for="display">display: </label>
+    <select id="display">
+      <option value="block" selected>block</option>
+      <option value="flex">flex</option>
+      <option value="grid">grid</option>
+    </select>
+  </div>
+  <div class="row">
+    <label for="alignContent">align-content: </label>
+    <select id="alignContent">
+      <option value="normal" selected>normal</option>
+      <option value="start">start</option>
+      <option value="center">center</option>
+      <option value="end">end</option>
+      <option value="flex-start">flex-start</option>
+      <option value="flex-end">flex-end</option>
+      <option value="space-between">space-between</option>
+      <option value="space-around">space-around</option>
+      <option value="space-evenly">space-evenly</option>
+    </select>
+  </div>
+  <p>CSS applied</p>
+  <pre>
 section {
   display: <span id="displayStyle">block</span>;
   align-content: <span id="align">normal</span>
 }
     </pre>
-  </fieldset>
-</div>
+</fieldset>
 ```
 
 #### CSS
 
 ```css hidden
-.wrapper {
+body {
   font-size: 1.25rem;
   display: flex;
   gap: 1rem;

--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -194,7 +194,7 @@ section {
   display: <span id="displayStyle">block</span>;
   align-content: <span id="align">normal</span>
 }
-    </pre>
+  </pre>
 </fieldset>
 ```
 

--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -152,10 +152,6 @@ In this example, you can switch between three different {{cssxref("display")}} p
 
 #### HTML
 
-```html-nolint hidden
-<div class="wrapper">
-```
-
 ```html
 <section>
   <div class="olive">Olive</div>

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -337,13 +337,14 @@ This example demonstrates the various values of the `clip-path` property clippin
 The HTML includes an `<img>` that will be clipped, a star-shaped `<clipPath>`, and a {{htmlelement("select")}} element to choose a `clip-path` property value from.
 
 ```html
-<img id="clipped"
+<img
+  id="clipped"
   src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
   alt="Pride flag" />
 <svg height="0" width="0">
   <defs>
     <clipPath id="star">
-      <path d="M100,0 42,180 196,70 4,70 158,180z">
+      <path d="M100,0 42,180 196,70 4,70 158,180z" />
     </clipPath>
   </defs>
 </svg>

--- a/files/en-us/web/css/clip-rule/index.md
+++ b/files/en-us/web/css/clip-rule/index.md
@@ -117,10 +117,10 @@ We include an SVG with two `<clipPath>` elements that define star shapes, which 
 <svg height="0" width="0">
   <defs>
     <clipPath id="star1">
-      <path d="M100,0 42,180 196,70 4,70 158,180z">
+      <path d="M100,0 42,180 196,70 4,70 158,180z" />
     </clipPath>
     <clipPath id="star2">
-      <path d="M100,0 42,180 196,70 4,70 158,180z">
+      <path d="M100,0 42,180 196,70 4,70 158,180z" />
     </clipPath>
   </defs>
 </svg>

--- a/files/en-us/web/css/css_masking/clipping/index.md
+++ b/files/en-us/web/css/css_masking/clipping/index.md
@@ -409,7 +409,8 @@ Instead of passing an SVG {{svgattr("d")}} attribute string as the `path()` func
 <div class="heart"></div>
 <svg height="0" width="0">
   <clipPath id="heart">
-    <path d="M20,70 A40,40,0,0,1,100,70 A40,40,0,0,1,180,70 Q180,130,100,190 Q20,130,20,70 Z">
+    <path
+      d="M20,70 A40,40,0,0,1,100,70 A40,40,0,0,1,180,70 Q180,130,100,190 Q20,130,20,70 Z" />
   </clipPath>
 </svg>
 ```

--- a/files/en-us/web/css/line-style/index.md
+++ b/files/en-us/web/css/line-style/index.md
@@ -212,37 +212,35 @@ This example demonstrates line-style and color choice. With some `<line-style>` 
 
 This example uses multiple {{HTMLElement( "div" )}} elements, each with a different `border-color` set as an inline [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style).
 
-```html-nolint hidden
-<section>
-```
-
 ```html
 <div style="border-color: #000000"></div>
 ```
 
-```html hidden
-<div style="border-color: #000001"></div>
-<div style="border-color: #ffffff"></div>
+```html hidden live-sample___line_style_colors
+<section>
+  <div style="border-color: #000000"></div>
+  <div style="border-color: #000001"></div>
+  <div style="border-color: #ffffff"></div>
 
-<div style="border-color: #ff00ff"></div>
-<div style="border-color: #ffff00"></div>
-<div style="border-color: #00ffff"></div>
+  <div style="border-color: #ff00ff"></div>
+  <div style="border-color: #ffff00"></div>
+  <div style="border-color: #00ffff"></div>
 
-<div style="border-color: #cc33cc"></div>
-<div style="border-color: #cccc33"></div>
-<div style="border-color: #33cccc"></div>
+  <div style="border-color: #cc33cc"></div>
+  <div style="border-color: #cccc33"></div>
+  <div style="border-color: #33cccc"></div>
 
-<div style="border-color: #ff0000"></div>
-<div style="border-color: #00ff00"></div>
-<div style="border-color: #0000ff"></div>
+  <div style="border-color: #ff0000"></div>
+  <div style="border-color: #00ff00"></div>
+  <div style="border-color: #0000ff"></div>
 
-<div style="border-color: #cc3333"></div>
-<div style="border-color: #33cc33"></div>
-<div style="border-color: #3333cc"></div>
+  <div style="border-color: #cc3333"></div>
+  <div style="border-color: #33cc33"></div>
+  <div style="border-color: #3333cc"></div>
 
-<div style="border-color: #993333"></div>
-<div style="border-color: #339933"></div>
-<div style="border-color: #333399"></div>
+  <div style="border-color: #993333"></div>
+  <div style="border-color: #339933"></div>
+  <div style="border-color: #333399"></div>
 </section>
 ```
 
@@ -250,7 +248,7 @@ This example uses multiple {{HTMLElement( "div" )}} elements, each with a differ
 
 The four sides of each `<div>` have a different `<line-style>` value, and each list item has a different {{cssxref("color_value", "&lt;color>")}} value. We use [generated content](/en-US/docs/Web/CSS/content) to display the CSS declared inline.
 
-```css hidden
+```css hidden live-sample___line_style_colors
 section {
   display: flex;
   flex-wrap: wrap;
@@ -260,7 +258,7 @@ section {
 }
 ```
 
-```css
+```css live-sample___line_style_colors
 div {
   border-width: 10px;
   border-style: inset groove ridge outset;
@@ -273,7 +271,7 @@ div::before {
 
 #### Result
 
-{{EmbedLiveSample("Line_style_colors", "500", "400")}}
+{{EmbedLiveSample("line_style_colors", "500", "400")}}
 
 Notice that the almost-black color of `#000001` may be different from the actual black, and the contrast between the dark and light edges is more noticeable when using lighter colors.
 

--- a/files/en-us/web/svg/reference/element/svg/index.md
+++ b/files/en-us/web/svg/reference/element/svg/index.md
@@ -50,20 +50,37 @@ In this example, the `height` and `width` attributes on the `svg` element are se
 <div class="resizer">
   <iframe
     class="resized"
-    srcdoc="
+    srcdoc='
 ```
 
-```html-nolint
-<svg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg' height='60vmin' width='60vmin'>
-  <rect x='0' y='0' width='50%' height='50%' fill='tomato' opacity='0.75' />
-  <rect x='25%' y='25%' width='50%' height='50%' fill='slategrey' opacity='0.75' />
-  <rect x='50%' y='50%' width='50%' height='50%' fill='olive' opacity='0.75' />
-  <rect x='0' y='0' width='100%' height='100%' stroke='cadetblue' stroke-width='0.5%' fill='none' />
+```html
+<svg
+  viewBox="0 0 400 400"
+  xmlns="http://www.w3.org/2000/svg"
+  height="60vmin"
+  width="60vmin">
+  <rect x="0" y="0" width="50%" height="50%" fill="tomato" opacity="0.75" />
+  <rect
+    x="25%"
+    y="25%"
+    width="50%"
+    height="50%"
+    fill="slategrey"
+    opacity="0.75" />
+  <rect x="50%" y="50%" width="50%" height="50%" fill="olive" opacity="0.75" />
+  <rect
+    x="0"
+    y="0"
+    width="100%"
+    height="100%"
+    stroke="cadetblue"
+    stroke-width="0.5%"
+    fill="none" />
 </svg>
 ```
 
 ```html hidden
-  "></iframe>
+  '></iframe>
 </div>
 ```
 


### PR DESCRIPTION
- Add context for additional methods and properties
- Make JSX valid by having a single element
- Remove unnecessary strict IIFE wrapper
- Remove unnecessary `<div class="wrapper">` by directly apply styles to `body`
- Fix some invalid SVG markup (missing a trailing slash)
- Other anecdotal improvements