### PR TITLE
Add missing "to" in html basics course debugging walkthrough page

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/debugging_html/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/debugging_html/index.md
@@ -84,7 +84,7 @@ So why is this both good and bad? Well, in this case the browser has created the
 > [!NOTE]
 > HTML is parsed permissively because when the web was first created, it was decided that getting content published was more important than making sure the syntax was absolutely correct. The web would probably not be as popular as it is today if it had been more strict from the very beginning.
 
-So how do you find markup errors? Later on we will show you how to find errors in HTML using a tool called the [HTML validator](#html_validation), but first we will show you how inspect your HTML manually using a **DOM inspector**, and then explore what kinds of markup errors you might be looking for, and how the browser might interpret those.
+So how do you find markup errors? Later on we will show you how to find errors in HTML using a tool called the [HTML validator](#html_validation), but first we will show you how to inspect your HTML manually using a **DOM inspector**, and then explore what kinds of markup errors you might be looking for, and how the browser might interpret those.
 
 ## Using a DOM inspector
 


### PR DESCRIPTION
added missing "to"

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There was a missing "to" in this paragraph, before the word "inspect". 

"So how do you find markup errors? Later on we will show you how to find errors in HTML using a tool called the [HTML validator](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Debugging_HTML#html_validation), but first we will show you how inspect your HTML manually using a DOM inspector, and then explore what kinds of markup errors you might be looking for, and how the browser might interpret those."

### Motivation

I would like to make the MDN HTML course easier to understand by addressing any grammatical errors that I might come across. 

### Additional details

N/A

### Related issues and pull requests

N/A
