### PR TITLE
Editorial review: SVG <use>: Omit URL fragment to reference external root

### DIFF
--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -76,7 +76,7 @@ You can load nodes from an external SVG file via the `<use>` element by specifyi
 Historically, the URL fragment was always required, even if you just wanted to load the entire SVG document. In such a case, the `id` would be included on the SVG root element:
 
 ```html
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" id="my-fragment">
+<svg xmlns="http://www.w3.org/2000/svg" id="my-fragment">
   <circle cx="150" cy="100" r="80" fill="green" />
 </svg>
 ```

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -7,7 +7,7 @@ sidebar: svgref
 ---
 
 The **`<use>`** element takes nodes from within an SVG document, and duplicates them somewhere else.
-The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `<use>` element is, much like cloned [template elements](/en-US/docs/Web/HTML/Reference/Elements/template).
+The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `<use>` element is, much like cloned {{HTMLElement("template")}} elements.
 
 ## Example
 

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -6,12 +6,12 @@ browser-compat: svg.elements.use
 sidebar: svgref
 ---
 
-The **`<use>`** element takes nodes from within the SVG document, and duplicates them somewhere else.
-The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `use` element is, much like cloned [template elements](/en-US/docs/Web/HTML/Reference/Elements/template).
+The **`<use>`** element takes nodes from within an SVG document, and duplicates them somewhere else.
+The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `<use>` element is, much like cloned [template elements](/en-US/docs/Web/HTML/Reference/Elements/template).
 
 ## Example
 
