### PR TITLE
css(update): add usages of 'alpha' placeholder in relative colors doc

### DIFF
--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -97,7 +97,7 @@ rgb(from red r g b / 100%)
 rgb(from red r g b)
 rgb(from red r g b / alpha)
 
-/* For red color, g and b values are equal, making them interchangeable */
+/* With `red`, the g and b are the same, making them interchangeable */
 rgb(from red r g g)
 rgb(from red r b b)
 rgb(from red 255 g g)
@@ -295,7 +295,7 @@ The output is as follows:
 
 ## Manipulating the alpha channel
 
-This example demonstrates how to change the alpha channel of a given color. Here, we have an item wrapped in a container, both having a `teal` colored background. To make them distinguishable, we bring variation in the alpha channel value using the relative color feature, the `calc()` function, and a custom property `--alpha-multiplier`.
+This example demonstrates changing the alpha channel of a named color. Here, we have an item wrapped in a container that both have a `teal` background. To distinguish between the backgrounds, we vary the alpha channel value using the relative color feature, the [`calc()` function](/en-US/docs/Web/CSS/calc), and a [custom property](/en-US/docs/Web/CSS/--*).
 
 ```html
 <div class="container">
@@ -329,7 +329,7 @@ div {
 }
 ```
 
-In the above code, the alpha channel is referenced using the name `alpha`. The `calc(alpha * var(--alpha-multiplier))` expression modifies the alpha channel value by multiplying it with `--alpha-multiplier`. The container gets a semitransparent background because of the smaller multiplier `0.3`.
+The alpha channel is referenced using the `alpha` keyword. In this case, the `calc(alpha * var(--alpha-multiplier))` expression modifies the alpha channel value by multiplying `alpha` with the `--alpha-multiplier` custom property value. The container gets a semitransparent background because of the multiplier of `0.3` is less than `1.0`.
 
 The output is as follows:
 

