### PR TITLE
Lint: migrate function expressions to arrow functions or declarations

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
@@ -205,9 +205,9 @@ const boxMaterial = new BABYLON.StandardMaterial("material", scene);
 boxMaterial.emissiveColor = new BABYLON.Color3(0, 0.58, 0.86);
 box.material = boxMaterial;
 
-const renderLoop = function () {
+function renderLoop() {
   scene.render();
-};
+}
 
 engine.runRenderLoop(renderLoop);
 ```
@@ -367,13 +367,13 @@ cylinderMaterial.emissiveColor = new BABYLON.Color3(1, 0.58, 0);
 cylinder.material = cylinderMaterial;
 
 let t = 0;
-const renderLoop = function () {
+function renderLoop() {
   scene.render();
   t -= 0.01;
   box.rotation.y = t * 2;
   torus.scaling.z = Math.abs(Math.sin(t * 2)) + 0.5;
   cylinder.position.y = Math.sin(t * 3);
-};
+}
 engine.runRenderLoop(renderLoop);
 ```
 

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/editor/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/editor/index.md
@@ -110,7 +110,7 @@ Animating 3D models might be considered an [advanced](https://developer.playcanv
 If you double click on it, you'll be moved to a code editor. As you can see, the file contains some boilerplate code already:
 
 ```js
-pc.script.create("boxAnimation", function (app) {
+pc.script.create("boxAnimation", (app) => {
   class BoxAnimation {
     constructor(entity) {
       this.entity = entity;

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -208,7 +208,7 @@ boxMaterial.diffuse.set(0, 0.58, 0.86);
 boxMaterial.update();
 box.model.model.meshInstances[0].material = boxMaterial;
 
-window.addEventListener("resize", function () {
+window.addEventListener("resize", () => {
   app.resizeCanvas(canvas.width, canvas.height);
 });
 ```
@@ -393,7 +393,7 @@ cone.model.model.meshInstances[0].material = coneMaterial;
 
 // Animate shapes
 let timer = 0;
-app.on("update", function (deltaTime) {
+app.on("update", (deltaTime) => {
   timer += deltaTime;
   box.rotate(deltaTime * 10, deltaTime * 20, deltaTime * 3);
   cylinder.setLocalScale(1, Math.abs(Math.sin(timer)), 1);

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -149,9 +149,10 @@ function startGame() {
   setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
-  this.disabled = true;
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -239,9 +239,10 @@ function startGame() {
   interval = setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
-  this.disabled = true;
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -282,9 +282,10 @@ function startGame() {
   interval = setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
-  this.disabled = true;
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -283,9 +283,10 @@ function draw() {
   requestAnimationFrame(draw);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
-  draw();
-  this.disabled = true;
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
+  startGame();
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -183,9 +183,10 @@ function startGame() {
   interval = setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
-  this.disabled = true;
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -217,8 +217,10 @@ function startGame() {
   interval = setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -179,9 +179,10 @@ function startGame() {
   setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
-  this.disabled = true;
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -211,9 +211,10 @@ function startGame() {
   setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
-  this.disabled = true;
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -261,8 +261,10 @@ function startGame() {
   interval = setInterval(draw, 10);
 }
 
-document.getElementById("runButton").addEventListener("click", function () {
+const runButton = document.getElementById("runButton");
+runButton.addEventListener("click", () => {
   startGame();
+  runButton.disabled = true;
 });
 ```
 

--- a/files/en-us/learn_web_development/core/scripting/loops/index.md
+++ b/files/en-us/learn_web_development/core/scripting/loops/index.md
@@ -670,7 +670,7 @@ function updateCode() {
   eval(textarea.value);
 }
 
-reset.addEventListener("click", function () {
+reset.addEventListener("click", () => {
   textarea.value = code;
   userEntry = textarea.value;
   solutionEntry = jsSolution;
@@ -678,7 +678,7 @@ reset.addEventListener("click", function () {
   updateCode();
 });
 
-solution.addEventListener("click", function () {
+solution.addEventListener("click", () => {
   if (solution.value === "Show solution") {
     textarea.value = solutionEntry;
     solution.value = "Hide solution";
@@ -851,7 +851,7 @@ function updateCode() {
   eval(textarea.value);
 }
 
-reset.addEventListener("click", function () {
+reset.addEventListener("click", () => {
   textarea.value = code;
   userEntry = textarea.value;
   solutionEntry = jsSolution;
@@ -859,7 +859,7 @@ reset.addEventListener("click", function () {
   updateCode();
 });
 
-solution.addEventListener("click", function () {
+solution.addEventListener("click", () => {
   if (solution.value === "Show solution") {
     textarea.value = solutionEntry;
     solution.value = "Hide solution";

--- a/files/en-us/learn_web_development/core/scripting/useful_string_methods/index.md
+++ b/files/en-us/learn_web_development/core/scripting/useful_string_methods/index.md
@@ -462,7 +462,7 @@ function updateCode() {
   eval(textarea.value);
 }
 
-reset.addEventListener("click", function () {
+reset.addEventListener("click", () => {
   textarea.value = code;
   userEntry = textarea.value;
   solutionEntry = jsSolution;
@@ -470,7 +470,7 @@ reset.addEventListener("click", function () {
   updateCode();
 });
 
-solution.addEventListener("click", function () {
+solution.addEventListener("click", () => {
   if (solution.value === "Show solution") {
     textarea.value = solutionEntry;
     solution.value = "Hide solution";
@@ -641,7 +641,7 @@ function updateCode() {
   eval(textarea.value);
 }
 
-reset.addEventListener("click", function () {
+reset.addEventListener("click", () => {
   textarea.value = code;
   userEntry = textarea.value;
   solutionEntry = jsSolution;
@@ -649,7 +649,7 @@ reset.addEventListener("click", function () {
   updateCode();
 });
 
-solution.addEventListener("click", function () {
+solution.addEventListener("click", () => {
   if (solution.value === "Show solution") {
     textarea.value = solutionEntry;
     solution.value = "Hide solution";

--- a/files/en-us/learn_web_development/core/structuring_content/general_embedding_technologies/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/general_embedding_technologies/index.md
@@ -119,7 +119,7 @@ function updateCode() {
   output.innerHTML = textarea.value;
 }
 
-reset.addEventListener("click", function () {
+reset.addEventListener("click", () => {
   textarea.value = code;
   userEntry = textarea.value;
   solutionEntry = htmlSolution;
@@ -127,7 +127,7 @@ reset.addEventListener("click", function () {
   updateCode();
 });
 
-solution.addEventListener("click", function () {
+solution.addEventListener("click", () => {
   if (solution.value === "Show solution") {
     textarea.value = solutionEntry;
     solution.value = "Hide solution";

--- a/files/en-us/learn_web_development/core/structuring_content/including_vector_graphics_in_html/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/including_vector_graphics_in_html/index.md
@@ -252,7 +252,7 @@ function updateCode() {
   output.innerHTML = textarea.value;
 }
 
-reset.addEventListener("click", function () {
+reset.addEventListener("click", () => {
   textarea.value = code;
   userEntry = textarea.value;
   solutionEntry = htmlSolution;
@@ -260,7 +260,7 @@ reset.addEventListener("click", function () {
   updateCode();
 });
 
-solution.addEventListener("click", function () {
+solution.addEventListener("click", () => {
   if (solution.value === "Show solution") {
     textarea.value = solutionEntry;
     solution.value = "Hide solution";
@@ -280,7 +280,7 @@ window.addEventListener("load", updateCode);
 // stop tab key tabbing out of textarea and
 // make it write a tab at the caret position instead
 
-textarea.onkeydown = function (e) {
+textarea.onkeydown = (e) => {
   if (e.code === "Tab") {
     e.preventDefault();
     insertAtCaret("\t");
@@ -310,7 +310,7 @@ function insertAtCaret(text) {
 
 // Update the saved userCode every time the user updates the text area code
 
-textarea.onkeyup = function () {
+textarea.onkeyup = () => {
   // We only want to save the state when the user code is being shown,
   // not the solution, so that solution is not saved over the user code
   if (solution.value === "Show solution") {

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -67,7 +67,7 @@ The following example creates a web server that listens for any kind of HTTP req
    const port = 8000;
 
    // Create HTTP server
-   const server = http.createServer(function (req, res) {
+   const server = http.createServer((req, res) => {
      // Set the response HTTP header with HTTP status and Content type
      res.writeHead(200, { "Content-Type": "text/plain" });
 
@@ -76,7 +76,7 @@ The following example creates a web server that listens for any kind of HTTP req
    });
 
    // Prints a log once the server starts listening
-   server.listen(port, hostname, function () {
+   server.listen(port, hostname, () => {
      console.log(`Server running at http://${hostname}:${port}/`);
    });
    ```
@@ -158,11 +158,11 @@ const express = require("express");
 const app = express();
 const port = 3000;
 
-app.get("/", function (req, res) {
+app.get("/", (req, res) => {
   res.send("Hello World!");
 });
 
-app.listen(port, function () {
+app.listen(port, () => {
   console.log(`Example app listening on port ${port}!`);
 });
 ```
@@ -243,7 +243,7 @@ console.log("Second");
 By contrast, an asynchronous API is one in which the API will start an operation and immediately return (before the operation is complete). Once the operation finishes, the API will use some mechanism to perform additional operations. For example, the code below will print out "Second, First" because even though `setTimeout()` method is called first, and returns immediately, the operation doesn't complete for several seconds.
 
 ```js
-setTimeout(function () {
+setTimeout(() => {
   console.log("First");
 }, 3000);
 console.log("Second");
@@ -264,7 +264,7 @@ There are a number of ways for an asynchronous API to notify your application th
 In our _Hello World_ Express example (see above), we defined a (callback) route handler function for HTTP `GET` requests to the site root (`'/'`).
 
 ```js
-app.get("/", function (req, res) {
+app.get("/", (req, res) => {
   res.send("Hello World!");
 });
 ```
@@ -281,7 +281,7 @@ The _Express application_ object also provides methods to define route handlers 
 There is a special routing method, `app.all()`, which will be called in response to any HTTP method. This is used for loading middleware functions at a particular path for all request methods. The following example (from the Express documentation) shows a handler that will be executed for requests to `/secret` irrespective of the HTTP verb used (provided it is supported by the [http module](https://nodejs.org/docs/latest/api/http.html#httpmethods)).
 
 ```js
-app.all("/secret", function (req, res, next) {
+app.all("/secret", (req, res, next) => {
   console.log("Accessing the secret section…");
   next(); // pass control to the next handler
 });
@@ -299,12 +299,12 @@ const express = require("express");
 const router = express.Router();
 
 // Home page route
-router.get("/", function (req, res) {
+router.get("/", (req, res) => {
   res.send("Wiki home page");
 });
 
 // About page route
-router.get("/about", function (req, res) {
+router.get("/about", (req, res) => {
   res.send("About this wiki");
 });
 
@@ -367,19 +367,19 @@ const express = require("express");
 const app = express();
 
 // An example middleware function
-const a_middleware_function = function (req, res, next) {
+function aMiddlewareFunction(req, res, next) {
   // Perform some operations
   next(); // Call next() so Express will call the next middleware function in the chain.
-};
+}
 
 // Function added with use() for all routes and verbs
-app.use(a_middleware_function);
+app.use(aMiddlewareFunction);
 
 // Function added with use() for a specific route
-app.use("/some-route", a_middleware_function);
+app.use("/some-route", aMiddlewareFunction);
 
 // A middleware function added for a specific HTTP verb and route
-app.get("/", a_middleware_function);
+app.get("/", aMiddlewareFunction);
 
 app.listen(3000);
 ```
@@ -435,7 +435,7 @@ http://localhost:3000/media/cry.mp3
 Errors are handled by one or more special middleware functions that have four arguments, instead of the usual three: `(err, req, res, next)`. For example:
 
 ```js
-app.use(function (err, req, res, next) {
+app.use((err, req, res, next) => {
   console.error(err.stack);
   res.status(500).send("Something broke!");
 });
@@ -531,7 +531,7 @@ app.set("view engine", "some_template_engine_name");
 The appearance of the template will depend on what engine you use. Assuming that you have a template file named "index.\<template_extension>" that contains placeholders for data variables named 'title' and "message", you would call [`Response.render()`](https://expressjs.com/en/4x/api.html#res.render) in a route handler function to create and send the HTML response:
 
 ```js
-app.get("/", function (req, res) {
+app.get("/", (req, res) => {
   res.render("index", { title: "About dogs", message: "Dogs rock!" });
 });
 ```

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/routes/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/routes/index.md
@@ -72,12 +72,12 @@ const express = require("express");
 const router = express.Router();
 
 // Home page route.
-router.get("/", function (req, res) {
+router.get("/", (req, res) => {
   res.send("Wiki home page");
 });
 
 // About page route.
-router.get("/about", function (req, res) {
+router.get("/about", (req, res) => {
   res.send("About this wiki");
 });
 
@@ -103,7 +103,7 @@ The two routes defined in our wiki route module are then accessible from `/wiki/
 Our module above defines a couple of typical route functions. The "about" route (reproduced below) is defined using the `Router.get()` method, which responds only to HTTP GET requests. The first argument to this method is the URL path while the second is a callback function that will be invoked if an HTTP GET request with the path is received.
 
 ```js
-router.get("/about", function (req, res) {
+router.get("/about", (req, res) => {
   res.send("About this wiki");
 });
 ```
@@ -145,7 +145,7 @@ Route paths can also be string patterns. String patterns use a form of regular e
 The route paths can also be JavaScript [regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_expressions). For example, the route path below will match `catfish` and `dogfish`, but not `catflap`, `catfishhead`, and so on. Note that the path for a regular expression uses regular expression syntax (it is not a quoted string as in the previous cases).
 
 ```js
-app.get(/.*fish$/, function (req, res) {
+app.get(/.*fish$/, (req, res) => {
   // …
 });
 ```
@@ -209,7 +209,7 @@ In order for the framework to properly handle exceptions, they must be caught, a
 Re-imagining the simple example from the previous section with `About.find().exec()` as a database query that returns a promise, we might write the route function inside a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block like this:
 
 ```js
-exports.get("/about", async function (req, res, next) {
+exports.get("/about", async (req, res, next) => {
   try {
     const successfulResult = await About.find({}).exec();
     res.render("about_view", { title: "About", list: successfulResult });
@@ -661,7 +661,7 @@ Open **/routes/index.js** and replace the existing route with the function below
 
 ```js
 // GET home page.
-router.get("/", function (req, res) {
+router.get("/", (req, res) => {
   res.redirect("/catalog");
 });
 ```

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -701,7 +701,7 @@ Below is an example on how to interact with the TestingBot API with the NodeJS c
      api_secret: "your-tb-secret",
    });
 
-   tb.getTests(function (err, tests) {
+   tb.getTests((err, tests) => {
      console.log(tests);
    });
    ```

--- a/files/en-us/learn_web_development/extensions/testing/feature_detection/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/feature_detection/index.md
@@ -43,7 +43,7 @@ Let's recap and look at the example we touched on in our [JavaScript debugging a
 
 ```js
 if ("geolocation" in navigator) {
-  navigator.geolocation.getCurrentPosition(function (position) {
+  navigator.geolocation.getCurrentPosition((position) => {
     // show the location on a map, such as the Google Maps API
   });
 } else {

--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -117,7 +117,7 @@ For specific cases where it is seen as beneficial, a separate **Formal syntax** 
 The aim is to make the syntax block as pure and unambiguous a definition of the feature's syntax as possible — don't include any irrelevant syntax. For example, you may see this syntax form used to describe promises in many places on the site:
 
 ```js-nolint
-caches.match(request, options).then(function (response) {
+caches.match(request, options).then((response) => {
   // Do something with the response
 })
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/cloneinto/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/cloneinto/index.md
@@ -10,7 +10,7 @@ browser-compat: webextensions.api.contentScriptGlobalScope.cloneInto
 This function provides a safe way to take an object defined in a privileged scope and create a [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) of it in a less-privileged scope. It returns a reference to the clone:
 
 ```js
-const clonedObject = cloneInto(myObject, targetWindow);
+var clonedObject = cloneInto(myObject, targetWindow);
 ```
 
 You can then assign the clone to an object in the target scope as an expando property, and scripts running in that scope can access it:
@@ -54,7 +54,7 @@ This content script creates an object, clones it into the content window and mak
 
 ```js
 // content script
-const addonScriptObject = { greeting: "hello from your extension" };
+var addonScriptObject = { greeting: "hello from your extension" };
 window.addonScriptObject = cloneInto(addonScriptObject, window);
 ```
 
@@ -64,7 +64,7 @@ Scripts running in the page can access the object:
 // page script
 button.addEventListener(
   "click",
-  () => {
+  function () {
     console.log(window.addonScriptObject.greeting); // "hello from your extension"
   },
   false,
@@ -91,18 +91,18 @@ The content script can define an object, clone it, and pass it into this functio
 
 ```js
 // content script
-const addonScriptObject = { message: "hello from your extension" };
+var addonScriptObject = { message: "hello from your extension" };
 window.foo(cloneInto(addonScriptObject, window)); // "they said: hello from your extension"
 ```
 
 ### Cloning objects that have functions
 
-If the object to clone contains functions, you must pass the `{ cloneFunctions: true }` flag, or you get an error. If you do pass this flag, then functions in the object are cloned using the same mechanism used in [`exportFunction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts/exportFunction):
+If the object to clone contains functions, you must pass the `{cloneFunctions:true}` flag, or you get an error. If you do pass this flag, then functions in the object are cloned using the same mechanism used in [`exportFunction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts/exportFunction):
 
 ```js
 // content script
-const addonScriptObject = {
-  greetMe() {
+var addonScriptObject = {
+  greetMe: function () {
     alert("hello from your extension");
   },
 };
@@ -113,10 +113,10 @@ window.addonScriptObject = cloneInto(addonScriptObject, window, {
 
 ```js
 // page script
-const test = document.getElementById("test");
+var test = document.getElementById("test");
 test.addEventListener(
   "click",
-  () => {
+  function () {
     window.addonScriptObject.greetMe();
   },
   false,
@@ -125,11 +125,11 @@ test.addEventListener(
 
 ### Cloning objects that contain DOM elements
 
-By default, if the object you clone contains objects reflected from C++, such as DOM elements, the cloning operation fails with an error. If you pass the `{ wrapReflectors: true }` flag, then the object you clone contains these objects:
+By default, if the object you clone contains objects reflected from C++, such as DOM elements, the cloning operation fails with an error. If you pass the `{wrapReflectors:true}` flag, then the object you clone contains these objects:
 
 ```js
 // content script
-const addonScriptObject = {
+var addonScriptObject = {
   body: window.document.body,
 };
 window.addonScriptObject = cloneInto(addonScriptObject, window, {
@@ -139,10 +139,10 @@ window.addonScriptObject = cloneInto(addonScriptObject, window, {
 
 ```js
 // page script
-const test = document.getElementById("test");
+var test = document.getElementById("test");
 test.addEventListener(
   "click",
-  () => {
+  function () {
     console.log(window.addonScriptObject.body.innerHTML);
   },
   false,

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/cloneinto/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/cloneinto/index.md
@@ -10,7 +10,7 @@ browser-compat: webextensions.api.contentScriptGlobalScope.cloneInto
 This function provides a safe way to take an object defined in a privileged scope and create a [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) of it in a less-privileged scope. It returns a reference to the clone:
 
 ```js
-var clonedObject = cloneInto(myObject, targetWindow);
+const clonedObject = cloneInto(myObject, targetWindow);
 ```
 
 You can then assign the clone to an object in the target scope as an expando property, and scripts running in that scope can access it:
@@ -54,7 +54,7 @@ This content script creates an object, clones it into the content window and mak
 
 ```js
 // content script
-var addonScriptObject = { greeting: "hello from your extension" };
+const addonScriptObject = { greeting: "hello from your extension" };
 window.addonScriptObject = cloneInto(addonScriptObject, window);
 ```
 
@@ -64,7 +64,7 @@ Scripts running in the page can access the object:
 // page script
 button.addEventListener(
   "click",
-  function () {
+  () => {
     console.log(window.addonScriptObject.greeting); // "hello from your extension"
   },
   false,
@@ -91,18 +91,18 @@ The content script can define an object, clone it, and pass it into this functio
 
 ```js
 // content script
-var addonScriptObject = { message: "hello from your extension" };
+const addonScriptObject = { message: "hello from your extension" };
 window.foo(cloneInto(addonScriptObject, window)); // "they said: hello from your extension"
 ```
 
 ### Cloning objects that have functions
 
-If the object to clone contains functions, you must pass the `{cloneFunctions:true}` flag, or you get an error. If you do pass this flag, then functions in the object are cloned using the same mechanism used in [`exportFunction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts/exportFunction):
+If the object to clone contains functions, you must pass the `{ cloneFunctions: true }` flag, or you get an error. If you do pass this flag, then functions in the object are cloned using the same mechanism used in [`exportFunction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts/exportFunction):
 
 ```js
 // content script
-var addonScriptObject = {
-  greetMe: function () {
+const addonScriptObject = {
+  greetMe() {
     alert("hello from your extension");
   },
 };
@@ -113,10 +113,10 @@ window.addonScriptObject = cloneInto(addonScriptObject, window, {
 
 ```js
 // page script
-var test = document.getElementById("test");
+const test = document.getElementById("test");
 test.addEventListener(
   "click",
-  function () {
+  () => {
     window.addonScriptObject.greetMe();
   },
   false,
@@ -125,11 +125,11 @@ test.addEventListener(
 
 ### Cloning objects that contain DOM elements
 
-By default, if the object you clone contains objects reflected from C++, such as DOM elements, the cloning operation fails with an error. If you pass the `{wrapReflectors:true}` flag, then the object you clone contains these objects:
+By default, if the object you clone contains objects reflected from C++, such as DOM elements, the cloning operation fails with an error. If you pass the `{ wrapReflectors: true }` flag, then the object you clone contains these objects:
 
 ```js
 // content script
-var addonScriptObject = {
+const addonScriptObject = {
   body: window.document.body,
 };
 window.addonScriptObject = cloneInto(addonScriptObject, window, {
@@ -139,10 +139,10 @@ window.addonScriptObject = cloneInto(addonScriptObject, window, {
 
 ```js
 // page script
-var test = document.getElementById("test");
+const test = document.getElementById("test");
 test.addEventListener(
   "click",
-  function () {
+  () => {
     console.log(window.addonScriptObject.body.innerHTML);
   },
   false,

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/exportfunction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/exportfunction/index.md
@@ -64,11 +64,11 @@ exportFunction(changeMyName, window, {
 
 ```js
 // less-privileged scope: for example, a page script
-const user = { name: "Jim" };
-const test = document.getElementById("test");
+var user = { name: "Jim" };
+var test = document.getElementById("test");
 test.addEventListener(
   "click",
-  () => {
+  function () {
     console.log(user.name); // "Jim"
     window.changeMyName(user);
     console.log(user.name); // "Bill"
@@ -96,15 +96,15 @@ exportFunction(logUser, window, {
 
 ```js
 // less-privileged scope: for example, a page script
-const user = {
-  getUser() {
+var user = {
+  getUser: function () {
     return "Bill";
   },
 };
-const test = document.getElementById("test");
+var test = document.getElementById("test");
 test.addEventListener(
   "click",
-  () => {
+  function () {
     window.logUser(user);
   },
   false,
@@ -132,10 +132,10 @@ exportFunction(logUser, unsafeWindow, {
 function getUser() {
   return "Bill";
 }
-const test = document.getElementById("test");
+var test = document.getElementById("test");
 test.addEventListener(
   "click",
-  () => {
+  function () {
     window.logUser(getUser);
   },
   false,
@@ -154,7 +154,7 @@ This script defines a function and then exports it to a content window:
 
 ```js
 // extension-script.js
-const salutation = "hello ";
+var salutation = "hello ";
 function greetMe(user) {
   return salutation + user;
 }
@@ -165,7 +165,7 @@ Instead of using `defineAs`, the script can assign the result of `exportFunction
 
 ```js
 // extension-script.js
-const salutation = "hello ";
+var salutation = "hello ";
 function greetMe(user) {
   return salutation + user;
 }
@@ -176,18 +176,18 @@ Either way, code running in the content window's scope can call the function:
 
 ```js
 // page-script.js
-const greeting = foo("alice");
+var greeting = foo("alice");
 console.log(greeting);
 // "hello alice"
 ```
 
 ### Export to an existing local object
 
-Instead of attaching the function to the target's global `window` object, the caller can attach it to any other object in the target context. Suppose the content window defines a global `bar`:
+Instead of attaching the function to the target's global `window` object, the caller can attach it to any other object in the target context. Suppose the content window defines a local variable `bar`:
 
 ```js
 // page-script.js
-window.bar = {};
+var bar = {};
 ```
 
 Now the extension script can attach the function to `bar`:
@@ -201,7 +201,7 @@ exportFunction(greetMe, window.bar, {
 
 ```js
 // page-script.js
-const value = bar.greetMe("bob");
+var value = bar.greetMe("bob");
 console.log(value);
 // "hello bob"
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/exportfunction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/exportfunction/index.md
@@ -64,11 +64,11 @@ exportFunction(changeMyName, window, {
 
 ```js
 // less-privileged scope: for example, a page script
-var user = { name: "Jim" };
-var test = document.getElementById("test");
+const user = { name: "Jim" };
+const test = document.getElementById("test");
 test.addEventListener(
   "click",
-  function () {
+  () => {
     console.log(user.name); // "Jim"
     window.changeMyName(user);
     console.log(user.name); // "Bill"
@@ -96,15 +96,15 @@ exportFunction(logUser, window, {
 
 ```js
 // less-privileged scope: for example, a page script
-var user = {
-  getUser: function () {
+const user = {
+  getUser() {
     return "Bill";
   },
 };
-var test = document.getElementById("test");
+const test = document.getElementById("test");
 test.addEventListener(
   "click",
-  function () {
+  () => {
     window.logUser(user);
   },
   false,
@@ -132,10 +132,10 @@ exportFunction(logUser, unsafeWindow, {
 function getUser() {
   return "Bill";
 }
-var test = document.getElementById("test");
+const test = document.getElementById("test");
 test.addEventListener(
   "click",
-  function () {
+  () => {
     window.logUser(getUser);
   },
   false,
@@ -154,7 +154,7 @@ This script defines a function and then exports it to a content window:
 
 ```js
 // extension-script.js
-var salutation = "hello ";
+const salutation = "hello ";
 function greetMe(user) {
   return salutation + user;
 }
@@ -165,7 +165,7 @@ Instead of using `defineAs`, the script can assign the result of `exportFunction
 
 ```js
 // extension-script.js
-var salutation = "hello ";
+const salutation = "hello ";
 function greetMe(user) {
   return salutation + user;
 }
@@ -176,18 +176,18 @@ Either way, code running in the content window's scope can call the function:
 
 ```js
 // page-script.js
-var greeting = foo("alice");
+const greeting = foo("alice");
 console.log(greeting);
 // "hello alice"
 ```
 
 ### Export to an existing local object
 
-Instead of attaching the function to the target's global `window` object, the caller can attach it to any other object in the target context. Suppose the content window defines a local variable `bar`:
+Instead of attaching the function to the target's global `window` object, the caller can attach it to any other object in the target context. Suppose the content window defines a global `bar`:
 
 ```js
 // page-script.js
-var bar = {};
+window.bar = {};
 ```
 
 Now the extension script can attach the function to `bar`:
@@ -201,7 +201,7 @@ exportFunction(greetMe, window.bar, {
 
 ```js
 // page-script.js
-var value = bar.greetMe("bob");
+const value = bar.greetMe("bob");
 console.log(value);
 // "hello bob"
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -251,10 +251,8 @@ Reflect.defineProperty(
   ev.wrappedJSObject,
   "propC",
   {
-    get: exportFunction(() => {
-      // getters must be exported like regular functions
-      return "propC";
-    }, window),
+    // getters must be exported like regular functions
+    get: exportFunction(() => "propC", window),
   },
 );
 

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -249,7 +249,7 @@ Unlike the other mechanisms this returns when all fonts defined in the document 
 When the promise resolves we iterate the values in the document's font faces.
 
 ```js
-document.fonts.ready.then(function () {
+document.fonts.ready.then(() => {
   log.textContent += `\nFontFaces in document: ${document.fonts.size}.\n`;
 
   for (const fontFace of document.fonts.values()) {

--- a/files/en-us/web/api/delegatedinktrailpresenter/index.md
+++ b/files/en-us/web/api/delegatedinktrailpresenter/index.md
@@ -65,7 +65,7 @@ canvas.addEventListener("pointermove", (evt) => {
       "rgb(" + r + " " + g + " " + b + " / 100%)";
   }
   move_cnt += 1;
-  presenter.then(function (v) {
+  presenter.then((v) => {
     v.updateInkTrailStartPoint(evt, style);
   });
 });

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -460,9 +460,9 @@ event listener.
 
 ```js
 // Function to change the content of t2
-function modifyText(new_text) {
+function modifyText(newText) {
   const t2 = document.getElementById("t2");
-  t2.firstChild.nodeValue = new_text;
+  t2.firstChild.nodeValue = newText;
 }
 
 // Function to add event listener to table
@@ -506,9 +506,9 @@ notation.
 
 ```js
 // Function to change the content of t2
-function modifyText(new_text) {
+function modifyText(newText) {
   const t2 = document.getElementById("t2");
-  t2.firstChild.nodeValue = new_text;
+  t2.firstChild.nodeValue = newText;
 }
 
 // Add event listener to table with an arrow function

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -78,7 +78,7 @@ Websites often want to send analytics or diagnostics to the server when the user
 The most reliable way to do this is to send the data on the [`visibilitychange`](/en-US/docs/Web/API/Document/visibilitychange_event) event:
 
 ```js
-document.addEventListener("visibilitychange", function logData() {
+document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "hidden") {
     navigator.sendBeacon("/log", analyticsData);
   }
@@ -112,7 +112,7 @@ Like `beforeunload` and `unload`, this event is not reliably fired, especially o
 The following example specifies a handler for the {{domxref("document.visibilitychange_event", "visibilitychange")}} event. The handler calls `sendBeacon()` to send analytics.
 
 ```js
-document.addEventListener("visibilitychange", function logData() {
+document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "hidden") {
     navigator.sendBeacon("/log", analyticsData);
   }

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -40,7 +40,7 @@ In worker.js
 self.addEventListener("connect", (event) => {
   const port = event.ports[0];
 
-  port.onmessage = function (event) {
+  port.onmessage = (event) => {
     const workerTaskStart = performance.now();
     // doSomeWork()
     const workerTaskEnd = performance.now();

--- a/files/en-us/web/api/performancescripttiming/sourcefunctionname/index.md
+++ b/files/en-us/web/api/performancescripttiming/sourcefunctionname/index.md
@@ -19,12 +19,12 @@ For example, if an event handler calls a top-level function, which then calls a 
 In the following snippet:
 
 ```js
-setTimeout(function lib_func() {
-  slow_function();
+setTimeout(function libFunc() {
+  slowFunction();
 });
 ```
 
-`sourceFunctionName` would report `lib_func`, not `slow_function`.
+`sourceFunctionName` would report `libFunc`, not `slowFunction`.
 
 ## Value
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -71,7 +71,7 @@ This minimum example has `main` create an `ArrayBuffer` and transfer it to `myWo
 const myWorker = new Worker("myWorker.js");
 
 // listen for myWorker to transfer the buffer back to main
-myWorker.addEventListener("message", function handleMessageFromWorker(msg) {
+myWorker.addEventListener("message", (msg) => {
   console.log("message from worker received in main:", msg);
 
   const bufTransferredBackFromWorker = msg.data;

--- a/files/en-us/web/api/xmlhttprequest_api/html_in_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/html_in_xmlhttprequest/index.md
@@ -70,7 +70,7 @@ If the file is named `detect.html`, the following function can be used for detec
 ```js
 function detectHtmlInXhr(callback) {
   if (!window.XMLHttpRequest) {
-    setTimeout(function () {
+    setTimeout(() => {
       callback(false);
     }, 0);
 
@@ -101,7 +101,7 @@ function detectHtmlInXhr(callback) {
     xhr.responseType = "document";
     xhr.send();
   } catch (e) {
-    setTimeout(function () {
+    setTimeout(() => {
       if (!done) {
         done = true;
         callback(false);

--- a/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
+++ b/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
@@ -159,9 +159,9 @@ Changing between `display: flow-root` and `display: block flow-root` will achiev
 
 ```js hidden
 function changeDisplayType() {
-  var parentDiv = document.getElementById("parent");
-  var siblingDiv = document.getElementById("sibling");
-  var displayType = document.getElementById("displayType").value;
+  const parentDiv = document.getElementById("parent");
+  const siblingDiv = document.getElementById("sibling");
+  const displayType = document.getElementById("displayType").value;
 
   parentDiv.style.display = displayType;
   siblingDiv.style.display = displayType;

--- a/files/en-us/web/css/css_filter_effects/index.md
+++ b/files/en-us/web/css/css_filter_effects/index.md
@@ -172,7 +172,7 @@ for (control of controls) {
 document.querySelector("button").addEventListener(
   "click",
   () => {
-    setTimeout(function () {
+    setTimeout(() => {
       changeCSS();
     }, 50);
   },

--- a/files/en-us/web/http/guides/browser_detection_using_the_user_agent/index.md
+++ b/files/en-us/web/http/guides/browser_detection_using_the_user_agent/index.md
@@ -75,7 +75,7 @@ You can do this by checking for a `geolocation` property available on the global
 
 ```js
 if ("geolocation" in navigator) {
-  navigator.geolocation.getCurrentPosition(function (position) {
+  navigator.geolocation.getCurrentPosition((position) => {
     // show the location on a map, such as the Google Maps API
   });
 } else {

--- a/files/en-us/web/javascript/guide/closures/index.md
+++ b/files/en-us/web/javascript/guide/closures/index.md
@@ -205,7 +205,7 @@ The shared lexical environment is created in the body of an anonymous function, 
 Those three public functions form closures that share the same lexical environment. Thanks to JavaScript's lexical scoping, they each have access to the `privateCounter` variable and the `changeBy` function.
 
 ```js
-const makeCounter = function () {
+function makeCounter() {
   let privateCounter = 0;
   function changeBy(val) {
     privateCounter += val;
@@ -223,7 +223,7 @@ const makeCounter = function () {
       return privateCounter;
     },
   };
-};
+}
 
 const counter1 = makeCounter();
 const counter2 = makeCounter();

--- a/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
@@ -54,9 +54,9 @@ const mySet = new Set();
 ["bar", "baz"].forEach(mySet.add);
 // mySet.add is a function, but "mySet" is not captured as this.
 
-const myFun = function () {
+function myFun() {
   console.log(this);
-};
+}
 ["bar", "baz"].forEach(myFun.bind);
 // myFun.bind is a function, but "myFun" is not captured as this.
 ```
@@ -68,9 +68,9 @@ const mySet = new Set();
 ["bar", "baz"].forEach(mySet.add.bind(mySet));
 // This works due to binding "mySet" as this.
 
-const myFun = function () {
+function myFun() {
   console.log(this);
-};
+}
 ["bar", "baz"].forEach((x) => myFun.bind(x));
 // This works using the "bind" function. It creates a new function forwarding the argument.
 ```

--- a/files/en-us/web/javascript/reference/errors/not_a_function/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_function/index.md
@@ -68,9 +68,7 @@ which will work with {{jsxref("Array")}} objects only.
 ```js example-bad
 const obj = { a: 13, b: 37, c: 42 };
 
-obj.map(function (num) {
-  return num * 2;
-});
+obj.map((num) => num * 2);
 
 // TypeError: obj.map is not a function
 ```
@@ -80,9 +78,7 @@ Use an array instead:
 ```js example-good
 const numbers = [1, 4, 9];
 
-numbers.map(function (num) {
-  return num * 2;
-}); // [2, 8, 18]
+numbers.map((num) => num * 2); // [2, 8, 18]
 ```
 
 ### Function shares a name with a pre-existing property
@@ -153,7 +149,7 @@ Ensure you are importing the module correctly.
 An example helpers library (`helpers.js`)
 
 ```js
-const helpers = function () {};
+function helpers() {}
 
 helpers.groupBy = function (objectArray, property) {
   return objectArray.reduce((acc, obj) => {

--- a/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
@@ -59,7 +59,7 @@ did not. To get around this `arguments.callee` was added so you could do
 However, the design of `arguments.callee` has multiple issues. The first problem is that the recursive call will get a different `this` value. For example:
 
 ```js
-const sillyFunction = function (recursed) {
+function sillyFunction(recursed) {
   if (this !== globalThis) {
     console.log("This is:", this);
   } else {
@@ -69,7 +69,7 @@ const sillyFunction = function (recursed) {
   if (!recursed) {
     return arguments.callee(true);
   }
-};
+}
 
 sillyFunction();
 // This is the global

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -400,9 +400,9 @@ const obj = {
 globalThis.num = 42;
 
 // A traditional function to operate on "this"
-const add = function (a, b, c) {
+function add(a, b, c) {
   return this.num + a + b + c;
-};
+}
 
 console.log(add.call(obj, 1, 2, 3)); // 106
 console.log(add.apply(obj, [1, 2, 3])); // 106

--- a/files/en-us/web/javascript/reference/global_objects/function/displayname/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/displayname/index.md
@@ -37,7 +37,7 @@ If none of the above patterns match, the entire `displayName` is displayed.
 By entering the following in a Firefox console, it should display as something like `function MyFunction()`:
 
 ```js
-const a = function () {};
+function a() {}
 a.displayName = "MyFunction";
 
 a; // function MyFunction()

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -376,7 +376,7 @@ const myMap = new Map();
 
 const keyString = "a string";
 const keyObj = {};
-const keyFunc = function () {};
+const keyFunc = () => {};
 
 // setting the values
 myMap.set(keyString, "value associated with 'a string'");
@@ -392,7 +392,7 @@ console.log(myMap.get(keyFunc)); // "value associated with keyFunc"
 
 console.log(myMap.get("a string")); // "value associated with 'a string'", because keyString === 'a string'
 console.log(myMap.get({})); // undefined, because keyObj !== {}
-console.log(myMap.get(function () {})); // undefined, because keyFunc !== function () {}
+console.log(myMap.get(() => {})); // undefined, because keyFunc !== () => {}
 ```
 
 ### Using NaN as Map keys

--- a/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
@@ -64,7 +64,7 @@ console.log(shape.__proto__ === Circle); // false
 ```
 
 ```js
-const ShapeA = function () {};
+function ShapeA() {}
 const ShapeB = {
   a() {
     console.log("aaa");
@@ -80,7 +80,7 @@ console.log(ShapeA.prototype === shapeA.__proto__); // true
 ```
 
 ```js
-const ShapeC = function () {};
+function ShapeC() {}
 const ShapeD = {
   a() {
     console.log("a");

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -69,7 +69,7 @@ const wm1 = new WeakMap();
 const wm2 = new WeakMap();
 const wm3 = new WeakMap();
 const o1 = {};
-const o2 = function () {};
+const o2 = () => {};
 const o3 = window;
 
 wm1.set(o1, 37);

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/weakmap/index.md
@@ -32,7 +32,7 @@ const wm1 = new WeakMap();
 const wm2 = new WeakMap();
 const wm3 = new WeakMap();
 const o1 = {};
-const o2 = function () {};
+const o2 = () => {};
 const o3 = window;
 
 wm1.set(o1, 37);

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -17,7 +17,7 @@ async function* foo() {
   yield 2;
 }
 
-(async function () {
+(async () => {
   for await (const num of foo()) {
     console.log(num);
     // Expected output: 1

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -362,9 +362,9 @@ Similarly, [`arguments.callee`](/en-US/docs/Web/JavaScript/Reference/Functions/a
 
 ```js
 "use strict";
-const f = function () {
+function f() {
   return arguments.callee;
-};
+}
 f(); // throws a TypeError
 ```
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/index.md
@@ -173,12 +173,12 @@ Next, if supported connect the webcam source to the video element:
 if (navigator.mediaDevices) {
   navigator.mediaDevices
     .getUserMedia({ video: true, audio: false })
-    .then(function onSuccess(stream) {
+    .then((stream) => {
       const video = document.getElementById("webcam");
       video.autoplay = true;
       video.srcObject = stream;
     })
-    .catch(function onError() {
+    .catch(() => {
       alert(
         "There has been a problem retrieving the streams - are you running on file:/// or did you disallow access?",
       );
@@ -199,7 +199,7 @@ The main mechanism is outlined below:
 ```js
 navigator.mediaDevices
   .getUserMedia({ audio: true })
-  .then(function onSuccess(stream) {
+  .then((stream) => {
     const recorder = new MediaRecorder(stream);
 
     const data = [];
@@ -218,7 +218,7 @@ navigator.mediaDevices
       rec.stop();
     }, 5000);
   })
-  .catch(function onError(error) {
+  .catch((error) => {
     console.log(error.message);
   });
 ```


### PR DESCRIPTION
Our coding style guide prescribes the use of arrow functions for callbacks, and function declarations for creating identifier bindings. This PR removes most usage of function expressions.