### PR TITLE
FF140 Relnote: Notification.maxActions unpublished to nightly

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1263,11 +1263,11 @@ The non-standard events [`beforescriptexecute`](/en-US/docs/Web/API/Document/bef
   </tbody>
 </table>
 
-### Notification.actions
+### Notification actions and maxActions properties
 
-The {{domxref("Notification.actions","actions")}} read-only property of the {{domxref("Notification")}} interface is supported in Nightly.
-This contains notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}}.
-([Firefox bug 1225110](https://bugzil.la/1225110)).
+The {{domxref("Notification/actions","actions")}} read-only property and the [`maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static read-only property of the {{domxref("Notification")}} interface are supported in Nightly on desktop.
+These contain the notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}}, and the maximum number of actions that can be set, respectively.
+([Firefox bug 1225110](https://bugzil.la/1225110), [Firefox bug 1963263](https://bugzil.la/1963263)).
 
 <table>
   <thead>
@@ -1281,6 +1281,7 @@ This contains notification actions set with {{domxref("ServiceWorkerRegistration
     <tr>
       <th>Nightly</th>
       <td>138</td>
+      <td>Yes (desktop only)</td>
     </tr>
     <tr>
       <th>Developer Edition</th>

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -69,8 +69,8 @@ These features are shipping in Firefox 140 but are disabled by default. To exper
 
 - **`Notification.maxActions`** (Nightly): `dom.webnotifications.actions.enabled`
 
-  The [`Notification.maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static property returns the maximum number of actions that can be associated with a `Notification`, as set using {{domxref("ServiceWorkerRegistration.showNotification()")}}.
-  This was prematurely released in Firefox version 138, and this change makes it available only in the Nightly build ([Firefox bug 1963263](https://bugzil.la/1963263)).
+  The [`Notification.maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) read-only static property returns the browser limit on the number of actions that can be associated with a `Notification`, which you create using {{domxref("ServiceWorkerRegistration.showNotification()")}}.
+  This was released prematurely in Firefox version 138, and this change makes it available only in the Nightly build. ([Firefox bug 1963263](https://bugzil.la/1963263)).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -67,6 +67,11 @@ This article provides information about the changes in Firefox 140 that affect d
 
 These features are shipping in Firefox 140 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **`Notification.maxActions`** (Nightly): `dom.webnotifications.actions.enabled`
+
+  The [`Notification.maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static property returns the maximum number of actions that can be associated with a `Notification`, as set using {{domxref("ServiceWorkerRegistration.showNotification()")}}.
+  This was prematurely released in Firefox version 138, and this change makes it available only in the Nightly build ([Firefox bug 1963263](https://bugzil.la/1963263)).
+
 ## Older versions
 
 {{Firefox_for_developers}}


### PR DESCRIPTION
FF140 puts [`Notification.maxActions`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/maxActions_static) behind the pref `dom.webnotifications.actions.enabled` which is enabled in nightly - it was previously released in FF138.

This adds a note to the release note, which is in the experimental features section.

Related docs work can be tracked in #39620
