### PR TITLE
docs(aria-busy): add intro paragraph explaining aria-busy purpose and use cases

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-busy/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-busy/index.md
@@ -7,7 +7,7 @@ spec-urls: https://w3c.github.io/aria/#aria-busy
 sidebar: accessibilitysidebar
 ---
 
-Used in [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions), the global `aria-busy` state indicates an element is being modified and that assistive technologies may want to wait until the changes are complete before informing the user about the update.
+The `aria-busy` attribute is a global ARIA state that indicates whether an element is currently being modified. It helps assistive technologies understand that content is not yet ready to be read or announced. While `aria-busy` is commonly used in [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) to delay announcements until updates are complete, it can also be used outside of live regions—for example, in widgets or feeds—to signal ongoing changes or loading.
 
 When multiple parts of a live region need to be loaded before changes are announced to the user, set `aria-busy="true"` until loading is complete. Then set to `aria-busy="false"`. This prevents assistive technologies from announcing changes before updates are done.
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-busy/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-busy/index.md
@@ -7,7 +7,9 @@ spec-urls: https://w3c.github.io/aria/#aria-busy
 sidebar: accessibilitysidebar
 ---
 
-The `aria-busy` attribute is a global ARIA state that indicates whether an element is currently being modified. It helps assistive technologies understand that content is not yet ready to be read or announced. While `aria-busy` is commonly used in [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) to delay announcements until updates are complete, it can also be used outside of live regions—for example, in widgets or feeds—to signal ongoing changes or loading.
+The `aria-busy` attribute is a global ARIA state that indicates whether an element is currently being modified.
+It helps assistive technologies understand that changes to the content are not yet complete, and that they may want to wait before informing users of the update.
+While `aria-busy` is commonly used in [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) to delay announcements until updates are complete, it can also be used outside of live regions—for example, in widgets or feeds—to signal ongoing changes or loading.
 
 When multiple parts of a live region need to be loaded before changes are announced to the user, set `aria-busy="true"` until loading is complete. Then set to `aria-busy="false"`. This prevents assistive technologies from announcing changes before updates are done.
 


### PR DESCRIPTION
Description
Adds an introductory paragraph to the aria-busy attribute documentation. The new paragraph clearly explains the purpose of aria-busy as a global ARIA state that indicates when an element is being updated, helping assistive technologies understand when content is not ready to be read. It also highlights common use cases both inside and outside of ARIA live regions.

Motivation
This addition improves clarity for developers by providing a straightforward explanation of aria-busy early in the document. It helps readers better understand how and why to use the attribute effectively, enhancing accessibility implementation.


Fixes #32293
