### PR TITLE
Main event loop => main thread

### DIFF
--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Window.requestIdleCallback
 
 The **`window.requestIdleCallback()`** method queues a function
 to be called during a browser's idle periods. This enables developers to perform
-background and low priority work on the main event loop, without impacting
+background and low priority work on the main thread, without impacting
 latency-critical events such as animation and input response. Functions are generally
 called in first-in-first-out order; however, callbacks which have a `timeout`
 specified may be called out-of-order if necessary in order to run them before the


### PR DESCRIPTION
It seems that semantically it should be "the main thread", that the benefit of this method is to use main thread without conflicting the important code