### PR TITLE
chore(css): Add short titles for the CSS sidebar

### DIFF
--- a/files/en-us/web/css/@position-try/index.md
+++ b/files/en-us/web/css/@position-try/index.md
@@ -13,7 +13,7 @@ The **`@position-try`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS
 
 Each position option is named with a {{cssxref("dashed-ident")}} and contains a descriptor list specifying declarations that define information such as inset position, margin, sizing, and self-alignment. The `<dashed-ident>` is used to reference the custom position option in the {{cssxref("position-try-fallbacks")}} property and {{cssxref("position-try")}} shorthand.
 
-For detailed information on anchor features and position try fallback usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
+For detailed information on anchor features and position try fallback usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
 
 ## Syntax
 
@@ -234,5 +234,5 @@ In some cases, we need to set values inside the custom position options to turn 
 - The {{cssxref("anchor-size()")}} function
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
 - {{domxref("CSSPositionTryRule")}}

--- a/files/en-us/web/css/_doublecolon_picker/index.md
+++ b/files/en-us/web/css/_doublecolon_picker/index.md
@@ -56,7 +56,7 @@ A further side-effect of the implicit invoker/popover relationship mentioned abo
   position-area: block-end span-inline-end;
   ```
 
-- The browser default styles also define some position-try fallbacks that reposition the picker if it is in danger of overflowing the viewport. Position-try fallbacks are explained in [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding). For reference, the related default fallback styles are as follows:
+- The browser default styles also define some position-try fallbacks that reposition the picker if it is in danger of overflowing the viewport. Position-try fallbacks are explained in the [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide. For reference, the related default fallback styles are as follows:
 
   ```css
   position-try-order: most-block-size;

--- a/files/en-us/web/css/anchor/index.md
+++ b/files/en-us/web/css/anchor/index.md
@@ -551,5 +551,5 @@ The positioned element is positioned relative to both anchor elements. Drag them
 - {{cssxref("position-area")}}
 - {{cssxref("anchor-size()")}} function
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module

--- a/files/en-us/web/css/background-size/index.md
+++ b/files/en-us/web/css/background-size/index.md
@@ -205,5 +205,5 @@ See [Resizing background images](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders
 ## See also
 
 - [Resizing background images](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Resizing_background_images)
-- [Scaling of SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)
+- [Scaling SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)
 - {{cssxref("object-fit")}}

--- a/files/en-us/web/css/css_anchor_positioning/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/index.md
@@ -63,7 +63,7 @@ In addition, the specification provides CSS-only mechanisms to:
 
   - : An introductory guide to fundamental anchor positioning concepts, including associating, positioning, and sizing elements relative to their anchor.
 
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding)
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding)
 
   - : A guide to the mechanisms CSS anchor positioning provides to prevent anchor-positioned elements from overflowing their containing elements or the viewport, including position try fallback options and conditionally hiding elements.
 

--- a/files/en-us/web/css/css_anchor_positioning/try_options_hiding/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/try_options_hiding/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Handling overflow: try fallbacks and conditional hiding"
+title: Fallback options and conditional hiding for overflow
+short-title: Handling overflow
 slug: Web/CSS/CSS_anchor_positioning/Try_options_hiding
 page-type: guide
 ---

