### PR TITLE
Match Example "Content-Length" header to body length

### DIFF
--- a/files/en-us/web/http/guides/messages/index.md
+++ b/files/en-us/web/http/guides/messages/index.md
@@ -48,9 +48,9 @@ Let's look at the following example HTTP `POST` request that's sent after a user
 POST /users HTTP/1.1
 Host: example.com
 Content-Type: application/x-www-form-urlencoded
-Content-Length: 50
+Content-Length: 49
 
-name=FirstName%20LastName&email=bsmth%40example.com
+name=FirstName+LastName&email=bsmth%40example.com
 ```
 
 The start-line in HTTP/1.x requests (`POST /users HTTP/1.1` in the example above) is called a "request-line" and is made of three parts:
@@ -111,7 +111,7 @@ In the [form submission example](#http_requests) above, they are the following l
 ```http
 Host: example.com
 Content-Type: application/x-www-form-urlencoded
-Content-Length: 50
+Content-Length: 49
 ```
 
 In HTTP/1.x, each header is a **case-insensitive** string followed by a colon (`:`) and a value whose format depends on the header.
@@ -133,7 +133,7 @@ Only `PATCH`, `POST`, and `PUT` requests have a body.
 In the [form submission example](#http_requests), this part is the body:
 
 ```http
-name=FirstName%20LastName&email=bsmth%40example.com
+name=FirstName+LastName&email=bsmth%40example.com
 ```
 
 The body in the form submission request contains a relatively small amount of information as `key=value` pairs, but a request body could contain other types of data that the server expects:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The length of "name=FirstName%20LastName&email=bsmth%40example.com " is 51 characters but the Content-Length header says the content is 50 characters long.

### Motivation

I wanted an example of a plain text HTTP message to show someone how a server knows when it has read the full content of a message. I wanted to show them that the text after the empty line had the same number of characters as the value of the Content-Length header, so the message size can be figured out at the application layer.  When I saw 51 characters popup as the length I got confused and realised this example probably isn't the best one for me to use in its current state.

### Related issues and pull requests

Fixes #39554

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
