### PR TITLE
Add and update Japanese translations for learn sidebar

### DIFF
--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -451,12 +451,36 @@ l10n:
     Django_web_framework_(Python): Django (Python)
     Further_resources: Ressources complémentaires
   ja:
+    Getting_started_modules: 入門モジュール
+    Environment_setup: 環境設定
+    Your_first_website: 初めてのウェブサイト
+    Web_standards: ウェブ標準
+    Soft_skills: ソフトスキル
+    Core_modules: コア学習モジュール
+    Structuring_content_with_HTML: HTML によるコンテンツの構造化
+    CSS_styling_basics: CSS によるスタイル設定の基本
+    CSS_text_styling: CSS テキスト装飾
     CSS_layout: CSS レイアウト
-    Asynchronous_JavaScript: 非同期 JavaScript
+    Dynamic_scripting_with_JavaScript: JavaScript による動的スクリプティング
+    JavaScript_frameworks_and_libraries: JavaScript フレームワークとライブラリー
+    Accessibility: アクセシビリティ
+    Design_for_developers: 開発者のためのデザイン
+    Version_control: バージョン管理
+    Extension_modules: 発展モジュール
+    Advanced JavaScript objects: 高度な JavaScript オブジェクト
     Client-side_web_APIs: クライアントサイド Web API
-    Web_forms: ウェブフォーム — ユーザーデータの操作
-    Django_web_framework_(Python): Django ウェブフレームワーク (Python)
+    Asynchronous_JavaScript: 非同期 JavaScript
+    Web_forms: ウェブフォーム
+    Understanding_client-side_tools: クライアントサイドウェブ開発ツール
+    Django_web_framework_(Python): Django (Python)
+    Express_web_framework_(Node.js): Express (Node.js)
+    Web_performance: ウェブのパフォーマンス
+    Testing: テスト
     Further_resources: その他のリソース
+    How_to_solve_common_problems: よくある質問
+    About: 概要
+    Resources_for_educators: 教育者向けリソース
+    Changelog: 変更履歴
   ko:
     CSS_layout: CSS 레이아웃
     Asynchronous_JavaScript: JavaScript의 비동기성


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- 📝 For large changes, check our contribution guide:
     https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests -->

<!-- 🚨 Low-quality, spammy, or disruptive pull requests are moderated heavily.
     Severe or repeated violations can result in being banned from contributing.
     Make sure you've read and agree to the following:
     - Community Participation Guidelines: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines
     - MDN Content Enforcement Policy: https://developer.mozilla.org/en-US/docs/MDN/Community/Community_Participation_Guidelines -->

<!-- Please complete all sections, especially the Motivation field. If there’s no related issue, explaining why this change is needed helps reviewers understand the context and prioritize your request. Without it, your PR may be delayed or closed. -->

<!-- 👷‍♀️ After submitting, go to the 'Checks' tab of your PR for the build status -->
---

### Description

Add and update Japanese translations for learn sidebar.

### Motivation

I want to show the sidebar in Japanese for Japanese translated contents.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
