### PR TITLE
Lint: improve import/label/comment formatting

### DIFF
--- a/files/en-us/games/techniques/control_mechanisms/other/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/other/index.md
@@ -170,6 +170,7 @@ There's even a [Cylon.js-supported Makey Button functionality](https://cylonjs.c
 
 ```js
 const Cylon = require("cylon");
+
 Cylon.robot({
   connections: {
     arduino: { adaptor: "firmata", port: "/dev/ttyACM0" },

--- a/files/en-us/glossary/bitwise_flags/index.md
+++ b/files/en-us/glossary/bitwise_flags/index.md
@@ -11,7 +11,9 @@ page-type: glossary-definition
 For example, in the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}}, a {{domxref("GPUBuffer")}} object instance is created using the {{domxref("GPUDevice.createBuffer()")}} method. When invoking this method, you define a `usage` property in the descriptor containing one or more flags that enable different allowed usages of that buffer.
 
 ```js
-usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE;
+const descriptor = {
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+};
 ```
 
 These values are defined inside the same namespace, and each one has a hexadecimal value:

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_getting_started/index.md
@@ -213,8 +213,8 @@ Let's open `src/App.jsx`, since our browser is prompting us to edit it. This fil
 
 ```jsx
 import { useState } from "react";
-import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
+import reactLogo from "./assets/react.svg";
 import "./App.css";
 
 function App() {
@@ -257,8 +257,8 @@ The `import` statements at the top of the file allow `App.jsx` to use code that 
 
 ```jsx
 import { useState } from "react";
-import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
+import reactLogo from "./assets/react.svg";
 import "./App.css";
 ```
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_components/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_components/index.md
@@ -283,6 +283,7 @@ We'll edit our `Todo` component to emit a `remove` event, passing the to-do bein
 
    ```js
    import { createEventDispatcher } from "svelte";
+
    const dispatch = createEventDispatcher();
    ```
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_reactivity_lifecycle_accessibility/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_reactivity_lifecycle_accessibility/index.md
@@ -94,6 +94,7 @@ Now we'll tackle the _Check All_ and _Remove Completed_ buttons. Let's create a 
    ```svelte
    <script>
      import { createEventDispatcher } from "svelte";
+
      const dispatch = createEventDispatcher();
 
      let completed = true;

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_stores/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_stores/index.md
@@ -121,18 +121,18 @@ Let's now create our `Alert` component and see how we can read values from the s
 
    ```svelte
    <script>
-     import { alert } from '../stores.js'
-     import { onDestroy } from 'svelte'
+     import { alert } from "../stores.js";
+     import { onDestroy } from "svelte";
 
-     let alertContent = ''
+     let alertContent = "";
 
-     const unsubscribe = alert.subscribe((value) => alertContent = value)
+     const unsubscribe = alert.subscribe((value) => (alertContent = value));
 
-     onDestroy(unsubscribe)
+     onDestroy(unsubscribe);
    </script>
 
    {#if alertContent}
-   <div on:click={() => alertContent = ''}>
+   <div on:click={() => (alertContent = "")}>
      <p>{ alertContent }</p>
    </div>
    {/if}
@@ -236,11 +236,11 @@ And `$myStore` will be fully reactive. This also applies to your own custom stor
 
    ```svelte
    <script>
-     import { alert } from '../stores.js'
+     import { alert } from "../stores.js";
    </script>
 
    {#if $alert}
-   <div on:click={() => $alert = ''}>
+   <div on:click={() => $alert = ""}>
      <p>{ $alert }</p>
    </div>
    {/if}
@@ -451,7 +451,7 @@ So let's start by using a regular writable store to save our to-dos.
      $todos = [
        { id: 1, name: "Create a Svelte starter app", completed: true },
        { id: 2, name: "Create your first component", completed: true },
-       { id: 3, name: "Complete the rest of the tutorial", completed: false }
+       { id: 3, name: "Complete the rest of the tutorial", completed: false },
      ];
    </script>
 
@@ -515,6 +515,7 @@ Usually you don't implement stores from scratch; instead you'd use the writable 
 
 ```js
 import { writable } from "svelte/store";
+
 function myStore() {
   const { subscribe, set, update } = writable(0);
 
@@ -608,10 +609,10 @@ Moreover, because web storage only supports saving string values, we will have t
 
    ```svelte
    <script>
-     import Todos from './components/Todos.svelte'
-     import Alert from './components/Alert.svelte'
+     import Todos from "./components/Todos.svelte";
+     import Alert from "./components/Alert.svelte";
 
-     import { todos } from './stores.js'
+     import { todos } from "./stores.js";
    </script>
 
    <Alert />

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
@@ -354,28 +354,32 @@ You can tell Svelte to ignore this warning for the next block of markup with a [
 If you want to globally disable this warning, you can add this `onwarn` handler to your `rollup.config.js` file inside the configuration for the `Svelte` plugin, like this:
 
 ```js
-plugins: [
-  svelte({
-    dev: !production,
-    css: (css) => {
-      css.write("public/build/bundle.css");
-    },
-    // Warnings are normally passed straight to Rollup. You can
-    // optionally handle them here, for example to squelch
-    // warnings with a particular code
-    onwarn: (warning, handler) => {
-      // e.g. I don't care about screen readers -> please DON'T DO THIS!!!
-      if (warning.code === "a11y-missing-attribute") {
-        return;
-      }
-
-      // let Rollup handle all other warnings normally
-      handler(warning);
-    },
-  }),
-
+export default {
   // …
-];
+  plugins: [
+    svelte({
+      dev: !production,
+      css: (css) => {
+        css.write("public/build/bundle.css");
+      },
+      // Warnings are normally passed straight to Rollup. You can
+      // optionally handle them here, for example to squelch
+      // warnings with a particular code
+      onwarn: (warning, handler) => {
+        // e.g. I don't care about screen readers -> please DON'T DO THIS!!!
+        if (warning.code === "a11y-missing-attribute") {
+          return;
+        }
+
+        // let Rollup handle all other warnings normally
+        handler(warning);
+      },
+    }),
+
+    // …
+  ],
+  // …
+};
 ```
 
 By design, these warnings are implemented in the compiler itself, and not as a plug-in that you may choose to add to your project. The idea is to check for a11y issues in your markup by default and let you opt out of specific warnings.

--- a/files/en-us/learn_web_development/core/frameworks_libraries/vue_rendering_lists/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/vue_rendering_lists/index.md
@@ -93,8 +93,8 @@ To make sure that Vue can accurately compare the `key` attributes, they need to 
    The `<script>` element in `App.vue` should now have the following contents:
 
    ```js
-   import ToDoItem from "./components/ToDoItem.vue";
    import { nanoid } from "nanoid";
+   import ToDoItem from "./components/ToDoItem.vue";
 
    export default {
      name: "app",

--- a/files/en-us/learn_web_development/extensions/client-side_apis/third_party_apis/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/third_party_apis/index.md
@@ -111,8 +111,8 @@ Let's add some more functionality to the Mapquest example to show how to use som
 
 There are a number of different types of map that can be shown with the Mapquest API. To do this, find the following line:
 
-```js
-layers: L.mapquest.tileLayer("map");
+```js-nolint
+layers: L.mapquest.tileLayer("map"),
 ```
 
 Try changing `'map'` to `'hybrid'` to show a hybrid-style map. Try some other values too. The [`tileLayer` reference page](https://developer.mapquest.com/documentation/mapquest-js/v1.3/l-mapquest-tile-layer/) shows the different available options, plus a lot more information.

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
@@ -128,6 +128,7 @@ Replace the line with the following code that uses `process.env.MONGODB_URI` to 
 ```js
 // Set up mongoose connection
 const mongoose = require("mongoose");
+
 mongoose.set("strictQuery", false);
 
 const dev_db_url =

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -144,6 +144,7 @@ As a slightly more exciting test let's create a very basic "pure node" server th
    ```js
    // Load HTTP module
    const http = require("http");
+
    const hostname = "127.0.0.1";
    const port = 3000;
 
@@ -256,6 +257,7 @@ The following steps show how you can use npm to download a package, save it into
 
    ```js
    const express = require("express");
+
    const app = express();
    const port = 3000;
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -17,14 +17,7 @@ Open **/controllers/genreController.js**, and add the following line at the top 
 const { body, validationResult } = require("express-validator");
 ```
 
-> [!NOTE]
-> This syntax allows us to use `body` and `validationResult` as the associated middleware functions, as you will see in the post route section below. It is equivalent to:
->
-> ```js
-> const validator = require("express-validator");
-> const body = validator.body;
-> const validationResult = validator.validationResult;
-> ```
+Note that `require("express-validator")` is just a function call that returns an object, and we [destructure](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring) the two properties, `body` and `validationResult`, from the object, so we can use them as variables directly.
 
 ## Controller—get route
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -154,6 +154,7 @@ First lets consider the standard Express [Hello World](https://expressjs.com/en/
 
 ```js
 const express = require("express");
+
 const app = express();
 const port = 3000;
 
@@ -180,6 +181,7 @@ The code below shows how we import a module by name, using the _Express_ framewo
 
 ```js
 const express = require("express");
+
 const app = express();
 ```
 
@@ -203,6 +205,7 @@ We can import this module using `require()`, and then call the exported method(s
 
 ```js
 const square = require("./square"); // Here we require() the name of the file without the (optional) .js file extension
+
 console.log(`The area of a square with a width of 4 is ${square.area(4)}`);
 ```
 
@@ -292,6 +295,7 @@ Often it is useful to group route handlers for a particular part of a site toget
 // wiki.js - Wiki route module
 
 const express = require("express");
+
 const router = express.Router();
 
 // Home page route
@@ -314,6 +318,7 @@ To use the router in our main app file we would then `require()` the route modul
 
 ```js
 const wiki = require("./wiki.js");
+
 // …
 app.use("/wiki", wiki);
 ```
@@ -341,6 +346,7 @@ You could then call `use()` on the _Express application object_ to add the middl
 ```js
 const express = require("express");
 const logger = require("morgan");
+
 const app = express();
 app.use(logger("dev"));
 // …
@@ -357,6 +363,7 @@ The example below shows how you can add the middleware function using both appro
 
 ```js
 const express = require("express");
+
 const app = express();
 
 // An example middleware function
@@ -461,7 +468,7 @@ The database itself can be installed locally or on a cloud server. In your Expre
 This works with older versions of MongoDB version ~ 2.2.33:
 
 ```js
-const MongoClient = require("mongodb").MongoClient;
+const { MongoClient } = require("mongodb");
 
 MongoClient.connect("mongodb://localhost:27017/animals", (err, db) => {
   if (err) throw err;
@@ -479,7 +486,7 @@ MongoClient.connect("mongodb://localhost:27017/animals", (err, db) => {
 For MongoDB version 3.0 and up:
 
 ```js
-const MongoClient = require("mongodb").MongoClient;
+const { MongoClient } = require("mongodb");
 
 MongoClient.connect("mongodb://localhost:27017/animals", (err, client) => {
   if (err) throw err;
@@ -511,6 +518,7 @@ In your application settings code you set the template engine to use and the loc
 ```js
 const express = require("express");
 const path = require("path");
+
 const app = express();
 
 // Set directory to contain the templates ('views')

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
@@ -687,6 +687,7 @@ Replace the database URL string ('_insert_your_database_url_here_') with the loc
 ```js
 // Set up mongoose connection
 const mongoose = require("mongoose");
+
 mongoose.set("strictQuery", false);
 const mongoDB = "insert_your_database_url_here";
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/routes/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/routes/index.md
@@ -68,6 +68,7 @@ First we create routes for a wiki in a module named **wiki.js**. The code first 
 // wiki.js - Wiki route module.
 
 const express = require("express");
+
 const router = express.Router();
 
 // Home page route.
@@ -90,6 +91,7 @@ To use the router module in our main app file we first `require()` the route mod
 
 ```js
 const wiki = require("./wiki.js");
+
 // …
 app.use("/wiki", wiki);
 ```
@@ -507,13 +509,14 @@ Open **/routes/catalog.js** and copy in the code below:
 
 ```js
 const express = require("express");
-const router = express.Router();
 
 // Require controller modules.
 const book_controller = require("../controllers/bookController");
 const author_controller = require("../controllers/authorController");
 const genre_controller = require("../controllers/genreController");
 const book_instance_controller = require("../controllers/bookinstanceController");
+
+const router = express.Router();
 
 /// BOOK ROUTES ///
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
@@ -439,6 +439,7 @@ This file creates an `express` application object (named `app`, by convention), 
 
 ```js
 const express = require("express");
+
 const app = express();
 // …
 module.exports = app;
@@ -534,6 +535,7 @@ Then it specifies a route on that object and lastly exports the router from the 
 
 ```js
 const express = require("express");
+
 const router = express.Router();
 
 /* GET users listing. */

--- a/files/en-us/learn_web_development/extensions/testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/your_own_automation_environment/index.md
@@ -583,7 +583,10 @@ Let's update our `bstack_duck_test.js` demo, to show how these features work:
 3. Now we'll update our `capabilities` object to include a project name — add the following line before the closing curly brace, remembering to add a comma at the end of the previous line (you can vary the build and project names to organize the tests in different windows in the BrowserStack automation dashboard):
 
    ```js
-   project: "DuckDuckGo test 2";
+   const capabilities = {
+     // …
+     project: "DuckDuckGo test 2",
+   };
    ```
 
 4. Next we'll retrieve the `sessionId` of the current session, and use it (along with your `userName` and `accessKey`) to assemble the URL to send requests to, to update the BrowserStack data. Include the following lines just below the block that creates the `driver` object (which starts with `const driver = new Builder()`) :
@@ -631,6 +634,7 @@ Let's look at an example that demonstrates getting Selenium tests to run remotel
 
    ```js
    const { Builder, By, Key } = require("selenium-webdriver");
+
    const username = "YOUR-USER-NAME";
    const accessKey = "YOUR-ACCESS-KEY";
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -48,7 +48,7 @@ Note that it is possible to call menus API functions synchronously, and in this 
 
 ```js
 browser.menus.onShown.addListener(async (info, tab) => {
-  browser.menus.update(menuId /*, …*/);
+  browser.menus.update(menuId /*, … */);
   // Note: Not waiting for returned promise.
   browser.menus.refresh();
 });
@@ -61,7 +61,7 @@ browser.menus.onShown.addListener(async (info, tab) => {
   let menuInstanceId = nextMenuInstanceId++;
   lastMenuInstanceId = menuInstanceId;
 
-  await browser.menus.update(menuId /*, …*/);
+  await browser.menus.update(menuId /*, … */);
   // must now perform the check
   if (menuInstanceId !== lastMenuInstanceId) {
     return;

--- a/files/en-us/web/api/chapterinformation/index.md
+++ b/files/en-us/web/api/chapterinformation/index.md
@@ -31,40 +31,43 @@ The sample code below from [Video / Media Session Sample](https://googlechrome.g
 ```js
 const BASE_URL = "https://storage.googleapis.com/media-session/";
 
-chapterInfo: [
-  {
-    title: "Chapter 1",
-    startTime: 0,
-    artwork: [
-      {
-        src: BASE_URL + "sintel/chapter1-128.png",
-        sizes: "128x128",
-        type: "image/png",
-      },
-      {
-        src: BASE_URL + "sintel/chapter1-512.png",
-        sizes: "512x512",
-        type: "image/png",
-      },
-    ],
-  },
-  {
-    title: "Chapter 2",
-    startTime: 37,
-    artwork: [
-      {
-        src: BASE_URL + "sintel/chapter2-128.png",
-        sizes: "128x128",
-        type: "image/png",
-      },
-      {
-        src: BASE_URL + "sintel/chapter2-512.png",
-        sizes: "512x512",
-        type: "image/png",
-      },
-    ],
-  },
-];
+const metadata = {
+  // …
+  chapterInfo: [
+    {
+      title: "Chapter 1",
+      startTime: 0,
+      artwork: [
+        {
+          src: BASE_URL + "sintel/chapter1-128.png",
+          sizes: "128x128",
+          type: "image/png",
+        },
+        {
+          src: BASE_URL + "sintel/chapter1-512.png",
+          sizes: "512x512",
+          type: "image/png",
+        },
+      ],
+    },
+    {
+      title: "Chapter 2",
+      startTime: 37,
+      artwork: [
+        {
+          src: BASE_URL + "sintel/chapter2-128.png",
+          sizes: "128x128",
+          type: "image/png",
+        },
+        {
+          src: BASE_URL + "sintel/chapter2-512.png",
+          sizes: "512x512",
+          type: "image/png",
+        },
+      ],
+    },
+  ],
+};
 ```
 
 The following snippet shows how it can be used inside Media Session code (the above object property is part of the `playlist` object referenced below):

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -84,7 +84,7 @@ self.onmessage = (e) => {
   }
 
   try {
-    const fs = requestFileSystemSync(TEMPORARY, 1024 * 1024 /*1MB*/);
+    const fs = requestFileSystemSync(TEMPORARY, 1024 * 1024 /* 1MB */);
 
     getAllEntries(fs.root.createReader());
 

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -98,10 +98,10 @@ toggleButton.addEventListener("click", () => {
 
   toggleButton.setAttribute("aria-expanded", !isExpanded);
   panel1.style.display = isExpanded ? "none" : "block";
-  panel1.setAttribute("aria-hidden", isExpanded); //true when hidden, false when shown.
+  panel1.setAttribute("aria-hidden", isExpanded); // true when hidden, false when shown.
 
   panel2.style.display = isExpanded ? "none" : "block";
-  panel2.setAttribute("aria-hidden", isExpanded); //true when hidden, false when shown.
+  panel2.setAttribute("aria-hidden", isExpanded); // true when hidden, false when shown.
 });
 ```
 

--- a/files/en-us/web/api/filesystemdirectoryentry/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/index.md
@@ -42,7 +42,7 @@ function onFs(fs) {
 }
 
 // Opening a file system with temporary storage
-window.requestFileSystem(TEMPORARY, 1024 * 1024 /*1MB*/, onFs, onError);
+window.requestFileSystem(TEMPORARY, 1024 * 1024 /* 1MB */, onFs, onError);
 ```
 
 ## Instance properties

--- a/files/en-us/web/api/filesystementry/index.md
+++ b/files/en-us/web/api/filesystementry/index.md
@@ -31,7 +31,7 @@ window.requestFileSystem =
 // Opening a file system with temporary storage
 window.requestFileSystem(
   TEMPORARY,
-  1024 * 1024 /*1MB*/,
+  1024 * 1024 /* 1MB */,
   (fs) => {
     fs.root.getFile(
       "log.txt",

--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -154,7 +154,7 @@ class MockHypotheticalSocket {
     const resultObj = {};
     resultObj["bytesRead"] = 0;
 
-    return new Promise((resolve /*, reject*/) => {
+    return new Promise((resolve /*, reject */) => {
       if (this.data_read >= this.max_data) {
         // Out of data
         resolve(resultObj);

--- a/files/en-us/web/api/remote_playback_api/index.md
+++ b/files/en-us/web/api/remote_playback_api/index.md
@@ -55,8 +55,8 @@ function availabilityCallback(available) {
 }
 
 videoElem.remote.watchAvailability(availabilityCallback).catch(() => {
-  /* If the device cannot continuously watch available,
-  show the button to allow the user to try to prompt for a connection.*/
+  // If the device cannot continuously watch available,
+  // show the button to allow the user to try to prompt for a connection.
   deviceBtn.style.display = "inline";
 });
 ```

--- a/files/en-us/web/api/remoteplayback/index.md
+++ b/files/en-us/web/api/remoteplayback/index.md
@@ -70,8 +70,8 @@ function availabilityCallback(available) {
 }
 
 videoElem.remote.watchAvailability(availabilityCallback).catch(() => {
-  /* If the device cannot continuously watch available,
-  show the button to allow the user to try to prompt for a connection.*/
+  // If the device cannot continuously watch available,
+  // show the button to allow the user to try to prompt for a connection.
   deviceBtn.style.display = "inline";
 });
 ```

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -102,7 +102,7 @@ class MockHypotheticalSocket {
     const resultObj = {};
     resultObj["bytesRead"] = 0;
 
-    return new Promise((resolve /*, reject*/) => {
+    return new Promise((resolve /*, reject */) => {
       if (this.data_read >= this.max_data) {
         // Out of data
         resolve(resultObj);
@@ -440,7 +440,7 @@ class MockUnderlyingFileHandle {
     resultObj["buffer"] = buffer;
     resultObj["bytesRead"] = 0;
 
-    return new Promise((resolve /*, reject*/) => {
+    return new Promise((resolve /*, reject */) => {
       if (position >= this.maxdata) {
         // Out of data
         resolve(resultObj);
@@ -701,7 +701,7 @@ class MockUnderlyingFileHandle {
     resultObj["buffer"] = buffer;
     resultObj["bytesRead"] = 0;
 
-    return new Promise((resolve /*, reject*/) => {
+    return new Promise((resolve /*, reject */) => {
       if (position >= this.maxdata) {
         // Out of data
         resolve(resultObj);
@@ -941,7 +941,7 @@ class MockUnderlyingFileHandle {
     resultObj["buffer"] = buffer;
     resultObj["bytesRead"] = 0;
 
-    return new Promise((resolve /*, reject*/) => {
+    return new Promise((resolve /*, reject */) => {
       if (position >= this.maxdata) {
         // Out of data
         resolve(resultObj);

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -415,7 +415,8 @@ function reply(queryMethodListener, ...queryMethodArguments) {
   });
 }
 
-/* This method is called when main page calls QueryWorker's postMessage method directly*/
+// This method is called when main page calls QueryWorker's postMessage
+// method directly
 function defaultReply(message) {
   // do something
 }

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
@@ -33,7 +33,7 @@ const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.pauseTransformFeedback();
-//…
+// …
 gl.resumeTransformFeedback();
 gl.drawArrays(gl.TRIANGLES, 0, 3);
 gl.endTransformFeedback();

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
@@ -38,9 +38,10 @@ In this article we'll set up the server for our phone app. The server file will 
    const express = require("express");
    const http = require("http");
    const path = require("path");
+   const { ExpressPeerServer } = require("peer");
+
    const app = express();
    const server = http.createServer(app);
-   const { ExpressPeerServer } = require("peer");
    const port = process.env.PORT || "8000";
 
    const peerServer = ExpressPeerServer(server, {

--- a/files/en-us/web/html/reference/elements/script/index.md
+++ b/files/en-us/web/html/reference/elements/script/index.md
@@ -239,22 +239,22 @@ Browsers that support the `module` value for the [`type`](/en-US/docs/Web/HTML/R
 ### Importing modules with importmap
 
 When importing modules in scripts, if you don't use the [`type=importmap`](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) feature, then each module must be imported using a module specifier that is either an absolute or relative URL.
-In the example below, the first module specifier ("./shapes/square.js") resolves relative to the base URL of the document, while the second is an absolute URL.
+In the example below, the first module specifier is an absolute URL, while the second (`"./shapes/square.js"`) resolves relative to the base URL of the document.
 
 ```js
-import { name as squareName, draw } from "./shapes/square.js";
 import { name as circleName } from "https://example.com/shapes/circle.js";
+import { name as squareName, draw } from "./shapes/square.js";
 ```
 
 An import map allows you to provide a mapping that, if matched, can replace the text in the module specifier.
-The import map below defines keys `square` and `circle` that can be used as aliases for the module specifiers shown above.
+The import map below defines keys `circle` and `square` that can be used as aliases for the module specifiers shown above.
 
 ```html
 <script type="importmap">
   {
     "imports": {
-      "square": "./shapes/square.js",
-      "circle": "https://example.com/shapes/circle.js"
+      "circle": "https://example.com/shapes/circle.js",
+      "square": "./shapes/square.js"
     }
   }
 </script>
@@ -263,8 +263,8 @@ The import map below defines keys `square` and `circle` that can be used as alia
 This allows us to import modules using names in the module specifier (rather than absolute or relative URLs).
 
 ```js
-import { name as squareName, draw } from "square";
 import { name as circleName } from "circle";
+import { name as squareName, draw } from "square";
 ```
 
 For more examples of what you can do with import maps, see the [Importing modules using import maps](/en-US/docs/Web/JavaScript/Guide/Modules#importing_modules_using_import_maps) section in the JavaScript modules guide.

--- a/files/en-us/web/html/reference/elements/script/type/importmap/index.md
+++ b/files/en-us/web/html/reference/elements/script/type/importmap/index.md
@@ -40,25 +40,25 @@ Browsers generate console warnings for other cases where the import map JSON doe
 When importing a [JavaScript module](/en-US/docs/Web/JavaScript/Guide/Modules), both the [`import` statement](/en-US/docs/Web/JavaScript/Reference/Statements/import) and [`import()` operator](/en-US/docs/Web/JavaScript/Reference/Operators/import) have a "module specifier" that indicates the module to be imported.
 A browser must be able to resolve this specifier to an absolute URL in order to import the module.
 
-For example, the following statements import elements from the module specifier `"./modules/shapes/square.js"`, which is a path relative to the base URL of the document, and the module specifier `"https://example.com/shapes/circle.js"`, which is an absolute URL.
+For example, the following statements import elements from the module specifier `"https://example.com/shapes/circle.js"`, which is an absolute URL, and the module specifier `"./modules/shapes/square.js"`, which is a path relative to the base URL of the document.
 
 ```js
-import { name as squareName, draw } from "./modules/shapes/square.js";
 import { name as circleName } from "https://example.com/shapes/circle.js";
+import { name as squareName, draw } from "./modules/shapes/square.js";
 ```
 
 Import maps allow developers to specify (almost) any text they want in the module specifier; the map provides a corresponding value that will replace the text when the module specifier is resolved.
 
 ### Bare modules
 
-The import map below defines an `imports` key that has a "module specifier map" with properties `square` and `circle`.
+The import map below defines an `imports` key that has a "module specifier map" with properties `circle` and `square`.
 
 ```html
 <script type="importmap">
   {
     "imports": {
-      "square": "./modules/shapes/square.js",
-      "circle": "https://example.com/shapes/circle.js"
+      "circle": "https://example.com/shapes/circle.js",
+      "square": "./modules/shapes/square.js"
     }
   }
 </script>
@@ -67,8 +67,8 @@ The import map below defines an `imports` key that has a "module specifier map" 
 With this import map we can import the same modules as above, but using "bare modules" in our module specifiers:
 
 ```js
-import { name as squareName, draw } from "square";
 import { name as circleName } from "circle";
+import { name as squareName, draw } from "square";
 ```
 
 ### Mapping path prefixes

--- a/files/en-us/web/html/reference/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/reference/global_attributes/nonce/index.md
@@ -33,7 +33,8 @@ From your web server, generate a random base64-encoded string of at least 128 bi
 random number generator. Nonces should be generated differently each time the page loads (nonce only once!). For example, in nodejs:
 
 ```js
-const crypto = require("crypto");
+import crypto from "node:crypto";
+
 crypto.randomBytes(16).toString("base64");
 // '8IBTHwOdqNKAWeKl7plt8g=='
 ```

--- a/files/en-us/web/http/reference/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/reference/headers/x-frame-options/index.md
@@ -117,7 +117,8 @@ http-response set-header X-Frame-Options SAMEORIGIN
 To set `X-Frame-Options` to `SAMEORIGIN` using [Helmet](https://helmetjs.github.io/) add the following to your server configuration:
 
 ```js
-const helmet = require("helmet");
+import helmet from "helmet";
+
 const app = express();
 app.use(
   helmet({

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -354,7 +354,7 @@ checkIandJ: while (i < 4) {
     console.log(j);
     j -= 1;
     if (j % 2 === 0) {
-      continue checkJ;
+      continue;
     }
     console.log(j, "is odd.");
   }

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -150,8 +150,8 @@ reportPerimeter(square1.length, reportList);
 Above we saw how a browser can import a module using a module specifier that is either an absolute URL, or a relative URL that is resolved using the base URL of the document:
 
 ```js
-import { name as squareName, draw } from "./shapes/square.js";
 import { name as circleName } from "https://example.com/shapes/circle.js";
+import { name as squareName, draw } from "./shapes/square.js";
 ```
 
 [Import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) allow developers to instead specify almost any text they want in the module specifier when importing a module; the map provides a corresponding value that will replace the text when the module URL is resolved.
@@ -493,18 +493,18 @@ Inside your `import` and `export` statement's curly braces, you can use the keyw
 So for example, both of the following would do the same job, albeit in a slightly different way:
 
 ```js
-// inside module.js
+// -- module.js --
 export { function1 as newFunctionName, function2 as anotherNewFunctionName };
 
-// inside main.js
+// -- main.js --
 import { newFunctionName, anotherNewFunctionName } from "./modules/module.js";
 ```
 
 ```js
-// inside module.js
+// -- module.js --
 export { function1, function2 };
 
-// inside main.js
+// -- main.js --
 import {
   function1 as newFunctionName,
   function2 as anotherNewFunctionName,

--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -65,7 +65,7 @@ The following example iterates over an async generator, logging values 1–6 to 
 // An async task. Pretend it's doing something more useful
 // in practice.
 function delayedValue(time, value) {
-  return new Promise((resolve /*, reject*/) => {
+  return new Promise((resolve /*, reject */) => {
     setTimeout(() => resolve(value), time);
   });
 }

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -230,7 +230,7 @@ p.toString();
 // '1,2'
 
 // The thisArg's value doesn't matter because it's ignored
-const YAxisPoint = Point.bind(null, 0 /*x*/);
+const YAxisPoint = Point.bind(null, 0 /* x */);
 
 const axisPoint = new YAxisPoint(5);
 axisPoint.toString(); // '0,5'
@@ -246,7 +246,7 @@ The corollary is that you need not do anything special to create a bound functio
 
 ```js
 const emptyObj = {};
-const YAxisPoint = Point.bind(emptyObj, 0 /*x*/);
+const YAxisPoint = Point.bind(emptyObj, 0 /* x */);
 
 // Can still be called as a normal function
 // (although usually this is undesirable)

--- a/files/en-us/web/javascript/reference/statements/continue/index.md
+++ b/files/en-us/web/javascript/reference/statements/continue/index.md
@@ -86,7 +86,7 @@ checkIAndJ: while (i < 4) {
     console.log(`j: ${j}`);
     j -= 1;
 
-    if (j % 2 === 0) continue checkJ;
+    if (j % 2 === 0) continue;
     console.log(`${j} is odd.`);
   }
   console.log(`i = ${i}`);

--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -130,6 +130,7 @@ export default k;
 ```js
 // some other file
 import m from "./test"; // note that we have the freedom to use import m instead of import k, because k was default export
+
 console.log(m); // 12
 ```
 
@@ -159,6 +160,7 @@ Which is comparable to a combination of import and export, except that `function
 
 ```js
 import { default as function1, function2 } from "bar.js";
+
 export { function1, function2 };
 ```
 
@@ -282,6 +284,7 @@ Then, in another script, it is straightforward to import the default export:
 
 ```js
 import cube from "./cube.js";
+
 console.log(cube(3)); // 27
 ```
 


### PR DESCRIPTION
Fix a few cosmetic things that Prettier can't handle itself.

- The `a: b` syntax is misparsed by Prettier as a label, and therefore adds a `;` instead of the correct `,`
- There should be a new line after import/require statements.
- Imports should appear at the top of the file.
- Comments should have padding spaces: `// a` instead of `//a`.