### PR TITLE
fix(html): Add the qualifier to global attribute page titles

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/accesskey/index.md
+++ b/files/en-us/web/html/reference/global_attributes/accesskey/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: accesskey"
+title: accesskey global attribute
 short-title: accesskey
 slug: Web/HTML/Reference/Global_attributes/accesskey
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/accesskey/index.md
+++ b/files/en-us/web/html/reference/global_attributes/accesskey/index.md
@@ -1,5 +1,6 @@
 ---
-title: accesskey
+title: "HTML global attribute: accesskey"
+short-title: accesskey
 slug: Web/HTML/Reference/Global_attributes/accesskey
 page-type: html-attribute
 browser-compat: html.global_attributes.accesskey

--- a/files/en-us/web/html/reference/global_attributes/accesskey/index.md
+++ b/files/en-us/web/html/reference/global_attributes/accesskey/index.md
@@ -1,5 +1,5 @@
 ---
-title: accesskey global attribute
+title: HTML accesskey global attribute
 short-title: accesskey
 slug: Web/HTML/Reference/Global_attributes/accesskey
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/anchor/index.md
+++ b/files/en-us/web/html/reference/global_attributes/anchor/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: anchor"
+title: anchor global attribute
 short-title: anchor
 slug: Web/HTML/Reference/Global_attributes/anchor
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/anchor/index.md
+++ b/files/en-us/web/html/reference/global_attributes/anchor/index.md
@@ -1,5 +1,5 @@
 ---
-title: anchor global attribute
+title: HTML anchor global attribute
 short-title: anchor
 slug: Web/HTML/Reference/Global_attributes/anchor
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/anchor/index.md
+++ b/files/en-us/web/html/reference/global_attributes/anchor/index.md
@@ -1,5 +1,6 @@
 ---
-title: anchor
+title: "HTML global attribute: anchor"
+short-title: anchor
 slug: Web/HTML/Reference/Global_attributes/anchor
 page-type: html-attribute
 status:

--- a/files/en-us/web/html/reference/global_attributes/autocapitalize/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autocapitalize/index.md
@@ -1,5 +1,6 @@
 ---
-title: autocapitalize
+title: "HTML global attribute: autocapitalize"
+short-title: autocapitalize
 slug: Web/HTML/Reference/Global_attributes/autocapitalize
 page-type: html-attribute
 browser-compat: html.global_attributes.autocapitalize

--- a/files/en-us/web/html/reference/global_attributes/autocapitalize/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autocapitalize/index.md
@@ -1,5 +1,5 @@
 ---
-title: autocapitalize global attribute
+title: HTML autocapitalize global attribute
 short-title: autocapitalize
 slug: Web/HTML/Reference/Global_attributes/autocapitalize
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/autocapitalize/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autocapitalize/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: autocapitalize"
+title: autocapitalize global attribute
 short-title: autocapitalize
 slug: Web/HTML/Reference/Global_attributes/autocapitalize
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autocorrect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: autocorrect"
+title: autocorrect global attribute
 short-title: autocorrect
 slug: Web/HTML/Reference/Global_attributes/autocorrect
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autocorrect/index.md
@@ -1,5 +1,5 @@
 ---
-title: autocorrect global attribute
+title: HTML autocorrect global attribute
 short-title: autocorrect
 slug: Web/HTML/Reference/Global_attributes/autocorrect
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autocorrect/index.md
@@ -1,5 +1,6 @@
 ---
-title: autocorrect
+title: "HTML global attribute: autocorrect"
+short-title: autocorrect
 slug: Web/HTML/Reference/Global_attributes/autocorrect
 page-type: html-attribute
 browser-compat: html.global_attributes.autocorrect

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -1,5 +1,5 @@
 ---
-title: autofocus global attribute
+title: HTML autofocus global attribute
 short-title: autofocus
 slug: Web/HTML/Reference/Global_attributes/autofocus
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: autofocus"
+title: autofocus global attribute
 short-title: autofocus
 slug: Web/HTML/Reference/Global_attributes/autofocus
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -1,5 +1,6 @@
 ---