-The following example shows how to use the `use` element to draw a circle with a different fill and stroke color.
+The following example shows how to use the `<use>` element to draw a circle with a different fill and stroke color.
 In the last circle, `stroke="red"` will be ignored because stroke was already set on `myCircle`.
 
 ```css hidden
@@ -38,36 +38,64 @@ svg {
   - : The URL to an element/fragment that needs to be duplicated. See [Usage notes](#usage_notes) for details on common pitfalls.<br/> _Value type_: [**`<URL>`**](/en-US/docs/Web/SVG/Guides/Content_type#url); _Default value_: none; _Animatable_: **yes**
 - {{SVGAttr("xlink:href")}} {{Deprecated_Inline}}
   - : An [`<IRI>`](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to an element/fragment that needs to be duplicated. If both {{SVGAttr("href")}} and {{SVGAttr("xlink:href")}} are present, the value given by {{SVGAttr("href")}} is used.<br/> _Value type_: [**`<IRI>`**](/en-US/docs/Web/SVG/Guides/Content_type#iri); _Default value_: none; _Animatable_: **yes**
+    > [!WARNING]
+    > Since SVG 2, the {{SVGAttr("xlink:href")}} attribute is deprecated in favor of {{SVGAttr("href")}}. See {{SVGAttr("xlink:href")}} page for more information.
 - {{SVGAttr("x")}}
   - : The x coordinate of an additional final offset transformation applied to the `<use>` element.<br/> _Value type_: [**`<coordinate>`**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("y")}}
   - : The y coordinate of an additional final offset transformation applied to the `<use>` element.<br/> _Value type_: [**`<coordinate>`**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("width")}}
-  - : The width of the use element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
+  - : The width of the `<use>` element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 - {{SVGAttr("height")}}
-  - : The height of the use element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
+  - : The height of the `<use>` element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 
-> **Note:** `width`, and `height` have no effect on `use` elements, unless the element referenced has a [viewBox](/en-US/docs/Web/SVG/Reference/Attribute/viewBox) - i.e., they only have an effect when `use` refers to a `svg` or `symbol` element.
+> **Note:** `width`, and `height` have no effect on `<use>` elements, unless the element referenced has a [viewBox](/en-US/docs/Web/SVG/Reference/Attribute/viewBox) - i.e., they only have an effect when `<use>` refers to a `svg` or `symbol` element.
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
 ## Usage notes
 
-Most attributes on `use` are ignored if the corresponding attribute is already defined on the element _referenced_ by `use`. (This differs from how CSS style attributes override those set 'earlier' in the cascade).
-**Only** the attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}} and {{SVGAttr("href")}} on the `use` element will or may have some effect, described later, if the referenced element has already defined the corresponding attribute. However, _any other attributes_ not set on the referenced element **will** be applied to the `use` element.
+Most attributes on `<use>` are ignored if the corresponding attribute is already defined on the element _referenced_ by `<use>`. (This differs from how CSS style attributes override those set 'earlier' in the cascade).
+**Only** the attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}} and {{SVGAttr("href")}} on the `<use>` element will or may have some effect, described later, if the referenced element has already defined the corresponding attribute. However, _any other attributes_ not set on the referenced element **will** be applied to the `<use>` element.
 
-Since the cloned nodes are not exposed, care must be taken when using [CSS](/en-US/docs/Web/CSS) to style a `use` element and its cloned descendants. CSS properties are not guaranteed to be inherited by the cloned DOM unless you explicitly request them using [CSS inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance).
+Since the cloned nodes are not exposed, care must be taken when using [CSS](/en-US/docs/Web/CSS) to style a `<use>` element and its cloned descendants. CSS properties are not guaranteed to be inherited by the cloned DOM unless you explicitly request them using [CSS inheritance](/en-US/docs/Web/CSS/CSS_cascade/Inheritance).
 
-For security reasons, browsers may apply the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) on `use` elements and may refuse to load a cross-origin URL in the {{SVGAttr("href")}} attribute. There is currently no defined way to set a cross-origin policy for `use` elements.
+For security reasons, browsers may apply the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) on `<use>` elements and may refuse to load a cross-origin URL in the {{SVGAttr("href")}} attribute. There is currently no defined way to set a cross-origin policy for `<use>` elements.
 
-> [!WARNING]
-> Loading resources with data URIs in the `href` attribute is deprecated for security reasons.
-> This applies to `<use href="data:...` and also when setting `href` by using the [`set`](/en-US/docs/Web/SVG/Reference/Element/set) or [`setAttribute`](/en-US/docs/Web/API/Element/setAttribute) method.
-> See "Load from data: URI" in the [Browser compatibility](#browser_compatibility) table to check support in different browser versions.
+### Loading resources from external files via `<use>`
 
-> [!WARNING]
-> Since SVG 2, the {{SVGAttr("xlink:href")}} attribute is deprecated in favor of {{SVGAttr("href")}}. See {{SVGAttr("xlink:href")}} page for more information.
+You can load nodes from an external SVG file via the `<use>` element by specifying the path of the file followed by a URL fragment pointing to the `id` of the node to load:
+
+```html
+<svg>
+  <use href="../assets/my-svg.svg#my-fragment"></use>
+</svg>
+```
+
+Historically, the URL fragment was always required, even if you just wanted to load the entire SVG document. In such a case, the `id` would be included on the SVG root element:
+
+```html
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" id="my-fragment">
+  <circle cx="150" cy="100" r="80" fill="green" />
+</svg>
+```
+
+However, modern implementations have been updated so that if you want to load the entire external document, you can refer to it without a URL fragment (and the `id` is no longer needed on the SVG document root element):
+
+```html
+<svg>
+  <use href="../assets/my-svg.svg"></use>
+</svg>
+```
+
+Check the [Browser compatibility](#browser_compatibility) table for browser support.
+
+### Loading resources from data URIs via `<use>`
+
+Loading resources with data URIs in the `href` attribute is deprecated for security reasons. This applies to `<use href="data:...` and also when setting `href` by using the [`set`](/en-US/docs/Web/SVG/Reference/Element/set) or [`setAttribute`](/en-US/docs/Web/API/Element/setAttribute) method.
+
+Again, check the [Browser compatibility](#browser_compatibility) table for browser support.
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -49,7 +49,7 @@ svg {
 - {{SVGAttr("height")}}
   - : The height of the `<use>` element.<br/> _Value type_: [**`<length>`**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 
-> **Note:** `width`, and `height` have no effect on `<use>` elements, unless the element referenced has a [viewBox](/en-US/docs/Web/SVG/Reference/Attribute/viewBox) - i.e., they only have an effect when `<use>` refers to a `svg` or `symbol` element.
+> **Note:** `width`, and `height` have no effect on `<use>` elements, unless the element referenced has a [viewBox](/en-US/docs/Web/SVG/Reference/Attribute/viewBox) - i.e., they only have an effect when `<use>` refers to a `<svg>` or `<symbol>` element.
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In Chrome 137, you can now omit the fragment in an SVG `<use>` element `href` when referencing an external SVG file, to reference the SVG root element. See https://chromestatus.com/feature/5128141573718016.

This PR updates the `<use>` reference page to add information about this.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
