### PR TITLE
Extract inline script/style into separate CSS/HTML blocks

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
@@ -288,23 +288,6 @@ Everything is rendered properly and animating — congratulations on building yo
       dur: 2000; loop: true; easing: linear;">
   </a-entity>
 </a-scene>
-
-<script>
-  const scene = document.querySelector("a-scene");
-  const cylinder = document.createElement("a-cylinder");
-  cylinder.setAttribute("color", "#FF9500");
-  cylinder.setAttribute("height", "2");
-  cylinder.setAttribute("radius", "0.75");
-  cylinder.setAttribute("position", "3 1 0");
-  scene.appendChild(cylinder);
-  let t = 0;
-  function render() {
-    t += 0.01;
-    requestAnimationFrame(render);
-    cylinder.setAttribute("position", `3 ${Math.sin(t * 2) + 1} 0`);
-  }
-  render();
-</script>
 ```
 
 ```css hidden live-sample___a-frame-animation
@@ -315,6 +298,23 @@ body {
   height: 100%;
   font-size: 0;
 }
+```
+
+```js live-sample___a-frame-animation
+const scene = document.querySelector("a-scene");
+const cylinder = document.createElement("a-cylinder");
+cylinder.setAttribute("color", "#FF9500");
+cylinder.setAttribute("height", "2");
+cylinder.setAttribute("radius", "0.75");
+cylinder.setAttribute("position", "3 1 0");
+scene.appendChild(cylinder);
+let t = 0;
+function render() {
+  t += 0.01;
+  requestAnimationFrame(render);
+  cylinder.setAttribute("position", `3 ${Math.sin(t * 2) + 1} 0`);
+}
+render();
 ```
 
 {{embedlivesample("a-frame-animation", "", "400px")}}

--- a/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.md
@@ -50,14 +50,14 @@ Here's the HTML structure we will use.
     <meta charset="utf-8" />
     <title>MDN Games: Shaders demo</title>
     <style>
-      body {
+      html,
+      body,
+      canvas {
         margin: 0;
         padding: 0;
-        font-size: 0;
-      }
-      canvas {
         width: 100%;
         height: 100%;
+        font-size: 0;
       }
     </style>
     <script src="three.min.js"></script>

--- a/files/en-us/games/techniques/async_scripts/index.md
+++ b/files/en-us/games/techniques/async_scripts/index.md
@@ -32,7 +32,7 @@ Two common situations in which a script is _not_ async (as [defined by the HTML 
 
 ```html
 <script async>
-  code();
+  // Inline JavaScript code
 </script>
 ```
 
@@ -40,7 +40,7 @@ and
 
 ```js
 const script = document.createElement("script");
-script.textContent = "code()";
+script.textContent = "// Inline JavaScript code";
 document.body.appendChild(script);
 ```
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
@@ -174,7 +174,7 @@ Components are the building blocks of Svelte applications. They are written into
 
 All three sections — `<script>`, `<style>`, and markup — are optional, and can appear in any order you like.
 
-```html
+```svelte
 <script>
   // logic goes here
 </script>
@@ -191,7 +191,7 @@ All three sections — `<script>`, `<style>`, and markup — are optional, and c
 
 With this in mind, let's have a look at the `src/App.svelte` file that came with the starter template. You should see something like the following:
 
-```html
+```svelte
 <script>
   export let name;
 </script>
@@ -231,7 +231,7 @@ With this in mind, let's have a look at the `src/App.svelte` file that came with
 
 The `<script>` block contains JavaScript that runs when a component instance is created. Variables declared (or imported) at the top level are 'visible' from the component's markup. Top-level variables are the way Svelte handles the component state, and they are reactive by default. We will explain in detail what this means later on.
 
-```html
+```svelte
 <script>
   export let name;
 </script>
@@ -243,7 +243,7 @@ Svelte uses the [`export`](/en-US/docs/Web/JavaScript/Reference/Statements/expor
 
 In the markup section you can insert any HTML you like, and in addition you can insert valid JavaScript expressions inside single curly braces (`{}`). In this case we are embedding the value of the `name` prop right after the `Hello` text.
 
-```html
+```svelte
 <main>
   <h1>Hello {name}!</h1>
   <p>
@@ -259,7 +259,7 @@ Svelte also supports tags like `{#if}`, `{#each}`, and `{#await}` — these exam
 
 If you have experience working with CSS, the following snippet should make sense:
 
-```html
+```svelte
 <style>
   main {
     text-align: center;
@@ -301,7 +301,7 @@ When compiling the app, Svelte changes our `h1` styles definition to `h1.svelte-
 Now that we have a general idea of how it all fits together, we can start making a few changes.
 At this point you can try updating your `App.svelte` component — for example change the `<h1>` element in `App.svelte` so that it reads like this:
 
-```html
+```svelte
 <h1>Hello {name} from MDN!</h1>
 ```
 
@@ -315,7 +315,7 @@ In Svelte, reactivity is triggered by assigning a new value to any top-level var
 
 Try updating your `<script>` and markup sections like so:
 
-```html
+```svelte
 <script>
   export let name;
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
@@ -168,117 +168,117 @@ There are already some styles present in the file. Let's remove those and replac
 
 Update your `App.vue` file's `<style>` element so it looks like so:
 
-```html
+```vue
 <style>
-  /* Global styles */
-  .btn {
-    padding: 0.8rem 1rem 0.7rem;
-    border: 0.2rem solid #4d4d4d;
-    cursor: pointer;
-    text-transform: capitalize;
-  }
-  .btn__danger {
-    color: #fff;
-    background-color: #ca3c3c;
-    border-color: #bd2130;
-  }
-  .btn__filter {
-    border-color: lightgrey;
-  }
-  .btn__danger:focus {
-    outline-color: #c82333;
-  }
-  .btn__primary {
-    color: #fff;
-    background-color: #000;
-  }
-  .btn-group {
-    display: flex;
-    justify-content: space-between;
-  }
-  .btn-group > * {
-    flex: 1 1 auto;
-  }
-  .btn-group > * + * {
-    margin-left: 0.8rem;
-  }
-  .label-wrapper {
-    margin: 0;
-    flex: 0 0 100%;
-    text-align: center;
-  }
+/* Global styles */
+.btn {
+  padding: 0.8rem 1rem 0.7rem;
+  border: 0.2rem solid #4d4d4d;
+  cursor: pointer;
+  text-transform: capitalize;
+}
+.btn__danger {
+  color: #fff;
+  background-color: #ca3c3c;
+  border-color: #bd2130;
+}
+.btn__filter {
+  border-color: lightgrey;
+}
+.btn__danger:focus {
+  outline-color: #c82333;
+}
+.btn__primary {
+  color: #fff;
+  background-color: #000;
+}
+.btn-group {
+  display: flex;
+  justify-content: space-between;
+}
+.btn-group > * {
+  flex: 1 1 auto;
+}
+.btn-group > * + * {
+  margin-left: 0.8rem;
+}
+.label-wrapper {
+  margin: 0;
+  flex: 0 0 100%;
+  text-align: center;
+}
+[class*="__lg"] {
+  display: inline-block;
+  width: 100%;
+  font-size: 1.9rem;
+}
+[class*="__lg"]:not(:last-child) {
+  margin-bottom: 1rem;
+}
+@media screen and (min-width: 620px) {
   [class*="__lg"] {
-    display: inline-block;
-    width: 100%;
-    font-size: 1.9rem;
+    font-size: 2.4rem;
   }
-  [class*="__lg"]:not(:last-child) {
-    margin-bottom: 1rem;
-  }
-  @media screen and (min-width: 620px) {
-    [class*="__lg"] {
-      font-size: 2.4rem;
-    }
-  }
-  .visually-hidden {
-    position: absolute;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(1px, 1px, 1px, 1px);
-    clip-path: rect(1px 1px 1px 1px);
-    white-space: nowrap;
-  }
-  [class*="stack"] > * {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
+}
+.visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: rect(1px 1px 1px 1px);
+  white-space: nowrap;
+}
+[class*="stack"] > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.stack-small > * + * {
+  margin-top: 1.25rem;
+}
+.stack-large > * + * {
+  margin-top: 2.5rem;
+}
+@media screen and (min-width: 550px) {
   .stack-small > * + * {
-    margin-top: 1.25rem;
+    margin-top: 1.4rem;
   }
   .stack-large > * + * {
-    margin-top: 2.5rem;
+    margin-top: 2.8rem;
   }
-  @media screen and (min-width: 550px) {
-    .stack-small > * + * {
-      margin-top: 1.4rem;
-    }
-    .stack-large > * + * {
-      margin-top: 2.8rem;
-    }
-  }
-  /* End global styles */
+}
+/* End global styles */
+#app {
+  background: #fff;
+  margin: 2rem 0 4rem 0;
+  padding: 1rem;
+  padding-top: 0;
+  position: relative;
+  box-shadow:
+    0 2px 4px 0 rgb(0 0 0 / 20%),
+    0 2.5rem 5rem 0 rgb(0 0 0 / 10%);
+}
+@media screen and (min-width: 550px) {
   #app {
-    background: #fff;
-    margin: 2rem 0 4rem 0;
-    padding: 1rem;
-    padding-top: 0;
-    position: relative;
-    box-shadow:
-      0 2px 4px 0 rgb(0 0 0 / 20%),
-      0 2.5rem 5rem 0 rgb(0 0 0 / 10%);
+    padding: 4rem;
   }
-  @media screen and (min-width: 550px) {
-    #app {
-      padding: 4rem;
-    }
-  }
-  #app > * {
-    max-width: 50rem;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  #app > form {
-    max-width: 100%;
-  }
-  #app h1 {
-    display: block;
-    min-width: 100%;
-    width: 100%;
-    text-align: center;
-    margin: 0;
-    margin-bottom: 1rem;
-  }
+}
+#app > * {
+  max-width: 50rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+#app > form {
+  max-width: 100%;
+}
+#app h1 {
+  display: block;
+  min-width: 100%;
+  width: 100%;
+  text-align: center;
+  margin: 0;
+  margin-bottom: 1rem;
+}
 </style>
 ```
 
@@ -336,9 +336,9 @@ The last component we want to style is our `ToDoItem` component. To keep the sty
 
 To use the `scoped` modifier, create a `<style>` element inside `ToDoItem.vue`, at the bottom of the file, and give it a `scoped` attribute:
 
-```html
+```vue
 <style scoped>
-  /* … */
+/* … */
 </style>
 ```
 

