### PR TITLE
Add short-title for CSS landing page

### DIFF
--- a/files/en-us/web/css/index.md
+++ b/files/en-us/web/css/index.md
@@ -1,5 +1,6 @@
 ---
 title: "CSS: Cascading Style Sheets"
+short-title: CSS
 slug: Web/CSS
 page-type: landing-page
 ---


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds short-title for the CSS/Learn/Privacy/PWA (root) landing pages.

### Motivation

This should allow us to remove [this title mapping](https://github.com/mdn/rari/blob/5a2ead64bb8d4f46f9c548b942072838fb686281/crates/rari-doc/src/helpers/title.rs#L6-L16) in rari.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
