### PR TITLE
css(fix): fix circle using aspect-ratio example

### DIFF
--- a/files/en-us/web/css/css_box_sizing/understanding_aspect-ratio/index.md
+++ b/files/en-us/web/css/css_box_sizing/understanding_aspect-ratio/index.md
@@ -173,12 +173,12 @@ We could have created this same distorted effect using the CSS {{cssxref("aspect
 
 ```css live-sample___stretch
 img {
-  height: 100vh;
+  height: 90vh;
   aspect-ratio: 3;
 }
 ```
 
-{{EmbedLiveSample("stretch", "100", "230")}}
+{{EmbedLiveSample("stretch", "100", "270")}}
 
 We have declared a single dimension; `100vh` is the full height of the example {{htmlelement("iframe")}} viewport. For `aspect-ratio` to apply to replaced elements, only one dimension must be set. Setting both or neither doesn't work.
 
@@ -387,6 +387,7 @@ p {
 div {
   width: 200px;
   padding: 5px;
+  border: 1px solid black;
   background-color: #66ccff;
 }
 
@@ -403,22 +404,16 @@ p {
 To make the `<div>` a circle, we can set the `height` and `width` to the same value, or set `aspect-ratio: 1` and set the `overflow` to `auto` or `hidden`. Alternatively, we can simply remove the margins on the paragraph with [`margin-block: 0`](/en-US/docs/Web/CSS/margin-block). Both these options are shown below.
 
 ```html live-sample___circle2
-<section>
-  <div><p>Hello world</p></div>
-  <div><p>Hello world</p></div>
-  <section></section>
-</section>
+<div><p>Hello world</p></div>
+<div><p>Hello world</p></div>
 ```
 
 ```css hidden live-sample___circle2
-section {
-  display: flex;
-  gap: 20px;
-}
-
 div {
   width: 200px;
   padding: 5px;
+  margin: 1rem;
+  border: 1px solid black;
   background-color: #66ccff;
 }
 
@@ -445,7 +440,7 @@ div:last-of-type p {
 }
 ```
 
-{{EmbedLiveSample("circle2", "100", "250")}}
+{{EmbedLiveSample("circle2", "100", "520")}}
 
 ## Common `aspect-ratio` use cases
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/39077

The section container with display flex with flex direction row is forcing the two `<div>`s to have the same height. Because they are on the same row.

The entire wrapper setup is unnecessary and distracting. We don't have to put both divs on the same row for aesthetic purposes.