### PR TITLE
FF140 Relnote: Serializes < and > in attributes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -37,6 +37,11 @@ This article provides information about the changes in Firefox 140 that affect d
 
 ### APIs
 
+### Escape < and > in attributes when serializing HTML
+
+- {{domxref("Element.innerHTML")}}, {{domxref("Element.outerHTML")}}, {{domxref("Element.getHTML()")}}, {{domxref("ShadowRoot.innerHTML")}}, and {{domxref("ShadowRoot.getHTML()")}} now replace the `<` and `>` characters with `&lt;` and `&gt;` (respectively) when serializing the HTML to a string. This prevents certain exploits where HTML is serialized and then injected back into the DOM.
+  ([Firefox bug 1962084](https://bugzil.la/1962084)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF140 ships support for escaping `<` and `>` to `&lt;` and `&gt;` in attributes when serializing HTML in https://bugzilla.mozilla.org/show_bug.cgi?id=1962084. This affects all the obvious methods like innerHTML, outerHTML, getHTML.

This adds a release note for the feature.

Related docs work can be tracked in #39628