-title: autofocus
+title: "HTML global attribute: autofocus"
+short-title: autofocus
 slug: Web/HTML/Reference/Global_attributes/autofocus
 page-type: html-attribute
 browser-compat: html.global_attributes.autofocus

--- a/files/en-us/web/html/reference/global_attributes/class/index.md
+++ b/files/en-us/web/html/reference/global_attributes/class/index.md
@@ -1,5 +1,5 @@
 ---
-title: class global attribute
+title: HTML class global attribute
 short-title: class
 slug: Web/HTML/Reference/Global_attributes/class
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/class/index.md
+++ b/files/en-us/web/html/reference/global_attributes/class/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: class"
+title: class global attribute
 short-title: class
 slug: Web/HTML/Reference/Global_attributes/class
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/class/index.md
+++ b/files/en-us/web/html/reference/global_attributes/class/index.md
@@ -1,5 +1,6 @@
 ---
-title: class
+title: "HTML global attribute: class"
+short-title: class
 slug: Web/HTML/Reference/Global_attributes/class
 page-type: html-attribute
 browser-compat: html.global_attributes.class

--- a/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
@@ -1,5 +1,5 @@
 ---
-title: contenteditable global attribute
+title: HTML contenteditable global attribute
 short-title: contenteditable
 slug: Web/HTML/Reference/Global_attributes/contenteditable
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: contenteditable"
+title: contenteditable global attribute
 short-title: contenteditable
 slug: Web/HTML/Reference/Global_attributes/contenteditable
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
@@ -1,5 +1,6 @@
 ---
-title: contenteditable
+title: "HTML global attribute: contenteditable"
+short-title: contenteditable
 slug: Web/HTML/Reference/Global_attributes/contenteditable
 page-type: html-attribute
 browser-compat: html.global_attributes.contenteditable

--- a/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
@@ -1,5 +1,5 @@
 ---
-title: data-* global attribute
+title: HTML data-* global attribute
 short-title: data-*
 slug: Web/HTML/Reference/Global_attributes/data-*
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
@@ -1,5 +1,6 @@
 ---
-title: data-*
+title: "HTML global attribute: data-*"
+short-title: data-*
 slug: Web/HTML/Reference/Global_attributes/data-*
 page-type: html-attribute
 browser-compat: html.global_attributes.data_attributes

--- a/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: data-*"
+title: data-* global attribute
 short-title: data-*
 slug: Web/HTML/Reference/Global_attributes/data-*
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -1,5 +1,6 @@
 ---
-title: dir
+title: "HTML global attribute: dir"
+short-title: dir
 slug: Web/HTML/Reference/Global_attributes/dir
 page-type: html-attribute
 browser-compat: html.global_attributes.dir

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: dir"
+title: dir global attribute
 short-title: dir
 slug: Web/HTML/Reference/Global_attributes/dir
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -1,5 +1,5 @@
 ---
-title: dir global attribute
+title: HTML dir global attribute
 short-title: dir
 slug: Web/HTML/Reference/Global_attributes/dir
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/draggable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/draggable/index.md
@@ -1,5 +1,5 @@
 ---
-title: draggable global attribute
+title: HTML draggable global attribute
 short-title: draggable
 slug: Web/HTML/Reference/Global_attributes/draggable
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/draggable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/draggable/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: draggable"
+title: draggable global attribute
 short-title: draggable
 slug: Web/HTML/Reference/Global_attributes/draggable
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/draggable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/draggable/index.md
@@ -1,5 +1,6 @@
 ---
-title: draggable
+title: "HTML global attribute: draggable"
+short-title: draggable
 slug: Web/HTML/Reference/Global_attributes/draggable
 page-type: html-attribute
 browser-compat: html.global_attributes.draggable