--- a/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -303,16 +303,24 @@ p {
     transparent 2px 1lh
   );
 }
+
+.lh-2 {
+  line-height: 2em;
+}
+
+.lh-4 {
+  line-height: 4em;
+}
 ```
 
 ```html
-<p style="line-height: 2em">
+<p class="lh-2">
   Summer is a time for adventure, and this year was no exception. I had many
   exciting experiences, but two of my favorites were my trip to the beach and my
   week at summer camp.
 </p>
 
-<p style="line-height: 4em">
+<p class="lh-4">
   At the beach, I spent my days swimming, collecting shells, and building
   sandcastles. I also went on a boat ride and saw dolphins swimming alongside
   us.

--- a/files/en-us/learn_web_development/extensions/forms/user_input_methods/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/user_input_methods/index.md
@@ -112,11 +112,13 @@ The [Drag & Drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API) API enables users 
 Here is an example that allows a section of content to be dragged.
 
 ```html
-<div
-  draggable="true"
-  ondragstart="event.dataTransfer.setData('text/plain', 'This text may be dragged')">
-  This text <strong>may</strong> be dragged.
-</div>
+<div draggable="true">This text <strong>may</strong> be dragged.</div>
+```
+
+```js
+document.querySelector("div").addEventListener("dragstart", (event) => {
+  event.dataTransfer.setData("text/plain", "This text may be dragged.");
+});
 ```
 
 in which we:

--- a/files/en-us/learn_web_development/extensions/performance/web_performance_basics/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/web_performance_basics/index.md
@@ -27,17 +27,24 @@ Below is a quick review of best practices, tools, APIs with links to provide mor
 
 ### CSS
 
-Web performance is all about user experience and perceived performance. As we learned in the [critical rendering path](/en-US/docs/Web/Performance/Guides/Critical_rendering_path) document, linking CSS with a traditional link tag with rel="stylesheet" is synchronous and blocks rendering. Optimize the rendering of your page by removing blocking CSS.
+Web performance is all about user experience and perceived performance. As we learned in the [critical rendering path](/en-US/docs/Web/Performance/Guides/Critical_rendering_path) document, linking CSS with a traditional link tag with `rel="stylesheet"` is synchronous and blocks rendering. Optimize the rendering of your page by removing blocking CSS.
 
-To load CSS asynchronously one can set the media type to print and then change to all once loaded. The following snippet includes an onload attribute, requiring JavaScript, so it is important to include a noscript tag with a traditional fallback.
+To load CSS asynchronously one can set the media type to `print` and then change to `all` once loaded. This requires JavaScript, so it is important to include a `<noscript>` tag with a traditional fallback.
 
 ```html
 <link
+  id="my-stylesheet"
   rel="stylesheet"
   href="/path/to/my.css"
-  media="print"
-  onload="this.media='all'" />
+  media="print" />
 <noscript><link rel="stylesheet" href="/path/to/my.css" /></noscript>
+```
+
+```js
+const stylesheet = document.getElementById("my-stylesheet");
+stylesheet.addEventListener("load", () => {
+  stylesheet.media = "all";
+});
 ```
 
 The downside with this approach is the flash of unstyled text (FOUT.) The simplest way to address this is by inlining CSS that is required for any content that is rendered above the fold, or what you see in the browser viewport before scrolling. These styles will improve perceived performance as the CSS does not require a file request.
@@ -50,7 +57,7 @@ The downside with this approach is the flash of unstyled text (FOUT.) The simple
 
 ### JavaScript
 
