### PR TITLE
webextension.api.webNavigation event Chrome only properties

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -47,6 +47,12 @@ Events have three functions:
 
 ### details
 
+- `documentId`
+  - : `string`. A UUID of the document loaded.
+- `parentDocumentId`
+  - : `string`. A UUID of the parent document owning the frame. Not set if there is no parent.
+- `documentLifecycle`
+  - : `string`. The lifecycle the document is in. Returns the values `"prerender"`, `"active"`, `"cached"`, and `"pending_deletion"`.
 - `tabId`
   - : `integer`. The ID of the tab in which the navigation is about to occur.
 - `url`
@@ -57,6 +63,8 @@ Events have three functions:
   - : `integer`. Frame in which the navigation will occur. `0` indicates that navigation happens in the tab's top-level browsing context, not in a nested {{HTMLElement("iframe")}}. A positive value indicates that navigation happens in a nested iframe. Frame IDs are unique for a given tab and process.
 - `parentFrameId`
   - : `integer`. ID of this frame's parent. Set to `-1` if this is a top-level frame.
+- `frameType`
+  - : `string`. The type of frame the navigation occurred in. Returns the values `"outermost_frame"`, `"fenced_frame"`, and `"sub_frame"`.
 - `timeStamp`
   - : `number`. The time that the navigation was committed, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `transitionType`

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -55,6 +55,8 @@ Events have three functions:
   - : `integer`. This value is not set in modern browsers. When it was set, it represented the ID of the process running the renderer for this tab.
 - `frameId`
   - : `integer`. Frame in which the navigation has occurred. `0` indicates that navigation happened in the tab's top-level browsing context, not in a nested {{HTMLElement("iframe")}}. A positive value indicates that navigation happened in a nested iframe. Frame IDs are unique for a given tab and process.
+- `parentFrameId`
+  - : `integer`. ID of this frame's parent. Set to `-1` if this is a top-level frame.
 - `timeStamp`
   - : `number`. The time at which the page finished loading, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -55,6 +55,8 @@ Events have three functions:
   - : `integer`. This value is not set in modern browsers. When it was set, it represented the ID of the process running the renderer for this tab.
 - `frameId`
   - : `integer`. Frame in which the navigation is occurring. `0` indicates that navigation happens in the tab's top-level browsing context, not in a nested {{HTMLElement("iframe")}}. A positive value indicates that navigation happens in a nested iframe. Frame IDs are unique for a given tab and process.
+- `parentFrameId`
+  - : `integer`. ID of this frame's parent. Set to `-1` if this is a top-level frame.
 - `timeStamp`
   - : `number`. The time at which `DOMContentLoaded` was fired, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -59,6 +59,8 @@ Events have three functions:
 
             Frame IDs are unique for a given tab and process.
 
+        - `parentFrameId`
+          - : `integer`. ID of this frame's parent. Set to `-1` if this is a top-level frame.
         - `timeStamp`
           - : `number`. The time at which the error occurred, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
         - `error`

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -55,6 +55,8 @@ Events have three functions:
   - : `integer`. This value is not set in modern browsers. When it was set, it represented the ID of the process running the renderer for this tab.
 - `frameId`
   - : `integer`. Frame in which the navigation will occur. `0` indicates that navigation happens in the tab's top-level browsing context, not in a nested {{HTMLElement("iframe")}}. A positive value indicates that navigation happens in a nested iframe. Frame IDs are unique for a given tab and process.
+- `parentFrameId`
+  - : `integer`. ID of this frame's parent. Set to `-1` if this is a top-level frame.
 - `timeStamp`
   - : `number`. The time that the URL was changed by the history API, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `transitionType`

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -55,6 +55,8 @@ Events have three functions:
   - : `integer`. This value is not set in modern browsers. When it was set, it represented the ID of the process running the renderer for this tab.
 - `frameId`
   - : `integer`. Frame in which the navigation will occur. `0` indicates that navigation happens in the tab's top-level browsing context, not in a nested {{HTMLElement("iframe")}}. A positive value indicates that navigation happens in a nested iframe. Frame IDs are unique for a given tab and process.
+- `parentFrameId`
+  - : `integer`. ID of this frame's parent. Set to `-1` if this is a top-level frame.
 - `timeStamp`
   - : `number`. The time that the fragment identifier for the page was changed, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `transitionType`

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -38,18 +38,13 @@ Events have three functions:
   - : The function called when this event occurs. The function is passed this argument:
 
     - `details`
-      - : `object`. See the [details](#details) section for more information.
-
-## Additional objects
-
-### details
-
-- `replacedTabId`
-  - : `integer`. The ID of the tab that was replaced.
-- `tabId`
-  - : `integer`. The ID of the tab that replaced the old tab.
-- `timeStamp`
-  - : `number`. The time when the replacement happened, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
+      - : `object`. Details about the tab replacement.
+        - `replacedTabId`
+          - : `integer`. The ID of the replaced tab.
+        - `tabId`
+          - : `integer`. The ID of the replacement tab.
+        - `timeStamp`
+          - : `number`. The time when the replacement happened, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 
 ## Browser compatibility
 


### PR DESCRIPTION
### Description

Adds `webNavigation` event `details` properties that are only available in Chrome.

### Motivation

To align with the updated BCD. This was updated to clarify that these properties are not available in Firefox after feedback in #39630. This change also makes the documentation more complete.

### Related issues and pull requests

Fixes #39630
"**Depends on:** #123"  https://github.com/mdn/browser-compat-data/pull/27012