--- a/files/en-us/web/html/reference/global_attributes/enterkeyhint/index.md
+++ b/files/en-us/web/html/reference/global_attributes/enterkeyhint/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: enterkeyhint"
+title: enterkeyhint global attribute
 short-title: enterkeyhint
 slug: Web/HTML/Reference/Global_attributes/enterkeyhint
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/enterkeyhint/index.md
+++ b/files/en-us/web/html/reference/global_attributes/enterkeyhint/index.md
@@ -1,5 +1,5 @@
 ---
-title: enterkeyhint global attribute
+title: HTML enterkeyhint global attribute
 short-title: enterkeyhint
 slug: Web/HTML/Reference/Global_attributes/enterkeyhint
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/enterkeyhint/index.md
+++ b/files/en-us/web/html/reference/global_attributes/enterkeyhint/index.md
@@ -1,5 +1,6 @@
 ---
-title: enterkeyhint
+title: "HTML global attribute: enterkeyhint"
+short-title: enterkeyhint
 slug: Web/HTML/Reference/Global_attributes/enterkeyhint
 page-type: html-attribute
 browser-compat: html.global_attributes.enterkeyhint

--- a/files/en-us/web/html/reference/global_attributes/exportparts/index.md
+++ b/files/en-us/web/html/reference/global_attributes/exportparts/index.md
@@ -1,5 +1,6 @@
 ---
-title: exportparts
+title: "HTML global attribute: exportparts"
+short-title: exportparts
 slug: Web/HTML/Reference/Global_attributes/exportparts
 page-type: html-attribute
 browser-compat: html.global_attributes.exportparts

--- a/files/en-us/web/html/reference/global_attributes/exportparts/index.md
+++ b/files/en-us/web/html/reference/global_attributes/exportparts/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: exportparts"
+title: exportparts global attribute
 short-title: exportparts
 slug: Web/HTML/Reference/Global_attributes/exportparts
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/exportparts/index.md
+++ b/files/en-us/web/html/reference/global_attributes/exportparts/index.md
@@ -1,5 +1,5 @@
 ---
-title: exportparts global attribute
+title: HTML exportparts global attribute
 short-title: exportparts
 slug: Web/HTML/Reference/Global_attributes/exportparts
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: hidden"
+title: hidden global attribute
 short-title: hidden
 slug: Web/HTML/Reference/Global_attributes/hidden
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -1,5 +1,5 @@
 ---
-title: hidden global attribute
+title: HTML hidden global attribute
 short-title: hidden
 slug: Web/HTML/Reference/Global_attributes/hidden
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -1,5 +1,6 @@
 ---
-title: hidden
+title: "HTML global attribute: hidden"
+short-title: hidden
 slug: Web/HTML/Reference/Global_attributes/hidden
 page-type: html-attribute
 browser-compat: html.global_attributes.hidden

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: id"
+title: id global attribute
 short-title: id
 slug: Web/HTML/Reference/Global_attributes/id
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -1,5 +1,6 @@
 ---
-title: id
+title: "HTML global attribute: id"
+short-title: id
 slug: Web/HTML/Reference/Global_attributes/id
 page-type: html-attribute
 browser-compat: html.global_attributes.id

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -1,5 +1,5 @@
 ---
-title: id global attribute
+title: HTML id global attribute
 short-title: id
 slug: Web/HTML/Reference/Global_attributes/id
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/inert/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inert/index.md
@@ -1,5 +1,6 @@
 ---
-title: inert
+title: "HTML global attribute: inert"
+short-title: inert
 slug: Web/HTML/Reference/Global_attributes/inert
 page-type: html-attribute
 browser-compat: html.global_attributes.inert

--- a/files/en-us/web/html/reference/global_attributes/inert/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inert/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: inert"
+title: inert global attribute
 short-title: inert
 slug: Web/HTML/Reference/Global_attributes/inert
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/inert/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inert/index.md
@@ -1,5 +1,5 @@
 ---
-title: inert global attribute
+title: HTML inert global attribute
 short-title: inert
 slug: Web/HTML/Reference/Global_attributes/inert
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/inputmode/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inputmode/index.md
@@ -1,5 +1,6 @@
 ---
