### PR TITLE
FF140 Relnote - CookieStore API update

### DIFF
--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -42,17 +42,10 @@ This article provides information about the changes in Firefox 140 that affect d
 
 ### APIs
 
-- A subset of the [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) is now supported ([Firefox bug 1958875](https://bugzil.la/1958875)).
+- The [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) is now supported ([Firefox bug 1958875](https://bugzil.la/1958875)).
 
-  The API is a modern, {{glossary("asynchronous")}} {{jsxref("Promise")}}-based method of managing cookies, which can be used in both the main thread and in [service workers](/en-US/docs/Web/API/Service_Worker_API). The part of the API that is supported includes:
-
-  - The [`CookieStore`](/en-US/docs/Web/API/CookieStore) interface, for getting, setting, and deleting cookies.
-  - The [`Window.cookieStore`](/en-US/docs/Web/API/Window/cookieStore) and [`ServiceWorkerGlobalScope.cookieStore`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/cookieStore) properties for getting `CookieStore` instances.
-  - The [`change` event](/en-US/docs/Web/API/CookieStore/change_event) (and its interface [`CookieChangeEvent`](/en-US/docs/Web/API/CookieChangeEvent)), which fires in main thread and service worker contexts when cookies are set or deleted.
-
-    Note that while any of the supported cookie properties can be [set](/en-US/docs/Web/API/CookieStore/set), the cookie objects returned by the [`get()`](/en-US/docs/Web/API/CookieStore/get) and [`getAll()`](/en-US/docs/Web/API/CookieStore/getAll) methods, and in the `change` event, omit all properties other than `name` and `value` (matching the information returned by the {{domxref("document.cookie")}}).
-
-  The following interfaces and properties are not implemented: [`ServiceWorkerRegistration.cookies`](/en-US/docs/Web/API/ServiceWorkerRegistration/cookies), [`CookieStoreManager`](/en-US/docs/Web/API/CookieStoreManager), and [`ExtendableCookieChangeEvent`](/en-US/docs/Web/API/ExtendableCookieChangeEvent).
+  This provides a modern, {{glossary("asynchronous")}} {{jsxref("Promise")}}-based method of managing cookies, which can be used in both the main thread and in [service workers](/en-US/docs/Web/API/Service_Worker_API).
+  The API is supported with the exception that cookie objects returned by the [`get()`](/en-US/docs/Web/API/CookieStore/get) and [`getAll()`](/en-US/docs/Web/API/CookieStore/getAll) methods of the {{domxref("CookieStore")}} interface, and in the `change` event, omit all properties other than `name` and `value` (matching the information returned by the {{domxref("document.cookie")}}). The other cookie properties can still be [set](/en-US/docs/Web/API/CookieStore/set), and these will be used internally.
 
 ### Escape < and > in attributes when serializing HTML
 

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -11,14 +11,11 @@ The **`ExtendableCookieChangeEvent`** interface of the {{domxref("Cookie Store A
 
 Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are:
 
-- A cookie is newly created and not immediately removed.
+- A cookie is newly created and not immediately removed, or if a cookies is replaced.
   In this case `type` is "changed".
 - A cookie is newly created and immediately removed.
   In this case `type` is "deleted"
 - A cookie is removed. In this case `type` is "deleted".
-
-> [!NOTE]
-> A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -7,12 +7,14 @@ browser-compat: api.ExtendableCookieChangeEvent
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{AvailableInWorkers("service")}}
 
-The **`ExtendableCookieChangeEvent`** interface of the {{domxref("Cookie Store API", "", "", "nocode")}} is the event type passed to {{domxref("ServiceWorkerGlobalScope/cookiechange_event", "cookiechange")}} event fired at the {{domxref("ServiceWorkerGlobalScope")}} when any cookie changes occur which match the service worker's cookie change subscription list. A cookie change event consists of a cookie and a type. (either "changed" or "deleted")
+The **`ExtendableCookieChangeEvent`** interface of the {{domxref("Cookie Store API", "", "", "nocode")}} is the event type passed to {{domxref("ServiceWorkerGlobalScope/cookiechange_event", "cookiechange")}} event fired at the {{domxref("ServiceWorkerGlobalScope")}} when any cookie changes occur which match the service worker's cookie change subscription list. A cookie change event consists of a cookie and a type (either "changed" or "deleted").
 
 Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are:
 
-- A cookie is newly created and not immediately removed. In this case `type` is "changed".
-- A cookie is newly created and immediately removed. In this case `type` is "deleted"
+- A cookie is newly created and not immediately removed.
+  In this case `type` is "changed".
+- A cookie is newly created and immediately removed.
+  In this case `type` is "deleted"
 - A cookie is removed. In this case `type` is "deleted".
 
 > [!NOTE]


### PR DESCRIPTION
This fixes the FF140 Cookie Store API release note updated in https://github.com/mdn/content/pull/39676.

BCD shows that the whole API is supported (the missing bits were implemented in the short window while this was unpublished and not tagged as dev-docs-needed). 

This updates the docs to match. Note that I believe the comment about the returned properties to still be true, but I'm querying that in https://bugzilla.mozilla.org/show_bug.cgi?id=1958875#c15

Related docs work can be tracked in #39612

