### PR TITLE
COEP and COOP reporting documentation

### DIFF
--- a/files/en-us/web/api/coepviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/coepviolationreportbody/blockedurl/index.md
@@ -1,0 +1,42 @@
+---
+title: "COEPViolationReportBody: blockedURL property"
+short-title: blockedURL
+slug: Web/API/COEPViolationReportBody/blockedURL
+page-type: web-api-instance-property
+browser-compat: api.COEPViolationReportBody.blockedURL
+---
+
+{{APIRef("Reporting API")}}
+
+The **`blockedURL`** read-only property of the {{domxref("COEPViolationReportBody")}} interface returns the URL of the resource that triggered the violation.
+
+## Value
+
+An string containing a URL value.
+
+## Examples
+
+### Get the URL of the resource that triggered the report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `blockedURL` to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport.body.blockedURL); // the URL of the violating resource
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coepviolationreportbody/disposition/index.md
+++ b/files/en-us/web/api/coepviolationreportbody/disposition/index.md
@@ -1,0 +1,49 @@
+---
+title: "COEPViolationReportBody: disposition property"
+short-title: disposition
+slug: Web/API/COEPViolationReportBody/disposition
+page-type: web-api-instance-property
+browser-compat: api.COEPViolationReportBody.disposition
+---
+
+{{APIRef("Reporting API")}}
+
+The **`disposition`** read-only property of the {{domxref("COEPViolationReportBody")}} dictionary represents whether the report is for a violation that was blocked or only reported.
+
+## Value
+
+A string that can have one of the following values:
+
+- `"enforce"`
+  - : The violation caused loading of the embedded resource to be blocked.
+    This is set for violations of policies set with {{httpheader("Cross-Origin-Embedder-Policy")}}.
+- `"reporting"`
+  - : The violation was reported without blocking the resource from loading.
+    This is set for violations of policies set with {{httpheader("Cross-Origin-Embedder-Policy-Report-Only")}}.
+
+## Examples
+
+### Get the disposition of a report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `disposition` to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport.body.disposition);
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coepviolationreportbody/index.md
+++ b/files/en-us/web/api/coepviolationreportbody/index.md
@@ -1,0 +1,95 @@
+---
+title: COEPViolationReportBody
+slug: Web/API/COEPViolationReportBody
+page-type: web-api-interface
+browser-compat: api.COEPViolationReportBody
+---
+
+{{APIRef("Reporting API")}}
+
+The `COEPViolationReportBody` dictionary represents the {{domxref("Report.body","body")}} of an [Cross-Origin-Embedder-Policy (COEP)](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy) policy violation report.
+
+> [!NOTE]
+> This object does not derive from {{domxref("ReportBody")}} (unlike other {{domxref("Report.body")}} values).
+
+## Instance properties
+
+- {{domxref("COEPViolationReportBody.type")}} {{ReadOnlyInline}}
+  - : A string representing whether the violation was caused by loading a child resource or a dedicated worker.
+- {{domxref("COEPViolationReportBody.blockedURL")}} {{ReadOnlyInline}}
+  - : A string containing the URL of the blocked resource.
+- {{domxref("COEPViolationReportBody.disposition")}} {{ReadOnlyInline}}
+  - : A string representing whether the violation blocked resource loading or was only reported on.
+
+<!--
+- {{domxref("COEPViolationReportBody.destination")}} {{ReadOnlyInline}}
+  - : A string indicating the parent navigable for which loading was was blocked: `"iframe"`.
+-->
+
+## Description
+
+COEP policy violations are reported using the [Reporting API](/en-US/docs/Web/API/Reporting_API) generic reporting framework.
+
+The reports are enabled by setting the `report-to` parameter with a valid reporting endpoint name on the {{httpheader("Cross-Origin-Embedder-Policy")}} and/or {{httpheader("Cross-Origin-Embedder-Policy-Report-Only")}} headers used to set the policy.
+Valid endpoint names are defined using the {{httpheader("Reporting-Endpoints")}} header.
+
+Violation reports are generated whenever a policy set by {{httpheader("Cross-Origin-Embedder-Policy")}} or {{httpheader("Cross-Origin-Embedder-Policy-Report-Only")}} blocks or would block the loading of a resource, respectively.
+
+A report is a {{domxref("Report")}} instance which has the {{domxref("Report.type","type")}} of `coep` and a {{domxref("Report.body","body")}} property that is an object of this type.
+Reports can be returned via the {{domxref("ReportingObserver")}} interface or serialized and sent in a `POST` to the reporting endpoint.
+
+There are two may causes of violations, which are indicated by the value of the {{domxref("Report.type","type")}} property.
+The first is a `navigation` violation, which is caused when an {{htmlelement("iframe")}} or other child browsing context attempts to load a new document or other resource that is not compatible with the embedder policy of its parent for cross origin isolation.
+The second is a `"worker initialization"` violation, which is when a page attempts to load a dedicated worker with an embedder policy that is not compatible with the page policy for cross origin isolation.
+
+In both cases "incompatible" means that the parent embedder policy requires cross origin isolation but the embedder policy of the child resource does not provide those that isolation.
+If the resource isn't loaded into a child context (such as a frame), or if the parent does not require isolation, then the embedder policy of the loaded resource doesn't matter.
+
+## Examples
+
+### COEP report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe coep reports, then log the first report to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport);
+}, options);
+```
+
+The logged report object for a COEP violation from loading an iframe might look like this:
+
+```json
+[
+  {
+    "type": "coep",
+    "url": "https://url-where-report-sent",
+    "body": {
+      "type": "navigation",
+      "blockedURL": "https://url-of-frame-that-was-blocked",
+      "disposition": "enforce"
+    }
+  }
+]
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{httpheader("Reporting-Endpoints")}}
+- [Reporting API](/en-US/docs/Web/API/Reporting_API)
+- [The Reporting API](https://developer.chrome.com/docs/capabilities/web-apis/reporting-api)

--- a/files/en-us/web/api/coepviolationreportbody/type/index.md
+++ b/files/en-us/web/api/coepviolationreportbody/type/index.md
@@ -1,0 +1,47 @@
+---
+title: "COEPViolationReportBody: type property"
+short-title: type
+slug: Web/API/COEPViolationReportBody/type
+page-type: web-api-instance-property
+browser-compat: api.COEPViolationReportBody.type
+---
+
+{{APIRef("Reporting API")}}{{AvailableInWorkers}}
+
+The **`type`** read-only property of the {{domxref("COEPViolationReportBody")}} dictionary returns a value that indicates whether the violation was caused by attempting to load a child resource or a dedicated worker.
+
+## Value
+
+A string that can have one of the following values:
+
+- `"navigation"`
+  - : The violation was caused by an {{htmlelement("iframe")}} or other child browsing context attempting to load a new document.
+- `"worker initialization"`
+  - : The violation was caused by a page attempting to load a dedicated worker.
+
+## Examples
+
+### Get the type of a COEP violation report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `type` to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport.body.type); // navigation or worker initialization
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1374,6 +1374,8 @@
       "overview": ["Reporting API"],
       "guides": [],
       "interfaces": [
+        "COEPViolationReportBody",
+        "COOPViolationReportBody",
         "CSPViolationReportBody",
         "DeprecationReportBody",
         "InterventionReportBody",


### PR DESCRIPTION
COOP and COEP use the reporting API to report violations. This adds docs.

- [ ] `COEPViolationReportBody` - report structure for COEP violations 
- [ ] `COOPViolationReportBody` - report structure for COOP violations 
- [ ] Update Reporting API docs everywhere to include links to these
- [ ] `Cross-Origin-Embedder-Policy-Report-Only` - add report-to
- [ ] `Cross-Origin-Embedder-Policy` - add report-to
- [ ] `Cross-Origin-Opener-Policy` - add report-to
- [ ] `Cross-Origin-Opener-Policy-Report-Only` - add report-to

Fixes #39814