-title: inputmode
+title: "HTML global attribute: inputmode"
+short-title: inputmode
 slug: Web/HTML/Reference/Global_attributes/inputmode
 page-type: html-attribute
 browser-compat: html.global_attributes.inputmode

--- a/files/en-us/web/html/reference/global_attributes/inputmode/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inputmode/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: inputmode"
+title: inputmode global attribute
 short-title: inputmode
 slug: Web/HTML/Reference/Global_attributes/inputmode
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/inputmode/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inputmode/index.md
@@ -1,5 +1,5 @@
 ---
-title: inputmode global attribute
+title: HTML inputmode global attribute
 short-title: inputmode
 slug: Web/HTML/Reference/Global_attributes/inputmode
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/is/index.md
+++ b/files/en-us/web/html/reference/global_attributes/is/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: is"
+title: is global attribute
 short-title: is
 slug: Web/HTML/Reference/Global_attributes/is
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/is/index.md
+++ b/files/en-us/web/html/reference/global_attributes/is/index.md
@@ -1,5 +1,5 @@
 ---
-title: is global attribute
+title: HTML is global attribute
 short-title: is
 slug: Web/HTML/Reference/Global_attributes/is
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/is/index.md
+++ b/files/en-us/web/html/reference/global_attributes/is/index.md
@@ -1,5 +1,6 @@
 ---
-title: is
+title: "HTML global attribute: is"
+short-title: is
 slug: Web/HTML/Reference/Global_attributes/is
 page-type: html-attribute
 browser-compat: html.global_attributes.is

--- a/files/en-us/web/html/reference/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemid/index.md
@@ -1,5 +1,5 @@
 ---
-title: itemid global attribute
+title: HTML itemid global attribute
 short-title: itemid
 slug: Web/HTML/Reference/Global_attributes/itemid
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemid/index.md
@@ -1,5 +1,6 @@
 ---
-title: itemid
+title: "HTML global attribute: itemid"
+short-title: itemid
 slug: Web/HTML/Reference/Global_attributes/itemid
 page-type: html-attribute
 spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid

--- a/files/en-us/web/html/reference/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemid/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: itemid"
+title: itemid global attribute
 short-title: itemid
 slug: Web/HTML/Reference/Global_attributes/itemid
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemprop/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: itemprop"
+title: itemprop global attribute
 short-title: itemprop
 slug: Web/HTML/Reference/Global_attributes/itemprop
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemprop/index.md
@@ -1,5 +1,5 @@
 ---
-title: itemprop global attribute
+title: HTML itemprop global attribute
 short-title: itemprop
 slug: Web/HTML/Reference/Global_attributes/itemprop
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemprop/index.md
@@ -1,5 +1,6 @@
 ---
-title: itemprop
+title: "HTML global attribute: itemprop"
+short-title: itemprop
 slug: Web/HTML/Reference/Global_attributes/itemprop
 page-type: html-attribute
 spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemref/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: itemref"
+title: itemref global attribute
 short-title: itemref
 slug: Web/HTML/Reference/Global_attributes/itemref
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemref/index.md
@@ -1,5 +1,5 @@
 ---
-title: itemref global attribute
+title: HTML itemref global attribute
 short-title: itemref
 slug: Web/HTML/Reference/Global_attributes/itemref
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemref/index.md
@@ -1,5 +1,6 @@
 ---
-title: itemref
+title: "HTML global attribute: itemref"
+short-title: itemref
 slug: Web/HTML/Reference/Global_attributes/itemref
 page-type: html-attribute
 spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemref

--- a/files/en-us/web/html/reference/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemscope/index.md
@@ -1,5 +1,5 @@
 ---
-title: itemscope global attribute
+title: HTML itemscope global attribute
 short-title: itemscope
 slug: Web/HTML/Reference/Global_attributes/itemscope
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemscope/index.md
@@ -1,5 +1,6 @@
 ---
-title: itemscope
+title: "HTML global attribute: itemscope"
+short-title: itemscope
 slug: Web/HTML/Reference/Global_attributes/itemscope
 page-type: html-attribute
 spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemscope

