### PR TITLE
Replace "blue" with "red" where referring to the hex code #a71e14

### DIFF
--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -79,7 +79,7 @@ The following live demo mixes two colors, `color-one` and `color-two`, using the
 
 ### Mixing two colors
 
-This example demonstrates mixing two colors, blue `#a71e14` at different percentages and white with no percentage given. The higher the percentage of `#a71e14` is mixed, the more blue and less white the output color is.
+This example demonstrates mixing two colors, red `#a71e14` at different percentages and white with no percentage given. The higher the percentage of `#a71e14` is mixed, the more red and less white the output color is.
 
 #### HTML
 
@@ -96,7 +96,7 @@ This example demonstrates mixing two colors, blue `#a71e14` at different percent
 
 #### CSS
 
-The `color-mix()` function is used to add increasing percentages of blue, up to 100%. The 6th {{htmlelement("li")}} doesn't include a percentage for either color.
+The `color-mix()` function is used to add increasing percentages of red, up to 100%. The 6th {{htmlelement("li")}} doesn't include a percentage for either color.
 
 ```css hidden
 ul {


### PR DESCRIPTION
### Description

To replace the places where `#a71e14` is referred to as "blue" with "red"

### Motivation

It will help reduce the confusion as the visual examples show a red hue instead of a blue one 

### Additional details

Refer to the color picker at https://mdn.github.io/css-examples/tools/color-picker/ with `#a71e14` hex value

### Related issues and pull requests

None
