### PR TITLE
Remove codepen in web audio user control

### DIFF
--- a/files/en-us/web/api/web_audio_api/best_practices/index.md
+++ b/files/en-us/web/api/web_audio_api/best_practices/index.md
@@ -82,9 +82,9 @@ You might instead be working with an {{domxref("OfflineAudioContext")}}, in whic
 
 If your website or application contains sound, you should allow the user control over it, otherwise again, it will become annoying. This can be achieved by play/stop and volume/mute controls. The [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API) tutorial goes over how to do this.
 
-If you have buttons that switch audio on and off, using the ARIA [`role="switch"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role) attribute on them is a good option for signalling to assistive technology what the button's exact purpose is, and therefore making the app more accessible. There's a [demo of how to use it here](https://codepen.io/Wilto/pen/ZoGoQm?editors=1100).
+Some controls you may find useful are: {{HTMLElement("button")}} elements for play/pause, {{HTMLElement("select")}} elements for selecting options like playback speed, [`<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox) elements for toggling mute, and [`<input type="range">`](/en-US/docs/Web/HTML/Element/input/range) elements for volume control and inputting other number values.
 
-As you work with a lot of changing values within the Web Audio API and will want to provide users with control over these, the [`<input type="range">`](/en-US/docs/Web/HTML/Reference/Elements/input/range) is often a good choice of control to use. It's a good option as you can set minimum and maximum values, as well as increments with the [`step`](/en-US/docs/Web/HTML/Reference/Elements/input#step) attribute.
+All the common considerations about form accessibility apply. When using {{HTMLElement("button")}} elements, you should ensure that they have a clear [label](/en-US/docs/Web/HTML/Reference/Elements/label). This will help screen readers and other assistive technologies to understand the purpose of the button. If you have buttons that switch audio on and off, using the ARIA [`role="switch"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role) attribute on them is a good option for signalling to assistive technology what the button's exact purpose is, and therefore making the app more accessible.
 
 ## Setting AudioParam values
 


### PR DESCRIPTION
This example doesn't really illustrate anything and doesn't pertain to web audio in particular. Also rewrote the text a bit to promote HTML rather than ARIA.

https://github.com/mdn/content/issues/16120