--- a/files/en-us/web/html/reference/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemscope/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: itemscope"
+title: itemscope global attribute
 short-title: itemscope
 slug: Web/HTML/Reference/Global_attributes/itemscope
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemtype/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: itemtype"
+title: itemtype global attribute
 short-title: itemtype
 slug: Web/HTML/Reference/Global_attributes/itemtype
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemtype/index.md
@@ -1,5 +1,6 @@
 ---
-title: itemtype
+title: "HTML global attribute: itemtype"
+short-title: itemtype
 slug: Web/HTML/Reference/Global_attributes/itemtype
 page-type: html-attribute
 spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemtype

--- a/files/en-us/web/html/reference/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/reference/global_attributes/itemtype/index.md
@@ -1,5 +1,5 @@
 ---
-title: itemtype global attribute
+title: HTML itemtype global attribute
 short-title: itemtype
 slug: Web/HTML/Reference/Global_attributes/itemtype
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/lang/index.md
+++ b/files/en-us/web/html/reference/global_attributes/lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: lang global attribute
+title: HTML lang global attribute
 short-title: lang
 slug: Web/HTML/Reference/Global_attributes/lang
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/lang/index.md
+++ b/files/en-us/web/html/reference/global_attributes/lang/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: lang"
+title: lang global attribute
 short-title: lang
 slug: Web/HTML/Reference/Global_attributes/lang
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/lang/index.md
+++ b/files/en-us/web/html/reference/global_attributes/lang/index.md
@@ -1,5 +1,6 @@
 ---
-title: lang
+title: "HTML global attribute: lang"
+short-title: lang
 slug: Web/HTML/Reference/Global_attributes/lang
 page-type: html-attribute
 browser-compat: html.global_attributes.lang

--- a/files/en-us/web/html/reference/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/reference/global_attributes/nonce/index.md
@@ -1,5 +1,5 @@
 ---
-title: nonce global attribute
+title: HTML nonce global attribute
 short-title: nonce
 slug: Web/HTML/Reference/Global_attributes/nonce
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/reference/global_attributes/nonce/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: nonce"
+title: nonce global attribute
 short-title: nonce
 slug: Web/HTML/Reference/Global_attributes/nonce
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/reference/global_attributes/nonce/index.md
@@ -1,5 +1,6 @@
 ---
-title: nonce
+title: "HTML global attribute: nonce"
+short-title: nonce
 slug: Web/HTML/Reference/Global_attributes/nonce
 page-type: html-attribute
 browser-compat: html.global_attributes.nonce

--- a/files/en-us/web/html/reference/global_attributes/part/index.md
+++ b/files/en-us/web/html/reference/global_attributes/part/index.md
@@ -1,5 +1,5 @@
 ---
-title: part global attribute
+title: HTML part global attribute
 short-title: part
 slug: Web/HTML/Reference/Global_attributes/part
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/part/index.md
+++ b/files/en-us/web/html/reference/global_attributes/part/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: part"
+title: part global attribute
 short-title: part
 slug: Web/HTML/Reference/Global_attributes/part
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/part/index.md
+++ b/files/en-us/web/html/reference/global_attributes/part/index.md
@@ -1,5 +1,6 @@
 ---
-title: part
+title: "HTML global attribute: part"
+short-title: part
 slug: Web/HTML/Reference/Global_attributes/part
 page-type: html-attribute
 browser-compat: html.global_attributes.part

--- a/files/en-us/web/html/reference/global_attributes/popover/index.md
+++ b/files/en-us/web/html/reference/global_attributes/popover/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: popover"
+title: popover global attribute
 short-title: popover
 slug: Web/HTML/Reference/Global_attributes/popover
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/popover/index.md
+++ b/files/en-us/web/html/reference/global_attributes/popover/index.md
@@ -1,5 +1,6 @@
 ---
-title: popover
+title: "HTML global attribute: popover"
+short-title: popover
 slug: Web/HTML/Reference/Global_attributes/popover
 page-type: html-attribute
 browser-compat: html.global_attributes.popover

