### PR TITLE
Make SVG element pages adhere to page template

### DIFF
--- a/files/en-us/web/svg/reference/element/a/index.md
+++ b/files/en-us/web/svg/reference/element/a/index.md
@@ -10,6 +10,44 @@ The **`<a>`** [SVG](/en-US/docs/Web/SVG) element creates a hyperlink to other we
 
 SVG's `<a>` element is a container, which means you can create a link around text (like in HTML) but also around any shape.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download)
+  - : Instructs browsers to download a {{Glossary("URL")}} instead of navigating to it, so the user will be prompted to save it as a local file.
+    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
+- {{SVGAttr("href")}}
+  - : The {{Glossary("URL")}} or URL fragment the hyperlink points to.
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **yes**
+- [`hreflang`](/en-US/docs/Web/HTML/Reference/Elements/a#hreflang)
+  - : The human language of the URL or URL fragment that the hyperlink points to.
+    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
+- [`ping`](/en-US/docs/Web/HTML/Reference/Elements/a#ping) {{experimental_inline}}
+  - : A space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking. For a more widely-supported feature addressing the same use cases, see {{domxref("Navigator.sendBeacon()")}}.
+    _Value type_: **[\<list-of-URLs>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: _none_; _Animatable_: **no**
+- [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy)
+  - : Which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the {{Glossary("URL")}}.
+    _Value type_: `no-referrer` | `no-referrer-when-downgrade` | `same-origin` | `origin` | `strict-origin` | `origin-when-cross-origin` | `strict-origin-when-cross-origin` | `unsafe-url`; _Default value_: _none_; _Animatable_: **no**
+- [`rel`](/en-US/docs/Web/HTML/Reference/Elements/a#rel)
+  - : The relationship of the target object to the link object.
+    _Value type_: **[\<list-of-Link-Types>](/en-US/docs/Web/HTML/Reference/Attributes/rel)**; _Default value_: _none_; _Animatable_: **no**
+- {{SVGAttr("target")}}
+  - : Where to display the linked {{Glossary("URL")}}.
+    _Value type_: `_self` | `_parent` | `_top` | `_blank` | **\<XML-Name>**; _Default value_: `_self`; _Animatable_: **yes**
+- [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type)
+  - : A {{Glossary("MIME type")}} for the linked URL.
+    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
+  - : The URL or URL fragment that the hyperlink points to. May be required for backwards compatibility for older browsers.
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGAElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -64,40 +102,6 @@ svg|a:active {
 
 > [!WARNING]
 > Since this element shares its tag name with [HTML's `<a>` element](/en-US/docs/Web/HTML/Reference/Elements/a), selecting `a` with CSS or {{domxref("Document.querySelector", "querySelector")}} may apply to the wrong kind of element. Try [the `@namespace` rule](/en-US/docs/Web/CSS/@namespace) to distinguish the two.
-
-## Attributes
-
-- [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download)
-  - : Instructs browsers to download a {{Glossary("URL")}} instead of navigating to it, so the user will be prompted to save it as a local file.
-    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
-- {{SVGAttr("href")}}
-  - : The {{Glossary("URL")}} or URL fragment the hyperlink points to.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **yes**
-- [`hreflang`](/en-US/docs/Web/HTML/Reference/Elements/a#hreflang)
-  - : The human language of the URL or URL fragment that the hyperlink points to.
-    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
-- [`ping`](/en-US/docs/Web/HTML/Reference/Elements/a#ping) {{experimental_inline}}
-  - : A space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking. For a more widely-supported feature addressing the same use cases, see {{domxref("Navigator.sendBeacon()")}}.
-    _Value type_: **[\<list-of-URLs>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: _none_; _Animatable_: **no**
-- [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy)
-  - : Which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the {{Glossary("URL")}}.
-    _Value type_: `no-referrer` | `no-referrer-when-downgrade` | `same-origin` | `origin` | `strict-origin` | `origin-when-cross-origin` | `strict-origin-when-cross-origin` | `unsafe-url`; _Default value_: _none_; _Animatable_: **no**
-- [`rel`](/en-US/docs/Web/HTML/Reference/Elements/a#rel)
-  - : The relationship of the target object to the link object.
-    _Value type_: **[\<list-of-Link-Types>](/en-US/docs/Web/HTML/Reference/Attributes/rel)**; _Default value_: _none_; _Animatable_: **no**
-- {{SVGAttr("target")}}
-  - : Where to display the linked {{Glossary("URL")}}.
-    _Value type_: `_self` | `_parent` | `_top` | `_blank` | **\<XML-Name>**; _Default value_: `_self`; _Animatable_: **yes**
-- [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type)
-  - : A {{Glossary("MIME type")}} for the linked URL.
-    _Value type_: **\<string>**; _Default value_: _none_; _Animatable_: **no**
-- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
-  - : The URL or URL fragment that the hyperlink points to. May be required for backwards compatibility for older browsers.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/animate/index.md
+++ b/files/en-us/web/svg/reference/element/animate/index.md
@@ -8,6 +8,10 @@ sidebar: svgref
 
 The **`<animate>`** [SVG](/en-US/docs/Web/SVG) element provides a way to animate an attribute of an element over time.
 
+## DOM Interface
+
+This element implements the {{domxref("SVGAnimateElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -33,10 +37,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Usage notes
-
-This element implements the {{domxref("SVGAnimateElement")}} interface.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/svg/reference/element/animate/index.md
+++ b/files/en-us/web/svg/reference/element/animate/index.md
@@ -8,6 +8,14 @@ sidebar: svgref
 
 The **`<animate>`** [SVG](/en-US/docs/Web/SVG) element provides a way to animate an attribute of an element over time.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+This element only includes global attributes.
+
 ## DOM Interface
 
 This element implements the {{domxref("SVGAnimateElement")}} interface.

--- a/files/en-us/web/svg/reference/element/animatemotion/index.md
+++ b/files/en-us/web/svg/reference/element/animatemotion/index.md
@@ -11,37 +11,6 @@ The **`<animateMotion>`** [SVG](/en-US/docs/Web/SVG) element provides a way to d
 > [!NOTE]
 > To reuse an existing path, it will be necessary to use an {{SVGElement("mpath")}} element inside the `<animateMotion>` element instead of the {{SVGAttr("path")}} attribute.
 
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  display: block;
-}
-```
-
-```html
-<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-  <path
-    fill="none"
-    stroke="lightgrey"
-    d="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z" />
-
-  <circle r="5" fill="red">
-    <animateMotion
-      dur="10s"
-      repeatCount="indefinite"
-      path="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z" />
-  </circle>
-</svg>
-```
-
-{{EmbedLiveSample('Example', 150, '100%')}}
-
 ## Usage context
 
 {{svginfo}}
@@ -72,9 +41,40 @@ svg {
 - [Animation event attributes](/en-US/docs/Web/SVG/Reference/Attribute#event_attributes)
   - : Most notably: `onbegin`, `onend`, `onrepeat`
 
-## Usage notes
+## DOM Interface
 
 This element implements the {{domxref("SVGAnimateMotionElement")}} interface.
+
+## Example
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+```
+
+```html
+<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill="none"
+    stroke="lightgrey"
+    d="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z" />
+
+  <circle r="5" fill="red">
+    <animateMotion
+      dur="10s"
+      repeatCount="indefinite"
+      path="M20,50 C20,-50 180,150 180,50 C180-50 20,150 20,50 z" />
+  </circle>
+</svg>
+```
+
+{{EmbedLiveSample('Example', 150, '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/circle/index.md
+++ b/files/en-us/web/svg/reference/element/circle/index.md
@@ -8,23 +8,9 @@ sidebar: svgref
 
 The **`<circle>`** [SVG](/en-US/docs/Web/SVG) element is an [SVG basic shape](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Basic_shapes), used to draw circles based on a center point and a radius.
 
-## Example
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="50" cy="50" r="50" />
-</svg>
-```
-
-{{EmbedLiveSample('Example', 100, 100)}}
+{{svginfo}}
 
 ## Attributes
 
@@ -44,9 +30,27 @@ svg {
 > [!NOTE]
 > Starting with SVG2, `cx`, `cy`, and `r` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage context
+## DOM Interface
 
-{{svginfo}}
+This element implements the {{domxref("SVGCircleElement")}} interface.
+
+## Example
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="50" />
+</svg>
+```
+
+{{EmbedLiveSample('Example', 100, 100)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/clippath/index.md
+++ b/files/en-us/web/svg/reference/element/clippath/index.md
@@ -10,6 +10,20 @@ The **`<clipPath>`** [SVG](/en-US/docs/Web/SVG) element defines a clipping path,
 
 A clipping path restricts the region to which paint can be applied. Conceptually, parts of the drawing that lie outside of the region bounded by the clipping path are not drawn.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("clipPathUnits")}}
+  - : Defines the coordinate system for the contents of the `<clipPath>` element.
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGClipPathElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -66,16 +80,6 @@ svg {
 A clipping path is conceptually equivalent to a custom viewport for the referencing element. Thus, it affects the _rendering_ of an element, but not the element's _inherent geometry_. The bounding box of a clipped element (meaning, an element which references a `<clipPath>` element via a {{SVGAttr("clip-path")}} property, or a child of the referencing element) must remain the same as if it were not clipped.
 
 By default, {{cssxref("pointer-events")}} are not dispatched on clipped regions. For example, a circle with a radius of `10` which is clipped to a circle with a radius of `5` will not receive "click" events outside the smaller radius.
-
-## Attributes
-
-- {{SVGAttr("clipPathUnits")}}
-  - : Defines the coordinate system for the contents of the `<clipPath>` element.
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/defs/index.md
+++ b/files/en-us/web/svg/reference/element/defs/index.md
@@ -10,6 +10,14 @@ The **`<defs>`** [SVG](/en-US/docs/Web/SVG) element is used to store graphical o
 
 Graphical objects can be referenced from anywhere, however, defining these objects inside of a `<defs>` element promotes understandability of the SVG content and is beneficial to the overall accessibility of the document.
 
+## Usage context
+
+{{svginfo}}
+
+## DOM Interface
+
+This element implements the {{domxref("SVGDefsElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -38,10 +46,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/defs/index.md
+++ b/files/en-us/web/svg/reference/element/defs/index.md
@@ -14,6 +14,10 @@ Graphical objects can be referenced from anywhere, however, defining these objec
 
 {{svginfo}}
 
+## Attributes
+
+This element only includes global attributes.
+
 ## DOM Interface
 
 This element implements the {{domxref("SVGDefsElement")}} interface.

--- a/files/en-us/web/svg/reference/element/desc/index.md
+++ b/files/en-us/web/svg/reference/element/desc/index.md
@@ -12,6 +12,18 @@ Text in a `<desc>` element is not rendered as part of the graphic. If the elemen
 
 The hidden text of a `<desc>` element can also be concatenated with the visible text of other elements using multiple IDs in an `aria-describedby` value. In that case, the `<desc>` element must provide an ID for reference.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+This element only includes global attributes.
+
+## DOM Interface
+
+This element implements the {{domxref("SVGDescElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -34,14 +46,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-This element only includes global attributes
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/ellipse/index.md
+++ b/files/en-us/web/svg/reference/element/ellipse/index.md
@@ -11,23 +11,9 @@ The **`<ellipse>`** [SVG](/en-US/docs/Web/SVG) element is an SVG basic shape, us
 > [!NOTE]
 > Ellipses are unable to specify the exact orientation of the ellipse (if, for example, you wanted to draw an ellipse tilted at a 45 degree angle), but it can be rotated by using the {{SVGAttr("transform")}} attribute.
 
-## Example
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-  <ellipse cx="100" cy="50" rx="100" ry="50" />
-</svg>
-```
-
-{{EmbedLiveSample('Example', 100, '100%')}}
+{{svginfo}}
 
 ## Attributes
 
@@ -50,9 +36,23 @@ svg {
 > [!NOTE]
 > Starting with SVG2 `cx`, `cy`, `rx` and `ry` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage context
+## Example
 
-{{svginfo}}
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="100" cy="50" rx="100" ry="50" />
+</svg>
+```
+
+{{EmbedLiveSample('Example', 100, '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/fedropshadow/index.md
+++ b/files/en-us/web/svg/reference/element/fedropshadow/index.md
@@ -13,6 +13,26 @@ The **`<feDropShadow>`** [SVG](/en-US/docs/Web/SVG) filter primitive creates a d
 
 Like other filter primitives, it handles color components in the `linearRGB` {{glossary("color space")}} by default. You can use {{svgattr("color-interpolation-filters")}} to use `sRGB` instead.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("dx")}}
+  - : This attribute defines the x offset of the drop shadow.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
+- {{SVGAttr("dy")}}
+  - : This attribute defines the y offset of the drop shadow.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
+- {{SVGAttr("stdDeviation")}}
+  - : This attribute defines the standard deviation for the blur operation in the drop shadow.
+    _Value type_: [**\<number-optional-number>**](/en-US/docs/Web/SVG/Guides/Content_type#number-optional-number); _Default value_: `2`; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGFEDropShadowElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -51,22 +71,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("dx")}}
-  - : This attribute defines the x offset of the drop shadow.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
-- {{SVGAttr("dy")}}
-  - : This attribute defines the y offset of the drop shadow.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
-- {{SVGAttr("stdDeviation")}}
-  - : This attribute defines the standard deviation for the blur operation in the drop shadow.
-    _Value type_: [**\<number-optional-number>**](/en-US/docs/Web/SVG/Guides/Content_type#number-optional-number); _Default value_: `2`; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/foreignobject/index.md
+++ b/files/en-us/web/svg/reference/element/foreignobject/index.md
@@ -8,6 +8,32 @@ sidebar: svgref
 
 The **`<foreignObject>`** [SVG](/en-US/docs/Web/SVG) element includes elements from a different XML namespace. In the context of a browser, it is most likely (X)HTML.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("height")}}
+  - : The height of the foreignObject.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
+- {{SVGAttr("width")}}
+  - : The width of the foreignObject.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
+- {{SVGAttr("x")}}
+  - : The x coordinate of the foreignObject.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("y")}}
+  - : The y coordinate of the foreignObject.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+
+> [!NOTE]
+> Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
+
+## DOM Interface
+
+This element implements the {{domxref("SVGForeignObjectElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -48,32 +74,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("height")}}
-  - : The height of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
-- {{SVGAttr("width")}}
-  - : The width of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
-- {{SVGAttr("x")}}
-  - : The x coordinate of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("y")}}
-  - : The y coordinate of the foreignObject.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-
-> [!NOTE]
-> Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
-
-## DOM Interface
-
-This element implements the {{domxref("SVGForeignObjectElement")}} interface.
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -14,6 +14,10 @@ Transformations applied to the `<g>` element are performed on its child elements
 
 {{svginfo}}
 
+## Attributes
+
+This element only includes global attributes.
+
 ## DOM Interface
 
 This element implements the {{domxref("SVGGElement")}} interface.

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -10,6 +10,14 @@ The **`<g>`** [SVG](/en-US/docs/Web/SVG) element is a container used to group ot
 
 Transformations applied to the `<g>` element are performed on its child elements, and its attributes are inherited by its children. It can also group multiple elements to be referenced later with the {{SVGElement("use")}} element.
 
+## Usage context
+
+{{svginfo}}
+
+## DOM Interface
+
+This element implements the {{domxref("SVGGElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -31,10 +39,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, '100%')}}
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/line/index.md
+++ b/files/en-us/web/svg/reference/element/line/index.md
@@ -8,6 +8,32 @@ sidebar: svgref
 
 The **`<line>`** [SVG](/en-US/docs/Web/SVG) element is an SVG basic shape used to create a line connecting two points.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr('x1')}}
+  - : Defines the x-axis coordinate of the line starting point.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr('x2')}}
+  - : Defines the x-axis coordinate of the line ending point.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr('y1')}}
+  - : Defines the y-axis coordinate of the line starting point.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr('y2')}}
+  - : Defines the y-axis coordinate of the line ending point.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("pathLength")}}
+  - : Defines the total path length in user units.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGLineElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -28,28 +54,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, 100)}}
-
-## Attributes
-
-- {{SVGAttr('x1')}}
-  - : Defines the x-axis coordinate of the line starting point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr('x2')}}
-  - : Defines the x-axis coordinate of the line ending point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr('y1')}}
-  - : Defines the y-axis coordinate of the line starting point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr('y2')}}
-  - : Defines the y-axis coordinate of the line ending point.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("pathLength")}}
-  - : Defines the total path length in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/lineargradient/index.md
+++ b/files/en-us/web/svg/reference/element/lineargradient/index.md
@@ -8,34 +8,9 @@ sidebar: svgref
 
 The **`<linearGradient>`** [SVG](/en-US/docs/Web/SVG) element lets authors define linear gradients to apply to other SVG elements.
 
-## Example
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg
-  viewBox="0 0 10 10"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <defs>
-    <linearGradient id="myGradient" gradientTransform="rotate(90)">
-      <stop offset="5%" stop-color="gold" />
-      <stop offset="95%" stop-color="red" />
-    </linearGradient>
-  </defs>
-
-  <!-- using my linear gradient -->
-  <circle cx="5" cy="5" r="4" fill="url('#myGradient')" />
-</svg>
-```
-
-{{EmbedLiveSample('Example', 150, '100%')}}
+{{svginfo}}
 
 ## Attributes
 
@@ -67,9 +42,38 @@ svg {
   - : This attribute defines the y coordinate of the ending point of the vector gradient along which the linear gradient is drawn.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0%`; _Animatable_: **yes**
 
-## Usage context
+## DOM Interface
 
-{{svginfo}}
+This element implements the {{domxref("SVGLinearGradientElement")}} interface.
+
+## Example
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg
+  viewBox="0 0 10 10"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="myGradient" gradientTransform="rotate(90)">
+      <stop offset="5%" stop-color="gold" />
+      <stop offset="95%" stop-color="red" />
+    </linearGradient>
+  </defs>
+
+  <!-- using my linear gradient -->
+  <circle cx="5" cy="5" r="4" fill="url('#myGradient')" />
+</svg>
+```
+
+{{EmbedLiveSample('Example', 150, '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/marker/index.md
+++ b/files/en-us/web/svg/reference/element/marker/index.md
@@ -10,6 +10,41 @@ The **`<marker>`** [SVG](/en-US/docs/Web/SVG) element defines a graphic used for
 
 Markers can be attached to shapes using the {{SVGAttr("marker-start")}}, {{SVGAttr("marker-mid")}}, and {{SVGAttr("marker-end")}} properties.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("markerHeight")}}
+  - : This attribute defines the height of the marker viewport.
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**; _Default value_: `3`; _Animatable_: **yes**
+- {{SVGAttr("markerUnits")}}
+  - : This attribute defines the coordinate system for the attributes `markerWidth`, `markerHeight` and the contents of the `<marker>`.
+    _Value type_: `userSpaceOnUse` | `strokeWidth`; _Default value_: `strokeWidth`; _Animatable_: **yes**
+- {{SVGAttr("markerWidth")}}
+  - : This attribute defines the width of the marker viewport.
+    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**; _Default value_: `3`; _Animatable_: **yes**
+- {{SVGAttr("orient")}}
+  - : This attribute defines the orientation of the marker relative to the shape it is attached to.
+    _Value type_: `auto` | `auto-start-reverse` | **[\<angle>](/en-US/docs/Web/SVG/Guides/Content_type#angle)**; _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("preserveAspectRatio")}}
+  - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+- {{SVGAttr("refX")}}
+  - : This attribute defines the x coordinate for the reference point of the marker.
+    _Value type_: `left` | `center` | `right` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)**; _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("refY")}}
+  - : This attribute defines the y coordinate for the reference point of the marker.
+    _Value type_: `top` | `center` | `bottom` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)**; _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("viewBox")}}
+  - : This attribute defines the bound of the SVG viewport for the current SVG fragment.
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGMarkerElement")}} interface.
+
 ## Examples
 
 ### Drawing arrowheads
@@ -162,37 +197,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Using_context_fill_and_stroke', 200, 200)}}
-
-## Attributes
-
-- {{SVGAttr("markerHeight")}}
-  - : This attribute defines the height of the marker viewport.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**; _Default value_: `3`; _Animatable_: **yes**
-- {{SVGAttr("markerUnits")}}
-  - : This attribute defines the coordinate system for the attributes `markerWidth`, `markerHeight` and the contents of the `<marker>`.
-    _Value type_: `userSpaceOnUse` | `strokeWidth`; _Default value_: `strokeWidth`; _Animatable_: **yes**
-- {{SVGAttr("markerWidth")}}
-  - : This attribute defines the width of the marker viewport.
-    _Value type_: **[\<length>](/en-US/docs/Web/SVG/Guides/Content_type#length)**; _Default value_: `3`; _Animatable_: **yes**
-- {{SVGAttr("orient")}}
-  - : This attribute defines the orientation of the marker relative to the shape it is attached to.
-    _Value type_: `auto` | `auto-start-reverse` | **[\<angle>](/en-US/docs/Web/SVG/Guides/Content_type#angle)**; _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("preserveAspectRatio")}}
-  - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
-- {{SVGAttr("refX")}}
-  - : This attribute defines the x coordinate for the reference point of the marker.
-    _Value type_: `left` | `center` | `right` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)**; _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("refY")}}
-  - : This attribute defines the y coordinate for the reference point of the marker.
-    _Value type_: `top` | `center` | `bottom` | **[\<coordinate>](/en-US/docs/Web/SVG/Guides/Content_type#coordinate)**; _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("viewBox")}}
-  - : This attribute defines the bound of the SVG viewport for the current SVG fragment.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/mask/index.md
+++ b/files/en-us/web/svg/reference/element/mask/index.md
@@ -8,6 +8,38 @@ sidebar: svgref
 
 The **`<mask>`** [SVG](/en-US/docs/Web/SVG) element defines a mask for compositing the current object into the background. A mask is used/referenced using the {{SVGAttr("mask")}} property and CSS {{cssxref("mask-image")}} property.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("height")}}
+  - : This attribute defines the height of the masking area.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `120%`; _Animatable_: **yes**
+- {{SVGAttr("mask-type")}}
+  - : This attribute defines the mask mode for the contents for the contents of the `<mask>`.
+    _Value type_: `alpha` | `luminance`; _Default value_: `luminance`; _Animatable_: **yes**
+- {{SVGAttr("maskContentUnits")}}
+  - : This attribute defines the coordinate system for the contents of the `<mask>`.
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
+- {{SVGAttr("maskUnits")}}
+  - : This attribute defines the coordinate system for attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}} and {{SVGAttr("height")}} on the `<mask>`.
+    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
+- {{SVGAttr("x")}}
+  - : This attribute defines the x-axis coordinate of the top-left corner of the masking area.
+    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `-10%`; _Animatable_: **yes**
+- {{SVGAttr("y")}}
+  - : This attribute defines the y-axis coordinate of the top-left corner of the masking area.
+    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `-10%`; _Animatable_: **yes**
+- {{SVGAttr("width")}}
+  - : This attribute defines the width of the masking area.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `120%`; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGMaskElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -39,34 +71,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, 100)}}
-
-## Attributes
-
-- {{SVGAttr("height")}}
-  - : This attribute defines the height of the masking area.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `120%`; _Animatable_: **yes**
-- {{SVGAttr("mask-type")}}
-  - : This attribute defines the mask mode for the contents for the contents of the `<mask>`.
-    _Value type_: `alpha` | `luminance`; _Default value_: `luminance`; _Animatable_: **yes**
-- {{SVGAttr("maskContentUnits")}}
-  - : This attribute defines the coordinate system for the contents of the `<mask>`.
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
-- {{SVGAttr("maskUnits")}}
-  - : This attribute defines the coordinate system for attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}} and {{SVGAttr("height")}} on the `<mask>`.
-    _Value type_: `userSpaceOnUse` | `objectBoundingBox`; _Default value_: `objectBoundingBox`; _Animatable_: **yes**
-- {{SVGAttr("x")}}
-  - : This attribute defines the x-axis coordinate of the top-left corner of the masking area.
-    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `-10%`; _Animatable_: **yes**
-- {{SVGAttr("y")}}
-  - : This attribute defines the y-axis coordinate of the top-left corner of the masking area.
-    _Value type_: [**\<coordinate>**](/en-US/docs/Web/SVG/Guides/Content_type#coordinate); _Default value_: `-10%`; _Animatable_: **yes**
-- {{SVGAttr("width")}}
-  - : This attribute defines the width of the masking area.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `120%`; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/metadata/index.md
+++ b/files/en-us/web/svg/reference/element/metadata/index.md
@@ -12,6 +12,10 @@ The **`<metadata>`** [SVG](/en-US/docs/Web/SVG) element adds metadata to SVG con
 
 {{svginfo}}
 
+## Attributes
+
+This element only includes global attributes.
+
 ## DOM Interface
 
 This element implements the {{domxref("SVGMetadataElement")}} interface.

--- a/files/en-us/web/svg/reference/element/path/index.md
+++ b/files/en-us/web/svg/reference/element/path/index.md
@@ -8,6 +8,23 @@ sidebar: svgref
 
 The **`<path>`** [SVG](/en-US/docs/Web/SVG) element is the generic element to define a shape. All the basic shapes can be created with a path element.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("d")}}
+  - : This attribute defines the shape of the path.
+    _Value type_: **\<string>**; _Default value_: `''`; _Animatable_: **yes**
+- {{SVGAttr("pathLength")}}
+  - : This attribute lets authors specify the total length for the path, in user units.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGPathElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -30,23 +47,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, 100)}}
-
-## Attributes
-
-- {{SVGAttr("d")}}
-  - : This attribute defines the shape of the path.
-    _Value type_: **\<string>**; _Default value_: `''`; _Animatable_: **yes**
-- {{SVGAttr("pathLength")}}
-  - : This attribute lets authors specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
-
-## DOM Interface
-
-This element implements the {{domxref("SVGPathElement")}} interface.
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/path/index.md
+++ b/files/en-us/web/svg/reference/element/path/index.md
@@ -46,7 +46,7 @@ svg {
 
 ## DOM interface
 
-The <path> element is associated with the [SVGPathElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement) interface.
+The <path> element is associated with the [SVGPathElement](/en-US/docs/Web/API/SVGPathElement) interface.
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/path/index.md
+++ b/files/en-us/web/svg/reference/element/path/index.md
@@ -44,9 +44,9 @@ svg {
 
 {{svginfo}}
 
-## DOM interface
+## DOM Interface
 
-The <path> element is associated with the [SVGPathElement](/en-US/docs/Web/API/SVGPathElement) interface.
+This element implements the {{domxref("SVGPathElement")}} interface.
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/path/index.md
+++ b/files/en-us/web/svg/reference/element/path/index.md
@@ -44,6 +44,10 @@ svg {
 
 {{svginfo}}
 
+## DOM interface
+
+The <path> element is associated with the [SVGPathElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement) interface.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/svg/reference/element/pattern/index.md
+++ b/files/en-us/web/svg/reference/element/pattern/index.md
@@ -10,36 +10,9 @@ The **`<pattern>`** [SVG](/en-US/docs/Web/SVG) element defines a graphics object
 
 The `<pattern>` is referenced by the {{SVGAttr("fill")}} and/or {{SVGAttr("stroke")}} attributes on other [graphics elements](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Basic_shapes) to fill or stroke those elements with the referenced pattern.
 
-## Examples
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 230 100" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <pattern id="star" viewBox="0,0,10,10" width="10%" height="10%">
-      <polygon points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2" />
-    </pattern>
-  </defs>
-
-  <circle cx="50" cy="50" r="50" fill="url(#star)" />
-  <circle
-    cx="180"
-    cy="50"
-    r="40"
-    fill="none"
-    stroke-width="20"
-    stroke="url(#star)" />
-</svg>
-```
-
-{{EmbedLiveSample('Examples', 150, '100%')}}
+{{svginfo}}
 
 ## Attributes
 
@@ -87,9 +60,40 @@ svg {
   - : This attribute determines the y coordinate shift of the pattern tile.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length); _Default value_: `0`; _Animatable_: **yes**
 
-## Usage context
+## DOM Interface
 
-{{svginfo}}
+This element implements the {{domxref("SVGPatternElement")}} interface.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 230 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="star" viewBox="0,0,10,10" width="10%" height="10%">
+      <polygon points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2" />
+    </pattern>
+  </defs>
+
+  <circle cx="50" cy="50" r="50" fill="url(#star)" />
+  <circle
+    cx="180"
+    cy="50"
+    r="40"
+    fill="none"
+    stroke-width="20"
+    stroke="url(#star)" />
+</svg>
+```
+
+{{EmbedLiveSample('Examples', 150, '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/polygon/index.md
+++ b/files/en-us/web/svg/reference/element/polygon/index.md
@@ -10,6 +10,23 @@ The **`<polygon>`** [SVG](/en-US/docs/Web/SVG) element defines a closed shape co
 
 For open shapes, see the {{SVGElement("polyline")}} element.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr('points')}}
+  - : This attribute defines the list of points (pairs of `x,y` absolute coordinates) required to draw the polygon.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+; _Default value_: `""`; _Animatable_: **yes**
+- {{SVGAttr("pathLength")}}
+  - : This attribute lets specify the total length for the path, in user units.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGPolygonElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -31,19 +48,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, 100)}}
-
-## Attributes
-
-- {{SVGAttr('points')}}
-  - : This attribute defines the list of points (pairs of `x,y` absolute coordinates) required to draw the polygon.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+; _Default value_: `""`; _Animatable_: **yes**
-- {{SVGAttr("pathLength")}}
-  - : This attribute lets specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/polyline/index.md
+++ b/files/en-us/web/svg/reference/element/polyline/index.md
@@ -8,6 +8,23 @@ sidebar: svgref
 
 The **`<polyline>`** [SVG](/en-US/docs/Web/SVG) element is an SVG basic shape that creates straight lines connecting several points. Typically a `polyline` is used to create open shapes as the last point doesn't have to be connected to the first point. For closed shapes see the {{SVGElement("polygon")}} element.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr('points')}}
+  - : This attribute defines the list of points (pairs of x,y absolute coordinates) required to draw the polyline
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+; _Default value_: `""`; _Animatable_: **yes**
+- {{SVGAttr("pathLength")}}
+  - : This attribute lets specify the total length for the path, in user units.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGPolylineElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -29,19 +46,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, 100)}}
-
-## Attributes
-
-- {{SVGAttr('points')}}
-  - : This attribute defines the list of points (pairs of x,y absolute coordinates) required to draw the polyline
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number)+; _Default value_: `""`; _Animatable_: **yes**
-- {{SVGAttr("pathLength")}}
-  - : This attribute lets specify the total length for the path, in user units.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/radialgradient/index.md
+++ b/files/en-us/web/svg/reference/element/radialgradient/index.md
@@ -11,34 +11,9 @@ The **`<radialGradient>`** [SVG](/en-US/docs/Web/SVG) element lets authors defin
 > [!NOTE]
 > Don't be confused with CSS {{cssxref('gradient/radial-gradient', 'radial-gradient()')}} as CSS gradients can only apply to HTML elements where SVG gradient can only apply to SVG elements.
 
-## Example
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg
-  viewBox="0 0 10 10"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-  <defs>
-    <radialGradient id="myGradient">
-      <stop offset="10%" stop-color="gold" />
-      <stop offset="95%" stop-color="red" />
-    </radialGradient>
-  </defs>
-
-  <!-- using my radial gradient -->
-  <circle cx="5" cy="5" r="4" fill="url('#myGradient')" />
-</svg>
-```
-
-{{EmbedLiveSample('Example', 150, '100%')}}
+{{svginfo}}
 
 ## Attributes
 
@@ -76,9 +51,38 @@ svg {
   - : An [\<IRI>](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to another `<radialGradient>` element that will be used as a template.
     _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Guides/Content_type#iri); _Default value_: none; _Animatable_: **yes**
 
-## Usage context
+## DOM Interface
 
-{{svginfo}}
+This element implements the {{domxref("SVGRadialGradientElement")}} interface.
+
+## Example
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg
+  viewBox="0 0 10 10"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <radialGradient id="myGradient">
+      <stop offset="10%" stop-color="gold" />
+      <stop offset="95%" stop-color="red" />
+    </radialGradient>
+  </defs>
+
+  <!-- using my radial gradient -->
+  <circle cx="5" cy="5" r="4" fill="url('#myGradient')" />
+</svg>
+```
+
+{{EmbedLiveSample('Example', 150, '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/rect/index.md
+++ b/files/en-us/web/svg/reference/element/rect/index.md
@@ -8,27 +8,9 @@ sidebar: svgref
 
 The **`<rect>`** [SVG](/en-US/docs/Web/SVG) element is a [basic SVG shape](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Basic_shapes) that draws rectangles, defined by their position, width, and height. The rectangles may have their corners rounded.
 
-## Example
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 220 100" xmlns="http://www.w3.org/2000/svg">
-  <!-- Regular rectangle -->
-  <rect width="100" height="100" />
-
-  <!-- Rounded corner rectangle -->
-  <rect x="120" width="100" height="100" rx="15" />
-</svg>
-```
-
-{{EmbedLiveSample('Example', 100, '100%')}}
+{{svginfo}}
 
 ## Attributes
 
@@ -57,9 +39,31 @@ svg {
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, `height`, `rx` and `ry` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage context
+## DOM Interface
 
-{{svginfo}}
+This element implements the {{domxref("SVGRectElement")}} interface.
+
+## Example
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 220 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- Regular rectangle -->
+  <rect width="100" height="100" />
+
+  <!-- Rounded corner rectangle -->
+  <rect x="120" width="100" height="100" rx="15" />
+</svg>
+```
+
+{{EmbedLiveSample('Example', 100, '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/script/index.md
+++ b/files/en-us/web/svg/reference/element/script/index.md
@@ -11,6 +11,29 @@ The **`<script>`** [SVG](/en-US/docs/Web/SVG) element allows to add scripts to a
 > [!NOTE]
 > While SVG's `script` element is equivalent to the HTML {{HTMLElement('script')}} element, it has some discrepancies, like it uses the {{SVGAttr('href')}} attribute instead of [`src`](/en-US/docs/Web/HTML/Reference/Elements/script#src) and it doesn't support ECMAScript modules so far (See browser compatibility below for details)
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- [`crossorigin`](/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin)
+  - : This attribute defines [CORS settings](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) as define for the HTML {{HTMLElement('script')}} element.
+    _Value type_: [**[ anonymous | use-credentials ]?**](/en-US/docs/Web/CSS/string); _Default value_: `?`; _Animatable_: **yes**
+- {{SVGAttr("href")}}
+  - : The {{Glossary("URL")}} to the script to load.
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
+- {{SVGAttr("type")}}
+  - : This attribute defines type of the script language to use.
+    _Value type_: [**`<media-type>`**](/en-US/docs/Glossary/MIME_type); _Default value_: `application/ecmascript`; _Animatable_: **no**
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
+  - : The {{Glossary("URL")}} to the script to load.
+    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGScriptElement")}} interface.
+
 ## Example
 
 ```html
@@ -49,25 +72,6 @@ Click the circle to change colors.
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- [`crossorigin`](/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin)
-  - : This attribute defines [CORS settings](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) as define for the HTML {{HTMLElement('script')}} element.
-    _Value type_: [**[ anonymous | use-credentials ]?**](/en-US/docs/Web/CSS/string); _Default value_: `?`; _Animatable_: **yes**
-- {{SVGAttr("href")}}
-  - : The {{Glossary("URL")}} to the script to load.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
-- {{SVGAttr("type")}}
-  - : This attribute defines type of the script language to use.
-    _Value type_: [**`<media-type>`**](/en-US/docs/Glossary/MIME_type); _Default value_: `application/ecmascript`; _Animatable_: **no**
-- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
-  - : The {{Glossary("URL")}} to the script to load.
-    _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/set/index.md
+++ b/files/en-us/web/svg/reference/element/set/index.md
@@ -13,6 +13,20 @@ It supports all attribute types, including those that cannot reasonably be inter
 > [!NOTE]
 > The `<set>` element is non-additive. The {{SVGAttr('additive')}} and {{SVGAttr('accumulate')}} attributes are not allowed, and will be ignored if specified.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("to")}}
+  - : This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute.
+    _Value type_: [**\<anything>**](/en-US/docs/Web/SVG/Guides/Content_type#anything); _Default value_: none; _Animatable_: **no**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGSetElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -42,16 +56,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("to")}}
-  - : This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute.
-    _Value type_: [**\<anything>**](/en-US/docs/Web/SVG/Guides/Content_type#anything); _Default value_: none; _Animatable_: **no**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/stop/index.md
+++ b/files/en-us/web/svg/reference/element/stop/index.md
@@ -8,6 +8,26 @@ sidebar: svgref
 
 The **`<stop>`** [SVG](/en-US/docs/Web/SVG) element defines a color and its position to use on a gradient. This element is always a child of a {{SVGElement("linearGradient")}} or {{SVGElement("radialGradient")}} element.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("offset")}}
+  - : This attribute defines where the gradient stop is placed along the gradient vector.
+    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("stop-color")}}
+  - : This attribute defines the color of the gradient stop. It can be used as a CSS property.
+    _Value type_: [**\<color>**](/en-US/docs/Web/SVG/Guides/Content_type#color); _Default value_: `black`; _Animatable_: **yes**
+- {{SVGAttr("stop-opacity")}}
+  - : This attribute defines the opacity of the gradient stop. It can be used as a CSS property.
+    _Value type_: [**\<opacity-value>**](/en-US/docs/Web/SVG/Guides/Content_type#opacity_value); _Default value_: `1`; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGStopElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -36,22 +56,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("offset")}}
-  - : This attribute defines where the gradient stop is placed along the gradient vector.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("stop-color")}}
-  - : This attribute defines the color of the gradient stop. It can be used as a CSS property.
-    _Value type_: [**\<color>**](/en-US/docs/Web/SVG/Guides/Content_type#color); _Default value_: `black`; _Animatable_: **yes**
-- {{SVGAttr("stop-opacity")}}
-  - : This attribute defines the opacity of the gradient stop. It can be used as a CSS property.
-    _Value type_: [**\<opacity-value>**](/en-US/docs/Web/SVG/Guides/Content_type#opacity_value); _Default value_: `1`; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/style/index.md
+++ b/files/en-us/web/svg/reference/element/style/index.md
@@ -11,6 +11,26 @@ The **`<style>`** [SVG](/en-US/docs/Web/SVG) element allows style sheets to be e
 > [!NOTE]
 > SVG's `style` element has the same attributes as the corresponding element in HTML (see HTML's {{HTMLElement("style")}} element).
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("type")}}
+  - : This attribute defines type of the style sheet language to use as a media type string.
+    _Value type_: [**`<media-type>`**](/en-US/docs/Glossary/MIME_type); _Default value_: `text/css`; _Animatable_: **no**
+- {{SVGAttr("media")}}
+  - : This attribute defines to which {{cssxref('@media', 'media')}} the style applies.
+    _Value type_: [**`<media-query-list>`**](/en-US/docs/Web/CSS/@media#syntax); _Default value_: `all`; _Animatable_: **no**
+- {{SVGAttr("title")}}
+  - : This attribute is the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/HTML/Reference/Attributes/rel/alternate_stylesheet).
+    _Value type_: [**`<string>`**](/en-US/docs/Web/CSS/string); _Default value_: _none_; _Animatable_: **no**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGStyleElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -36,22 +56,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("type")}}
-  - : This attribute defines type of the style sheet language to use as a media type string.
-    _Value type_: [**`<media-type>`**](/en-US/docs/Glossary/MIME_type); _Default value_: `text/css`; _Animatable_: **no**
-- {{SVGAttr("media")}}
-  - : This attribute defines to which {{cssxref('@media', 'media')}} the style applies.
-    _Value type_: [**`<media-query-list>`**](/en-US/docs/Web/CSS/@media#syntax); _Default value_: `all`; _Animatable_: **no**
-- {{SVGAttr("title")}}
-  - : This attribute is the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/HTML/Reference/Attributes/rel/alternate_stylesheet).
-    _Value type_: [**`<string>`**](/en-US/docs/Web/CSS/string); _Default value_: _none_; _Animatable_: **no**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/svg/index.md
+++ b/files/en-us/web/svg/reference/element/svg/index.md
@@ -11,6 +11,44 @@ The **`<svg>`** [SVG](/en-US/docs/Web/SVG) element is a container that defines a
 > [!NOTE]
 > The `xmlns` attribute is only required on the outermost `svg` element of _SVG documents_, or inside HTML documents with XML serialization. It is unnecessary for inner `svg` elements or inside HTML documents with HTML serialization.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("baseProfile")}} {{deprecated_inline}}
