### PR TITLE
Correct variables in console.log

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/temporal/instant/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/instant/from/index.md
@@ -46,11 +46,11 @@ const instant = Temporal.Instant.from("1970-01-01T00Z");
 console.log(instant.toString()); // 1970-01-01T00:00:00Z
 
 const instant2 = Temporal.Instant.from("1970-01-01T00+08:00");
-console.log(instant.toString()); // 1969-12-31T16:00:00Z
+console.log(instant2.toString()); // 1969-12-31T16:00:00Z
 
 // America/New_York is UTC-5 in January 1970, not UTC+8
 const instant3 = Temporal.Instant.from("1970-01-01T00+08:00[America/New_York]");
-console.log(instant.toString()); // 1969-12-31T16:00:00Z; the time zone name is ignored
+console.log(instant3.toString()); // 1969-12-31T16:00:00Z; the time zone name is ignored
 ```
 
 ### Creating an instant from another instant


### PR DESCRIPTION
The second and third `console.log()` in the first example on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/from#examples use `instant` instead of `instant2`/`instant3`