### PR TITLE
Lint: use concise assignment operators

### DIFF
--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -215,7 +215,7 @@ function draw() {
     dy = -dy;
   } else if (y + dy > canvas.height - ballRadius) {
     if (x > paddleX && x < paddleX + paddleWidth) {
-      if ((y = y - paddleHeight)) {
+      if ((y -= paddleHeight)) {
         dy = -dy;
       }
     } else {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -258,7 +258,7 @@ function draw() {
     dy = -dy;
   } else if (y + dy > canvas.height - ballRadius) {
     if (x > paddleX && x < paddleX + paddleWidth) {
-      if ((y = y - paddleHeight)) {
+      if ((y -= paddleHeight)) {
         dy = -dy;
       }
     } else {

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -494,10 +494,9 @@ async function* makeTextFileLineIterator(fileURL) {
   const response = await fetch(fileURL);
   const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
 
-  let { value: chunk, done: readerDone } = await reader.read();
-  chunk = chunk || "";
+  let { value: chunk = "", done: readerDone } = await reader.read();
 
-  const newline = /\r?\n/gm;
+  const newline = /\r?\n/g;
   let startIndex = 0;
 
   while (true) {

--- a/files/en-us/web/api/htmltablecellelement/colspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/colspan/index.md
@@ -82,14 +82,14 @@ const increaseButton = document.getElementById("increase");
 const decreaseButton = document.getElementById("decrease");
 
 increaseButton.addEventListener("click", () => {
-  cell.colSpan = cell.colSpan + 1;
+  cell.colSpan += 1;
 
   // Update the display
   output.textContent = cell.colSpan;
 });
 
 decreaseButton.addEventListener("click", () => {
-  cell.colSpan = cell.colSpan - 1;
+  cell.colSpan -= 1;
 
   // Update the display
   output.textContent = cell.colSpan;

--- a/files/en-us/web/api/htmltablecellelement/rowspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/rowspan/index.md
@@ -83,14 +83,14 @@ const increaseButton = document.getElementById("increase");
 const decreaseButton = document.getElementById("decrease");
 
 increaseButton.addEventListener("click", () => {
-  cell.rowSpan = cell.rowSpan + 1;
+  cell.rowSpan += 1;
 
   // Update the display
   output.textContent = cell.rowSpan;
 });
 
 decreaseButton.addEventListener("click", () => {
-  cell.rowSpan = cell.rowSpan - 1;
+  cell.rowSpan -= 1;
 
   // Update the display
   output.textContent = `${cell.rowSpan == 0 ? "all remaining" : cell.rowSpan}`;

--- a/files/en-us/web/api/htmltablecolelement/span/index.md
+++ b/files/en-us/web/api/htmltablecolelement/span/index.md
@@ -86,14 +86,14 @@ const increaseButton = document.getElementById("increase");
 const decreaseButton = document.getElementById("decrease");
 
 increaseButton.addEventListener("click", () => {
-  col.span = col.span + 1;
+  col.span += 1;
 
   // Update the display
   output.textContent = col.span;
 });
 
 decreaseButton.addEventListener("click", () => {
-  col.span = col.span - 1;
+  col.span -= 1;
 
   // Update the display
   output.textContent = col.span;

--- a/files/en-us/web/api/mutationrecord/addednodes/index.md
+++ b/files/en-us/web/api/mutationrecord/addednodes/index.md
@@ -69,7 +69,7 @@ function logNewNodes(records) {
   for (const record of records) {
     // Check if the childlist of the target node has been mutated
     if (record.type === "childList") {
-      totalAddedNodes = totalAddedNodes + record.addedNodes.length;
+      totalAddedNodes += record.addedNodes.length;
       // Log the number of nodes added
       counter.textContent = `Total added nodes: ${totalAddedNodes}`;
     }

--- a/files/en-us/web/api/mutationrecord/removednodes/index.md
+++ b/files/en-us/web/api/mutationrecord/removednodes/index.md
@@ -69,7 +69,7 @@ function logRemovedNodes(records) {
   for (const record of records) {
     // Check if the childlist of the target node has been mutated
     if (record.type === "childList") {
-      totalRemovedNodes = totalRemovedNodes + record.removedNodes.length;
+      totalRemovedNodes += record.removedNodes.length;
       // Log the number of nodes added
       counter.textContent = `Total removed nodes: ${totalRemovedNodes}`;
     }

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -397,22 +397,6 @@ With this table in place, we can find out the frequency for a given note in a pa
 > [!NOTE]
 > The values in the example table above have been rounded to two decimal places.
 
-```js hidden
-if (!Object.entries) {
-  Object.entries = function entries(O) {
-    return reduce(
-      keys(O),
-      (e, k) =>
-        concat(
-          e,
-          typeof k === "string" && isEnumerable(O, k) ? [[k, O[k]]] : [],
-        ),
-      [],
-    );
-  };
-}
-```
-
 ### Building the keyboard
 
 The `setup()` function is responsible for building the keyboard and preparing the app to play music.

--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
@@ -587,7 +587,7 @@ Demo: [Device pixel presnap](https://kdashg.github.io/misc/webgl/device-pixel-pr
 
 ## ResizeObserver and 'device-pixel-content-box'
 
-On supporting browsers (Chromium?), `ResizeObserver` can be used with `'device-pixel-content-box'` to request a callback that includes the true {{glossary("device pixel")}} size of an element. This can be used to build an async-but-accurate function:
+On [supporting browsers](/en-US/docs/Web/API/ResizeObserverEntry/devicePixelContentBoxSize#browser_compatibility), `ResizeObserver` can be used with `'device-pixel-content-box'` to request a callback that includes the true {{glossary("device pixel")}} size of an element. This can be used to build an async-but-accurate function:
 
 ```js
 function getDevicePixelSize(elem) {

--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
@@ -590,27 +590,25 @@ Demo: [Device pixel presnap](https://kdashg.github.io/misc/webgl/device-pixel-pr
 On supporting browsers (Chromium?), `ResizeObserver` can be used with `'device-pixel-content-box'` to request a callback that includes the true {{glossary("device pixel")}} size of an element. This can be used to build an async-but-accurate function:
 
 ```js
-window.getDevicePixelSize =
-  window.getDevicePixelSize ||
-  (async (elem) => {
-    await new Promise((resolve) => {
-      const observer = new ResizeObserver(([cur]) => {
-        if (!cur) {
-          throw new Error(
-            `device-pixel-content-box not observed for elem ${elem}`,
-          );
-        }
-        const devSize = cur.devicePixelContentBoxSize;
-        const ret = {
-          width: devSize[0].inlineSize,
-          height: devSize[0].blockSize,
-        };
-        resolve(ret);
-        observer.disconnect();
-      });
-      observer.observe(elem, { box: "device-pixel-content-box" });
+function getDevicePixelSize(elem) {
+  return new Promise((resolve) => {
+    const observer = new ResizeObserver(([cur]) => {
+      if (!cur) {
+        throw new Error(
+          `device-pixel-content-box not observed for elem ${elem}`,
+        );
+      }
+      const devSize = cur.devicePixelContentBoxSize;
+      const ret = {
+        width: devSize[0].inlineSize,
+        height: devSize[0].blockSize,
+      };
+      resolve(ret);
+      observer.disconnect();
     });
+    observer.observe(elem, { box: "device-pixel-content-box" });
   });
+}
 ```
 
 Please refer to [the specification](https://www.w3.org/TR/resize-observer/#resize-observer-interface) for more details.

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -50,10 +50,10 @@ new ArrayBuffer(Math.pow(2, 32)); // 32-bit system
 new ArrayBuffer(-1);
 
 const a = [];
-a.length = a.length - 1; // set the length property to -1
+a.length -= 1; // set the length property to -1
 
 const b = new Array(Math.pow(2, 32) - 1);
-b.length = b.length + 1; // set the length property to 2^32
+b.length += 1; // set the length property to 2^32
 b.length = 2.5; // set the length property to a floating-point number
 
 const c = new Array(2.5); // pass a floating-point number

--- a/files/en-us/web/javascript/reference/global_objects/asyncgeneratorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgeneratorfunction/index.md
@@ -32,7 +32,7 @@ let str = "";
 
 async function generate() {
   for await (const val of foo()) {
-    str = str + val;
+    str += val;
   }
   console.log(str);
 }

--- a/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
@@ -30,7 +30,7 @@ const foo = new GeneratorFunction(`
 
 let str = "";
 for (const val of foo()) {
-  str = str + val;
+  str += val;
 }
 
 console.log(str);

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -101,29 +101,9 @@ Object.defineProperty(obj, "key2", {
   value: "static",
 });
 
-// 3. Recycling same object
-function withValue(value) {
-  const d =
-    withValue.d ||
-    (withValue.d = {
-      enumerable: false,
-      writable: false,
-      configurable: false,
-      value,
-    });
-
-  // avoiding duplicate operation for assigning value
-  if (d.value !== value) d.value = value;
-
-  return d;
-}
-// and
-Object.defineProperty(obj, "key", withValue("static"));
-
-// if freeze is available, prevents adding or
-// removing the object prototype properties
+// 3. Prevents adding or removing the object prototype properties
 // (value, get, set, enumerable, writable, configurable)
-(Object.freeze || Object)(Object.prototype);
+Object.freeze(Object.prototype);
 ```
 
 When the property already exists, `Object.defineProperty()` attempts to modify the property according to the values in the descriptor and the property's current configuration.

--- a/files/en-us/web/javascript/reference/operators/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/async_function_star_/index.md
@@ -17,7 +17,7 @@ You can also define async generator functions using the [`async function*` decla
 async function joinAll(generator) {
   let str = "";
   for await (const val of generator()) {
-    str = str + val;
+    str += val;
   }
   return str;
 }

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.md
@@ -22,7 +22,7 @@ const foo = function* () {
 
 let str = "";
 for (const val of foo()) {
-  str = str + val;
+  str += val;
 }
 
 console.log(str);

--- a/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
@@ -24,7 +24,7 @@ let str = "";
 
 async function generate() {
   for await (const val of foo()) {
-    str = str + val;
+    str += val;
   }
   console.log(str);
 }

--- a/files/en-us/web/javascript/reference/statements/break/index.md
+++ b/files/en-us/web/javascript/reference/statements/break/index.md
@@ -18,7 +18,7 @@ while (i < 6) {
   if (i === 3) {
     break;
   }
-  i = i + 1;
+  i += 1;
 }
 
 console.log(i);

--- a/files/en-us/web/javascript/reference/statements/continue/index.md
+++ b/files/en-us/web/javascript/reference/statements/continue/index.md
@@ -18,7 +18,7 @@ for (let i = 0; i < 10; i++) {
   if (i === 3) {
     continue;
   }
-  text = text + i;
+  text += i;
 }
 
 console.log(text);

--- a/files/en-us/web/javascript/reference/statements/do...while/index.md
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.md
@@ -16,8 +16,8 @@ let result = "";
 let i = 0;
 
 do {
-  i = i + 1;
-  result = result + i;
+  i += 1;
+  result += i;
 } while (i < 5);
 
 console.log(result);

--- a/files/en-us/web/javascript/reference/statements/for/index.md
+++ b/files/en-us/web/javascript/reference/statements/for/index.md
@@ -15,7 +15,7 @@ The **`for`** statement creates a loop that consists of three optional expressio
 let str = "";
 
 for (let i = 0; i < 9; i++) {
-  str = str + i;
+  str += i;
 }
 
 console.log(str);

--- a/files/en-us/web/javascript/reference/statements/label/index.md
+++ b/files/en-us/web/javascript/reference/statements/label/index.md
@@ -18,7 +18,7 @@ loop1: for (let i = 0; i < 5; i++) {
   if (i === 1) {
     continue loop1;
   }
-  str = str + i;
+  str += i;
 }
 
 console.log(str);


### PR DESCRIPTION
Prefer `a += b` to `a = a + b` for more concise and less bug-prone code.