### PR TITLE
FF140 Relnote - TaskSignal.any()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -72,6 +72,12 @@ These features are shipping in Firefox 140 but are disabled by default. To exper
   The [`Notification.maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) read-only static property returns the browser limit on the number of actions that can be associated with a `Notification`, which you create using {{domxref("ServiceWorkerRegistration.showNotification()")}}.
   This was released prematurely in Firefox version 138, and this change makes it available only in the Nightly build. ([Firefox bug 1963263](https://bugzil.la/1963263)).
 
+- **Prioritized Task Scheduling API** (Nightly release).
+  The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third-party libraries and frameworks.
+  This adds support for the [`TaskSignal.any()`](/en-US/docs/Web/API/TaskSignal/any_static) static method, which returns a signal that is triggered when any of the `TaskSignal` objects it is created from are triggered.
+  The API is now feature complete.
+  ([Firefox bug 1964407](https://bugzil.la/1964407)).
+
 ## Older versions
 
 {{Firefox_for_developers}}


### PR DESCRIPTION
FF140 supports [`TaskSignal.any()`](https://developer.mozilla.org/en-US/docs/Web/API/TaskSignal/any_static) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1964407

This adds a release note entry (in the experimental section)

Related work can be tracked in #39627