### PR TITLE
Lint: use modern syntax, object shorthand/exponentiation/regex literal

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_deployment_next/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_deployment_next/index.md
@@ -131,7 +131,7 @@ export default {
       dev: !production,
       // we'll extract any component CSS out into
       // a separate file - better for performance
-      css: (css) => {
+      css(css) {
         css.write("public/build/bundle.css");
       },
     }),

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_stores/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_stores/index.md
@@ -568,7 +568,7 @@ Moreover, because web storage only supports saving string values, we will have t
 
      return {
        subscribe,
-       set: (value) => {
+       set(value) {
          localStorage.setItem(key, toString(value)); // save also to local storage as a string
          return set(value);
        },

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
@@ -359,13 +359,13 @@ export default {
   plugins: [
     svelte({
       dev: !production,
-      css: (css) => {
+      css(css) {
         css.write("public/build/bundle.css");
       },
       // Warnings are normally passed straight to Rollup. You can
       // optionally handle them here, for example to squelch
       // warnings with a particular code
-      onwarn: (warning, handler) => {
+      onwarn(warning, handler) {
         // e.g. I don't care about screen readers -> please DON'T DO THIS!!!
         if (warning.code === "a11y-missing-attribute") {
           return;

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_typescript/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_typescript/index.md
@@ -784,7 +784,7 @@ import { localStore } from "./localStore";
 
      return {
        subscribe,
-       set: (value: JsonValue) => {
+       set(value: JsonValue) {
          localStorage.setItem(key, toString(value)); // save also to local storage as a string
          return set(value);
        },
@@ -971,7 +971,7 @@ export const localStore = <T extends JsonValue>(key: string, initial: T) => {
 
   return {
     subscribe,
-    set: (value: T) => {
+    set(value: T) {
       localStorage.setItem(key, toString(value)); // save also to local storage as a string
       return set(value);
     },

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
@@ -175,7 +175,7 @@ exports.author_update_get = asyncHandler(async (req, res, next) => {
     return next(err);
   }
 
-  res.render("author_form", { title: "Update Author", author: author });
+  res.render("author_form", { title: "Update Author", author });
 });
 ```
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/author_detail_page/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/author_detail_page/index.md
@@ -37,7 +37,7 @@ exports.author_detail = asyncHandler(async (req, res, next) => {
 
   res.render("author_detail", {
     title: "Author Detail",
-    author: author,
+    author,
     author_books: allBooksByAuthor,
   });
 });

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/book_detail_page/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/book_detail_page/index.md
@@ -29,7 +29,7 @@ exports.book_detail = asyncHandler(async (req, res, next) => {
 
   res.render("book_detail", {
     title: book.title,
-    book: book,
+    book,
     book_instances: bookInstances,
   });
 });

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
@@ -38,7 +38,7 @@ exports.genre_detail = asyncHandler(async (req, res, next) => {
 
   res.render("genre_detail", {
     title: "Genre Detail",
-    genre: genre,
+    genre,
     genre_books: booksInGenre,
   });
 });

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_author_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_author_form/index.md
@@ -76,7 +76,7 @@ exports.author_create_post = [
       // There are errors. Render form again with sanitized values/errors messages.
       res.render("author_form", {
         title: "Create Author",
-        author: author,
+        author,
         errors: errors.array(),
       });
       return;

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_book_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_book_form/index.md
@@ -104,7 +104,7 @@ exports.book_create_post = [
         title: "Create Book",
         authors: allAuthors,
         genres: allGenres,
-        book: book,
+        book,
         errors: errors.array(),
       });
     } else {

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -59,7 +59,7 @@ exports.genre_create_post = [
       // There are errors. Render the form again with sanitized values/error messages.
       res.render("genre_form", {
         title: "Create Genre",
-        genre: genre,
+        genre,
         errors: errors.array(),
       });
       return;
@@ -115,7 +115,7 @@ asyncHandler(async (req, res, next) => {
     // There are errors. Render the form again with sanitized values/error messages.
     res.render("genre_form", {
       title: "Create Genre",
-      genre: genre,
+      genre,
       errors: errors.array(),
     });
     return;

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -31,7 +31,7 @@ exports.author_delete_get = asyncHandler(async (req, res, next) => {
 
   res.render("author_delete", {
     title: "Delete Author",
-    author: author,
+    author,
     author_books: allBooksByAuthor,
   });
 });
@@ -69,7 +69,7 @@ exports.author_delete_post = asyncHandler(async (req, res, next) => {
     // Author has books. Render in same way as for GET route.
     res.render("author_delete", {
       title: "Delete Author",
-      author: author,
+      author,
       author_books: allBooksByAuthor,
     });
     return;

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/update_book_form/index.md
@@ -37,7 +37,7 @@ exports.book_update_get = asyncHandler(async (req, res, next) => {
     title: "Update Book",
     authors: allAuthors,
     genres: allGenres,
-    book: book,
+    book,
   });
 });
 ```
@@ -118,7 +118,7 @@ exports.book_update_post = [
         title: "Update Book",
         authors: allAuthors,
         genres: allGenres,
-        book: book,
+        book,
         errors: errors.array(),
       });
       return;

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -60,7 +60,7 @@ const groupId = await browser.tabs.group({
 const tab3 = await browser.tabs.create({});
 await browser.tabs.group({
   tabIds: tab3.id,
-  groupId: groupId,
+  groupId,
 });
 ```
 

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -99,7 +99,7 @@ The following example creates a new {{domxref("AudioEncoder")}} and configures i
 ```js
 const init = {
   output: handleOutput,
-  error: (e) => {
+  error(e) {
     console.log(e.message);
   },
 };
@@ -123,7 +123,7 @@ The following example creates a new {{domxref("AudioEncoder")}} and configures i
 ```js
 const init = {
   output: handleOutput,
-  error: (e) => {
+  error(e) {
     console.log(e.message);
   },
 };

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -404,7 +404,7 @@ function draw() {
   ctx.moveTo(0, 100);
   for (let i = 0; i < 24; i++) {
     const dy = i % 2 === 0 ? 25 : -25;
-    ctx.lineTo(Math.pow(i, 1.5) * 2, 75 + dy);
+    ctx.lineTo(i ** 1.5 * 2, 75 + dy);
   }
   ctx.stroke();
   return false;

--- a/files/en-us/web/api/createmonitor/index.md
+++ b/files/en-us/web/api/createmonitor/index.md
@@ -36,7 +36,7 @@ A `CreateMonitor` instance is used via the `monitor` property of an AI API's `cr
 const summarizer = await Summarizer.create({
   sharedContext:
     "A general summary to help a user decide if the text is worth reading",
-  monitor: (monitor) => {
+  monitor(monitor) {
     monitor.addEventListener("downloadprogress", (e) => {
       console.log(`download progress: ${e.loaded}/${e.total}`);
     });

--- a/files/en-us/web/api/gpu/getpreferredcanvasformat/index.md
+++ b/files/en-us/web/api/gpu/getpreferredcanvasformat/index.md
@@ -40,7 +40,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/gpu/index.md
+++ b/files/en-us/web/api/gpu/index.md
@@ -55,7 +55,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/gpucanvascontext/configure/index.md
+++ b/files/en-us/web/api/gpucanvascontext/configure/index.md
@@ -75,7 +75,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/gpucanvascontext/getconfiguration/index.md
+++ b/files/en-us/web/api/gpucanvascontext/getconfiguration/index.md
@@ -45,7 +45,7 @@ if (!adapter) {
 const device = await adapter.requestDevice();
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/gpucanvascontext/getcurrenttexture/index.md
+++ b/files/en-us/web/api/gpucanvascontext/getcurrenttexture/index.md
@@ -39,7 +39,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/gpucanvascontext/index.md
+++ b/files/en-us/web/api/gpucanvascontext/index.md
@@ -36,7 +36,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/gpucanvascontext/unconfigure/index.md
+++ b/files/en-us/web/api/gpucanvascontext/unconfigure/index.md
@@ -34,7 +34,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/languagedetector/availability_static/index.md
+++ b/files/en-us/web/api/languagedetector/availability_static/index.md
@@ -76,7 +76,7 @@ async function getDetector(languages) {
   }
   return await LanguageDetector.create({
     expectedInputLanguages: languages,
-    monitor: (monitor) => {
+    monitor(monitor) {
       monitor.addEventListener("downloadprogress", (e) => {
         console.log(`Downloaded ${Math.floor(e.loaded * 100)}%`);
       });

--- a/files/en-us/web/api/progressevent/progressevent/index.md
+++ b/files/en-us/web/api/progressevent/progressevent/index.md
@@ -52,8 +52,8 @@ The example demonstrates how a `ProgressEvent` is built using a constructor. Thi
 function updateProgress(loaded, total) {
   const progressEvent = new ProgressEvent("progress", {
     lengthComputable: true,
-    loaded: loaded,
-    total: total,
+    loaded,
+    total,
   });
 
   document.dispatchEvent(progressEvent);

--- a/files/en-us/web/api/rtcencodedvideoframe/type/index.md
+++ b/files/en-us/web/api/rtcencodedvideoframe/type/index.md
@@ -30,7 +30,7 @@ The implementation of a `transform()` function in a [WebRTC Encoded Transform](/
 
 ```js
 const transformer = new TransformStream({
-  transform: async (encodedFrame, controller) => {
+  async transform(encodedFrame, controller) {
     if (encodedFrame.type === "key") {
       // Apply key frame transformation
     } else if (encodedFrame.type === "delta") {

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -519,7 +519,7 @@ function getKey(keyMaterial, salt) {
   return window.crypto.subtle.deriveKey(
     {
       name: "HKDF",
-      salt: salt,
+      salt,
       info: new TextEncoder().encode("Encryption example"),
       hash: "SHA-256",
     },

--- a/files/en-us/web/api/subtlecrypto/encrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.md
@@ -208,14 +208,7 @@ function encryptMessage(key) {
   let encoded = getMessageEncoding();
   // iv will be needed for decryption
   iv = window.crypto.getRandomValues(new Uint8Array(16));
-  return window.crypto.subtle.encrypt(
-    {
-      name: "AES-CBC",
-      iv: iv,
-    },
-    key,
-    encoded,
-  );
+  return window.crypto.subtle.encrypt({ name: "AES-CBC", iv }, key, encoded);
 }
 ```
 
@@ -236,11 +229,7 @@ function encryptMessage(key) {
   const encoded = getMessageEncoding();
   // iv will be needed for decryption
   const iv = window.crypto.getRandomValues(new Uint8Array(12));
-  return window.crypto.subtle.encrypt(
-    { name: "AES-GCM", iv: iv },
-    key,
-    encoded,
-  );
+  return window.crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
 }
 ```
 

--- a/files/en-us/web/api/summarizer_api/using/index.md
+++ b/files/en-us/web/api/summarizer_api/using/index.md
@@ -113,7 +113,7 @@ const summarizer = await Summarizer.create({
     "A general summary to help a user decide if the text is worth reading",
   type: "tl;dr",
   length: "short",
-  monitor: (monitor) => {
+  monitor(monitor) {
     monitor.addEventListener("downloadprogress", (e) => {
       console.log(`Downloaded ${Math.floor(e.loaded * 100)}%`);
     });

--- a/files/en-us/web/api/translator/availability_static/index.md
+++ b/files/en-us/web/api/translator/availability_static/index.md
@@ -77,7 +77,7 @@ async function getTranslator(languages) {
   }
   return await Translator.create({
     ...languages,
-    monitor: (monitor) => {
+    monitor(monitor) {
       monitor.addEventListener("downloadprogress", (e) => {
         console.log(`Downloaded ${Math.floor(e.loaded * 100)}%`);
       });

--- a/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
+++ b/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
@@ -152,7 +152,7 @@ You can use this event to expose loading progress data:
 translator = await Translator.create({
   sourceLanguage: "en",
   targetLanguage: "ja",
-  monitor: (monitor) => {
+  monitor(monitor) {
     monitor.addEventListener("downloadprogress", (e) => {
       console.log(`Downloaded ${Math.floor(e.loaded * 100)}%`);
     });
@@ -313,7 +313,7 @@ Finally, we set the submit button to not be disabled, so the form can be submitt
 async function detectLanguage() {
   if (textarea.value.length > 20) {
     const detector = await LanguageDetector.create({
-      monitor: (monitor) => {
+      monitor(monitor) {
         monitor.addEventListener("downloadprogress", (e) => {
           console.log(`Downloaded ${e.loaded * 100}%`);
         });
@@ -378,7 +378,7 @@ If the test passes, we open a [`try { ... }`](/en-US/docs/Web/JavaScript/Referen
       translator = await Translator.create({
         sourceLanguage: detectedLanguage,
         targetLanguage: formData.get("translateLanguage"),
-        monitor: (monitor) => {
+        monitor(monitor) {
           monitor.addEventListener("downloadprogress", (e) => {
             translateOutput.textContent = `Downloaded ${Math.floor(
               e.loaded * 100
@@ -425,7 +425,7 @@ textarea.addEventListener("input", detectLanguage);
 async function detectLanguage() {
   if (textarea.value.length > 20) {
     const detector = await LanguageDetector.create({
-      monitor: (monitor) => {
+      monitor(monitor) {
         monitor.addEventListener("downloadprogress", (e) => {
           console.log(`Downloaded ${e.loaded * 100}%`);
         });
@@ -478,7 +478,7 @@ async function handleTranslation(e) {
       translator = await Translator.create({
         sourceLanguage: detectedLanguage,
         targetLanguage: formData.get("translateLanguage"),
-        monitor: (monitor) => {
+        monitor(monitor) {
           monitor.addEventListener("downloadprogress", (e) => {
             translateOutput.textContent = `Downloaded ${Math.floor(
               e.loaded * 100,

--- a/files/en-us/web/api/trusted_types_api/index.md
+++ b/files/en-us/web/api/trusted_types_api/index.md
@@ -95,7 +95,7 @@ If you create a policy named `"default"`, and your CSP enforces the use of trust
 
 ```js
 trustedTypes.createPolicy("default", {
-  createHTML: (value) => {
+  createHTML(value) {
     console.log("Please refactor this code");
     return sanitize(value);
   },
@@ -117,7 +117,7 @@ If the default policy returned `null` or `undefined`, then the browser will thro
 
 ```js
 trustedTypes.createPolicy("default", {
-  createHTML: (value) => {
+  createHTML(value) {
     console.log("Please refactor this code");
     return null;
   },

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -62,7 +62,7 @@ The default policy logs a message to the console to remind the developer to refa
 
 ```js
 trustedTypes.createPolicy("default", {
-  createScriptURL: (s, type, sink) => {
+  createScriptURL(s, type, sink) {
     console.log("Please refactor.");
     return `${s}?default-policy-used&type=${encodeURIComponent(
       type,

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -70,13 +70,13 @@ console.log(url.origin);
 
 const add_params = {
   c: "a",
-  d: new String(2),
-  e: false.toString(),
+  d: 2,
+  e: false,
 };
 
 const new_params = new URLSearchParams([
   ...Array.from(url.searchParams.entries()), // [["a","hello"],["b","world"]]
-  ...Object.entries(add_params), // [["c","a"],["d","2"],["e","false"]]
+  ...Object.entries(add_params), // [["c","a"],["d",2],["e",false]]
 ]).toString();
 console.log(new_params);
 // a=hello&b=world&c=a&d=2&e=false

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -81,7 +81,7 @@ The following example creates a new {{domxref("VideoDecoder")}} and configures i
 ```js
 const init = {
   output: handleFrame,
-  error: (e) => {
+  error(e) {
     console.log(e.message);
   },
 };

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -82,7 +82,7 @@ The following example creates a new {{domxref("VideoEncoder")}} and configures i
 ```js
 const init = {
   output: handleChunk,
-  error: (e) => {
+  error(e) {
     console.log(e.message);
   },
 };

--- a/files/en-us/web/api/webgpu_api/index.md
+++ b/files/en-us/web/api/webgpu_api/index.md
@@ -157,7 +157,7 @@ const canvas = document.querySelector("#gpuCanvas");
 const context = canvas.getContext("webgpu");
 
 context.configure({
-  device: device,
+  device,
   format: navigator.gpu.getPreferredCanvasFormat(),
   alphaMode: "premultiplied",
 });

--- a/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_javascript_deno/index.md
+++ b/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_javascript_deno/index.md
@@ -25,7 +25,7 @@ Create a `main.js` file. This file will contain the code for a simple HTTP serve
 ```js
 Deno.serve({
   port: 80,
-  handler: async (request) => {
+  async handler(request) {
     if (request.headers.get("upgrade") !== "websocket") {
       // If the request is a normal HTTP request,
       // we serve the client HTML file.

--- a/files/en-us/web/javascript/reference/errors/bad_super_prop/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_super_prop/index.md
@@ -33,7 +33,7 @@ You can't use `super.x` outside of a method in an object:
 ```js example-bad
 const obj = {
   __proto__: { x: 1 },
-  x: super.x, // SyntaxError
+  x: super.x, // SyntaxError: use of super property accesses only valid within methods or eval code within methods
 };
 ```
 
@@ -41,13 +41,13 @@ You can't use `super.x` in a function, even if that function has the effect of b
 
 ```js example-bad
 function getX() {
-  return super.x; // SyntaxError
+  return super.x; // SyntaxError: use of super property accesses only valid within methods or eval code within methods
 }
 
 const obj = {
   getX,
   getX2: function () {
-    return super.x; // SyntaxError
+    return super.x; // SyntaxError: use of super property accesses only valid within methods or eval code within methods
   },
 };
 

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -44,15 +44,15 @@ If you are creating an `Array` using the constructor, you probably want to use t
 ### Invalid cases
 
 ```js example-bad
-new Array(Math.pow(2, 40));
+new Array(2 ** 40);
 new Array(-1);
-new ArrayBuffer(Math.pow(2, 32)); // 32-bit system
+new ArrayBuffer(2 ** 32); // 32-bit system
 new ArrayBuffer(-1);
 
 const a = [];
 a.length -= 1; // set the length property to -1
 
-const b = new Array(Math.pow(2, 32) - 1);
+const b = new Array(2 ** 32 - 1);
 b.length += 1; // set the length property to 2^32
 b.length = 2.5; // set the length property to a floating-point number
 
@@ -68,16 +68,16 @@ for (const e of arr) {
 ### Valid cases
 
 ```js example-good
-[Math.pow(2, 40)]; // [ 1099511627776 ]
+[2 ** 40]; // [ 1099511627776 ]
 [-1]; // [ -1 ]
-new ArrayBuffer(Math.pow(2, 31) - 1);
-new ArrayBuffer(Math.pow(2, 33)); // 64-bit systems after Firefox 89
+new ArrayBuffer(2 ** 31 - 1);
+new ArrayBuffer(2 ** 33); // 64-bit systems after Firefox 89
 new ArrayBuffer(0);
 
 const a = [];
 a.length = Math.max(0, a.length - 1);
 
-const b = new Array(Math.pow(2, 32) - 1);
+const b = new Array(2 ** 32 - 1);
 b.length = Math.min(0xffffffff, b.length + 1);
 // 0xffffffff is the hexadecimal notation for 2^32 - 1
 // which can also be written as (-1 >>> 0)

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -14,7 +14,7 @@ The **`bind()`** method of {{jsxref("Function")}} instances creates a new functi
 ```js interactive-example
 const module = {
   x: 42,
-  getX: function () {
+  getX() {
     return this.x;
   },
 };

--- a/files/en-us/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/infinity/index.md
@@ -12,7 +12,7 @@ The **`Infinity`** global property is a numeric value representing infinity.
 {{InteractiveExample("JavaScript Demo: Infinity")}}
 
 ```js interactive-example
-const maxNumber = Math.pow(10, 1000); // Max positive number
+const maxNumber = 10 ** 1000; // Max positive number
 
 if (maxNumber === Infinity) {
   console.log("Let's call it Infinity!");
@@ -44,7 +44,7 @@ This value behaves slightly differently than mathematical infinity; see {{jsxref
 ```js
 console.log(Infinity); /* Infinity */
 console.log(Infinity + 1); /* Infinity */
-console.log(Math.pow(10, 1000)); /* Infinity */
+console.log(10 ** 1000); /* Infinity */
 console.log(Math.log(0)); /* -Infinity */
 console.log(1 / Infinity); /* 0 */
 console.log(1 / 0); /* Infinity */

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -19,10 +19,10 @@ function warn(x) {
   return "Precision may be lost!";
 }
 
-console.log(warn(Math.pow(2, 53)));
+console.log(warn(2 ** 53));
 // Expected output: "Precision may be lost!"
 
-console.log(warn(Math.pow(2, 53) - 1));
+console.log(warn(2 ** 53 - 1));
 // Expected output: "Precision safe."
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -14,7 +14,7 @@ The **`Object.create()`** static method creates a new object, using an existing 
 ```js interactive-example
 const person = {
   isHuman: false,
-  printIntroduction: function () {
+  printIntroduction() {
     console.log(`My name is ${this.name}. Am I human? ${this.isHuman}`);
   },
 };

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
@@ -17,7 +17,7 @@ function sum(a, b) {
 }
 
 const handler = {
-  apply: function (target, thisArg, argumentsList) {
+  apply(target, thisArg, argumentsList) {
     console.log(`Calculate sum: ${argumentsList}`);
     // Expected output: "Calculate sum: 1,2"
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.md
@@ -18,7 +18,7 @@ const monster1 = {
 };
 
 const handler1 = {
-  get: function (target, prop, receiver) {
+  get(target, prop, receiver) {
     if (prop === "secret") {
       return `${target.secret.substring(0, 4)} ... shhhh!`;
     }

--- a/files/en-us/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -38,7 +38,7 @@ None ({{jsxref("undefined")}}).
 The following example shows how to recompile a regular expression with a new pattern and a new flag.
 
 ```js
-const regexObj = new RegExp("foo", "gi");
+const regexObj = /foo/gi;
 regexObj.compile("new foo", "g");
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -12,12 +12,12 @@ The **`dotAll`** accessor property of {{jsxref("RegExp")}} instances returns whe
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.dotAll")}}
 
 ```js interactive-example
-const regex1 = new RegExp("f.o", "s");
+const regex1 = /f.o/s;
 
 console.log(regex1.dotAll);
 // Expected output: true
 
-const regex2 = new RegExp("bar");
+const regex2 = /bar/;
 
 console.log(regex2.dotAll);
 // Expected output: false

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -12,7 +12,7 @@ The **`exec()`** method of {{jsxref("RegExp")}} instances executes a search with
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.exec()")}}
 
 ```js interactive-example
-const regex1 = RegExp("fo+", "g");
+const regex1 = /fo+/g;
 const str1 = "table football, foosball";
 let array1;
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/global/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/global/index.md
@@ -12,12 +12,12 @@ The **`global`** accessor property of {{jsxref("RegExp")}} instances returns whe
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.global")}}
 
 ```js interactive-example
-const regex1 = new RegExp("foo", "g");
+const regex1 = /foo/g;
 
 console.log(regex1.global);
 // Expected output: true
 
-const regex2 = new RegExp("bar", "i");
+const regex2 = /bar/i;
 
 console.log(regex2.global);
 // Expected output: false

--- a/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.md
@@ -12,12 +12,12 @@ The **`hasIndices`** accessor property of {{jsxref("RegExp")}} instances returns
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.hasIndices")}}
 
 ```js interactive-example
-const regex1 = new RegExp("foo", "d");
+const regex1 = /foo/d;
 
 console.log(regex1.hasIndices);
 // Expected output: true
 
-const regex2 = new RegExp("bar");
+const regex2 = /bar/;
 
 console.log(regex2.hasIndices);
 // Expected output: false

--- a/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -12,8 +12,8 @@ The **`ignoreCase`** accessor property of {{jsxref("RegExp")}} instances returns
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.ignoreCase")}}
 
 ```js interactive-example
-const regex1 = new RegExp("foo");
-const regex2 = new RegExp("foo", "i");
+const regex1 = /foo/;
+const regex2 = /foo/i;
 
 console.log(regex1.test("Football"));
 // Expected output: false

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.md
@@ -12,7 +12,7 @@ The **`lastIndex`** data property of a {{jsxref("RegExp")}} instance specifies t
 {{InteractiveExample("JavaScript Demo: RegExp: lastIndex")}}
 
 ```js interactive-example
-const regex1 = new RegExp("foo", "g");
+const regex1 = /foo/g;
 const str1 = "table football, foosball";
 
 regex1.test(str1);

--- a/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.md
@@ -12,8 +12,8 @@ The **`multiline`** accessor property of {{jsxref("RegExp")}} instances returns 
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.multiline", "taller")}}
 
 ```js interactive-example
-const regex1 = new RegExp("^football");
-const regex2 = new RegExp("^football", "m");
+const regex1 = /^football/;
+const regex2 = /^football/m;
 
 console.log(regex1.multiline);
 // Expected output: false

--- a/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.md
@@ -13,7 +13,7 @@ The **`sticky`** accessor property of {{jsxref("RegExp")}} instances returns whe
 
 ```js interactive-example
 const str1 = "table football";
-const regex1 = new RegExp("foo", "y");
+const regex1 = /foo/y;
 
 regex1.lastIndex = 6;
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/symbol.split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/symbol.split/index.md
@@ -22,7 +22,7 @@ class RegExp1 extends RegExp {
 console.log("2016-01-02".split(new RegExp1("-")));
 // Expected output: Array ["(2016)", "(01)", "(02)"]
 
-console.log("2016-01-02".split(new RegExp("-")));
+console.log("2016-01-02".split(/-/));
 // Expected output: Array ["2016", "01", "02"]
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/test/index.md
@@ -21,8 +21,8 @@ of text (with capture groups).
 ```js interactive-example
 const str = "table football";
 
-const regex = new RegExp("fo+");
-const globalRegex = new RegExp("fo+", "g");
+const regex = /fo+/;
+const globalRegex = /fo+/g;
 
 console.log(regex.test(str));
 // Expected output: true

--- a/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.md
@@ -12,8 +12,8 @@ The **`unicode`** accessor property of {{jsxref("RegExp")}} instances returns wh
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.unicode")}}
 
 ```js interactive-example
-const regex1 = new RegExp("\\u{61}");
-const regex2 = new RegExp("\\u{61}", "u");
+const regex1 = /\u{61}/;
+const regex2 = /\u{61}/u;
 
 console.log(regex1.unicode);
 // Expected output: false

--- a/files/en-us/web/javascript/reference/global_objects/regexp/unicodesets/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/unicodesets/index.md
@@ -12,8 +12,8 @@ The **`unicodeSets`** accessor property of {{jsxref("RegExp")}} instances return
 {{InteractiveExample("JavaScript Demo: RegExp.prototype.unicodeSets")}}
 
 ```js interactive-example
-const regex1 = new RegExp("[\\p{Lowercase}&&\\p{Script=Greek}]");
-const regex2 = new RegExp("[\\p{Lowercase}&&\\p{Script=Greek}]", "v");
+const regex1 = /[\p{Lowercase}&&\p{Script=Greek}]/;
+const regex2 = /[\p{Lowercase}&&\p{Script=Greek}]/v;
 
 console.log(regex1.unicodeSets);
 // Expected output: false

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -18,7 +18,7 @@ The value of `this` in JavaScript depends on how a function is invoked (runtime 
 ```js interactive-example
 const test = {
   prop: 42,
-  func: function () {
+  func() {
     return this.prop;
   },
 };

--- a/files/en-us/webassembly/reference/control_flow/call/index.md
+++ b/files/en-us/webassembly/reference/control_flow/call/index.md
@@ -32,7 +32,7 @@ Calling the `greet` function imported from JavaScript using `call`:
 const url = "{%wasm-url%}";
 await WebAssembly.instantiateStreaming(fetch(url), {
   env: {
-    greet: function () {
+    greet() {
       console.log("Hello");
       // Expected output: "Hello"
     },


### PR DESCRIPTION
Our style guide prescribes the use of modern syntax. This PR enforces the use of:

- Object shorthand, including method syntax and `a: a` => `a`
- Regex literals instead of `new RegExp`
- Exponentiation `**` instead of `Math.pow`