### PR TITLE
WebExt: cleanup useless tag of year

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -70,7 +70,7 @@ To use this API you need to have the "webNavigation" [permission](/en-US/docs/Mo
 - {{WebExtAPIRef("webNavigation.onTabReplaced")}}
   - : Fired when the contents of the tab is replaced by a different (usually previously pre-rendered) tab.
 - {{WebExtAPIRef("webNavigation.onHistoryStateUpdated")}}
-  - : Fired when the page used the [history API (2011)](/en-US/docs/Web/API/History_API) to update the URL displayed in the browser's location bar.
+  - : Fired when the page used the [history API](/en-US/docs/Web/API/History_API) to update the URL displayed in the browser's location bar.
 
 ## Browser compatibility
 


### PR DESCRIPTION
```diff
  - : Fired when the page used the [history API (2011)](/en-US/docs/Web/API/History_API) to update the URL displayed in the browser's location bar.
  - : Fired when the page used the [history API](/en-US/docs/Web/API/History_API) to update the URL displayed in the browser's location bar.
```

the mark of year (2011) was added in mdn/content#19644 (ref:https://github.com/mdn/content/pull/19644/files#diff-f3e7ba440cefdb995b0dcd70ea3cc161e66ce1370dde036d80941a212251fd13), which seems to be a little bit useless.

@Josh-Cena removed the first mark of year in a later cleanup, but missed? the second mark of year 
 (mdn/content#36070, ref:https://github.com/mdn/content/pull/36070/files#diff-f3e7ba440cefdb995b0dcd70ea3cc161e66ce1370dde036d80941a212251fd13)

per @yin1999's suggestion and my perspective, may the second tag be removed as well as it seems to be a little bit useless here?

