### PR TITLE
Fix broken playgrounds (and some improvements) in CSS positioning tutorial

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/positioning/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/positioning/index.md
@@ -50,6 +50,10 @@ Static positioning is the default that every element gets. It just means "put th
 
 To see this (and get your example set up for future sections) first add a `class` of `positioned` to the second {{htmlelement("p")}} in the HTML:
 
+```html hidden live-sample___static-positioning
+<h1>Static positioning</h1>
+```
+
 ```html hidden live-sample___relative-positioning
 <h1>Relative positioning</h1>
 ```
@@ -62,16 +66,16 @@ To see this (and get your example set up for future sections) first add a `class
 <h1>Positioning context</h1>
 ```
 
-```html hidden live-sample___z-index-1
+```html hidden live-sample___z-index-initial live-sample___z-index-1
 <h1>z-index</h1>
 ```
 
-```html hidden live-sample___fixed-positioning
+```html hidden live-sample___fixed-positioning-broken live-sample___fixed-positioning
 <h1>Fixed positioning</h1>
 ```
 
 <!-- prettier-ignore-start -->
-```html hidden live-sample___relative-positioning live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-1 live-sample___fixed-positioning
+```html hidden live-sample___static-positioning live-sample___relative-positioning live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-initial live-sample___z-index-1 live-sample___fixed-positioning-broken live-sample___fixed-positioning
 
 
 <p>
@@ -81,7 +85,7 @@ To see this (and get your example set up for future sections) first add a `class
 
 ```
 
-```html live-sample___relative-positioning
+```html live-sample___static-positioning live-sample___relative-positioning
 <p class="positioned">
   By default we span 100% of the width of our parent element, and we
   are as tall as our child content. Our total width and height is our
@@ -89,18 +93,18 @@ To see this (and get your example set up for future sections) first add a `class
 </p>
 ```
 
-```html hidden live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-1
+```html hidden live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-initial live-sample___z-index-1
 <p class="positioned">
   Now I'm absolutely positioned relative to the
   <code>&lt;body&gt;</code> element, not the <code>&lt;html&gt;</code> element!
 </p>
 ```
 
-```html hidden live-sample___fixed-positioning
+```html hidden live-sample___fixed-positioning-broken live-sample___fixed-positioning
 <p class="positioned">I'm not positioned any more.</p>
 ```
 
-```html hidden live-sample___relative-positioning live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-1 live-sample___fixed-positioning
+```html hidden live-sample___static-positioning live-sample___relative-positioning live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-initial live-sample___z-index-1 live-sample___fixed-positioning-broken live-sample___fixed-positioning
 
 
 <p>
@@ -123,7 +127,8 @@ To see this (and get your example set up for future sections) first add a `class
 
 Now add the following rule to the bottom of your CSS:
 
-```css hidden live-sample___relative-positioning live-sample___absolute-positioning
+<!-- prettier-ignore-start -->
+```css hidden live-sample___static-positioning live-sample___relative-positioning live-sample___absolute-positioning
 body {
   width: 500px;
   margin: 0 auto;
@@ -140,9 +145,11 @@ span {
   background: red;
   border: 1px solid black;
 }
-```
 
-```css
+```
+<!-- prettier-ignore-end -->
+
+```css live-sample___static-positioning
 .positioned {
   position: static;
   background: yellow;
@@ -150,6 +157,8 @@ span {
 ```
 
 If you save and refresh, you'll see no difference at all, except for the updated background color of the 2nd paragraph. This is fine — as we said before, static positioning is the default behavior!
+
+{{ EmbedLiveSample('static-positioning', '', 500) }}
 
 > [!NOTE]
 > You can see the example at this point live at [`1_static-positioning.html`](https://mdn.github.io/learning-area/css/css-layout/positioning/1_static-positioning.html) ([see source code](https://github.com/mdn/learning-area/blob/main/css/css-layout/positioning/1_static-positioning.html)).
@@ -219,14 +228,14 @@ Let's try changing the position declaration in your code as follows:
 ```
 <!-- prettier-ignore-end -->
 
-If you now save and refresh, you should see something like so:
-
 ```css hidden live-sample___absolute-positioning
   background: yellow;
   top: 30px;
   left: 30px;
 }
 ```
+
+If you now save and refresh, you should see something like so:
 
 {{ EmbedLiveSample('absolute-positioning', '', 450) }}
 
@@ -251,21 +260,19 @@ If no ancestor elements have their position property explicitly defined, then by
 
 The positioned element is nested inside the {{htmlelement("body")}} in the HTML source, but in the final layout it's 30px away from the top and the left edges of the page. We can change the **positioning context**, that is, which element the absolutely positioned element is positioned relative to. This is done by setting positioning on one of the element's ancestors: to one of the elements it's nested inside of (you can't position it relative to an element it's not nested inside of). To see this, add the following declaration to your `body` rule:
 
-```css hidden live-sample___positioning-context live-sample___z-index-1
+```css hidden live-sample___positioning-context live-sample___z-index-initial live-sample___z-index-1
 body {
   width: 500px;
   margin: 0 auto;
 ```
 
 <!-- prettier-ignore-start -->
