### PR TITLE
Add note about `beforeinstallprompt` event not fired if PWA already installed

### DIFF
--- a/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
@@ -52,7 +52,7 @@ The event handler here does three things:
 
 Note that the event will not fire if:
 
-- The PWA is already installed (valid only for desktop and WebAPK on Android).
+- The PWA is already installed.
 - The app does not pass the [PWA installation criteria](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability).
 - The PWA is not installable on the current device (for example, because of a lack of permissions).
 

--- a/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
@@ -52,7 +52,7 @@ The event handler here does three things:
 
 Note that the event will not fire if:
 
-- The PWA is aleardy installed (valid only for desktop and WebAPK on Android).
+- The PWA is already installed (valid only for desktop and WebAPK on Android).
 - The app does not pass the PWA installation criteria.
 - The PWA is not installable on the current device (for example, because of a lack of permissions).
 

--- a/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
@@ -50,6 +50,12 @@ The event handler here does three things:
 - Take a reference to the event object that's passed into the handler. This is an instance of {{domxref("BeforeInstallPromptEvent")}}, and is what will enable us to prompt the user to install the app.
 - Reveal our in-app install UI by removing the `hidden` attribute on the button.
 
+Note that the event will not fire if:
+
+- The PWA is aleardy installed (valid only for desktop and WebAPK on Android).
+- The app does not pass the PWA installation criteria.
+- The PWA is not installable on the current device (for example, because of a lack of permissions).
+
 ## Triggering the install prompt
 
 Next, we need to add a click handler to our in-app install button:
@@ -99,7 +105,7 @@ function disableInAppInstallPrompt() {
 
 ## Responding to platform-specific apps being installed
 
-One case not covered by the above examples is where you have a platform-specific version of the app as well as a web app, and you want to personalize the web app experience depending on whether the platform-specific app is already installed. You might not want to invite users to install the PWA if they already have the platform-specific app installed, and/or you might want to invite them to head over to the platform-specific app to view content.
+If you have a platform-specific version of the app as well as a web app, and you want to personalize the web app experience depending on whether the platform-specific app is already installed. You might not want to invite users to install the PWA if they already have the platform-specific app installed, and/or you might want to invite them to head over to the platform-specific app to view content.
 
 This can be handled with the {{domxref("Navigator.getInstalledRelatedApps()")}} method, which allows you to detect installed related platform-specific apps (or PWAs) and respond appropriately.
 
@@ -137,3 +143,4 @@ window.addEventListener("beforeinstallprompt", async (event) => {
 - [Making PWAs installable](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable)
 - {{domxref("Window.beforeinstallprompt_event", "beforeinstallprompt")}} event
 - [How to provide your own in-app install experience](https://web.dev/articles/customize-install) on web.dev (2021)
+- [Installation prompt](https://web.dev/learn/pwa/installation-prompt) on web.dev (2022)

--- a/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
@@ -53,7 +53,7 @@ The event handler here does three things:
 Note that the event will not fire if:
 
 - The PWA is already installed (valid only for desktop and WebAPK on Android).
-- The app does not pass the PWA installation criteria.
+- The app does not pass the [PWA installation criteria](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability).
 - The PWA is not installable on the current device (for example, because of a lack of permissions).
 
 ## Triggering the install prompt


### PR DESCRIPTION




<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- 📝 For large changes, check our contribution guide:
     https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests -->

<!-- 🚨 Low-quality, spammy, or disruptive pull requests are moderated heavily.
     Severe or repeated violations can result in being banned from contributing.
     Make sure you've read and agree to the following:
     - Community Participation Guidelines: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines
     - MDN Content Enforcement Policy: https://developer.mozilla.org/en-US/docs/MDN/Community/Community_Participation_Guidelines -->

<!-- Please complete all sections, especially the Motivation field. If there’s no related issue, explaining why this change is needed helps reviewers understand the context and prioritize your request. Without it, your PR may be delayed or closed. -->

<!-- 👷‍♀️ After submitting, go to the 'Checks' tab of your PR for the build status -->
---

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Add note about `beforeinstallprompt` event not fired if the PWA is already installed, so users don't think using `getInstalledRelatedApps` is required.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I wasted time digging into `getInstalledRelatedApps` and was disappointed that it wasn't supported by Chrome on desktop, only to realise thanks to https://web.dev/learn/pwa/installation-prompt that we actually don't need it :-)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://web.dev/learn/pwa/installation-prompt

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
