### PR TITLE
Use WebP icons in web app manifest

### DIFF
--- a/files/en-us/web/progressive_web_apps/manifest/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/index.md
@@ -31,14 +31,14 @@ All members are optional in the specification, but some applications require som
   "name": "MDN Web Docs",
   "icons": [
     {
-      "src": "/favicon-192x192.png",
+      "src": "/favicon-192x192.webp",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/webp"
     },
     {
-      "src": "/favicon-512x512.png",
+      "src": "/favicon-512x512.webp",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/webp"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
### Description

This updates the web app manifest from recommending PNG images to instead recommend WebP images.

### Motivation

The [MDN image file type and format guide](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) recommends WebP over PNG.

### Additional details

N/A

### Related issues and pull requests