+  - : The minimum SVG language profile that the document requires.
+    _Value type_: **\<string>**; _Default value_: none; _Animatable_: **no**
+- {{SVGAttr("height")}}
+  - : The displayed height of the rectangular viewport. (Not the height of its coordinate system.)
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
+- {{SVGAttr("preserveAspectRatio")}}
+  - : How the `svg` fragment must be deformed if it is displayed with a different {{glossary("aspect ratio")}}.
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+- {{SVGAttr("version")}} {{deprecated_inline}}
+  - : Which version of SVG is used for the inner content of the element.
+    _Value type_: **[\<number>](/en-US/docs/Web/SVG/Guides/Content_type#number)**; _Default value_: none; _Animatable_: **no**
+- {{SVGAttr("viewBox")}}
+  - : The SVG viewport coordinates for the current SVG fragment.
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
+- {{SVGAttr("width")}}
+  - : The displayed width of the rectangular viewport. (Not the width of its coordinate system.)
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
+- {{SVGAttr("x")}}
+  - : The displayed x coordinate of the svg container. No effect on outermost `svg` elements.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("y")}}
+  - : The displayed y coordinate of the svg container. No effect on outermost `svg` elements.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+
+> [!NOTE]
+> Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning these attributes can also be used as CSS properties.
+
+## DOM Interface
+
+This element implements the {{domxref("SVGSVGElement")}} interface.
+
 ## Examples
 
 ### Nested `svg` element
