### PR TITLE
Lint: use concise arrows

### DIFF
--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -54,11 +54,12 @@ deleted, or `false` otherwise.
 ## Examples
 
 ```js
-caches.open("v1").then((cache) => {
-  cache.delete("/images/image.png").then((response) => {
+caches
+  .open("v1")
+  .then((cache) => cache.delete("/images/image.png"))
+  .then((response) => {
     someUIUpdateFunction();
   });
-});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -83,86 +83,85 @@ self.addEventListener("fetch", (event) => {
   console.log("Handling fetch event for", event.request.url);
 
   event.respondWith(
-    caches.open(CURRENT_CACHES.font).then((cache) => {
-      return cache
-        .match(event.request)
-        .then((response) => {
-          if (response) {
-            // If there is an entry in the cache for event.request,
-            // then response will be defined and we can just return it.
-            // Note that in this example, only font resources are cached.
-            console.log(" Found response in cache:", response);
+    caches
+      .open(CURRENT_CACHES.font)
+      .then((cache) => cache.match(event.request))
+      .then((response) => {
+        if (response) {
+          // If there is an entry in the cache for event.request,
+          // then response will be defined and we can just return it.
+          // Note that in this example, only font resources are cached.
+          console.log(" Found response in cache:", response);
 
-            return response;
-          }
+          return response;
+        }
 
-          // Otherwise, if there is no entry in the cache for event.request,
-          // response will be undefined, and we need to fetch() the resource.
+        // Otherwise, if there is no entry in the cache for event.request,
+        // response will be undefined, and we need to fetch() the resource.
+        console.log(
+          " No response for %s found in cache. About to fetch " +
+            "from network…",
+          event.request.url,
+        );
+
+        // We call .clone() on the request since we might use it
+        // in a call to cache.put() later on.
+        // Both fetch() and cache.put() "consume" the request,
+        // so we need to make a copy.
+        // (see https://developer.mozilla.org/en-US/docs/Web/API/Request/clone)
+        return fetch(event.request.clone()).then((response) => {
           console.log(
-            " No response for %s found in cache. About to fetch " +
-              "from network…",
+            "  Response for %s from network is: %O",
             event.request.url,
+            response,
           );
 
-          // We call .clone() on the request since we might use it
-          // in a call to cache.put() later on.
-          // Both fetch() and cache.put() "consume" the request,
-          // so we need to make a copy.
-          // (see https://developer.mozilla.org/en-US/docs/Web/API/Request/clone)
-          return fetch(event.request.clone()).then((response) => {
-            console.log(
-              "  Response for %s from network is: %O",
-              event.request.url,
-              response,
-            );
+          if (
+            response.status < 400 &&
+            response.headers.has("content-type") &&
+            response.headers.get("content-type").match(/^font\//i)
+          ) {
+            // This avoids caching responses that we know are errors
+            // (i.e. HTTP status code of 4xx or 5xx).
+            // We also only want to cache responses that correspond
+            // to fonts, i.e. have a Content-Type response header that
+            // starts with "font/".
+            // Note that for opaque filtered responses
+            // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
+            // we can't access to the response headers, so this check will
+            // always fail and the font won't be cached.
+            // All of the Google Web Fonts are served from a domain that
+            // supports CORS, so that isn't an issue here.
+            // It is something to keep in mind if you're attempting
+            // to cache other resources from a cross-origin
+            // domain that doesn't support CORS, though!
+            console.log("  Caching the response to", event.request.url);
+            // We call .clone() on the response to save a copy of it
+            // to the cache. By doing so, we get to keep the original
+            // response object which we will return back to the controlled
+            // page.
+            // https://developer.mozilla.org/en-US/docs/Web/API/Request/clone
+            cache.put(event.request, response.clone());
+          } else {
+            console.log("  Not caching the response to", event.request.url);
+          }
 
-            if (
-              response.status < 400 &&
-              response.headers.has("content-type") &&
-              response.headers.get("content-type").match(/^font\//i)
-            ) {
-              // This avoids caching responses that we know are errors
-              // (i.e. HTTP status code of 4xx or 5xx).
-              // We also only want to cache responses that correspond
-              // to fonts, i.e. have a Content-Type response header that
-              // starts with "font/".
-              // Note that for opaque filtered responses
-              // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
-              // we can't access to the response headers, so this check will
-              // always fail and the font won't be cached.
-              // All of the Google Web Fonts are served from a domain that
-              // supports CORS, so that isn't an issue here.
-              // It is something to keep in mind if you're attempting
-              // to cache other resources from a cross-origin
-              // domain that doesn't support CORS, though!
-              console.log("  Caching the response to", event.request.url);
-              // We call .clone() on the response to save a copy of it
-              // to the cache. By doing so, we get to keep the original
-              // response object which we will return back to the controlled
-              // page.
-              // https://developer.mozilla.org/en-US/docs/Web/API/Request/clone
-              cache.put(event.request, response.clone());
-            } else {
-              console.log("  Not caching the response to", event.request.url);
-            }
-
-            // Return the original response object, which will be used to
-            // fulfill the resource request.
-            return response;
-          });
-        })
-        .catch((error) => {
-          // This catch() will handle exceptions that arise from the match()
-          // or fetch() operations.
-          // Note that a HTTP error response (e.g. 404) will NOT trigger
-          // an exception.
-          // It will return a normal response object that has the appropriate
-          // error code set.
-          console.error("  Error in fetch handler:", error);
-
-          throw error;
+          // Return the original response object, which will be used to
+          // fulfill the resource request.
+          return response;
         });
-    }),
+      })
+      .catch((error) => {
+        // This catch() will handle exceptions that arise from the match()
+        // or fetch() operations.
+        // Note that a HTTP error response (e.g. 404) will NOT trigger
+        // an exception.
+        // It will return a normal response object that has the appropriate
+        // error code set.
+        console.error("  Error in fetch handler:", error);
+
+        throw error;
+      }),
   );
 });
 ```

