### PR TITLE
Remove external script dependency & jsfiddle in 2D collision detection

### DIFF
--- a/files/en-us/games/techniques/2d_collision_detection/index.md
+++ b/files/en-us/games/techniques/2d_collision_detection/index.md
@@ -49,15 +49,18 @@ const collider = {
   },
 };
 
+const container = document.getElementById("container");
+
 class BaseEntity {
   ref;
   position;
-  constructor(ref) {
-    this.ref = ref;
-    this.position = {
-      x: parseInt(ref.style.left, 10),
-      y: parseInt(ref.style.top, 10),
-    };
+  constructor(position) {
+    this.position = position;
+    this.ref = document.createElement("div");
+    this.ref.classList.add("entity");
+    this.ref.style.left = `${this.position.x}px`;
+    this.ref.style.top = `${this.position.y}px`;
+    container.appendChild(this.ref);
   }
   shiftPosition(dx, dy) {
     this.position.x += dx;
@@ -79,8 +82,6 @@ class BaseEntity {
     throw new Error("isCollidingWith must be implemented in subclasses");
   }
 }
-
-const container = document.getElementById("container");
 
 document.addEventListener("keydown", (e) => {
   e.preventDefault();
@@ -143,15 +144,18 @@ const collider = {
   },
 };
 
+const container = document.getElementById("container");
+
 class BaseEntity {
   ref;
   position;
-  constructor(ref) {
-    this.ref = ref;
-    this.position = {
-      x: parseInt(ref.style.left, 10),
-      y: parseInt(ref.style.top, 10),
-    };
+  constructor(position) {
+    this.position = position;
+    this.ref = document.createElement("div");
+    this.ref.classList.add("entity");
+    this.ref.style.left = `${this.position.x}px`;
+    this.ref.style.top = `${this.position.y}px`;
+    container.appendChild(this.ref);
   }
   shiftPosition(dx, dy) {
     this.position.x += dx;
@@ -173,8 +177,6 @@ class BaseEntity {
     throw new Error("isCollidingWith must be implemented in subclasses");
   }
 }
-
-const container = document.getElementById("container");
 
 document.addEventListener("keydown", (e) => {
   e.preventDefault();
@@ -213,25 +215,18 @@ class BoxEntity extends BaseEntity {
 ```
 
 ```js hidden
-// create a bunch of random divs
 for (let i = 0; i < 100; i++) {
-  const newStaticDiv = document.createElement("div");
-  newStaticDiv.style.top = `${Math.floor(Math.random() * 500)}px`;
-  newStaticDiv.style.left = `${Math.floor(Math.random() * 500)}px`;
-  newStaticDiv.classList.add("entity");
-  container.appendChild(newStaticDiv);
-  const entity = new BoxEntity(newStaticDiv);
-  collider.staticEntities.push(entity);
+  collider.staticEntities.push(
+    new BoxEntity({
+      x: Math.floor(Math.random() * 500),
+      y: Math.floor(Math.random() * 500),
+    }),
+  );
 }
 
-// create the moveable div
-const newMoveableDiv = document.createElement("div");
-newMoveableDiv.style.left = "500px";
-newMoveableDiv.style.top = "500px";
-newMoveableDiv.classList.add("entity", "movable");
-container.appendChild(newMoveableDiv);
-const entity = new BoxEntity(newMoveableDiv);
-collider.moveableEntity = entity;
+const moveableEntity = new BoxEntity({ x: 500, y: 500 });
+moveableEntity.ref.classList.add("movable");
+collider.moveableEntity = moveableEntity;
 ```
 
 {{EmbedLiveSample("axis-aligned_bounding_box", "", 550)}}
@@ -283,15 +278,18 @@ const collider = {
   },
 };
 
+const container = document.getElementById("container");
+
 class BaseEntity {
   ref;
   position;
-  constructor(ref) {
-    this.ref = ref;
-    this.position = {
-      x: parseInt(ref.style.left, 10),
-      y: parseInt(ref.style.top, 10),
-    };
+  constructor(position) {
+    this.position = position;
+    this.ref = document.createElement("div");
+    this.ref.classList.add("entity");
+    this.ref.style.left = `${this.position.x}px`;
+    this.ref.style.top = `${this.position.y}px`;
+    container.appendChild(this.ref);
   }
   shiftPosition(dx, dy) {
     this.position.x += dx;
@@ -313,8 +311,6 @@ class BaseEntity {
     throw new Error("isCollidingWith must be implemented in subclasses");
   }
 }
-
-const container = document.getElementById("container");
 
 document.addEventListener("keydown", (e) => {
   e.preventDefault();
@@ -344,7 +340,7 @@ class CircleEntity extends BaseEntity {
     const dx =
       this.position.x + this.radius - (other.position.x + other.radius);
     const dy =
-      this.position.y + this.radius - (other.position.t + other.radius);
+      this.position.y + this.radius - (other.position.y + other.radius);
     const distance = Math.sqrt(dx * dx + dy * dy);
     return distance < this.radius + other.radius;
   }
@@ -352,25 +348,18 @@ class CircleEntity extends BaseEntity {
 ```
 
 ```js hidden
-// create a bunch of random divs
 for (let i = 0; i < 100; i++) {
-  const newStaticDiv = document.createElement("div");
-  newStaticDiv.classList.add("entity");
-  newStaticDiv.style.top = `${Math.floor(Math.random() * 500)}px`;
-  newStaticDiv.style.left = `${Math.floor(Math.random() * 500)}px`;
-  container.appendChild(newStaticDiv);
-  const entity = new CircleEntity(newStaticDiv);
-  collider.staticEntities.push(entity);
+  collider.staticEntities.push(
+    new CircleEntity({
+      x: Math.floor(Math.random() * 500),
+      y: Math.floor(Math.random() * 500),
+    }),
+  );
 }
 
-// create the moveable div
-const newMoveableDiv = document.createElement("div");
-newMoveableDiv.style.left = "500px";
-newMoveableDiv.style.top = "500px";
-newMoveableDiv.classList.add("entity", "movable");
-container.appendChild(newMoveableDiv);
-const entity = new CircleEntity(newMoveableDiv);
-collider.moveableEntity = entity;
+const moveableEntity = new CircleEntity({ x: 500, y: 500 });
+moveableEntity.ref.classList.add("movable");
+collider.moveableEntity = moveableEntity;
 ```
 
 > [!NOTE]

--- a/files/en-us/games/techniques/2d_collision_detection/index.md
+++ b/files/en-us/games/techniques/2d_collision_detection/index.md
@@ -12,11 +12,11 @@ Algorithms to detect collision in 2D games depend on the type of shapes that can
 
 The demos in this page don't rely on any external library, so we implement all the orchestration ourselves, which includes rendering, handling user input, and invoking behaviors of each entity. The code is shown below (it won't be repeated for each example):
 
-```html
+```html live-sample___box_collision_ex live-sample___circle_collision_ex
 <div id="container"></div>
 ```
 
-```css
+```css live-sample___box_collision_ex live-sample___circle_collision_ex
 .entity {
   display: inline-block;
   position: absolute;
@@ -36,7 +36,7 @@ The demos in this page don't rely on any external library, so we implement all t
 }
 ```
 
-```js
+```js live-sample___box_collision_ex live-sample___circle_collision_ex
 const collider = {
   moveableEntity: null,
   staticEntities: [],
@@ -107,98 +107,7 @@ document.addEventListener("keydown", (e) => {
 
 One of the simpler forms of collision detection is between two rectangles that are axis aligned — meaning no rotation. The algorithm works by ensuring there is no gap between any of the 4 sides of the rectangles. Any gap means a collision does not exist.
 
-```html hidden
-<div id="container"></div>
-```
-
-```css hidden
-.entity {
-  display: inline-block;
-  position: absolute;
-  height: 20px;
-  width: 20px;
-  background-color: blue;
-}
-
-.movable {
-  left: 50px;
-  top: 50px;
-  background-color: red;
-}
-
-.collision-state {
-  background-color: green !important;
-}
-```
-
-```js hidden
-const collider = {
-  moveableEntity: null,
-  staticEntities: [],
-  checkCollision() {
-    // Important: the isCollidingWith method is what we are implementing
-    const isColliding = this.staticEntities.some((staticEntity) =>
-      this.moveableEntity.isCollidingWith(staticEntity),
-    );
-    this.moveableEntity.setCollisionState(isColliding);
-  },
-};
-
-const container = document.getElementById("container");
-
-class BaseEntity {
-  ref;
-  position;
-  constructor(position) {
-    this.position = position;
-    this.ref = document.createElement("div");
-    this.ref.classList.add("entity");
-    this.ref.style.left = `${this.position.x}px`;
-    this.ref.style.top = `${this.position.y}px`;
-    container.appendChild(this.ref);
-  }
-  shiftPosition(dx, dy) {
-    this.position.x += dx;
-    this.position.y += dy;
-    this.redraw();
-  }
-  redraw() {
-    this.ref.style.left = `${this.position.x}px`;
-    this.ref.style.top = `${this.position.y}px`;
-  }
-  setCollisionState(isColliding) {
-    if (isColliding && !this.ref.classList.contains("collision-state")) {
-      this.ref.classList.add("collision-state");
-    } else if (!isColliding) {
-      this.ref.classList.remove("collision-state");
-    }
-  }
-  isCollidingWith(other) {
-    throw new Error("isCollidingWith must be implemented in subclasses");
-  }
-}
-
-document.addEventListener("keydown", (e) => {
-  e.preventDefault();
-  switch (e.key) {
-    case "ArrowLeft":
-      collider.moveableEntity.shiftPosition(-5, 0);
-      break;
-    case "ArrowUp":
-      collider.moveableEntity.shiftPosition(0, -5);
-      break;
-    case "ArrowRight":
-      collider.moveableEntity.shiftPosition(5, 0);
-      break;
-    case "ArrowDown":
-      collider.moveableEntity.shiftPosition(0, 5);
-      break;
-  }
-  collider.checkCollision();
-});
-```
-
-```js
+```js live-sample___box_collision_ex
 class BoxEntity extends BaseEntity {
   width = 20;
   height = 20;
@@ -214,7 +123,7 @@ class BoxEntity extends BaseEntity {
 }
 ```
 
-```js hidden
+```js hidden live-sample___box_collision_ex
 for (let i = 0; i < 100; i++) {
   collider.staticEntities.push(
     new BoxEntity({
@@ -229,110 +138,19 @@ moveableEntity.ref.classList.add("movable");
 collider.moveableEntity = moveableEntity;
 ```
 
-{{EmbedLiveSample("axis-aligned_bounding_box", "", 550)}}
+{{EmbedLiveSample("box_collision_ex", "", 550)}}
 
 ## Circle collision
 
 Another simple shape for collision detection is between two circles. This algorithm works by taking the center points of the two circles and ensuring the distance between the center points are less than the two radii added together.
 
-```html hidden
-<div id="container"></div>
-```
-
-```css hidden
-.entity {
-  display: inline-block;
-  position: absolute;
-  height: 20px;
-  width: 20px;
-  background-color: blue;
-}
-
-.movable {
-  left: 50px;
-  top: 50px;
-  background-color: red;
-}
-
-.collision-state {
-  background-color: green !important;
-}
-```
-
-```css
+```css live-sample___circle_collision_ex
 .entity {
   border-radius: 50%;
 }
 ```
 
-```js hidden
-const collider = {
-  moveableEntity: null,
-  staticEntities: [],
-  checkCollision() {
-    // Important: the isCollidingWith method is what we are implementing
-    const isColliding = this.staticEntities.some((staticEntity) =>
-      this.moveableEntity.isCollidingWith(staticEntity),
-    );
-    this.moveableEntity.setCollisionState(isColliding);
-  },
-};
-
-const container = document.getElementById("container");
-
-class BaseEntity {
-  ref;
-  position;
-  constructor(position) {
-    this.position = position;
-    this.ref = document.createElement("div");
-    this.ref.classList.add("entity");
-    this.ref.style.left = `${this.position.x}px`;
-    this.ref.style.top = `${this.position.y}px`;
-    container.appendChild(this.ref);
-  }
-  shiftPosition(dx, dy) {
-    this.position.x += dx;
-    this.position.y += dy;
-    this.redraw();
-  }
-  redraw() {
-    this.ref.style.left = `${this.position.x}px`;
-    this.ref.style.top = `${this.position.y}px`;
-  }
-  setCollisionState(isColliding) {
-    if (isColliding && !this.ref.classList.contains("collision-state")) {
-      this.ref.classList.add("collision-state");
-    } else if (!isColliding) {
-      this.ref.classList.remove("collision-state");
-    }
-  }
-  isCollidingWith(other) {
-    throw new Error("isCollidingWith must be implemented in subclasses");
-  }
-}
-
-document.addEventListener("keydown", (e) => {
-  e.preventDefault();
-  switch (e.key) {
-    case "ArrowLeft":
-      collider.moveableEntity.shiftPosition(-5, 0);
-      break;
-    case "ArrowUp":
-      collider.moveableEntity.shiftPosition(0, -5);
-      break;
-    case "ArrowRight":
-      collider.moveableEntity.shiftPosition(5, 0);
-      break;
-    case "ArrowDown":
-      collider.moveableEntity.shiftPosition(0, 5);
-      break;
-  }
-  collider.checkCollision();
-});
-```
-
-```js
+```js live-sample___circle_collision_ex
 class CircleEntity extends BaseEntity {
   radius = 10;
 
@@ -347,7 +165,7 @@ class CircleEntity extends BaseEntity {
 }
 ```
 
-```js hidden
+```js hidden live-sample___circle_collision_ex
 for (let i = 0; i < 100; i++) {
   collider.staticEntities.push(
     new CircleEntity({
@@ -365,7 +183,7 @@ collider.moveableEntity = moveableEntity;
 > [!NOTE]
 > The circles' `x` and `y` coordinates refer to their top left corners, so we need to add the radius to compare their centers.
 
-{{EmbedLiveSample("circle_collision", "", 550)}}
+{{EmbedLiveSample("circle_collision_ex", "", 550)}}
 
 ## Separating Axis Theorem
 


### PR DESCRIPTION
Remove existing examples, which use an obscure library, and replace them with the jsfiddle ones, modernized and completely refactored.

Part of https://github.com/mdn/content/issues/16120