@@ -105,40 +143,6 @@ In this example, the `height` and `width` attributes on the `svg` element are se
 {{EmbedLiveSample('using_dynamic_viewport_lengths', '100%', 500)}}
 
 To change the iframe's dimensions try resizing the dotted red border from bottom right corner.
-
-## Attributes
-
-- {{SVGAttr("baseProfile")}} {{deprecated_inline}}
-  - : The minimum SVG language profile that the document requires.
-    _Value type_: **\<string>**; _Default value_: none; _Animatable_: **no**
-- {{SVGAttr("height")}}
-  - : The displayed height of the rectangular viewport. (Not the height of its coordinate system.)
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
-- {{SVGAttr("preserveAspectRatio")}}
-  - : How the `svg` fragment must be deformed if it is displayed with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
-- {{SVGAttr("version")}} {{deprecated_inline}}
-  - : Which version of SVG is used for the inner content of the element.
-    _Value type_: **[\<number>](/en-US/docs/Web/SVG/Guides/Content_type#number)**; _Default value_: none; _Animatable_: **no**
-- {{SVGAttr("viewBox")}}
-  - : The SVG viewport coordinates for the current SVG fragment.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
-- {{SVGAttr("width")}}
-  - : The displayed width of the rectangular viewport. (Not the width of its coordinate system.)
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
-- {{SVGAttr("x")}}
-  - : The displayed x coordinate of the svg container. No effect on outermost `svg` elements.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("y")}}
-  - : The displayed y coordinate of the svg container. No effect on outermost `svg` elements.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-
-> [!NOTE]
-> Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning these attributes can also be used as CSS properties.
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/switch/index.md
+++ b/files/en-us/web/svg/reference/element/switch/index.md
@@ -17,6 +17,10 @@ Other direct children will be bypassed and therefore not rendered. If a child el
 
 {{svginfo}}
 
