### PR TITLE
chore(glossary): Use a shorter page title

### DIFF
--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -13,5 +13,4 @@ This glossary provides definitions of words and abbreviations you need to know t
 Use the sidebar to browse through or jump to specific glossary terms. You can also use the search "Filter" at the top of the sidebar to quickly look for a term.
 
 > [!NOTE]
-> This glossary is a never-ending work in progress.
-> You can help improve it by [writing new entries](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) or by making the existing ones better.
+You can help by contributing [new terms](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) or improving the existing defintions.

--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -12,5 +12,4 @@ This glossary provides definitions of words and abbreviations you need to know t
 
 Use the sidebar to browse through or jump to specific glossary terms. You can also use the search "Filter" at the top of the sidebar to quickly look for a term.
 
-> [!NOTE]
 You can help by contributing [new terms](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) or improving the existing defintions.

--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -1,5 +1,5 @@
 ---
-title: Glossary definitions of Web-related terms
+title: Glossary of web terms
 short-title: Glossary
 slug: Glossary
 page-type: landing-page

--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MDN Web Docs Glossary: Definitions of Web-related terms"
+title: Glossary definitions of Web-related terms
 short-title: Glossary
 slug: Glossary
 page-type: landing-page
@@ -7,9 +7,11 @@ page-type: landing-page
 
 {{GlossarySidebar}}
 
-Web technologies contain long lists of jargon and abbreviations that are used in documentation and coding. This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.
+Web technologies use many types of jargon, acronyms, and abbreviations in documentation, programming languages, and other contexts.
+This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.
 
 Glossary terms can be selected from the sidebar.
 
 > [!NOTE]
-> This glossary is a never-ending work in progress. You can help improve it by [writing new entries](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) or by making the existing ones better.
+> This glossary is a never-ending work in progress.
+> You can help improve it by [writing new entries](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) or by making the existing ones better.

--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -7,10 +7,10 @@ page-type: landing-page
 
 {{GlossarySidebar}}
 
-Web technologies use many types of jargon, acronyms, and abbreviations in documentation, programming languages, and other contexts.
+Web technologies use many types of jargon, acronyms, and abbreviations in documentation, code, and other contexts.
 This glossary provides definitions of words and abbreviations you need to know to successfully understand and build for the web.
 
-Glossary terms can be selected from the sidebar.
+Use the sidebar to browse through or jump to specific glossary terms. You can also use the search "Filter" at the top of the sidebar to quickly look for a term.
 
 > [!NOTE]
 > This glossary is a never-ending work in progress.


### PR DESCRIPTION
### Description

The title is used in lots of child pages and it's quite long. We can get rid of some redundancy here by making the title of the root page a little shorter.
