### PR TITLE
Lint: use strict equality, avoid numeric loss of precision

### DIFF
--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -157,17 +157,17 @@ document.addEventListener("keydown", keyDownHandler, false);
 document.addEventListener("keyup", keyUpHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -180,17 +180,17 @@ document.addEventListener("keydown", keyDownHandler, false);
 document.addEventListener("keyup", keyUpHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }
@@ -198,7 +198,7 @@ function collisionDetection() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
       let b = bricks[c][r];
-      if (b.status == 1) {
+      if (b.status === 1) {
         if (
           x > b.x &&
           x < b.x + brickWidth &&
@@ -229,7 +229,7 @@ function drawPaddle() {
 function drawBricks() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
-      if (bricks[c][r].status == 1) {
+      if (bricks[c][r].status === 1) {
         let brickX = c * (brickWidth + brickPadding) + brickOffsetLeft;
         let brickY = r * (brickHeight + brickPadding) + brickOffsetTop;
         bricks[c][r].x = brickX;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -153,17 +153,17 @@ document.addEventListener("keyup", keyUpHandler, false);
 document.addEventListener("mousemove", mouseMoveHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }
@@ -178,7 +178,7 @@ function collisionDetection() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
       let b = bricks[c][r];
-      if (b.status == 1) {
+      if (b.status === 1) {
         if (
           x > b.x &&
           x < b.x + brickWidth &&
@@ -188,7 +188,7 @@ function collisionDetection() {
           dy = -dy;
           b.status = 0;
           score++;
-          if (score == brickRowCount * brickColumnCount) {
+          if (score === brickRowCount * brickColumnCount) {
             alert("YOU WIN, CONGRATS!");
             document.location.reload();
           }
@@ -215,7 +215,7 @@ function drawPaddle() {
 function drawBricks() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
-      if (bricks[c][r].status == 1) {
+      if (bricks[c][r].status === 1) {
         const brickX = r * (brickWidth + brickPadding) + brickOffsetLeft;
         const brickY = c * (brickHeight + brickPadding) + brickOffsetTop;
         bricks[c][r].x = brickX;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -119,17 +119,17 @@ document.addEventListener("keydown", keyDownHandler, false);
 document.addEventListener("keyup", keyUpHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -97,17 +97,17 @@ document.addEventListener("keyup", keyUpHandler, false);
 document.addEventListener("mousemove", mouseMoveHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }
@@ -122,7 +122,7 @@ function collisionDetection() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
       let b = bricks[c][r];
-      if (b.status == 1) {
+      if (b.status === 1) {
         if (
           x > b.x &&
           x < b.x + brickWidth &&
@@ -132,7 +132,7 @@ function collisionDetection() {
           dy = -dy;
           b.status = 0;
           score++;
-          if (score == brickRowCount * brickColumnCount) {
+          if (score === brickRowCount * brickColumnCount) {
             alert("YOU WIN, CONGRATS!");
             document.location.reload();
             clearInterval(interval); // Needed for Chrome to end game
@@ -160,7 +160,7 @@ function drawPaddle() {
 function drawBricks() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
-      if (bricks[c][r].status == 1) {
+      if (bricks[c][r].status === 1) {
         const brickX = r * (brickWidth + brickPadding) + brickOffsetLeft;
         const brickY = c * (brickHeight + brickPadding) + brickOffsetTop;
         bricks[c][r].x = brickX;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -149,17 +149,17 @@ document.addEventListener("keydown", keyDownHandler, false);
 document.addEventListener("keyup", keyUpHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -148,17 +148,17 @@ document.addEventListener("keydown", keyDownHandler, false);
 document.addEventListener("keyup", keyUpHandler, false);
 
 function keyDownHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = true;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = true;
   }
 }
 
 function keyUpHandler(e) {
-  if (e.key == "Right" || e.key == "ArrowRight") {
+  if (e.key === "Right" || e.key === "ArrowRight") {
     rightPressed = false;
-  } else if (e.key == "Left" || e.key == "ArrowLeft") {
+  } else if (e.key === "Left" || e.key === "ArrowLeft") {
     leftPressed = false;
   }
 }
@@ -166,7 +166,7 @@ function collisionDetection() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
       let b = bricks[c][r];
-      if (b.status == 1) {
+      if (b.status === 1) {
         if (
           x > b.x &&
           x < b.x + brickWidth &&
@@ -176,7 +176,7 @@ function collisionDetection() {
           dy = -dy;
           b.status = 0;
           score++;
-          if (score == brickRowCount * brickColumnCount) {
+          if (score === brickRowCount * brickColumnCount) {
             alert("YOU WIN, CONGRATS!");
             document.location.reload();
             clearInterval(interval); // Needed for Chrome to end game
@@ -204,7 +204,7 @@ function drawPaddle() {
 function drawBricks() {
   for (let c = 0; c < brickColumnCount; c++) {
     for (let r = 0; r < brickRowCount; r++) {
-      if (bricks[c][r].status == 1) {
+      if (bricks[c][r].status === 1) {
         const brickX = r * (brickWidth + brickPadding) + brickOffsetLeft;
         const brickY = c * (brickHeight + brickPadding) + brickOffsetTop;
         bricks[c][r].x = brickX;

--- a/files/en-us/learn_web_development/core/frameworks_libraries/angular_filtering/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/angular_filtering/index.md
@@ -58,21 +58,21 @@ In the following snippet, the existing sections in your HTML are in comments so 
 <div class="btn-wrapper">
   <button
     class="btn btn-menu"
-    [class.active]="filter == 'all'"
+    [class.active]="filter === 'all'"
     (click)="filter = 'all'">
     All
   </button>
 
   <button
     class="btn btn-menu"
-    [class.active]="filter == 'active'"
+    [class.active]="filter === 'active'"
     (click)="filter = 'active'">
     To Do
   </button>
 
   <button
     class="btn btn-menu"
-    [class.active]="filter == 'done'"
+    [class.active]="filter === 'done'"
     (click)="filter = 'done'">
     Done
   </button>
@@ -90,7 +90,7 @@ Clicking the buttons changes the `filter` values, which determines the `items` t
 
 A class attribute binding, using square brackets, `[]`, controls the text color of the buttons.
 The class binding, `[class.active]`, applies the `active` class when the value of `filter` matches the expression.
-For example, when the user clicks the **Done** button, which sets the `filter` value to `done`, the class binding expression of `filter == 'done'` evaluates to `true`.
+For example, when the user clicks the **Done** button, which sets the `filter` value to `done`, the class binding expression of `filter === 'done'` evaluates to `true`.
 When the `filter` value is `done`, Angular applies the `active` class to the **Done** button to make the text color green.
 As soon as the user clicks on one of the other buttons, the value a `filter` is no longer `done`, so the green text color no longer applies.
 

--- a/files/en-us/learn_web_development/core/scripting/math/index.md
+++ b/files/en-us/learn_web_development/core/scripting/math/index.md
@@ -89,7 +89,7 @@ The [`Number`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) objec
 For example, to round your number to a fixed number of decimal places, use the [`toFixed()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) method. Type the following lines into your browser's [console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html):
 
 ```js
-const lotsOfDecimal = 1.766584958675746364;
+const lotsOfDecimal = 1.7665849587;
 lotsOfDecimal;
 const twoDecimalPlaces = lotsOfDecimal.toFixed(2);
 twoDecimalPlaces;

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getcontexts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getcontexts/index.md
@@ -73,7 +73,7 @@ This example gets all the contexts associated with the extension in private brow
 ```js
 function gotContextInfo(contexts) {
   for (const context of contexts) {
-    if (context.tabId == -1) {
+    if (context.tabId === -1) {
       console.log("Not hosted in a tab");
     } else {
       console.log(

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -205,7 +205,7 @@ To illustrate, this is an example of a cross-browser extension that supports `sc
 And, background.js contains:
 
 ```js
-if (typeof browser == "undefined") {
+if (typeof browser === "undefined") {
   // Chrome does not support the browser namespace yet.
   globalThis.browser = chrome;
 }

--- a/files/en-us/web/api/capturecontroller/capturecontroller/index.md
+++ b/files/en-us/web/api/capturecontroller/capturecontroller/index.md
@@ -35,10 +35,10 @@ const stream = await navigator.mediaDevices.getDisplayMedia({ controller });
 const [track] = stream.getVideoTracks();
 const displaySurface = track.getSettings().displaySurface;
 
-if (displaySurface == "browser") {
+if (displaySurface === "browser") {
   // Focus the captured tab.
   controller.setFocusBehavior("focus-captured-surface");
-} else if (displaySurface == "window") {
+} else if (displaySurface === "window") {
   // Do not move focus to the captured window.
   // Keep the capturing page focused.
   controller.setFocusBehavior("no-focus-change");

--- a/files/en-us/web/api/capturecontroller/index.md
+++ b/files/en-us/web/api/capturecontroller/index.md
@@ -36,10 +36,10 @@ const stream = await navigator.mediaDevices.getDisplayMedia({ controller });
 const [track] = stream.getVideoTracks();
 const displaySurface = track.getSettings().displaySurface;
 
-if (displaySurface == "browser") {
+if (displaySurface === "browser") {
   // Focus the captured tab.
   controller.setFocusBehavior("focus-captured-surface");
-} else if (displaySurface == "window") {
+} else if (displaySurface === "window") {
   // Do not move focus to the captured window.
   // Keep the capturing page focused.
   controller.setFocusBehavior("no-focus-change");

--- a/files/en-us/web/api/capturecontroller/setfocusbehavior/index.md
+++ b/files/en-us/web/api/capturecontroller/setfocusbehavior/index.md
@@ -50,10 +50,10 @@ const stream = await navigator.mediaDevices.getDisplayMedia({ controller });
 const [track] = stream.getVideoTracks();
 const displaySurface = track.getSettings().displaySurface;
 
-if (displaySurface == "browser") {
+if (displaySurface === "browser") {
   // Focus the captured tab.
   controller.setFocusBehavior("focus-captured-surface");
-} else if (displaySurface == "window") {
+} else if (displaySurface === "window") {
   // Do not move focus to the captured window.
   // Keep the capturing page focused.
   controller.setFocusBehavior("no-focus-change");

--- a/files/en-us/web/api/commandevent/command/index.md
+++ b/files/en-us/web/api/commandevent/command/index.md
@@ -24,7 +24,7 @@ document.body.addEventListener(
   (event) => {
     const theAction = event.command;
 
-    if (theAction == "show-modal") {
+    if (theAction === "show-modal") {
       console.log("Showing modal dialog");
     }
   },

--- a/files/en-us/web/api/commandevent/index.md
+++ b/files/en-us/web/api/commandevent/index.md
@@ -66,9 +66,9 @@ popover.addEventListener("command", (event) => {
 const image = document.getElementById("the-image");
 
 image.addEventListener("command", (event) => {
-  if (event.command == "--rotate-left") {
+  if (event.command === "--rotate-left") {
     event.target.style.rotate = "-90deg";
-  } else if (event.command == "--rotate-right") {
+  } else if (event.command === "--rotate-right") {
     event.target.style.rotate = "90deg";
   }
 });

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -20,7 +20,7 @@ A {{domxref("StyleSheet")}} object.
 
 ```js
 const docRules = document.styleSheets[0].cssRules;
-console.log(docRules[0].parentStyleSheet == document.styleSheets[0]); // returns true
+console.log(docRules[0].parentStyleSheet === document.styleSheets[0]); // returns true
 ```
 
 ## Specifications

--- a/files/en-us/web/api/dedicatedworkerglobalscope/rtctransform_event/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/rtctransform_event/index.md
@@ -46,9 +46,9 @@ The `event.transformer` is a {{domxref("RTCRtpScriptTransformer")}}, the worker 
 addEventListener("rtctransform", (event) => {
   let transform;
   // Select a transform based on passed options
-  if (event.transformer.options.name == "senderTransform")
+  if (event.transformer.options.name === "senderTransform")
     transform = createSenderTransform(); // A TransformStream
-  else if (event.transformer.options.name == "receiverTransform")
+  else if (event.transformer.options.name === "receiverTransform")
     transform = createReceiverTransform(); // A TransformStream
   else return;
 

--- a/files/en-us/web/api/delegatedinktrailpresenter/index.md
+++ b/files/en-us/web/api/delegatedinktrailpresenter/index.md
@@ -52,7 +52,7 @@ canvas.addEventListener("pointermove", (evt) => {
   const pointSize = 10;
   ctx.fillStyle = "#000000";
   ctx.fillRect(evt.pageX, evt.pageY, pointSize, pointSize);
-  if (move_cnt == 50) {
+  if (move_cnt === 50) {
     let r = getRandomInt(0, 255);
     let g = getRandomInt(0, 255);
     let b = getRandomInt(0, 255);

--- a/files/en-us/web/api/delegatedinktrailpresenter/updateinktrailstartpoint/index.md
+++ b/files/en-us/web/api/delegatedinktrailpresenter/updateinktrailstartpoint/index.md
@@ -90,7 +90,7 @@ canvas.addEventListener("pointermove", async (evt) => {
   const pointSize = 10;
   ctx.fillStyle = style.color;
   ctx.fillRect(evt.pageX, evt.pageY, pointSize, pointSize);
-  if (move_cnt == 20) {
+  if (move_cnt === 20) {
     const r = getRandomInt(0, 255);
     const g = getRandomInt(0, 255);
     const b = getRandomInt(0, 255);

--- a/files/en-us/web/api/editcontext/updateselection/index.md
+++ b/files/en-us/web/api/editcontext/updateselection/index.md
@@ -48,7 +48,7 @@ const editContext = new EditContext();
 canvas.editContext = editContext;
 
 canvas.addEventListener("keydown", (e) => {
-  if (e.key == "ArrowLeft") {
+  if (e.key === "ArrowLeft") {
     const newPosition = Math.max(editContext.selectionStart - 1, 0);
 
     if (e.shiftKey) {
@@ -56,7 +56,7 @@ canvas.addEventListener("keydown", (e) => {
     } else {
       editContext.updateSelection(newPosition, newPosition);
     }
-  } else if (e.key == "ArrowRight") {
+  } else if (e.key === "ArrowRight") {
     const newPosition = Math.min(
       editContext.selectionEnd + 1,
       editContext.text.length,

--- a/files/en-us/web/api/editcontext/updatetext/index.md
+++ b/files/en-us/web/api/editcontext/updatetext/index.md
@@ -64,7 +64,7 @@ editContext.addEventListener("textupdate", (e) => {
 });
 
 canvas.addEventListener("keydown", async (e) => {
-  if (e.key == "v" && (e.ctrlKey || e.metaKey)) {
+  if (e.key === "v" && (e.ctrlKey || e.metaKey)) {
     const pastedText = await navigator.clipboard.readText();
     console.log(
       `The user pasted the text: ${pastedText}. Updating the EditContext text.`,

--- a/files/en-us/web/api/htmlbuttonelement/command/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/command/index.md
@@ -51,9 +51,9 @@ toggleBtn.command = "show-popover";
 const image = document.getElementById("the-image");
 
 image.addEventListener("command", (event) => {
-  if (event.command == "--rotate-left") {
+  if (event.command === "--rotate-left") {
     event.target.style.rotate = "-90deg";
-  } else if (event.command == "--rotate-right") {
+  } else if (event.command === "--rotate-right") {
     event.target.style.rotate = "90deg";
   }
 });

--- a/files/en-us/web/api/htmlbuttonelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/reportvalidity/index.md
@@ -87,7 +87,7 @@ exampleButton.addEventListener("invalid", () => {
 
 exampleButton.addEventListener("click", (e) => {
   e.preventDefault();
-  if (exampleButton.value == "error") {
+  if (exampleButton.value === "error") {
     breakOrFixButton("fixed");
   } else {
     breakOrFixButton("error");
@@ -97,7 +97,7 @@ exampleButton.addEventListener("click", (e) => {
 
 const breakOrFixButton = () => {
   const state = toggleButton();
-  if (state == "error") {
+  if (state === "error") {
     exampleButton.setCustomValidity("This is a custom error message");
   } else {
     exampleButton.setCustomValidity("");
@@ -105,7 +105,7 @@ const breakOrFixButton = () => {
 };
 
 const toggleButton = () => {
-  if (exampleButton.value == "error") {
+  if (exampleButton.value === "error") {
     exampleButton.value = "fixed";
     exampleButton.innerHTML = "No error";
   } else {

--- a/files/en-us/web/api/htmlinputelement/cancel_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/cancel_event/index.md
@@ -57,7 +57,7 @@ elem.addEventListener("cancel", () => {
 });
 
 elem.addEventListener("change", () => {
-  if (elem.files.length == 1) {
+  if (elem.files.length === 1) {
     result.textContent = "File Selected.";
   }
 });

--- a/files/en-us/web/api/htmltablecellelement/rowspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/rowspan/index.md
@@ -93,7 +93,7 @@ decreaseButton.addEventListener("click", () => {
   cell.rowSpan -= 1;
 
   // Update the display
-  output.textContent = `${cell.rowSpan == 0 ? "all remaining" : cell.rowSpan}`;
+  output.textContent = `${cell.rowSpan === 0 ? "all remaining" : cell.rowSpan}`;
 });
 ```
 

--- a/files/en-us/web/api/ink_api/index.md
+++ b/files/en-us/web/api/ink_api/index.md
@@ -85,7 +85,7 @@ canvas.addEventListener("pointermove", async (evt) => {
   const pointSize = 10;
   ctx.fillStyle = style.color;
   ctx.fillRect(evt.pageX, evt.pageY, pointSize, pointSize);
-  if (move_cnt == 20) {
+  if (move_cnt === 20) {
     const r = getRandomInt(0, 255);
     const g = getRandomInt(0, 255);
     const b = getRandomInt(0, 255);

--- a/files/en-us/web/api/invoker_commands_api/index.md
+++ b/files/en-us/web/api/invoker_commands_api/index.md
@@ -80,9 +80,9 @@ Historically creating these kinds of controls has required JavaScript event list
 const myImg = document.getElementById("my-img");
 
 myImg.addEventListener("command", (event) => {
-  if (event.command == "--rotate-left") {
+  if (event.command === "--rotate-left") {
     myImg.style.rotate = "-90deg";
-  } else if (event.command == "--rotate-right") {
+  } else if (event.command === "--rotate-right") {
     myImg.style.rotate = "90deg";
   }
 });

--- a/files/en-us/web/api/navigator/getautoplaypolicy/index.md
+++ b/files/en-us/web/api/navigator/getautoplaypolicy/index.md
@@ -269,7 +269,7 @@ if (!navigator.getAutoplayPolicy) {
     "navigator.getAutoplayPolicy() not supported. It may or may not autoplay, depending on the browser!";
 } else {
   // Here we pass in the HTMLVideoElement to check
-  log.textContent = `navigator.getAutoplayPolicy(video) == ${navigator.getAutoplayPolicy(
+  log.textContent = `navigator.getAutoplayPolicy(video) === ${navigator.getAutoplayPolicy(
     "mediaelement",
   )}`;
 

--- a/files/en-us/web/api/response/bytes/index.md
+++ b/files/en-us/web/api/response/bytes/index.md
@@ -128,7 +128,7 @@ The file name and the file type are then logged.
 
 ```js
 async function checkSignature(url) {
-  if (url == "") return;
+  if (url === "") return;
   log(`File: ${url}`);
   const response = await fetch(url);
   const image = await response.bytes();

--- a/files/en-us/web/api/rtcrtpscripttransformer/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/index.md
@@ -99,10 +99,10 @@ Note that the properties of the object are arbitrary (provided the values can be
 // Code to instantiate transform and attach them to sender/receiver pipelines.
 onrtctransform = (event) => {
   let transform;
-  if (event.transformer.options.name == "senderTransform")
+  if (event.transformer.options.name === "senderTransform")
     transform = createSenderTransform();
   // returns a TransformStream (not shown)
-  else if (event.transformer.options.name == "receiverTransform")
+  else if (event.transformer.options.name === "receiverTransform")
     transform = createReceiverTransform();
   // returns a TransformStream (not shown)
   else return;

--- a/files/en-us/web/api/rtcrtpscripttransformer/options/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/options/index.md
@@ -59,9 +59,9 @@ First we implement a handler for the {{domxref("DedicatedWorkerGlobalScope.rtctr
 addEventListener("rtctransform", (event) => {
   let transform;
   // Select a transform based on passed options
-  if (event.transformer.options.name == "senderTransform")
+  if (event.transformer.options.name === "senderTransform")
     transform = createSenderTransform(); // A TransformStream
-  else if (event.transformer.options.name == "receiverTransform")
+  else if (event.transformer.options.name === "receiverTransform")
     transform = createReceiverTransform(); // A TransformStream
   else return;
 

--- a/files/en-us/web/api/rtcrtpscripttransformer/readable/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/readable/index.md
@@ -26,9 +26,9 @@ The following example shows how `readable` is piped through a {{domxref("Transfo
 addEventListener("rtctransform", (event) => {
   let transform;
   // Select a transform based on passed options
-  if (event.transformer.options.name == "senderTransform")
+  if (event.transformer.options.name === "senderTransform")
     transform = createSenderTransform(); // A TransformStream
-  else if (event.transformer.options.name == "receiverTransform")
+  else if (event.transformer.options.name === "receiverTransform")
     transform = createReceiverTransform(); // A TransformStream
   else return;
 

--- a/files/en-us/web/api/rtcrtpscripttransformer/writable/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/writable/index.md
@@ -26,9 +26,9 @@ The following example shows how {{domxref("RTCRtpScriptTransformer.readable")}} 
 addEventListener("rtctransform", (event) => {
   let transform;
   // Select a transform based on passed options
-  if (event.transformer.options.name == "senderTransform")
+  if (event.transformer.options.name === "senderTransform")
     transform = createSenderTransform(); // A TransformStream
-  else if (event.transformer.options.name == "receiverTransform")
+  else if (event.transformer.options.name === "receiverTransform")
     transform = createReceiverTransform(); // A TransformStream
   else return;
 

--- a/files/en-us/web/api/rtcstatsreport/entries/index.md
+++ b/files/en-us/web/api/rtcstatsreport/entries/index.md
@@ -40,7 +40,7 @@ The properties of statistics objects with the `type` of `outbound-rtp` are logge
 const stats = await myPeerConnection.getStats();
 
 for (const stat of stats.entries()) {
-  if (stat.type != "outbound-rtp") continue;
+  if (stat.type !== "outbound-rtp") continue;
   Object.keys(stat).forEach((statName) => {
     console.log(`${statName}: ${report[statName]}`);
   });

--- a/files/en-us/web/api/rtcstatsreport/index.md
+++ b/files/en-us/web/api/rtcstatsreport/index.md
@@ -117,7 +117,7 @@ It assumes you already have an `RTCRtpSender` object named "sender".
 const stats = await sender.getStats();
 
 for (const stat of stats.values()) {
-  if (stat.type != "outbound-rtp") continue;
+  if (stat.type !== "outbound-rtp") continue;
   Object.keys(stat).forEach((statName) => {
     console.log(`${statName}: ${report[statName]}`);
   });

--- a/files/en-us/web/api/rtcstatsreport/keys/index.md
+++ b/files/en-us/web/api/rtcstatsreport/keys/index.md
@@ -39,7 +39,7 @@ const stats = await myPeerConnection.getStats();
 for (const id of stats.keys()) {
   // Get dictionary associated with key (id)
   const stat = stats.get(id);
-  if (stat.type != "outbound-rtp") continue;
+  if (stat.type !== "outbound-rtp") continue;
   Object.keys(stat).forEach((statName) => {
     console.log(`${statName}: ${report[statName]}`);
   });

--- a/files/en-us/web/api/rtcstatsreport/values/index.md
+++ b/files/en-us/web/api/rtcstatsreport/values/index.md
@@ -36,7 +36,7 @@ The properties of statistics objects with the `type` of `outbound-rtp` are logge
 const stats = await myPeerConnection.getStats();
 
 for (const stat of stats.values()) {
-  if (stat.type != "outbound-rtp") continue;
+  if (stat.type !== "outbound-rtp") continue;
   Object.keys(stat).forEach((statName) => {
     console.log(`${statName}: ${report[statName]}`);
   });

--- a/files/en-us/web/api/rtctransformevent/index.md
+++ b/files/en-us/web/api/rtctransformevent/index.md
@@ -44,9 +44,9 @@ The code at the end shows how the stream is piped through the transform stream f
 addEventListener("rtctransform", (event) => {
   let transform;
   // Select a transform based on passed options
-  if (event.transformer.options.name == "senderTransform") {
+  if (event.transformer.options.name === "senderTransform") {
     transform = createSenderTransform(); // A TransformStream (not shown)
-  } else if (event.transformer.options.name == "receiverTransform") {
+  } else if (event.transformer.options.name === "receiverTransform") {
     transform = createReceiverTransform(); // A TransformStream (not shown)
   }
   // Pipe frames from the readable to writeable through TransformStream

--- a/files/en-us/web/api/speechrecognition/audioend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/audioend_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `audioend` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("audioend", () => {
   console.log("Audio capturing ended");

--- a/files/en-us/web/api/speechrecognition/audiostart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/audiostart_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `audiostart` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("audiostart", () => {
   console.log("Audio capturing started");

--- a/files/en-us/web/api/speechrecognition/end_event/index.md
+++ b/files/en-us/web/api/speechrecognition/end_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `end` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("end", () => {
   console.log("Speech recognition service disconnected");

--- a/files/en-us/web/api/speechrecognition/error_event/index.md
+++ b/files/en-us/web/api/speechrecognition/error_event/index.md
@@ -40,7 +40,7 @@ _In addition to the properties listed below, properties from the parent interfac
 You can use the `error` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("error", (event) => {
   console.error(`Speech recognition error detected: ${event.error}`);

--- a/files/en-us/web/api/speechrecognition/nomatch_event/index.md
+++ b/files/en-us/web/api/speechrecognition/nomatch_event/index.md
@@ -46,7 +46,7 @@ _In addition to the properties listed below, properties from the parent interfac
 You can use the `nomatch` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("nomatch", () => {
   console.error("Speech not recognized");

--- a/files/en-us/web/api/speechrecognition/soundend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/soundend_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `soundend` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("soundend", (event) => {
   console.log("Sound has stopped being received");

--- a/files/en-us/web/api/speechrecognition/soundstart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/soundstart_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `soundstart` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("soundstart", () => {
   console.log("Some sound is being received");

--- a/files/en-us/web/api/speechrecognition/speechend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/speechend_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `speechend` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("speechend", () => {
   console.log("Speech has stopped being detected");

--- a/files/en-us/web/api/speechrecognition/speechstart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/speechstart_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `speechstart` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("speechstart", () => {
   console.log("Speech has been detected");

--- a/files/en-us/web/api/speechrecognition/start_event/index.md
+++ b/files/en-us/web/api/speechrecognition/start_event/index.md
@@ -29,7 +29,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `start` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new (SpeechRecognition || webkitSpeechRecognition)();
 
 recognition.addEventListener("start", () => {
   console.log("Speech recognition service has started");

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -354,7 +354,7 @@ function makePushSourceStream() {
       readRepeatedly().catch((e) => controller.error(e));
       function readRepeatedly() {
         return pushSource.dataRequest().then((result) => {
-          if (result.data.length == 0) {
+          if (result.data.length === 0) {
             logSource(`No data from source: closing`);
             controller.close();
             return;

--- a/files/en-us/web/api/trusted_types_api/index.md
+++ b/files/en-us/web/api/trusted_types_api/index.md
@@ -155,7 +155,7 @@ In this section we'll look at how the trusted types tinyfill can protect a websi
 The trusted types tinyfill is just this:
 
 ```js
-if (typeof trustedTypes == "undefined")
+if (typeof trustedTypes === "undefined")
   trustedTypes = { createPolicy: (n, rules) => rules };
 ```
 

--- a/files/en-us/web/api/validitystate/customerror/index.md
+++ b/files/en-us/web/api/validitystate/customerror/index.md
@@ -70,7 +70,7 @@ function log(text) {
 
 const check = (input) => {
   // Handle cases where input is too vague
-  if (input.value == "good" || input.value == "fine") {
+  if (input.value === "good" || input.value === "fine") {
     input.setCustomValidity(`"${input.value}" is not a feeling.`);
   } else {
     // An empty string resets the custom validity state

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -85,7 +85,7 @@ if (codec.includes("vp09")) {
   encodeOptions.av1 = { quantizer: qp };
 } else if (codec.includes("avc")) {
   encodeOptions.avc = { quantizer: qp };
-} else if (codec.includes("hvc1" || codec.includes("hev1"))) {
+} else if (codec.includes("hvc1") || codec.includes("hev1")) {
   encodeOptions.hevc = { quantizer: qp };
 }
 

--- a/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
+++ b/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
@@ -216,19 +216,19 @@ When the user clicks the play/pause toggle button while the oscillators aren't p
 function startOscillators() {
   oscNode1 = new OscillatorNode(context, {
     type: "sine",
-    frequency: 261.625565300598634, // middle C$
+    frequency: 261.6255653005986, // middle C$
   });
   oscNode1.connect(gainNode1);
 
   oscNode2 = new OscillatorNode(context, {
     type: "sine",
-    frequency: 329.627556912869929, // E
+    frequency: 329.6275569128699, // E
   });
   oscNode2.connect(gainNode2);
 
   oscNode3 = new OscillatorNode(context, {
     type: "sine",
-    frequency: 391.995435981749294, // G
+    frequency: 391.99543598174927, // G
   });
   oscNode3.connect(gainNode3);
 

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -227,123 +227,42 @@ Finally, global variables that will be used when constructing waveforms are crea
 
 ### Creating the note table
 
-The `createNoteTable()` function builds the array `noteFreq` to contain an array of objects representing each octave. Each octave, in turn, has one named property for each note in that octave; the property's name is the note's name (such as "C#" to represent C-sharp), and the value is the frequency, in Hertz, of that note.
+The `createNoteTable()` function builds the array `noteFreq` to contain an array of objects representing each octave. Each octave, in turn, has one named property for each note in that octave; the property's name is the note's name (such as "C#" to represent C-sharp), and the value is the frequency, in Hertz, of that note. We only hardcode one octave; each subsequent octave can be derived from the previous octave by doubling each note.
 
 ```js
 function createNoteTable() {
-  const noteFreq = [];
-  for (let i = 0; i < 9; i++) {
-    noteFreq[i] = [];
+  const noteFreq = [
+    { A: 27.5, "A#": 29.13523509488062, B: 30.867706328507754 },
+    {
+      C: 32.70319566257483,
+      "C#": 34.64782887210901,
+      D: 36.70809598967595,
+      "D#": 38.89087296526011,
+      E: 41.20344461410874,
+      F: 43.65352892912549,
+      "F#": 46.2493028389543,
+      G: 48.99942949771866,
+      "G#": 51.91308719749314,
+      A: 55,
+      "A#": 58.27047018976124,
+      B: 61.73541265701551,
+    },
+  ];
+  for (let octave = 2; octave <= 7; octave++) {
+    noteFreq.push(
+      Object.fromEntries(
+        Object.entries(noteFreq[octave - 1]).map(([key, freq]) => [
+          key,
+          freq * 2,
+        ]),
+      ),
+    );
   }
-
-  noteFreq[0]["A"] = 27.500000000000000;
-  noteFreq[0]["A#"] = 29.135235094880619;
-  noteFreq[0]["B"] = 30.867706328507756;
-
-  noteFreq[1]["C"] = 32.703195662574829;
-  noteFreq[1]["C#"] = 34.647828872109012;
-  noteFreq[1]["D"] = 36.708095989675945;
-  noteFreq[1]["D#"] = 38.890872965260113;
-  noteFreq[1]["E"] = 41.203444614108741;
-  noteFreq[1]["F"] = 43.653528929125485;
-  noteFreq[1]["F#"] = 46.249302838954299;
-  noteFreq[1]["G"] = 48.999429497718661;
-  noteFreq[1]["G#"] = 51.913087197493142;
-  noteFreq[1]["A"] = 55.000000000000000;
-  noteFreq[1]["A#"] = 58.270470189761239;
-  noteFreq[1]["B"] = 61.735412657015513;
-  // …
-```
-
-Several octaves not shown for brevity.
-
-```js hidden
-noteFreq[2]["C"] = 65.406391325149658;
-noteFreq[2]["C#"] = 69.295657744218024;
-noteFreq[2]["D"] = 73.41619197935189;
-noteFreq[2]["D#"] = 77.781745930520227;
-noteFreq[2]["E"] = 82.406889228217482;
-noteFreq[2]["F"] = 87.307057858250971;
-noteFreq[2]["F#"] = 92.498605677908599;
-noteFreq[2]["G"] = 97.998858995437323;
-noteFreq[2]["G#"] = 103.826174394986284;
-noteFreq[2]["A"] = 110.0;
-noteFreq[2]["A#"] = 116.540940379522479;
-noteFreq[2]["B"] = 123.470825314031027;
-
-noteFreq[3]["C"] = 130.812782650299317;
-noteFreq[3]["C#"] = 138.591315488436048;
-noteFreq[3]["D"] = 146.83238395870378;
-noteFreq[3]["D#"] = 155.563491861040455;
-noteFreq[3]["E"] = 164.813778456434964;
-noteFreq[3]["F"] = 174.614115716501942;
-noteFreq[3]["F#"] = 184.997211355817199;
-noteFreq[3]["G"] = 195.997717990874647;
-noteFreq[3]["G#"] = 207.652348789972569;
-noteFreq[3]["A"] = 220.0;
-noteFreq[3]["A#"] = 233.081880759044958;
-noteFreq[3]["B"] = 246.941650628062055;
-
-noteFreq[4]["C"] = 261.625565300598634;
-noteFreq[4]["C#"] = 277.182630976872096;
-noteFreq[4]["D"] = 293.66476791740756;
-noteFreq[4]["D#"] = 311.12698372208091;
-noteFreq[4]["E"] = 329.627556912869929;
-noteFreq[4]["F"] = 349.228231433003884;
-noteFreq[4]["F#"] = 369.994422711634398;
-noteFreq[4]["G"] = 391.995435981749294;
-noteFreq[4]["G#"] = 415.304697579945138;
-noteFreq[4]["A"] = 440.0;
-noteFreq[4]["A#"] = 466.163761518089916;
-noteFreq[4]["B"] = 493.883301256124111;
-
-noteFreq[5]["C"] = 523.251130601197269;
-noteFreq[5]["C#"] = 554.365261953744192;
-noteFreq[5]["D"] = 587.32953583481512;
-noteFreq[5]["D#"] = 622.253967444161821;
-noteFreq[5]["E"] = 659.255113825739859;
-noteFreq[5]["F"] = 698.456462866007768;
-noteFreq[5]["F#"] = 739.988845423268797;
-noteFreq[5]["G"] = 783.990871963498588;
-noteFreq[5]["G#"] = 830.609395159890277;
-noteFreq[5]["A"] = 880.0;
-noteFreq[5]["A#"] = 932.327523036179832;
-noteFreq[5]["B"] = 987.766602512248223;
-
-noteFreq[6]["C"] = 1046.502261202394538;
-noteFreq[6]["C#"] = 1108.730523907488384;
-noteFreq[6]["D"] = 1174.659071669630241;
-noteFreq[6]["D#"] = 1244.507934888323642;
-noteFreq[6]["E"] = 1318.510227651479718;
-noteFreq[6]["F"] = 1396.912925732015537;
-noteFreq[6]["F#"] = 1479.977690846537595;
-noteFreq[6]["G"] = 1567.981743926997176;
-noteFreq[6]["G#"] = 1661.218790319780554;
-noteFreq[6]["A"] = 1760.0;
-noteFreq[6]["A#"] = 1864.655046072359665;
-noteFreq[6]["B"] = 1975.533205024496447;
-```
-
-```js
-  noteFreq[7]["C"] = 2093.004522404789077;
-  noteFreq[7]["C#"] = 2217.461047814976769;
-  noteFreq[7]["D"] = 2349.318143339260482;
-  noteFreq[7]["D#"] = 2489.015869776647285;
-  noteFreq[7]["E"] = 2637.020455302959437;
-  noteFreq[7]["F"] = 2793.825851464031075;
-  noteFreq[7]["F#"] = 2959.955381693075191;
-  noteFreq[7]["G"] = 3135.963487853994352;
-  noteFreq[7]["G#"] = 3322.437580639561108;
-  noteFreq[7]["A"] = 3520.000000000000000;
-  noteFreq[7]["A#"] = 3729.310092144719331;
-  noteFreq[7]["B"] = 3951.066410048992894;
-
-  noteFreq[8]["C"] = 4186.009044809578154;
-  return noteFreq;
+  noteFreq.push({ C: 4186.009044809578 });
 }
 ```
 
-The result is an array, `noteFreq`, with an object for each octave. Each octave object has named properties in it where the property name is the name of the note (such as "C#" to represent C-sharp) and the property's value is the note's frequency in Hertz. In part, the resulting object looks like this:
+In part, the resulting object looks like this:
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -213,7 +213,6 @@ References to elements we'll need access to are obtained:
 - `volumeControl` is the {{HTMLElement("input")}} element (of type `"range"`) used to control the main audio volume.
 
 ```js
-let noteFreq = null;
 let customWaveform = null;
 let sineTerms = null;
 let cosineTerms = null;
@@ -221,7 +220,6 @@ let cosineTerms = null;
 
 Finally, global variables that will be used when constructing waveforms are created:
 
-- `noteFreq` will be an array of arrays; each array represents one octave, each of which contains one entry for each note in that octave. The value for each is the frequency, in Hertz, of the note's tone.
 - `customWaveform` will be set up as a {{domxref("PeriodicWave")}} describing the waveform to use when the user selects "Custom" from the waveform picker.
 - `sineTerms` and `cosineTerms` will be used to store the data for generating the waveform; each will contain an array that's generated when the user chooses "Custom".
 
@@ -259,6 +257,7 @@ function createNoteTable() {
     );
   }
   noteFreq.push({ C: 4186.009044809578 });
+  return noteFreq;
 }
 ```
 
@@ -322,7 +321,7 @@ The `setup()` function is responsible for building the keyboard and preparing th
 
 ```js
 function setup() {
-  noteFreq = createNoteTable();
+  const noteFreq = createNoteTable();
 
   volumeControl.addEventListener("change", changeVolume, false);
 
@@ -494,8 +493,9 @@ This sets the value of the main gain node's `gain` {{domxref("AudioParam")}} to 
 
 The code below adds [`keydown`](/en-US/docs/Web/API/Element/keydown_event) and [`keyup`](/en-US/docs/Web/API/Element/keyup_event) event listeners to handle keyboard input. The `keydown` event handler calls `notePressed()` to start playing the note corresponding to the key that was pressed, and the `keyup` event handler calls `noteReleased()` to stop playing the note corresponding to the key that was released.
 
-```js-nolint
+```js
 const synthKeys = document.querySelectorAll(".key");
+// prettier-ignore
 const keyCodes = [
   "Space",
   "ShiftLeft", "KeyZ", "KeyX", "KeyC", "KeyV", "KeyB", "KeyN", "KeyM", "Comma", "Period", "Slash", "ShiftRight",

--- a/files/en-us/web/api/web_bluetooth_api/index.md
+++ b/files/en-us/web/api/web_bluetooth_api/index.md
@@ -73,7 +73,7 @@ const btPermission = await navigator.permissions.query({
   name: "bluetooth",
   deviceId: sessionStorage.lastDevice,
 });
-if (result.devices.length == 1) {
+if (result.devices.length === 1) {
   return result.devices[0];
 } else {
   throw new DOMException("Lost permission", "NotFoundError");

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -498,7 +498,7 @@ class ExpandingList extends HTMLUListElement {
           const nextUl = e.target.nextElementSibling;
 
           // Toggle visible state and update class attribute on ul
-          if (nextUl.style.display == "block") {
+          if (nextUl.style.display === "block") {
             nextUl.style.display = "none";
             nextUl.parentNode.setAttribute("class", "closed");
           } else {

--- a/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
+++ b/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
@@ -152,7 +152,7 @@ signaler.onmessage = async ({ data: { description, candidate } }) => {
       if (ignoreOffer) {
         return;
       }
-      isSettingRemoteAnswerPending = description.type == "answer";
+      isSettingRemoteAnswerPending = description.type === "answer";
       await pc.setRemoteDescription(description);
       isSettingRemoteAnswerPending = false;
       if (description.type === "offer") {

--- a/files/en-us/web/api/webrtc_api/using_encoded_transforms/index.md
+++ b/files/en-us/web/api/webrtc_api/using_encoded_transforms/index.md
@@ -161,9 +161,9 @@ The value of the `name` property is used to determine which `TransformStream` to
 // Code to instantiate transform and attach them to sender/receiver pipelines.
 onrtctransform = (event) => {
   let transform;
-  if (event.transformer.options.name == "senderTransform")
+  if (event.transformer.options.name === "senderTransform")
     transform = createSenderTransform(); // returns a TransformStream
-  else if (event.transformer.options.name == "receiverTransform")
+  else if (event.transformer.options.name === "receiverTransform")
     transform = createReceiverTransform(); // returns a TransformStream
   else return;
   event.transformer.readable

--- a/files/en-us/web/api/webtransport/reliability/index.md
+++ b/files/en-us/web/api/webtransport/reliability/index.md
@@ -37,7 +37,7 @@ async function initTransport(url) {
   // Prior to this the reliability is "pending"
   await transport.ready;
 
-  if (transport.reliability == "reliable-only") {
+  if (transport.reliability === "reliable-only") {
     // Use connection only with reliable transports
   } else {
     // Use connection with either reliable or unreliable transports.

--- a/files/en-us/web/css/css_filter_effects/index.md
+++ b/files/en-us/web/css/css_filter_effects/index.md
@@ -198,7 +198,7 @@ function changeCSS() {
 }
 function blur() {
   let blurValue = document.getElementsByName("blur")[0].value;
-  return blurValue == "0" ? "" : `blur(${blurValue}rem) `;
+  return blurValue === "0" ? "" : `blur(${blurValue}rem) `;
 }
 function brightness() {
   let brightnessValue = document.getElementsByName("brightness")[0].value;
@@ -208,37 +208,37 @@ function brightness() {
 }
 function contrast() {
   let contrastValue = document.getElementsByName("contrast")[0].value;
-  return contrastValue == 1 ? "" : `contrast(${contrastValue}) `;
+  return contrastValue === 1 ? "" : `contrast(${contrastValue}) `;
 }
 function dropShadow() {
   let dropShadowValue = document.getElementsByName("dropShadow")[0].value;
-  return dropShadowValue == 0
+  return dropShadowValue === 0
     ? ""
     : `drop-shadow(${dropShadowValue}rem ${dropShadowValue}rem 0rem orange) `;
 }
 function grayscale() {
   let grayscaleValue = document.getElementsByName("grayscale")[0].value;
-  return grayscaleValue == 0 ? "" : `grayscale(${grayscaleValue}) `;
+  return grayscaleValue === 0 ? "" : `grayscale(${grayscaleValue}) `;
 }
 function hueRotate() {
   let hueRotateValue = document.getElementsByName("hueRotate")[0].value;
-  return hueRotateValue == 0 ? "" : `hue-rotate(${hueRotateValue}turn) `;
+  return hueRotateValue === 0 ? "" : `hue-rotate(${hueRotateValue}turn) `;
 }
 function invert() {
   let invertValue = document.getElementsByName("invert")[0].value;
-  return invertValue == 0 ? "" : `invert(${invertValue}) `;
+  return invertValue === 0 ? "" : `invert(${invertValue}) `;
 }
 function opacity() {
   let opacityValue = document.getElementsByName("opacity")[0].value;
-  return opacityValue == 1 ? "" : `opacity(${opacityValue}) `;
+  return opacityValue === 1 ? "" : `opacity(${opacityValue}) `;
 }
 function saturate() {
   let saturateValue = document.getElementsByName("saturate")[0].value;
-  return saturateValue == 1 ? "" : `saturate(${saturateValue}) `;
+  return saturateValue === 1 ? "" : `saturate(${saturateValue}) `;
 }
 function sepia() {
   let sepiaValue = document.getElementsByName("sepia")[0].value;
-  return sepiaValue == 0 ? "" : `sepia(${sepiaValue})`;
+  return sepiaValue === 0 ? "" : `sepia(${sepiaValue})`;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -204,7 +204,7 @@ elem.addEventListener("cancel", () => {
   console.log("Cancelled.");
 });
 elem.addEventListener("change", () => {
-  if (elem.files.length == 1) {
+  if (elem.files.length === 1) {
     console.log("File selected: ", elem.files[0]);
   }
 });

--- a/files/en-us/web/javascript/guide/numbers_and_strings/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_strings/index.md
@@ -65,9 +65,9 @@ const m = 0644; // 420
 Hexadecimal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "X" (`0x` or `0X`). If the digits after 0x are outside the range (0123456789ABCDEF), the following {{jsxref("SyntaxError")}} is thrown: "Identifier starts immediately after numeric literal".
 
 ```js-nolint
-0xFFFFFFFFFFFFFFFFF // 295147905179352830000
-0x123456789ABCDEF   // 81985529216486900
-0XA                 // 10
+0xFFFFFFFFFFFFF // 4503599627370495
+0xabcdef123456  // 188900967593046
+0XA             // 10
 ```
 
 ### Exponentiation

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
@@ -75,50 +75,6 @@ uint8 = new Uint8Array([4, 5, 7, 8, 9, 11, 12]);
 console.log(uint8.findLast(isPrime)); // 11
 ```
 
-### All elements are visited and may be modified by the callback
-
-The following examples show that all elements _are_ visited, and that the value passed to the callback is their value when visited:
-
-```js
-// Declare array with no elements at indexes 2, 3, and 4
-// The missing elements will be initialized to zero.
-const uint8 = new Uint8Array([0, 1, , , , 5, 6]);
-
-// Iterate through the elements in reverse order.
-// Note that all elements are visited.
-uint8.findLast((value, index) => {
-  console.log(`Visited index ${index} with value ${value}`);
-  return false;
-});
-
-// Shows all indexes, including deleted
-uint8.findLast((value, index) => {
-  // Modify element 3 on first iteration
-  if (index === 6) {
-    console.log("Set uint8[3] to 44");
-    uint8[3] = 44;
-  }
-  // Element 3 is still visited but will have a new value.
-  console.log(`Visited index ${index} with value ${value}`);
-  return false;
-});
-// Visited index 6 with value 6
-// Visited index 5 with value 5
-// Visited index 4 with value 0
-// Visited index 3 with value 0
-// Visited index 2 with value 0
-// Visited index 1 with value 1
-// Visited index 0 with value 0
-// Set uint8[3] to 44
-// Visited index 6 with value 6
-// Visited index 5 with value 5
-// Visited index 4 with value 0
-// Visited index 3 with value 44
-// Visited index 2 with value 0
-// Visited index 1 with value 1
-// Visited index 0 with value 0
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -380,9 +380,9 @@ Octal number syntax uses a leading zero followed by a lowercase or uppercase Lat
 Hexadecimal number syntax uses a leading zero followed by a lowercase or uppercase Latin letter "X" (`0x` or `0X`). Any character after the `0x` that is outside the range (0123456789ABCDEF) will terminate the literal sequence.
 
 ```js-nolint
-0xFFFFFFFFFFFFFFFFF // 295147905179352830000
-0x123456789ABCDEF   // 81985529216486900
-0XA                 // 10
+0xFFFFFFFFFFFFF // 4503599627370495
+0xabcdef123456  // 188900967593046
+0XA             // 10
 ```
 
 #### BigInt literal

--- a/files/en-us/web/progressive_web_apps/guides/offline_and_background_operation/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/offline_and_background_operation/index.md
@@ -169,7 +169,7 @@ As soon as the device has network connectivity, the `sync` event fires in the se
 // service-worker.js
 
 self.addEventListener("sync", (event) => {
-  if (event.tag == "send-message") {
+  if (event.tag === "send-message") {
     event.waitUntil(sendMessage());
   }
 });


### PR DESCRIPTION
Avoid some features that commonly indicate subtle bugs:

- Loose equality is forbidden by our style guide
- Numeric literals that don't evaluate to the value they represent. I also fixed https://github.com/mdn/content/issues/37617 so I don't have to type so many numeric literals
- Avoid constant binary expressions (those whose result is deterministic)
- Removed one example that involves sparse arrays since typed arrays can't be sparse anyway