### PR TITLE
FF140 TaskSignal.any() - added to expr feat

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1921,8 +1921,7 @@ See [Firefox bug 1697647](https://bugzil.la/1697647) for more details.
 ### Prioritized Task Scheduling API
 
 The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third-party libraries and frameworks.
-Support for most of the API was added behind a preference in Firefox version 101.
-Firefox version 139 adds support for {{domxref("scheduler.yield()")}} and enables the API in the Nightly release.
+From Firefox version 140 the API is both feature complete and enabled in the Nightly release.
 ([Firefox bug 1734997](https://bugzil.la/1734997) and [Firefox bug 1920115](https://bugzil.la/1920115)).
 
 <table>

--- a/files/en-us/web/api/tasksignal/any_static/index.md
+++ b/files/en-us/web/api/tasksignal/any_static/index.md
@@ -29,7 +29,7 @@ TaskSignal.any(signals, init)
   - : Contains optional configuration parameters. Currently only one property is defined:
     - `priority` {{optional_inline}}
       - : One of the following:
-        - A string which is one of `user-blocking`, `user-visible` and `background`.
+        - A [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) string which is one of `user-blocking`, `user-visible` and `background`.
         - A {{domxref("TaskSignal")}}.
 
 ### Return value
@@ -41,7 +41,7 @@ A `TaskSignal` instance. It will be aborted when the first signal passed into `s
 - Its {{domxref("TaskSignal.priority", "priority")}} property will be determined by the `priority` parameter:
 
   - If the `priority` parameter was a string, it will be the value of the string.
-  - If the `priority` parameter was a `TaskSignal`, it will be the value of that signal's `priority`.
+  - If the `priority` parameter was a `TaskSignal`, it will be the value of that signal's {{domxref("TaskSignal/priority","priority")}}.
 
 ## Examples
 


### PR DESCRIPTION
FF140 supports [`TaskSignal.any()`](https://developer.mozilla.org/en-US/docs/Web/API/TaskSignal/any_static) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1964407

This adds a minor tweak to the docs to link to priority definitions. It also updates the experimental features to note that in FF140 the API is feature complete.

Related work can be tracked in #39627