### PR TITLE
Correct documentation around non-shared views to `Atomics.notify()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -32,12 +32,12 @@ Atomics.notify(typedArray, index, count)
 ### Return value
 
 - Returns the number of woken up agents.
-- Returns `0`, if a non-shared {{jsxref("ArrayBuffer")}} object is used.
+- Returns `0`, if `typedArray` is a view on a non-shared {{jsxref("ArrayBuffer")}}.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if `typedArray` is not an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}} that views a {{jsxref("SharedArrayBuffer")}}.
+  - : Thrown if `typedArray` is not an {{jsxref("Int32Array")}} or {{jsxref("BigInt64Array")}}.
 - {{jsxref("RangeError")}}
   - : Thrown if `index` is out of bounds in the `typedArray`.
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/notify/index.md
@@ -31,8 +31,7 @@ Atomics.notify(typedArray, index, count)
 
 ### Return value
 
-- Returns the number of woken up agents.
-- Returns `0`, if `typedArray` is a view on a non-shared {{jsxref("ArrayBuffer")}}.
+Returns the number of woken up agents, or `0` if `typedArray` is a view on a non-shared {{jsxref("ArrayBuffer")}}.
 
 ### Exceptions
 


### PR DESCRIPTION
### Description

Unlike the wait methods, `Atomics.notify()` does not throw when passed a view on a non-shared array buffer. The MDN documentation mostly alludes to this behaviour correctly, but incorrectly states that it will throw a `TypeError` if passed such an argument.

### Additional details

https://tc39.es/ecma262/#sec-atomics.notify
