### PR TITLE
FF140 Relnote/Expr Atomics.waitAsync()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -918,6 +918,49 @@ The `withCalendar()` method for [`PlainDate`](/en-US/docs/Web/JavaScript/Referen
   </tbody>
 </table>
 
+### Atomics
+
+#### Atomics.waitAsync()
+
+The {{jsxref("Atomics.waitAsync()")}} static method waits asynchronously on a shared memory location and returns an object representing the result of the operation.
+It is non-blocking and usable on the main thread. ([Firefox bug 1467846](https://bugzil.la/1467846)).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>140</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>140</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>140</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>140</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>javascript.options.atomics_wait_async</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## APIs
 
 ### CloseWatcher Interface

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -72,6 +72,12 @@ These features are shipping in Firefox 140 but are disabled by default. To exper
   The [`Notification.maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) read-only static property returns the browser limit on the number of actions that can be associated with a `Notification`, which you create using {{domxref("ServiceWorkerRegistration.showNotification()")}}.
   This was released prematurely in Firefox version 138, and this change makes it available only in the Nightly build. ([Firefox bug 1963263](https://bugzil.la/1963263)).
 
+- **`Atomics.waitAsync()`**: `javascript.options.atomics_wait_async`
+
+  The {{jsxref("Atomics.waitAsync()")}} static method waits asynchronously on a shared memory location and returns an object representing the result of the operation.
+  It is non-blocking and usable on the main thread.
+  ([Firefox bug 1467846](https://bugzil.la/1467846)).
+
 ## Older versions
 
 {{Firefox_for_developers}}


### PR DESCRIPTION
FF140 adds support for [`Atomics.waitAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync) behind a pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1467846

This adds the release info and experimental features updates.

Related docs work can be tracked in #39615