### PR TITLE
added experimental release note for view transition api

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1754,7 +1754,7 @@ Notifications have the [`requireInteraction`](/en-US/docs/Web/API/Notification/r
 
 ### View Transition API
 
-The [View Transition API](/en-US/docs/Web/API/View_Transition_API) has been enabled for [SPAs (Single-page Applications)](/en-US/docs/Glossary/SPA) in the Nightly release. This provides a mechanism for easily creating animated transitions between different website views. ([Firefox bug 1950759](https://bugzil.la/1950759)).
+The [View Transition API](/en-US/docs/Web/API/View_Transition_API) provides a mechanism for easily creating animated transitions between different website views. This is especially useful for [SPAs (single-page applications)](/en-US/docs/Glossary/SPA). ([Firefox bug 1950759](https://bugzil.la/1950759)).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1752,6 +1752,46 @@ Notifications have the [`requireInteraction`](/en-US/docs/Web/API/Notification/r
   </tbody>
 </table>
 
+### View Transition API
+
+The [View Transition API](/en-US/docs/Web/API/View_Transition_API) has been enabled for [SPAs (Single-page Applications)](/en-US/docs/Glossary/SPA) in the Nightly release. This provides a mechanism for easily creating animated transitions between different website views. ([Firefox bug 1950759](https://bugzil.la/1950759)).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version changed</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>139</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>—</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>—</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>—</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">N/A</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Security and privacy
 
 ### Block plain text requests from Flash on encrypted pages

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -99,6 +99,8 @@ These features are newly shipped in Firefox 139 but are disabled by default. To 
   The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third-party libraries and frameworks.
   This adds support for the {{domxref("scheduler.yield()")}} method and re-enables the whole API in the Nightly release.
   ([Firefox bug 1958943](https://bugzil.la/1958943), [Firefox bug 1920115](https://bugzil.la/1920115)).
+- **View Transition API** (Nightly release).
+  The [View Transition API](/en-US/docs/Web/API/View_Transition_API) has been enabled for [SPAs (Single-page Applications)](/en-US/docs/Glossary/SPA) in the Nightly release. This provides a mechanism for easily creating animated transitions between different website views. ([Firefox bug 1950759](https://bugzil.la/1950759)).
 - **Support for escaping `<` and `>` in attributes when serializing HTML**: `dom.security.html_serialization_escape_lt_gt`.
   Firefox now replaces the `<` and `>` characters with `&lt;` and `&gt;`, respectively, in attributes when serializing HTML. This helps prevent certain exploits where HTML is serialized and then injected back into the DOM.
   The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347)).

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -100,7 +100,7 @@ These features are newly shipped in Firefox 139 but are disabled by default. To 
   This adds support for the {{domxref("scheduler.yield()")}} method and re-enables the whole API in the Nightly release.
   ([Firefox bug 1958943](https://bugzil.la/1958943), [Firefox bug 1920115](https://bugzil.la/1920115)).
 - **View Transition API** (Nightly release).
-  The [View Transition API](/en-US/docs/Web/API/View_Transition_API) has been enabled for [SPAs (Single-page Applications)](/en-US/docs/Glossary/SPA) in the Nightly release. This provides a mechanism for easily creating animated transitions between different website views. ([Firefox bug 1950759](https://bugzil.la/1950759)).
+  The [View Transition API](/en-US/docs/Web/API/View_Transition_API) has been enabled for [SPAs (single-page applications)](/en-US/docs/Glossary/SPA). It provides a mechanism for easily creating animated transitions between different website views. ([Firefox bug 1950759](https://bugzil.la/1950759)).
 - **Support for escaping `<` and `>` in attributes when serializing HTML**: `dom.security.html_serialization_escape_lt_gt`.
   Firefox now replaces the `<` and `>` characters with `&lt;` and `&gt;`, respectively, in attributes when serializing HTML. This helps prevent certain exploits where HTML is serialized and then injected back into the DOM.
   The affected methods and properties are: {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}}. ([Firefox bug 1941347](https://bugzil.la/1941347)).


### PR DESCRIPTION
### Description

- Added experimental release note for View transition API to:
  - Experimental features
  - Firefox 139 (experimental web sections)

### Motivation

- Working on [issue #39305](https://github.com/mdn/content/issues/39305)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/39593)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/26851)