### PR TITLE
Fix typo: Remove a duplicated word

### DIFF
--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
@@ -536,7 +536,7 @@ We can also apply the {{cssxref("content-distribution")}} space distribution val
 
 If an item spans more than one grid track, using a space distribution value will likely cause items on your grid to become larger because the space that's added between the tracks is added to the spanning item. Therefore, if you use these values, make sure the content of the tracks can cope with the extra space or that you have used alignment properties on the items, so they move to the start or end rather than stretch.
 
-In the below image, we placed the grid with two different `align-content` values to compare `start` and `space-between`. You can see how the first two items, which span two row tracks, have taken on extra height in the `space-between` example as they gain the space that exists because of the of the free space that was distributed _between_ the three rows:
+In the below image, we placed the grid with two different `align-content` values to compare `start` and `space-between`. You can see how the first two items, which span two row tracks, have taken on extra height in the `space-between` example as they gain the space that exists because of the free space that was distributed _between_ the three rows:
 
 ![Demonstrating how items become larger if we use space-between.](7_space-between.png)
 


### PR DESCRIPTION
### Description

Removed a duplicated word ("of the") in a sentence describing the `align-content` property in a CSS Grid example.

### Motivation

Correcting a minor typographical error improves the clarity and professionalism of the documentation, helping readers better understand the example.

### Additional details

N/A

### Related issues and pull requests

N/A
