### PR TITLE
Refactor: Replace deprecated `Window.showModalDialog` API with modern alternatives

### DIFF
--- a/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
@@ -44,7 +44,7 @@ const offlineAudioCtx = new OfflineAudioContext();
 
 offlineAudioCtx.addEventListener("complete", () => {
   console.log("Offline audio processing now complete");
-  showModalDialog("Song processed and ready to play");
+  alert("Song processed and ready to play");
   playBtn.disabled = false;
 });
 ```
@@ -56,7 +56,7 @@ const offlineAudioCtx = new OfflineAudioContext();
 
 offlineAudioCtx.oncomplete = () => {
   console.log("Offline audio processing now complete");
-  showModalDialog("Song processed and ready to play");
+  alert("Song processed and ready to play");
   playBtn.disabled = false;
 };
 ```

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -54,7 +54,7 @@ where `<value>` can optionally be one of the following values:
 - `allow-pointer-lock`
   - : Allows the page to use the [Pointer Lock API](/en-US/docs/Web/API/Pointer_Lock_API).
 - `allow-popups`
-  - : Allows popups (like from {{domxref("Window.open()")}}, `target="_blank"`, {{domxref("Window.showModalDialog()")}}). If this keyword is not used, that functionality will silently fail.
+  - : Allows popups (like from {{domxref("Window.open()")}}, `target="_blank"`, {{domxref("HTMLDialogElement.showModal()")}}). If this keyword is not used, that functionality will silently fail.
 - `allow-popups-to-escape-sandbox`
   - : Allows a sandboxed document to open new windows without forcing the sandboxing flags upon them. This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon the page the ad links to.
 - `allow-presentation`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

doc[complete_event]: change `showModalDialog` to `alert`
doc[sandbox]: change `Window.showModalDialog` to `HTMLDialogElement.showModal`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to #39556
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
