### PR TITLE
Add the default value indicator in prose

### DIFF
--- a/files/en-us/web/css/content-visibility/index.md
+++ b/files/en-us/web/css/content-visibility/index.md
@@ -74,7 +74,7 @@ content-visibility: unset;
 ### Values
 
 - `visible`
-  - : No effect. The element's contents are laid out and rendered as normal.
+  - : No effect. The element's contents are laid out and rendered as normal. This is the default value.
 - `hidden`
   - : The element [skips its contents](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment#skips_its_contents). The skipped contents must not be accessible to user-agent features, such as find-in-page, tab-order navigation, etc., nor be selectable or focusable. This is similar to giving the contents `display: none`.
 - `auto`

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -89,7 +89,7 @@ content: unset;
 
 The value can be:
 
-- One of two keywords — `none` or `normal`.
+- One of two keywords: `none` or `normal`. `normal` is the default property value.
 - `<content-replacement>` when replacing a DOM node. `<content-replacement>` is always an `<image>`.
 - A `<content-list>` when replacing pseudo-elements and margin boxes. A `<content-list>` is a list of one or more anonymous inline boxes appearing in the order specified. Each `<content-list>` item is of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
 - An optional alternative text value of a `<string>` or `<counter>`, preceded by a slash (`/`).
@@ -103,7 +103,7 @@ The keywords and data types mentioned above are described in more detail below:
 
 - `normal`
 
-  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to the element's descendants.
+  - : For the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements, this value computes to `none` . For other pseudo-elements such as {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}, it produces the element's initial (or normal) content. For regular elements or page margin boxes, it computes to the element's descendants. `normal` is the default value for the `content` property.
 
 - {{cssxref("&lt;string&gt;")}}
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -103,7 +103,7 @@ The keywords and data types mentioned above are described in more detail below:
 
 - `normal`
 
-  - : For the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements, this value computes to `none` . For other pseudo-elements such as {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}, it produces the element's initial (or normal) content. For regular elements or page margin boxes, it computes to the element's descendants. `normal` is the default value for the `content` property.
+  - : For the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements, this value computes to `none` . For other pseudo-elements such as {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}, it produces the element's initial (or normal) content. For regular elements or page margin boxes, it computes to the element's descendants. This is the default value.
 
 - {{cssxref("&lt;string&gt;")}}
 

--- a/files/en-us/web/css/forced-color-adjust/index.md
+++ b/files/en-us/web/css/forced-color-adjust/index.md
@@ -29,7 +29,7 @@ The `forced-color-adjust` property's value must be one of the following keywords
 ### Values
 
 - `auto`
-  - : The element's colors are adjusted by the {{Glossary("user agent")}} in forced colors mode. This is the default.
+  - : The element's colors are adjusted by the {{Glossary("user agent")}} in forced colors mode. This is the default value.
 - `none`
   - : The element's colors are not automatically adjusted by the {{Glossary("user agent")}} in forced colors mode.
 - `preserve-parent-color`

--- a/files/en-us/web/css/grid-column-end/index.md
+++ b/files/en-us/web/css/grid-column-end/index.md
@@ -90,7 +90,7 @@ grid-column-end: unset;
   - : Contributes nothing to the grid item's placement, indicating auto-placement, an automatic span, or a default span of `1`. This is the default value.
 - `<custom-ident>`
 
-  - : Contributes the first line to the grid item's placement if there is a named line with the name '\<custom-ident>-end'.
+  - : Contributes the first line to the grid item's placement if there is a named line with the name `<custom-ident>-end`.
 
     > [!NOTE]
     > Named grid areas automatically generate implicit named lines of this form, so specifying `grid-column-end: foo;` will choose the end edge of that named grid area (unless another line named `foo-end` was explicitly specified before it).

--- a/files/en-us/web/css/grid-column-end/index.md
+++ b/files/en-us/web/css/grid-column-end/index.md
@@ -87,10 +87,10 @@ grid-column-end: unset;
 ### Values
 
 - `auto`
-  - : Is a keyword indicating that the property contributes nothing to the grid item's placement, indicating auto-placement, an automatic span, or a default span of `1`.
+  - : Contributes nothing to the grid item's placement, indicating auto-placement, an automatic span, or a default span of `1`. This is the default value.
 - `<custom-ident>`
 
-  - : If there is a named line with the name '\<custom-ident>-end', it contributes the first such line to the grid item's placement.
+  - : Contributes the first line to the grid item's placement if there is a named line with the name '\<custom-ident>-end'.
 
     > [!NOTE]
     > Named grid areas automatically generate implicit named lines of this form, so specifying `grid-column-end: foo;` will choose the end edge of that named grid area (unless another line named `foo-end` was explicitly specified before it).

--- a/files/en-us/web/css/grid-template/index.md
+++ b/files/en-us/web/css/grid-template/index.md
@@ -114,7 +114,7 @@ grid-template: unset;
 ### Values
 
 - `none`
-  - : Is a keyword that sets all three longhand properties to `none`, meaning there is no explicit grid. There are no named grid areas. Rows and columns will be implicitly generated; their size will be determined by the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties.
+  - : Sets all three longhand properties to `none`, meaning there is no explicit grid. There are no named grid areas. Rows and columns will be implicitly generated; their size will be determined by the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties. This is the default value.
 - `<'grid-template-rows'> / <'grid-template-columns'>`
   - : Sets {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} to the specified values, and sets {{cssxref("grid-template-areas")}} to `none`.
 - `[ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?`


### PR DESCRIPTION


### Description

As pointed out by @caugner, the [content-visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility#values) property page doesn't explicitly mention in prose what the default value is. This PR adds that sentence.

I looked at a few more pages randomly and added the similar "default value" statement in the "Values" section.

### Motivation

To provide default value info alongside the value's description in addition to the info being present in the Formal definition section.

