### PR TITLE
fix WebGPU timestampWrites

### DIFF
--- a/files/en-us/web/api/gpucommandencoder/begincomputepass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/begincomputepass/index.md
@@ -31,15 +31,13 @@ beginComputePass(descriptor)
     - `timestampWrites` {{optional_inline}}
 
       - : An array of objects defining where and when timestamp query values will be written for this pass. These objects have the following properties:
-
-        - `location`: An enumerated value specifying when the timestamp will be executed. Available values are:
-          - `"beginning"`: The timestamp is executed along with the other encoded commands in the compute pass once the corresponding {{domxref("GPUCommandBuffer")}} is submitted.
-          - `"end"`: The timestamp is executed as part of a separate list of timestamp attachments once the pass ends.
-        - `queryIndex`: A number specifying the index position in the `querySet` that the timestamp will be written to.
-        - `querySet`: The {{domxref("GPUQuerySet")}} that the timestamp will be written to.
+      - 
+        - `querySet`: A {{domxref("GPUQuerySet")}} of type `"timestamp"` that the timestamp query results will be written to.
+        - `beginningOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the beginning of the render pass will be written. This is optional - if not defined, no timestamp will be written for the beginning of the pass.
+        - `endOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the end of the render pass will be written. This is optional - if not defined, no timestamp will be written for the end of the pass.
 
         > [!NOTE]
-        > The `timestamp-query` [feature](/en-US/docs/Web/API/GPUSupportedFeatures) needs to be enabled to use timestamp queries.
+        > The `timestamp-query` [feature](/en-US/docs/Web/API/GPUSupportedFeatures) needs to be enabled to use timestamp queries. Timestamp query values are written in nanoseconds, but how the value is determined is implementation-defined.
 
 ### Return value
 