--- a/files/en-us/web/css/css_anchor_positioning/using/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/using/index.md
@@ -788,7 +788,7 @@ Try tabbing to the anchor or hovering over it with the mouse pointer, and note h
 ## See also
 
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module
-- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding)
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
 - [Learn: Positioning](/en-US/docs/Learn_web_development/Core/CSS_layout/Positioning)
 - [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module
 - [Learn: Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing)

--- a/files/en-us/web/css/css_anchor_positioning/using/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/using/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS anchor positioning
+short-title: Using anchor positioning
 slug: Web/CSS/CSS_anchor_positioning/Using
 page-type: guide
 ---
@@ -10,7 +11,7 @@ The **CSS anchor positioning** module defines features that allow you to tether 
 
 CSS anchor positioning also provides CSS-only mechanisms for specifying multiple alternative positions for an anchor-positioned element. For example, if a tooltip is anchored to a form field but the tooltip would otherwise be rendered offscreen in its default position settings, the browser can try rendering it in a different suggested position so it is placed onscreen, or, alternatively, hide it altogether if desired.
 
-This article explains the fundamental anchor positioning concepts, and how to use the module's association, positioning, and sizing features at a basic level. We've included links to reference pages with additional examples and syntax details for each concept discussed below. For information on specifying alternative positions and hiding anchor-positioned elements, see [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding).
+This article explains the fundamental anchor positioning concepts, and how to use the module's association, positioning, and sizing features at a basic level. We've included links to reference pages with additional examples and syntax details for each concept discussed below. For information on specifying alternative positions and hiding anchor-positioned elements, see the [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
 
 ## Fundamental concepts
 
@@ -787,7 +788,7 @@ Try tabbing to the anchor or hovering over it with the mouse pointer, and note h
 ## See also
 
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding)
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding)
 - [Learn: Positioning](/en-US/docs/Learn_web_development/Core/CSS_layout/Positioning)
 - [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module
 - [Learn: Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing)

--- a/files/en-us/web/css/css_animated_properties/index.md
+++ b/files/en-us/web/css/css_animated_properties/index.md
@@ -1,5 +1,6 @@
 ---
 title: Animatable CSS properties
+short-title: Animatable properties
 slug: Web/CSS/CSS_animated_properties
 page-type: landing-page
 ---

--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS animations
+short-title: Using animations
 slug: Web/CSS/CSS_animations/Using_CSS_animations
 page-type: guide
 ---

--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -145,7 +145,7 @@ Click "Play" in the example above to see or edit the code for the animation in t
   - : Setting one or more backgrounds on an element.
 - [Resizing background images](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Resizing_background_images)
   - : Changing the size and repeating behavior of background images.
-- [Scaling of SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)
+- [Scaling SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)
   - : How SVG aspect ratio, SVG dimension values, and the CSS `background-size` property impact the scaling of SVG background images.
 - [Using CSS gradients](/en-US/docs/Web/CSS/CSS_images/Using_CSS_gradients)
   - : Creating CSS gradients and using them as background images.

--- a/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
@@ -135,4 +135,4 @@ The `cover` value specifies that the background image should be sized so that it
 
 - {{cssxref("background-size")}}
 - {{cssxref("background")}}
-- [Scaling SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)
+- [Scaling SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds) guide

--- a/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
@@ -135,4 +135,4 @@ The `cover` value specifies that the background image should be sized so that it
 
 - {{cssxref("background-size")}}
 - {{cssxref("background")}}
-- [Scaling of SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)
+- [Scaling SVG backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds)

--- a/files/en-us/web/css/css_backgrounds_and_borders/scaling_of_svg_backgrounds/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/scaling_of_svg_backgrounds/index.md
@@ -1,5 +1,5 @@
 ---
-title: Scaling of SVG backgrounds
+title: Scaling SVG backgrounds
 slug: Web/CSS/CSS_backgrounds_and_borders/Scaling_of_SVG_backgrounds
 page-type: guide
 ---

--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -1,5 +1,6 @@
 ---
-title: Introduction to the CSS basic box model
+title: Introduction to the CSS box model
+short-title: Introduction
 slug: Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model
 page-type: guide
 ---

--- a/files/en-us/web/css/css_cascade/cascade/index.md
+++ b/files/en-us/web/css/css_cascade/cascade/index.md
@@ -1,5 +1,6 @@
 ---
-title: Introducing the CSS Cascade
+title: Introduction to the CSS cascade
+short-title: Introduction
 slug: Web/CSS/CSS_cascade/Cascade
 page-type: guide
 spec-urls: https://drafts.csswg.org/css-cascade/

--- a/files/en-us/web/css/css_cascade/value_processing/index.md
+++ b/files/en-us/web/css/css_cascade/value_processing/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS property value processing
+short-title: Property value processing
 slug: Web/CSS/CSS_cascade/Value_processing
 page-type: guide
 ---
@@ -26,10 +27,16 @@ After applying the cascading rules and resolving values step by step, the browse
 
 All elements that are part of the document's flattened element tree have declared, cascaded, specified, computed, used, and actual values. For a specific property, these values may or may not be the same. For example, if your large code base includes the CSS `p { font-size: 1.25em; }` and your HTML includes `<p>CSS is fun!</p>`, what size will the paragraph be? The {{cssxref("font-size")}} value moves through a few stages to go from the `em` specified value to the rendered `px` value.
 
-- [Initial value](#initial_value)
-- [Specified value](#specified_value)
-- [Computed value](#computed_value)
-- [Used Value](#used_value)
+- [Property values](#property-values)
+- [Processing stages](#processing-stages)
+  - [Initial value](#initial-value)
+  - [Specified value](#specified-value)
+  - [Computed value](#computed-value)
+  - [Used value](#used-value)
+- [Rendered values](#rendered-values)
+  - [Actual Value](#actual-value)
+  - [Resolved value](#resolved-value)
+- [See also](#see-also)
 
 These values are used to determine the final [rendered value](#rendered_values).
 

--- a/files/en-us/web/css/css_cascading_variables/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/css_cascading_variables/using_css_custom_properties/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS custom properties (variables)
+short-title: Using custom properties
 slug: Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties
 page-type: guide
 ---

--- a/files/en-us/web/css/css_containment/container_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_queries/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS container queries
+short-title: Container queries
 slug: Web/CSS/CSS_containment/Container_queries
 page-type: guide
 ---

--- a/files/en-us/web/css/css_containment/using_css_containment/index.md
+++ b/files/en-us/web/css/css_containment/using_css_containment/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS containment
+short-title: Using containment
 slug: Web/CSS/CSS_containment/Using_CSS_containment
 page-type: guide
 ---

--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS counters
+short-title: Using counters
 slug: Web/CSS/CSS_counter_styles/Using_CSS_counters
 page-type: guide
 spec-urls: https://drafts.csswg.org/css-lists/#auto-numbering

--- a/files/en-us/web/css/css_display/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/en-us/web/css/css_display/block_and_inline_layout_in_normal_flow/index.md
@@ -1,5 +1,6 @@
 ---
 title: Block and inline layout in normal flow
+short-title: Block and inline layout
 slug: Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
 page-type: guide
 ---

--- a/files/en-us/web/css/css_display/flow_layout/index.md
+++ b/files/en-us/web/css/css_display/flow_layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS flow layout
+short-title: Flow layout
 slug: Web/CSS/CSS_display/Flow_layout
 page-type: guide
 ---

--- a/files/en-us/web/css/css_display/introduction_to_formatting_contexts/index.md
+++ b/files/en-us/web/css/css_display/introduction_to_formatting_contexts/index.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to formatting contexts
+short-title: Formatting contexts
 slug: Web/CSS/CSS_display/Introduction_to_formatting_contexts
 page-type: guide
 ---

--- a/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
+++ b/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using the multi-keyword syntax with CSS display
+short-title: Using multi-keyword syntax
 slug: Web/CSS/CSS_display/multi-keyword_syntax_of_display
 page-type: guide
 ---

--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -1,5 +1,6 @@
 ---
 title: Aligning items in a flex container
+short-title: Aligning flex items
 slug: Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container
 page-type: guide
 ---

--- a/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -1,5 +1,6 @@
 ---
 title: Basic concepts of flexbox
+short-title: Basic concepts
 slug: Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox
 page-type: guide
 ---

--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
@@ -1,5 +1,6 @@
 ---
 title: Controlling ratios of flex items along the main axis
+short-title: Controlling flex item ratios
 slug: Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis
 page-type: guide
 ---

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -1,5 +1,6 @@
 ---
 title: Mastering wrapping of flex items
+short-title: Wrapping flex items
 slug: Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items
 page-type: guide
 ---

--- a/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -1,12 +1,13 @@
 ---
 title: Relationship of flexbox to other layout methods
+short-title: Flexbox and other layouts
 slug: Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods
 page-type: guide
 ---
 
 {{CSSRef}}
 
-In this article we will take a look at how flexbox fits in with all the other CSS modules. We'll find out which specifications you also need to take notice of if you want to learn flexbox, and find out why flexbox is different to some other modules.
+In this article, we will take a look at how flexbox fits in with all the other CSS modules. We'll find out which specifications you also need to take notice of if you want to learn flexbox, and find out why flexbox is different to some other modules.
 
 ## The box alignment module
 

--- a/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -1,5 +1,6 @@
 ---
 title: Typical use cases of flexbox
+short-title: Typical use cases
 slug: Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox
 page-type: guide
 ---

--- a/files/en-us/web/css/css_fonts/index.md
+++ b/files/en-us/web/css/css_fonts/index.md
@@ -150,11 +150,11 @@ The specification also defines the `font-language-override`, `font-named-instanc
 
   - : This beginner's learning article explains how to use custom fonts on your web page to allow for more varied and custom text styling.
 
-- [OpenType font features guide](/en-US/docs/Web/CSS/CSS_fonts/OpenType_fonts_guide)
+- [OpenType font features](/en-US/docs/Web/CSS/CSS_fonts/OpenType_fonts_guide)
 
   - : Font features or variants refer to different glyphs or character styles contained within an OpenType font. These include things like ligatures (special glyphs that combine characters like 'fi' or 'ffl'), kerning (adjustments to the spacing between specific letterform pairings), fractions, numeral styles, and a number of others. These are all referred to as OpenType Features, and are made available to use on the web via specific properties and a low-level control property — {{cssxref("font-feature-settings")}}. This article provides you with all you need to know about using OpenType font features in CSS.
 
-- [Variable fonts guide](/en-US/docs/Web/CSS/CSS_fonts/Variable_fonts_guide)
+- [Variable fonts](/en-US/docs/Web/CSS/CSS_fonts/Variable_fonts_guide)
 
   - : This article will help you get started with using variable fonts.
 

--- a/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: OpenType font features guide
+title: OpenType font features
 slug: Web/CSS/CSS_fonts/OpenType_fonts_guide
 page-type: guide
 ---

--- a/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -1,5 +1,6 @@
 ---
 title: OpenType font features
+short-title: OpenType features
 slug: Web/CSS/CSS_fonts/OpenType_fonts_guide
 page-type: guide
 ---

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: Variable fonts guide
+title: Variable fonts
 slug: Web/CSS/CSS_fonts/Variable_fonts_guide
 page-type: guide
 ---

--- a/files/en-us/web/css/css_fonts/woff/index.md
+++ b/files/en-us/web/css/css_fonts/woff/index.md
@@ -1,5 +1,5 @@
 ---
-title: The Web Open Font Format (WOFF)
+title: Web Open Font Format (WOFF)
 short-title: Web Open Font Format (WOFF)
 slug: Web/CSS/CSS_fonts/WOFF
 page-type: guide

--- a/files/en-us/web/css/css_fonts/woff/index.md
+++ b/files/en-us/web/css/css_fonts/woff/index.md
@@ -1,6 +1,6 @@
 ---
 title: Web Open Font Format (WOFF)
-short-title: Web Open Font Format (WOFF)
+short-title: WOFF
 slug: Web/CSS/CSS_fonts/WOFF
 page-type: guide
 browser-compat:

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_grid_layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: Auto-placement in grid layout
+short-title: Auto-placement
 slug: Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: Basic concepts of grid layout
+short-title: Basic concepts
 slug: Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_grid_layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: Aligning items in CSS grid layout
+short-title: Aligning items
 slug: Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -1,5 +1,6 @@
 ---
 title: Grid layout using line-based placement
+short-title: Using line-based placement
 slug: Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_named_grid_lines/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_named_grid_lines/index.md
@@ -1,5 +1,6 @@
 ---
 title: Layout using named grid lines
+short-title: Using named grid lines
 slug: Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Grids, logical values, and writing modes
+short-title: Logical grids and writing modes
 slug: Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
@@ -1,6 +1,6 @@
 ---
 title: Grids, logical values, and writing modes
-short-title: Logical grids and writing modes
+short-title: Logical values and writing modes
 slug: Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
@@ -1,5 +1,6 @@
 ---
 title: Realizing common layouts using grids
+short-title: Common grid layouts
 slug: Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids
 page-type: guide
 ---

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout_with_other_layout_methods/index.md
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout_with_other_layout_methods/index.md
@@ -1,5 +1,6 @@
 ---
 title: Relationship of grid layout to other layout methods
+short-title: Grid and other layouts
 slug: Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods
 page-type: guide
 ---

--- a/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -1,5 +1,6 @@
 ---
 title: Implementing image sprites in CSS
+short-title: Implementing image sprites
 slug: Web/CSS/CSS_images/Implementing_image_sprites_in_CSS
 page-type: guide
 ---

--- a/files/en-us/web/css/css_images/using_css_gradients/index.md
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS gradients
+short-title: Using gradients
 slug: Web/CSS/CSS_images/Using_CSS_gradients
 page-type: guide
 ---

--- a/files/en-us/web/css/css_lists/consistent_list_indentation/index.md
+++ b/files/en-us/web/css/css_lists/consistent_list_indentation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Consistent list indentation
+short-title: Indenting lists
 slug: Web/CSS/CSS_lists/Consistent_list_indentation
 page-type: guide
 ---
@@ -10,9 +11,9 @@ One of the most common style changes made to lists is a change in the indentatio
 
 To understand why this is the case, and more importantly how to avoid the problem altogether, it's necessary to examine the details of list construction.
 
-## Making a List
+## Creating a list
 
-### The stand-alone list item
+### Stand-alone list item
 
 First, we consider the pure list item, not nested in a list of items. When using the HTML {{htmlelement("li")}} element, the browser sets the {{cssxref("display")}} value to `list-item`. Whether list items not nested in a list are provided a marker (otherwise known as a "bullet") depends on the browser. We can remove that bullet with {{cssxref("list-style-type", "list-style-type: none")}}.
 
@@ -46,7 +47,7 @@ li {
 
 That dotted red border represents the outer edges of the content area of each list item. At this point, the list items have no padding or borders.
 
-### List items nested in a list
+### Nested list items
 
 Now we wrap these in a parent element; in this case, we'll wrap them in an unordered list (i.e., `<ul>`). According to the CSS box model, the list items' boxes must be displayed within the parent element's content area.
 

--- a/files/en-us/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
+++ b/files/en-us/web/css/css_logical_properties_and_values/basic_concepts_of_logical_properties_and_values/index.md
@@ -1,5 +1,6 @@
 ---
 title: Basic concepts of logical properties and values
+short-title: Basic concepts
 slug: Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values
 page-type: guide
 ---

--- a/files/en-us/web/css/css_logical_properties_and_values/sizing/index.md
+++ b/files/en-us/web/css/css_logical_properties_and_values/sizing/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{CSSRef}}
 
-In this guide we will explain the flow-relative mappings between physical dimension properties and logical properties used for sizing elements on our pages.
+In this guide, we will explain the flow-relative mappings between physical dimension properties and logical properties used for sizing elements on our pages.
 
 When specifying the size of an item, the [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module gives you the ability to indicate sizing as it relates to the flow of text (inline and block) rather than physical sizing which relates to the physical dimensions of horizontal and vertical (e.g., left and right). While these flow relative mappings may well become the default for many of us, in a design you may well use both physical and logical sizing. You might want some features to always relate to the physical dimensions whatever the writing mode.
 

--- a/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
+++ b/files/en-us/web/css/css_multicol_layout/basic_concepts/index.md
@@ -1,5 +1,6 @@
 ---
-title: Basic concepts of multi-column layout
+title: Basic concepts of multi-column layouts
+short-title: Basic concepts
 slug: Web/CSS/CSS_multicol_layout/Basic_concepts
 page-type: guide
 ---

--- a/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: Handling content breaks in multi-column layout
+short-title: Handling content breaks
 slug: Web/CSS/CSS_multicol_layout/Handling_content_breaks_in_multicol_layout
 page-type: guide
 ---

--- a/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: Handling overflow in multi-column layout
+short-title: Handling overflow
 slug: Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout
 page-type: guide
 ---

--- a/files/en-us/web/css/css_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/index.md
@@ -296,18 +296,18 @@ blockquote p::after {
 
 ## Guides
 
-- [Basic concepts of multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/Basic_concepts)
-  - : An overview of the Multiple-column Layout specification
+- [Basic concepts of multi-column layouts](/en-US/docs/Web/CSS/CSS_multicol_layout/Basic_concepts)
+  - : Overview of the multiple-column layout specification.
 - [Using multi-column layouts](/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts)
-  - : Guide to using multi-column properties to layout out text.
+  - : Guide to using multi-column properties for laying out text.
 - [Styling columns](/en-US/docs/Web/CSS/CSS_multicol_layout/Styling_columns)
-  - : How to use column rules and manage the spacing between columns.
+  - : Guide to styling columns and managing spacing between columns.
 - [Spanning and balancing](/en-US/docs/Web/CSS/CSS_multicol_layout/Spanning_balancing_columns)
   - : How to make elements span across all columns and control the way columns are filled.
 - [Handling overflow in multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_overflow_in_multicol_layout)
   - : What happens when an item overflows the column it is in and what happens when there is too much columned content to fit a container.
 - [Handling content breaks in multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/Handling_content_breaks_in_multicol_layout)
-  - : Introduction to the Fragmentation specification and how to control where column content breaks.
+  - : Introduction to the fragmentation specification and how to control where column content breaks.
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_nesting/nesting_and_specificity/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_and_specificity/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS nesting and specificity
+short-title: Nesting and specificity
 slug: Web/CSS/CSS_nesting/Nesting_and_specificity
 page-type: guide
 ---

--- a/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS nesting at-rules
+short-title: Nesting at-rules
 slug: Web/CSS/CSS_nesting/Nesting_at-rules
 page-type: guide
 ---

--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS nesting
+short-title: Using nesting
 slug: Web/CSS/CSS_nesting/Using_CSS_nesting
 page-type: guide
 ---

--- a/files/en-us/web/css/css_overflow/css_carousels/index.md
+++ b/files/en-us/web/css/css_overflow/css_carousels/index.md
@@ -1,5 +1,6 @@
 ---
 title: Creating CSS carousels
+short-title: Creating carousels
 slug: Web/CSS/CSS_overflow/CSS_carousels
 page-type: guide
 ---

--- a/files/en-us/web/css/css_positioned_layout/stacking_without_z-index/index.md
+++ b/files/en-us/web/css/css_positioned_layout/stacking_without_z-index/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stacking without the z-index property
+short-title: Stacking without z-index
 slug: Web/CSS/CSS_positioned_layout/Stacking_without_z-index
 page-type: guide
 ---

--- a/files/en-us/web/css/css_scroll_anchoring/index.md
+++ b/files/en-us/web/css/css_scroll_anchoring/index.md
@@ -26,7 +26,7 @@ For scroll containers that are [snapped](/en-US/docs/Glossary/Scroll_snap) to an
 
 ## Guides
 
-- [Understanding scroll anchoring](/en-US/docs/Web/CSS/CSS_scroll_anchoring/Scroll_anchoring)
+- [Overview of scroll anchoring(/en-US/docs/Web/CSS/CSS_scroll_anchoring/Scroll_anchoring)
   - : What is scroll anchoring, suppression triggers, and when and how to enable and disable this browser feature.
 
 ## Related concepts

--- a/files/en-us/web/css/css_scroll_anchoring/scroll_anchoring/index.md
+++ b/files/en-us/web/css/css_scroll_anchoring/scroll_anchoring/index.md
@@ -1,5 +1,6 @@
 ---
-title: Understanding scroll anchoring
+title: Overview of scroll anchoring
+short-title: Overview
 slug: Web/CSS/CSS_scroll_anchoring/Scroll_anchoring
 page-type: guide
 browser-compat: css.properties.overflow-anchor

--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -1,5 +1,6 @@
 ---
 title: Basic concepts of scroll snap
+short-title: Basic concepts
 slug: Web/CSS/CSS_scroll_snap/Basic_concepts
 page-type: guide
 ---

--- a/files/en-us/web/css/css_selectors/privacy_and_the_visited_selector/index.md
+++ b/files/en-us/web/css/css_selectors/privacy_and_the_visited_selector/index.md
@@ -1,5 +1,6 @@
 ---
 title: Privacy and the :visited selector
+short-title: Using :visited
 slug: Web/CSS/CSS_selectors/Privacy_and_the_visited_selector
 page-type: guide
 ---

--- a/files/en-us/web/css/css_selectors/privacy_and_the_visited_selector/index.md
+++ b/files/en-us/web/css/css_selectors/privacy_and_the_visited_selector/index.md
@@ -1,6 +1,6 @@
 ---
 title: Privacy and the :visited selector
-short-title: Using :visited
+short-title: Privacy and :visited
 slug: Web/CSS/CSS_selectors/Privacy_and_the_visited_selector
 page-type: guide
 ---

--- a/files/en-us/web/css/css_selectors/selector_structure/index.md
+++ b/files/en-us/web/css/css_selectors/selector_structure/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS selector structure
+short-title: Selector structure
 slug: Web/CSS/CSS_selectors/Selector_structure
 page-type: guide
 spec-urls: https://drafts.csswg.org/selectors/

--- a/files/en-us/web/css/css_selectors/selectors_and_combinators/index.md
+++ b/files/en-us/web/css/css_selectors/selectors_and_combinators/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS selectors and combinators
+short-title: Selectors and combinators
 slug: Web/CSS/CSS_selectors/Selectors_and_combinators
 page-type: guide
 spec-urls:

--- a/files/en-us/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using the :target pseudo-class in selectors
+short-title: Using :target
 slug: Web/CSS/CSS_selectors/Using_the_:target_pseudo-class_in_selectors
 page-type: guide
 ---

--- a/files/en-us/web/css/css_shapes/basic_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/basic_shapes/index.md
@@ -1,12 +1,13 @@
 ---
 title: Basic shapes with shape-outside
+short-title: Using shape-outside
 slug: Web/CSS/CSS_shapes/Basic_shapes
 page-type: guide
 ---
 
 {{CSSRef}}
 
-CSS Shapes can be defined using the {{cssxref("&lt;basic-shape&gt;")}} type. In this guide, we discuss creating rectangles, circles, ellipses, and polygons with the {{cssxref("shape-outside")}} property. These are features defined in the [CSS shapes module](/en-US/docs/Web/CSS/CSS_shapes).
+CSS shapes can be defined using the {{cssxref("&lt;basic-shape&gt;")}} type. In this guide, we discuss creating rectangles, circles, ellipses, and polygons with the {{cssxref("shape-outside")}} property. These are features defined in the [CSS shapes module](/en-US/docs/Web/CSS/CSS_shapes).
 
 Before looking at shapes, it is worth understanding two pieces of information that go together to make these shapes possible:
 

--- a/files/en-us/web/css/css_shapes/from_box_values/index.md
+++ b/files/en-us/web/css/css_shapes/from_box_values/index.md
@@ -1,12 +1,13 @@
 ---
 title: Shapes from box values
+short-title: Box-value shapes
 slug: Web/CSS/CSS_shapes/From_box_values
 page-type: guide
 ---
 
 {{CSSRef}}
 
-A straightforward way to create a shape is to use a value from the [CSS Box Model](/en-US/docs/Web/CSS/CSS_box_model) module. This article explains how to do this.
+A straightforward way to create a shape is to use a value from the [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module. This article explains how to do this.
 
 The {{cssxref("box-edge")}} box values allowable as a shape value are:
 

--- a/files/en-us/web/css/css_shapes/overview_of_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/overview_of_shapes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of shapes
+short-title: Overview
 slug: Web/CSS/CSS_shapes/Overview_of_shapes
 page-type: guide
 ---

--- a/files/en-us/web/css/css_shapes/shapes_from_images/index.md
+++ b/files/en-us/web/css/css_shapes/shapes_from_images/index.md
@@ -1,5 +1,6 @@
 ---
 title: Shapes from images
+short-title: Image-based shapes
 slug: Web/CSS/CSS_shapes/Shapes_from_images
 page-type: guide
 ---

--- a/files/en-us/web/css/css_syntax/at-rule_functions/index.md
+++ b/files/en-us/web/css/css_syntax/at-rule_functions/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS at-rule functions
+short-title: At-rule functions
 slug: Web/CSS/CSS_syntax/At-rule_functions
 page-type: guide
 ---

--- a/files/en-us/web/css/css_syntax/error_handling/index.md
+++ b/files/en-us/web/css/css_syntax/error_handling/index.md
@@ -1,5 +1,6 @@
 ---
 title: CSS error handling
+short-title: Error handling
 slug: Web/CSS/CSS_syntax/Error_handling
 page-type: guide
 ---

--- a/files/en-us/web/css/css_syntax/index.md
+++ b/files/en-us/web/css/css_syntax/index.md
@@ -48,9 +48,9 @@ This module doesn't define any properties, [data types](/en-US/docs/Web/CSS/CSS_
 
   - : Explains the formal grammar for defining valid values for CSS properties and functions, along with semantic constraints. A guide for understanding CSS component value types, combinators, and multipliers.
 
-- [CSS syntax error handling](/en-US/docs/Web/CSS/CSS_syntax/Error_handling)
+- [CSS error handling](/en-US/docs/Web/CSS/CSS_syntax/Error_handling)
 
-  - : Overview of how the user agent handles invalid CSS.
+  - : Overview of how browsers handle invalid CSS.
 
 - [Learn CSS first steps: CSS syntax](/en-US/docs/Learn_web_development/Core/Styling_basics/What_is_CSS#css_syntax_basics)
 

--- a/files/en-us/web/css/css_syntax/index.md
+++ b/files/en-us/web/css/css_syntax/index.md
@@ -40,9 +40,9 @@ This module doesn't define any properties, [data types](/en-US/docs/Web/CSS/CSS_
 
 ## Guides
 
-- [Syntax](/en-US/docs/Web/CSS/CSS_syntax/Syntax)
+- [Introduction to CSS syntax: declarations, rulesets, and statements](/en-US/docs/Web/CSS/CSS_syntax/Syntax)
 
-  - : Overview of CSS syntax, including CSS declarations, declaration blocks, rulesets, and statements.
+  - : Explains the overall CSS syntax and how declarations, declaration blocks, rulesets, and statements form the style rules.
 
 - [Value definition syntax](/en-US/docs/Web/CSS/CSS_Values_and_Units/Value_definition_syntax)
 

--- a/files/en-us/web/css/css_syntax/syntax/index.md
+++ b/files/en-us/web/css/css_syntax/syntax/index.md
@@ -1,5 +1,5 @@
 ---
-title: Syntax
+title: "Introduction to CSS syntax: declarations, rulesets, and statements"
 short-title: Introduction
 slug: Web/CSS/CSS_syntax/Syntax
 page-type: guide

--- a/files/en-us/web/css/css_syntax/syntax/index.md
+++ b/files/en-us/web/css/css_syntax/syntax/index.md
@@ -1,5 +1,6 @@
 ---
 title: Syntax
+short-title: Introduction
 slug: Web/CSS/CSS_syntax/Syntax
 page-type: guide
 ---

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS transforms
+short-title: Using transforms
 slug: Web/CSS/CSS_transforms/Using_CSS_transforms
 page-type: guide
 ---

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS transitions
+short-title: Using transitions
 slug: Web/CSS/CSS_transitions/Using_CSS_transitions
 page-type: guide
 spec-urls: https://drafts.csswg.org/css-transitions/

--- a/files/en-us/web/css/css_values_and_units/using_css_math_functions/index.md
+++ b/files/en-us/web/css/css_values_and_units/using_css_math_functions/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using CSS math functions
+short-title: Using math functions
 slug: Web/CSS/CSS_Values_and_Units/Using_CSS_math_functions
 page-type: guide
 ---

--- a/files/en-us/web/css/cssom_view/viewport_concepts/index.md
+++ b/files/en-us/web/css/cssom_view/viewport_concepts/index.md
@@ -1,5 +1,6 @@
 ---
 title: Viewport concepts
+short-title: Viewports
 slug: Web/CSS/CSSOM_view/Viewport_concepts
 page-type: guide
 ---
@@ -143,7 +144,7 @@ Generally, when you write the above media query, the styles are applied if the v
 
 The [Visual Viewport API](/en-US/docs/Web/API/Visual_Viewport_API) provides a mechanism for querying and modifying the properties of the visual viewport.
 
-## Mobile Viewports
+## Mobile viewports
 
 Mobile devices come in all shapes and sizes, with screens of differing {{glossary("device pixel")}} ratios. The mobile browser's viewport is the area of the window in which web content can be seen, which is not necessarily the same size as the rendered page. Mobile browsers render pages in a virtual window or viewport, generally at 980px, which is usually wider than the screen, and then shrink the rendered result down so it can all be seen at once. Users can then pan and zoom to see different areas of the page. For example, if a mobile screen has a width of 320px, a website might be rendered with a virtual viewport of 980px, and then it will be shrunk down to fit into the 320px space, which, depending on the design, is illegible for many if not everyone. To tell a mobile browser to use the viewport width instead of the default 980px as the width of the screen, developers can include a viewport meta tag, like the following:
 

--- a/files/en-us/web/css/cssom_view/viewport_concepts/index.md
+++ b/files/en-us/web/css/cssom_view/viewport_concepts/index.md
@@ -1,6 +1,5 @@
 ---
 title: Viewport concepts
-short-title: Viewports
 slug: Web/CSS/CSSOM_view/Viewport_concepts
 page-type: guide
 ---

--- a/files/en-us/web/css/font-variation-settings/index.md
+++ b/files/en-us/web/css/font-variation-settings/index.md
@@ -137,7 +137,7 @@ To use variable fonts on your operating system, you need to make sure that it is
 
 ## Examples
 
-You can find a number of other variable font examples in our [Variable fonts guide](/en-US/docs/Web/CSS/CSS_fonts/Variable_fonts_guide).
+You can find a number of other variable font examples in our [Variable fonts](/en-US/docs/Web/CSS/CSS_fonts/Variable_fonts_guide) guide.
 
 ### Controlling variable font weight (wght)
 

--- a/files/en-us/web/css/guides/index.md
+++ b/files/en-us/web/css/guides/index.md
@@ -23,7 +23,7 @@ If you are not using a flex or grid layout, then your content is laid out using 
   - : How flow layout works if you use a different writing mode, such as vertical text.
 - [Flow layout and overflow](/en-US/docs/Web/CSS/CSS_display/Flow_layout_and_overflow)
   - : Understanding and managing overflow.
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
   - : Understanding the box model is a CSS fundamental; this guide explains how it works.
 - [Mastering margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - : Find out why you sometimes end up with less margin than you expect, due to margin collapsing in normal flow.

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -226,5 +226,5 @@ div {
 - {{cssxref("clamp", "clamp()")}}
 - {{cssxref("clamp", "minmax()")}}
 - SVG {{SVGAttr("height")}} attribute
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
@@ -29,13 +29,17 @@ A recipe consists of:
 
 ## Steps to publish a recipe
 
-To create a recipe and add it to the CSS Layout Cookbook, follow these steps:
+To create a recipe and add it to the CSS layout cookbook, follow these steps:
 
-1. [Build a pattern](#1._build_a_pattern)
-2. [Create a live example](#2._create_a_live_example)
-3. [Create a downloadable version](#3._create_a_downloadable_version)
-4. [Open a pull request](#4._open_a_pull_request_with_your_example)
-5. [Add your content to MDN](#5._create_your_page)
+- [What makes a good recipe?](#what-makes-a-good-recipe)
+- [Steps to publish a recipe](#steps-to-publish-a-recipe)
+  - [1. Build a pattern](#1-build-a-pattern)
+  - [2. Create a live example](#2-create-a-live-example)
+    - [Useful tips](#useful-tips)
+  - [3. Create a downloadable version](#3-create-a-downloadable-version)
+  - [4. Open a pull request with your example](#4-open-a-pull-request-with-your-example)
+  - [5. Create your page](#5-create-your-page)
+- [See also](#see-also)
 
 ### 1. Build a pattern
 

--- a/files/en-us/web/css/layout_cookbook/index.md
+++ b/files/en-us/web/css/layout_cookbook/index.md
@@ -1,5 +1,6 @@
 ---
-title: CSS Layout cookbook
+title: CSS layout cookbook
+short-title: Layout cookbook
 slug: Web/CSS/Layout_cookbook
 page-type: landing-page
 ---

--- a/files/en-us/web/css/margin/index.md
+++ b/files/en-us/web/css/margin/index.md
@@ -220,5 +220,5 @@ margin: auto; /* top and bottom: 0 margin     */
 - {{cssxref("margin-block-start")}}, {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}}, and {{cssxref("margin-inline-end")}}
 - {{cssxref("margin-block")}} and {{cssxref("margin-inline")}} shorthands
 - [Mastering margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -142,5 +142,5 @@ form {
 - {{cssxref("max-inline-size")}}
 - {{cssxref("max-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -142,5 +142,5 @@ form {
 - {{cssxref("max-inline-size")}}
 - {{cssxref("max-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -163,5 +163,5 @@ In this example, the "child" will be either 150 pixels wide or the width of the 
 - {{cssxref("max-inline-size")}}
 - {{cssxref("max-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -163,5 +163,5 @@ In this example, the "child" will be either 150 pixels wide or the width of the 
 - {{cssxref("max-inline-size")}}
 - {{cssxref("max-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/min-height/index.md
+++ b/files/en-us/web/css/min-height/index.md
@@ -135,5 +135,5 @@ form {
 - {{cssxref("min-inline-size")}}
 - {{cssxref("min-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/min-height/index.md
+++ b/files/en-us/web/css/min-height/index.md
@@ -135,5 +135,5 @@ form {
 - {{cssxref("min-inline-size")}}
 - {{cssxref("min-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/min-width/index.md
+++ b/files/en-us/web/css/min-width/index.md
@@ -138,5 +138,5 @@ form {
 - {{cssxref("min-inline-size")}}
 - {{cssxref("min-block-size")}}
 - {{cssxref("box-sizing")}}
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/overflow-anchor/index.md
+++ b/files/en-us/web/css/overflow-anchor/index.md
@@ -155,5 +155,5 @@ To prevent scroll anchoring in a document, use the `overflow-anchor` property.
 
 ## See also
 
-- [Understanding scroll anchoring](/en-US/docs/Web/CSS/CSS_scroll_anchoring/Scroll_anchoring)
+- [Overview of scroll anchoring](/en-US/docs/Web/CSS/CSS_scroll_anchoring/Scroll_anchoring)
 - [CSS scroll anchoring](/en-US/docs/Web/CSS/CSS_scroll_anchoring) module

--- a/files/en-us/web/css/padding-bottom/index.md
+++ b/files/en-us/web/css/padding-bottom/index.md
@@ -124,5 +124,5 @@ The `padding-bottom` property is specified as a single value chosen from the lis
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
-- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-bottom/index.md
+++ b/files/en-us/web/css/padding-bottom/index.md
@@ -124,5 +124,5 @@ The `padding-bottom` property is specified as a single value chosen from the lis
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-right/index.md
+++ b/files/en-us/web/css/padding-right/index.md
@@ -122,5 +122,5 @@ The `padding-right` property is specified as a single value chosen from the list
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding-top/index.md
+++ b/files/en-us/web/css/padding-top/index.md
@@ -124,5 +124,5 @@ The `padding-top` property is specified as a single value chosen from the list b
 - {{cssxref("padding")}} shorthand
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/padding/index.md
+++ b/files/en-us/web/css/padding/index.md
@@ -175,5 +175,5 @@ padding: 1em 3px 30px 5px; /* top:    1em padding  */
 - {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}}, and {{cssxref("padding-left")}}
 - {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}}, {{cssxref("padding-inline-start")}}, and {{cssxref("padding-inline-end")}}
 - {{cssxref("padding-block")}} and {{cssxref("padding-inline")}} shorthands
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/position-area/index.md
+++ b/files/en-us/web/css/position-area/index.md
@@ -435,5 +435,5 @@ Try selecting new `position-area` values from the `<select>` menu to see the eff
 - The [`anchor()`](/en-US/docs/Web/CSS/anchor) function
 - The [`<position-area>`](/en-US/docs/Web/CSS/position-area_value) value
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module

--- a/files/en-us/web/css/position-area_value/index.md
+++ b/files/en-us/web/css/position-area_value/index.md
@@ -388,5 +388,5 @@ For detailed information on anchor features and usage, see the [CSS anchor posit
 - {{cssxref("position-anchor")}}
 - [`anchor()`](/en-US/docs/Web/CSS/anchor) function
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module

--- a/files/en-us/web/css/position-try-fallbacks/index.md
+++ b/files/en-us/web/css/position-try-fallbacks/index.md
@@ -86,7 +86,7 @@ If no option can be found that will place the positioned element completely on-s
 > [!NOTE]
 > In some situations you might want to just hide overflowing positioned elements, which can be achieved using the {{cssxref("position-visibility")}} property. In most cases however it is better to keep them on-screen and usable.
 
-For detailed information on anchor features and position try fallback usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
+For detailed information on anchor features and position try fallback usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
 
 ### Predefined &lt;try-tactic&gt; values
 
@@ -370,6 +370,6 @@ See the {{cssxref("@position-try")}} reference page.
 - {{cssxref("@position-try")}} at-rule
 - {{cssxref("position-area")}}
 - [`<position-area>`](/en-US/docs/Web/CSS/position-area_value) value
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module

--- a/files/en-us/web/css/position-try-order/index.md
+++ b/files/en-us/web/css/position-try-order/index.md
@@ -57,7 +57,7 @@ The browser will test the available position-try fallback options to find which 
 
 If no position try fallback option is available that provides more width/height than the initial positioning assigned to the element, no position try option will be applied. In effect, the behavior is as if `position-try-order` was set to `normal`.
 
-For detailed information on anchor features and position try option usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
+For detailed information on anchor features and position try option usage, see the [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module landing page and the [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide.
 
 ## Formal definition
 
@@ -215,4 +215,4 @@ Try selecting the `most-height` order option. This has the effect of applying `-
 - The {{cssxref("@position-try")}} at-rule
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide

--- a/files/en-us/web/css/position-try/index.md
+++ b/files/en-us/web/css/position-try/index.md
@@ -175,4 +175,4 @@ The element appears below its anchor, even though it is initially positioned abo
 - The [`<position-area>`](/en-US/docs/Web/CSS/position-area_value) value
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide

--- a/files/en-us/web/css/position-visibility/index.md
+++ b/files/en-us/web/css/position-visibility/index.md
@@ -46,7 +46,7 @@ The `position-visibility` property can be used to `always` show the anchor-posit
 
 When an element is hidden due to `position-visibility`, it is referred to as **strongly hidden**. This means that it will act as though it and its descendant elements have a {{cssxref("visibility")}} value of `hidden` set, regardless of what their actual visibility value is.
 
-`position-visibility` should only be used in situations in which hiding the positioned element altogether is preferred. In most cases, it makes more sense to attempt to change the placement of positioned elements when they start to overflow, to keep them on-screen and usable. This can be done with the {{cssxref("position-try-fallbacks")}} property and {{cssxref("@position-try")}} at-rule. See the [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide for more information.
+`position-visibility` should only be used in situations in which hiding the positioned element altogether is preferred. In most cases, it makes more sense to attempt to change the placement of positioned elements when they start to overflow, to keep them on-screen and usable. This can be done with the {{cssxref("position-try-fallbacks")}} property and {{cssxref("@position-try")}} at-rule. See the [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide for more information.
 
 ## Formal definition
 
@@ -236,4 +236,4 @@ Select different `position-visibility` values and then scroll the page up and do
 - {{cssxref("position-area")}}
 - [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning) module
 - [Using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using) guide
-- [Handling overflow: try fallbacks and conditional hiding](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide
+- [Fallback options and conditional hiding for overflow](/en-US/docs/Web/CSS/CSS_anchor_positioning/Try_options_hiding) guide

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -269,5 +269,5 @@ p.min-blue {
 - {{cssxref("block-size")}}, {{cssxref("inline-size")}}
 - {{cssxref("anchor-size()")}}
 - SVG {{SVGAttr("width")}} attribute
-- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model) guide
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -269,5 +269,5 @@ p.min-blue {
 - {{cssxref("block-size")}}, {{cssxref("inline-size")}}
 - {{cssxref("anchor-size()")}}
 - SVG {{SVGAttr("width")}} attribute
-- [Introduction to the CSS basic box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
+- [Introduction to the CSS box model](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model)
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -143,6 +143,18 @@ sidebar:
     children:
       - /Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model
       - /Web/CSS/CSS_box_model/Mastering_margin_collapsing
+  - title: Cascade
+    details: closed
+    children:
+      - /Web/CSS/CSS_cascade/Cascade
+      - /Web/CSS/CSS_cascade/Inheritance
+      - /Web/CSS/CSS_cascade/Specificity
+      - /Web/CSS/CSS_cascade/Value_processing
+      - /Web/CSS/CSS_cascade/Shorthand_properties
+  - type: listSubPages
+    path: /Web/CSS/CSS_cascading_variables
+    title: Custom properties
+    details: closed
   - title: Colors
     details: closed
     children:
@@ -191,8 +203,13 @@ sidebar:
       - /Web/CSS/CSS_display/Containing_block
       - /Web/CSS/CSS_display/Introduction_to_formatting_contexts
       - /Web/CSS/CSS_display/Block_formatting_context
+      - /Web/CSS/CSS_inline_layout/Inline_formatting_context
       - /Web/CSS/CSS_display/multi-keyword_syntax_of_display
       - /Web/CSS/CSS_display/Visual_formatting_model
+  - type: listSubPages
+    path: /Web/CSS/CSS_filter_effects
+    title: Filter_effects
+    details: closed
   - title: Flexbox
     details: closed
     children:
@@ -253,6 +270,10 @@ sidebar:
       - /Web/CSS/CSS_nesting/Nesting_at-rules
       - /Web/CSS/CSS_nesting/Nesting_and_specificity
       - /Web/CSS/CSS_nesting/Using_CSS_nesting
+  - type: listSubPages
+    path: /Web/CSS/CSS_overflow
+    title: Overflow
+    details: closed
   - title: Positioning
     details: closed
     children:
@@ -262,8 +283,16 @@ sidebar:
       - /Web/CSS/CSS_positioned_layout/Using_z-index
       - /Web/CSS/CSS_positioned_layout/Stacking_without_z-index
   - type: listSubPages
+    path: /Web/CSS/CSS_scroll_anchoring
+    title: Scroll_anchoring
+    details: closed
+  - type: listSubPages
     path: /Web/CSS/CSS_scroll_snap
     title: Scroll_snap
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/CSS_selectors
+    title: Selectors
     details: closed
   - title: Shapes
     details: closed
@@ -272,6 +301,13 @@ sidebar:
       - /Web/CSS/CSS_shapes/From_box_values
       - /Web/CSS/CSS_shapes/Shapes_from_images
       - /Web/CSS/CSS_shapes/Basic_shapes
+  - title: Syntax
+    details: closed
+    children:
+      - /Web/CSS/CSS_syntax/Syntax
+      - /Web/CSS/CSS_syntax/Comments
+      - /Web/CSS/CSS_syntax/At-rule_functions
+      - /Web/CSS/CSS_syntax/Error_handling
   - title: Text
     details: closed
     children:
@@ -373,6 +409,7 @@ l10n:
     Resizing_background_images: Resizing background images
     Box_alignment_in_block_layout: Box alignment in block layout
     Box_model: Box model
+    Cascade: Cascade
     Colors: Colors
     Color_contrast: "Accessibility: Color contrast"
     Columns: Columns
@@ -380,6 +417,7 @@ l10n:
     Containment: Containment
     CSSOM_view: CSSOM view
     Display: Display
+    Filter_effects: Filter effects
     Flexbox: Flexbox
     Fonts: Fonts
     Grid: Grid
@@ -388,9 +426,13 @@ l10n:
     Logical_properties: Logical properties
     Media_queries: Media queries
     Nesting: Nesting style rules
+    Overflow: Overflow
     Positioning: Positioning
+    Selectors: Selectors
+    Scroll_anchoring: Scroll anchoring
     Scroll_snap: Scroll snap
     Shapes: Shapes
+    Syntax: Syntax
     Text: Text
     Transforms: Transforms
     Transitions: Transitions

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -111,11 +111,6 @@ sidebar:
   - type: section
     link: /Web/CSS/Guides
     title: Guides
-  - title: Anchor_positioning
-    details: closed
-    children:
-      - /Web/CSS/CSS_anchor_positioning/Using
-      - /Web/CSS/CSS_anchor_positioning/Try_options_hiding
   - title: Animations
     details: closed
     children:
@@ -143,18 +138,6 @@ sidebar:
     children:
       - /Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model
       - /Web/CSS/CSS_box_model/Mastering_margin_collapsing
-  - title: Cascade
-    details: closed
-    children:
-      - /Web/CSS/CSS_cascade/Cascade
-      - /Web/CSS/CSS_cascade/Inheritance
-      - /Web/CSS/CSS_cascade/Specificity
-      - /Web/CSS/CSS_cascade/Value_processing
-      - /Web/CSS/CSS_cascade/Shorthand_properties
-  - type: listSubPages
-    path: /Web/CSS/CSS_cascading_variables
-    title: Custom properties
-    details: closed
   - title: Colors
     details: closed
     children:
@@ -184,31 +167,17 @@ sidebar:
   - title: Containment
     details: closed
     children:
-      - /Web/CSS/CSS_containment/Container_queries
       - /Web/CSS/CSS_containment/Using_CSS_containment
+      - /Web/CSS/CSS_containment/Container_queries
       - /Web/CSS/CSS_containment/Container_size_and_style_queries
   - title: CSSOM_view
     details: closed
     children:
       - /Web/CSS/CSSOM_view/Coordinate_systems
       - /Web/CSS/CSSOM_view/Viewport_concepts
-  - title: Display
-    details: closed
-    children:
-      - /Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
-      - /Web/CSS/CSS_display/Flow_layout
-      - /Web/CSS/CSS_display/Flow_layout_and_overflow
-      - /Web/CSS/CSS_display/Flow_layout_and_writing_modes
-      - /Web/CSS/CSS_display/In_flow_and_out_of_flow
-      - /Web/CSS/CSS_display/Containing_block
-      - /Web/CSS/CSS_display/Introduction_to_formatting_contexts
-      - /Web/CSS/CSS_display/Block_formatting_context
-      - /Web/CSS/CSS_inline_layout/Inline_formatting_context
-      - /Web/CSS/CSS_display/multi-keyword_syntax_of_display
-      - /Web/CSS/CSS_display/Visual_formatting_model
   - type: listSubPages
-    path: /Web/CSS/CSS_filter_effects
-    title: Filter_effects
+    path: /Web/CSS/CSS_display
+    title: Display
     details: closed
   - title: Flexbox
     details: closed
@@ -229,15 +198,15 @@ sidebar:
     children:
       - /Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout
       - /Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods
-      - /Web/CSS/CSS_grid_layout/Grid_template_areas
       - /Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement
+      - /Web/CSS/CSS_grid_layout/Grid_template_areas
       - /Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines
       - /Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout
       - /Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout
       - /Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes
+      - /Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility
       - /Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids
       - /Web/CSS/CSS_grid_layout/Subgrid
-      - /Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility
       - /Web/CSS/CSS_grid_layout/Masonry_layout
   - title: Images
     details: closed
@@ -267,13 +236,9 @@ sidebar:
   - title: Nesting
     details: closed
     children:
+      - /Web/CSS/CSS_nesting/Using_CSS_nesting
       - /Web/CSS/CSS_nesting/Nesting_at-rules
       - /Web/CSS/CSS_nesting/Nesting_and_specificity
-      - /Web/CSS/CSS_nesting/Using_CSS_nesting
-  - type: listSubPages
-    path: /Web/CSS/CSS_overflow
-    title: Overflow
-    details: closed
   - title: Positioning
     details: closed
     children:
@@ -283,31 +248,16 @@ sidebar:
       - /Web/CSS/CSS_positioned_layout/Using_z-index
       - /Web/CSS/CSS_positioned_layout/Stacking_without_z-index
   - type: listSubPages
-    path: /Web/CSS/CSS_scroll_anchoring
-    title: Scroll_anchoring
-    details: closed
-  - type: listSubPages
     path: /Web/CSS/CSS_scroll_snap
     title: Scroll_snap
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/CSS_selectors
-    title: Selectors
     details: closed
   - title: Shapes
     details: closed
     children:
       - /Web/CSS/CSS_shapes/Overview_of_shapes
       - /Web/CSS/CSS_shapes/From_box_values
-      - /Web/CSS/CSS_shapes/Shapes_from_images
       - /Web/CSS/CSS_shapes/Basic_shapes
-  - title: Syntax
-    details: closed
-    children:
-      - /Web/CSS/CSS_syntax/Syntax
-      - /Web/CSS/CSS_syntax/Comments
-      - /Web/CSS/CSS_syntax/At-rule_functions
-      - /Web/CSS/CSS_syntax/Error_handling
+      - /Web/CSS/CSS_shapes/Shapes_from_images
   - title: Text
     details: closed
     children:
@@ -403,13 +353,11 @@ l10n:
     CSS_text_styling: CSS text styling
     CSS_layout: CSS layout
     Guides: Guides
-    Anchor_positioning: Anchor positioning
     Animations: Animations
-    Backgrounds_and_Borders: Backgrounds and borders
+    Backgrounds_and_Borders: Backgrounds and Borders
     Resizing_background_images: Resizing background images
     Box_alignment_in_block_layout: Box alignment in block layout
     Box_model: Box model
-    Cascade: Cascade
     Colors: Colors
     Color_contrast: "Accessibility: Color contrast"
     Columns: Columns
@@ -417,7 +365,6 @@ l10n:
     Containment: Containment
     CSSOM_view: CSSOM view
     Display: Display
-    Filter_effects: Filter effects
     Flexbox: Flexbox
     Fonts: Fonts
     Grid: Grid
@@ -426,13 +373,9 @@ l10n:
     Logical_properties: Logical properties
     Media_queries: Media queries
     Nesting: Nesting style rules
-    Overflow: Overflow
     Positioning: Positioning
-    Selectors: Selectors
-    Scroll_anchoring: Scroll anchoring
     Scroll_snap: Scroll snap
     Shapes: Shapes
-    Syntax: Syntax
     Text: Text
     Transforms: Transforms
     Transitions: Transitions

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -121,7 +121,7 @@ sidebar:
     children:
       - /Web/CSS/CSS_animated_properties
       - /Web/CSS/CSS_animations/Using_CSS_animations
-  - title: Backgrounds_and_borders
+  - title: Backgrounds_and_Borders
     details: closed
     children:
       - /Web/CSS/CSS_backgrounds_and_borders/Using_multiple_backgrounds
@@ -155,7 +155,7 @@ sidebar:
         title: Accessibility_Understanding_colors_and_luminance
       - link: /Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast
         title: Color_contrast
-  - title: Multi-column layouts
+  - title: Columns
     details: closed
     children:
       - /Web/CSS/CSS_multicol_layout/Basic_concepts
@@ -367,14 +367,15 @@ l10n:
     Guides: Guides
     Anchor_positioning: Anchor positioning
     Animations: Animations
-    Backgrounds_and_borders: Backgrounds and borders
-    Containment: Containment
+    Backgrounds_and_Borders: Backgrounds and borders
     Resizing_background_images: Resizing background images
     Box_alignment_in_block_layout: Box alignment in block layout
     Box_model: Box model
     Colors: Colors
     Color_contrast: "Accessibility: Color contrast"
+    Columns: Columns
     Conditional_rules: Conditional rules
+    Containment: Containment
     CSSOM_view: CSSOM view
     Display: Display
     Flexbox: Flexbox

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -323,12 +323,14 @@ l10n:
     Accessibility_Understanding_colors_and_luminance: "Barrierefreiheit: Farbwerte verstehen"
     Applying_color_to_HTML_elements: Farben auf HTML-Elemente anwenden
     At-rules: At-Regeln
+    Backgrounds_and_Borders: Hintergründe und Rahmen
     Resizing_background_images: Hintergrundbilder skalieren
     Box alignment: Box-Ausrichtung
     Box_alignment_in_block_layout: Box-Ausrichtung im Block-Layout
     Box_model: Box-Modell
     Colors: Farben
     Color_contrast: "Barrierefreiheit: Farbkontrast"
+    Columns: Spalten
     Combinators: Kombinatoren
     Conditional_rules: Bedingte Regeln
     Containment: Containment
@@ -397,9 +399,11 @@ l10n:
     CSS_layout: Dispositions CSS
     Guides: Guides
     Animations: Animations
+    Backgrounds_and_Borders: Arrière-plans et bordures
     Resizing_background_images: Redimensionner les images d'arrière-plan
     Box_alignment_in_block_layout: Alignement des boîtes avec la disposition en bloc
     Box_model: Modèle de boîte
+    Columns: Colonnes
     Conditional_rules: Règles conditionnelles
     CSSOM_view: Vue CSSOM
     Flexbox: Boîtes flexibles
@@ -428,12 +432,14 @@ l10n:
     CSS_layout: CSS レイアウト
     Guides: ガイド
     Animations: アニメーション
+    Backgrounds_and_Borders: 背景と境界
     Resizing_background_images: 背景画像の拡大縮小
     Box alignment: ボックス配置
     Box_alignment_in_block_layout: ブロックレイアウトでのボックス配置
     Box_model: ボックスモデル
     Colors: 色
     Color_contrast: "アクセシビリティ: 色のコントラスト"
+    Columns: 段組み
     Combinators: 結合子
     Conditional_rules: 条件付きルール
     Containment: コンテナー
@@ -467,9 +473,11 @@ l10n:
     CSS_layout: CSS 레이아웃
     Guides: 안내서
     Animations: 애니메이션
+    Backgrounds_and_Borders: 배경과 보더
     Resizing_background_images: 배경 이미지 크기 조정하기
     Box_alignment_in_block_layout: 블록 레이아웃 박스 정렬하기
     Box_model: 박스 모델
+    Columns: 열
     Conditional_rules: CSS에서 규칙 정의하기
     CSSOM_view: CSSOM view
     Display: 플로 레이아웃
@@ -495,9 +503,11 @@ l10n:
     CSS_layout: CSS макет
     Guides: Руководства
     Animations: Анимации
+    Backgrounds_and_Borders: Фоны и границы
     Resizing_background_images: Изменение размера фоновых изображений
     Box_alignment_in_block_layout: Выравнивание в блочной раскладке
     Box_model: Блочная модель
+    Columns: Колонки
     Conditional_rules: Условные конструкции
     CSSOM_view: CSSOM View
     Display: Потоковая раскладка
@@ -526,12 +536,14 @@ l10n:
     Guides: 指南
     Animations: 动画
     At-rules: At 规则
+    Backgrounds_and_Borders: 背景和边框
     Resizing_background_images: 调整背景图片的大小
     Box alignment: 盒对齐
     Box_alignment_in_block_layout: 块布局中的盒对齐方式
     Box_model: 盒模型
     Colors: 颜色
     Color_contrast: Web 无障碍：色彩对比度
+    Columns: 多列
     Conditional_rules: 条件规则
     CSSOM_view: CSS 对象模型视图
     Display: 流式布局

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -111,12 +111,17 @@ sidebar:
   - type: section
     link: /Web/CSS/Guides
     title: Guides
+  - title: Anchor_positioning
+    details: closed
+    children:
+      - /Web/CSS/CSS_anchor_positioning/Using
+      - /Web/CSS/CSS_anchor_positioning/Try_options_hiding
   - title: Animations
     details: closed
     children:
       - /Web/CSS/CSS_animated_properties
       - /Web/CSS/CSS_animations/Using_CSS_animations
-  - title: Backgrounds_and_Borders
+  - title: Backgrounds_and_borders
     details: closed
     children:
       - /Web/CSS/CSS_backgrounds_and_borders/Using_multiple_backgrounds
@@ -150,7 +155,7 @@ sidebar:
         title: Accessibility_Understanding_colors_and_luminance
       - link: /Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast
         title: Color_contrast
-  - title: Columns
+  - title: Multi-column layouts
     details: closed
     children:
       - /Web/CSS/CSS_multicol_layout/Basic_concepts
@@ -167,18 +172,27 @@ sidebar:
   - title: Containment
     details: closed
     children:
-      - /Web/CSS/CSS_containment/Using_CSS_containment
       - /Web/CSS/CSS_containment/Container_queries
+      - /Web/CSS/CSS_containment/Using_CSS_containment
       - /Web/CSS/CSS_containment/Container_size_and_style_queries
   - title: CSSOM_view
     details: closed
     children:
       - /Web/CSS/CSSOM_view/Coordinate_systems
       - /Web/CSS/CSSOM_view/Viewport_concepts
-  - type: listSubPages
-    path: /Web/CSS/CSS_display
-    title: Display
+  - title: Display
     details: closed
+    children:
+      - /Web/CSS/CSS_display/Block_and_inline_layout_in_normal_flow
+      - /Web/CSS/CSS_display/Flow_layout
+      - /Web/CSS/CSS_display/Flow_layout_and_overflow
+      - /Web/CSS/CSS_display/Flow_layout_and_writing_modes
+      - /Web/CSS/CSS_display/In_flow_and_out_of_flow
+      - /Web/CSS/CSS_display/Containing_block
+      - /Web/CSS/CSS_display/Introduction_to_formatting_contexts
+      - /Web/CSS/CSS_display/Block_formatting_context
+      - /Web/CSS/CSS_display/multi-keyword_syntax_of_display
+      - /Web/CSS/CSS_display/Visual_formatting_model
   - title: Flexbox
     details: closed
     children:
@@ -198,15 +212,15 @@ sidebar:
     children:
       - /Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout
       - /Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods
-      - /Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement
       - /Web/CSS/CSS_grid_layout/Grid_template_areas
+      - /Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement
       - /Web/CSS/CSS_grid_layout/Grid_layout_using_named_grid_lines
       - /Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout
       - /Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout
       - /Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes
-      - /Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility
       - /Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids
       - /Web/CSS/CSS_grid_layout/Subgrid
+      - /Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility
       - /Web/CSS/CSS_grid_layout/Masonry_layout
   - title: Images
     details: closed
@@ -236,9 +250,9 @@ sidebar:
   - title: Nesting
     details: closed
     children:
-      - /Web/CSS/CSS_nesting/Using_CSS_nesting
       - /Web/CSS/CSS_nesting/Nesting_at-rules
       - /Web/CSS/CSS_nesting/Nesting_and_specificity
+      - /Web/CSS/CSS_nesting/Using_CSS_nesting
   - title: Positioning
     details: closed
     children:
@@ -256,8 +270,8 @@ sidebar:
     children:
       - /Web/CSS/CSS_shapes/Overview_of_shapes
       - /Web/CSS/CSS_shapes/From_box_values
-      - /Web/CSS/CSS_shapes/Basic_shapes
       - /Web/CSS/CSS_shapes/Shapes_from_images
+      - /Web/CSS/CSS_shapes/Basic_shapes
   - title: Text
     details: closed
     children:
@@ -309,14 +323,12 @@ l10n:
     Accessibility_Understanding_colors_and_luminance: "Barrierefreiheit: Farbwerte verstehen"
     Applying_color_to_HTML_elements: Farben auf HTML-Elemente anwenden
     At-rules: At-Regeln
-    Backgrounds_and_Borders: Hintergründe und Rahmen
     Resizing_background_images: Hintergrundbilder skalieren
     Box alignment: Box-Ausrichtung
     Box_alignment_in_block_layout: Box-Ausrichtung im Block-Layout
     Box_model: Box-Modell
     Colors: Farben
     Color_contrast: "Barrierefreiheit: Farbkontrast"
-    Columns: Spalten
     Combinators: Kombinatoren
     Conditional_rules: Bedingte Regeln
     Containment: Containment
@@ -353,16 +365,16 @@ l10n:
     CSS_text_styling: CSS text styling
     CSS_layout: CSS layout
     Guides: Guides
+    Anchor_positioning: Anchor positioning
     Animations: Animations
-    Backgrounds_and_Borders: Backgrounds and Borders
+    Backgrounds_and_borders: Backgrounds and borders
+    Containment: Containment
     Resizing_background_images: Resizing background images
     Box_alignment_in_block_layout: Box alignment in block layout
     Box_model: Box model
     Colors: Colors
     Color_contrast: "Accessibility: Color contrast"
-    Columns: Columns
     Conditional_rules: Conditional rules
-    Containment: Containment
     CSSOM_view: CSSOM view
     Display: Display
     Flexbox: Flexbox
@@ -384,11 +396,9 @@ l10n:
     CSS_layout: Dispositions CSS
     Guides: Guides
     Animations: Animations
-    Backgrounds_and_Borders: Arrière-plans et bordures
     Resizing_background_images: Redimensionner les images d'arrière-plan
     Box_alignment_in_block_layout: Alignement des boîtes avec la disposition en bloc
     Box_model: Modèle de boîte
-    Columns: Colonnes
     Conditional_rules: Règles conditionnelles
     CSSOM_view: Vue CSSOM
     Flexbox: Boîtes flexibles
@@ -417,14 +427,12 @@ l10n:
     CSS_layout: CSS レイアウト
     Guides: ガイド
     Animations: アニメーション
-    Backgrounds_and_Borders: 背景と境界
     Resizing_background_images: 背景画像の拡大縮小
     Box alignment: ボックス配置
     Box_alignment_in_block_layout: ブロックレイアウトでのボックス配置
     Box_model: ボックスモデル
     Colors: 色
     Color_contrast: "アクセシビリティ: 色のコントラスト"
-    Columns: 段組み
     Combinators: 結合子
     Conditional_rules: 条件付きルール
     Containment: コンテナー
@@ -458,11 +466,9 @@ l10n:
     CSS_layout: CSS 레이아웃
     Guides: 안내서
     Animations: 애니메이션
-    Backgrounds_and_Borders: 배경과 보더
     Resizing_background_images: 배경 이미지 크기 조정하기
     Box_alignment_in_block_layout: 블록 레이아웃 박스 정렬하기
     Box_model: 박스 모델
-    Columns: 열
     Conditional_rules: CSS에서 규칙 정의하기
     CSSOM_view: CSSOM view
     Display: 플로 레이아웃
@@ -488,11 +494,9 @@ l10n:
     CSS_layout: CSS макет
     Guides: Руководства
     Animations: Анимации
-    Backgrounds_and_Borders: Фоны и границы
     Resizing_background_images: Изменение размера фоновых изображений
     Box_alignment_in_block_layout: Выравнивание в блочной раскладке
     Box_model: Блочная модель
-    Columns: Колонки
     Conditional_rules: Условные конструкции
     CSSOM_view: CSSOM View
     Display: Потоковая раскладка
@@ -521,14 +525,12 @@ l10n:
     Guides: 指南
     Animations: 动画
     At-rules: At 规则
-    Backgrounds_and_Borders: 背景和边框
     Resizing_background_images: 调整背景图片的大小
     Box alignment: 盒对齐
     Box_alignment_in_block_layout: 块布局中的盒对齐方式
     Box_model: 盒模型
     Colors: 颜色
     Color_contrast: Web 无障碍：色彩对比度
-    Columns: 多列
     Conditional_rules: 条件规则
     CSSOM_view: CSS 对象模型视图
     Display: 流式布局


### PR DESCRIPTION
### Description

- Shortened sidebar titles ("CSS" is unnecessary in the sidebar) by adding `short-title` to corresponding pages.
- Updated `title` on a few pages for consistency and clarity. This had a cascade effect, so I've updated other pages that reference these titles.
- Added links to more guides in the sidebar => moved this to https://github.com/mdn/content/pull/39834

### Motivation

Keeping the items in the sidebar short (while retaining key words so they can appear in "Filter" search) makes them more readable and scanable.
And it's always a good idea to expose more pages through our sidebar navigation.