### PR TITLE
Remove unnecessary pseudo-namespace declarations.

### DIFF
--- a/files/en-us/web/svg/reference/element/stop/index.md
+++ b/files/en-us/web/svg/reference/element/stop/index.md
@@ -19,10 +19,7 @@ svg {
 ```
 
 ```html
-<svg
-  viewBox="0 0 10 10"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 10 10">
   <defs>
     <linearGradient id="myGradient" gradientTransform="rotate(90)">
       <stop offset="5%" stop-color="gold" />


### PR DESCRIPTION
Given that the example is apparently embedded in HTML5, the `xmlns` attributes are useless.