-```css live-sample___positioning-context live-sample___z-index-1
+```css live-sample___positioning-context live-sample___z-index-initial live-sample___z-index-1
   position: relative;
 ```
 <!-- prettier-ignore-end -->
 
-This should give the following result:
-
-```css hidden live-sample___positioning-context live-sample___z-index-1
+```css hidden live-sample___positioning-context live-sample___z-index-initial live-sample___z-index-1
 }
 
 p {
@@ -288,6 +295,8 @@ span {
 }
 ```
 
+This should give the following result:
+
 {{ EmbedLiveSample('positioning-context', '', 420) }}
 
 The positioned element now sits relative to the {{htmlelement("body")}} element.
@@ -301,11 +310,14 @@ All this absolute positioning is good fun, but there's another feature we haven'
 
 Try adding the following to your CSS to make the first paragraph absolutely positioned too:
 
-```css hidden live-sample___z-index-1
+<!-- prettier-ignore-start -->
+```css hidden live-sample___z-index-initial live-sample___z-index-1
+
 
 ```
+<!-- prettier-ignore-end -->
 
-```css
+```css live-sample___z-index-initial
 p:nth-of-type(1) {
   position: absolute;
   background: lime;
@@ -315,6 +327,8 @@ p:nth-of-type(1) {
 ```
 
 At this point you'll see the first paragraph colored lime, moved out of the document flow, and positioned a bit above from where it originally was. It's also stacked below the original `.positioned` paragraph where the two overlap. This is because the `.positioned` paragraph is the second paragraph in the source order, and positioned elements later in the source order win over positioned elements earlier in the source order.
+
+{{ EmbedLiveSample('z-index-initial', '', 400) }}
 
 Can you change the stacking order? Yes, you can, by using the {{cssxref("z-index")}} property. "z-index" is a reference to the z-axis. You may recall from previous points in the course where we discussed web pages using horizontal (x-axis) and vertical (y-axis) coordinates to work out positioning for things like background images and drop shadow offsets. For languages that run left to right, (0,0) is at the top left of the page (or element), and the x- and y-axes run across to the right and down the page.
 
@@ -336,11 +350,11 @@ p:nth-of-type(1) {
 ```
 <!-- prettier-ignore-end -->
 
-You should now see the lime paragraph on top:
-
 ```css hidden live-sample___z-index-1
 }
 ```
+
+You should now see the lime paragraph on top:
 
 {{ EmbedLiveSample('z-index-1', '', 400) }}
 
@@ -357,7 +371,7 @@ Let's put together a simple example to show what we mean. First of all, delete t
 
 Now update the `body` rule to remove the `position: relative;` declaration and add a fixed height, like so:
 
-```css live-sample___fixed-positioning
+```css live-sample___fixed-positioning-broken live-sample___fixed-positioning
 body {
   width: 500px;
   height: 1400px;
@@ -367,7 +381,7 @@ body {
 
 Now we're going to give the {{htmlelement("Heading_Elements", "&lt;h1>")}} element `position: fixed;` and have it sit at the top of the viewport. Add the following rule to your CSS:
 
-```css hidden live-sample___fixed-positioning
+```css hidden live-sample___fixed-positioning-broken live-sample___fixed-positioning
 p {
   background: aqua;
   border: 3px solid blue;
@@ -381,7 +395,7 @@ span {
 }
 ```
 
