### PR TITLE
doc[sandbox]: remove `HTMLDialogElement.showModal` from `allow-popups`

### DIFF
--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -7,11 +7,8 @@ browser-compat: http.headers.Content-Security-Policy.sandbox
 
 {{HTTPSidebar}}
 
-The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
-**`sandbox`** directive enables a sandbox for the requested
-resource similar to the {{HTMLElement("iframe")}} [`sandbox`](/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox)
-attribute. It applies restrictions to a page's actions including preventing popups,
-preventing the execution of plugins and scripts, and enforcing a same-origin policy.
+The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`sandbox`** directive enables a sandbox for the requested resource similar to the {{HTMLElement("iframe")}} [`sandbox`](/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox) attribute.
+It applies restrictions to a page's actions including preventing popups, preventing the execution of plugins and scripts, and enforcing a same-origin policy.
 
 <table class="properties">
   <tbody>
@@ -25,10 +22,7 @@ preventing the execution of plugins and scripts, and enforcing a same-origin pol
     </tr>
     <tr>
       <th colspan="2" scope="row">
-        This directive is not supported in the {{HTMLElement("meta")}}
-        element or by the
-        {{HTTPHeader("Content-Security-policy-Report-Only")}}
-        header field.
+        This directive is not supported in the {{HTMLElement("meta")}} element or by the {{HTTPHeader("Content-Security-policy-Report-Only")}} header field.
       </th>
     </tr>
   </tbody>
@@ -44,7 +38,8 @@ Content-Security-Policy: sandbox <value>;
 where `<value>` can optionally be one of the following values:
 
 - `allow-downloads`
-  - : Allows downloading files through an {{HTMLElement("a")}} or {{HTMLElement("area")}} element with the [download](/en-US/docs/Web/HTML/Reference/Elements/a#download) attribute, as well as through the navigation that leads to a download of a file. This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction.
+  - : Allows downloading files through an {{HTMLElement("a")}} or {{HTMLElement("area")}} element with the [download](/en-US/docs/Web/HTML/Reference/Elements/a#download) attribute, as well as through the navigation that leads to a download of a file.
+    This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction.
 - `allow-forms`
   - : Allows the page to submit forms. If this keyword is not used, form will be displayed as normal, but submitting it will not trigger input validation, sending data to a web server or closing a dialog.
 - `allow-modals`

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -49,7 +49,8 @@ where `<value>` can optionally be one of the following values:
 - `allow-pointer-lock`
   - : Allows the page to use the [Pointer Lock API](/en-US/docs/Web/API/Pointer_Lock_API).
 - `allow-popups`
-  - : Allows popups (created, for example, by {{domxref("Window.open()")}} or `target="_blank"`). If this keyword is not used, such functionality will silently fail.
+  - : Allows popups (created, for example, by {{domxref("Window.open()")}} or `target="_blank"`).
+    If this keyword is not used, popup display will silently fail.
 - `allow-popups-to-escape-sandbox`
   - : Allows a sandboxed document to open new windows without forcing the sandboxing flags upon them. This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon the page the ad links to.
 - `allow-presentation`

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -54,7 +54,7 @@ where `<value>` can optionally be one of the following values:
 - `allow-pointer-lock`
   - : Allows the page to use the [Pointer Lock API](/en-US/docs/Web/API/Pointer_Lock_API).
 - `allow-popups`
-  - : Allows popups (like from {{domxref("Window.open()")}}, `target="_blank"`, {{domxref("Window.showModalDialog()")}}). If this keyword is not used, that functionality will silently fail.
+  - : Allows popups (created, for example, by {{domxref("Window.open()")}} or `target="_blank"`). If this keyword is not used, such functionality will silently fail.
 - `allow-popups-to-escape-sandbox`
   - : Allows a sandboxed document to open new windows without forcing the sandboxing flags upon them. This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon the page the ad links to.
 - `allow-presentation`


### PR DESCRIPTION
Relates to #39556, #39580 and #39583