### PR TITLE
Fix error in "Modify an element's style" sample

### DIFF
--- a/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
+++ b/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
@@ -69,7 +69,7 @@ p1.addEventListener("click", () => {
   p1.style.background = "green";
 });
 button.addEventListener("click", () => {
-  elem.style.background = "white";
+  p1.style.background = "white";
 });
 ```
 


### PR DESCRIPTION
Hi,

[The code sample in "Modify an element's style"](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information#modify_an_elements_style) was not working correctly (throwing an error) when clicking on the "Reset background color" button.

Changing `elem` to `p1` fixes it.