### PR TITLE
Remove GPC spec links in see also

### DIFF
--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -39,5 +39,4 @@ console.log(navigator.globalPrivacyControl);
 
 - {{HTTPHeader("Sec-GPC")}} header
 - [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Global Privacy Control Spec](https://privacycg.github.io/gpc-spec/)
 - [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)

--- a/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
@@ -39,5 +39,4 @@ console.log(navigator.globalPrivacyControl);
 
 - {{HTTPHeader("Sec-GPC")}} header
 - [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Global Privacy Control Spec](https://privacycg.github.io/gpc-spec/)
 - [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)

--- a/files/en-us/web/http/reference/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/reference/headers/sec-gpc/index.md
@@ -64,5 +64,4 @@ navigator.globalPrivacyControl; // "false" or "true"
 - {{HTTPHeader("DNT")}} header
 - {{HTTPHeader("Tk")}} header
 - [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Global Privacy Control Spec](https://privacycg.github.io/gpc-spec/)
 - [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)


### PR DESCRIPTION
Following up from https://github.com/mdn/content/pull/39820; these links should be in the specifications section anyway.