### PR TITLE
chore(learn): De-duplicate intro paras for Node and Django apps

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
@@ -8,7 +8,8 @@ sidebar: learnsidebar
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django/web_application_security", "Learn_web_development/Extensions/Server-side/Django")}}
 
-Now you've created (and tested) an awesome [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) website, you're going to want to install it on a public web server so that it can be accessed by library staff and members over the internet. This article provides an overview of how you might go about finding a host to deploy your website, and what you need to do in order to get your site ready for production.
+You've already created and tested example website using Django, so now, it's time to install it on a web server so it can be accessed by anyone over the public internet.
+This page describes how to host a Django project and what you need to prepare your site for a production deployment.
 
 <table>
   <tbody>

--- a/files/en-us/learn_web_development/extensions/server-side/django/tutorial_local_library_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/tutorial_local_library_website/index.md
@@ -8,7 +8,8 @@ sidebar: learnsidebar
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/development_environment", "Learn_web_development/Extensions/Server-side/Django/skeleton_website", "Learn_web_development/Extensions/Server-side/Django")}}
 
-The first article in our practical tutorial series explains what you'll learn, and provides an overview of the "local library" example website we'll be working through and evolving in subsequent articles.
+This article is an overview of the MDN Django tutorial and introduces the "local library" example website we'll be using throughout the next few pages.
+You'll find out what the tutorial covers, how to get started, how to ask for help, and everything else you need to build and deploy your first server-side Python app.
 
 <table>
   <tbody>

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
@@ -8,7 +8,8 @@ sidebar: learnsidebar
 
 {{PreviousMenu("Learn_web_development/Extensions/Server-side/Express_Nodejs/forms", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}
 
-Now you've created (and tested) an awesome [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) website, you're going to want to install it on a public web server so that it can be accessed by library staff and members over the Internet. This article provides an overview of how you might go about finding a host to deploy your website, and what you need to do in order to get your site ready for production.
+Now that you've created and tested a sample website using Express, it's time to deploy it to a web server so people can access it over the public internet.
+This page explains how to host an Express project and outlines what you need to get it ready for production.
 
 <table>
   <tbody>

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/tutorial_local_library_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/tutorial_local_library_website/index.md
@@ -8,7 +8,8 @@ sidebar: learnsidebar
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment", "Learn_web_development/Extensions/Server-side/Express_Nodejs/skeleton_website", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}
 
-The first article in our practical tutorial series explains what you'll learn, and provides an overview of the "local library" example website we'll be working through and evolving in subsequent articles.
+This article is an overview of the MDN Express tutorial and introduces the "local library" example website we'll be using throughout the next few pages.
+You'll find out what the tutorial covers, how to get started, how to ask for help, and everything else you need to build and deploy your first server-side JavaScript app.
 
 <table>
   <tbody>


### PR DESCRIPTION
### Description

These two tutorials have duplicate intros.
This PR keeps some similar wording, but disambiguating using "server-side JavaScript" v "server-side Python" and "Express" v "Django"

### Motivation

Differentiating between server-side JS and Python tutorials.