--- a/files/en-us/web/html/reference/global_attributes/popover/index.md
+++ b/files/en-us/web/html/reference/global_attributes/popover/index.md
@@ -1,5 +1,5 @@
 ---
-title: popover global attribute
+title: HTML popover global attribute
 short-title: popover
 slug: Web/HTML/Reference/Global_attributes/popover
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/slot/index.md
+++ b/files/en-us/web/html/reference/global_attributes/slot/index.md
@@ -1,5 +1,5 @@
 ---
-title: slot global attribute
+title: HTML slot global attribute
 short-title: slot
 slug: Web/HTML/Reference/Global_attributes/slot
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/slot/index.md
+++ b/files/en-us/web/html/reference/global_attributes/slot/index.md
@@ -1,5 +1,6 @@
 ---
-title: slot
+title: "HTML global attribute: slot"
+short-title: slot
 slug: Web/HTML/Reference/Global_attributes/slot
 page-type: html-attribute
 browser-compat: html.global_attributes.slot

--- a/files/en-us/web/html/reference/global_attributes/slot/index.md
+++ b/files/en-us/web/html/reference/global_attributes/slot/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: slot"
+title: slot global attribute
 short-title: slot
 slug: Web/HTML/Reference/Global_attributes/slot
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/reference/global_attributes/spellcheck/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: spellcheck"
+title: spellcheck global attribute
 short-title: spellcheck
 slug: Web/HTML/Reference/Global_attributes/spellcheck
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/reference/global_attributes/spellcheck/index.md
@@ -1,5 +1,5 @@
 ---
-title: spellcheck global attribute
+title: HTML spellcheck global attribute
 short-title: spellcheck
 slug: Web/HTML/Reference/Global_attributes/spellcheck
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/reference/global_attributes/spellcheck/index.md
@@ -1,5 +1,6 @@
 ---
-title: spellcheck
+title: "HTML global attribute: spellcheck"
+short-title: spellcheck
 slug: Web/HTML/Reference/Global_attributes/spellcheck
 page-type: html-attribute
 browser-compat: html.global_attributes.spellcheck

--- a/files/en-us/web/html/reference/global_attributes/style/index.md
+++ b/files/en-us/web/html/reference/global_attributes/style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: style"
+title: style global attribute
 short-title: style
 slug: Web/HTML/Reference/Global_attributes/style
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/style/index.md
+++ b/files/en-us/web/html/reference/global_attributes/style/index.md
@@ -1,5 +1,6 @@
 ---
-title: style
+title: "HTML global attribute: style"
+short-title: style
 slug: Web/HTML/Reference/Global_attributes/style
 page-type: html-attribute
 browser-compat: html.global_attributes.style

--- a/files/en-us/web/html/reference/global_attributes/style/index.md
+++ b/files/en-us/web/html/reference/global_attributes/style/index.md
@@ -1,5 +1,5 @@
 ---
-title: style global attribute
+title: HTML style global attribute
 short-title: style
 slug: Web/HTML/Reference/Global_attributes/style
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/tabindex/index.md
+++ b/files/en-us/web/html/reference/global_attributes/tabindex/index.md
@@ -1,5 +1,6 @@
 ---
-title: tabindex
+title: "HTML global attribute: tabindex"
+short-title: tabindex
 slug: Web/HTML/Reference/Global_attributes/tabindex
 page-type: html-attribute
 browser-compat: html.global_attributes.tabindex

--- a/files/en-us/web/html/reference/global_attributes/tabindex/index.md
+++ b/files/en-us/web/html/reference/global_attributes/tabindex/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: tabindex"
+title: tabindex global attribute
 short-title: tabindex
 slug: Web/HTML/Reference/Global_attributes/tabindex
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/tabindex/index.md
+++ b/files/en-us/web/html/reference/global_attributes/tabindex/index.md
@@ -1,5 +1,5 @@
 ---
