### PR TITLE
Specify which credientials header value is default

### DIFF
--- a/files/en-us/web/api/request/credentials/index.md
+++ b/files/en-us/web/api/request/credentials/index.md
@@ -20,8 +20,9 @@ A string with one of the following values:
 
 - `omit`
   - : Never send credentials in the request or include credentials in the response.
-- `same-origin` (the default)
+- `same-origin`
   - : Only send and include credentials for same-origin requests.
+    This is the default.
 - `include`
   - : Always include credentials, even for cross-origin requests.
 

--- a/files/en-us/web/api/request/credentials/index.md
+++ b/files/en-us/web/api/request/credentials/index.md
@@ -20,7 +20,7 @@ A string with one of the following values:
 
 - `omit`
   - : Never send credentials in the request or include credentials in the response.
-- `same-origin`
+- `same-origin` (the default)
   - : Only send and include credentials for same-origin requests.
 - `include`
   - : Always include credentials, even for cross-origin requests.


### PR DESCRIPTION
- Technically this is redundant because the example that follows mentions it in a comment, but I think the typical reader will expect to find that information here, not in the example.
- I tried to make this change similar in format to https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials
