### PR TITLE
css(add): contrast-color() function page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12321,8 +12321,8 @@
 /en-US/docs/Web/CSS/clamp()	/en-US/docs/Web/CSS/clamp
 /en-US/docs/Web/CSS/color-adjust	/en-US/docs/Web/CSS/print-color-adjust
 /en-US/docs/Web/CSS/color_value/color()	/en-US/docs/Web/CSS/color_value/color
-/en-US/docs/Web/CSS/color_value/color-contrast	/en-US/docs/Web/CSS/color_value
-/en-US/docs/Web/CSS/color_value/color-contrast()	/en-US/docs/Web/CSS/color_value
+/en-US/docs/Web/CSS/color_value/color-contrast	/en-US/docs/Web/CSS/color_value/contrast-color
+/en-US/docs/Web/CSS/color_value/color-contrast()	/en-US/docs/Web/CSS/color_value/contrast-color
 /en-US/docs/Web/CSS/color_value/color-mix()	/en-US/docs/Web/CSS/color_value/color-mix
 /en-US/docs/Web/CSS/color_value/color_keywords	/en-US/docs/Web/CSS/named-color
 /en-US/docs/Web/CSS/color_value/device-cmyk()	/en-US/docs/Web/CSS/color_value/device-cmyk

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -13,11 +13,6 @@ The **`contrast-color()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web
 
 `contrast-color()` makes it easy, for example, to specify a text color when background colors are created dynamically, or vice versa. It avoids the need to maintain background-text color pairs.
 
-The function produces only `white` or `black` value, depending on which value produces maximum contrast with the input color. If both white and black colors produce the same contrast, then the `white` value is returned.
-
-> [!WARNING]
-> There is no guarantee that the resulting colors obtained using the `contrast-color()` function will always be accessible. For example, generally, mid-tone background colors don't result in enough contrast. It is recommended to use clearly-light or clearly-dark colors with the `contrast-color()` function.
-
 ## Syntax
 
 ```css
@@ -30,9 +25,20 @@ contrast-color(var(--backgroundColor))
 - `color`
   - : Any valid {{cssxref("&lt;color&gt;")}} value.
 
-### Examples
+### Return value
 
-#### Contrasting text for a button
+Either `white` or `black` color value.
+
+## Description
+
+The function produces only `white` or `black` value, depending on which value produces maximum contrast with the input color. If both white and black colors produce the same contrast, then the `white` value is returned.
+
+> [!WARNING]
+> There is no guarantee that the values returned using the `contrast-color()` function will produce an accessible result. Mid-tone background colors generally don't provide enough contrast. It is recommended therefore to use light or dark colors with the `contrast-color()` function.
+
+## Examples
+
+### Contrasting text for a button
 
 In the following example, the browser automatically applies a contrasting color to the submit {{htmlelement("button")}} text when you change its background color.
 
@@ -100,7 +106,7 @@ updateColor();
 
 {{EmbedLiveSample("Contrasting text for a button", "", 250)}}
 
-#### Light and dark mode usage
+### Light and dark mode usage
 
 In the following example, the [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) has been used to set a background color based on operating system or browser color scheme settings. The `contrast-color()` function is used to automatically set the text color.
 
@@ -172,11 +178,10 @@ pre {
 
 ## See also
 
-- [How to have the browser pick a contrasting color in CSS](https://webkit.org/blog/16929/contrast-color/)
-- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
-- {{cssxref("color_value", "&lt;color>")}} data type
-- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast)
-- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
-- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) and [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) {{cssxref("@media")}} features
 - [`contrast()`](/en-US/docs/Web/CSS/filter-function/contrast)
+- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
 - [CSS custom properties](/en-US/docs/Web/CSS/--*) and {{cssxref("var")}}
+- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) and [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) {{cssxref("@media")}} features
+- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast)
+- [How to have the browser pick a contrasting color in CSS](https://webkit.org/blog/16929/contrast-color/) on webkit.org (2025)
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) on webaim.org (2025)

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -32,6 +32,8 @@ contrast-color(var(--backgroundColor))
 
 #### Contrasting text for a button
 
+In the following example when you change background color of the button, the webbrowser automatically applies a contrasting color to the `Submit` text.
+
 ```html hidden
 <label>
   Select background color of the button:
@@ -49,6 +51,7 @@ contrast-color(var(--backgroundColor))
 button {
   background-color: var(--button-color);
 
+  /* set contrasting text color automatically */
   color: contrast-color(var(--button-color));
 }
 ```
@@ -94,6 +97,68 @@ updateColor();
 ```
 
 {{EmbedLiveSample("Contrasting text for a button", "", 250)}}
+
+#### Light and dark mode usage
+
+In the following example [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) has been used to set background color based on operating system or browser color scheme/theme setting. The `contrast-color()` function sets text color automatically.
+
+In the browser setting try changing the dark mode setting to see the effect.
+
+```html hidden
+<pre>
+    Q: How does CSS transform light into energy?
+  Ans: Using <a href="/en-US/docs/Web/CSS/font-synthesis">font-synthesis</a>.
+</pre>
+```
+
+```css
+:root {
+  --background-color: navy;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --background-color: wheat;
+  }
+}
+
+body,
+a {
+  background-color: var(--background-color);
+  color: contrast-color(var(--background-color));
+}
+```
+
+```css hidden
+body {
+  padding: 2rem;
+  font-size: 1.2rem;
+}
+
+pre {
+  margin-top: 3rem;
+}
+
+@supports not (color: contrast-color(red)) {
+  body::before {
+    content: "Your browser doesn't support the contrast-color() function.";
+    background-color: wheat;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body {
+    background-color: white;
+  }
+
+  body > * {
+    display: none;
+  }
+}
+```
+
+{{EmbedLiveSample("Light and dark mode usage", "", 250)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -19,8 +19,8 @@ The function produces only `white` or `black` value, depending on which value pr
 ## Syntax
 
 ```css
-color-contrast(red)
-color-contrast(var(--backgroundColor))
+contrast-color(red)
+contrast-color(var(--backgroundColor))
 ```
 
 ### Values
@@ -49,9 +49,9 @@ button {
 ```
 
 ```css hidden live-sample__button_text_ex
-@supports not (color: color-contrast(red)) {
+@supports not (color: contrast-color(red)) {
   body::before {
-    content: "Your browser doesn't support the color-contrast() function.";
+    content: "Your browser doesn't support the contrast-color() function.";
     background-color: wheat;
     display: block;
     width: 100%;

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -1,0 +1,86 @@
+---
+title: contrast-color()
+slug: Web/CSS/color_value/contrast-color
+page-type: css-function
+status:
+  - experimental
+browser-compat: css.types.color.contrast-color
+---
+
+{{CSSRef}}{{SeeCompatTable}}
+
+The **`contrast-color()`** functional notation takes a {{cssxref("color_value","color")}} value and returns a [guaranteed](https://www.w3.org/TR/WCAG21/#contrast-minimum) contrasting color. The function makes it easy to specify text color when background colors are created dynamically. It saves developers from maintaining background-text color pairs. It is not limited to deriving text colors; you can use it for deriving colors of anything, such as border, background, etc.
+
+The function produces only `white` or `black` value, depending on which value produces maximum contrast with the input color. If both white and black colors produce the same contrast, then the `white` value is returned.
+
+> [!WARNING]
+> There is no guarantee that the resulting colors obtained using the `contrast-color()` function will always be accessible. For example, generally, mid-tone background colors don't result in enough contrast. It is recommended to use clearly-light or clearly-dark colors with the `contrast-color()` function.
+
+## Syntax
+
+```css
+color-contrast(red)
+color-contrast(var(--backgroundColor))
+```
+
+### Values
+
+- `color`
+  - : Any valid {{cssxref("&lt;color&gt;")}}.
+
+### Examples
+
+#### Contrasting text for a button
+
+```html hidden live-sample__button_text_ex
+<button>Submit</button>
+```
+
+```css live-sample__button_text_ex
+:root {
+  --button-color: lightblue;
+}
+
+button {
+  background-color: var(--button-color);
+
+  color: contrast-color(var(--button-color));
+}
+```
+
+```css hidden live-sample__button_text_ex
+@supports not (color: color-contrast(red)) {
+  body::before {
+    content: "Your browser doesn't support the color-contrast() function.";
+    background-color: wheat;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body > * {
+    display: none;
+  }
+}
+```
+
+{{EmbedLiveSample("button_text_ex", "", 200)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [How to have the browser pick a contrasting color in CSS](https://webkit.org/blog/16929/contrast-color/)
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- {{cssxref("color_value", "&lt;color>")}} data type
+- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast)
+- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
+- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) and [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) {{cssxref("@media")}} features
+- [`contrast()`](/en-US/docs/Web/CSS/filter-function/contrast)
+- [CSS custom properties](/en-US/docs/Web/CSS/--*) and {{cssxref("var")}}

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -11,7 +11,7 @@ browser-compat: css.types.color.contrast-color
 
 The **`contrast-color()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_Value_Functions) takes a {{cssxref("color_value","color")}} value and returns a [guaranteed](https://www.w3.org/TR/WCAG21/#contrast-minimum) contrasting color.
 
-`contrast-color()` makes it easy, for example, to specify a text color when background colors are created dynamically, or vice versa. It avoids the need to maintain background-text color pairs.
+`contrast-color()` makes it easy, for example, to specify a text color and automatically generate a contrasting background color, or vice versa. It avoids the need to maintain background-text color pairs.
 
 ## Syntax
 
@@ -27,11 +27,11 @@ contrast-color(var(--backgroundColor))
 
 ### Return value
 
-Either `white` or `black` color value.
+A {{cssxref("named-color")}} of either `white` or `black`.
 
 ## Description
 
-The function produces only `white` or `black` value, depending on which value produces maximum contrast with the input color. If both white and black colors produce the same contrast, then the `white` value is returned.
+The `contrast-color()` function returns a value of `white` or `black`, depending on which value has the greatest contrast with the input color. If both `white` and `black` have the same contrast with the input color, `white` is returned.
 
 > [!WARNING]
 > There is no guarantee that the values returned using the `contrast-color()` function will produce an accessible result. Mid-tone background colors generally don't provide enough contrast. It is recommended therefore to use light or dark colors with the `contrast-color()` function.
@@ -108,7 +108,7 @@ updateColor();
 
 ### Light and dark mode usage
 
-In the following example, the [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) has been used to set a background color based on operating system or browser color scheme settings. The `contrast-color()` function is used to automatically set the text color.
+In the following example, the [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) is used to set a background color based on operating system or browser color scheme settings. The `contrast-color()` function is used to set the text color automatically.
 
 Try changing the browser or OS dark mode setting to see the effect.
 

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -33,6 +33,11 @@ contrast-color(var(--backgroundColor))
 #### Contrasting text for a button
 
 ```html hidden
+<label>
+  Select background color of the button:
+  <input type="color" id="colorPicker" value="#660066" />
+</label>
+<br />
 <button>Submit</button>
 ```
 
@@ -49,6 +54,18 @@ button {
 ```
 
 ```css hidden
+body {
+  padding: 1rem;
+}
+
+button {
+  margin: 3rem;
+  padding: 1rem;
+  width: 150px;
+  font-size: 2rem;
+  border-radius: 1rem;
+}
+
 @supports not (color: contrast-color(red)) {
   body::before {
     content: "Your browser doesn't support the contrast-color() function.";
@@ -64,7 +81,19 @@ button {
 }
 ```
 
-{{EmbedLiveSample("button_text_ex", "", 200)}}
+```js hidden
+const colorPicker = document.getElementById("colorPicker");
+const root = document.documentElement;
+
+function updateColor(color) {
+  root.style.setProperty("--button-color", colorPicker.value);
+}
+
+colorPicker.addEventListener("change", updateColor);
+updateColor();
+```
+
+{{EmbedLiveSample("Contrasting text for a button", "", 250)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -9,7 +9,9 @@ browser-compat: css.types.color.contrast-color
 
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`contrast-color()`** functional notation takes a {{cssxref("color_value","color")}} value and returns a [guaranteed](https://www.w3.org/TR/WCAG21/#contrast-minimum) contrasting color. The function makes it easy to specify text color when background colors are created dynamically. It saves developers from maintaining background-text color pairs. It is not limited to deriving text colors; you can use it for deriving colors of anything, such as border, background, etc.
+The **`contrast-color()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_Value_Functions) takes a {{cssxref("color_value","color")}} value and returns a [guaranteed](https://www.w3.org/TR/WCAG21/#contrast-minimum) contrasting color.
+
+`contrast-color()` makes it easy, for example, to specify a text color when background colors are created dynamically, or vice versa. It avoids the need to maintain background-text color pairs.
 
 The function produces only `white` or `black` value, depending on which value produces maximum contrast with the input color. If both white and black colors produce the same contrast, then the `white` value is returned.
 
@@ -23,16 +25,16 @@ contrast-color(red)
 contrast-color(var(--backgroundColor))
 ```
 
-### Values
+### Parameters
 
 - `color`
-  - : Any valid {{cssxref("&lt;color&gt;")}}.
+  - : Any valid {{cssxref("&lt;color&gt;")}} value.
 
 ### Examples
 
 #### Contrasting text for a button
 
-In the following example when you change background color of the button, the webbrowser automatically applies a contrasting color to the `Submit` text.
+In the following example, the browser automatically applies a contrasting color to the submit {{htmlelement("button")}} text when you change its background color.
 
 ```html hidden
 <label>
@@ -51,7 +53,7 @@ In the following example when you change background color of the button, the web
 button {
   background-color: var(--button-color);
 
-  /* set contrasting text color automatically */
+  /* Set contrasting text color automatically */
   color: contrast-color(var(--button-color));
 }
 ```
@@ -100,9 +102,9 @@ updateColor();
 
 #### Light and dark mode usage
 
-In the following example [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) has been used to set background color based on operating system or browser color scheme/theme setting. The `contrast-color()` function sets text color automatically.
+In the following example, the [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) has been used to set a background color based on operating system or browser color scheme settings. The `contrast-color()` function is used to automatically set the text color.
 
-In the browser setting try changing the dark mode setting to see the effect.
+Try changing the browser or OS dark mode setting to see the effect.
 
 ```html hidden
 <pre>

--- a/files/en-us/web/css/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/color_value/contrast-color/index.md
@@ -32,11 +32,11 @@ contrast-color(var(--backgroundColor))
 
 #### Contrasting text for a button
 
-```html hidden live-sample__button_text_ex
+```html hidden
 <button>Submit</button>
 ```
 
-```css live-sample__button_text_ex
+```css
 :root {
   --button-color: lightblue;
 }
@@ -48,7 +48,7 @@ button {
 }
 ```
 
-```css hidden live-sample__button_text_ex
+```css hidden
 @supports not (color: contrast-color(red)) {
   body::before {
     content: "Your browser doesn't support the contrast-color() function.";

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -76,7 +76,7 @@ A `<color>` value can be specified using one of the methods listed below:
   - Other color spaces: {{CSSXref("color_value/color", "color()")}}.
 - By using [relative color](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) syntax to output a new color based on an existing color. Any of the above color functions can take an **origin color** preceded by the `from` keyword and followed by definitions of the channel values for the new **output color**.
 - By mixing two colors: {{CSSXref("color_value/color-mix", "color-mix()")}}.
-- By selecting a color with maximum contrast: {{CSSXref("color_value/contrast-color", "contrast-color()")}}.
+- By specifying a color that you want a contrasting color returned for: {{CSSXref("color_value/contrast-color", "contrast-color()")}}.
 - By specifying two colors, using the first for light color-schemes and the second for dark color-schemes: {{CSSXref("color_value/light-dark", "light-dark()")}}.
 
 ### `currentcolor` keyword

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -76,6 +76,7 @@ A `<color>` value can be specified using one of the methods listed below:
   - Other color spaces: {{CSSXref("color_value/color", "color()")}}.
 - By using [relative color](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) syntax to output a new color based on an existing color. Any of the above color functions can take an **origin color** preceded by the `from` keyword and followed by definitions of the channel values for the new **output color**.
 - By mixing two colors: {{CSSXref("color_value/color-mix", "color-mix()")}}.
+- By selecting a color with maximum contrast: {{CSSXref("color_value/contrast-color", "contrast-color()")}}.
 - By specifying two colors, using the first for light color-schemes and the second for dark color-schemes: {{CSSXref("color_value/light-dark", "light-dark()")}}.
 
 ### `currentcolor` keyword

--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -47,6 +47,7 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
   - [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch)
   - [`color()`](/en-US/docs/Web/CSS/color_value/color)
 - [`color-mix()`](/en-US/docs/Web/CSS/color_value/color-mix)
+- [`contrast-color()`](/en-US/docs/Web/CSS/color_value/contrast-color)
 - {{CSSXref("color_value/light-dark", "light-dark()")}}
 
 > [!NOTE]

--- a/files/en-us/web/css/css_values_and_units/css_value_functions/index.md
+++ b/files/en-us/web/css/css_values_and_units/css_value_functions/index.md
@@ -202,6 +202,8 @@ The {{CSSxRef("color_value","&lt;color&gt;")}} CSS [data type](/en-US/docs/Web/C
   - : Specifies a particular, specified colorspace rather than the implicit sRGB colorspace.
 - {{CSSxRef("color_value/color-mix", "color-mix()")}}
   - : Mixes two color values in a given colorspace by a given amount.
+- {{CSSxRef("color_value/contrast-color", "contrast-color()")}}
+  - : Returns color with maximum color contrast for a given color.
 - {{CSSxRef("color_value/device-cmyk", "device-cmyk()")}}
   - : Defines CMYK colors in a device-dependent way.
 - {{CSSXref("color_value/light-dark", "light-dark()")}}

--- a/files/en-us/web/css/css_values_and_units/css_value_functions/index.md
+++ b/files/en-us/web/css/css_values_and_units/css_value_functions/index.md
@@ -203,7 +203,7 @@ The {{CSSxRef("color_value","&lt;color&gt;")}} CSS [data type](/en-US/docs/Web/C
 - {{CSSxRef("color_value/color-mix", "color-mix()")}}
   - : Mixes two color values in a given colorspace by a given amount.
 - {{CSSxRef("color_value/contrast-color", "contrast-color()")}}
-  - : Returns color with maximum color contrast for a given color.
+  - : Returns a color with maximum color contrast for a given color.
 - {{CSSxRef("color_value/device-cmyk", "device-cmyk()")}}
   - : Defines CMYK colors in a device-dependent way.
 - {{CSSXref("color_value/light-dark", "light-dark()")}}


### PR DESCRIPTION
### Description

Add contrast-color() function page.

### Motivation

The feature is in Safari Technology Preview now.

### Additional details

The function is completely different now from the original `color-contrast()` function. The current version is simple, accepting only one parameter and returning only two possible values.
- https://www.w3.org/TR/css-color-5/#contrast-color
- https://webkit.org/blog/16929/contrast-color/

### Related issues and pull requests

- https://github.com/mdn/content/pull/36973#issuecomment-2939957505