-title: tabindex global attribute
+title: HTML tabindex global attribute
 short-title: tabindex
 slug: Web/HTML/Reference/Global_attributes/tabindex
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/title/index.md
+++ b/files/en-us/web/html/reference/global_attributes/title/index.md
@@ -1,5 +1,5 @@
 ---
-title: title global attribute
+title: HTML title global attribute
 short-title: title
 slug: Web/HTML/Reference/Global_attributes/title
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/title/index.md
+++ b/files/en-us/web/html/reference/global_attributes/title/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: title"
+title: title global attribute
 short-title: title
 slug: Web/HTML/Reference/Global_attributes/title
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/title/index.md
+++ b/files/en-us/web/html/reference/global_attributes/title/index.md
@@ -1,5 +1,6 @@
 ---
-title: title
+title: "HTML global attribute: title"
+short-title: title
 slug: Web/HTML/Reference/Global_attributes/title
 page-type: html-attribute
 browser-compat: html.global_attributes.title

--- a/files/en-us/web/html/reference/global_attributes/translate/index.md
+++ b/files/en-us/web/html/reference/global_attributes/translate/index.md
@@ -1,5 +1,6 @@
 ---
-title: translate
+title: "HTML global attribute: translate"
+short-title: translate
 slug: Web/HTML/Reference/Global_attributes/translate
 page-type: html-attribute
 browser-compat: html.global_attributes.translate

--- a/files/en-us/web/html/reference/global_attributes/translate/index.md
+++ b/files/en-us/web/html/reference/global_attributes/translate/index.md
@@ -1,5 +1,5 @@
 ---
-title: translate global attribute
+title: HTML translate global attribute
 short-title: translate
 slug: Web/HTML/Reference/Global_attributes/translate
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/translate/index.md
+++ b/files/en-us/web/html/reference/global_attributes/translate/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: translate"
+title: translate global attribute
 short-title: translate
 slug: Web/HTML/Reference/Global_attributes/translate
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
+++ b/files/en-us/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
@@ -1,5 +1,5 @@
 ---
-title: virtualkeyboardpolicy global attribute
+title: HTML virtualkeyboardpolicy global attribute
 short-title: virtualkeyboardpolicy
 slug: Web/HTML/Reference/Global_attributes/virtualkeyboardpolicy
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
+++ b/files/en-us/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
@@ -1,5 +1,6 @@
 ---
-title: virtualkeyboardpolicy
+title: "HTML global attribute: virtualkeyboardpolicy"
+short-title: virtualkeyboardpolicy
 slug: Web/HTML/Reference/Global_attributes/virtualkeyboardpolicy
 page-type: html-attribute
 status:

--- a/files/en-us/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
+++ b/files/en-us/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: virtualkeyboardpolicy"
+title: virtualkeyboardpolicy global attribute
 short-title: virtualkeyboardpolicy
 slug: Web/HTML/Reference/Global_attributes/virtualkeyboardpolicy
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
+++ b/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
@@ -1,5 +1,5 @@
 ---
-title: writingsuggestions global attribute
+title: HTML writingsuggestions global attribute
 short-title: writingsuggestions
 slug: Web/HTML/Reference/Global_attributes/writingsuggestions
 page-type: html-attribute

--- a/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
+++ b/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
@@ -1,5 +1,6 @@
 ---
-title: writingsuggestions
+title: "HTML global attribute: writingsuggestions"
+short-title: writingsuggestions
 slug: Web/HTML/Reference/Global_attributes/writingsuggestions
 page-type: html-attribute
 browser-compat: html.global_attributes.writingsuggestions

--- a/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
+++ b/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML global attribute: writingsuggestions"
+title: writingsuggestions global attribute
 short-title: writingsuggestions
 slug: Web/HTML/Reference/Global_attributes/writingsuggestions
 page-type: html-attribute


### PR DESCRIPTION

### Description

We have the qualifier "HTML attribute:" on attribute pages ([example](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/accept)), but it is missing from titles for global attributes. 
This PR adds "HTML global attribute:" to the `title` key and repurposes the existing title as `short-title`.

### Motivation

To ensure consistency in title format in the same technology area. This also benefits SEO.


