### PR TITLE
docs(Fx139): Add relnote for hidden until found, beforematch

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -13,6 +13,9 @@ This article provides information about the changes in Firefox 139 that affect d
 
 ### HTML
 
+- The [`hidden=until-found` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#the_hidden_until_found_state) and the [`beforematch` event](/en-US/docs/Web/API/Element/beforematch_event) are now enabled by default.
+  A _hidden until found_ state allows you to hide the contents of an element (`content-visibility: hidden`) until found by search ("find in page") or by fragment navigation, and the `beforematch` event fires before the `hidden` attribute is removed ([Firefox bug 1761043](https://bugzil.la/1761043) and [Firefox bug 1955379](https://bugzil.la/1955379)).
+
 #### Removals
 
 ### CSS
@@ -22,7 +25,7 @@ This article provides information about the changes in Firefox 139 that affect d
 ### JavaScript
 
 - The Temporal API is now supported, this aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations ([Firefox bug 1912511](https://bugzil.la/1912511) and [Firefox bug 1954138](https://bugzil.la/1954138)).
-This includes:
+  This includes:
   - A **duration** (difference between two time points): {{jsxref("Temporal.Duration")}}
   - **Points in time**:
     - As a unique instant in history:

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -13,8 +13,9 @@ This article provides information about the changes in Firefox 139 that affect d
 
 ### HTML
 
-- The [`hidden=until-found` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#the_hidden_until_found_state) and the [`beforematch` event](/en-US/docs/Web/API/Element/beforematch_event) are now enabled by default.
-  A _hidden until found_ state allows you to hide the contents of an element (`content-visibility: hidden`) until found by search ("find in page") or by fragment navigation, and the `beforematch` event fires before the `hidden` attribute is removed ([Firefox bug 1761043](https://bugzil.la/1761043) and [Firefox bug 1955379](https://bugzil.la/1955379)).
+- The [`hidden=until-found`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#the_hidden_until_found_state) HTML attribute and the [`beforematch` event](/en-US/docs/Web/API/Element/beforematch_event) are now supported.
+  The _hidden until found_ state allows you to hide the contents of an element until it is found by user search (for example, using "Find in page") or by fragment navigation.
+  The `beforematch` event fires just before the `hidden` attribute is removed ([Firefox bug 1761043](https://bugzil.la/1761043) and [Firefox bug 1955379](https://bugzil.la/1955379)).
 
 #### Removals
 


### PR DESCRIPTION
### Description

Relnote for enabling `hidden="until-found"` and `beforematch`

### Bugs

- [Implement hidden=until-found attribute and beforematch event](https://bugzilla.mozilla.org/show_bug.cgi?id=1761043)
- [Enable about:config pref 'dom.hidden_until_found.enabled'](https://bugzilla.mozilla.org/show_bug.cgi?id=1955379)

### Related issues and pull requests

- [ ] Parent issue https://github.com/mdn/content/issues/39306