+## Attributes
+
+This element only includes global attributes.
+
 ## DOM Interface
 
 This element implements the {{domxref("SVGSwitchElement")}} interface.

--- a/files/en-us/web/svg/reference/element/symbol/index.md
+++ b/files/en-us/web/svg/reference/element/symbol/index.md
@@ -10,6 +10,44 @@ The **`<symbol>`** [SVG](/en-US/docs/Web/SVG) element is used to define graphica
 
 The use of `<symbol>` elements for graphics that are used multiple times in the same document adds structure and semantics. Documents that are rich in structure may be rendered graphically, as speech, or as Braille, and thus promote accessibility.
 
+> [!NOTE]
+> A `<symbol>` element itself is not meant to be rendered. Only instances of a `<symbol>` element (i.e., a reference to a `<symbol>` by a {{SVGElement("use")}} element) are rendered. That means that some browsers could refuse to directly display a `<symbol>` element even if the CSS {{cssxref('display')}} property tells otherwise.
+
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("height")}}
+  - : This attribute determines the height of the symbol.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
+- {{SVGAttr("preserveAspectRatio")}}
+  - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
+    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
+- {{SVGAttr("refX")}}
+  - : This attribute determines the x coordinate of the reference point of the symbol.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `left` | `center` | `right`; _Default value_: None; _Animatable_: **yes**
+- {{SVGAttr("refY")}}
+  - : This attribute determines the y coordinate of the reference point of the symbol.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `top` | `center` | `bottom`; _Default value_: None; _Animatable_: **yes**
+- {{SVGAttr("viewBox")}}
+  - : This attribute defines the bound of the SVG viewport for the current symbol.
+    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
+- {{SVGAttr("width")}}
+  - : This attribute determines the width of the symbol.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
+- {{SVGAttr("x")}}
+  - : This attribute determines the x coordinate of the symbol.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("y")}}
+  - : This attribute determines the y coordinate of the symbol.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGSymbolElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -43,40 +81,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("height")}}
-  - : This attribute determines the height of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
-- {{SVGAttr("preserveAspectRatio")}}
-  - : This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different {{glossary("aspect ratio")}}.
-    _Value type_: (`none` | `xMinYMin` | `xMidYMin` | `xMaxYMin` | `xMinYMid` | `xMidYMid` | `xMaxYMid` | `xMinYMax` | `xMidYMax` | `xMaxYMax`) (`meet` | `slice`)?; _Default value_: `xMidYMid meet`; _Animatable_: **yes**
-- {{SVGAttr("refX")}}
-  - : This attribute determines the x coordinate of the reference point of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `left` | `center` | `right`; _Default value_: None; _Animatable_: **yes**
-- {{SVGAttr("refY")}}
-  - : This attribute determines the y coordinate of the reference point of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | `top` | `center` | `bottom`; _Default value_: None; _Animatable_: **yes**
-- {{SVGAttr("viewBox")}}
-  - : This attribute defines the bound of the SVG viewport for the current symbol.
-    _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
-- {{SVGAttr("width")}}
-  - : This attribute determines the width of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `auto`; _Animatable_: **yes**
-- {{SVGAttr("x")}}
-  - : This attribute determines the x coordinate of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("y")}}
-  - : This attribute determines the y coordinate of the symbol.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: `0`; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
-
-> [!NOTE]
-> A `<symbol>` element itself is not meant to be rendered. Only instances of a `<symbol>` element (i.e., a reference to a `<symbol>` by a {{SVGElement("use")}} element) are rendered. That means that some browsers could refuse to directly display a `<symbol>` element even if the CSS {{cssxref('display')}} property tells otherwise.
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/text/index.md
+++ b/files/en-us/web/svg/reference/element/text/index.md
@@ -13,6 +13,38 @@ If text is included in SVG not inside of a `<text>` element, it is not rendered.
 > [!NOTE]
 > The `<text>` element does not wrap by default, to make this happen it needs to be styled with the {{CSSXRef("white-space")}} CSS property.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("x")}}
+  - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("y")}}
+  - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("dx")}}
+  - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
+- {{SVGAttr("dy")}}
+  - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
+- {{SVGAttr("rotate")}}
+  - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
+    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts); _Default value_: none; _Animatable_: **yes**
+- {{SVGAttr("lengthAdjust")}}
+  - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
+    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
+- {{SVGAttr("textLength")}}
+  - : A width that the text should be scaled to fit.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGTextElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -49,34 +81,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("x")}}
-  - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("y")}}
-  - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("dx")}}
-  - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
-- {{SVGAttr("dy")}}
-  - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
-- {{SVGAttr("rotate")}}
-  - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
-    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts); _Default value_: none; _Animatable_: **yes**
-- {{SVGAttr("lengthAdjust")}}
-  - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
-    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
-- {{SVGAttr("textLength")}}
-  - : A width that the text should be scaled to fit.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/textpath/index.md
+++ b/files/en-us/web/svg/reference/element/textpath/index.md
@@ -9,34 +9,9 @@ sidebar: svgref
 The **`<textPath>`** [SVG](/en-US/docs/Web/SVG) element is used to render text along the shape of a {{SVGElement("path")}} element.
 The text must be enclosed in the `<textPath>` element and its {{SVGAttr("href")}} attribute is used to reference the desired `<path>`.
 
