### PR TITLE
fix: missing newline before WebGL2-specific information

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
@@ -23,13 +23,17 @@ bindTexture(target, texture)
 
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target). Possible values:
 
-    - `gl.TEXTURE_2D`: A two-dimensional texture.
-    - `gl.TEXTURE_CUBE_MAP`: A cube-mapped texture.
-      When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
-      the following values are available additionally:
+    - `gl.TEXTURE_2D`
+      - : A two-dimensional texture.
+    - `gl.TEXTURE_CUBE_MAP`
+      - : A cube-mapped texture.
 
-      - `gl.TEXTURE_3D`: A three-dimensional texture.
-      - `gl.TEXTURE_2D_ARRAY`: A two-dimensional array texture.
+    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the following values are available additionally:
+
+    - `gl.TEXTURE_3D`
+      - : A three-dimensional texture.
+    - `gl.TEXTURE_2D_ARRAY`
+      - : A two-dimensional array texture.
 
 - `texture`
   - : A {{domxref("WebGLTexture")}} object to bind.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Refactored the [`bindTexture`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindTexture) docs formatting to properly separate WebGL2–specific texture types and improve consistency with similar pages

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/078ba398-8eb6-4356-943e-a34ae72da21c)|![image](https://github.com/user-attachments/assets/a78ac024-9c2f-419e-9238-0dfc4a8de2d3)|

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Previously, the line about WebGL2 support appeared directly under `gl.TEXTURE_CUBE_MAP`, making it seem like a nested child. This caused confusion and inconsistent presentation. The new formatting:

- Adds a newline before the WebGL2-specific block
- Switches to consistent formatting where descriptions follow a `- :` structure (used across MDN)
- Mirrors the structure of [`bufferData`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bufferData), which handles WebGL2 notes correctly

### Additional details

NA

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

Fixes #39605
