### PR TITLE
Fix grammar

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -130,7 +130,7 @@ The {{jsxref("Date/Date", "Date()")}} constructor can be called with two or more
 > [!NOTE]
 > Some methods, including the `Date()` constructor, `Date.UTC()`, and the deprecated {{jsxref("Date/getYear", "getYear()")}}/{{jsxref("Date/setYear", "setYear()")}} methods, interpret a two-digit year as a year in the 1900s. For example, `new Date(99, 5, 24)` is interpreted as June 24, 1999, not June 24, 99. See [Interpretation of two-digit years](#interpretation_of_two-digit_years) for more information.
 
-When a segment overflows or underflows its expected range, it usually "carries over to" or "borrows from" the higher segment. For example, if the month is set to 12 (months are zero-based, so December is 11), it become the January of the next year. If the day of month is set to 0, it becomes the last day of the previous month. This also applies to dates specified with the [date time string format](#date_time_string_format).
+When a segment overflows or underflows its expected range, it usually "carries over to" or "borrows from" the higher segment. For example, if the month is set to 12 (months are zero-based, so December is 11), it becomes the January of the next year. If the day of month is set to 0, it becomes the last day of the previous month. This also applies to dates specified with the [date time string format](#date_time_string_format).
 
 ### Date time string format
 


### PR DESCRIPTION
# Pull Request: Fix grammar in Date object documentation

This fixes a grammatical error in the Date object documentation where "it become" should be "it becomes" when describing date overflow behavior.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- 📝 For large changes, check our contribution guide:
     https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests -->

<!-- 🚨 Low-quality, spammy, or disruptive pull requests are moderated heavily.
     Severe or repeated violations can result in being banned from contributing.
     Make sure you've read and agree to the following:
     - Community Participation Guidelines: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines
     - MDN Content Enforcement Policy: https://developer.mozilla.org/en-US/docs/MDN/Community/Community_Participation_Guidelines -->

<!-- Please complete all sections, especially the Motivation field. If there's no related issue, explaining why this change is needed helps reviewers understand the context and prioritize your request. Without it, your PR may be delayed or closed. -->

<!-- 👷‍♀️ After submitting, go to the 'Checks' tab of your PR for the build status -->
---

## Description

This fixes a grammatical error in the Date object documentation where "it become" should be "it becomes" when describing date overflow behavior.

## Motivation

This change improves the grammatical correctness of the MDN documentation. The sentence describing how date segments overflow was missing the "s" in "becomes", which made it grammatically incorrect. Proper grammar helps maintain the professional quality and readability of MDN's technical documentation for developers worldwide.

## Additional details

- **File changed**: `/files/en-us/web/javascript/reference/global_objects/date/index.md`
- **Change made**: "it become the January" → "it becomes the January"
- **Type**: Grammar/typo fix
- **Impact**: Improves documentation readability and correctness
- **Testing**: Passed all pre-commit linting checks including markdown formatting and URL validation
- **Branch**: `fix-date-grammar-typo`

### Before
```markdown
For example, if the month is set to 12 (months are zero-based, so December is 11), it become the January of the next year.
```

### After
```markdown
For example, if the month is set to 12 (months are zero-based, so December is 11), it becomes the January of the next year.
```

## Related issues and pull requests

No related issues. This was identified during documentation review as a standalone grammatical error that needed correction.

---

### Checklist

- [x] Read and followed the [MDN contribution guidelines](https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests)
- [x] Tested changes locally using `yarn fix:md`
- [x] Followed proper commit message format
- [x] Used descriptive branch name (`fix-date-grammar-typo`)
- [x] Made minimal, focused change addressing only the grammar issue
- [x] Verified no other similar issues exist in the same file

Fixes #39817