-## Example
+## Usage context
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <!-- to hide the path, it is usually wrapped in a <defs> element -->
-  <!-- <defs> -->
-  <path
-    id="MyPath"
-    fill="none"
-    stroke="red"
-    d="M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 Q70,70 75,50" />
-  <!-- </defs> -->
-
-  <text>
-    <textPath href="#MyPath">Quick brown fox jumps over the lazy dog.</textPath>
-  </text>
-</svg>
-```
-
-{{EmbedLiveSample('Example', 200, 200)}}
+{{svginfo}}
 
 ## Attributes
 
@@ -65,9 +40,38 @@ svg {
   - : The width of the space into which the text will render.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage) | [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: _auto_; _Animatable_: **yes**
 
-## Usage context
+## DOM Interface
 
-{{svginfo}}
+This element implements the {{domxref("SVGTextPathElement")}} interface.
+
+## Example
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- to hide the path, it is usually wrapped in a <defs> element -->
+  <!-- <defs> -->
+  <path
+    id="MyPath"
+    fill="none"
+    stroke="red"
+    d="M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 Q70,70 75,50" />
+  <!-- </defs> -->
+
+  <text>
+    <textPath href="#MyPath">Quick brown fox jumps over the lazy dog.</textPath>
+  </text>
+</svg>
+```
+
+{{EmbedLiveSample('Example', 200, 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/title/index.md
+++ b/files/en-us/web/svg/reference/element/title/index.md
@@ -13,6 +13,18 @@ Text in a `<title>` element is not rendered as part of the graphic, but browsers
 > [!NOTE]
 > For backward compatibility with SVG 1.1, `<title>` elements should be the first child element of their parent.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+This element only includes global attributes.
+
+## DOM Interface
+
+This element implements the {{domxref("SVGTitleElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -36,14 +48,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 150, '100%')}}
-
-## Attributes
-
-This element only includes global attributes
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/tspan/index.md
+++ b/files/en-us/web/svg/reference/element/tspan/index.md
@@ -11,6 +11,38 @@ The **`<tspan>`** [SVG](/en-US/docs/Web/SVG) element defines a subtext within a 
 > [!NOTE]
 > The `<tspan>` element does not wrap by default, to make this happen it needs to be styled with the {{CSSXRef("white-space")}} CSS property.
 
+## Usage context
+
+{{svginfo}}
+
+## Attributes
+
+- {{SVGAttr("x")}}
+  - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("y")}}
+  - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
+- {{SVGAttr("dx")}}
+  - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
+- {{SVGAttr("dy")}}
+  - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
+    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
+- {{SVGAttr("rotate")}}
+  - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
+    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts); _Default value_: none; _Animatable_: **yes**
+- {{SVGAttr("lengthAdjust")}}
+  - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
+    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
+- {{SVGAttr("textLength")}}
+  - : A width that the text should be scaled to fit.
+    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: _none_; _Animatable_: **yes**
+
+## DOM Interface
+
+This element implements the {{domxref("SVGTSpanElement")}} interface.
+
 ## Example
 
 ```css hidden
@@ -42,34 +74,6 @@ svg {
 ```
 
 {{EmbedLiveSample('Example', 100, '100%')}}
-
-## Attributes
-
-- {{SVGAttr("x")}}
-  - : The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("y")}}
-  - : The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: `0`; _Animatable_: **yes**
-- {{SVGAttr("dx")}}
-  - : Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
-- {{SVGAttr("dy")}}
-  - : Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided.
-    _Value type_: List of ([**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage)); _Default value_: _none_; _Animatable_: **yes**
-- {{SVGAttr("rotate")}}
-  - : Rotates orientation of each individual glyph. Can rotate glyphs individually.
-    _Value type_: [**\<list-of-number>**](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts); _Default value_: none; _Animatable_: **yes**
-- {{SVGAttr("lengthAdjust")}}
-  - : How the text is stretched or compressed to fit the width defined by the `textLength` attribute.
-    _Value type_: `spacing` | `spacingAndGlyphs`; _Default value_: `spacing`; _Animatable_: **yes**
-- {{SVGAttr("textLength")}}
-  - : A width that the text should be scaled to fit.
-    _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Guides/Content_type#length) | [**\<percentage>**](/en-US/docs/Web/SVG/Guides/Content_type#percentage); _Default value_: _none_; _Animatable_: **yes**
-
-## Usage context
-
-{{svginfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -9,28 +9,9 @@ sidebar: svgref
 The **`<use>`** element takes nodes from within an SVG document, and duplicates them somewhere else.
 The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `<use>` element is, much like cloned {{HTMLElement("template")}} elements.
 
-## Example
+## Usage context
 
-The following example shows how to use the `<use>` element to draw a circle with a different fill and stroke color.
-In the last circle, `stroke="red"` will be ignored because stroke was already set on `myCircle`.
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
-  <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue" />
-  <use href="#myCircle" x="10" fill="blue" />
-  <use href="#myCircle" x="20" fill="white" stroke="red" />
-</svg>
-```
-
-{{EmbedLiveSample('Example', 200, 200)}}
+{{SVGInfo}}
 
 ## Attributes
 
@@ -53,6 +34,33 @@ svg {
 
 > [!NOTE]
 > Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
+
+## DOM Interface
+
+This element implements the {{domxref("SVGUseElement")}} interface.
+
+## Example
+
+The following example shows how to use the `<use>` element to draw a circle with a different fill and stroke color.
+In the last circle, `stroke="red"` will be ignored because stroke was already set on `myCircle`.
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+  <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue" />
+  <use href="#myCircle" x="10" fill="blue" />
+  <use href="#myCircle" x="20" fill="white" stroke="red" />
+</svg>
+```
+
+{{EmbedLiveSample('Example', 200, 200)}}
 
 ## Usage notes
 
@@ -96,10 +104,6 @@ Check the [Browser compatibility](#browser_compatibility) table for browser supp
 Loading resources with data URIs in the `href` attribute is deprecated for security reasons. This applies to `<use href="data:...` and also when setting `href` by using the [`set`](/en-US/docs/Web/SVG/Reference/Element/set) or [`setAttribute`](/en-US/docs/Web/API/Element/setAttribute) method.
 
 Again, check the [Browser compatibility](#browser_compatibility) table for browser support.
-
-## Usage context
-
-{{SVGInfo}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/view/index.md
+++ b/files/en-us/web/svg/reference/element/view/index.md
@@ -24,6 +24,10 @@ The **`<view>`** [SVG](/en-US/docs/Web/SVG) element defines a particular view of
   - : This attribute specifies whether the SVG document can be magnified and panned.
     _Value type_: **disable | magnify**; _Default value_: magnify; _Animatable_: **no**
 
+## DOM Interface
+
+This element implements the {{domxref("SVGViewElement")}} interface.
+
 ## Example
 
 ### SVG


### PR DESCRIPTION
### Description

Added a "DOM interface" section to the <path> SVG element documentation, linking to the SVGPathElement interface.

### Motivation

This change clarifies the relationship between the <path> element and its corresponding DOM interface, helping readers understand how to interact with <path> elements via JavaScript and find relevant API documentation more easily.

### Additional details

See [SVGPathElement - MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement) for more information about the interface.

### Related issues and pull requests

Fixes #39788