-```css live-sample___fixed-positioning
+```css live-sample___fixed-positioning-broken live-sample___fixed-positioning
 h1 {
   position: fixed;
   top: 0;
@@ -394,7 +408,11 @@ h1 {
 
 The `top: 0;` is required to make it stick to the top of the screen. We give the heading the same width as the content column and then a white background and some padding and margin so the content won't be visible underneath it.
 
-If you save and refresh, you'll see a fun little effect of the heading staying fixed — the content appears to scroll up and disappear underneath it. But notice how some of the content is initially clipped under the heading. This is because the positioned heading no longer appears in the document flow, so the rest of the content moves up to the top. We could improve this by moving the paragraphs all down a bit. We can do this by setting some top margin on the first paragraph. Add this now:
+If you save and refresh, you'll see a fun little effect of the heading staying fixed:
+
+{{ EmbedLiveSample('fixed-positioning-broken', '', 400) }}
+
+The content appears to scroll up and disappear underneath it. But notice how some of the content is initially clipped under the heading. This is because the positioned heading no longer appears in the document flow, so the rest of the content moves up to the top. We could improve this by moving the paragraphs all down a bit. We can do this by setting some top margin on the first paragraph. Add this now:
 
 ```css hidden live-sample___fixed-positioning
 
@@ -464,7 +482,7 @@ Sticky positioning can be used, for example, to cause a navigation bar to scroll
 ```css hidden
 body {
   width: 500px;
-  margin: 0 auto;
+  margin: 0 auto 100vh auto;
 }
 
 .positioned {
@@ -480,7 +498,6 @@ body {
 .positioned {
   position: sticky;
   top: 30px;
-  left: 30px;
 }
 ```
 
@@ -524,6 +541,13 @@ An interesting and common use of `position: sticky` is to create a scrolling ind
 
 The CSS might look as follows. In normal flow the {{htmlelement("dt")}} elements will scroll with the content. When we add `position: sticky` to the {{htmlelement("dt")}} element, along with a {{cssxref("top")}} value of 0, supporting browsers will stick the headings to the top of the viewport as they reach that position. Each subsequent header will then replace the previous one as it scrolls up to that position.
 
+```css hidden
+body {
+  width: 500px;
+  margin: 0 auto 100vh auto;
+}
+```
+
 ```css
 dt {
   background-color: black;
@@ -531,16 +555,7 @@ dt {
   padding: 10px;
   position: sticky;
   top: 0;
-  left: 0;
   margin: 1em 0;
-}
-```
-
-```css hidden
-body {
-  width: 500px;
-  height: 880px;
-  margin: 0 auto;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/css_layout/positioning/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/positioning/index.md
@@ -50,9 +50,76 @@ Static positioning is the default that every element gets. It just means "put th
 
 To see this (and get your example set up for future sections) first add a `class` of `positioned` to the second {{htmlelement("p")}} in the HTML:
 
-```html
-<p class="positioned">…</p>
+```html hidden live-sample___relative-positioning
+<h1>Relative positioning</h1>
 ```
+
+```html hidden live-sample___absolute-positioning
+<h1>Absolute positioning</h1>
+```
+
+```html hidden live-sample___positioning-context
+<h1>Positioning context</h1>
+```
+
+```html hidden live-sample___z-index-1
+<h1>z-index</h1>
+```
+
+```html hidden live-sample___fixed-positioning
+<h1>Fixed positioning</h1>
+```
+
+<!-- prettier-ignore-start -->
+```html hidden live-sample___relative-positioning live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-1 live-sample___fixed-positioning
+
+
+<p>
+  I am a basic block level element. My adjacent block level elements
+  sit on new lines below me.
+</p>
+
+```
+
+```html live-sample___relative-positioning
+<p class="positioned">
+  By default we span 100% of the width of our parent element, and we
+  are as tall as our child content. Our total width and height is our
+  content + padding + border width/height.
+</p>
+```
+
+```html hidden live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-1
+<p class="positioned">
+  Now I'm absolutely positioned relative to the
+  <code>&lt;body&gt;</code> element, not the <code>&lt;html&gt;</code> element!
+</p>
+```
+
+```html hidden live-sample___fixed-positioning
+<p class="positioned">I'm not positioned any more.</p>
+```
+
+```html hidden live-sample___relative-positioning live-sample___absolute-positioning live-sample___positioning-context live-sample___z-index-1 live-sample___fixed-positioning
+
+
+<p>
+  We are separated by our margins. Because of margin collapsing, we are
+  separated by the width of one of our margins, not both.
+</p>
+
+<p>
+  Inline elements <span>like this one</span> and <span>this one</span>
+  sit on the same line as one another, and adjacent text nodes,
+  if there is space on the same line. Overflowing inline elements
+  <span>wrap onto a new line if possible — like this one containing text</span>,
+  or just go on to a new line if not, much like this image will do:
+  <img
+    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
+    alt="snippet of cloth" />
+</p>
+```
+<!-- prettier-ignore-end -->
 
 Now add the following rule to the bottom of your CSS:
 
@@ -95,37 +162,6 @@ If you save and refresh at this stage, you won't see a change in the result at a
 > The values of these properties can take any [units](/en-US/docs/Learn_web_development/Core/Styling_basics/Values_and_units) you'd reasonably expect: pixels, mm, rems, %, etc.
 
 If you now save and refresh, you'll get a result something like this:
-
-```html hidden live-sample___relative-positioning
-<h1>Relative positioning</h1>
-
-<p>
-  I am a basic block level element. My adjacent block level elements sit on new
-  lines below me.
-</p>
-
-<p class="positioned">
-  By default we span 100% of the width of our parent element, and we are as tall
-  as our child content. Our total width and height is our content + padding +
-  border width/height.
-</p>
-
-<p>
-  We are separated by our margins. Because of margin collapsing, we are
-  separated by the width of one of our margins, not both.
-</p>
-
-<p>
-  Inline elements <span>like this one</span> and <span>this one</span> sit on
-  the same line as one another, and adjacent text nodes, if there is space on
-  the same line. Overflowing inline elements
-  <span>wrap onto a new line if possible — like this one containing text</span>,
-  or just go on to a new line if not, much like this image will do:
-  <img
-    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
-    alt="snippet of cloth" />
-</p>
-```
 
 ```css hidden live-sample___relative-positioning
 body {
@@ -175,37 +211,6 @@ Let's try changing the position declaration in your code as follows:
 <!-- prettier-ignore-end -->
 
 If you now save and refresh, you should see something like so:
-
-```html hidden live-sample___absolute-positioning
-<h1>Absolute positioning</h1>
-
-<p>
-  I am a basic block level element. My adjacent block level elements sit on new
-  lines below me.
-</p>
-
-<p class="positioned">
-  By default we span 100% of the width of our parent element, and we are as tall
-  as our child content. Our total width and height is our content + padding +
-  border width/height.
-</p>
-
-<p>
-  We are separated by our margins. Because of margin collapsing, we are
-  separated by the width of one of our margins, not both.
-</p>
-
-<p>
-  inline elements <span>like this one</span> and <span>this one</span> sit on
-  the same line as one another, and adjacent text nodes, if there is space on
-  the same line. Overflowing inline elements
-  <span>wrap onto a new line if possible — like this one containing text</span>,
-  or just go on to a new line if not, much like this image will do:
-  <img
-    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
-    alt="snippet of cloth" />
-</p>
-```
 
 ```css hidden live-sample___absolute-positioning
 body {
@@ -263,36 +268,6 @@ The positioned element is nested inside the {{htmlelement("body")}} in the HTML 
 <!-- prettier-ignore-end -->
 
 This should give the following result:
-
-```html hidden live-sample___positioning-context
-<h1>Positioning context</h1>
-
-<p>
-  I am a basic block level element. My adjacent block level elements sit on new
-  lines below me.
-</p>
-
-<p class="positioned">
-  Now I'm absolutely positioned relative to the
-  <code>&lt;body&gt;</code> element, not the <code>&lt;html&gt;</code> element!
-</p>
-
-<p>
-  We are separated by our margins. Because of margin collapsing, we are
-  separated by the width of one of our margins, not both.
-</p>
-
-<p>
-  inline elements <span>like this one</span> and <span>this one</span> sit on
-  the same line as one another, and adjacent text nodes, if there is space on
-  the same line. Overflowing inline elements
-  <span>wrap onto a new line if possible — like this one containing text</span>,
-  or just go on to a new line if not, much like this image will do:
-  <img
-    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
-    alt="snippet of cloth" />
-</p>
-```
 
 ```css hidden live-sample___positioning-context
 body {
@@ -358,36 +333,6 @@ To change the stacking order, try adding the following declaration to your `p:nt
 <!-- prettier-ignore-end -->
 
 You should now see the lime paragraph on top:
-
-```html hidden live-sample___z-index-1
-<h1>z-index</h1>
-
-<p>
-  I am a basic block level element. My adjacent block level elements sit on new
-  lines below me.
-</p>
-
-<p class="positioned">
-  Now I'm absolutely positioned relative to the
-  <code>&lt;body&gt;</code> element, not the <code>&lt;html&gt;</code> element!
-</p>
-
-<p>
-  We are separated by our margins. Because of margin collapsing, we are
-  separated by the width of one of our margins, not both.
-</p>
-
-<p>
-  inline elements <span>like this one</span> and <span>this one</span> sit on
-  the same line as one another, and adjacent text nodes, if there is space on
-  the same line. Overflowing inline elements
-  <span>wrap onto a new line if possible — like this one containing text</span>,
-  or just go on to a new line if not, much like this image will do:
-  <img
-    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
-    alt="snippet of cloth" />
-</p>
-```
 
 ```css hidden live-sample___z-index-1
 body {
@@ -471,33 +416,6 @@ p:nth-of-type(1) {
 ```
 
 You should now see the finished example:
-
-```html hidden live-sample___fixed-positioning
-<h1>Fixed positioning</h1>
-
-<p>
-  I am a basic block level element. My adjacent block level elements sit on new
-  lines below me.
-</p>
-
-<p class="positioned">I'm not positioned any more.</p>
-
-<p>
-  We are separated by our margins. Because of margin collapsing, we are
-  separated by the width of one of our margins, not both.
-</p>
-
-<p>
-  Inline elements <span>like this one</span> and <span>this one</span> sit on
-  the same line as one another, and adjacent text nodes, if there is space on
-  the same line. Overflowing inline elements
-  <span>wrap onto a new line if possible — like this one containing text</span>,
-  or just go on to a new line if not, much like this image will do:
-  <img
-    src="https://mdn.github.io/shared-assets/images/examples/long.jpg"
-    alt="snippet of cloth" />
-</p>
-```
 
 ```css hidden live-sample___fixed-positioning
 body {

--- a/files/en-us/learn_web_development/core/css_layout/positioning/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/positioning/index.md
@@ -123,6 +123,25 @@ To see this (and get your example set up for future sections) first add a `class
 
 Now add the following rule to the bottom of your CSS:
 
+```css hidden live-sample___relative-positioning live-sample___absolute-positioning
+body {
+  width: 500px;
+  margin: 0 auto;
+}
+
+p {
+  background: aqua;
+  border: 3px solid blue;
+  padding: 10px;
+  margin: 10px;
+}
+
+span {
+  background: red;
+  border: 1px solid black;
+}
+```
+
 ```css
 .positioned {
   position: static;
@@ -139,9 +158,17 @@ If you save and refresh, you'll see no difference at all, except for the updated
 
 Relative positioning is the first position type we'll take a look at. This is very similar to static positioning, except that once the positioned element has taken its place in the normal flow, you can then modify its final position, including making it overlap other elements on the page. Go ahead and update the `position` declaration in your code:
 
+```css hidden live-sample___relative-positioning
+.positioned {
+```
+
 <!-- prettier-ignore-start -->
-```css
+```css live-sample___relative-positioning
   position: relative;
+```
+
+```css hidden live-sample___relative-positioning
+  background: yellow;
 ```
 <!-- prettier-ignore-end -->
 
@@ -152,42 +179,20 @@ If you save and refresh at this stage, you won't see a change in the result at a
 {{cssxref("top")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("right")}} are used alongside {{cssxref("position")}} to specify exactly where to move the positioned element to. To try this out, add the following declarations to the `.positioned` rule in your CSS:
 
 <!-- prettier-ignore-start -->
-```css
+```css live-sample___relative-positioning
   top: 30px;
   left: 30px;
 ```
 <!-- prettier-ignore-end -->
 
+```css hidden live-sample___relative-positioning
+}
+```
+
 > [!NOTE]
 > The values of these properties can take any [units](/en-US/docs/Learn_web_development/Core/Styling_basics/Values_and_units) you'd reasonably expect: pixels, mm, rems, %, etc.
 
 If you now save and refresh, you'll get a result something like this:
-
-```css hidden live-sample___relative-positioning
-body {
-  width: 500px;
-  margin: 0 auto;
-}
-
-p {
-  background: aqua;
-  border: 3px solid blue;
-  padding: 10px;
-  margin: 10px;
-}
-
-span {
-  background: red;
-  border: 1px solid black;
-}
-
-.positioned {
-  position: relative;
-  background: yellow;
-  top: 30px;
-  left: 30px;
-}
-```
 
 {{ EmbedLiveSample('relative-positioning', '', 500) }}
 
@@ -204,8 +209,12 @@ Absolute positioning brings very different results.
 
 Let's try changing the position declaration in your code as follows:
 
+```css hidden live-sample___absolute-positioning
+.positioned {
+```
+
 <!-- prettier-ignore-start -->
-```css
+```css live-sample___absolute-positioning
   position: absolute;
 ```
 <!-- prettier-ignore-end -->
@@ -213,25 +222,6 @@ Let's try changing the position declaration in your code as follows:
 If you now save and refresh, you should see something like so:
 
 ```css hidden live-sample___absolute-positioning
-body {
-  width: 500px;
-  margin: 0 auto;
-}
-
-p {
-  background: aqua;
-  border: 3px solid blue;
-  padding: 10px;
-  margin: 10px;
-}
-
-span {
-  background: red;
-  border: 1px solid black;
-}
-
-.positioned {
-  position: absolute;
   background: yellow;
   top: 30px;
   left: 30px;
@@ -261,19 +251,21 @@ If no ancestor elements have their position property explicitly defined, then by
 
 The positioned element is nested inside the {{htmlelement("body")}} in the HTML source, but in the final layout it's 30px away from the top and the left edges of the page. We can change the **positioning context**, that is, which element the absolutely positioned element is positioned relative to. This is done by setting positioning on one of the element's ancestors: to one of the elements it's nested inside of (you can't position it relative to an element it's not nested inside of). To see this, add the following declaration to your `body` rule:
 
+```css hidden live-sample___positioning-context live-sample___z-index-1
+body {
+  width: 500px;
+  margin: 0 auto;
+```
+
 <!-- prettier-ignore-start -->
-```css
+```css live-sample___positioning-context live-sample___z-index-1
   position: relative;
 ```
 <!-- prettier-ignore-end -->
 
 This should give the following result:
 
-```css hidden live-sample___positioning-context
-body {
-  width: 500px;
-  margin: 0 auto;
-  position: relative;
+```css hidden live-sample___positioning-context live-sample___z-index-1
 }
 
 p {
@@ -309,6 +301,10 @@ All this absolute positioning is good fun, but there's another feature we haven'
 
 Try adding the following to your CSS to make the first paragraph absolutely positioned too:
 
+```css hidden live-sample___z-index-1
+
+```
+
 ```css
 p:nth-of-type(1) {
   position: absolute;
@@ -326,8 +322,16 @@ Web pages also have a z-axis: an imaginary line that runs from the surface of yo
 
 To change the stacking order, try adding the following declaration to your `p:nth-of-type(1)` rule:
 
+```css hidden live-sample___z-index-1
+p:nth-of-type(1) {
+  position: absolute;
+  background: lime;
+  top: 10px;
+  right: 30px;
+```
+
 <!-- prettier-ignore-start -->
-```css
+```css live-sample___z-index-1
   z-index: 1;
 ```
 <!-- prettier-ignore-end -->
@@ -335,37 +339,6 @@ To change the stacking order, try adding the following declaration to your `p:nt
 You should now see the lime paragraph on top:
 
 ```css hidden live-sample___z-index-1
-body {
-  width: 500px;
-  margin: 0 auto;
-  position: relative;
-}
-
-p {
-  background: aqua;
-  border: 3px solid blue;
-  padding: 10px;
-  margin: 10px;
-}
-
-span {
-  background: red;
-  border: 1px solid black;
-}
-
-.positioned {
-  position: absolute;
-  background: yellow;
-  top: 30px;
-  left: 30px;
-}
-
-p:nth-of-type(1) {
-  position: absolute;
-  background: lime;
-  top: 10px;
-  right: 30px;
-  z-index: 1;
 }
 ```
 
@@ -384,7 +357,7 @@ Let's put together a simple example to show what we mean. First of all, delete t
 
 Now update the `body` rule to remove the `position: relative;` declaration and add a fixed height, like so:
 
-```css
+```css live-sample___fixed-positioning
 body {
   width: 500px;
   height: 1400px;
@@ -394,7 +367,21 @@ body {
 
 Now we're going to give the {{htmlelement("Heading_Elements", "&lt;h1>")}} element `position: fixed;` and have it sit at the top of the viewport. Add the following rule to your CSS:
 
-```css
+```css hidden live-sample___fixed-positioning
+p {
+  background: aqua;
+  border: 3px solid blue;
+  padding: 10px;
+  margin: 10px;
+}
+
+span {
+  background: red;
+  border: 1px solid black;
+}
+```
+
+```css live-sample___fixed-positioning
 h1 {
   position: fixed;
   top: 0;
@@ -409,46 +396,17 @@ The `top: 0;` is required to make it stick to the top of the screen. We give the
 
 If you save and refresh, you'll see a fun little effect of the heading staying fixed — the content appears to scroll up and disappear underneath it. But notice how some of the content is initially clipped under the heading. This is because the positioned heading no longer appears in the document flow, so the rest of the content moves up to the top. We could improve this by moving the paragraphs all down a bit. We can do this by setting some top margin on the first paragraph. Add this now:
 
-```css
+```css hidden live-sample___fixed-positioning
+
+```
+
+```css live-sample___fixed-positioning
 p:nth-of-type(1) {
   margin-top: 60px;
 }
 ```
 
 You should now see the finished example:
-
-```css hidden live-sample___fixed-positioning
-body {
-  width: 500px;
-  height: 1400px;
-  margin: 0 auto;
-}
-
-p {
-  background: aqua;
-  border: 3px solid blue;
-  padding: 10px;
-  margin: 10px;
-}
-
-span {
-  background: red;
-  border: 1px solid black;
-}
-
-h1 {
-  position: fixed;
-  top: 0px;
-  width: 500px;
-  margin-top: 0;
-  background: white;
-  padding: 10px;
-}
-
-p:nth-of-type(1) {
-  margin-top: 60px;
-}
-```
 
 {{ EmbedLiveSample('fixed-positioning', '', 400) }}
 

--- a/files/en-us/learn_web_development/core/css_layout/positioning/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/positioning/index.md
@@ -72,9 +72,11 @@ If you save and refresh, you'll see no difference at all, except for the updated
 
 Relative positioning is the first position type we'll take a look at. This is very similar to static positioning, except that once the positioned element has taken its place in the normal flow, you can then modify its final position, including making it overlap other elements on the page. Go ahead and update the `position` declaration in your code:
 
+<!-- prettier-ignore-start -->
 ```css
-position: relative;
+  position: relative;
 ```
+<!-- prettier-ignore-end -->
 
 If you save and refresh at this stage, you won't see a change in the result at all. So how do you modify the element's position? You need to use the {{cssxref("top")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("right")}} properties, which we'll explain in the next section.
 
@@ -82,17 +84,19 @@ If you save and refresh at this stage, you won't see a change in the result at a
 
 {{cssxref("top")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("right")}} are used alongside {{cssxref("position")}} to specify exactly where to move the positioned element to. To try this out, add the following declarations to the `.positioned` rule in your CSS:
 
+<!-- prettier-ignore-start -->
 ```css
-top: 30px;
-left: 30px;
+  top: 30px;
+  left: 30px;
 ```
+<!-- prettier-ignore-end -->
 
 > [!NOTE]
 > The values of these properties can take any [units](/en-US/docs/Learn_web_development/Core/Styling_basics/Values_and_units) you'd reasonably expect: pixels, mm, rems, %, etc.
 
 If you now save and refresh, you'll get a result something like this:
 
-```html hidden
+```html hidden live-sample___relative-positioning
 <h1>Relative positioning</h1>
 
 <p>
@@ -123,7 +127,7 @@ If you now save and refresh, you'll get a result something like this:
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___relative-positioning
 body {
   width: 500px;
   margin: 0 auto;
@@ -149,7 +153,7 @@ span {
 }
 ```
 
-{{ EmbedLiveSample('Introducing_top_bottom_left_and_right', '100%', 500) }}
+{{ EmbedLiveSample('relative-positioning', '', 500) }}
 
 Cool, huh? Ok, so this probably wasn't what you were expecting. Why has it moved to the bottom and to the right if we specified _top_ and _left_? This may seem counterintuitive. You need to think of it as if there's an invisible force that pushes the specified side of the positioned box, moving it in the opposite direction. So, for example, if you specify `top: 30px;`, it's as if a force will push the top of the box, causing it to move downwards by 30px.
 
@@ -164,13 +168,15 @@ Absolute positioning brings very different results.
 
 Let's try changing the position declaration in your code as follows:
 
+<!-- prettier-ignore-start -->
 ```css
-position: absolute;
+  position: absolute;
 ```
+<!-- prettier-ignore-end -->
 
 If you now save and refresh, you should see something like so:
 
-```html hidden
+```html hidden live-sample___absolute-positioning
 <h1>Absolute positioning</h1>
 
 <p>
@@ -201,7 +207,7 @@ If you now save and refresh, you should see something like so:
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___absolute-positioning
 body {
   width: 500px;
   margin: 0 auto;
@@ -227,7 +233,7 @@ span {
 }
 ```
 
-{{ EmbedLiveSample('Setting_position_absolute', '100%', 450) }}
+{{ EmbedLiveSample('absolute-positioning', '', 450) }}
 
 First of all, note that the gap where the positioned element should be in the document flow is no longer there — the first and third elements have closed together like it no longer exists! Well, in a way, this is true. An absolutely positioned element no longer exists in the normal document flow. Instead, it sits on its own layer separate from everything else. This is very useful: it means that we can create isolated UI features that don't interfere with the layout of other elements on the page. For example, popup information boxes, control menus, rollover panels, UI features that can be dragged and dropped anywhere on the page, and so on.
 
@@ -250,13 +256,15 @@ If no ancestor elements have their position property explicitly defined, then by
 
 The positioned element is nested inside the {{htmlelement("body")}} in the HTML source, but in the final layout it's 30px away from the top and the left edges of the page. We can change the **positioning context**, that is, which element the absolutely positioned element is positioned relative to. This is done by setting positioning on one of the element's ancestors: to one of the elements it's nested inside of (you can't position it relative to an element it's not nested inside of). To see this, add the following declaration to your `body` rule:
 
+<!-- prettier-ignore-start -->
 ```css
-position: relative;
+  position: relative;
 ```
+<!-- prettier-ignore-end -->
 
 This should give the following result:
 
-```html hidden
+```html hidden live-sample___positioning-context
 <h1>Positioning context</h1>
 
 <p>
@@ -286,7 +294,7 @@ This should give the following result:
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___positioning-context
 body {
   width: 500px;
   margin: 0 auto;
@@ -313,7 +321,7 @@ span {
 }
 ```
 
-{{ EmbedLiveSample('Positioning_contexts', '100%', 420) }}
+{{ EmbedLiveSample('positioning-context', '', 420) }}
 
 The positioned element now sits relative to the {{htmlelement("body")}} element.
 
@@ -343,13 +351,15 @@ Web pages also have a z-axis: an imaginary line that runs from the surface of yo
 
 To change the stacking order, try adding the following declaration to your `p:nth-of-type(1)` rule:
 
+<!-- prettier-ignore-start -->
 ```css
-z-index: 1;
+  z-index: 1;
 ```
+<!-- prettier-ignore-end -->
 
 You should now see the lime paragraph on top:
 
-```html hidden
+```html hidden live-sample___z-index-1
 <h1>z-index</h1>
 
 <p>
@@ -379,7 +389,7 @@ You should now see the lime paragraph on top:
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___z-index-1
 body {
   width: 500px;
   margin: 0 auto;
@@ -414,7 +424,7 @@ p:nth-of-type(1) {
 }
 ```
 
-{{ EmbedLiveSample('Introducing_z-index', '100%', 400) }}
+{{ EmbedLiveSample('z-index-1', '', 400) }}
 
 Note that `z-index` only accepts unitless index values; you can't specify that you want one element to be 23 pixels up the Z-axis — it doesn't work like that. Higher values will go above lower values and it's up to you what values you use. Using values of 2 or 3 would give the same effect as values of 300 or 40000.
 
@@ -462,7 +472,7 @@ p:nth-of-type(1) {
 
 You should now see the finished example:
 
-```html hidden
+```html hidden live-sample___fixed-positioning
 <h1>Fixed positioning</h1>
 
 <p>
@@ -489,7 +499,7 @@ You should now see the finished example:
 </p>
 ```
 
-```css hidden
+```css hidden live-sample___fixed-positioning
 body {
   width: 500px;
   height: 1400px;
@@ -512,6 +522,7 @@ h1 {
   position: fixed;
   top: 0px;
   width: 500px;
+  margin-top: 0;
   background: white;
   padding: 10px;
 }
@@ -521,7 +532,7 @@ p:nth-of-type(1) {
 }
 ```
 
-{{ EmbedLiveSample('Fixed_positioning', '100%', 400) }}
+{{ EmbedLiveSample('fixed-positioning', '', 400) }}
 
 > [!NOTE]
 > You can see an example for this live at [`6_fixed-positioning.html`](https://mdn.github.io/learning-area/css/css-layout/positioning/6_fixed-positioning.html) ([see source code](https://github.com/mdn/learning-area/blob/main/css/css-layout/positioning/6_fixed-positioning.html)).
@@ -597,7 +608,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Basic_example', '100%', 200) }}
+{{ EmbedLiveSample('Basic_example', '', 200) }}
 
 ### Scrolling index
 
@@ -657,7 +668,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('Scrolling_index', '100%', 200) }}
+{{ EmbedLiveSample('Scrolling_index', '', 200) }}
 
 Sticky elements are "sticky" relative to the nearest ancestor with a "scrolling mechanism", which is determined by its ancestors' [overflow](/en-US/docs/Web/CSS/overflow) property.
 

--- a/files/en-us/learn_web_development/core/css_layout/positioning/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/positioning/index.md
@@ -381,7 +381,10 @@ body {
 
 Now we're going to give the {{htmlelement("Heading_Elements", "&lt;h1>")}} element `position: fixed;` and have it sit at the top of the viewport. Add the following rule to your CSS:
 
+<!-- prettier-ignore-start -->
 ```css hidden live-sample___fixed-positioning-broken live-sample___fixed-positioning
+
+
 p {
   background: aqua;
   border: 3px solid blue;
@@ -393,7 +396,9 @@ span {
   background: red;
   border: 1px solid black;
 }
+
 ```
+<!-- prettier-ignore-end -->
 
 ```css live-sample___fixed-positioning-broken live-sample___fixed-positioning
 h1 {
@@ -414,9 +419,12 @@ If you save and refresh, you'll see a fun little effect of the heading staying f
 
 The content appears to scroll up and disappear underneath it. But notice how some of the content is initially clipped under the heading. This is because the positioned heading no longer appears in the document flow, so the rest of the content moves up to the top. We could improve this by moving the paragraphs all down a bit. We can do this by setting some top margin on the first paragraph. Add this now:
 
+<!-- prettier-ignore-start -->
 ```css hidden live-sample___fixed-positioning
 
+
 ```
+<!-- prettier-ignore-end -->
 
 ```css live-sample___fixed-positioning
 p:nth-of-type(1) {


### PR DESCRIPTION
### Description

Fix broken code examples on https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Positioning. And add some improvements.

### Motivation

Look e.g. at the current status around https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Positioning#introducing_top_bottom_left_and_right,  the linked playground there contains code such as 

```css
top: 30px;
left: 30px;

body {
  width: 500px;
  margin: 0 auto;
}

p {
  background: aqua;
  border: 3px solid blue;
  padding: 10px;
  margin: 10px;
}

span {
  background: red;
  border: 1px solid black;
}

.positioned {
  position: relative;
  background: yellow;
  top: 30px;
  left: 30px;
}
```
because more code snippets are aggregated into this than what the author anticipated. And this is then of course broken (and results in the `body { … }` rule to be ignored entirely).

Also, there are multiple places where a textual description of a *very interesting **and** very significant for understanding`position`* intermediate state without any visualization of what happens.

Thus I have *added* 3 such visualizations / playground states, which look as follows:

#### A displayed version of the `static` code example
![Bildschirmfoto_20250610_035221](https://github.com/user-attachments/assets/0ac9d5bf-166f-494a-8cb9-14dae4f0b67f)

#### The not-yet `z-index` flipped state, for visual contrast
![Bildschirmfoto_20250610_035301](https://github.com/user-attachments/assets/01c1fe73-a51c-404c-8930-27e8ab1e9167)

#### The not-yet `margin-top`-fixed state for fixed positioning, also for visual contrast
![Bildschirmfoto_20250610_035313](https://github.com/user-attachments/assets/dd2698a8-5e99-4cb0-b266-e01e68d73798)


### Additional details

Additionally there are also some minor tweaks here and there. E.g. a `0px` becoming `0` for consistency with the snippet that was already displayed; some margin-based height extension for sticky examples using `100vh` so now it works on the page and *also* on the linked playground. And probably more.

I probably overdid it a bit with the de-duplicating of shared parts of code snippets. But I've iterated on this long enough now, so I'll just submit the PR now. One user-facing benefit of this piecework is that now also these shortened snippets have gained links to the corresponding playgrounds, e.g.:
![Bildschirmfoto_20250610_035935](https://github.com/user-attachments/assets/6ccbcb0d-a753-401d-867f-772e540abb9f)

Also, the newlines (or lack therof) for some of the generated playgrounds without added things such as single empty lines at the end, or double empty lines at the beginning of some of the hidden code blocks was a bit tricky to work with/around[^1].

[^1]: especially since you guys’s `prettier` tooling tended to somewhat silently simply erase all this work from history as soon as one wants to finish their commit. (And I really *do* mean **erase** since the way it's in a pre-commit hook which appears to then also add the changes to the work tree, *and* the staging area *and* the current commit means the original version of how things were is relatively thoroughly fully eliminated :-/]