--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -66,13 +66,14 @@ objects.
 ## Examples
 
 ```js
-caches.open("v1").then((cache) => {
-  cache.keys().then((keys) => {
+caches
+  .open("v1")
+  .then((cache) => cache.keys())
+  .then((keys) => {
     keys.forEach((request, index, array) => {
       cache.delete(request);
     });
   });
-});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cache/matchall/index.md
+++ b/files/en-us/web/api/cache/matchall/index.md
@@ -66,11 +66,12 @@ The following example retrieves all responses in the `v1` cache matching the URL
 It then logs the number of matching responses.
 
 ```js
-caches.open("v1").then((cache) => {
-  cache.matchAll("/", { ignoreSearch: true }).then((responses) => {
+caches
+  .open("v1")
+  .then((cache) => cache.matchAll("/", { ignoreSearch: true }))
+  .then((responses) => {
     console.log(`Found ${responses.length} matching responses`);
   });
-});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cache/put/index.md
+++ b/files/en-us/web/api/cache/put/index.md
@@ -79,9 +79,7 @@ const cachedResponse = caches
   .then((r) => (r !== undefined ? r : fetch(event.request)))
   .then((r) => {
     response = r;
-    caches.open("v1").then((cache) => {
-      cache.put(event.request, response);
-    });
+    caches.open("v1").then((cache) => cache.put(event.request, response));
     return response.clone();
   })
   .catch(() => caches.match("/gallery/myLittleVader.jpg"));

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -86,9 +86,9 @@ self.addEventListener("fetch", (event) => {
             // and serve second one
             let responseClone = response.clone();
 
-            caches.open("v1").then((cache) => {
-              cache.put(event.request, responseClone);
-            });
+            caches
+              .open("v1")
+              .then((cache) => cache.put(event.request, responseClone));
             return response;
           })
           .catch(() => caches.match("/gallery/myLittleVader.jpg"));

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -92,9 +92,9 @@ self.addEventListener("fetch", (event) => {
             // and serve second one
             let responseClone = response.clone();
 
-            caches.open("v1").then((cache) => {
-              cache.put(event.request, responseClone);
-            });
+            caches
+              .open("v1")
+              .then((cache) => cache.put(event.request, responseClone));
             return response;
           })
           .catch(() => caches.match("/gallery/myLittleVader.jpg"));

--- a/files/en-us/web/api/characterboundsupdateevent/index.md
+++ b/files/en-us/web/api/characterboundsupdateevent/index.md
@@ -81,9 +81,10 @@ editContext.addEventListener("characterboundsupdate", (e) => {
   console.log(
     "The required character bounds are",
     charBounds
-      .map((bound) => {
-        return `(x: ${bound.x}, y: ${bound.y}, width: ${bound.width}, height: ${bound.height})`;
-      })
+      .map(
+        (bound) =>
+          `(x: ${bound.x}, y: ${bound.y}, width: ${bound.width}, height: ${bound.height})`,
+      )
       .join(", "),
   );
 });

--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -126,10 +126,8 @@ The policy also uses the `trusted-types` directive to specify that a {{domxref("
 
   <script>
     const policy = trustedTypes.createPolicy("somePolicy", {
-      createHTML: (string) => {
-        // Some (insufficient) sanitization code
-        return string.replace(/</g, "&lt;");
-      },
+      // Some (insufficient) sanitization code
+      createHTML: (string) => string.replace(/</g, "&lt;"),
     });
   </script>
 </html>
@@ -193,10 +191,8 @@ In order to avoid the violation we would need to update the script to define a t
 
 ```js
 const policy = trustedTypes.createPolicy("myPolicy", {
-  createHTML: (string) => {
-    // Some (insufficient) sanitization code
-    return string.replace(/</g, "&lt;");
-  },
+  // Some (insufficient) sanitization code
+  createHTML: (string) => string.replace(/</g, "&lt;"),
 });
 
 function updateContent() {

--- a/files/en-us/web/api/css_custom_highlight_api/index.md
+++ b/files/en-us/web/api/css_custom_highlight_api/index.md
@@ -178,9 +178,7 @@ query.addEventListener("input", () => {
 
   // Iterate over all text nodes and find matches.
   const ranges = allTextNodes
-    .map((el) => {
-      return { el, text: el.textContent.toLowerCase() };
-    })
+    .map((el) => ({ el, text: el.textContent.toLowerCase() }))
     .map(({ text, el }) => {
       const indices = [];
       let startPos = 0;

--- a/files/en-us/web/api/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/index.md
@@ -64,16 +64,15 @@ self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open(CURRENT_CACHES["prefetch"])
-      .then((cache) => {
-        return cache
-          .addAll(
-            urlsToPrefetch.map((urlToPrefetch) => {
-              return new Request(urlToPrefetch, { mode: "no-cors" });
-            }),
-          )
-          .then(() => {
-            console.log("All resources have been fetched and cached.");
-          });
+      .then((cache) =>
+        cache.addAll(
+          urlsToPrefetch.map(
+            (urlToPrefetch) => new Request(urlToPrefetch, { mode: "no-cors" }),
+          ),
+        ),
+      )
+      .then(() => {
+        console.log("All resources have been fetched and cached.");
       })
       .catch((error) => {
         console.error("Pre-fetching failed:", error);

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -59,16 +59,15 @@ self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open(CURRENT_CACHES["prefetch"])
-      .then((cache) => {
-        return cache
-          .addAll(
-            urlsToPrefetch.map((urlToPrefetch) => {
-              return new Request(urlToPrefetch, { mode: "no-cors" });
-            }),
-          )
-          .then(() => {
-            console.log("All resources have been fetched and cached.");
-          });
+      .then((cache) =>
+        cache.addAll(
+          urlsToPrefetch.map(
+            (urlToPrefetch) => new Request(urlToPrefetch, { mode: "no-cors" }),
+          ),
+        ),
+      )
+      .then(() => {
+        console.log("All resources have been fetched and cached.");
       })
       .catch((error) => {
         console.error("Pre-fetching failed:", error);

--- a/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
@@ -439,11 +439,12 @@ function startVideo() {
         videoTrack = videoTracks[0];
       }
     })
-    .then(() => {
-      return new Promise((resolve) => {
-        videoElement.onloadedmetadata = resolve;
-      });
-    })
+    .then(
+      () =>
+        new Promise((resolve) => {
+          videoElement.onloadedmetadata = resolve;
+        }),
+    )
     .then(() => {
       getCurrentSettings();
     })

--- a/files/en-us/web/api/performanceresourcetiming/contenttype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/contenttype/index.md
@@ -45,9 +45,9 @@ The `buffered` option is used for accessing entries from before the observer cre
 
 ```js
 const observer = new PerformanceObserver((list) => {
-  const javascriptResources = list.getEntries().filter((entry) => {
-    return entry.contentType === "text/javascript";
-  });
+  const javascriptResources = list
+    .getEntries()
+    .filter((entry) => entry.contentType === "text/javascript");
   console.log(javascriptResources);
 });
 
@@ -57,9 +57,9 @@ observer.observe({ type: "resource", buffered: true });
 The following example uses {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call the method.
 
 ```js
-const scripts = performance.getEntriesByType("resource").filter((entry) => {
-  return entry.contentType === "text/javascript";
-});
+const scripts = performance
+  .getEntriesByType("resource")
+  .filter((entry) => entry.contentType === "text/javascript");
 console.log(scripts);
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/deliverytype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/deliverytype/index.md
@@ -33,9 +33,9 @@ The following example uses a {{domxref("PerformanceObserver")}} to notify of new
 
 ```js
 const observer = new PerformanceObserver((list) => {
-  const cachedResources = list.getEntries().filter((entry) => {
-    return entry.deliveryType === "cache";
-  });
+  const cachedResources = list
+    .getEntries()
+    .filter((entry) => entry.deliveryType === "cache");
   console.log(cachedResources);
 });
 
@@ -45,9 +45,9 @@ observer.observe({ type: "resource", buffered: true });
 The following example uses {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call the method.
 
 ```js
-const scripts = performance.getEntriesByType("resource").filter((entry) => {
-  return entry.deliveryType === "cache";
-});
+const scripts = performance
+  .getEntriesByType("resource")
+  .filter((entry) => entry.deliveryType === "cache");
 console.log(scripts);
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -70,9 +70,9 @@ Example using a {{domxref("PerformanceObserver")}}, which notifies of new `resou
 
 ```js
 const observer = new PerformanceObserver((list) => {
-  const scripts = list.getEntries().filter((entry) => {
-    return entry.initiatorType === "script";
-  });
+  const scripts = list
+    .getEntries()
+    .filter((entry) => entry.initiatorType === "script");
   console.log(scripts);
 });
 
@@ -82,9 +82,9 @@ observer.observe({ type: "resource", buffered: true });
 Example using {{domxref("Performance.getEntriesByType()")}}, which only shows `resource` performance entries present in the browser's performance timeline at the time you call this method:
 
 ```js
-const scripts = performance.getEntriesByType("resource").filter((entry) => {
-  return entry.initiatorType === "script";
-});
+const scripts = performance
+  .getEntriesByType("resource")
+  .filter((entry) => entry.initiatorType === "script");
 console.log(scripts);
 ```
 

--- a/files/en-us/web/api/request/ishistorynavigation/index.md
+++ b/files/en-us/web/api/request/ishistorynavigation/index.md
@@ -33,9 +33,9 @@ self.addEventListener("request", (event) => {
           return fetch(event.request).then((response) => {
             const responseClone = response.clone();
 
-            caches.open("v1").then((cache) => {
-              cache.put(event.request, responseClone);
-            });
+            caches
+              .open("v1")
+              .then((cache) => cache.put(event.request, responseClone));
 
             return response;
           });

--- a/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
@@ -41,16 +41,16 @@ self.addEventListener("activate", (event) => {
   const cacheAllowlist = ["v2"];
 
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
         cacheNames.map((cacheName) => {
           if (!cacheAllowlist.includes(cacheName)) {
             return caches.delete(cacheName);
           }
           return undefined;
         }),
-      );
-    }),
+      ),
+    ),
   );
 });
 ```

--- a/files/en-us/web/api/storageaccesshandle/locks/index.md
+++ b/files/en-us/web/api/storageaccesshandle/locks/index.md
@@ -20,9 +20,7 @@ A {{domxref("LockManager")}} object.
 document.requestStorageAccess({ locks: true }).then(
   (handle) => {
     console.log("locks access granted");
-    await handle.locks.request('foo', async lock => {
-        return "ok";
-    });
+    handle.locks.request("foo", (lock) => "ok");
   },
   () => {
     console.log("locks access denied");

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -379,9 +379,7 @@ function makePushSourceStream() {
 
 ```js hidden
 // Monkey patch fetch() so it returns a response that is a mocked stream
-window.fetch = async (...args) => {
-  return { body: stream };
-};
+window.fetch = async (...args) => ({ body: stream });
 ```
 
 The code below shows a more complete example.

--- a/files/en-us/web/api/window/caches/index.md
+++ b/files/en-us/web/api/window/caches/index.md
@@ -20,9 +20,7 @@ A {{domxref("CacheStorage")}} object.
 The following example shows how a window can retrieve cached data.
 
 ```js
-window.caches.open("v1").then((cache) => {
-  return cache.match("/list");
-});
+caches.open("v1").then((cache) => cache.match("/list"));
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_constructor/index.md
@@ -82,31 +82,31 @@ When returning an immediately-resolved or immediately-rejected Promise, you do n
 This is not legal (the [`Promise` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) is not being called correctly) and will throw a `TypeError: this is not a constructor` exception:
 
 ```js example-bad
-const fn = () => {
+function fn() {
   return new Promise.resolve(true);
-};
+}
 ```
 
 This is legal, but unnecessarily long:
 
 ```js
-const fn = () => {
+function fn() {
   return new Promise((resolve, reject) => {
     resolve(true);
   });
-};
+}
 ```
 
 Instead, return the static method:
 
 ```js example-good
-const resolveAlways = () => {
+function resolveAlways() {
   return Promise.resolve(true);
-};
+}
 
-const rejectAlways = () => {
+function rejectAlways() {
   return Promise.reject(new Error());
-};
+}
 ```
 
 ## See also

--- a/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
+++ b/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
@@ -105,9 +105,7 @@ This can be converted to the following expression:
 ```js example-good
 const callback = (() => {
   "use strict";
-  return (...args) => {
-    return this.run(args);
-  };
+  return (...args) => this.run(args);
 })();
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -198,9 +198,10 @@ products.forEach((product) => {
 Or, if you want to create a new array instead:
 
 ```js
-const productsWithPrice = products.map((product) => {
-  return { ...product, price: 100 };
-});
+const productsWithPrice = products.map((product) => ({
+  ...product,
+  price: 100,
+}));
 ```
 
 ### Using the third argument of callbackFn

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -223,9 +223,7 @@ temporary array to achieve the right order.
 const data = ["delta", "alpha", "charlie", "bravo"];
 
 // temporary array holds objects with position and sort-value
-const mapped = data.map((v, i) => {
-  return { i, value: someSlowOperation(v) };
-});
+const mapped = data.map((v, i) => ({ i, value: someSlowOperation(v) }));
 
 // sorting the mapped array containing the reduced values
 mapped.sort((a, b) => {

--- a/files/en-us/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/parse/index.md
@@ -68,9 +68,9 @@ Similar to the `replacer` parameter of {{jsxref("JSON.stringify()")}}, for array
 If you return another value from `reviver`, that value will completely replace the originally parsed value. This even applies to the root value. For example:
 
 ```js
-const transformedObj1 = JSON.parse('[1,5,{"s":1}]', (key, value) => {
-  return typeof value === "object" ? undefined : value;
-});
+const transformedObj1 = JSON.parse('[1,5,{"s":1}]', (key, value) =>
+  typeof value === "object" ? undefined : value,
+);
 
 console.log(transformedObj1); // undefined
 ```

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -237,10 +237,8 @@ function rejectLater(resolve, reject) {
 }
 
 const p1 = Promise.resolve("foo");
-const p2 = p1.then(() => {
-  // Return promise here, that will be resolved to 10 after 1 second
-  return new Promise(resolveLater);
-});
+// Return promise here, that will be resolved to 10 after 1 second
+const p2 = p1.then(() => new Promise(resolveLater));
 p2.then(
   (v) => {
     console.log("resolved", v); // "resolved", 10
@@ -251,10 +249,8 @@ p2.then(
   },
 );
 
-const p3 = p1.then(() => {
-  // Return promise here, that will be rejected with 'Error' after 1 second
-  return new Promise(rejectLater);
-});
+// Return promise here, that will be rejected with 'Error' after 1 second
+const p3 = p1.then(() => new Promise(rejectLater));
 p3.then(
   (v) => {
     // not called

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -146,9 +146,7 @@ function storeNewPeriod(startDate, endDate) {
 
   // Sort the array so that periods are ordered by start date, from newest
   // to oldest.
-  periods.sort((a, b) => {
-    return new Date(b.startDate) - new Date(a.startDate);
-  });
+  periods.sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
 
   // Store the updated array back in the storage.
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(periods));
@@ -267,9 +265,7 @@ function checkDatesInvalid(startDate, endDate) {
 function storeNewPeriod(startDate, endDate) {
   const periods = getAllStoredPeriods();
   periods.push({ startDate, endDate });
-  periods.sort((a, b) => {
-    return new Date(b.startDate) - new Date(a.startDate);
-  });
+  periods.sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(periods));
 }
 

--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
@@ -190,16 +190,16 @@ Remember the `activate` event we skipped? It can be used to clear out the old ca
 ```js
 self.addEventListener("activate", (e) => {
   e.waitUntil(
-    caches.keys().then((keyList) => {
-      return Promise.all(
+    caches.keys().then((keyList) =>
+      Promise.all(
         keyList.map((key) => {
           if (key === cacheName) {
             return undefined;
           }
           return caches.delete(key);
         }),
-      );
-    }),
+      ),
+    ),
   );
 });
 ```

--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/re-engageable_notifications_push/index.md
@@ -74,9 +74,10 @@ You can examine the [Service Workers Cookbook examples](https://github.com/mdn/s
 As mentioned before, to be able to receive push messages, you have to have a service worker, the basics of which are already explained in the [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers) article. Inside the service worker, a push-service subscription mechanism is created by calling the [`getSubscription()`](/en-US/docs/Web/API/PushManager/getSubscription) method of the [`PushManager`](/en-US/docs/Web/API/PushManager) interface.
 
 ```js
-navigator.serviceWorker.register("service-worker.js").then((registration) => {
-  return registration.pushManager.getSubscription().then(/* ... */);
-});
+navigator.serviceWorker
+  .register("service-worker.js")
+  .then((registration) => registration.pushManager.getSubscription())
+  .then(/* … */);
 ```
 
 Once the user is subscribed, they can receive push notifications from the server.
@@ -112,13 +113,7 @@ The `index.js` file starts by registering the service worker:
 ```js
 navigator.serviceWorker
   .register("service-worker.js")
-  .then((registration) => {
-    return registration.pushManager
-      .getSubscription()
-      .then(async (subscription) => {
-        // registration part
-      });
-  })
+  .then((registration) => registration.pushManager.getSubscription())
   .then((subscription) => {
     // subscription part
   });


### PR DESCRIPTION
Our style guide explicitly requires the use of concise arrows `(a) => b` over `(a) => { return b; }`.