### PR TITLE
doc[iframe/index.md]: change `Window.showModalDialog()` to `HTMLDialogElement.showModal()`

### DIFF
--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -128,7 +128,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
     - `allow-pointer-lock`
       - : Allows the page to use the [Pointer Lock API](/en-US/docs/Web/API/Pointer_Lock_API).
     - `allow-popups`
-      - : Allows popups (like from {{domxref("Window.open()")}}, `target="_blank"`, {{domxref("Window.showModalDialog()")}}). If this keyword is not used, that functionality will silently fail.
+      - : Allows popups (like from {{domxref("Window.open()")}}, `target="_blank"`, {{domxref("HTMLDialogElement.showModal()")}}). If this keyword is not used, that functionality will silently fail.
     - `allow-popups-to-escape-sandbox`
       - : Allows a sandboxed document to open a new browsing context without forcing the sandboxing flags upon it. This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon the page the ad links to. If this flag is not included, a redirected page, popup window, or new tab will be subject to the same sandbox restrictions as the originating `<iframe>`.
     - `allow-presentation`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The link of `Window.showModalDialog()` is currently points to [HTMLDialogElement.showModal()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
