### PR TITLE
Lint: prefer Object.hasOwn, avoid eval

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetaction/index.md
@@ -47,7 +47,7 @@ const toggleBtn = document.getElementById("toggleBtn");
 
 // Check for popover API support.
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 ```
 
@@ -94,7 +94,7 @@ A `manual` popover must be closed explicitly, and not "light dismissed" by selec
 
 ```js
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 
 const popover = document.getElementById("mypopover");

--- a/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/popovertargetelement/index.md
@@ -45,7 +45,7 @@ const toggleBtn = document.getElementById("toggleBtn");
 
 // Check for popover API support.
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 ```
 

--- a/files/en-us/web/api/htmlelement/popover/index.md
+++ b/files/en-us/web/api/htmlelement/popover/index.md
@@ -42,7 +42,7 @@ You can use the `popover` attribute to feature detect the [Popover API](/en-US/d
 
 ```js
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 ```
 

--- a/files/en-us/web/api/htmlelement/togglepopover/index.md
+++ b/files/en-us/web/api/htmlelement/togglepopover/index.md
@@ -95,7 +95,7 @@ First we check whether popovers are supported, and if they aren't we hide the po
 const instructions = document.getElementById("instructions");
 const popover = document.getElementById("mypopover");
 
-if (!HTMLElement.prototype.hasOwnProperty("popover")) {
+if (!Object.hasOwn(HTMLElement.prototype, "popover")) {
   popover.innerText = "";
   instructions.innerText = "Popovers not supported";
 }
@@ -105,7 +105,7 @@ If popovers are supported we add a listener for the `h` key to be pressed, and u
 We also log whether the popup was open or closed after the call, but only if a `true` or `false` was returned.
 
 ```js
-if (HTMLElement.prototype.hasOwnProperty("popover")) {
+if (Object.hasOwn(HTMLElement.prototype, "popover")) {
   document.addEventListener("keydown", (event) => {
     if (event.key === "h") {
       const popupOpened = popover.togglePopover();

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -47,7 +47,7 @@ const toggleBtn = document.getElementById("toggleBtn");
 
 // Check for popover API support.
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 ```
 
@@ -94,7 +94,7 @@ A `manual` popover must be closed explicitly, and not "light dismissed" by selec
 
 ```js
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 
 const popover = document.getElementById("mypopover");

--- a/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
@@ -25,7 +25,7 @@ A reference to a popover element in the DOM.
 
 ```js
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 
 const popover = document.getElementById("mypopover");
@@ -64,7 +64,7 @@ const toggleBtn = document.getElementById("toggleBtn");
 
 // Check for popover API support.
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 ```
 

--- a/files/en-us/web/api/popover_api/using/index.md
+++ b/files/en-us/web/api/popover_api/using/index.md
@@ -102,7 +102,7 @@ The {{domxref("HTMLElement.popover")}} property can be used to get or set the [`
 
 ```js
 function supportsPopover() {
-  return HTMLElement.prototype.hasOwnProperty("popover");
+  return Object.hasOwn(HTMLElement.prototype, "popover");
 }
 ```
 

--- a/files/en-us/web/api/rtccertificate/getfingerprints/index.md
+++ b/files/en-us/web/api/rtccertificate/getfingerprints/index.md
@@ -100,7 +100,7 @@ let serverFingerprintDict = Object.fromEntries(
 // and all common properties match.
 function compareObjects(obj1, obj2) {
   const commonProperties = Object.keys(obj1).filter((prop) =>
-    obj2.hasOwnProperty(prop),
+    Object.hasOwn(obj2, prop),
   );
   // Return false if there are no common properties
   if (Object.keys(commonProperties).length === 0) return false;

--- a/files/en-us/web/html/reference/elements/template/index.md
+++ b/files/en-us/web/html/reference/elements/template/index.md
@@ -177,8 +177,10 @@ In this example, a hidden support warning is included at the beginning of the ma
 ```
 
 ```js
-const isShadowRootModeSupported =
-  HTMLTemplateElement.prototype.hasOwnProperty("shadowRootMode");
+const isShadowRootModeSupported = Object.hasOwn(
+  HTMLTemplateElement.prototype,
+  "shadowRootMode",
+);
 
 document
   .querySelector("p[hidden]")

--- a/files/en-us/web/http/guides/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/guides/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -243,12 +243,9 @@ Pattern and mask specification is done the same way as for SOCKS configuration.
 #### Examples
 
 ```js
-function alertEval(str) {
-  alert(`${str} is ${eval(str)}`);
-}
 function FindProxyForURL(url, host) {
-  alertEval('isInNet(host, "192.0.2.172", "255.255.255.255")');
-  // "PAC-alert: isInNet(host, "192.0.2.172", "255.255.255.255") is true"
+  alert(isInNet(host, "192.0.2.172", "255.255.255.255"));
+  // "PAC-alert: true"
 }
 ```
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -971,7 +971,6 @@ For methods and functions, the `typeof` operator returns results as follows:
 
 ```js
 typeof blur; // returns "function"
-typeof eval; // returns "function"
 typeof parseInt; // returns "function"
 typeof shape.split; // returns "function"
 ```


### PR DESCRIPTION
Remove usage of `hasOwnProperty` to promote good practices. Avoid unnecessary usage of `eval`.