-Avoid JavaScript blocking by using the [async](/en-US/docs/Web/HTML/Reference/Elements/script) or [defer](/en-US/docs/Web/HTML/Reference/Elements/script) attributes, or link JavaScript assets after the page's DOM elements. JavaScript only block rendering for elements that appear after the script tag in the DOM tree.
+Avoid JavaScript blocking by using the [`async`](/en-US/docs/Web/HTML/Reference/Elements/script) or [`defer`](/en-US/docs/Web/HTML/Reference/Elements/script) attributes, or link JavaScript assets after the page's DOM elements. JavaScript only block rendering for elements that appear after the script tag in the DOM tree.
 
 ### Web Fonts
 

--- a/files/en-us/web/accessibility/aria/guides/live_regions/index.md
+++ b/files/en-us/web/accessibility/aria/guides/live_regions/index.md
@@ -213,7 +213,7 @@ Another example of `aria-atomic` - an update/notification made as a result of a 
 ```html
 <div id="date-input">
   <label for="year">Year:</label>
-  <input type="text" id="year" value="1990" onblur="change(event)" />
+  <input type="text" id="year" value="1990" />
 </div>
 
 <div id="date-output" aria-atomic="true" aria-live="polite">
@@ -230,10 +230,10 @@ function change(event) {
     case "year":
       yearOut.textContent = event.target.value;
       break;
-    default:
-      return;
   }
 }
+
+document.getElementById("year").addEventListener("blur", change);
 ```
 
 Without `aria-atomic="true"` the screen reader announces only the changed value of year. With `aria-atomic="true"`, the screen reader announces "The set year is: _changed value_"

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-invalid/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-invalid/index.md
@@ -62,8 +62,7 @@ The following snippet shows a simplified version of two form fields with a valid
       name="name"
       id="name"
       aria-required="true"
-      aria-invalid="false"
-      onblur="checkValidity('name', ' ', 'Invalid name entered (requires both first and last name)');" />
+      aria-invalid="false" />
   </li>
   <li>
     <label for="email">Email Address</label>
@@ -72,10 +71,23 @@ The following snippet shows a simplified version of two form fields with a valid
       name="email"
       id="email"
       aria-required="true"
-      aria-invalid="false"
-      onblur="checkValidity('email', '@', 'Invalid email address');" />
+      aria-invalid="false" />
   </li>
 </ul>
+```
+
+```js
+document.getElementById("name").addEventListener("blur", () => {
+  checkValidity(
+    "name",
+    " ",
+    "Invalid name entered (requires both first and last name)",
+  );
+});
+
+document.getElementById("email").addEventListener("blur", () => {
+  checkValidity("email", "@", "Invalid email address");
+});
 ```
 
 Note that it is not necessary to validate the fields immediately on blur; the application could wait until the form is submitted (though this is not necessarily recommended).

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-label/index.md
@@ -18,7 +18,7 @@ In cases where an element that is not part of the [prohibited list](#associated_
 The code below shows an example of how to use the `aria-label` attribute to provide an accessible name for a `<button>` element. The button in this example contains an SVG graphic and lacks textual content, making the `aria-label` essential for screen reader users to understand its function, which in this case is "Close".
 
 ```html
-<button aria-label="Close" onclick="myDialog.close()">
+<button aria-label="Close">
   <svg
     aria-hidden="true"
     focusable="false"
@@ -30,6 +30,12 @@ The code below shows an example of how to use the `aria-label` attribute to prov
       fill="#000" />
   </svg>
 </button>
+```
+
+```js
+document.querySelector("button").addEventListener("click", () => {
+  myDialog.close();
+});
 ```
 
 > **Note:** `aria-label` is intended for naming elements where the implicit or explicit role does not prohibit naming. It is strongly recommended to prioritize the use of `aria-labelledby` over `aria-label` if a visible label exists for the element to reference and receive its name from.

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-modal/index.md
@@ -47,14 +47,20 @@ If a dialog is not modal — there is no inert background and focus isn't confin
     <div id="dialog_desc">
       <p>Are you sure you want to delete this file?</p>
     </div>
-    <button type="button" onclick="closeDialog(this)">
-      No. Close this popup.
-    </button>
-    <button type="button" onclick="deleteFile(this)">
-      Yes. Delete the file.
-    </button>
+    <button id="close-btn" type="button">No. Close this popup.</button>
+    <button id="confirm-btn" type="button">Yes. Delete the file.</button>
   </div>
 </div>
+```
+
+```js
+document.getElementById("close-btn").addEventListener("click", () => {
+  closeDialog();
+});
+
+document.getElementById("confirm-btn").addEventListener("click", (event) => {
+  deleteFile();
+});
 ```
 
 This partial example includes an `alertdialog` nested in a full-screen, non-scrollable backdrop.

--- a/files/en-us/web/accessibility/aria/reference/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/alertdialog_role/index.md
@@ -79,19 +79,22 @@ The code snippet above shows how to mark up an alert dialog that only provides a
   </div>
   <ul>
     <li>
-      <button type="button" onclick="closeThis()">No</button>
+      <button id="close-btn" type="button">No</button>
     </li>
     <li>
-      <button
-        type="button"
-        aria-controls="form"
-        id="delete_file_confirm"
-        onclick="deleteFile()">
-        Yes
-      </button>
+      <button id="confirm-btn" type="button" aria-controls="form">Yes</button>
     </li>
   </ul>
 </div>