@@ -50,8 +48,6 @@ A {{domxref("GPUComputePassEncoder")}} object instance.
 The following criteria must be met when calling **`beginComputePass()`**, otherwise a {{domxref("GPUValidationError")}} is generated and an invalid {{domxref("GPUComputePassEncoder")}} is returned:
 
 - The `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} is enabled in the {{domxref("GPUDevice")}}.
-- No two `timestampWrites` objects have the same `location`. In effect, this means that you can only run two timestamp queries per render pass.
-- For each timestamp query, the `querySet` {{domxref("GPUQuerySet.type")}} is `"timestamp"`, and the `queryIndex` value is less than the {{domxref("GPUQuerySet.count")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/gpucommandencoder/begincomputepass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/begincomputepass/index.md
@@ -31,10 +31,13 @@ beginComputePass(descriptor)
     - `timestampWrites` {{optional_inline}}
 
       - : An array of objects defining where and when timestamp query values will be written for this pass. These objects have the following properties:
-      - 
-        - `querySet`: A {{domxref("GPUQuerySet")}} of type `"timestamp"` that the timestamp query results will be written to.
-        - `beginningOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the beginning of the render pass will be written. This is optional - if not defined, no timestamp will be written for the beginning of the pass.
-        - `endOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the end of the render pass will be written. This is optional - if not defined, no timestamp will be written for the end of the pass.
+
+        - `querySet`
+          - : A {{domxref("GPUQuerySet")}} of type `"timestamp"` that the timestamp query results will be written to.
+        - `beginningOfPassWriteIndex`
+          - : A number specifying the query index in `querySet` where the timestamp at the beginning of the render pass will be written. This is optional - if not defined, no timestamp will be written for the beginning of the pass.
+        - `endOfPassWriteIndex`
+          - : A number specifying the query index in `querySet` where the timestamp at the end of the render pass will be written. This is optional - if not defined, no timestamp will be written for the end of the pass.
 
         > [!NOTE]
         > The `timestamp-query` [feature](/en-US/docs/Web/API/GPUSupportedFeatures) needs to be enabled to use timestamp queries. Timestamp query values are written in nanoseconds, but how the value is determined is implementation-defined.

--- a/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
@@ -39,9 +39,12 @@ beginRenderPass(descriptor)
 
       - : An array of objects defining where and when timestamp query values will be written for this pass. These objects have the following properties:
 
-        - `querySet`: A {{domxref("GPUQuerySet")}} of type `"timestamp"` that the timestamp query results will be written to.
-        - `beginningOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the beginning of the render pass will be written. This is optional - if not defined, no timestamp will be written for the beginning of the pass.
-        - `endOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the end of the render pass will be written. This is optional - if not defined, no timestamp will be written for the end of the pass.
+        - `querySet`
+          - : A {{domxref("GPUQuerySet")}} of type `"timestamp"` that the timestamp query results will be written to.
+        - `beginningOfPassWriteIndex`
+          - : A number specifying the query index in `querySet` where the timestamp at the beginning of the render pass will be written. This is optional - if not defined, no timestamp will be written for the beginning of the pass.
+        - `endOfPassWriteIndex`
+          - : A number specifying the query index in `querySet` where the timestamp at the end of the render pass will be written. This is optional - if not defined, no timestamp will be written for the end of the pass.
 
         > [!NOTE]
         > The `timestamp-query` [feature](/en-US/docs/Web/API/GPUSupportedFeatures) needs to be enabled to use timestamp queries. Timestamp query values are written in nanoseconds, but how the value is determined is implementation-defined.

--- a/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
@@ -39,14 +39,12 @@ beginRenderPass(descriptor)
 
       - : An array of objects defining where and when timestamp query values will be written for this pass. These objects have the following properties:
 
-        - `location`: An enumerated value specifying when the timestamp will be executed. Available values are:
-          - `"beginning"`: The timestamp is executed along with the other encoded commands in the compute pass once the corresponding {{domxref("GPUCommandBuffer")}} is submitted.
-          - `"end"`: The timestamp is executed as part of a separate list of timestamp attachments once the pass ends.
-        - `queryIndex`: A number specifying the index position in the `querySet` that the timestamp will be written to.
-        - `querySet`: The {{domxref("GPUQuerySet")}} that the timestamp will be written to.
+        - `querySet`: A {{domxref("GPUQuerySet")}} of type `"timestamp"` that the timestamp query results will be written to.
+        - `beginningOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the beginning of the render pass will be written. This is optional - if not defined, no timestamp will be written for the beginning of the pass.
+        - `endOfPassWriteIndex`: A number specifying the query index in `querySet` where the timestamp at the end of the render pass will be written. This is optional - if not defined, no timestamp will be written for the end of the pass.
 
         > [!NOTE]
-        > The `timestamp-query` [feature](/en-US/docs/Web/API/GPUSupportedFeatures) needs to be enabled to use timestamp queries.
+        > The `timestamp-query` [feature](/en-US/docs/Web/API/GPUSupportedFeatures) needs to be enabled to use timestamp queries. Timestamp query values are written in nanoseconds, but how the value is determined is implementation-defined.
 
 ### Color attachment object structure
 
@@ -177,9 +175,6 @@ For depth/stencil attachment objects:
 For timestamp queries:
 
 - The `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} is enabled in the {{domxref("GPUDevice")}}.
-- No two `timestampWrites` objects have the same `location`. In effect, this means that you can only run two timestamp queries per render pass.
-- For each timestamp query, the `querySet` {{domxref("GPUQuerySet.type")}} is `"timestamp"`, and the `queryIndex` value is less than the {{domxref("GPUQuerySet.count")}}.
-- No two `timestampWrites` objects have the same `queryIndex` and `querySet` pair.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Update WebGPU commandencoder timestampWrites

### Motivation

[gpuweb/pull/3930](https://github.com/gpuweb/gpuweb/pull/3930)

### Additional details

[w3.org/TR/webgpu/#render-pass-encoder-creation](https://www.w3.org/TR/webgpu/#render-pass-encoder-creation)
[w3.org/TR/webgpu/#compute-pass-encoder-creation](https://www.w3.org/TR/webgpu/#compute-pass-encoder-creation)

### Related issues and pull requests

it's outdated and wrong
