### PR TITLE
Lint: more concise regex syntax

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
@@ -788,7 +788,7 @@ const email = document.getElementById("mail");
 const error = document.getElementById("error");
 
 // Regular expression for email validation as per HTML specification
-const emailRegExp = /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)*$/i;
+const emailRegExp = /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z\d-]+(?:\.[a-z\d-]+)*$/i;
 
 // Check if the email is valid
 const isValidEmail = () => {

--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -44,7 +44,7 @@ A non-negative number.
 const colorEnd = document.getElementById("color");
 const text = document.querySelector("#pin");
 const pinBtn = document.querySelector("#pin-btn");
-const validPinChecker = /[^\d{3}-\d{2}-\d{3}]/g;
+const validPinChecker = /^\d{3}-\d{2}-\d{3}/g;
 const selectionEnd = text.value.length;
 const selectedText = text.value.substring(text.selectionStart, selectionEnd);
 

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -90,7 +90,7 @@ async function* makeTextFileLineIterator(fileURL) {
   let { value: chunk, done: readerDone } = await reader.read();
   chunk = chunk ? utf8Decoder.decode(chunk, { stream: true }) : "";
 
-  let re = /\r?\n/gm;
+  let re = /\r?\n/g;
   let startIndex = 0;
 
   for (;;) {

--- a/files/en-us/web/html/reference/elements/input/email/index.md
+++ b/files/en-us/web/html/reference/elements/input/email/index.md
@@ -239,7 +239,7 @@ There are two levels of content validation available for `email` inputs. First, 
 Browsers automatically provide validation to ensure that only text that matches the standard format for Internet email addresses is entered into the input box. Browsers use an algorithm equivalent to the following regular expression:
 
 ```js
-/^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i;
+/^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?)*$/i;
 ```
 
 To learn more about how form validation works and how to take advantage of the {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS properties to style the input based on whether the current value is valid, see [Form data validation](/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation).

--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -13,7 +13,7 @@ Groups group multiple patterns as a whole, and capturing groups provide extra su
 ```js interactive-example
 // Groups
 const imageDescription = "This image has a resolution of 1440×900 pixels.";
-const regexpSize = /([0-9]+)×([0-9]+)/;
+const regexpSize = /(\d+)×(\d+)/;
 const match = imageDescription.match(regexpSize);
 console.log(`Width: ${match[1]} / Height: ${match[2]}.`);
 // Expected output: "Width: 1440 / Height: 900."

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -148,7 +148,7 @@ The `array` argument is useful if you want to access another element in the arra
 ```js
 const names = ["JC63", "Bob132", "Ursula89", "Ben96"];
 const greatIDs = names
-  .map((name) => parseInt(name.match(/[0-9]+/)[0], 10))
+  .map((name) => parseInt(name.match(/\d+/)[0], 10))
   .filter((id, idx, arr) => {
     // Without the arr argument, there's no way to easily access the
     // intermediate array without saving it to a variable.

--- a/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -12,7 +12,7 @@ The **`dotAll`** accessor property of {{jsxref("RegExp")}} instances returns whe
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.dotAll")}}
 
 ```js interactive-example
-const regex1 = new RegExp("foo", "s");
+const regex1 = new RegExp("f.o", "s");
 
 console.log(regex1.dotAll);
 // Expected output: true

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -17,7 +17,7 @@ The **`flags`** accessor property of {{jsxref("RegExp")}} instances returns the 
 console.log(/foo/gi.flags);
 // Expected output: "gi"
 
-console.log(/bar/muy.flags);
+console.log(/^bar/muy.flags);
 // Expected output: "muy"
 ```
 
@@ -35,7 +35,7 @@ The set accessor of `flags` is `undefined`. You cannot change this property dire
 
 ```js-nolint
 /foo/ig.flags; // "gi"
-/bar/myu.flags; // "muy"
+/^bar/myu.flags; // "muy"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.md
@@ -39,7 +39,7 @@ The set accessor of `multiline` is `undefined`. You cannot change this property 
 ### Using multiline
 
 ```js
-const regex = /foo/m;
+const regex = /^foo/m;
 
 console.log(regex.multiline); // true
 ```

--- a/files/en-us/web/javascript/reference/global_objects/regexp/symbol.match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/symbol.match/index.md
@@ -22,7 +22,7 @@ class RegExp1 extends RegExp {
   }
 }
 
-console.log("2012-07-02".match(new RegExp1("([0-9]+)-([0-9]+)-([0-9]+)")));
+console.log("2012-07-02".match(new RegExp1("(\\d+)-(\\d+)-(\\d+)")));
 // Expected output: "VALID"
 ```
 
@@ -96,7 +96,7 @@ In addition, the `[Symbol.match]` property is used to check [whether an object i
 This method can be used in _almost_ the same way as {{jsxref("String.prototype.match()")}}, except the different `this` and the different arguments order.
 
 ```js
-const re = /[0-9]+/g;
+const re = /\d+/g;
 const str = "2016-01-02";
 const result = re[Symbol.match](str);
 console.log(result); // ["2016", "01", "02"]
@@ -119,7 +119,7 @@ class MyRegExp extends RegExp {
   }
 }
 
-const re = new MyRegExp("([0-9]+)-([0-9]+)-([0-9]+)");
+const re = new MyRegExp("(\\d+)-(\\d+)-(\\d+)");
 const str = "2016-01-02";
 const result = str.match(re); // String.prototype.match calls re[Symbol.match]().
 console.log(result.group(1)); // 2016

--- a/files/en-us/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/symbol.matchall/index.md
@@ -22,7 +22,7 @@ class MyRegExp extends RegExp {
   }
 }
 
-const re = new MyRegExp("-[0-9]+", "g");
+const re = new MyRegExp("-\\d+", "g");
 console.log("2016-01-02|2019-03-07".matchAll(re));
 // Expected output: Array [Array ["-01"], Array ["-02"], Array ["-03"], Array ["-07"]]
 ```
@@ -90,7 +90,7 @@ This method exists for customizing the behavior of `matchAll()` in {{jsxref("Reg
 This method can be used in almost the same way as {{jsxref("String.prototype.matchAll()")}}, except for the different value of `this` and the different order of arguments.
 
 ```js
-const re = /[0-9]+/g;
+const re = /\d+/g;
 const str = "2016-01-02";
 const result = re[Symbol.matchAll](str);
 
@@ -112,7 +112,7 @@ class MyRegExp extends RegExp {
   }
 }
 
-const re = new MyRegExp("([0-9]+)-([0-9]+)-([0-9]+)", "g");
+const re = new MyRegExp("(\\d+)-(\\d+)-(\\d+)", "g");
 const str = "2016-01-02|2019-03-07";
 const result = str.matchAll(re);
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -14,7 +14,7 @@ For more information, see [`RegExp.prototype[Symbol.matchAll]()`](/en-US/docs/We
 {{InteractiveExample("JavaScript Demo: Symbol.matchAll")}}
 
 ```js interactive-example
-const re = /[0-9]+/g;
+const re = /\d+/g;
 const str = "2016-01-02|2019-03-07";
 const result = re[Symbol.matchAll](str);
 
@@ -37,7 +37,7 @@ const str = "2016-01-02|2019-03-07";
 
 const numbers = {
   *[Symbol.matchAll](str) {
-    for (const n of str.matchAll(/[0-9]+/g)) yield n[0];
+    for (const n of str.matchAll(/\d+/g)) yield n[0];
   },
 };
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -38,7 +38,7 @@ The well-known symbol `Symbol.search`.
 ### Custom string search
 
 ```js
-class caseInsensitiveSearch {
+class CaseInsensitiveSearch {
   constructor(value) {
     this.value = value.toLowerCase();
   }
@@ -47,7 +47,7 @@ class caseInsensitiveSearch {
   }
 }
 
-console.log("foobar".search(new caseInsensitiveSearch("BaR"))); // 3
+console.log("foobar".search(new CaseInsensitiveSearch("BaR"))); // 3
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
@@ -147,7 +147,7 @@ The following function matches all non-ASCII numbers.
 
 ```js
 function nonASCIINumbers(str) {
-  return str.match(/[\p{Decimal_Number}--[0-9]]/gv);
+  return str.match(/[\p{Decimal_Number}--\d]/gv);
 }
 
 // 𑜹 is U+11739 AHOM DIGIT NINE


### PR DESCRIPTION
Use `\d` instead of `[0-9]`; make sure `m` and `s` regexes actually use the feature enabled by the flag (otherwise the flag is redundant)