### PR TITLE
Fix Safari support for Add to Dock on macOS

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -112,7 +112,7 @@ On desktop:
 
 - Chromium browsers support installing PWAs that have a manifest file on all supported desktop operating systems.
 - Safari supports Add to Dock on macOS Sonoma and later for any web app with or without a manifest file.
-- Firefox do not support installing PWAs using a manifest file.
+- Firefox does not support installing PWAs using a manifest file.
 
 On mobile:
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -111,7 +111,8 @@ Support for PWA installation promotion from the web varies by browser and by pla
 On desktop:
 
 - Chromium browsers support installing PWAs that have a manifest file on all supported desktop operating systems.
-- Firefox and Safari do not support installing PWAs using a manifest file.
+- Safari supports Add to Dock on macOS Sonoma and later for any web app with or without a manifest file.
+- Firefox do not support installing PWAs using a manifest file.
 
 On mobile:
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -111,7 +111,7 @@ Support for PWA installation promotion from the web varies by browser and by pla
 On desktop:
 
 - Chromium browsers support installing PWAs that have a manifest file on all supported desktop operating systems.
-- Safari supports Add to Dock on macOS Sonoma and later for any web app with or without a manifest file.
+- Safari supports Add to Dock (_File_ > _Add to Dock..._) on macOS Sonoma (Safari 17) and later for any web app with or without a manifest file.
 - Firefox does not support installing PWAs using a manifest file.
 
 On mobile:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- 📝 For large changes, check our contribution guide:
     https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests -->

<!-- 🚨 Low-quality, spammy, or disruptive pull requests are moderated heavily.
     Severe or repeated violations can result in being banned from contributing.
     Make sure you've read and agree to the following:
     - Community Participation Guidelines: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines
     - MDN Content Enforcement Policy: https://developer.mozilla.org/en-US/docs/MDN/Community/Community_Participation_Guidelines -->

<!-- Please complete all sections, especially the Motivation field. If there’s no related issue, explaining why this change is needed helps reviewers understand the context and prioritize your request. Without it, your PR may be delayed or closed. -->

<!-- 👷‍♀️ After submitting, go to the 'Checks' tab of your PR for the build status -->
---

### Description

Safari has supported Add to Dock since macOS Sonoma with or without a manifest file.

### Motivation

Updating inaccurate information due to browser release updates.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- https://support.apple.com/en-us/104996
- https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#Web-apps


