### PR TITLE
Clarifying SecurityError in StorageManager.getDirectory

### DIFF
--- a/files/en-us/web/api/storagemanager/getdirectory/index.md
+++ b/files/en-us/web/api/storagemanager/getdirectory/index.md
@@ -27,7 +27,10 @@ A {{jsxref('Promise')}} that fulfills with a {{domxref("FileSystemDirectoryHandl
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the user agent is not able to map the requested directory to the local OPFS.
+  - : Thrown if the user agent is not able to map the requested directory to the local OPFS, due to factors such as:
+    - **Storage or memory constraints** that prevent OPFS allocation.
+    - **Security policies**, including restrictions in non-secure contexts (e.g., non-HTTPS sessions).
+    - **Private browsing mode**, where OPFS access is commonly restricted by browsers to prevent persistent data storage.
 
 ## Examples
 

--- a/files/en-us/web/api/storagemanager/getdirectory/index.md
+++ b/files/en-us/web/api/storagemanager/getdirectory/index.md
@@ -27,9 +27,9 @@ A {{jsxref('Promise')}} that fulfills with a {{domxref("FileSystemDirectoryHandl
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the user agent is not able to map the requested directory to the local OPFS, due to factors such as:
-    - **Storage or memory constraints** that prevent OPFS allocation.
-    - **Private browsing mode**, where OPFS access is commonly restricted by browsers to prevent persistent data storage.
+  - : Thrown if the browser is not able to map the requested directory to the local OPFS, for example due to storage or memory constraints. Also thrown in some browsers if `getDirectory()` is called in private browsing mode.
+- `UnknownError` {{domxref("DOMException")}}
+  - : Thrown in some browsers if `getDirectory()` is called in private browsing mode.
 
 ## Examples
 

--- a/files/en-us/web/api/storagemanager/getdirectory/index.md
+++ b/files/en-us/web/api/storagemanager/getdirectory/index.md
@@ -29,7 +29,6 @@ A {{jsxref('Promise')}} that fulfills with a {{domxref("FileSystemDirectoryHandl
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the user agent is not able to map the requested directory to the local OPFS, due to factors such as:
     - **Storage or memory constraints** that prevent OPFS allocation.
-    - **Security policies**, including restrictions in non-secure contexts (e.g., non-HTTPS sessions).
     - **Private browsing mode**, where OPFS access is commonly restricted by browsers to prevent persistent data storage.
 
 ## Examples


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- 📝 For large changes, check our contribution guide:
     https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests -->

<!-- 🚨 Low-quality, spammy, or disruptive pull requests are moderated heavily.
     Severe or repeated violations can result in being banned from contributing.
     Make sure you've read and agree to the following:
     - Community Participation Guidelines: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines
     - MDN Content Enforcement Policy: https://developer.mozilla.org/en-US/docs/MDN/Community/Community_Participation_Guidelines -->

<!-- Please complete all sections, especially the Motivation field. If there’s no related issue, explaining why this change is needed helps reviewers understand the context and prioritize your request. Without it, your PR may be delayed or closed. -->

<!-- 👷‍♀️ After submitting, go to the 'Checks' tab of your PR for the build status -->
---

### Description

Add concrete examples of the error in OPFS getDirectory() method, at [StorageManager.getDirectory#Exceptions](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/getDirectory)

### Motivation

Currently, the documentation states:
```
SecurityError DOMException
  Thrown if the user agent is not able to map the requested directory to the local OPFS.
```
I propose adding concrete scenarios that cause this exception, as the lack of detail may lead to confusion for developers implementing OPFS-based storage, like:
```
SecurityError DOMException
  Thrown if the user agent is not able to map the requested directory to the local OPFS, due to factors such as:
    * Storage or memory constraints that prevent OPFS allocation.
    * Security policies, including restrictions in non-secure contexts (e.g., non-HTTPS sessions).
    * Private browsing mode, where OPFS access is commonly restricted by browsers to prevent persistent data storage.
```

### Additional details

SQLite developers have specifically highlighted OPFS limitations in Incognito and Guest modes in their documentation: [Achtung: Restrictions in Incognito and Guest Browsing Modes](https://sqlite.org/wasm/doc/trunk/persistence.md#incognito).

In real-world tests, both Firefox and Safari threw a SecurityError when calling getDirectory() inside Private Browsing mode:

Firefox 128.11.0 error: "Security error when calling GetDirectory"

Safari 17.6 error: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)"

While browsers intentionally obscure Private Browsing detection, a small note in MDN can help developers anticipate storage failures in such contexts without directly exposing detection mechanisms.

Would it be possible to add a small clarification about these known limitations to better support developers encountering this issue?

### Related issues and pull requests