### PR TITLE
Fix grammar: change 'become' to 'becomes' in Date overflow example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -130,7 +130,7 @@ The {{jsxref("Date/Date", "Date()")}} constructor can be called with two or more
 > [!NOTE]
 > Some methods, including the `Date()` constructor, `Date.UTC()`, and the deprecated {{jsxref("Date/getYear", "getYear()")}}/{{jsxref("Date/setYear", "setYear()")}} methods, interpret a two-digit year as a year in the 1900s. For example, `new Date(99, 5, 24)` is interpreted as June 24, 1999, not June 24, 99. See [Interpretation of two-digit years](#interpretation_of_two-digit_years) for more information.
 
-When a segment overflows or underflows its expected range, it usually "carries over to" or "borrows from" the higher segment. For example, if the month is set to 12 (months are zero-based, so December is 11), it become the January of the next year. If the day of month is set to 0, it becomes the last day of the previous month. This also applies to dates specified with the [date time string format](#date_time_string_format).
+When a segment overflows or underflows its expected range, it usually "carries over to" or "borrows from" the higher segment. For example, if the month is set to 12 (months are zero-based, so December is 11), it becomes the January of the next year. If the day of month is set to 0, it becomes the last day of the previous month. This also applies to dates specified with the [date time string format](#date_time_string_format).
 
 ### Date time string format
 


### PR DESCRIPTION
## Summary
   Fixed a grammar error in the Date object documentation.

   ## Changes
   - Changed "it become the January" to "it becomes the January" in the Date overflow explanation
   - Location: files/en-us/web/javascript/reference/global_objects/date/index.md, line 132

   ## Context
   This fixes a grammar error in the section explaining how Date components overflow to the next unit (e.g., month 12 becomes January of next year).
