### PR TITLE
Lint: remove unnecessary if/else/return

### DIFF
--- a/files/en-us/glossary/recursion/index.md
+++ b/files/en-us/glossary/recursion/index.md
@@ -25,6 +25,7 @@ recurse(10)
 
 The output will look like this:
 
+```plain
 10
 9
 8
@@ -35,6 +36,7 @@ The output will look like this:
 3
 2
 1
+```
 
 ### Recursion is limited by stack size
 
@@ -58,9 +60,8 @@ console.log(getMaxCallStackSize(0));
 const factorial = (n) => {
   if (n === 0) {
     return 1;
-  } else {
-    return n * factorial(n - 1);
   }
+  return n * factorial(n - 1);
 };
 console.log(factorial(10));
 // 3628800

--- a/files/en-us/learn_web_development/core/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/wai-aria_basics/index.md
@@ -1101,9 +1101,7 @@ class TabsManual {
       tab.addEventListener("keydown", this.onKeydown.bind(this));
       tab.addEventListener("click", this.onClick.bind(this));
 
-      if (!this.firstTab) {
-        this.firstTab = tab;
-      }
+      this.firstTab ??= tab;
       this.lastTab = tab;
     }
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_author_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_author_form/index.md
@@ -80,14 +80,13 @@ exports.author_create_post = [
         errors: errors.array(),
       });
       return;
-    } else {
-      // Data from form is valid.
-
-      // Save author.
-      await author.save();
-      // Redirect to new author record.
-      res.redirect(author.url);
     }
+    // Data from form is valid.
+
+    // Save author.
+    await author.save();
+    // Redirect to new author record.
+    res.redirect(author.url);
   }),
 ];
 ```

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_bookinstance_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_bookinstance_form/index.md
@@ -87,11 +87,10 @@ exports.bookinstance_create_post = [
         bookinstance: bookInstance,
       });
       return;
-    } else {
-      // Data from form is valid
-      await bookInstance.save();
-      res.redirect(bookInstance.url);
     }
+    // Data from form is valid
+    await bookInstance.save();
+    res.redirect(bookInstance.url);
   }),
 ];
 ```

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -63,20 +63,19 @@ exports.genre_create_post = [
         errors: errors.array(),
       });
       return;
+    }
+    // Data from form is valid.
+    // Check if Genre with same name already exists.
+    const genreExists = await Genre.findOne({ name: req.body.name })
+      .collation({ locale: "en", strength: 2 })
+      .exec();
+    if (genreExists) {
+      // Genre exists, redirect to its detail page.
+      res.redirect(genreExists.url);
     } else {
-      // Data from form is valid.
-      // Check if Genre with same name already exists.
-      const genreExists = await Genre.findOne({ name: req.body.name })
-        .collation({ locale: "en", strength: 2 })
-        .exec();
-      if (genreExists) {
-        // Genre exists, redirect to its detail page.
-        res.redirect(genreExists.url);
-      } else {
-        await genre.save();
-        // New genre saved. Redirect to genre detail page.
-        res.redirect(genre.url);
-      }
+      await genre.save();
+      // New genre saved. Redirect to genre detail page.
+      res.redirect(genre.url);
     }
   }),
 ];
@@ -120,10 +119,9 @@ asyncHandler(async (req, res, next) => {
       errors: errors.array(),
     });
     return;
-  } else {
-    // Data from form is valid.
-    // …
   }
+  // Data from form is valid.
+  // …
 });
 ```
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -73,11 +73,10 @@ exports.author_delete_post = asyncHandler(async (req, res, next) => {
       author_books: allBooksByAuthor,
     });
     return;
-  } else {
-    // Author has no books. Delete object and redirect to the list of authors.
-    await Author.findByIdAndDelete(req.body.authorid);
-    res.redirect("/catalog/authors");
   }
+  // Author has no books. Delete object and redirect to the list of authors.
+  await Author.findByIdAndDelete(req.body.authorid);
+  res.redirect("/catalog/authors");
 });
 ```
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/update_book_form/index.md
@@ -122,12 +122,11 @@ exports.book_update_post = [
         errors: errors.array(),
       });
       return;
-    } else {
-      // Data from form is valid. Update the record.
-      const updatedBook = await Book.findByIdAndUpdate(req.params.id, book, {});
-      // Redirect to book detail page.
-      res.redirect(updatedBook.url);
     }
