### PR TITLE
Add <noscript> scripting enabled behaviour note

### DIFF
--- a/files/en-us/web/html/reference/elements/noscript/index.md
+++ b/files/en-us/web/html/reference/elements/noscript/index.md
@@ -37,8 +37,8 @@ Rocks!
 
 The `<noscript>` element represents its children differently depending on if scripting is enabled:
 
- - If scripting is disabled the `<noscript>` element represents its children as [HTML content](/en-US/docs/Web/API/HTMLElement).
- - If scripting is enabled, the `<noscript>` element represents its children as [text](/en-US/docs/Web/API/Text).
+- If scripting is disabled the `<noscript>` element represents its children as [HTML content](/en-US/docs/Web/API/HTMLElement).
+- If scripting is enabled, the `<noscript>` element represents its children as [text](/en-US/docs/Web/API/Text).
 
 ## Technical summary
 

--- a/files/en-us/web/html/reference/elements/noscript/index.md
+++ b/files/en-us/web/html/reference/elements/noscript/index.md
@@ -27,6 +27,9 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 
 Rocks!
 
+> [!NOTE]
+> The `<noscript>` element contains a text representation of its children. Accessing [`.children`](/en-US/docs/Web/API/Element/children) will return an empty list.
+
 ### Result with scripting disabled
 
 [External Link](https://www.mozilla.org/)

--- a/files/en-us/web/html/reference/elements/noscript/index.md
+++ b/files/en-us/web/html/reference/elements/noscript/index.md
@@ -27,14 +27,18 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 
 Rocks!
 
-> [!NOTE]
-> The `<noscript>` element contains a text representation of its children. Accessing [`.children`](/en-US/docs/Web/API/Element/children) will return an empty list.
-
 ### Result with scripting disabled
 
 [External Link](https://www.mozilla.org/)
 
 Rocks!
+
+## Usage notes
+
+The `<noscript>` element represents its children differently depending on if scripting is enabled:
+
+ - If scripting is disabled the `<noscript>` element represents its children as [HTML content](/en-US/docs/Web/API/HTMLElement).
+ - If scripting is enabled, the `<noscript>` element represents its children as [text](/en-US/docs/Web/API/Text).
 
 ## Technical summary
 


### PR DESCRIPTION
### Description

The [behaviour]((https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element:the-head-element-7)) of the `<noscript>` element when scripting is enabled is undocumented.

`<noscript>` behaves differently to other elements when scripting is enabled, where it returns a [`Text node`](https://developer.mozilla.org/en-US/docs/Web/API/Text) instead of [`Element nodes`](https://developer.mozilla.org/en-US/docs/Web/API/Element).

### Motivation

```TS
const noscript = document.querySelector('noscript');
noscript.replaceWith(...noscript.children);
```

I was expecting the noscript element to be replaced with it's children but instead found the noscript element removed. Looking at the [docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/noscript) I could not find any mention of this behaviour and had to look for it in the [HTML Standard](https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element:the-head-element-7).

For that reason I think it's worth adding a note that describes this behaviour.

### Additional details

 - [\<noscript\>: The Noscript element (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/noscript)
 - [4.12.2 The noscript element (HTML Standard)](https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element)