### PR TITLE
Add machine-translated locales to Localization page

### DIFF
--- a/files/en-us/mdn/community/translated_content/index.md
+++ b/files/en-us/mdn/community/translated_content/index.md
@@ -56,6 +56,22 @@ If you need help or have any questions, feel free to get in touch with one of th
 - Discussions: [Matrix (`#mdn-l10n-es`)](https://chat.mozilla.org/#/room/#mdn-l10n-es:mozilla.org), [Telegram (`MDN l10n ES`)](https://t.me/+Dr6qKQCAepw4MjFj), [Discord (`#spanish`)](/discord)
 - Current maintainers: [JuanVqz](https://github.com/JuanVqz), [davbrito](https://github.com/davbrito), [Graywolf9](https://github.com/Graywolf9), [Vallejoanderson](https://github.com/Vallejoanderson), [marcelozarate](https://github.com/marcelozarate), [Jalkhov](https://github.com/Jalkhov)
 
+## Machine-translated locales
+
+The following experimental locales are machine-translated from the English locale.
+
+### German (`de`)
+
+- Repository: [mdn/translated-content-de](https://github.com/mdn/translated-content-de)
+- Discussions: [Discord (`#german`)](/discord)
+- Current maintainers: [caugner](https://github.com/caugner)
+
+### Italian (`it`)
+
+- Repository: [mdn/translated-content-it](https://github.com/mdn/translated-content-it)
+- Discussions: [Discord (`#italian`)](/discord)
+- Current maintainers: [caugner](https://github.com/caugner)
+
 ## See also
 
 - [MDN localization update, February 2021](https://hacks.mozilla.org/2021/02/mdn-localization-update-february-2021/) — the latest state of localization on MDN


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds a new section "Machine-translated locales" to the "MDN Web Docs localization" page, mention the experimental German and Italian locales.

### Motivation

Make it easier to discover where to discuss these locales, and how to reach out to the maintainers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