--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -29,7 +29,7 @@ Relative colors are created using the same [color functions](/en-US/docs/Web/CSS
 2. Pass in the **origin color** (represented above by _`origin-color`_) your relative color will be based on, preceded by the `from` keyword. This can be any valid {{cssxref("&lt;color&gt;")}} value using any available color model including a color value contained in a [CSS custom property](/en-US/docs/Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties), system colors, `currentColor`, or even another relative color.
 3. In the case of the [`color()`](/en-US/docs/Web/CSS/color_value/color) function, include the _[`colorspace`](/en-US/docs/Web/CSS/color_value/color#colorspace)_ of the output color.
 4. Provide an output value for each individual channel. The output color is defined after the origin color — represented above by the _`channel1`_, _`channel2`_, and _`channel3`_ placeholders. The channels defined here depend on the [color function](/en-US/docs/Web/CSS/CSS_colors#functions) you are using for your relative color. For example, if you are using [`hsl()`](/en-US/docs/Web/CSS/color_value/hsl), you would need to define the values for hue, saturation, and lightness. Each channel value can be a new value, the same as the original value, or a value relative to the channel value of the origin color.
-5. Optionally, an `alpha` channel value for the output color can be defined, preceded by a slash (`/`). If the `alpha` channel value is not explicitly specified, it defaults to the alpha channel value of the _`origin-color`_ (not 100%, which is the case for absolute color values).
+5. Optionally, an `alpha` channel value of type {{CSSXref("&lt;alpha-value&gt;")}} for the output color can be defined, preceded by a slash (`/`). If the `alpha` channel value is not explicitly specified, it defaults to the alpha channel value of the _`origin-color`_ (not 100%, which is the case for absolute color values).
 
 The browser converts the origin color to a syntax compatible with the color function then destructures it into component color channels (plus the `alpha` channel if the origin color has one). These are made available as appropriately-named values inside the color function — `r`, `g`, `b`, and `alpha` in the case of the `rgb()` function, `l`, `a`, `b`, and `alpha` in the case of the `lab()` function, `h`, `w`, `b`, and `alpha` in the case of `hwb()`, etc. — that can be used to calculate new output channel values.
 
@@ -62,7 +62,7 @@ Let's look at relative color syntax in action. The below CSS is used to style tw
 }
 
 #two {
-  background-color: rgb(from red 200 g b);
+  background-color: rgb(from red 150 g b / alpha);
 }
 ```
 
@@ -70,7 +70,7 @@ The output is as follows:
 
 {{ EmbedLiveSample("simple-relative-color", "100%", "200") }}
 
-The relative color uses the [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb) function, which takes `red` as the origin color, converts it to an equivalent `rgb()` color (`rgb(255 0 0)`) and then defines the new color as having a red channel of value `200` and green and blue channels with a value the same as the origin color (it uses the `g` and `b` values made available inside the function by the browser, which are both equal to `0`).
+The relative color uses the [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb) function, which takes `red` as the origin color, converts it to an equivalent `rgb()` color (`rgb(255 0 0)`) and then defines the new color as having a red channel of value `200` and green, blue and alpha channels with a value the same as the origin color (it uses the `g` and `b` values made available inside the function by the browser, which are both equal to `0`, and the `alpha` is `100%`).
 
 This results in an output of `rgb(200 0 0)` — a slightly darker red. If we had specified a red channel value of `255` (or just the `r` value), the resulting output color would be exactly the same as the input value. The browser's final output color (the computed value) is an sRGB `color()` value equivalent to `rgb(200 0 0)` — `color(srgb 0.784314 0 0)`.
 
@@ -80,14 +80,29 @@ This results in an output of `rgb(200 0 0)` — a slightly darker red. If we had
 > - Older sRGB color functions cannot express the full spectrum of visible colors. The output colors of ([`hsl()`](/en-US/docs/Web/CSS/color_value/hsl), [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb), and [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb)) are serialized to `color(srgb)` to avoid these limitations. That means that querying the output color value via the {{domxref("HTMLElement.style")}} property or the {{domxref("CSSStyleDeclaration.getPropertyValue()")}} method returns the output color as a [`color(srgb ...)`](/en-US/docs/Web/CSS/color_value/color) value.
 > - For more recent color functions (`lab()`, `oklab()`, `lch()`, and `oklch()`), relative color output values are expressed in the same syntax as the color function used. For example, if a [`lab()`](/en-US/docs/Web/CSS/color_value/lab) color function is being used, the output color will be a `lab()` value.
 
-These five lines all produce an equivalent output color:
+All the following lines produce an equivalent output color:
 
 ```css
 red
 rgb(255 0 0)
-rgb(from red r g b)
-rgb(from red 255 g b)
 rgb(from red 255 0 0)
+rgb(from red 255 0 0 / 1)
+rgb(from red 255 0 0 / 100%)
+
+rgb(from red 255 g b)
+rgb(from red r 0 0)
+rgb(from red r g b / 1)
+rgb(from red r g b / 100%)
+
+rgb(from red r g b)
+rgb(from red r g b / alpha)
+
+
+/* As the green and blue values are same */
+rgb(from red r g g)
+rgb(from red r b b)
+rgb(from red 255 g g)
+rgb(from red 255 b b)
 ```
 
 ## Syntax flexibility
@@ -278,6 +293,48 @@ The below CSS is used to style three {{htmlelement("div")}} elements with differ
 The output is as follows:
 
 {{ EmbedLiveSample("Using math functions", "100%", "200") }}
+
+## Manipulating alpha channel
+
+```html
+<div class="container">
+  <div class="item"></div>
+</div>
+```
+
+```css hidden
+.container {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+.item {
+  flex: 1;
+  margin: 60px;
+}
+```
+
+```css
+div {
+  background-color: rgb(
+    from teal r g b / calc(alpha * var(--alpha-multiplier))
+  );
+}
+
+.container {
+  --alpha-multiplier: 0.3;
+}
+
+.item {
+  --alpha-multiplier: 1;
+}
+```
+
+The output is as follows:
+
+{{ EmbedLiveSample("Manipulating alpha channel", "100%", "200") }}
 
 ## Channel values resolve to `<number>` values
 
@@ -601,7 +658,7 @@ function setBaseColor(e) {
 
 The output is as follows. This starts to show the power of relative CSS colors — we are defining multiple colors and generating palettes that are updated live by adjusting a single custom property.
 
-{{ EmbedLiveSample("Color palette generator", "100%", "470") }}
+{{ EmbedLiveSample("Color palette generator", "100%", "500") }}
 
 ### Live UI color scheme updater
 
@@ -764,7 +821,7 @@ function setHue(e) {
 
 The output is shown below. Relative CSS colors are being used here to control the color scheme of an entire UI, which can be adjusted live as a single value is modified.
 
-{{ EmbedLiveSample("Live UI color scheme updater", "100%", "400") }}
+{{ EmbedLiveSample("Live UI color scheme updater", "100%", "450") }}
 
 ## See also
 

--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -97,7 +97,7 @@ rgb(from red r g b / 100%)
 rgb(from red r g b)
 rgb(from red r g b / alpha)
 
-/* As the green and blue values are same */
+/* For red color, g and b values are equal, making them interchangeable */
 rgb(from red r g g)
 rgb(from red r b b)
 rgb(from red 255 g g)
@@ -293,7 +293,7 @@ The output is as follows:
 
 {{ EmbedLiveSample("Using math functions", "100%", "200") }}
 
-## Manipulating alpha channel
+## Manipulating the alpha channel
 
 ```html
 <div class="container">
@@ -303,15 +303,7 @@ The output is as follows:
 
 ```css hidden
 .container {
-  display: flex;
-  width: 100vw;
-  height: 100vh;
-  box-sizing: border-box;
-}
-
-.item {
-  flex: 1;
-  margin: 60px;
+  padding: 60px;
 }
 ```
 

--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -97,7 +97,6 @@ rgb(from red r g b / 100%)
 rgb(from red r g b)
 rgb(from red r g b / alpha)
 
-
 /* As the green and blue values are same */
 rgb(from red r g g)
 rgb(from red r b b)

--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -295,6 +295,8 @@ The output is as follows:
 
 ## Manipulating the alpha channel
 
+This example demonstrates how to change the alpha channel of a given color. Here, we have an item wrapped in a container, both having a `teal` colored background. To make them distinguishable, we bring variation in the alpha channel value using the relative color feature, the `calc()` function, and a custom property `--alpha-multiplier`.
+
 ```html
 <div class="container">
   <div class="item"></div>
@@ -304,6 +306,10 @@ The output is as follows:
 ```css hidden
 .container {
   padding: 60px;
+}
+
+.item {
+  height: 60px;
 }
 ```
 
@@ -322,6 +328,8 @@ div {
   --alpha-multiplier: 1;
 }
 ```
+
+In the above code, the alpha channel is referenced using the name `alpha`. The `calc(alpha * var(--alpha-multiplier))` expression modifies the alpha channel value by multiplying it with `--alpha-multiplier`. The container gets a semitransparent background because of the smaller multiplier `0.3`.
 
 The output is as follows:
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/39200

If not read carefully, one may not realize that the placeholder for the alpha channel is `alpha` and not `a`.

The PR
- sprinkles `alpha` keywords wherever possible
- adds a whole example about manipulating the alpha channel using the `calc()` function
- Increase the heights of some live samples to avoid vertical scrollbars