### PR TITLE
Atomics.wait()/waitAsync() improvements

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -10,6 +10,9 @@ browser-compat: javascript.builtins.Atomics.wait
 The **`Atomics.wait()`** static method verifies that a shared memory location contains a given value and if so sleeps, awaiting a wake-up notification or a time out.
 It returns a string which is `"not-equal"` if the memory location does not match the given value, `"ok"` if woken by {{jsxref("Atomics.notify()")}}, or `"timed-out"` if the timeout expires.
 
+`Atomics.wait()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory.
+A thread can proceed immediately, without waiting if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
+
 This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 
 The method is blocking and cannot be used in the main thread.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -7,16 +7,11 @@ browser-compat: javascript.builtins.Atomics.wait
 
 {{JSRef}}
 
-The **`Atomics.wait()`** static method verifies that a shared memory location contains a given value and if so sleeps, awaiting a wake-up notification or a time out.
-It returns a string which is `"not-equal"` if the memory location does not match the given value, `"ok"` if woken by {{jsxref("Atomics.notify()")}}, or `"timed-out"` if the timeout expires.
+The **`Atomics.wait()`** static method verifies that a shared memory location contains a given value and if so sleeps, awaiting a wake-up notification or a time out. It returns a string which is `"not-equal"` if the memory location does not match the given value, `"ok"` if woken by {{jsxref("Atomics.notify()")}}, or `"timed-out"` if the timeout expires.
 
-`Atomics.wait()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory.
-A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
+`Atomics.wait()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory. A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
 
-This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
-
-The method is blocking and cannot be used in the main thread.
-For a non-blocking, asynchronous version of this method, see {{jsxref("Atomics.waitAsync()")}}.
+This method only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}. It is blocking and cannot be used in the main thread. For a non-blocking, asynchronous version of this method, see {{jsxref("Atomics.waitAsync()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -11,7 +11,7 @@ The **`Atomics.wait()`** static method verifies that a shared memory location co
 It returns a string which is `"not-equal"` if the memory location does not match the given value, `"ok"` if woken by {{jsxref("Atomics.notify()")}}, or `"timed-out"` if the timeout expires.
 
 `Atomics.wait()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory.
-A thread can proceed immediately, without waiting if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
+A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
 
 This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -36,7 +36,7 @@ Atomics.wait(typedArray, index, value, timeout)
 
 ### Return value
 
-A string which is either `"ok"`, `"not-equal"`, or `"timed-out"`.
+A string which is either `"not-equal"`, `"ok"`, or `"timed-out"`.
 
 - `"not-equal"` is returned immediately if the initial `value` does not equal what is stored at `index`.
 - `"ok"` is returned if woken up by a call to `Atomics.notify()`, **regardless of whether the expected value has changed**.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -7,13 +7,13 @@ browser-compat: javascript.builtins.Atomics.wait
 
 {{JSRef}}
 
-The **`Atomics.wait()`** static
-method verifies that a shared memory location still contains a
-given value and if so sleeps, awaiting a wake-up notification or times out. It returns a string which
-is either `"ok"`, `"not-equal"`, or `"timed-out"`.
+The **`Atomics.wait()`** static method verifies that a shared memory location contains a given value and if so sleeps, awaiting a wake-up notification or a time out.
+It returns a string which is `"not-equal"` if the memory location does not match the given value, `"ok"` if woken by {{jsxref("Atomics.notify()")}}, or `"timed-out"` if the timeout expires.
+
+This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
+The method is blocking and cannot be used in the main thread.
 
 > [!NOTE]
-> This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}, and may not be allowed on the main thread.
 > For a non-blocking, asynchronous version of this method, see {{jsxref("Atomics.waitAsync()")}}.
 
 ## Syntax
@@ -38,9 +38,9 @@ Atomics.wait(typedArray, index, value, timeout)
 
 A string which is either `"ok"`, `"not-equal"`, or `"timed-out"`.
 
-- `"ok"` is returned if woken up by a call to `Atomics.notify()`, **regardless of if the expected value has changed**
-- `"not-equal"` is returned immediately if the initial `value` does not equal what is stored at `index`
-- `"timed-out"` is returned if a sleeping wait exceeds the specified `timeout` without being woken up by `Atomics.notify()`
+- `"ok"` is returned if woken up by a call to `Atomics.notify()`, **regardless of whether the expected value has changed**.
+- `"not-equal"` is returned immediately if the initial `value` does not equal what is stored at `index`.
+- `"timed-out"` is returned if a sleeping wait exceeds the specified `timeout` without being woken up by `Atomics.notify()`.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -38,8 +38,8 @@ Atomics.wait(typedArray, index, value, timeout)
 
 A string which is either `"ok"`, `"not-equal"`, or `"timed-out"`.
 
-- `"ok"` is returned if woken up by a call to `Atomics.notify()`, **regardless of whether the expected value has changed**.
 - `"not-equal"` is returned immediately if the initial `value` does not equal what is stored at `index`.
+- `"ok"` is returned if woken up by a call to `Atomics.notify()`, **regardless of whether the expected value has changed**.
 - `"timed-out"` is returned if a sleeping wait exceeds the specified `timeout` without being woken up by `Atomics.notify()`.
 
 ### Exceptions

