### PR TITLE
FF140 pointerrawupdate event - relnote/docs

### DIFF
--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -58,7 +58,7 @@ This article provides information about the changes in Firefox 140 that affect d
 
 - The [`pointerrawupdate` event](/en-US/docs/Web/API/Element/pointerrawupdate_event) is now supported.
   This event typically provides lower-latency access to pointer movement properties than the corresponding [`pointermove`](/en-US/docs/Web/API/Element/pointermove_event) event, by firing as soon as the pointer data is available.
-  It is intended for applications that require high-precision input handling, and that cannot achieve smooth interaction using coalesced pointermove events alone.
+  It is intended for applications that require high-precision input handling, and that cannot achieve smooth interaction using coalesced `pointermove` events alone.
   The event may impact performance, and should only be avoided for other use cases.
   ([Firefox bug 1550462](https://bugzil.la/1550462)).
 

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -57,9 +57,9 @@ This article provides information about the changes in Firefox 140 that affect d
 #### DOM
 
 - The [`pointerrawupdate` event](/en-US/docs/Web/API/Element/pointerrawupdate_event) is now supported.
-  This event typically provides lower-latency access to pointer movement properties than the corresponding [`pointermove`](/en-US/docs/Web/API/Element/pointermove_event) event, by firing as soon as the pointer data is available.
+  This event typically provides lower-latency access to pointer movement properties compared to the corresponding [`pointermove`](/en-US/docs/Web/API/Element/pointermove_event) events, firing as soon as the pointer data is available.
   It is intended for applications that require high-precision input handling, and that cannot achieve smooth interaction using coalesced `pointermove` events alone.
-  The event may impact performance, and should only be avoided for other use cases.
+  Because listening to this event may impact performance, you should avoid using it for other use cases.
   ([Firefox bug 1550462](https://bugzil.la/1550462)).
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -56,6 +56,12 @@ This article provides information about the changes in Firefox 140 that affect d
 
 #### DOM
 
+- The [`pointerrawupdate` event](/en-US/docs/Web/API/Element/pointerrawupdate_event) is now supported.
+  This event typically provides lower-latency access to pointer movement properties than the corresponding [`pointermove`](/en-US/docs/Web/API/Element/pointermove_event) event, by firing as soon as the pointer data is available.
+  It is intended for applications that require high-precision input handling, and that cannot achieve smooth interaction using coalesced pointermove events alone.
+  The event may impact performance, and should only be avoided for other use cases.
+  ([Firefox bug 1550462](https://bugzil.la/1550462)).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/element/pointerrawupdate_event/index.md
+++ b/files/en-us/web/api/element/pointerrawupdate_event/index.md
@@ -10,14 +10,17 @@ browser-compat: api.Element.pointerrawupdate_event
 
 {{APIRef}}{{SeeCompatTable}}{{secureContext_header}}
 
-The **`pointerrawupdate`** {{DOMxRef('PointerEvent')}} is fired when a pointer changes any properties that don't fire {{domxref('Element/pointerdown_event', 'pointerdown')}} or {{domxref('Element/pointerup_event', 'pointerup')}} events.
+The **`pointerrawupdate`** event is fired when a pointer changes any properties that don't fire {{domxref('Element/pointerdown_event', 'pointerdown')}} or {{domxref('Element/pointerup_event', 'pointerup')}} events.
 See {{domxref('Element/pointermove_event', 'pointermove')}} for a list of these properties.
 
 The `pointerrawupdate` event may have coalesced events if there is already another `pointerrawupdate` event with the same pointer ID that hasn't been dispatched in the event loop.
 For information on coalesced events, see the {{domxref("PointerEvent.getCoalescedEvents")}} documentation.
 
-Listeners for `pointerrawupdate` events should only be added if your JavaScript needs high-frequency events and can handle them as quickly as they are dispatched.
-For most use cases, other pointer event types should suffice as there may be performance implications to adding listeners for `pointerrawupdate` events.
+`pointerrawupdate` is intended for applications that require high-precision input handling, and that cannot achieve smooth interaction using coalesced pointermove events alone.
+However, as there may be performance implications to adding listeners for `pointerrawupdate` events, these listeners should only be added if your JavaScript needs high-frequency events and can handle them as quickly as they are dispatched.
+For most use cases, other pointer event types should suffice.
+
+This event [bubbles](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling) and is [composed](/en-US/docs/Web/API/Event/composed), but is not [cancelable](/en-US/docs/Web/API/Event/cancelable) and has no default action.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/pointerrawupdate_event/index.md
+++ b/files/en-us/web/api/element/pointerrawupdate_event/index.md
@@ -14,10 +14,10 @@ The **`pointerrawupdate`** event is fired when a pointer changes any properties 
 See {{domxref('Element/pointermove_event', 'pointermove')}} for a list of these properties.
 
 The `pointerrawupdate` event may have coalesced events if there is already another `pointerrawupdate` event with the same pointer ID that hasn't been dispatched in the event loop.
-For information on coalesced events, see the {{domxref("PointerEvent.getCoalescedEvents")}} documentation.
+For information on coalesced events, see the {{domxref("PointerEvent.getCoalescedEvents()")}} documentation.
 
-`pointerrawupdate` is intended for applications that require high-precision input handling, and that cannot achieve smooth interaction using coalesced pointermove events alone.
-However, as there may be performance implications to adding listeners for `pointerrawupdate` events, these listeners should only be added if your JavaScript needs high-frequency events and can handle them as quickly as they are dispatched.
+`pointerrawupdate` is intended for applications that require high-precision input handling and cannot achieve smooth interaction using coalesced [`pointermove`](/en-US/docs/Web/API/Element/pointermove_event) events alone.
+However, because listening to `pointerrawupdate` events can affect performance, you should add these listeners only if your JavaScript needs high-frequency events and can handle them as quickly as they are dispatched.
 For most use cases, other pointer event types should suffice.
 
 This event [bubbles](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling) and is [composed](/en-US/docs/Web/API/Event/composed), but is not [cancelable](/en-US/docs/Web/API/Event/cancelable) and has no default action.


### PR DESCRIPTION
FF140 adds suppor for the [`pointerrawupdate` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerrawupdate_event) in https://bugzilla.mozilla.org/show_bug.cgi?id=1550462

This adds a release note (based on the FF release note) and also updates the docs for the element slightly to capture when you would use this event (and not), and its bubble, cancel, composed properties.

Related docs work can be tracked in #39614