+    // Data from form is valid. Update the record.
+    const updatedBook = await Book.findByIdAndUpdate(req.params.id, book, {});
+    // Redirect to book detail page.
+    res.redirect(updatedBook.url);
   }),
 ];
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -304,13 +304,12 @@ function provideCredentialsAsync(requestDetails) {
   if (pendingRequests.includes(requestDetails.requestId)) {
     console.log(`bad credentials for: ${requestDetails.requestId}`);
     return { cancel: true };
-  } else {
-    pendingRequests.push(requestDetails.requestId);
-    console.log(`providing credentials for: ${requestDetails.requestId}`);
-    // we can return a promise that will be resolved
-    // with the stored credentials
-    return browser.storage.local.get(null);
   }
+  pendingRequests.push(requestDetails.requestId);
+  console.log(`providing credentials for: ${requestDetails.requestId}`);
+  // we can return a promise that will be resolved
+  // with the stored credentials
+  return browser.storage.local.get(null);
 }
 
 browser.webRequest.onAuthRequired.addListener(

--- a/files/en-us/web/accessibility/aria/reference/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/checkbox_role/index.md
@@ -139,7 +139,8 @@ function changeCheckbox(code) {
 
   if (code && code !== "Space") {
     return;
-  } else if (checked === "true") {
+  }
+  if (checked === "true") {
     item.setAttribute("aria-checked", "false");
   } else {
     item.setAttribute("aria-checked", "true");

--- a/files/en-us/web/accessibility/aria/reference/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/grid_role/index.md
@@ -257,16 +257,15 @@ function moveTo(newRow, newCol) {
   const tgt = document.querySelector(
     `[data-row="${newRow}"][data-col="${newCol}"]`,
   );
-  if (tgt?.getAttribute("role") === "gridcell") {
-    document.querySelectorAll("[role=gridcell]").forEach((el) => {
-      el.setAttribute("tabindex", "-1");
-    });
-    tgt.setAttribute("tabindex", "0");
-    tgt.focus();
-    return true;
-  } else {
+  if (tgt?.getAttribute("role") !== "gridcell") {
     return false;
   }
+  document.querySelectorAll("[role=gridcell]").forEach((el) => {
+    el.setAttribute("tabindex", "-1");
+  });
+  tgt.setAttribute("tabindex", "0");
+  tgt.focus();
+  return true;
 }
 
 document.querySelector("table").addEventListener("keydown", (event) => {

--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
@@ -58,9 +58,7 @@ You can see full code of this [example at output-timestamp](https://github.com/m
 // Press the play button
 playBtn.addEventListener("click", () => {
   // We can create the audioCtx as there has been some user action
-  if (!audioCtx) {
-    audioCtx = new AudioContext();
-  }
+  audioCtx ??= new AudioContext();
   source = new AudioBufferSourceNode(audioCtx);
   getData();
   source.start(0);

--- a/files/en-us/web/api/background_tasks_api/index.md
+++ b/files/en-us/web/api/background_tasks_api/index.md
@@ -196,26 +196,22 @@ Finally, we set up a couple of variables for other items:
 - `statusRefreshScheduled` is used to track whether or not we've already scheduled an update of the status display box for the upcoming frame, so that we only do it once per frame
 
 ```js hidden
-requestIdleCallback =
-  requestIdleCallback ||
-  ((handler) => {
-    const startTime = Date.now();
+window.requestIdleCallback ||= (handler) => {
+  const startTime = Date.now();
 
-    return setTimeout(() => {
-      handler({
-        didTimeout: false,
-        timeRemaining() {
-          return Math.max(0, 50.0 - (Date.now() - startTime));
-        },
-      });
-    }, 1);
-  });
+  return setTimeout(() => {
+    handler({
+      didTimeout: false,
+      timeRemaining() {
+        return Math.max(0, 50.0 - (Date.now() - startTime));
+      },
+    });
+  }, 1);
+};
 
-cancelIdleCallback =
-  cancelIdleCallback ||
-  ((id) => {
-    clearTimeout(id);
-  });
+window.cancelIdleCallback ||= (id) => {
+  clearTimeout(id);
+};
 ```
 
 #### Managing the task queue
@@ -235,9 +231,7 @@ function enqueueTask(taskHandler, taskData) {
 
   totalTaskCount++;
 
-  if (!taskHandle) {
-    taskHandle = requestIdleCallback(runTaskQueue, { timeout: 1000 });
-  }
+  taskHandle ||= requestIdleCallback(runTaskQueue, { timeout: 1000 });
 
   scheduleStatusRefresh();
 }
@@ -358,10 +352,7 @@ The `log()` function adds the specified text to the log. Since we don't know at 
 
 ```js
 function log(text) {
-  if (!logFragment) {
-    logFragment = document.createDocumentFragment();
-  }
-
+  logFragment ??= document.createDocumentFragment();
   const el = document.createElement("div");
   el.textContent = text;
   logFragment.appendChild(el);

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -78,21 +78,20 @@ self.addEventListener("fetch", (event) => {
       // but in case of success response will have value
       if (response !== undefined) {
         return response;
-      } else {
-        return fetch(event.request)
-          .then((response) => {
-            // response may be used only once
-            // we need to save clone to put one copy in cache
-            // and serve second one
-            let responseClone = response.clone();
-
-            caches
-              .open("v1")
-              .then((cache) => cache.put(event.request, responseClone));
-            return response;
-          })
-          .catch(() => caches.match("/gallery/myLittleVader.jpg"));
       }
+      return fetch(event.request)
+        .then((response) => {
+          // response may be used only once
+          // we need to save clone to put one copy in cache
+          // and serve second one
+          let responseClone = response.clone();
+
+          caches
+            .open("v1")
+            .then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match("/gallery/myLittleVader.jpg"));
     }),
   );
 });

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -84,21 +84,20 @@ self.addEventListener("fetch", (event) => {
       // but in case of success response will have value
       if (response !== undefined) {
         return response;
-      } else {
-        return fetch(event.request)
-          .then((response) => {
-            // response may be used only once
-            // we need to save clone to put one copy in cache
-            // and serve second one
-            let responseClone = response.clone();
-
-            caches
-              .open("v1")
-              .then((cache) => cache.put(event.request, responseClone));
-            return response;
-          })
-          .catch(() => caches.match("/gallery/myLittleVader.jpg"));
       }
+      return fetch(event.request)
+        .then((response) => {
+          // response may be used only once
+          // we need to save clone to put one copy in cache
+          // and serve second one
+          let responseClone = response.clone();
+
+          caches
+            .open("v1")
+            .then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match("/gallery/myLittleVader.jpg"));
     }),
   );
 });

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -193,7 +193,6 @@ window.onload = () => {
   lightMix();
   colorSphere();
   runComposite();
-  return;
 };
 ```
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -83,18 +83,14 @@ function putImageData(
   imageData,
   dx,
   dy,
-  dirtyX,
-  dirtyY,
-  dirtyWidth,
-  dirtyHeight,
+  dirtyX = 0,
+  dirtyY = 0,
+  dirtyWidth = imageData.width,
+  dirtyHeight = imageData.height,
 ) {
   const data = imageData.data;
   const height = imageData.height;
   const width = imageData.width;
-  dirtyX = dirtyX || 0;
-  dirtyY = dirtyY || 0;
-  dirtyWidth = dirtyWidth !== undefined ? dirtyWidth : width;
-  dirtyHeight = dirtyHeight !== undefined ? dirtyHeight : height;
   const limitBottom = dirtyY + dirtyHeight;
   const limitRight = dirtyX + dirtyWidth;
   for (let y = dirtyY; y < limitBottom; y++) {

--- a/files/en-us/web/api/clients/index.md
+++ b/files/en-us/web/api/clients/index.md
@@ -48,9 +48,7 @@ addEventListener("notificationclick", (event) => {
 
       // If we didn't find an existing chat window,
       // open a new one:
-      if (!chatClient) {
-        chatClient = await clients.openWindow("/chat/");
-      }
+      chatClient ??= await clients.openWindow("/chat/");
 
       // Message the client:
       chatClient.postMessage("New chat messages!");

--- a/files/en-us/web/api/history/scrollrestoration/index.md
+++ b/files/en-us/web/api/history/scrollrestoration/index.md
@@ -38,9 +38,7 @@ if (scrollRestoration === "manual") {
 ### Prevent automatic page location restoration
 
 ```js
-if (history.scrollRestoration) {
-  history.scrollRestoration = "manual";
-}
+history.scrollRestoration = "manual";
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlelement/draggable/index.md
+++ b/files/en-us/web/api/htmlelement/draggable/index.md
@@ -25,14 +25,10 @@ const draggableElement = document.querySelector(".draggable-element");
 const notDraggableElement = document.querySelector(".not-draggable-element");
 
 // enable the target element's ability to drag
-if (!draggableElement.draggable) {
-  draggableElement.draggable = true;
-}
+draggableElement.draggable = true;
 
 // disable the target element's ability to drag
-if (notDraggableElement.draggable) {
-  notDraggableElement.draggable = false;
-}
+notDraggableElement.draggable = false;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
@@ -580,7 +580,6 @@ openReq.onupgradeneeded = (event) => {
 openReq.onsuccess = (event) => {
   const db = event.target.result;
   useDatabase(db);
-  return;
 };
 
 function useDatabase(db) {

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -211,7 +211,9 @@ startButton.addEventListener(
         downloadButton.href = stream;
         preview.captureStream =
           preview.captureStream || preview.mozCaptureStream;
-        return new Promise((resolve) => (preview.onplaying = resolve));
+        return new Promise((resolve) => {
+          preview.onplaying = resolve;
+        });
       })
       .then(() => startRecording(preview.captureStream(), recordingTimeMS))
       .then((recordedChunks) => {

--- a/files/en-us/web/api/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/index.md
@@ -33,7 +33,9 @@ const stream = await navigator.mediaDevices.getUserMedia({ video: true });
 const [track] = stream.getVideoTracks();
 const worker = new Worker("worker.js");
 worker.postMessage({ track }, [track]);
-const { data } = await new Promise((r) => (worker.onmessage = r));
+const { data } = await new Promise((r) => {
+  worker.onmessage = r;
+});
 video.srcObject = new MediaStream([data.track]);
 ```
 

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.md
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.md
@@ -48,7 +48,7 @@ self.addEventListener("paymentrequest", async (e) => {
     client = await e.openWindow(checkoutURL);
     if (!client) {
       // Reject if the window fails to open
-      throw "Failed to open window";
+      throw new Error("Failed to open window");
     }
   } catch (err) {
     // Reject the promise on failure

--- a/files/en-us/web/api/pointer_lock_api/index.md
+++ b/files/en-us/web/api/pointer_lock_api/index.md
@@ -221,12 +221,10 @@ function updatePosition(e) {
   }
   tracker.textContent = `X position: ${x}, Y position: ${y}`;
 
-  if (!animation) {
-    animation = requestAnimationFrame(() => {
-      animation = null;
-      canvasDraw();
-    });
-  }
+  animation ??= requestAnimationFrame(() => {
+    animation = null;
+    canvasDraw();
+  });
 }
 ```
 

--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -189,9 +189,7 @@ class MockHypotheticalSocket {
   }
 
   // Dummy close function
-  close() {
-    return;
-  }
+  close() {}
 
   // Return random number bytes in this call of socket
   getNumberRandomBytesSocket() {

--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -115,11 +115,10 @@ You could then fetch this API request by passing the `Request` object in as a pa
 ```js
 fetch(request)
   .then((response) => {
-    if (response.status === 200) {
-      return response.json();
-    } else {
+    if (response.status !== 200) {
       throw new Error("Something went wrong on API server!");
     }
+    return response.json();
   })
   .then((response) => {
     console.debug(response);

--- a/files/en-us/web/api/request/ishistorynavigation/index.md
+++ b/files/en-us/web/api/request/ishistorynavigation/index.md
@@ -29,17 +29,16 @@ self.addEventListener("request", (event) => {
       caches.match(event.request).then((response) => {
         if (response !== undefined) {
           return response;
-        } else {
-          return fetch(event.request).then((response) => {
-            const responseClone = response.clone();
-
-            caches
-              .open("v1")
-              .then((cache) => cache.put(event.request, responseClone));
-
-            return response;
-          });
         }
+        return fetch(event.request).then((response) => {
+          const responseClone = response.clone();
+
+          caches
+            .open("v1")
+            .then((cache) => cache.put(event.request, responseClone));
+
+          return response;
+        });
       }),
     );
   }

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -190,11 +190,7 @@ async function setVideoParams(sender, height, bitrate) {
   const params = sender.getParameters();
 
   // If encodings is null, create it
-
-  if (!params.encodings) {
-    params.encodings = [{}];
-  }
-
+  params.encodings ??= [{}];
   params.encodings[0].scaleResolutionDownBy = Math.max(scaleRatio, 1);
   params.encodings[0].maxBitrate = bitrate;
   await sender.setParameters(params);

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -137,9 +137,7 @@ class MockHypotheticalSocket {
   }
 
   // Dummy close function
-  close() {
-    return;
-  }
+  close() {}
 
   // Return random number bytes in this call of socket
   getNumberRandomBytesSocket() {
@@ -355,7 +353,9 @@ function readStream(reader) {
         if (bytesReceived > 300 && bytesReceived < 600) {
           logConsumer(`Delaying read to emulate slow stream reading`);
           const delay = (ms) =>
-            new Promise((resolve) => setTimeout(resolve, ms));
+            new Promise((resolve) => {
+              setTimeout(resolve, ms);
+            });
           await delay(1000);
         }
 
@@ -473,9 +473,7 @@ class MockUnderlyingFileHandle {
   }
 
   // Dummy close function
-  close() {
-    return;
-  }
+  close() {}
 
   // Return random character string
   randomChars(length = 8) {
@@ -734,9 +732,7 @@ class MockUnderlyingFileHandle {
   }
 
   // Dummy close function
-  close() {
-    return;
-  }
+  close() {}
 
   // Return random character string
   randomChars(length = 8) {
@@ -974,9 +970,7 @@ class MockUnderlyingFileHandle {
   }
 
   // Dummy close function
-  close() {
-    return;
-  }
+  close() {}
 
   // Return random character string
   randomChars(length = 8) {

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -274,9 +274,7 @@ class MockPushSource {
   }
 
   // Dummy close function
-  close() {
-    return;
-  }
+  close() {}
 
   // Return random character string
   static #randomChars(length = 8) {

--- a/files/en-us/web/api/summarizer/availability_static/index.md
+++ b/files/en-us/web/api/summarizer/availability_static/index.md
@@ -67,27 +67,28 @@ Possible values include:
 ### Basic `availability()` usage
 
 ```js
-const options = {
-  sharedContext: "This is a scientific article",
-  type: "key-points",
-  format: "markdown",
-  length: "medium",
-};
+async function getSummarizer() {
+  const options = {
+    sharedContext: "This is a scientific article",
+    type: "key-points",
+    format: "markdown",
+    length: "medium",
+  };
 
-const availability = await Summarizer.availability(options);
-let summarizer;
-if (availability === "unavailable") {
-  // The Summarizer API isn't usable
-  return;
-} else if (availability === "available") {
-  // The Summarizer API can be used immediately
-  summarizer = await Summarizer.create(options);
-} else {
+  const availability = await Summarizer.availability(options);
+  if (availability === "unavailable") {
+    // The Summarizer API isn't usable
+    return undefined;
+  } else if (availability === "available") {
+    // The Summarizer API can be used immediately
+    return Summarizer.create(options);
+  }
   // The Summarizer API can be used after the model is downloaded
-  summarizer = await Summarizer.create(options);
+  const summarizer = await Summarizer.create(options);
   summarizer.addEventListener("downloadprogress", (e) => {
     console.log(`Downloaded ${e.loaded * 100}%`);
   });
+  return summarizer;
 }
 ```
 

--- a/files/en-us/web/api/summarizer_api/using/index.md
+++ b/files/en-us/web/api/summarizer_api/using/index.md
@@ -292,9 +292,8 @@ async function handleSubmission(e) {
   } else if (formData.get("summaryText").length < 100) {
     summaryOutput.innerHTML = `<span class="error">I'm not trying to summarize something that short!</span>`;
     return;
-  } else {
-    summaryOutput.innerHTML = "";
   }
+  summaryOutput.innerHTML = "";
 
   try {
     const summarizer = await Summarizer.create({

--- a/files/en-us/web/api/videotrackgenerator/index.md
+++ b/files/en-us/web/api/videotrackgenerator/index.md
@@ -34,7 +34,9 @@ const stream = await navigator.mediaDevices.getUserMedia({ video: true });
 const [track] = stream.getVideoTracks();
 const worker = new Worker("worker.js");
 worker.postMessage({ track }, [track]);
-const { data } = await new Promise((r) => (worker.onmessage = r));
+const { data } = await new Promise((r) => {
+  worker.onmessage = r;
+});
 video.srcObject = new MediaStream([data.track]);
 ```
 

--- a/files/en-us/web/api/webglprogram/index.md
+++ b/files/en-us/web/api/webglprogram/index.md
@@ -24,7 +24,7 @@ gl.linkProgram(program);
 
 if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
   const info = gl.getProgramInfoLog(program);
-  throw `Could not compile WebGL program. \n\n${info}`;
+  throw new Error(`Could not compile WebGL program. \n\n${info}`);
 }
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
@@ -39,7 +39,7 @@ gl.linkProgram(program);
 
 if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
   const info = gl.getProgramInfoLog(program);
-  throw `Could not compile WebGL program. \n\n${info}`;
+  throw new Error(`Could not compile WebGL program. \n\n${info}`);
 }
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/createprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createprogram/index.md
@@ -43,7 +43,7 @@ gl.linkProgram(program);
 
 if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
   const info = gl.getProgramInfoLog(program);
-  throw `Could not compile WebGL program. \n\n${info}`;
+  throw new Error(`Could not compile WebGL program. \n\n${info}`);
 }
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
@@ -42,7 +42,7 @@ gl.validateProgram(program);
 
 if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
   const info = gl.getProgramInfoLog(program);
-  throw `Could not compile WebGL program. \n\n${info}`;
+  throw new Error(`Could not compile WebGL program. \n\n${info}`);
 }
 
 gl.useProgram(program);

--- a/files/en-us/web/api/webglshader/index.md
+++ b/files/en-us/web/api/webglshader/index.md
@@ -24,7 +24,7 @@ function createShader(gl, sourceCode, type) {
 
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     const info = gl.getShaderInfoLog(shader);
-    throw `Could not compile WebGL program. \n\n${info}`;
+    throw new Error(`Could not compile WebGL program. \n\n${info}`);
   }
   return shader;
 }

--- a/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_javascript_deno/index.md
+++ b/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_javascript_deno/index.md
@@ -26,28 +26,27 @@ Create a `main.js` file. This file will contain the code for a simple HTTP serve
 Deno.serve({
   port: 80,
   handler: async (request) => {
-    // If the request is a websocket upgrade,
-    // we need to use the Deno.upgradeWebSocket helper
-    if (request.headers.get("upgrade") === "websocket") {
-      const { socket, response } = Deno.upgradeWebSocket(request);
-
-      socket.onopen = () => {
-        console.log("CONNECTED");
-      };
-      socket.onmessage = (event) => {
-        console.log(`RECEIVED: ${event.data}`);
-        socket.send("pong");
-      };
-      socket.onclose = () => console.log("DISCONNECTED");
-      socket.onerror = (error) => console.error("ERROR:", error);
-
-      return response;
-    } else {
+    if (request.headers.get("upgrade") !== "websocket") {
       // If the request is a normal HTTP request,
       // we serve the client HTML file.
       const file = await Deno.open("./index.html", { read: true });
       return new Response(file.readable);
     }
+    // If the request is a websocket upgrade,
+    // we need to use the Deno.upgradeWebSocket helper
+    const { socket, response } = Deno.upgradeWebSocket(request);
+
+    socket.onopen = () => {
+      console.log("CONNECTED");
+    };
+    socket.onmessage = (event) => {
+      console.log(`RECEIVED: ${event.data}`);
+      socket.send("pong");
+    };
+    socket.onclose = () => console.log("DISCONNECTED");
+    socket.onerror = (error) => console.error("ERROR:", error);
+
+    return response;
   },
 });
 ```

--- a/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
+++ b/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
@@ -136,10 +136,7 @@ function myDrawFrame(currentFrameTime, frame) {
   animationFrameRequestID = session.requestAnimationFrame(myDrawFrame);
 
   if (viewerPose) {
-    if (!previousViewerPose) {
-      previousViewerPose = viewerPose;
-    }
-
+    previousViewerPose ??= viewerPose;
     let offsetMatrix = mat4.create();
     mat4.sub(
       offsetMatrix,

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -45,9 +45,8 @@ function getBrowserName(userAgent) {
   } else if (userAgent.includes("Safari")) {
     // "Mozilla/5.0 (iPhone; CPU iPhone OS 15_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Mobile/15E148 Safari/604.1"
     return "Apple Safari";
-  } else {
-    return "unknown";
   }
+  return "unknown";
 }
 
 const browserName = getBrowserName(navigator.userAgent);

--- a/files/en-us/web/api/window/setinterval/index.md
+++ b/files/en-us/web/api/window/setinterval/index.md
@@ -100,9 +100,7 @@ let intervalId;
 
 function changeColor() {
   // check if an interval has already been set up
-  if (!intervalId) {
-    intervalId = setInterval(flashText, 1000);
-  }
+  intervalId ??= setInterval(flashText, 1000);
 }
 
 function flashText() {

--- a/files/en-us/web/css/transform-function/index.md
+++ b/files/en-us/web/css/transform-function/index.md
@@ -247,12 +247,11 @@ const example = document.querySelector("#example-element");
 selectElem.addEventListener("change", () => {
   if (selectElem.value === "Choose a function") {
     return;
-  } else {
-    example.style.transform = `rotate3d(1, 1, 1, 30deg) ${selectElem.value}`;
-    setTimeout(() => {
-      example.style.transform = "rotate3d(1, 1, 1, 30deg)";
-    }, 2000);
   }
+  example.style.transform = `rotate3d(1, 1, 1, 30deg) ${selectElem.value}`;
+  setTimeout(() => {
+    example.style.transform = "rotate3d(1, 1, 1, 30deg)";
+  }, 2000);
 });
 ```
 

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -414,9 +414,8 @@ function returnFileSize(number) {
     return `${number} bytes`;
   } else if (number >= 1e3 && number < 1e6) {
     return `${(number / 1e3).toFixed(1)} KB`;
-  } else {
-    return `${(number / 1e6).toFixed(1)} MB`;
   }
+  return `${(number / 1e6).toFixed(1)} MB`;
 }
 ```
 

--- a/files/en-us/web/http/guides/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/guides/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -548,9 +548,8 @@ All hosts which aren't fully qualified, or the ones that are in local domain, wi
 function FindProxyForURL(url, host) {
   if (isPlainHostName(host) || dnsDomainIs(host, ".mozilla.org")) {
     return "DIRECT";
-  } else {
-    return "PROXY w3proxy.mozilla.org:8080; DIRECT";
   }
+  return "PROXY w3proxy.mozilla.org:8080; DIRECT";
 }
 ```
 
@@ -571,9 +570,8 @@ function FindProxyForURL(url, host) {
     !localHostOrDomainIs(host, "merchant.mozilla.org")
   ) {
     return "DIRECT";
-  } else {
-    return "PROXY w3proxy.mozilla.org:8080; DIRECT";
   }
+  return "PROXY w3proxy.mozilla.org:8080; DIRECT";
 }
 ```
 
@@ -637,9 +635,8 @@ function FindProxyForURL(url, host) {
     isInNet(host, "192.0.2.0", "255.255.0.0")
   ) {
     return "DIRECT";
-  } else {
-    return "PROXY proxy.mydomain.com:8080";
   }
+  return "PROXY proxy.mydomain.com:8080";
 }
 ```
 
@@ -666,9 +663,8 @@ function FindProxyForURL(url, host) {
     return "PROXY proxy1.mydomain.com:8080; PROXY proxy4.mydomain.com:8080";
   } else if (shExpMatch(host, "*.edu")) {
     return "PROXY proxy2.mydomain.com:8080; PROXY proxy4.mydomain.com:8080";
-  } else {
-    return "PROXY proxy3.mydomain.com:8080; PROXY proxy4.mydomain.com:8080";
   }
+  return "PROXY proxy3.mydomain.com:8080; PROXY proxy4.mydomain.com:8080";
 }
 ```
 

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -333,18 +333,18 @@ function. If the value does not correspond to a month number
 `'InvalidMonthNo'` and the statements in the `catch` block set the
 `monthName` variable to `'unknown'`.
 
-```js-nolint
+```js
 function getMonthName(mo) {
   mo--; // Adjust month number for array index (so that 0 = Jan, 11 = Dec)
+  // prettier-ignore
   const months = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
   ];
-  if (months[mo]) {
-    return months[mo];
-  } else {
-    throw new Error("InvalidMonthNo"); // throw keyword is used here
+  if (!months[mo]) {
+    throw new Error("Invalid month code"); // throw keyword is used here
   }
+  return months[mo];
 }
 
 try {
@@ -520,9 +520,8 @@ For example:
 function doSomethingErrorProne() {
   if (ourCodeMakesAMistake()) {
     throw new Error("The message");
-  } else {
-    doSomethingToGetAJavaScriptError();
   }
+  doSomethingToGetAJavaScriptError();
 }
 
 try {

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -156,9 +156,8 @@ A function can call itself. For example, here is a function that computes factor
 function factorial(n) {
   if (n === 0 || n === 1) {
     return 1;
-  } else {
-    return n * factorial(n - 1);
   }
+  return n * factorial(n - 1);
 }
 ```
 

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -105,14 +105,14 @@ Normally, the `catch` block of a [`try...catch`](/en-US/docs/Web/JavaScript/Refe
 ```js
 var a = 2;
 try {
-  throw 42;
+  throw new Error();
 } catch (a) {
   var a = 1; // This 1 is assigned to the caught `a`, not the outer `a`.
 }
 console.log(a); // 2
 
 try {
-  throw 42;
+  throw new Error();
   // Note: identifier changed to `err` to avoid conflict with
   // the inner declaration of `a`.
 } catch (err) {

--- a/files/en-us/web/javascript/reference/errors/constructor_cant_be_used_directly/index.md
+++ b/files/en-us/web/javascript/reference/errors/constructor_cant_be_used_directly/index.md
@@ -49,11 +49,10 @@ class MyIterator extends Iterator {
     this.#end = end;
   }
   next() {
-    if (this.#step < this.#end) {
-      return { value: this.#step++, done: false };
-    } else {
+    if (this.#step >= this.#end) {
       return { done: true };
     }
+    return { value: this.#step++, done: false };
   }
 }
 

--- a/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -43,9 +43,8 @@ are deprecated (see the reference articles for more information).
 function myFunc() {
   if (myFunc.caller === null) {
     return "The function was called from the top!";
-  } else {
-    return `This function's caller was ${myFunc.caller}`;
   }
+  return `This function's caller was ${myFunc.caller}`;
 }
 
 myFunc();

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -301,13 +301,12 @@ const current = Object.prototype.valueOf;
 Object.prototype.valueOf = function (...args) {
   if (Object.hasOwn(this, "-prop-value")) {
     return this["-prop-value"];
-  } else {
-    // It doesn't look like one of my objects, so let's fall back on
-    // the default behavior by reproducing the current behavior as best we can.
-    // The apply behaves like "super" in some other languages.
-    // Even though valueOf() doesn't take arguments, some other hook may.
-    return current.apply(this, args);
   }
+  // It doesn't look like one of my objects, so let's fall back on
+  // the default behavior by reproducing the current behavior as best we can.
+  // The apply behaves like "super" in some other languages.
+  // Even though valueOf() doesn't take arguments, some other hook may.
+  return current.apply(this, args);
 };
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
@@ -59,9 +59,9 @@ function sleep(time, value, state) {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       if (state === "fulfill") {
-        return resolve(value);
+        resolve(value);
       } else {
-        return reject(new Error(value));
+        reject(new Error(value));
       }
     }, time);
   });

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -432,11 +432,10 @@ class SimpleClass {
       // Note: using an arrow function allows `this` to point to the
       // one of `[Symbol.iterator]()` instead of `next()`
       next: () => {
-        if (index < this.#data.length) {
-          return { value: this.#data[index++], done: false };
-        } else {
+        if (index >= this.#data.length) {
           return { done: true };
         }
+        return { value: this.#data[index++], done: false };
       },
     };
   }

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -154,9 +154,8 @@ const value = (() => {
   const randomValue = Math.random();
   if (randomValue > 0.5) {
     return "heads";
-  } else {
-    return "tails";
   }
+  return "tails";
 })();
 ```
 

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -163,7 +163,7 @@ When a `catch` block is used, the `catch` block is executed when any exception i
 
 ```js
 try {
-  throw "myException"; // generates an exception
+  throw new Error("My exception"); // generates an exception
 } catch (e) {
   // statements to handle any exceptions
   logMyErrors(e); // pass exception object to error handler

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -190,7 +190,7 @@ A `var` declaration within a `catch` block can have the same name as the `catch`
 
 ```js-nolint example-bad
 try {
-  throw 1;
+  throw new Error();
 } catch (e) {
   var e = 2; // Works
 }

--- a/files/en-us/web/mathml/tutorials/for_beginners/fractions_and_roots/index.md
+++ b/files/en-us/web/mathml/tutorials/for_beginners/fractions_and_roots/index.md
@@ -206,10 +206,9 @@ const comment = document.getElementById("comment");
 const checkboxes = Array.from(options.getElementsByTagName("input"));
 const status = document.getElementById("status");
 function verifyOption(checkbox) {
-  let mathml = checkbox.dataset.highlight;
-  if (mathml) {
-    mathml = document.getElementById(mathml);
-  }
+  const mathml = checkbox.dataset.highlight
+    ? document.getElementById(mathml)
+    : null;
   if (checkbox.checked) {
     comment.textContent = checkbox.dataset.comment;
     if (mathml) {

--- a/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
@@ -90,8 +90,6 @@ const processor = {
       frame.data[i * 4 + 2] = grey;
     }
     this.ctx1.putImageData(frame, 0, 0);
-
-    return;
   },
 };
 ```

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -331,7 +331,6 @@ peerConnection.addEventListener("icegatheringstatechange", (event) => {
     senders.forEach((sender) => {
       if (sender.track.kind === "video") {
         codecList = sender.getParameters().codecs;
-        return;
       }
     });
   }

--- a/files/en-us/web/xml/xpath/guides/snippets/index.md
+++ b/files/en-us/web/xml/xpath/guides/snippets/index.md
@@ -88,12 +88,15 @@ The following is a utility function to get (ordered) XPath results into an array
 // const els = docEvaluateArray('//a');
 // console.log(els[0].nodeName); // gives 'A' in HTML document with at least one link
 
-function docEvaluateArray(expr, doc, context, resolver) {
+function docEvaluateArray(
+  expr,
+  context,
+  doc = context ? context.ownerDocument : document,
+  resolver = null,
+) {
   let i;
   const a = [];
-  doc = doc || (context ? context.ownerDocument : document);
-  resolver = resolver || null;
-  context = context || doc;
+  context ||= doc;
 
   const result = doc.evaluate(
     expr,


### PR DESCRIPTION
It is explicitly written in our style guide that control flow should be concise to avoid unreachable code or unexpected states. This PR fixes reports from several rules:

- `no-else-return`
- `no-useless-return`
- `logical-assignment-operators`
- `no-throw-literal`