--- a/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/wait/index.md
@@ -11,10 +11,9 @@ The **`Atomics.wait()`** static method verifies that a shared memory location co
 It returns a string which is `"not-equal"` if the memory location does not match the given value, `"ok"` if woken by {{jsxref("Atomics.notify()")}}, or `"timed-out"` if the timeout expires.
 
 This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
-The method is blocking and cannot be used in the main thread.
 
-> [!NOTE]
-> For a non-blocking, asynchronous version of this method, see {{jsxref("Atomics.waitAsync()")}}.
+The method is blocking and cannot be used in the main thread.
+For a non-blocking, asynchronous version of this method, see {{jsxref("Atomics.waitAsync()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -10,6 +10,9 @@ browser-compat: javascript.builtins.Atomics.waitAsync
 The **`Atomics.waitAsync()`** static method verifies that a shared memory location contains a given value, immediately returning an object with the `value` property containing the string `"not-equal"` if the memory location does not match the given value, or `"timed-out"` if the timeout was set to zero.
 Otherwise the method returns an object where the `value` property is a {{jsxref("Promise")}} that fulfills with either `"ok"` when {{jsxref("Atomics.notify()")}} is called, or `"timed-out"` if the timeout expires.
 
+`Atomics.waitAsync()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory.
+A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
+
 `waitAsync` is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
 
 This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -7,15 +7,11 @@ browser-compat: javascript.builtins.Atomics.waitAsync
 
 {{JSRef}}
 
-The **`Atomics.waitAsync()`** static method verifies that a shared memory location contains a given value, immediately returning an object with the `value` property containing the string `"not-equal"` if the memory location does not match the given value, or `"timed-out"` if the timeout was set to zero.
-Otherwise the method returns an object where the `value` property is a {{jsxref("Promise")}} that fulfills with either `"ok"` when {{jsxref("Atomics.notify()")}} is called, or `"timed-out"` if the timeout expires.
+The **`Atomics.waitAsync()`** static method verifies that a shared memory location contains a given value, immediately returning an object with the `value` property containing the string `"not-equal"` if the memory location does not match the given value, or `"timed-out"` if the timeout was set to zero. Otherwise the method returns an object where the `value` property is a {{jsxref("Promise")}} that fulfills with either `"ok"` when {{jsxref("Atomics.notify()")}} is called, or `"timed-out"` if the timeout expires.
 
-`Atomics.waitAsync()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory.
-A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
+`Atomics.waitAsync()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory. A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
 
-`waitAsync` is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
-
-This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
+This method only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}. It is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -12,8 +12,7 @@ Otherwise the method returns a {{jsxref("Promise")}} that fulfills with either `
 
 `waitAsync` is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
 
-> [!NOTE]
-> This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
+This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -7,8 +7,8 @@ browser-compat: javascript.builtins.Atomics.waitAsync
 
 {{JSRef}}
 
-The **`Atomics.waitAsync()`** static method verifies that a shared memory location contains a given value, immediately returning with `"not-equal"` if the memory location does not match the given value, or `"timed-out"` if the timeout was set to zero.
-Otherwise the method returns a {{jsxref("Promise")}} that fulfills with either `"ok"` when {{jsxref("Atomics.notify()")}} is called, or `"timed-out"` if the timeout expires.
+The **`Atomics.waitAsync()`** static method verifies that a shared memory location contains a given value, immediately returning an object with the `value` property containing the string `"not-equal"` if the memory location does not match the given value, or `"timed-out"` if the timeout was set to zero.
+Otherwise the method returns an object where the `value` property is a {{jsxref("Promise")}} that fulfills with either `"ok"` when {{jsxref("Atomics.notify()")}} is called, or `"timed-out"` if the timeout expires.
 
 `waitAsync` is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -7,9 +7,10 @@ browser-compat: javascript.builtins.Atomics.waitAsync
 
 {{JSRef}}
 
-The **`Atomics.waitAsync()`** static method waits asynchronously on a shared memory location and returns an object representing the result of the operation.
+The **`Atomics.waitAsync()`** static method verifies that a shared memory location contains a given value, immediately returning with `"not-equal"` if the memory location does not match the given value, or `"timed-out"` if the timeout was set to zero.
+Otherwise the method returns a {{jsxref("Promise")}} that fulfills with either `"ok"` when {{jsxref("Atomics.notify()")}} is called, or `"timed-out"` if the timeout expires.
 
-Unlike {{jsxref("Atomics.wait()")}}, `waitAsync` is non-blocking and usable on the main thread.
+`waitAsync` is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
 
 > [!NOTE]
 > This operation only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.

--- a/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/waitasync/index.md
@@ -11,7 +11,7 @@ The **`Atomics.waitAsync()`** static method verifies that a shared memory locati
 
 `Atomics.waitAsync()` and {{jsxref("Atomics.notify()")}} are used together to enable thread synchronization based on a value in shared memory. A thread can proceed immediately if the synchronization value has changed, or it can wait for notification from another thread when it reaches the synchronization point.
 
-This method only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}. It is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread.
+This method only works with an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}. It is non-blocking and, unlike {{jsxref("Atomics.wait()")}}, can be used on the main thread. Because it does not block the whole thread, you still need to be careful not to access the shared memory before the promise settles.
 
 ## Syntax
 


### PR DESCRIPTION
This improves the docs for [`Atomics.waitAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync) and `Atomics.wait()`. I found them a little unclear. I think it helps to link to `notify()` earlier.

Notes about what/why inline

Related docs work can be tracked in #39615