### PR TITLE
Broaden cursive definition and add Comic Sans MS to fantasy fonts

### DIFF
--- a/files/en-us/web/css/generic-family/index.md
+++ b/files/en-us/web/css/generic-family/index.md
@@ -34,11 +34,11 @@ The `<generic-family>` {{glossary("enumerated")}} type is specified using one of
 
 - `cursive`
 
-  - : Glyphs in cursive fonts generally have either joining strokes or other cursive characteristics beyond those of italic typefaces. The glyphs are partially or completely connected, and the result looks more like handwritten pen or brush writing than printed letter work. Example cursive fonts include Brush Script MT, Brush Script Std, Lucida Calligraphy, Lucida Handwriting, and Apple Chancery.
+  - : Glyphs in cursive fonts generally use a script or handwriting style, and the result looks more like handwritten pen or brush writing than printed letterwork. CSS uses the term "cursive" to apply to a font for any script, including those that do not have joining strokes. Example cursive fonts include Brush Script MT, Brush Script Std, Lucida Calligraphy, Lucida Handwriting, and Apple Chancery.
 
 - `fantasy`
 
-  - : Fantasy fonts are primarily decorative fonts that contain playful representations of characters. Example fantasy fonts include Papyrus, Herculanum, Party LET, Curlz MT, and Harrington.
+  - : Fantasy fonts are primarily decorative fonts that contain playful representations of characters. Example fantasy fonts include Papyrus, Herculanum, Party LET, Curlz MT, Harrington, and Comic Sans MS.
 
 - `system-ui`
 

--- a/files/en-us/web/css/generic-family/index.md
+++ b/files/en-us/web/css/generic-family/index.md
@@ -34,7 +34,7 @@ The `<generic-family>` {{glossary("enumerated")}} type is specified using one of
 
 - `cursive`
 
-  - : Glyphs in cursive fonts generally use a script or handwriting style, and the result looks more like handwritten pen or brush writing than printed letterwork. CSS uses the term "cursive" to apply to a font for any script, including those that do not have joining strokes. Example cursive fonts include Brush Script MT, Brush Script Std, Lucida Calligraphy, Lucida Handwriting, and Apple Chancery.
+  - : Glyphs in cursive fonts generally use a cursive script or other handwriting style, and the result looks more like handwritten pen or brush writing than printed letterwork. CSS uses the term "cursive" to apply to a font for any script, including those that do not have joining strokes. Example cursive fonts include Brush Script MT, Brush Script Std, Lucida Calligraphy, Lucida Handwriting, and Apple Chancery.
 
 - `fantasy`
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Broaden the definition of the "cursive" generic font family to include all handwriting-style fonts, not just traditional cursive/script fonts, in line with the CSS specification. Add Comic Sans MS as an example under "fantasy" fonts for clarity and alignment with spec examples.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes #39568

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