+```
+
+```js
+document.getElementById("close-btn").addEventListener("click", () => {
+  closeDialog();
+});
+document.getElementById("confirm-btn").addEventListener("click", (event) => {
+  deleteFile();
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/accessibility/aria/reference/roles/button_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/button_role/index.md
@@ -117,13 +117,7 @@ Try the example by adding a name to the text box. The button will cause the name
 <ul id="nameList"></ul>
 <label for="newName">Enter your Name: </label>
 <input type="text" id="newName" />
-<span
-  role="button"
-  tabindex="0"
-  onclick="handleCommand(event)"
-  onKeyDown="handleCommand(event)"
-  >Add Name</span
->
+<span role="button" tabindex="0">Add Name</span>
 ```
 
 #### CSS
@@ -178,6 +172,10 @@ function handleCommand(event) {
     list.appendChild(listItem);
   }
 }
+
+const btn = document.querySelector("span[role='button']");
+btn.addEventListener("click", handleCommand);
+btn.addEventListener("keydown", handleCommand);
 ```
 
 {{EmbedLiveSample("Basic_button_example")}}
@@ -189,21 +187,9 @@ In this snippet a {{HTMLElement("span")}} element is converted to a toggle butto
 #### HTML
 
 ```html
-<button
-  type="button"
-  onclick="handleBtnClick(event)"
-  onKeyDown="handleBtnKeyDown(event)">
-  Mute Audio
-</button>
+<button type="button">Mute Audio</button>
 
-<span
-  role="button"
-  tabindex="0"
-  aria-pressed="false"
-  onclick="handleBtnClick(event)"
-  onKeyDown="handleBtnKeyDown(event)">
-  Mute Audio
-</span>
+<span role="button" tabindex="0" aria-pressed="false"> Mute Audio </span>
 
 <audio
   id="audio"
@@ -261,6 +247,13 @@ function toggleButton(element) {
     audio.play();
   }
 }
+
+const button = document.querySelector("button");
+const spanButton = document.querySelector("span[role='button']");
+button.addEventListener("click", handleBtnClick);
+button.addEventListener("keydown", handleBtnKeyDown);
+spanButton.addEventListener("click", handleBtnClick);
+spanButton.addEventListener("keydown", handleBtnKeyDown);
 ```
 
 #### Result

--- a/files/en-us/web/accessibility/aria/reference/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/checkbox_role/index.md
@@ -98,16 +98,9 @@ The following example creates an otherwise non-semantic checkbox element using C
   role="checkbox"
   id="chkPref"
   aria-checked="false"
-  onclick="changeCheckbox()"
-  onKeyDown="changeCheckbox(event.code)"
   tabindex="0"
   aria-labelledby="chk1-label"></span>
-<label
-  id="chk1-label"
-  onclick="changeCheckbox()"
-  onKeyDown="changeCheckbox(event.code)"
-  >Remember my preferences</label
->
+<label id="chk1-label">Remember my preferences</label>
 ```
 
 ### CSS
@@ -133,8 +126,10 @@ The following example creates an otherwise non-semantic checkbox element using C
 ### JavaScript
 
 ```js
+const item = document.getElementById("chkPref");
+const label = document.getElementById("chk1-label");
+
 function changeCheckbox(code) {
-  const item = document.getElementById("chkPref");
   const checked = item.getAttribute("aria-checked");
 
   if (code && code !== "Space") {
@@ -146,6 +141,17 @@ function changeCheckbox(code) {
     item.setAttribute("aria-checked", "true");
   }
 }
+
+item.addEventListener("keydown", (event) => {
+  changeCheckbox(event.code);
+});
+
+label.addEventListener("keydown", (event) => {
+  changeCheckbox(event.code);
+});
+
+item.addEventListener("click", changeCheckbox);
+label.addEventListener("click", changeCheckbox);
 ```
 
 {{EmbedLiveSample("Examples", 230, 250)}}

--- a/files/en-us/web/accessibility/aria/reference/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/listbox_role/index.md
@@ -143,9 +143,6 @@ The snippet below, using [`aria-activedescendant`](/en-US/docs/Web/Accessibility
   tabindex="0"
   id="listbox1"
   aria-labelledby="listbox1label"
-  onclick="return listItemClick(event);"
-  onkeydown="return listItemKeyEvent(event);"
-  onkeypress="return listItemKeyEvent(event);"
   aria-activedescendant="listbox1-1">
   <div role="option" id="listbox1-1" class="selected" aria-selected="true">
     Green
@@ -156,6 +153,13 @@ The snippet below, using [`aria-activedescendant`](/en-US/docs/Web/Accessibility
   <div role="option" id="listbox1-5">Violet</div>
   <div role="option" id="listbox1-6">Periwinkle</div>
 </div>
+```
+
+```js
+const listbox = document.getElementById("listbox1");
+listbox.addEventListener("click", listItemClick);
+listbox.addEventListener("keydown", listItemKeyEvent);
+listbox.addEventListener("keypress", listItemKeyEvent);
 ```
 
 This could have more easily been handled with the native HTML {{HTMLElement('select')}} and {{HTMLElement('label')}} elements.

--- a/files/en-us/web/accessibility/aria/reference/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/slider_role/index.md
@@ -176,8 +176,13 @@ Using semantic HTML, this could have been written as:
   max="25"
   step="0.1"
   value="20"
-  aria-valuetext="20 degrees celsius"
-  style="transform: rotate(-90deg);" />
+  aria-valuetext="20 degrees celsius" />
+```
+
+```css
+#temperatureSlider {
+  transform: rotate(-90deg);
+}
 ```
 
 By using {{HTMLElement('input')}}, we get an already-styled range-input widget with keyboard focus, focus styling, keyboard interactions, and `value` updated on user interaction for free. We still need to use JavaScript to change the `aria-valuetext` and the value of the {{HTMLElement('output')}} element.

--- a/files/en-us/web/accessibility/guides/keyboard-navigable_javascript_widgets/index.md
+++ b/files/en-us/web/accessibility/guides/keyboard-navigable_javascript_widgets/index.md
@@ -146,7 +146,11 @@ If your widget handles a key event, prevent the browser from also handling it (f
 For example:
 
 ```html
-<span tabindex="-1" onkeydown="return handleKeyDown();">…</span>
+<span tabindex="-1">…</span>
+```
+
+```js
+span.onkeydown = handleKeyDown;
 ```
 
 If `handleKeyDown()` returns `false`, the event will be consumed, preventing the browser from performing any action based on the keystroke.

--- a/files/en-us/web/accessibility/guides/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/guides/seizure_disorders/index.md
@@ -367,10 +367,7 @@ JavaScript is also an option for reducing contrast dynamically. Here's a code ex
 
 ```html
 <body>
-  <input
-    type="button"
-    value="Set paragraph background color"
-    onclick="set_background()" />
+  <input type="button" value="Set paragraph background color" />
   <p>hi</p>
   <p>hello</p>
 </body>
@@ -379,18 +376,18 @@ JavaScript is also an option for reducing contrast dynamically. Here's a code ex
 **JavaScript Content [(link to source page)](/en-US/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces#javascript_2)**
 
 ```js
-function set_background() {
-  // get a list of all the body elements (there will only be one),
-  // and then select the zeroth (or first) such element
-  myBody = document.getElementsByTagName("body")[0];
+function setBackground() {
+  // now, get all the p elements in the document
+  const paragraphs = document.getElementsByTagName("p");
 
-  // now, get all the p elements that are descendants of the body
-  myBodyElements = myBody.getElementsByTagName("p");
+  // get the second paragraph from the list
+  const secondParagraph = paragraphs[1];
 
-  // get the second item of the list of p elements
-  myP = myBodyElements[1];
-  myP.style.background = "rgb(255 0 0)";
+  // set the inline style
+  secondParagraph.style.background = "red";
 }
+
+document.querySelector("input").addEventListener("click", setBackground);
 ```
 
 #### Avoid fully saturated reds for flashing content
@@ -430,11 +427,9 @@ Use the {{HTMLElement('link')}} element, alongside with and together with the at
 
 **{{CSSxref('@import')}}** is also a way to incorporate style sheets, but it is not quite as well supported as the {{HTMLElement('link')}} element.
 
-```html
-<style>
-  @import url(alternate1.css);
-  @import url(alternate2.css);
-</style>
+```css
+@import url(alternate1.css);
+@import url(alternate2.css);
 ```
 
 By using alternate style sheets (remember to add the titles) you are setting it up for users to be able to use their browsers to choose alternate styles.

--- a/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -150,10 +150,7 @@ In this example we change the background color of a paragraph when a button is c
 
 ```html
 <body>
-  <input
-    type="button"
-    value="Set paragraph background color"
-    onclick="setBackground()" />
+  <input type="button" value="Set paragraph background color" />
   <p>hi</p>
   <p>hello</p>
 </body>
@@ -172,6 +169,8 @@ function setBackground() {
   // set the inline style
   secondParagraph.style.background = "red";
 }
+
+document.querySelector("input").addEventListener("click", setBackground);
 ```
 
 #### Result

--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -69,6 +69,8 @@ Then the four boxes defining the segments of the image are defined. Let's look a
   background-image: -moz-image-rect(url(firefox.png), 0%, 50%, 50%, 0%);
   width: 133px;
   height: 136px;
+  left: 0px;
+  top: 0px;
   position: absolute;
 }
 ```
@@ -80,6 +82,8 @@ This is the top-left corner of the image. It defines a rectangle containing the 
   background-image: -moz-image-rect(url(firefox.png), 0%, 100%, 50%, 50%);
   width: 133px;
   height: 136px;
+  left: 133px;
+  top: 0px;
   position: absolute;
 }
 ```
@@ -93,12 +97,16 @@ The other corners follow a similar pattern:
   background-image: -moz-image-rect(url(firefox.png), 50%, 50%, 100%, 0%);
   width: 133px;
   height: 136px;
+  left: 0px;
+  top: 136px;
   position: absolute;
 }
 #box4 {
   background-image: -moz-image-rect(url(firefox.png), 50%, 100%, 100%, 50%);
   width: 133px;
   height: 136px;
+  left: 133px;
+  top: 136px;
   position: absolute;
 }
 ```
@@ -108,17 +116,17 @@ The other corners follow a similar pattern:
 We include a container with four boxes:
 
 ```html
-<div id="container" onclick="rotate()">
-  <div id="box1" style="left:0px;top:0px;">Top left</div>
-  <div id="box2" style="left:133px;top:0px;">Top right</div>
-  <div id="box3" style="left:0px;top:136px;">Bottom left</div>
-  <div id="box4" style="left:133px;top:136px;">Bottom right</div>
+<div id="container">
+  <div id="box1">Top left</div>
+  <div id="box2">Top right</div>
+  <div id="box3">Bottom left</div>
+  <div id="box4">Bottom right</div>
 </div>
 ```
 
 This places the four segments of our image in a two-by-two box grid. These four segments are all contained within a larger {{HTMLElement("div")}} block whose primary purpose is to receive click events and dispatch them to our JavaScript code.
 
-### The JavaScript code
+### JavaScript
 
 This code handles the click event when the container receives a mouse click.
 
@@ -140,6 +148,8 @@ function rotate() {
     prevStyle = curStyle;
   }
 }
+
+document.getElementById("container").addEventListener("click", rotate);
 ```
 
 This uses {{DOMxRef("window.getComputedStyle()")}} to fetch the style of each element, shifting it to the following element. Notice that before it begins doing so it saves a copy of the last box's style since it will be overwritten by the third element's style. By copying the values of the {{CSSxRef("background-image")}} property from one element to the next with each mouse click, we achieve the desired effect.

--- a/files/en-us/web/css/attr/index.md
+++ b/files/en-us/web/css/attr/index.md
@@ -132,11 +132,12 @@ The `attr()` function can reference attributes that were never intended by the p
 ```html
 <!-- This won't work! -->
 <span data-icon="https://example.org/icons/question-mark.svg">help</span>
-<style>
-  span[data-icon] {
-    background-image: url(attr(data-icon));
-  }
-</style>
+```
+
+```css
+span[data-icon] {
+  background-image: url(attr(data-icon));
+}
 ```
 
 Values that use `attr()` get marked as _`attr()`-tainted_. Using an `attr()`-tainted value as or in a `<url>` makes a declaration become ["invalid at computed value time" or IACVT for short](https://www.bram.us/2024/02/26/css-what-is-iacvt/).

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -74,57 +74,47 @@ If the alignment is set using the element's `align` attribute, then the style is
 ### Setting box alignment
 
 ```html
-<!doctype html>
-<html lang="en-US">
-  <head>
-    <meta charset="UTF-8" />
-    <title>CSS box-align example</title>
-    <style>
-      div.example {
-        display: box; /* As specified */
-        display: -moz-box; /* Mozilla */
-        display: -webkit-box; /* WebKit */
+<div class="example">
+  <p>I will be second from the bottom of div.example, centered horizontally.</p>
+  <p>I will be on the bottom of div.example, centered horizontally.</p>
+</div>
+```
 
-        /* Make this box taller than the children,
+```css
+div.example {
+  display: box; /* As specified */
+  display: -moz-box; /* Mozilla */
+  display: -webkit-box; /* WebKit */
+
+  /* Make this box taller than the children,
      so there is room for the box-pack */
-        height: 400px;
+  height: 400px;
 
-        /* Make this box wider than the children
+  /* Make this box wider than the children
      so there is room for the box-align */
-        width: 300px;
+  width: 300px;
 
-        /* Children should be oriented vertically */
-        box-orient: vertical; /* As specified */
-        -moz-box-orient: vertical; /* Mozilla */
-        -webkit-box-orient: vertical; /* WebKit */
+  /* Children should be oriented vertically */
+  box-orient: vertical; /* As specified */
+  -moz-box-orient: vertical; /* Mozilla */
+  -webkit-box-orient: vertical; /* WebKit */
 
-        /* Align children to the horizontal center of this box */
-        box-align: center; /* As specified */
-        -moz-box-align: center; /* Mozilla */
-        -webkit-box-align: center; /* WebKit */
+  /* Align children to the horizontal center of this box */
+  box-align: center; /* As specified */
+  -moz-box-align: center; /* Mozilla */
+  -webkit-box-align: center; /* WebKit */
 
-        /* Pack children to the bottom of this box */
-        box-pack: end; /* As specified */
-        -moz-box-pack: end; /* Mozilla */
-        -webkit-box-pack: end; /* WebKit */
-      }
+  /* Pack children to the bottom of this box */
+  box-pack: end; /* As specified */
+  -moz-box-pack: end; /* Mozilla */
+  -webkit-box-pack: end; /* WebKit */
+}
 
-      div.example > p {
-        /* Make children narrower than their parent,
+div.example > p {
+  /* Make children narrower than their parent,
      so there is room for the box-align */
-        width: 200px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="example">
-      <p>
-        I will be second from the bottom of div.example, centered horizontally.
-      </p>
-      <p>I will be on the bottom of div.example, centered horizontally.</p>
-    </div>
-  </body>
-</html>
+  width: 200px;
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -70,37 +70,29 @@ A trick to make all content elements in a containing box the same size, is to gi
 ### Setting box-flex
 
 ```html
-<!doctype html>
-<html lang="en-US">
-  <head>
-    <meta charset="UTF-8" />
-    <title>-moz-box-flex example</title>
-    <style>
-      div.example {
-        display: -moz-box;
-        display: -webkit-box;
-        border: 1px solid black;
-        width: 100%;
-      }
-      div.example > p:nth-child(1) {
-        -moz-box-flex: 1; /* Mozilla */
-        -webkit-box-flex: 1; /* WebKit */
-        border: 1px solid black;
-      }
-      div.example > p:nth-child(2) {
-        -moz-box-flex: 0; /* Mozilla */
-        -webkit-box-flex: 0; /* WebKit */
-        border: 1px solid black;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="example">
-      <p>I will expand to fill extra space</p>
-      <p>I will not expand</p>
-    </div>
-  </body>
-</html>
+<div class="example">
+  <p>I will expand to fill extra space</p>
+  <p>I will not expand</p>
+</div>
+```
+
+```css
+div.example {
+  display: -moz-box;
+  display: -webkit-box;
+  border: 1px solid black;
+  width: 100%;
+}
+div.example > p:nth-child(1) {
+  -moz-box-flex: 1; /* Mozilla */
+  -webkit-box-flex: 1; /* WebKit */
+  border: 1px solid black;
+}
+div.example > p:nth-child(2) {
+  -moz-box-flex: 0; /* Mozilla */
+  -webkit-box-flex: 0; /* WebKit */
+  border: 1px solid black;
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -85,11 +85,22 @@ The `currentcolor` keyword represents the value of an element's {{Cssxref("color
 If `currentcolor` is used as the value of the `color` property, it instead takes its value from the inherited value of the `color` property.
 
 ```html
-<div style="color: blue; border: 1px dashed currentcolor;">
+<div class="container">
   The color of this text is blue.
-  <div style="background: currentcolor; height:9px;"></div>
+  <div class="child"></div>
   This block is surrounded by a blue border.
 </div>
+```
+
+```css
+.container {
+  color: blue;
+  border: 1px dashed currentcolor;
+}
+.child {
+  background: currentcolor;
+  height: 9px;
+}
 ```
 
 {{EmbedLiveSample("currentcolor_keyword", "100%", 80)}}

--- a/files/en-us/web/css/font-optical-sizing/index.md
+++ b/files/en-us/web/css/font-optical-sizing/index.md
@@ -21,7 +21,7 @@ font-optical-sizing: none;
 
 ```html interactive-example
 <section id="default-example">
-  <div id="example-element" style="font-optical-sizing: auto">
+  <div id="example-element">
     <h2>Chapter 3</h2>
     <p>
       On this particular Thursday, something was moving quietly through the

--- a/files/en-us/web/css/font-variant-east-asian/index.md
+++ b/files/en-us/web/css/font-variant-east-asian/index.md
@@ -114,7 +114,7 @@ This example require font "Yu Gothic" installed in your OS, other fonts may not 
 ```html
 <table>
   <thead></thead>
-  <tbody style="border:0;">
+  <tbody>
     <tr>
       <th>normal/jis78:</th>
       <td>麹町</td>
@@ -137,6 +137,10 @@ This example require font "Yu Gothic" installed in your OS, other fonts may not 
 #### CSS
 
 ```css
+tbody {
+  border: 0;
+}
+
 td {
   font-family: "Yu Gothic";
   font-size: 20px;

--- a/files/en-us/web/css/math-depth/index.md
+++ b/files/en-us/web/css/math-depth/index.md
@@ -64,7 +64,7 @@ The last two subformulas show the effect of setting `math-depth` to a specific v
 #### HTML
 
 ```html
-<p style="font-size: 3rem; margin: 1rem 0">
+<p>
   <math>
     <mtext>0</mtext>
 
@@ -91,6 +91,13 @@ The last two subformulas show the effect of setting `math-depth` to a specific v
     </mrow>
   </math>
 </p>
+```
+
+```css hidden
+p {
+  font-size: 3rem;
+  margin: 1rem 0;
+}
 ```
 
 #### Result

--- a/files/en-us/web/css/math-shift/index.md
+++ b/files/en-us/web/css/math-shift/index.md
@@ -48,6 +48,7 @@ math-shift: unset;
 ```css
 math {
   math-shift: compact;
+  font-size: 64pt;
 }
 ```
 
@@ -56,7 +57,7 @@ math {
 The following MathML displays two versions of "x squared" using a font with an OpenType MATH table. Browser implementing the `math-shift` property should raise the superscripts using slightly different shifts.
 
 ```html
-<math style="font-size: 64pt;">
+<math>
   <msup style="math-shift: normal">
     <mi>x</mi>
     <mn>2</mn>

--- a/files/en-us/web/css/percentage/index.md
+++ b/files/en-us/web/css/percentage/index.md
@@ -25,31 +25,55 @@ When animated, values of the `<percentage>` data type are {{Glossary("interpolat
 ### Width and margin-left
 
 ```html
-<div style="background-color:navy;">
-  <div style="width:50%; margin-left:20%; background-color:chartreuse;">
-    Width: 50%, Left margin: 20%
-  </div>
-  <div style="width:30%; margin-left:60%; background-color:pink;">
-    Width: 30%, Left margin: 60%
-  </div>
+<div class="container">
+  <div class="box1">Width: 50%, Left margin: 20%</div>
+  <div class="box2">Width: 30%, Left margin: 60%</div>
 </div>
 ```
 
-The above HTML will output:
+```css
+.container {
+  background-color: navy;
+}
+
+.box1 {
+  width: 50%;
+  margin-left: 20%;
+  background-color: chartreuse;
+}
+
+.box2 {
+  width: 30%;
+  margin-left: 60%;
+  background-color: pink;
+}
+```
 
 {{EmbedLiveSample('Width_and_margin-left', '600', 140)}}
 
 ### Font-size
 
 ```html
-<div style="font-size:18px;">
+<div class="container">
   <p>Full-size text (18px)</p>
-  <p><span style="font-size:50%;">50% (9px)</span></p>
-  <p><span style="font-size:200%;">200% (36px)</span></p>
+  <p><span class="half">50% (9px)</span></p>
+  <p><span class="double">200% (36px)</span></p>
 </div>
 ```
 
-The above HTML will output:
+```css
+.container {
+  font-size: 18px;
+}
+
+.half {
+  font-size: 50%;
+}
+
+.double {
+  font-size: 200%;
+}
+```
 
 {{EmbedLiveSample('Font-size', 'auto', 160)}}
 

--- a/files/en-us/web/css/text-align-last/index.md
+++ b/files/en-us/web/css/text-align-last/index.md
@@ -26,7 +26,7 @@ text-align-last: left;
 ```html interactive-example
 <section id="default-example">
   <div>
-    <p id="example-element" style="text-align: justify">
+    <p id="example-element">
       Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
       aliquip ex ea commodo consequat.
     </p>
@@ -41,6 +41,10 @@ section {
 
 #default-example > div {
   width: 250px;
+}
+
+#example-element {
+  text-align: justify;
 }
 ```
 

--- a/files/en-us/web/html/reference/attributes/rel/modulepreload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/modulepreload/index.md
@@ -53,11 +53,6 @@ Only after `main.js` has loaded does the browser discover and fetch the two depe
   <head>
     <meta charset="utf-8" />
     <title>Basic JavaScript module example</title>
-    <style>
-      canvas {
-        border: 1px solid black;
-      }
-    </style>
     <script type="module" src="main.js"></script>
   </head>
   <body></body>
@@ -77,12 +72,6 @@ By the time `main.js` has been parsed and its dependencies are known, they have 
     <link rel="modulepreload" href="main.js" />
     <link rel="modulepreload" href="modules/canvas.js" />
     <link rel="modulepreload" href="modules/square.js" />
-    <style>
-      canvas {
-        border: 1px solid black;
-      }
-    </style>
-
     <script type="module" src="main.js"></script>
   </head>
   <body></body>

--- a/files/en-us/web/html/reference/elements/center/index.md
+++ b/files/en-us/web/html/reference/elements/center/index.md
@@ -33,10 +33,16 @@ This element implements the {{domxref("HTMLElement")}} interface.
 ## Example 2 (CSS alternative)
 
 ```html
-<div style="text-align:center">
+<div class="center">
   This text will be centered.
   <p>So will this paragraph.</p>
 </div>
+```
+
+```css
+.center {
+  text-align: center;
+}
 ```
 
 ### Result
@@ -46,10 +52,16 @@ This element implements the {{domxref("HTMLElement")}} interface.
 ## Example 3 (CSS alternative)
 
 ```html
-<p style="text-align:center">
+<p class="center">
   This line will be centered.<br />
   And so will this line.
 </p>
+```
+
+```css
+.center {
+  text-align: center;
+}
 ```
 
 ### Result

--- a/files/en-us/web/html/reference/elements/figure/index.md
+++ b/files/en-us/web/html/reference/elements/figure/index.md
@@ -118,11 +118,13 @@ function NavigatorExample() {
 
 ```html
 <figure>
-  <p style="white-space:pre">
-    Bid me discourse, I will enchant thine ear, Or like a fairy trip upon the
-    green, Or, like a nymph, with long dishevelled hair, Dance on the sands, and
-    yet no footing seen: Love is a spirit all compact of fire, Not gross to
-    sink, but light, and will aspire.
+  <p>
+    Bid me discourse, I will enchant thine ear,<br />
+    Or like a fairy trip upon the green,<br />
+    Or, like a nymph, with long dishevelled hair,<br />
+    Dance on the sands, and yet no footing seen:<br />
+    Love is a spirit all compact of fire,<br />
+    Not gross to sink, but light, and will aspire.<br />
   </p>
   <figcaption><cite>Venus and Adonis</cite>, by William Shakespeare</figcaption>
 </figure>

--- a/files/en-us/web/html/reference/elements/input/number/index.md
+++ b/files/en-us/web/html/reference/elements/input/number/index.md
@@ -323,7 +323,7 @@ The HTML looks like this:
       required />
     <span class="validity"></span>
   </div>
-  <div class="feetInputGroup" style="display: none;">
+  <div class="feetInputGroup">
     <span>Enter your height — </span>
     <label for="feet">feet:</label>
     <input id="feet" type="number" name="feet" min="0" step="1" />
@@ -386,6 +386,8 @@ const metersInput = document.querySelector("#meters");
 const feetInput = document.querySelector("#feet");
 const inchesInput = document.querySelector("#inches");
 const switchBtn = document.querySelector('input[type="button"]');
+
+feetInputGroup.style.display = "none"; // Hide feet/inches inputs initially
 
 switchBtn.addEventListener("click", () => {
   if (switchBtn.getAttribute("class") === "meters") {

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -384,18 +384,18 @@ You can determine when a style sheet has been loaded by watching for a `load` ev
 
 ```html
 <link rel="stylesheet" href="mystylesheet.css" id="my-stylesheet" />
+```
 
-<script>
-  const stylesheet = document.getElementById("my-stylesheet");
+```js
+const stylesheet = document.getElementById("my-stylesheet");
 
-  stylesheet.onload = () => {
-    // Do something interesting; the sheet has been loaded
-  };
+stylesheet.onload = () => {
+  // Do something interesting; the sheet has been loaded
+};
 
-  stylesheet.onerror = () => {
-    console.log("An error occurred loading the stylesheet!");
-  };
-</script>
+stylesheet.onerror = () => {
+  console.log("An error occurred loading the stylesheet!");
+};
 ```
 
 > [!NOTE]

--- a/files/en-us/web/html/reference/elements/marquee/index.md
+++ b/files/en-us/web/html/reference/elements/marquee/index.md
@@ -50,9 +50,15 @@ The HTML `<marquee>` element is deprecated and its use is strongly discouraged. 
   width="250"
   height="200"
   behavior="alternate"
-  style="border:solid">
+  class="outlined">
   <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
+```
+
+```css
+.outlined {
+  border: solid;
+}
 ```
 
 ### Result

--- a/files/en-us/web/html/reference/elements/nobr/index.md
+++ b/files/en-us/web/html/reference/elements/nobr/index.md
@@ -15,7 +15,13 @@ The **`<nobr>`** [HTML](/en-US/docs/Web/HTML) element prevents the text it conta
 > Although this element is widely supported, it was _never_ standard HTML, so you shouldn't use it. Instead, use the CSS property {{CSSxRef("white-space")}} like this:
 
 ```html
-<span style="white-space: nowrap;">Long line with no breaks</span>
+<span class="nobr">Long line with no breaks</span>
+```
+
+```css
+.nobr {
+  white-space: nowrap;
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/html/reference/elements/small/index.md
+++ b/files/en-us/web/html/reference/elements/small/index.md
@@ -57,8 +57,14 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 ```html
 <p>
   This is the first sentence.
-  <span style="font-size:0.8em">This whole sentence is in small letters.</span>
+  <span class="small">This whole sentence is in small letters.</span>
 </p>
+```
+
+```css
+.small {
+  font-size: 0.8em;
+}
 ```
 
 #### Result

--- a/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
@@ -83,8 +83,17 @@ By adding `data-*` attributes, even ordinary HTML elements can become rather com
   data-shields="72%"
   data-x="414354"
   data-y="85160"
-  data-z="31940"
-  onclick="spaceships[this.dataset.shipId].blasted()" />
+  data-z="31940" />
+```
+
+```js
+function clickSpaceship() {
+  spaceships[this.dataset.shipId].blasted();
+}
+
+document.querySelectorAll("img.spaceship").forEach((ship) => {
+  ship.addEventListener("click", clickSpaceship);
+});
 ```
 
 For a more in-depth tutorial about using HTML data attributes, see [Using data attributes](/en-US/docs/Web/HTML/How_to/Use_data_attributes).

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -1057,30 +1057,41 @@ All operators eventually operate on one or more basic expressions. These basic e
 
 ### this
 
-Use the [`this` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/this) to refer to the current object.
-In general, `this` refers to the calling object in a method.
-Use `this` either with the dot or the bracket notation:
+The [`this` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/this) is usually used within a function. In general, when the function is attached to an object as a method, `this` refers to the object that the method is called on. It functions like a hidden parameter that is passed to the function. `this` is an expression that evaluates to the object, so you can use all the object operations we introduced.
 
 ```js
 this["propertyName"];
 this.propertyName;
+doSomething(this);
 ```
 
-Suppose a function called `validate` validates an object's `value` property, given the object and the high and low values:
+For example, suppose a function is defined as follows:
 
 ```js
-function validate(obj, lowVal, highVal) {
-  if (obj.value < lowVal || obj.value > highVal) {
-    console.log("Invalid Value!");
-  }
+function getFullName() {
+  return `${this.firstName} ${this.lastName}`;
 }
 ```
 
-You could call `validate` in each form element's `onChange` event handler, using `this` to pass it to the form element, as in the following example:
+We can now attach this function to an object, and it will use the properties of that object when called:
 
-```html
-<p>Enter a number between 18 and 99:</p>
-<input type="text" name="age" size="3" onChange="validate(this, 18, 99);" />
+```js
+const person1 = {
+  firstName: "Chris",
+  lastName: "Martin",
+};
+
+const person2 = {
+  firstName: "Chester",
+  lastName: "Bennington",
+};
+
+// Attach the same function
+person1.getFullName = getFullName;
+person2.getFullName = getFullName;
+
+console.log(person1.getFullName()); // "Chris Martin"
+console.log(person2.getFullName()); // "Chester Bennington"
 ```
 
 ### Grouping operator

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -447,7 +447,8 @@ To better picture this, we can take a closer look at how the realm might be an i
 To illustrate this a bit further we can take a look at how an [`<iframe>`](/en-US/docs/Web/HTML/Reference/Elements/iframe) embedded in a document communicates with its host. Since all web APIs are aware of the incumbent settings object, the following will work in all browsers:
 
 ```html
-<!doctype html> <iframe></iframe>
+<!doctype html>
+<iframe></iframe>
 <!-- we have a realm here -->
 <script>
   // we have a realm here as well
@@ -463,7 +464,8 @@ To illustrate this a bit further we can take a look at how an [`<iframe>`](/en-U
 The same concept applies to promises. If we modify the above example a little bit, we get this:
 
 ```html
-<!doctype html> <iframe></iframe>
+<!doctype html>
+<iframe></iframe>
 <!-- we have a realm here -->
 <script>
   // we have a realm here as well

--- a/files/en-us/web/media/guides/audio_and_video_delivery/cross-browser_audio_basics/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/cross-browser_audio_basics/index.md
@@ -422,8 +422,8 @@ Consider this snippet of HTML:
 
 <div id="controls">
   <span id="loading">loading</span>
-  <button id="play" style="display:none">play</button>
-  <button id="pause" style="display:none">pause</button>
+  <button id="play">play</button>
+  <button id="pause">pause</button>
 </div>
 <div id="progress">
   <div id="bar"></div>
@@ -448,53 +448,56 @@ Styled like so:
   background-color: green;
   width: 0;
 }
+
+#play,
+#pause {
+  display: none; /* hide until media is ready */
+}
 ```
 
 Now let's wire this thing up with JavaScript:
 
 ```js
-window.onload = () => {
-  const audio = document.getElementById("my-audio");
-  const play = document.getElementById("play");
-  const pause = document.getElementById("pause");
-  const loading = document.getElementById("loading");
-  const bar = document.getElementById("bar");
+const audio = document.getElementById("my-audio");
+const play = document.getElementById("play");
+const pause = document.getElementById("pause");
+const loading = document.getElementById("loading");
+const bar = document.getElementById("bar");
 
-  function displayControls() {
-    loading.style.display = "none";
-    play.style.display = "block";
-  }
+function displayControls() {
+  loading.style.display = "none";
+  play.style.display = "block";
+}
 
-  // Check that the media is ready before displaying the controls
-  if (audio.paused) {
+// Check that the media is ready before displaying the controls
+if (audio.paused) {
+  displayControls();
+} else {
+  // not ready yet - wait for canplay event
+  audio.addEventListener("canplay", () => {
     displayControls();
-  } else {
-    // not ready yet - wait for canplay event
-    audio.addEventListener("canplay", () => {
-      displayControls();
-    });
-  }
-
-  play.addEventListener("click", () => {
-    audio.play();
-    play.style.display = "none";
-    pause.style.display = "block";
   });
+}
 
-  pause.addEventListener("click", () => {
-    audio.pause();
-    pause.style.display = "none";
-    play.style.display = "block";
-  });
+play.addEventListener("click", () => {
+  audio.play();
+  play.style.display = "none";
+  pause.style.display = "block";
+});
 
-  // Display progress
-  audio.addEventListener("timeupdate", () => {
-    // Sets the percentage
-    bar.style.width = `${Math.floor(
-      (audio.currentTime / audio.duration) * 100,
-    )}%`;
-  });
-};
+pause.addEventListener("click", () => {
+  audio.pause();
+  pause.style.display = "none";
+  play.style.display = "block";
+});
+
+// Display progress
+audio.addEventListener("timeupdate", () => {
+  // Sets the percentage
+  bar.style.width = `${Math.floor(
+    (audio.currentTime / audio.duration) * 100,
+  )}%`;
+});
 ```
 
 You should end up with something like this:

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
@@ -308,25 +308,21 @@ Now that our service worker script is complete, we need to register the service 
 
 We start by checking that the browser supports the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) by using [feature detection](/en-US/docs/Learn_web_development/Extensions/Testing/Feature_detection#the_concept_of_feature_detection) for the presence of the [`serviceWorker`](/en-US/docs/Web/API/ServiceWorker) property on the global [`navigator`](/en-US/docs/Web/API/Navigator) object:
 
-```html
-<script>
-  // Does "serviceWorker" exist
-  if ("serviceWorker" in navigator) {
-    // If yes, we register the service worker
-  }
-</script>
+```js
+// Does "serviceWorker" exist
+if ("serviceWorker" in navigator) {
+  // If yes, we register the service worker
+}
 ```
 
 If the property is supported, we can then use the [`register()`](/en-US/docs/Web/API/ServiceWorkerContainer/register) method of the service worker API's [`ServiceWorkerContainer`](/en-US/docs/Web/API/ServiceWorkerContainer) interface.
 
-```html
-<script>
-  if ("serviceWorker" in navigator) {
-    // Register the app's service worker
-    // Passing the filename where that worker is defined.
-    navigator.serviceWorker.register("sw.js");
-  }
-</script>
+```js
+if ("serviceWorker" in navigator) {
+  // Register the app's service worker
+  // Passing the filename where that worker is defined.
+  navigator.serviceWorker.register("sw.js");
+}
 ```
 
 While the above suffices for the CycleTracker app needs, the `register()` method does return a {{jsxref("Promise")}} that resolves with a {{domxref("ServiceWorkerRegistration")}} object. For a more robust application, error check the registration:

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
@@ -18,7 +18,7 @@ Below you'll create a demonstration that runs in a browser.
 
 Make a new SVG document as a plain text file, `doc8.svg`. Copy and paste the content from here, making sure that you scroll to get all of it:
 
-```html
+```html live-sample___example
 <svg
   width="600px"
   height="600px"
@@ -253,7 +253,7 @@ Make a new SVG document as a plain text file, `doc8.svg`. Copy and paste the con
 
 Make a new CSS file, `style8.css` in the same directory as `doc8.svg`. Copy and paste the content from here, making sure that you scroll to get all of it:
 
-```css
+```css live-sample___example
 /*** SVG demonstration ***/
 
 /* page */
@@ -388,7 +388,7 @@ Open the `doc8.svg` document in your SVG-enabled browser. Move your mouse pointe
 
 ### Result
 
-{{EmbedLiveSample("Example", "660", "660")}}
+{{EmbedLiveSample("example", "660", "660")}}
 
 Notes about this demonstration:
 


### PR DESCRIPTION
I'm avoiding all `style` and `on*` attributes and `<script>` and `<style>` tags. There are a lot of benefits of this:

1. Better static analysis (most linters can't work on embedded CSS/JS _by default_; my checker can, but Prettier cannot)
2. Promote good practice of decoupling HTML from CSS/JS
3. Avoid CSP problems
4. Easier for the reader to separate different parts of the application