### PR TITLE
docs(Fx139): Refresh hidden until found, beforematch

### DIFF
--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -36,12 +36,12 @@ The HTML [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) att
 
 ### Using beforematch
 
-In this example we have two {{HTMLElement("div")}} elements.
-The first is not hidden, while the second has `hidden="until-found"` and `id="until-found-box"` attributes.
-The _hidden until found_ element has a dotted red border and a gray background.
+In this example, we have two {{HTMLElement("div")}} elements.
+The first is visible, while the second has the `hidden="until-found"` and `id="until-found-box"` attributes.
+The element with a _hidden until found_ state has a dotted red border and a gray background.
 
-We also have a link whose target is the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on the hidden until found element.
-The event handler changes the text content of the box as illustration of an action that can be taken when _hidden until found_ state is about to be removed.
+We also have a link that targets the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on that hidden element.
+The event handler changes the text content of the box to illustrate an action that can occur when the _hidden until found_ state is about to be removed.
 
 #### HTML
 
@@ -94,7 +94,8 @@ document.querySelector("#reset").addEventListener("click", () => {
 
 #### Result
 
-Clicking the "Go to hidden content" button navigates to the hidden-until-found element. The `beforematch` event fires, the text content is updated, and then the element's content is displayed.
+Clicking the "Go to hidden content" button navigates to the element in the _hidden until found_ state.
+The `beforematch` event fires, the text content is updated, and then the element's content is displayed (the `hidden` attribute is removed).
 
 To run the example again, click "Reload".
 

--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -38,7 +38,7 @@ The HTML [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) att
 
 In this example, we have two {{HTMLElement("div")}} elements.
 The first is visible, while the second has the `hidden="until-found"` and `id="until-found-box"` attributes.
-The element with a _hidden until found_ state has a dotted red border and a gray background.
+The element with a `until-found-box` id has a dotted red border and a gray background.
 
 We also have a link that targets the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on that hidden element.
 The event handler changes the text content of the box to illustrate an action that can occur when the _hidden until found_ state is about to be removed.

--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -36,12 +36,12 @@ The HTML [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) att
 
 ### Using beforematch
 
-In this example we have:
+In this example we have two {{HTMLElement("div")}} elements.
+The first is not hidden, while the second has `hidden="until-found"` and `id="until-found-box"` attributes.
+The _hidden until found_ element has a dotted red border and a gray background.
 
-- Two {{HTMLElement("div")}} elements. The first is not hidden, while the second has `hidden="until-found"` and `id="until-found-box"` attributes.
-- A link whose target is the `"until-found-box"` fragment.
-
-We also have some JavaScript that listens for the `beforematch` event firing on the hidden until found element. The event handler changes the text content of the box.
+We also have a link whose target is the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on the hidden until found element.
+The event handler changes the text content of the box as illustration of an action that can be taken when _hidden until found_ state is about to be removed.
 
 #### HTML
 
@@ -67,11 +67,11 @@ div {
   padding: 1rem;
   font-size: 2rem;
 }
-```
 
-```css hidden
-#until-found-box {
-  scroll-margin-top: 200px;
+div#until-found-box {
+  color: red;
+  border: 5px dotted red;
+  background-color: lightgray;
 }
 ```
 

--- a/files/en-us/web/api/element/beforematch_event/index.md
+++ b/files/en-us/web/api/element/beforematch_event/index.md
@@ -28,9 +28,9 @@ A generic {{domxref("Event")}}.
 
 The HTML [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute accepts a value `until-found`: when this value is specified, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation. When these features cause a scroll to an element in a "hidden until found" subtree, the browser will:
 
-- fire a `beforematch` event on the hidden element
-- remove the `hidden` attribute from the element
-- scroll to the element
+1. Fire a `beforematch` event on the hidden element
+2. Remove the `hidden` attribute from the element
+3. Scroll to the element
 
 ## Examples
 

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -82,14 +82,16 @@ This means that, unlike elements in the _hidden_ state, elements in the _hidden 
 - their margin, borders, padding, and background are rendered
 
 Also, the element needs to be affected by [layout containment](/en-US/docs/Web/CSS/CSS_containment) in order to be revealed.
-If the element in the _hidden until-found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by "Find in page" or fragment navigation.
+If the element in the _hidden until found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by "Find in page" or fragment navigation.
 
 ## Usage notes
 
 The `hidden` attribute must not be used to hide content just from one presentation.
 If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.
 
-Hidden elements shouldn't be linked from visible elements. For example, it would be incorrect to use the `href` attribute to link to a section marked with the `hidden` attribute. If the content is not applicable or relevant, it shouldn't be linked.
+Hidden elements shouldn't be linked from visible elements unless using `hidden="until-found"`.
+For example, it would be incorrect to use the `href` attribute to link to a section with the `hidden` attribute.
+If the content is not applicable or relevant, it shouldn't be linked.
 
 It is fine, however, to use the ARIA [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to refer to hidden descriptions. While hiding the descriptions implies that they're not useful on their own, they can provide helpful context when referenced in this way.
 

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -39,9 +39,9 @@ The attribute takes any one of the following values:
 
 - the keyword `hidden`
 - the keyword `until-found`
-- an empty string
+- an empty string or no value
 
-Invalid `hidden=` values also set an element to the _hidden_ state, meaning, all the following elements have a [_hidden_](#the_hidden_state) state:
+Invalid `hidden` attribute values also place the element in the _hidden_ state. Therefore, all the following elements are in the [_hidden_](#the_hidden_state) state:
 
 ```html
 <span hidden>I'm hidden</span>
@@ -66,32 +66,32 @@ For instance, elements styled `display: block` will be displayed despite the `hi
 
 ### The hidden until found state
 
-In the _hidden until found_ state, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation.
+In the _hidden until found_ state, the element is hidden but its content will be accessible to the browser's "Find in page" feature or to fragment navigation.
 When these features cause a scroll to an element in a _hidden until found_ subtree, the browser will:
 
 - fire a [`beforematch`](/en-US/docs/Web/API/Element/beforematch_event) event on the hidden element
 - remove the `hidden` attribute from the element
 - scroll to the element
 
-This enables a developer to collapse a section of content, but make it searchable and accessible through navigation.
+This lets you collapse a section of content while still allowing users to find it through search or navigation.
 
 Browsers typically implement _hidden until found_ using {{cssxref("content-visibility", "content-visibility: hidden")}}.
-This means that, unlike elements in the _hidden_ state, elements in the _hidden until found_ state will have generated boxes, and:
+This means that, unlike elements in the _hidden_ state, elements in the _hidden until-found_ state generate boxes, and:
 
-- the element will participate in page layout
-- margin, borders, padding, and background for the element will be rendered.
+- they participate in page layout
+- their margin, borders, padding, and background are rendered
 
 Also, the element needs to be affected by [layout containment](/en-US/docs/Web/CSS/CSS_containment) in order to be revealed.
-If the element in the _hidden until found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by "find in page" or fragment navigation.
+If the element in the _hidden until-found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by "Find in page" or fragment navigation.
 
-### Usage notes
+## Usage notes
 
 The `hidden` attribute must not be used to hide content just from one presentation.
 If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.
 
-Hidden elements shouldn't be linked from non-hidden elements. For example, it would be incorrect to use the `href` attribute to link to a section marked with the `hidden` attribute. If the content is not applicable or relevant, then there is no reason to link to it.
+Hidden elements shouldn't be linked from visible elements. For example, it would be incorrect to use the `href` attribute to link to a section marked with the `hidden` attribute. If the content is not applicable or relevant, it shouldn't be linked.
 
-It would be fine, however, to use the ARIA [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to refer to descriptions that are themselves hidden. While hiding the descriptions implies that they are not useful on their own, they could be written in such a way that they are useful in the specific context of being referenced from the element that they describe.
+It is fine, however, to use the ARIA [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to refer to hidden descriptions. While hiding the descriptions implies that they're not useful on their own, they can provide helpful context when referenced in this way.
 
 Similarly, a canvas element with the `hidden` attribute could be used by a scripted graphics engine as an off-screen buffer, and a form control could refer to a hidden form element using its form attribute.
 
@@ -101,7 +101,7 @@ Elements that are descendants of a hidden element are still active, which means 
 
 ### Using the hidden attribute
 
-In this example we have three {{HTMLElement("div")}} elements. The first and the third are not hidden, while the second has a `hidden` attribute.
+In this example, we have three {{HTMLElement("div")}} elements. The first and the third are not hidden, while the second has a `hidden` attribute.
 Note that the hidden element has no generated box.
 
 ```html
@@ -123,14 +123,14 @@ div {
 
 {{EmbedLiveSample("using_the_hidden_attribute", "", 300)}}
 
-### Using until-found
+### Using the until-found value
 
-In this example we have three {{HTMLElement("div")}} elements.
-The first and the third are not hidden, while the second has `hidden="until-found"` and `id="until-found-box"` attributes.
-The _hidden until found_ element has a dotted red border and a gray background.
+In this example, we have three {{HTMLElement("div")}} elements.
+The first and the third are visible, while the second has the `hidden="until-found"` and `id="until-found-box"` attributes.
+The element with a _hidden until found_ state has a dotted red border and a gray background.
 
-We also have a link whose target is the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on the hidden until found element.
-The event handler changes the text content of the box as illustration of an action that can be taken when _hidden until found_ state is about to be removed.
+We also have a link that targets the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on that hidden element.
+The event handler changes the text content of the box to illustrate an action that can occur when the _hidden until found_ state is about to be removed.
 
 #### HTML
 
@@ -190,7 +190,7 @@ document.querySelector("#reset").addEventListener("click", () => {
 
 #### Result
 
-Clicking the "Go to hidden content" button navigates to the _hidden until found_ element. The `beforematch` event fires, the text content is updated, and the element content is displayed.
+Clicking the "Go to hidden content" link navigates to the _hidden until found_ element. The `beforematch` event fires, the text content is updated, and the element becomes visible.
 Note that although the content of the element is hidden, the element still has a generated box, occupying space in the layout and with background and borders rendered.
 
 To run the example again, click "Reset".

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -34,41 +34,27 @@ p {
 
 ## Description
 
-The `hidden` attribute is used to indicate that the content of an element should not be presented to the user. This attribute can take any one of the following values:
+The `hidden` attribute indicates that the content of an element should not be presented to the user.
+The attribute can take any one of the following values:
 
-- an empty string
 - the keyword `hidden`
 - the keyword `until-found`
+- an empty string
 
-There are two states associated with the `hidden` attribute: the _hidden_ state and the _hidden until found_ state.
-
-- An empty string, or the keyword `hidden`, set the element to the _hidden_ state. Additionally, invalid values set the element to the _hidden_ state.
-
-- The keyword `until-found` sets the element to the _hidden until found_ state.
-
-Thus, all the following set the element to the [_hidden_](#the_hidden_state) state:
+Invalid values set an element to the _hidden_ state, meaning, all the following elements have the [_hidden_](#the_hidden_state) state:
 
 ```html
 <span hidden>I'm hidden</span>
 <span hidden="">I'm also hidden</span>
 <span hidden="hidden">I'm hidden too!</span>
+<span hidden="bananas">I'm equally as hidden!</span>
 ```
 
-The following sets the element to the [_hidden until found_](#the_hidden_until_found_state) state:
+Aside from the _hidden_ state, the keyword `until-found` sets the element to the [_hidden until found_](#the_hidden_until_found_state) state:
 
 ```html
 <span hidden="until-found">I'm hidden until found</span>
 ```
-
-The `hidden` attribute must not be used to hide content just from one presentation. If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.
-
-Hidden elements shouldn't be linked from non-hidden elements. For example, it would be incorrect to use the `href` attribute to link to a section marked with the `hidden` attribute. If the content is not applicable or relevant, then there is no reason to link to it.
-
-It would be fine, however, to use the ARIA [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to refer to descriptions that are themselves hidden. While hiding the descriptions implies that they are not useful on their own, they could be written in such a way that they are useful in the specific context of being referenced from the element that they describe.
-
-Similarly, a canvas element with the `hidden` attribute could be used by a scripted graphics engine as an off-screen buffer, and a form control could refer to a hidden form element using its form attribute.
-
-Elements that are descendants of a hidden element are still active, which means that script elements can still execute and form elements can still submit.
 
 ### The hidden state
 
@@ -93,18 +79,53 @@ Note that browsers typically implement _hidden until found_ using {{cssxref("con
 
 Also, the element needs to be affected by [layout containment](/en-US/docs/Web/CSS/CSS_containment) in order to be revealed. This means that if the element in the _hidden until found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by find in page or fragment navigation.
 
+### Usage notes
+
+The `hidden` attribute must not be used to hide content just from one presentation.
+If something is marked hidden, it is hidden from all presentations, including, for instance, screen readers.
+
+Hidden elements shouldn't be linked from non-hidden elements. For example, it would be incorrect to use the `href` attribute to link to a section marked with the `hidden` attribute. If the content is not applicable or relevant, then there is no reason to link to it.
+
+It would be fine, however, to use the ARIA [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attribute to refer to descriptions that are themselves hidden. While hiding the descriptions implies that they are not useful on their own, they could be written in such a way that they are useful in the specific context of being referenced from the element that they describe.
+
+Similarly, a canvas element with the `hidden` attribute could be used by a scripted graphics engine as an off-screen buffer, and a form control could refer to a hidden form element using its form attribute.
+
+Elements that are descendants of a hidden element are still active, which means that script elements can still execute and form elements can still submit.
+
 ## Examples
+
+### Using the hidden attribute
+
+In this example we have three {{HTMLElement("div")}} elements. The first and the third are not hidden, while the second has a `hidden` attribute.
+Note that the element has no generated box.
+
+```html
+<div>I'm not hidden</div>
+<div hidden>I'm hiding!</div>
+<div>I'm not hidden, either</div>
+```
+
+```css hidden
+div {
+  height: 40px;
+  width: 300px;
+  border: 5px dashed black;
+  margin: 1rem 0;
+  padding: 1rem;
+  font-size: 2rem;
+}
+```
+
+{{EmbedLiveSample("using_the_hidden_attribute", "", 300)}}
 
 ### Using until-found
 
-In this example we have:
+In this example we have three {{HTMLElement("div")}} elements.
+The first and the third are not hidden, while the second has `hidden="until-found"` and `id="until-found-box"` attributes.
+The _hidden until found_ element has a dotted red border and a gray background.
 
-- Three {{HTMLElement("div")}} elements. The first and the third are not hidden, while the second has `hidden="until-found"` and `id="until-found-box"` attributes.
-- A link whose target is the `"until-found-box"` fragment.
-
-The hidden until found element has a dotted red border and a gray background.
-
-We also have some JavaScript that listens for the `beforematch` event firing on the hidden until found element. The event handler changes the text content of the box.
+We also have a link whose target is the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on the hidden until found element.
+The event handler changes the text content of the box as illustration of an action that can be taken when _hidden until found_ state is about to be removed.
 
 #### HTML
 
@@ -113,7 +134,7 @@ We also have some JavaScript that listens for the `beforematch` event firing on 
 
 <div>I'm not hidden</div>
 <div id="until-found-box" hidden="until-found">Hidden until found</div>
-<div>I'm not hidden</div>
+<div>I'm hidden</div>
 ```
 
 ```html hidden
@@ -164,9 +185,8 @@ document.querySelector("#reset").addEventListener("click", () => {
 
 #### Result
 
+Clicking the "Go to hidden content" button navigates to the _hidden until found_ element. The `beforematch` event fires, the text content is updated, and the element content is displayed.
 Note that although the content of the element is hidden, the element still has a generated box, occupying space in the layout and with background and borders rendered.
-
-Clicking the "Go to hidden content" button navigates to the hidden until found element. The `beforematch` event fires, the text content is updated, and the element content is displayed.
 
 To run the example again, click "Reset".
 

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -69,9 +69,9 @@ For instance, elements styled `display: block` will be displayed despite the `hi
 In the _hidden until found_ state, the element is hidden but its content will be accessible to the browser's "Find in page" feature or to fragment navigation.
 When these features cause a scroll to an element in a _hidden until found_ subtree, the browser will:
 
-- fire a [`beforematch`](/en-US/docs/Web/API/Element/beforematch_event) event on the hidden element
-- remove the `hidden` attribute from the element
-- scroll to the element
+1. Fire a [`beforematch`](/en-US/docs/Web/API/Element/beforematch_event) event on the hidden element
+2. Remove the `hidden` attribute from the element
+3. Scroll to the element
 
 This lets you collapse a section of content while still allowing users to find it through search or navigation.
 
@@ -95,7 +95,15 @@ It is fine, however, to use the ARIA [`aria-describedby`](/en-US/docs/Web/Access
 
 Similarly, a canvas element with the `hidden` attribute could be used by a scripted graphics engine as an off-screen buffer, and a form control could refer to a hidden form element using its form attribute.
 
-Elements that are descendants of a hidden element are still active, which means that script elements can still execute and form elements can still submit.
+Finally, note that elements that are descendants of a hidden element are still active, which means that script elements can still execute, and form elements can still submit:
+
+```html
+<div hidden>
+  <script>
+    console.warn("Boo! I'm hidden *and* running!");
+  </script>
+</div>
+```
 
 ## Examples
 

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -137,7 +137,7 @@ div {
 
 In this example, we have three {{HTMLElement("div")}} elements.
 The first and the third are visible, while the second has the `hidden="until-found"` and `id="until-found-box"` attributes.
-The element with a _hidden until found_ state has a dotted red border and a gray background.
+The element with a `until-found-box` id has a dotted red border and a gray background.
 
 We also have a link that targets the `"until-found-box"` fragment and JavaScript that listens for the `beforematch` event firing on that hidden element.
 The event handler changes the text content of the box to illustrate an action that can occur when the _hidden until found_ state is about to be removed.

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -35,13 +35,13 @@ p {
 ## Description
 
 The `hidden` attribute indicates that the content of an element should not be presented to the user.
-The attribute can take any one of the following values:
+The attribute takes any one of the following values:
 
 - the keyword `hidden`
 - the keyword `until-found`
 - an empty string
 
-Invalid values set an element to the _hidden_ state, meaning, all the following elements have the [_hidden_](#the_hidden_state) state:
+Invalid `hidden=` values also set an element to the _hidden_ state, meaning, all the following elements have a [_hidden_](#the_hidden_state) state:
 
 ```html
 <span hidden>I'm hidden</span>
@@ -50,7 +50,7 @@ Invalid values set an element to the _hidden_ state, meaning, all the following 
 <span hidden="bananas">I'm equally as hidden!</span>
 ```
 
-Aside from the _hidden_ state, the keyword `until-found` sets the element to the [_hidden until found_](#the_hidden_until_found_state) state:
+The keyword `until-found` sets the element to the [_hidden until found_](#the_hidden_until_found_state) state:
 
 ```html
 <span hidden="until-found">I'm hidden until found</span>
@@ -60,24 +60,29 @@ Aside from the _hidden_ state, the keyword `until-found` sets the element to the
 
 The _hidden_ state indicates that the element is not currently relevant to the page, or that it is being used to declare content for reuse by other parts of the page and should not be directly presented to the user. The browser will not render elements that are in the _hidden_ state.
 
-Web browsers may implement the _hidden_ state using `display: none`, in which case the element will not participate in page layout. This also means that changing the value of the CSS {{cssxref("display")}} property on an element in the _hidden_ state will override the state. For instance, elements styled `display: block` will be displayed despite the `hidden` attribute's presence.
+Web browsers may implement the _hidden_ state using `display: none`, in which case the element will not participate in page layout.
+Additionally, changing the value of the CSS {{cssxref("display")}} property on a hidden element will override the _hidden_ state.
+For instance, elements styled `display: block` will be displayed despite the `hidden` attribute's presence.
 
 ### The hidden until found state
 
-In the _hidden until found_ state, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation. When these features cause a scroll to an element in a _hidden until found_ subtree, the browser will:
+In the _hidden until found_ state, the element is hidden but its content will be accessible to the browser's "find in page" feature or to fragment navigation.
+When these features cause a scroll to an element in a _hidden until found_ subtree, the browser will:
 
 - fire a [`beforematch`](/en-US/docs/Web/API/Element/beforematch_event) event on the hidden element
 - remove the `hidden` attribute from the element
 - scroll to the element
 
-This enables a developer to collapse a section of content, but make it searchable and accessible via fragment navigation.
+This enables a developer to collapse a section of content, but make it searchable and accessible through navigation.
 
-Note that browsers typically implement _hidden until found_ using {{cssxref("content-visibility", "content-visibility: hidden")}}. This means that unlike elements in the _hidden_ state, elements in the _hidden until found_ state will have generated boxes, meaning that:
+Browsers typically implement _hidden until found_ using {{cssxref("content-visibility", "content-visibility: hidden")}}.
+This means that, unlike elements in the _hidden_ state, elements in the _hidden until found_ state will have generated boxes, and:
 
 - the element will participate in page layout
 - margin, borders, padding, and background for the element will be rendered.
 
-Also, the element needs to be affected by [layout containment](/en-US/docs/Web/CSS/CSS_containment) in order to be revealed. This means that if the element in the _hidden until found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by find in page or fragment navigation.
+Also, the element needs to be affected by [layout containment](/en-US/docs/Web/CSS/CSS_containment) in order to be revealed.
+If the element in the _hidden until found_ state has a `display` value of `none`, `contents`, or `inline`, then the element will not be revealed by "find in page" or fragment navigation.
 
 ### Usage notes
 
@@ -97,7 +102,7 @@ Elements that are descendants of a hidden element are still active, which means 
 ### Using the hidden attribute
 
 In this example we have three {{HTMLElement("div")}} elements. The first and the third are not hidden, while the second has a `hidden` attribute.
-Note that the element has no generated box.
+Note that the hidden element has no generated box.
 
 ```html
 <div>I'm not hidden</div>


### PR DESCRIPTION
### Description

Taking the chance to refresh pages for `hidden="until-found"` and `beforematch`

### Bugs

- [Implement hidden=until-found attribute and beforematch event](https://bugzilla.mozilla.org/show_bug.cgi?id=1761043)
- [Enable about:config pref 'dom.hidden_until_found.enabled'](https://bugzilla.mozilla.org/show_bug.cgi?id=1955379)

### Related issues and pull requests

- [ ] Parent issue https://github.com/mdn/content/issues/39306
- [x] Relnote https://github.com/mdn/content/pull/39590