### PR TITLE
Add and update Japanese translations for the CSS sidebar

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -407,6 +407,9 @@ l10n:
     Transitions: Transitions
     Tools: Outils
   ja:
+    Accessibility_Understanding_colors_and_luminance: "アクセシビリティ: 色と輝度"
+    Applying_color_to_HTML_elements: HTML への色の適用
+    At-rules: アットルール
     Beginners: 初心者向けチュートリアル
     Styling_the_content: "初めてのウェブサイト: コンテンツのスタイル設定"
     CSS_styling_basics: CSS スタイル設定の基本
@@ -416,30 +419,41 @@ l10n:
     Animations: アニメーション
     Backgrounds_and_Borders: 背景と境界
     Resizing_background_images: 背景画像の拡大縮小
+    Box alignment: ボックス配置
     Box_alignment_in_block_layout: ブロックレイアウトでのボックス配置
     Box_model: ボックスモデル
     Colors: 色
     Color_contrast: "アクセシビリティ: 色のコントラスト"
     Columns: 段組み
+    Combinators: 結合子
     Conditional_rules: 条件付きルール
-    Containment: 拘束
-    Display: フローレイアウト
+    Containment: コンテナー
     CSSOM_view: CSSOM view
+    Display: 表示
     Flexbox: フレックスボックス
     Fonts: フォント
+    Functions: 関数
     Grid: グリッド
     Images: 画像
     Lists_and_counters: リストとカウンター
     Logical_properties: 論理的プロパティ
     Media_queries: メディアクエリー
+    Modules: モジュール
     Nesting: 入れ子のスタイルルール
+    Overview: 概要
     Positioning: 位置指定
+    Properties: プロパティ
+    Pseudo-classes: 擬似クラス
+    Pseudo-elements: 擬似要素
     Scroll_snap: スクロールスナップ
+    Selectors: セレクター
     Shapes: シェイプ
     Text: テキスト
     Transforms: 座標変換
     Transitions: トランジション
     Tools: ツール
+    Types: データ型
+    Values and units: 値と単位
   ko:
     CSS_layout: CSS 레이아웃
     Guides: 안내서

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -429,7 +429,7 @@ l10n:
     Conditional_rules: 条件付きルール
     Containment: コンテナー
     CSSOM_view: CSSOM view
-    Display: 表示
+    Display: 表示方法
     Flexbox: フレックスボックス
     Fonts: フォント
     Functions: 関数


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- 📝 For large changes, check our contribution guide:
     https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests -->

<!-- 🚨 Low-quality, spammy, or disruptive pull requests are moderated heavily.
     Severe or repeated violations can result in being banned from contributing.
     Make sure you've read and agree to the following:
     - Community Participation Guidelines: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines
     - MDN Content Enforcement Policy: https://developer.mozilla.org/en-US/docs/MDN/Community/Community_Participation_Guidelines -->

<!-- Please complete all sections, especially the Motivation field. If there’s no related issue, explaining why this change is needed helps reviewers understand the context and prioritize your request. Without it, your PR may be delayed or closed. -->

<!-- 👷‍♀️ After submitting, go to the 'Checks' tab of your PR for the build status -->
---

### Description

Add and update Japanese translations for the CSS sidebar

### Motivation

I want to show the sidebar in Japanese.

### Additional details

The translate word for "Containment" has been changed because the container query has been included and the old translate word isn't fit for the module's functionary.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
