### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/mdn/writing_guidelines/index.md
+++ b/files/en-us/mdn/writing_guidelines/index.md
@@ -13,7 +13,7 @@ MDN Web Docs is an open-source project. The sections outlined below describe our
 
     - [Inclusion criteria](/en-US/docs/MDN/Writing_guidelines/Criteria_for_inclusion)
 
-      - : Provides an in-depth criteria for content to be included on MDN Web Docs, the application process for getting new documentation added on MDN Web Docs, and the expectations and guidelines for a party applying.
+      - : This article describes, in detail, criteria for content to be included on MDN Web Docs, the application process for including new documentation, and expectations and guidelines for a party applying.
 
 - [Our writing style guide](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide)
 

--- a/files/en-us/mdn/writing_guidelines/index.md
+++ b/files/en-us/mdn/writing_guidelines/index.md
@@ -9,11 +9,11 @@ MDN Web Docs is an open-source project. The sections outlined below describe our
 
 - [What we write](/en-US/docs/MDN/Writing_guidelines/What_we_write)
 
-  - : This section covers what we include on MDN Web Docs and what we don't, as well as a number of other policies, such as when we write about new technologies, the content suggestion process, and whether we accept external links. This is a good place to start if you're considering writing or updating content for us. This section also includes:
+  - : This section covers what we include on MDN Web Docs and what we don't, as well as a number of other policies, such as when we write about new technologies, the content suggestion process, and whether we accept external links. This is a good place to start if you're considering writing or updating content for us.
 
-    - [Inclusion criteria](/en-US/docs/MDN/Writing_guidelines/Criteria_for_inclusion)
+- [Inclusion criteria](/en-US/docs/MDN/Writing_guidelines/Criteria_for_inclusion)
 
-      - : This article describes, in detail, criteria for content to be included on MDN Web Docs, the application process for including new documentation, and expectations and guidelines for a party applying.
+  - : This article describes, in detail, criteria for content to be included on MDN Web Docs, the application process for including new documentation, and expectations and guidelines for a party applying.
 
 - [Our writing style guide](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide)
 
@@ -21,7 +21,7 @@ MDN Web Docs is an open-source project. The sections outlined below describe our
 
 - [Learn web development writing guidelines](/en-US/docs/MDN/Writing_guidelines/Learning_content)
 
-  - : The [Learn web development](/en-US/docs/Learn_web_development) section of MDN is aimed specifically at folks learning the basic fundamentals of web development, and as such, requires a different approach to the rest of MDN's content. This articles provides guidelines for writing learning content.
+  - : The Learn web development section of MDN is aimed specifically at folks learning the basic fundamentals of web development, and as such, requires a different approach to the rest of MDN's content. This article provides guidelines for writing learning content.
 
 - [How to write for MDN Web Docs](/en-US/docs/MDN/Writing_guidelines/Howto)
 

--- a/files/en-us/mdn/writing_guidelines/index.md
+++ b/files/en-us/mdn/writing_guidelines/index.md
@@ -21,7 +21,7 @@ MDN Web Docs is an open-source project. The sections outlined below describe our
 
 - [Learn web development writing guidelines](/en-US/docs/MDN/Writing_guidelines/Learning_content)
 
-  - : The Learn web development section of MDN is aimed specifically at folks learning the basic fundamentals of web development, and as such, requires a different approach to the rest of MDN's content. This article provides guidelines for writing learning content.
+  - : The "Learn web development" section of MDN is aimed specifically at folks learning the basic fundamentals of web development, and as such, requires a different approach to the rest of MDN's content. This article provides guidelines for writing learning content.
 
 - [How to write for MDN Web Docs](/en-US/docs/MDN/Writing_guidelines/Howto)
 


### PR DESCRIPTION
### Description

The description for "Inclusion criteria" has a singular article with a plural noun: "an in-depth criteria." We could drop the article, but the sentence is still incomplete, as the subject is implied ("Provides…") rather than stated, as in the other examples (e.g., "This section covers," etc.). It seemed best to copy the introduction from "Inclusion criteria," which fixes both issues and keeps it consistent.

### Motivation

Criterion is a Greek loan word that retains its plural form (criteria). It's a common mistake to use the plural as a singular, and it's worth fixing so that folks who would spot the error don't begin to wonder about attention to detail elsewhere.

### Additional details

N/A, but I do have a degree in Greek and Latin Languages, so I'm your huckleberry.

### Related issues and pull requests

N/A
