### PR TITLE
Improves the explanation for the application-name metadata

### DIFF
--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -13,7 +13,8 @@ The {{htmlelement("meta")}} element can be used to provide document metadata in 
 
 The HTML specification defines the following set of standard metadata names:
 
-- `application-name`: the name of the application running in the web page. Only use this if the page is a web application. To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
+- `application-name`: the name of the application running in the web page.
+To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
 
 To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language:
 

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -18,9 +18,9 @@ The HTML specification defines the following set of standard metadata names:
 
 To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language:
 
-  ```html
-  <!-- English name -->
-  <meta name="application-name" content="Weather Wizard" lang="en" />
+```html
+<!-- English name -->
+<meta name="application-name" content="Weather Wizard" lang="en" />
 
   <!-- Spanish translation -->
   <meta name="application-name" content="Mago del Clima" lang="es" />

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -15,6 +15,8 @@ The HTML specification defines the following set of standard metadata names:
 
 - `application-name`: the name of the application running in the web page. Only use this if the page is a web application. To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
 
+To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language:
+
   ```html
   <!-- English name -->
   <meta name="application-name" content="Weather Wizard" lang="en" />

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -22,9 +22,9 @@ To provide translations, use multiple `<meta>` tags with the `lang` attribute fo
 <!-- English name -->
 <meta name="application-name" content="Weather Wizard" lang="en" />
 
-  <!-- Spanish translation -->
-  <meta name="application-name" content="Mago del Clima" lang="es" />
-  ```
+<!-- Spanish translation -->
+<meta name="application-name" content="Mago del Clima" lang="es" />
+```
 
   > [!NOTE]
   >

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -14,7 +14,6 @@ The {{htmlelement("meta")}} element can be used to provide document metadata in 
 The HTML specification defines the following set of standard metadata names:
 
 - `application-name`: the name of the application running in the web page.
-  To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
 
 To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language:
 

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -13,7 +13,14 @@ The {{htmlelement("meta")}} element can be used to provide document metadata in 
 
 The HTML specification defines the following set of standard metadata names:
 
-- `application-name`: the name of the application running in the web page.
+- `application-name`: the name of the application running in the web page. Only use this if the page is a web application. To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
+  ```html
+  <!-- English name -->
+  <meta name="application-name" content="Weather Wizard" lang="en" />
+
+  <!-- Spanish translation -->
+  <meta name="application-name" content="Mago del Clima" lang="es" />
+  ```
 
   > [!NOTE]
   >

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -14,7 +14,7 @@ The {{htmlelement("meta")}} element can be used to provide document metadata in 
 The HTML specification defines the following set of standard metadata names:
 
 - `application-name`: the name of the application running in the web page.
-To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
+  To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
 
 To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language:
 

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -14,6 +14,7 @@ The {{htmlelement("meta")}} element can be used to provide document metadata in 
 The HTML specification defines the following set of standard metadata names:
 
 - `application-name`: the name of the application running in the web page. Only use this if the page is a web application. To provide translations, use multiple `<meta>` tags with the `lang` attribute for each language.
+
   ```html
   <!-- English name -->
   <meta name="application-name" content="Weather Wizard" lang="en" />

--- a/files/en-us/web/html/reference/elements/meta/name/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/index.md
@@ -25,10 +25,10 @@ To provide translations, use multiple `<meta>` tags with the `lang` attribute fo
 <meta name="application-name" content="Mago del Clima" lang="es" />
 ```
 
-  > [!NOTE]
-  >
-  > - Browsers may use this to identify the application. It is different from the {{HTMLElement("title")}} element, which usually contain the application name, but may also contain information like the document name or a status.
-  > - Individual web pages shouldn't define an `application-name`.
+> [!NOTE]
+>
+> - Browsers may use this to identify the application. It is different from the {{HTMLElement("title")}} element, which usually contain the application name, but may also contain information like the document name or a status.
+> - Individual web pages shouldn't define an `application-name`.
 
 - `author`: the name of the document's author.
 - `description`: a short and accurate summary of the content of the page. Search engines like [Google](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions) may use this field to control the appearance of the webpage in the search result.


### PR DESCRIPTION
### Description
Adds an example on providing localized `application-name` using the `lang` attribute.

### Link to specification  - [application-name](https://html.spec.whatwg.org/multipage/semantics.html#meta-application-name)

