### PR TITLE
Fix security sidebar: remove "types of attacks" entry

### DIFF
--- a/files/sidebars/security.yaml
+++ b/files/sidebars/security.yaml
@@ -5,7 +5,6 @@ sidebar:
     link: /Web/Security
   - type: section
     title: Guides
-  - /Web/Security/Types_of_attacks
   - /Web/Security/Insecure_passwords
   - /Web/Security/Transport_Layer_Security
   - /Web/Security/Mixed_content


### PR DESCRIPTION
https://github.com/mdn/content/pull/39736 deleted "Types of attacks", this PR deletes the corresponding sidebar entry.