### PR TITLE
Add a missing backtick at the end of a code element

### DIFF
--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
@@ -316,7 +316,7 @@ By combining the align and justify properties we can easily center an item insid
 
 ## Aligning the grid tracks on the block axis
 
-If you have a situation where your grid tracks use an area that is smaller than the grid container you can align the grid tracks themselves inside that container. The {{cssxref("align-content")}} aligns the tracks on the block axis and {{cssxref("justify-content")}} aligns on the inline axis. As with the `*-items` and `*-item` properties, the {{CSSxRef("place-content")}} property is shorthand for `align-content` and `justify-content.
+If you have a situation where your grid tracks use an area that is smaller than the grid container you can align the grid tracks themselves inside that container. The {{cssxref("align-content")}} aligns the tracks on the block axis and {{cssxref("justify-content")}} aligns on the inline axis. As with the `*-items` and `*-item` properties, the {{CSSxRef("place-content")}} property is shorthand for `align-content` and `justify-content`.
 
 The values for `align-content`, `justify-content` and `place-content` all include the {{cssxref("content-distribution")}} and {{cssxref("content-position")}} values. The `align-content` property also accepts {{cssxref("baseline-position")}} values and, like the other `justify-*` properties, `justify-content` also accepts `left` and `right`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR adds a missing closing backtick (`) at the end of an inline code element to ensure proper formatting in the rendered documentation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The missing backtick caused incorrect rendering of the code snippet, which could confuse readers or lead to misinterpretation. This fix improves readability and maintains consistency with MDN's formatting standards.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The issue was spotted while reading the MDN page. Here's the direct link to the affected page:
[Aligning items in CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
None.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
