### PR TITLE
Fix element ID

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -131,7 +131,7 @@ canvas {
 
 ```js
 function draw() {
-  const canvas = document.getElementById("canvas");
+  const canvas = document.getElementById("tutorial");
   if (canvas.getContext) {
     const ctx = canvas.getContext("2d");
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -11,7 +11,7 @@ Let's start this tutorial by looking at the {{HTMLElement("canvas")}} {{Glossary
 ## The `<canvas>` element
 
 ```html
-<canvas id="tutorial" width="150" height="150"></canvas>
+<canvas id="canvas" width="150" height="150"></canvas>
 ```
 
 At first sight a {{HTMLElement("canvas")}} looks like the {{HTMLElement("img")}} element, with the only clear difference being that it doesn't have the `src` and `alt` attributes. Indeed, the `<canvas>` element has only two attributes, [`width`](/en-US/docs/Web/HTML/Reference/Elements/canvas#width) and [`height`](/en-US/docs/Web/HTML/Reference/Elements/canvas#height). These are both optional and can also be set using {{Glossary("DOM")}} [properties](/en-US/docs/Web/API/HTMLCanvasElement). When no `width` and `height` attributes are specified, the canvas will initially be **300 pixels** wide and **150 pixels** high. The element can be sized arbitrarily by {{Glossary("CSS")}}, but during rendering the image is scaled to fit its layout size: if the CSS sizing doesn't respect the ratio of the initial canvas, it will appear distorted.
@@ -56,7 +56,7 @@ The {{HTMLElement("canvas")}} element creates a fixed-size drawing surface that 
 The canvas is initially blank. To display something, a script first needs to access the rendering context and draw on it. The {{HTMLElement("canvas")}} element has a method called {{domxref("HTMLCanvasElement.getContext", "getContext()")}}, used to obtain the rendering context and its drawing functions. `getContext()` takes one parameter, the type of context. For 2D graphics, such as those covered by this tutorial, you specify `"2d"` to get a {{domxref("CanvasRenderingContext2D")}}.
 
 ```js
-const canvas = document.getElementById("tutorial");
+const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 ```
 
@@ -67,7 +67,7 @@ The first line in the script retrieves the node in the DOM representing the {{HT
 The fallback content is displayed in browsers which do not support {{HTMLElement("canvas")}}. Scripts can also check for support programmatically by testing for the presence of the `getContext()` method. Our code snippet from above becomes something like this:
 
 ```js
-const canvas = document.getElementById("tutorial");
+const canvas = document.getElementById("canvas");
 
 if (canvas.getContext) {
   const ctx = canvas.getContext("2d");
@@ -97,10 +97,10 @@ Here is a minimalistic template, which we'll be using as a starting point for la
     </style>
   </head>
   <body>
-    <canvas id="tutorial" width="150" height="150"></canvas>
+    <canvas id="canvas" width="150" height="150"></canvas>
     <script>
       function draw() {
-        const canvas = document.getElementById("tutorial");
+        const canvas = document.getElementById("canvas");
         if (canvas.getContext) {
           const ctx = canvas.getContext("2d");
         }
@@ -111,7 +111,7 @@ Here is a minimalistic template, which we'll be using as a starting point for la
 </html>
 ```
 
-The script includes a function called `draw()`, which is executed once the page finishes loading; this is done by listening for the {{domxref("Window/load_event", "load")}} event on the document. This function, or one like it, could also be called using {{domxref("Window.setTimeout", "setTimeout()")}}, {{domxref("Window.setInterval", "setInterval()")}}, or any other event handler, as long as the page has been loaded first.
+The script includes a function called `draw()`, which is executed once the page finishes loading; this is done by putting the script after the main body content. This function, or one like it, could also be called using {{domxref("Window.setTimeout", "setTimeout()")}}, {{domxref("Window.setInterval", "setInterval()")}}, or the {{domxref("Window/load_event", "load")}} event handler, as long as the page has been loaded first.
 
 At this point, this document should be rendered blank.
 
@@ -120,7 +120,7 @@ At this point, this document should be rendered blank.
 To begin, let's take a look at an example that draws two intersecting rectangles, one of which has alpha transparency. We'll explore how this works in more detail in later examples. Update your `script` element content to this:
 
 ```html hidden
-<canvas id="tutorial" width="150" height="150"></canvas>
+<canvas id="canvas" width="150" height="150"></canvas>
 ```
 
 ```css hidden
@@ -131,7 +131,7 @@ canvas {
 
 ```js
 function draw() {
-  const canvas = document.getElementById("tutorial");
+  const canvas = document.getElementById("canvas");
   if (canvas.getContext) {
     const ctx = canvas.getContext("2d");
 


### PR DESCRIPTION
…ml canvas element id

The canvas element id is 'tutorial'.
But the simple example is doing a get element by id of 'canvas' Changing the get element by id to 'tutorial' will allow the simple example to run and draw the two intersecting rectangles.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
The canvas element id is 'tutorial'.
But the simple example is doing a get element by id of 'canvas' Changing the get element by id to 'tutorial' will allow the simple example to run and draw the two intersecting rectangles.

### Motivation

Currently the simple example does not run because the canvas element id does not match the javascript simple example.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
