### PR TITLE
DataTransfer.files can also be accessed with paste event

### DIFF
--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -13,7 +13,7 @@ The **`files`** read-only property of [`DataTransfer`](/en-US/docs/Web/API/DataT
 This feature can be used to drag files from a user's desktop to the browser.
 
 > [!NOTE]
-> The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the `drop` event. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store).
+> The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the [Drag and Drop API's](/en-US/docs/Web/API/HTML_Drag_and_Drop_API) 'drop' and the [Clipboard API's](/en-US/docs/Web/API/Clipboard_API) 'paste' event. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store).
 
 ## Value
 

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -13,7 +13,7 @@ The **`files`** read-only property of [`DataTransfer`](/en-US/docs/Web/API/DataT
 This feature can be used to drag files from a user's desktop to the browser.
 
 > [!NOTE]
-> The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the [Drag and Drop API's](/en-US/docs/Web/API/HTML_Drag_and_Drop_API) 'drop' and the [Clipboard API's](/en-US/docs/Web/API/Clipboard_API) 'paste' event. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store).
+> The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the {{domxref("HTMLElement/drop_event", "drop")}} and {{domxref("Element/paste_event", "paste")}} events. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store).
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed the datatransfer: files page according to issue #39267 wherein the fact that it is accessible from the paste event too was not included in the notes section of the documentation

### Motivation

I have used the MDN web docs a lot when i am stuck and so wanted to give back by helping fix an issue i can easily fix

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #39267 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
