### PR TITLE
Fix #39848: Update `myConcat` example to skip first argument

### DIFF
--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -495,8 +495,8 @@ For example, consider a function that concatenates several strings. The only for
 function myConcat(separator) {
   let result = ""; // initialize list
   // iterate through arguments
-  for (const arg of arguments) {
-    result += arg + separator;
+  for (let i = 1; i < arguments.length; i++) {
+    result += arguments[i] + separator;
   }
   return result;
 }


### PR DESCRIPTION
### Description

The original example used a `for` loop that included the first argument (the separator) in the output. I corrected the loop to skip the first argument, starting from `i = 1`.

### Motivation

The code was producing incorrect output because it included the separator at the beginning. This change ensures that the separator is only placed between values.

### Additional details

Actual code:
![Screenshot 2025-06-08 123431](https://github.com/user-attachments/assets/b99bab75-10d3-4156-8d67-0ee27fed299b)
Actual Error output:
![Screenshot 2025-06-08 123657](https://github.com/user-attachments/assets/0698b056-e37d-45ce-a9bd-f8804bb7da98)
Corrected Code with Output:
![Screenshot 2025-06-08 123855](https://github.com/user-attachments/assets/ce89a5b5-a03f-42d1-b598-ab7ad7153f17)

### Related issues and pull requests
Fixes #39848

