### PR TITLE
ci(spelling-check-bot): Set 5 min timeout for spellchecker

### DIFF
--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description

Adding a 5 minute timeout for the spellchecker bot.

### Motivation

Default is 360 min (6 hours). It recently hung on a bad regex and ran for job max, which eats up our build minutes. 

### Additional details

The job typically takes 2 minutes to run, so if it takes more than 5 minutes, we can cancel it.

https://github.com/mdn/content/actions/workflows/spelling-check-bot.yml

### Related issues and pull requests

Fixes #39881

- [x] https://github.com/mdn/content/pull/39884
- [x] https://github.com/mdn/content/issues/39881