### PR TITLE
FF140 CloseWatcher in desktop preview - relnote/expr

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -373,12 +373,12 @@ For example, on Android you can close a dialog using the back button.
 The {{domxref("CloseWatcher")}} interface allows developers to implement UI components, such as custom sidebars, that can similarly be closed using native mechanisms.
 ([Firefox bug 1888729](https://bugzil.la/1888729)).
 
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 132           | No                  |
-| Developer Edition | 132           | Yes                 |
-| Beta              | 132           | Yes                 |
-| Release           | 132           | No                  |
+| Release channel   | Version added | Enabled by default?          |
+| ----------------- | ------------- | ---------------------------- |
+| Nightly           | 140           | Yes (Desktop). No (Android). |
+| Developer Edition | 132           | No                           |
+| Beta              | 132           | No                           |
+| Release           | 132           | No                           |
 
 - `dom.closewatcher.enabled`
   - : Set to `true` to enable.

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -119,7 +119,7 @@ These features are shipping in Firefox 140 but are disabled by default. To exper
   ([Firefox bug 1964407](https://bugzil.la/1964407)).
 
 - **`CloseWatcher`** (Nightly - desktop only): `dom.closewatcher.enabled`.
-  The {{domxref("CloseWatcher")}} interface enables developers to implement components that can be closed using device-native mechanisms, in the same way as built-in components. For example, on Android you can close a dialog using the back button: this interface allows you to similarly close a custom sidebar.([Firefox bug 1966459](https://bugzil.la/1966459)).
+  The {{domxref("CloseWatcher")}} interface enables you to implement components that can be closed using device-native mechanisms, in the same way as built-in components. On Windows this allows, for example, custom sidebars that will close when you select the <kbd>Esc</kbd> key. ([Firefox bug 1966459](https://bugzil.la/1966459)).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -118,6 +118,9 @@ These features are shipping in Firefox 140 but are disabled by default. To exper
   The API is now feature complete.
   ([Firefox bug 1964407](https://bugzil.la/1964407)).
 
+- **`CloseWatcher`** (Nightly - desktop only): `dom.closewatcher.enabled`.
+  The {{domxref("CloseWatcher")}} interface enables developers to implement components that can be closed using device-native mechanisms, in the same way as built-in components. For example, on Android you can close a dialog using the back button: this interface allows you to similarly close a custom sidebar.([Firefox bug 1966459](https://bugzil.la/1966459)).
+
 ## Older versions
 
 {{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -119,7 +119,7 @@ These features are shipping in Firefox 140 but are disabled by default. To exper
   ([Firefox bug 1964407](https://bugzil.la/1964407)).
 
 - **`CloseWatcher`** (Nightly - desktop only): `dom.closewatcher.enabled`.
-  The {{domxref("CloseWatcher")}} interface enables you to implement components that can be closed using device-native mechanisms, in the same way as built-in components. On Windows this allows, for example, custom sidebars that will close when you select the <kbd>Esc</kbd> key. ([Firefox bug 1966459](https://bugzil.la/1966459)).
+  The {{domxref("CloseWatcher")}} interface enables you to implement components that can be closed using device-native mechanisms, in the same way as built-in components. On Windows, for example, you can use this interface to make a custom sidebar close when users press the <kbd>Esc</kbd> key. ([Firefox bug 1966459](https://bugzil.la/1966459)).
 
 ## Older versions
 


### PR DESCRIPTION
FF140 enables CloseWatcher on desktop on nightly. This updates the experimental features. I also added a note to the release notes for this.

BCD work done in https://github.com/mdn/browser-compat-data/pull/27009