### PR TITLE
Lint: use parseInt with a radix

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
@@ -50,7 +50,7 @@ document.addEventListener(
       // set the context to "opening a tab context menu".
       browser.menus.overrideContext({
         context: "tab",
-        tabId: parseInt(foo.dataset.tabId),
+        tabId: parseInt(foo.dataset.tabId, 10),
       });
     }
   },

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -349,7 +349,7 @@ can be used to change an underlined element that is in focus.
             return;
           }
           /* Handle non-digits entered by parsing */
-          let value = parseInt(target.textContent);
+          let value = parseInt(target.textContent, 10);
           value = isNaN(value) ? 0 : value;
           textInput.updateFull(value);
           break;

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -551,7 +551,7 @@ registerPaint(
       // the values passed in the paint() function in the CSS
       const color = props.get("--boxColor");
       const strokeType = args[0].toString();
-      const strokeWidth = parseInt(args[1]);
+      const strokeWidth = parseInt(args[1], 10);
 
       // set the stroke width
       ctx.lineWidth = strokeWidth ?? 1.0;

--- a/files/en-us/web/api/htmlanchorelement/search/index.md
+++ b/files/en-us/web/api/htmlanchorelement/search/index.md
@@ -42,7 +42,7 @@ Alternatively, [`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examp
 
 ```js
 let params = new URLSearchParams(queryString);
-let q = parseInt(params.get("q")); // returns the number 123
+let q = parseInt(params.get("q"), 10); // returns the number 123
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlareaelement/search/index.md
+++ b/files/en-us/web/api/htmlareaelement/search/index.md
@@ -42,7 +42,7 @@ Alternatively, [`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examp
 
 ```js
 let params = new URLSearchParams(queryString);
-let q = parseInt(params.get("q")); // returns the number 123
+let q = parseInt(params.get("q"), 10); // returns the number 123
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -59,7 +59,7 @@ for (const prop in elementStyle) {
   // We also ensure that the property is a numeric index (indicating an inline style)
   if (
     Object.hasOwn(elementStyle, prop) &&
-    !Number.isNaN(Number.parseInt(prop))
+    !Number.isNaN(Number.parseInt(prop, 10))
   ) {
     out.textContent += `${
       elementStyle[prop]

--- a/files/en-us/web/api/location/search/index.md
+++ b/files/en-us/web/api/location/search/index.md
@@ -35,7 +35,7 @@ const queryString = anchor.search; // Returns:'?q=123'
 
 // Further parsing:
 const params = new URLSearchParams(queryString);
-const q = parseInt(params.get("q")); // is the number 123
+const q = parseInt(params.get("q"), 10); // is the number 123
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mathmlelement/style/index.md
+++ b/files/en-us/web/api/mathmlelement/style/index.md
@@ -62,7 +62,7 @@ for (const prop in elementStyle) {
   // We also ensure that the property is a numeric index (indicating an inline style)
   if (
     Object.hasOwn(elementStyle, prop) &&
-    !Number.isNaN(Number.parseInt(prop))
+    !Number.isNaN(Number.parseInt(prop, 10))
   ) {
     out.textContent += `${
       elementStyle[prop]

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -66,7 +66,7 @@ for (const prop in elementStyle) {
   // We also ensure that the property is a numeric index (indicating an inline style)
   if (
     Object.hasOwn(elementStyle, prop) &&
-    !Number.isNaN(Number.parseInt(prop))
+    !Number.isNaN(Number.parseInt(prop, 10))
   ) {
     out.textContent += `${
       elementStyle[prop]

--- a/files/en-us/web/api/url/searchparams/index.md
+++ b/files/en-us/web/api/url/searchparams/index.md
@@ -24,7 +24,7 @@ A {{domxref("URLSearchParams")}} object.
 const params = new URL("https://example.com/?name=Jonathan%20Smith&age=18")
   .searchParams;
 const name = params.get("name");
-const age = parseInt(params.get("age"));
+const age = parseInt(params.get("age"), 10);
 
 console.log(`name: ${name}`); // name: Jonathan Smith
 console.log(`age: ${age}`); // age: 18

--- a/files/en-us/web/api/workletsharedstorage/get/index.md
+++ b/files/en-us/web/api/workletsharedstorage/get/index.md
@@ -88,6 +88,7 @@ class KFreqMeasurementOperation {
       (await this.sharedStorage.get(hasReportedContentKey)) === "true";
     const impressionCount = parseInt(
       (await this.sharedStorage.get(impressionCountKey)) || 0,
+      10,
     );
 
     // Do not report if a report has been sent already

--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -607,25 +607,25 @@ const resetInput = (inputEl) => {
 };
 
 const updateOutputs = () => {
-  translateXOutput.value = `${parseInt(translateXRange.value)}px`;
-  translateYOutput.value = `${parseInt(translateYRange.value)}px`;
-  translateZOutput.value = `${parseInt(translateZRange.value)}px`;
+  translateXOutput.value = `${translateXRange.value}px`;
+  translateYOutput.value = `${translateYRange.value}px`;
+  translateZOutput.value = `${translateZRange.value}px`;
 
-  rotateXOutput.value = `${parseInt(rotateXRange.value)}°`;
-  rotateYOutput.value = `${parseInt(rotateYRange.value)}°`;
-  rotateZOutput.value = `${parseInt(rotateZRange.value)}°`;
+  rotateXOutput.value = `${rotateXRange.value}°`;
+  rotateYOutput.value = `${rotateYRange.value}°`;
+  rotateZOutput.value = `${rotateZRange.value}°`;
 
-  scaleXOutput.value = `${parseFloat(scaleXRange.value)}x`;
-  scaleYOutput.value = `${parseFloat(scaleYRange.value)}x`;
-  scaleZOutput.value = `${parseFloat(scaleZRange.value)}x`;
+  scaleXOutput.value = `${scaleXRange.value}x`;
+  scaleYOutput.value = `${scaleYRange.value}x`;
+  scaleZOutput.value = `${scaleZRange.value}x`;
 
-  skewXOutput.value = `${parseFloat(skewXRange.value)}°`;
-  skewYOutput.value = `${parseFloat(skewYRange.value)}°`;
+  skewXOutput.value = `${skewXRange.value}°`;
+  skewYOutput.value = `${skewYRange.value}°`;
 
-  perspectiveOutput.value = `${parseInt(perspectiveRange.value)}px`;
+  perspectiveOutput.value = `${perspectiveRange.value}px`;
 
-  perspectiveOriginXOutput.value = `${parseInt(perspectiveOriginXRange.value)}%`;
-  perspectiveOriginYOutput.value = `${parseInt(perspectiveOriginYRange.value)}%`;
+  perspectiveOriginXOutput.value = `${perspectiveOriginXRange.value}%`;
+  perspectiveOriginYOutput.value = `${perspectiveOriginYRange.value}%`;
 };
 
 const updateTransform = () => {

--- a/files/en-us/web/html/reference/elements/output/index.md
+++ b/files/en-us/web/html/reference/elements/output/index.md
@@ -49,8 +49,8 @@ const b = form.elements["b"];
 const result = form.elements["result"];
 
 function updateResult() {
-  const aValue = parseInt(a.value);
-  const bValue = parseInt(b.value);
+  const aValue = a.valueAsNumber;
+  const bValue = b.valueAsNumber;
   result.value = aValue + bValue;
 }
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -925,7 +925,7 @@ The parentheses are optional.
 Suppose you define the following variables:
 
 ```js
-const myFun = new Function("5 + 2");
+const myFun = () => 5 + 2;
 const shape = "round";
 const size = 1;
 const foo = ["Apple", "Mango", "Orange"];

--- a/files/en-us/web/javascript/reference/regular_expressions/named_capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/named_capturing_group/index.md
@@ -69,7 +69,7 @@ function parseLog(entry) {
     entry,
   ).groups;
   return `${author} committed on ${new Date(
-    parseInt(timestamp) * 1000,
+    parseInt(timestamp, 10) * 1000,
   ).toLocaleString()}`;
 }
 

--- a/files/en-us/web/svg/guides/namespaces_crash_course/example/index.md
+++ b/files/en-us/web/svg/guides/namespaces_crash_course/example/index.md
@@ -87,13 +87,12 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
 
   <script>
   <![CDATA[
-
     // Array of motes
     let motes;
 
     // Get the display element.
     function Display() {
-      return document.getElementById('display');
+      return document.getElementById("display");
     }
 
     // Determine dimensions of the display element.
@@ -101,8 +100,8 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
     function Dimensions() {
       // Our Rendering Element
       const display = Display();
-      const width = parseInt(display.getAttributeNS(null, 'width'));
-      const height = parseInt(display.getAttributeNS(null, 'height'));
+      const width = parseInt(display.getAttributeNS(null, "width"), 10);
+      const height = parseInt(display.getAttributeNS(null, "height"), 10);
 
       return [width, height];
     }
@@ -114,9 +113,9 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
       mouse_x = evt.clientX;
       mouse_y = evt.clientY;
 
-      const widget = document.getElementById('cursor');
-      widget.setAttributeNS(null,'cx',mouse_x);
-      widget.setAttributeNS(null,'cy',mouse_y);
+      const widget = document.getElementById("cursor");
+      widget.setAttributeNS(null, "cx", mouse_x);
+      widget.setAttributeNS(null, "cy", mouse_y);
     }
     document.onmousemove = OnMouseMove;
 
@@ -142,8 +141,7 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
     }
 
     // A nicer, integer random
-    function Rand(modulo)
-    {
+    function Rand(modulo) {
       return Math.round(Math.random() * (modulo - 1));
     }
 
@@ -184,12 +182,12 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
       } else if (pos[1] < this.y) {
         this.vy -= mag;
       }
-    }
+    };
 
     // Mote::capVelocity() — Apply an upper limit
     // on mote velocity.
     Mote.prototype.capVelocity = function () {
-      const max = parseInt(document.getElementById('max_velocity').value);
+      const max = parseInt(document.getElementById("max_velocity").value, 10);
 
       if (max < this.vx) {
         this.vx = max;
@@ -202,7 +200,7 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
       } else if (-max > this.vy) {
         this.vy = -max;
       }
-    }
+    };
 
     // Mote::capPosition() — Apply an upper/lower limit
     // on mote position.
@@ -219,17 +217,17 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
       } else if (this.y >= dims[1]) {
         this.y = dims[1] - 1;
       }
-    }
+    };
 
     // Mote::move() — move a mote, update the screen.
     Mote.prototype.move = function () {
       // Apply attraction to cursor.
-      const attract = parseInt(document.getElementById('attract_cursor').value);
+      const attract = parseInt(document.getElementById("attract_cursor").value, 10);
       const cursor = Cursor();
       this.applyForce(cursor, attract);
 
       // Apply repulsion from average mote position.
-      const repel = parseInt(document.getElementById('repel_peer').value);
+      const repel = parseInt(document.getElementById("repel_peer").value, 10);
       const average = AverageMotePosition();
       this.applyForce(average, -repel);
 
@@ -249,20 +247,20 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
 
       // Draw it.
       if (this.elt === null) {
-        const svg = 'http://www.w3.org/2000/svg';
-        this.elt = document.createElementNS(svg, 'line');
-        this.elt.setAttributeNS(null, 'stroke', 'green');
-        this.elt.setAttributeNS(null, 'stroke-width', '3');
-        this.elt.setAttributeNS(null, 'stroke-opacity', '0.5');
+        const svg = "http://www.w3.org/2000/svg";
+        this.elt = document.createElementNS(svg, "line");
+        this.elt.setAttributeNS(null, "stroke", "green");
+        this.elt.setAttributeNS(null, "stroke-width", "3");
+        this.elt.setAttributeNS(null, "stroke-opacity", "0.5");
         Display().appendChild(this.elt);
       }
 
-      this.elt.setAttributeNS(null, 'x1', old_x);
-      this.elt.setAttributeNS(null, 'y1', old_y);
+      this.elt.setAttributeNS(null, "x1", old_x);
+      this.elt.setAttributeNS(null, "y1", old_y);
 
-      this.elt.setAttributeNS(null, 'x2', this.x);
-      this.elt.setAttributeNS(null, 'y2', this.y);
-    }
+      this.elt.setAttributeNS(null, "x2", this.x);
+      this.elt.setAttributeNS(null, "y2", this.y);
+    };
 
     function update() {
       // First call?
@@ -271,8 +269,8 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
       }
 
       // How many motes should there be?
-      let num = parseInt( document.getElementById('num_motes').value );
-      if ( num < 0 ) {
+      let num = parseInt(document.getElementById("num_motes").value, 10);
+      if (num < 0) {
         num = 0;
       }
 
@@ -295,7 +293,7 @@ cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
       }
 
       // And do this again in 1/100 sec
-      setTimeout('update()', 10);
+      setTimeout(() => update(), 10);
     }
   ]]>
   </script>


### PR DESCRIPTION
`parseInt` tries to guess the radix if it's not explicitly provided, which often leads to unintended behavior. A radix of `10` should always be explicitly given.