### PR TITLE
Clarify stretch behavior in align-items documentation

### DIFF
--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -130,7 +130,7 @@ align-items: unset;
 
 - `stretch`
 
-  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
+  - : If the items are smaller than the alignment container, and their size on the cross axis is set to auto, they will be stretched to fill the container, while respecting any min-width, max-width, min-height, or max-height constraints.
 
 - `anchor-center`
 


### PR DESCRIPTION
Description
Clarified the behavior of the stretch value in the align-items CSS property documentation to better explain how auto-sized items are stretched within the container while respecting size constraints.

Motivation
The previous description of stretch was vague and caused confusion for readers trying to understand how stretching works when items have auto sizes. This clarification helps improve documentation accuracy and assists developers in using CSS flexbox alignment more effectively.

Additional details
This update aligns with the CSS Flexible Box Layout Module specification and common browser implementations regarding item stretching and size constraint

Related issues and pull requests
Fixes #39491 

