### PR TITLE
Use consistent naming for quirks/limited-quirks/no-quirks modes

### DIFF
--- a/files/en-us/web/html/guides/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/guides/quirks_mode_and_standards_mode/index.md
@@ -15,7 +15,7 @@ The limited-quirks and no-quirks modes used to be called "almost-standards" mode
 
 ## How do browsers determine which mode to use?
 
-For [HTML](/en-US/docs/Web/HTML) documents, browsers use a doctype in the beginning of the document to decide whether to handle it in quirks mode or standards mode. To ensure that your page uses full standards mode, make sure that your page has a doctype like in this example:
+For [HTML](/en-US/docs/Web/HTML) documents, browsers use a doctype in the beginning of the document to decide whether to handle it in quirks mode or no-quirks mode. To ensure that your page uses no-quirks mode, make sure that your page has a doctype like in this example:
 
 ```html
 <!doctype html>
@@ -28,7 +28,7 @@ For [HTML](/en-US/docs/Web/HTML) documents, browsers use a doctype in the beginn
 </html>
 ```
 
-The doctype shown in the example, `<!doctype html>`, is the simplest possible, and the one recommended by current HTML standards. Earlier versions of the HTML standard recommended other variants, but all existing browsers today will use full standards mode for this doctype. There are no valid reasons to use a more complicated doctype. If you do use another doctype, you may risk choosing one which triggers almost standards mode or quirks mode.
+The doctype shown in the example, `<!doctype html>`, is the simplest possible, and the one recommended by current HTML standards. Earlier versions of the HTML standard recommended other variants, but all existing browsers today will use no-quirks mode for this doctype. There are no valid reasons to use a more complicated doctype. If you do use another doctype, you may risk choosing one which triggers limited-quirks mode or quirks mode.
 
 Put the doctype right at the beginning of your HTML document, before any other content.
 
@@ -38,9 +38,9 @@ See also a detailed description of [when different browsers choose various modes
 
 ### XHTML
 
-If you serve your page as [XHTML](/en-US/docs/Glossary/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a doctype to enable standards mode, as such documents always use 'full standards mode'.
+If you serve your page as [XHTML](/en-US/docs/Glossary/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a doctype to enable no-quirks mode, as such documents always use no-quirks mode.
 
-If you serve XHTML-like content using the `text/html` MIME type, browsers will read it as HTML, and you will need the doctype to use standards mode.
+If you serve XHTML-like content using the `text/html` MIME type, browsers will read it as HTML, and you will need the doctype to use no-quirks mode.
 
 ## How do I see which mode is used?
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

After initial mention of legacy names for limited-quirks and no-quirks modes, subsequent references to those modes have been changed to use "limited-quirks mode" and "no-quirks mode" instead of the legacy names.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Using the legacy names across the rest of the document is inconsistent with the sentence in the introduction:
> The limited-quirks and no-quirks modes used to be called "almost-standards" mode and "full standards" mode, respectively. These names have been changed as the behavior is now standardized.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
