### PR TITLE
Better hasOwn() comparison

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -162,7 +162,7 @@ foo.prop = "exists";
 console.log(foo.hasOwnProperty("prop")) // Uncaught TypeError: foo.hasOwnProperty is not a function
                                         // hasOwnProperty is on the prototype chain, which foo doesn't have
 
-Console.log(Object.hasOwn(foo, "prop")) // true - works irrespective of how the object is created.
+Console.log(Object.hasOwn(foo, "prop")); // true - works irrespective of how the object is created.
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -7,8 +7,7 @@ browser-compat: javascript.builtins.Object.hasOwn
 
 {{JSRef}}
 
-The **`Object.hasOwn()`** static method returns `true` if the specified object has the indicated property as its _own_ property.
-If the property is inherited, or does not exist, the method returns `false`.
+The **`Object.hasOwn()`** static method returns `true` if the specified object has the indicated property as its _own_ property. If the property is inherited, or does not exist, the method returns `false`.
 
 > **Note:** `Object.hasOwn()` is intended as a replacement for {{jsxref("Object.prototype.hasOwnProperty()")}}.
 
@@ -44,26 +43,17 @@ Object.hasOwn(obj, prop)
 
 ### Return value
 
-`true` if the specified object has directly defined the specified property.
-Otherwise `false`
+`true` if the specified object has directly defined the specified property. Otherwise `false`
 
 ## Description
 
-The **`Object.hasOwn()`** method returns `true` if the specified property is a
-direct property of the object — even if the property value is `null` or `undefined`.
-The method returns `false` if the property is inherited, or has not been declared at all.
-Unlike the {{jsxref("Operators/in", "in")}} operator, this
-method does not check for the specified property in the object's prototype chain.
+The `Object.hasOwn()` method returns `true` if the specified property is a direct property of the object — even if the property value is `null` or `undefined`. The method returns `false` if the property is inherited, or has not been declared at all. Unlike the {{jsxref("Operators/in", "in")}} operator, this method does not check for the specified property in the object's prototype chain.
 
-It is recommended over {{jsxref("Object.prototype.hasOwnProperty()")}} because
-it works for [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) and with objects that
-have overridden the inherited `hasOwnProperty()` method. While it is possible to
-workaround these problems by calling `Object.prototype.hasOwnProperty()` on an
-external object, `Object.hasOwn()` is more intuitive.
+It is recommended over {{jsxref("Object.prototype.hasOwnProperty()")}} because it works for [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects) and with objects that have overridden the inherited `hasOwnProperty()` method. While it is possible to workaround these problems by accessing `Object.prototype.hasOwnProperty()` on another object (like `Object.prototype.hasOwnProperty.call(obj, prop)`, `Object.hasOwn()` is more intuitive and concise.
 
 ## Examples
 
-### Using hasOwn to test for a property's existence
+### Using Object.hasOwn() to test for a property's existence
 
 The following code shows how to determine whether the `example` object contains a property named `prop`.
 
@@ -124,8 +114,7 @@ for (const name in example) {
 
 ### Checking if an Array index exists
 
-The elements of an {{jsxref("Array")}} are defined as direct properties, so
-you can use `hasOwn()` method to check whether a particular index exists:
+The elements of an {{jsxref("Array")}} are defined as direct properties, so you can use `hasOwn()` method to check whether a particular index exists:
 
 ```js
 const fruits = ["Apple", "Banana", "Watermelon", "Orange"];
@@ -133,11 +122,9 @@ Object.hasOwn(fruits, 3); // true ('Orange')
 Object.hasOwn(fruits, 4); // false - not defined
 ```
 
-### Problematic cases for hasOwnProperty
+### Problematic cases for hasOwnProperty()
 
-This section demonstrates that `hasOwn()` is immune to the problems that affect
-`hasOwnProperty`. Firstly, it can be used with objects that have reimplemented
-`hasOwnProperty()`:
+This section demonstrates that `Object.hasOwn()` is immune to the problems that affect `hasOwnProperty()`. Firstly, it can be used with objects that have re-implemented `hasOwnProperty()`. In the example below, the re-implemented `hasOwnProperty()` method reports false for _every_ property, but the behavior of `Object.hasOwn()` remains unaffected:
 
 ```js
 const foo = {
@@ -147,21 +134,21 @@ const foo = {
   bar: "The dragons be out of office",
 };
 
-console.log(foo.hasOwnProperty("bar")); // false - re-implemented hasOwnProperty() reports false for *every* property
+console.log(foo.hasOwnProperty("bar")); // false
 
-console.log(Object.hasOwn(foo, "bar")); // true - re-implementation of hasOwnProperty() does not affect Object
+console.log(Object.hasOwn(foo, "bar")); // true
 ```
 
-It can also be used with [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects). These do
-not inherit from `Object.prototype`, and so `hasOwnProperty()` is inaccessible.
+It can also be used with [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects). These do not inherit from `Object.prototype`, and so `hasOwnProperty()` is inaccessible.
 
 ```js
 const foo = Object.create(null);
 foo.prop = "exists";
 
-console.log(foo.hasOwnProperty("prop")); // Uncaught TypeError: foo.hasOwnProperty is not a function - hasOwnProperty is on the prototype chain, which foo doesn't have
+console.log(foo.hasOwnProperty("prop"));
+// Uncaught TypeError: foo.hasOwnProperty is not a function
 
-console.log(Object.hasOwn(foo, "prop")); // true - works irrespective of how the object is created.
+console.log(Object.hasOwn(foo, "prop")); // true
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -159,10 +159,9 @@ not inherit from `Object.prototype`, and so `hasOwnProperty()` is inaccessible.
 const foo = Object.create(null);
 foo.prop = "exists";
 
-console.log(foo.hasOwnProperty("prop")) // Uncaught TypeError: foo.hasOwnProperty is not a function
-                                        // hasOwnProperty is on the prototype chain, which foo doesn't have
+console.log(foo.hasOwnProperty("prop")); // Uncaught TypeError: foo.hasOwnProperty is not a function - hasOwnProperty is on the prototype chain, which foo doesn't have
 
-Console.log(Object.hasOwn(foo, "prop")); // true - works irrespective of how the object is created.
+console.log(Object.hasOwn(foo, "prop")); // true - works irrespective of how the object is created.
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -147,9 +147,9 @@ const foo = {
   bar: "The dragons be out of office",
 };
 
-if (Object.hasOwn(foo, "bar")) {
-  console.log(foo.bar); // true - re-implementation of hasOwnProperty() does not affect Object
-}
+console.log(foo.hasOwnProperty("bar")); // false - re-implemented hasOwnProperty() reports false for *every* property
+
+console.log(Object.hasOwn(foo, "bar")); // true - re-implementation of hasOwnProperty() does not affect Object
 ```
 
 It can also be used with [`null`-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects). These do
@@ -158,9 +158,11 @@ not inherit from `Object.prototype`, and so `hasOwnProperty()` is inaccessible.
 ```js
 const foo = Object.create(null);
 foo.prop = "exists";
-if (Object.hasOwn(foo, "prop")) {
-  console.log(foo.prop); // true - works irrespective of how the object is created.
-}
+
+console.log(foo.hasOwnProperty("prop")) // Uncaught TypeError: foo.hasOwnProperty is not a function
+                                        // hasOwnProperty is on the prototype chain, which foo doesn't have
+
+Console.log(Object.hasOwn(foo, "prop")) // true - works irrespective of how the object is created.
 ```
 
 ## Specifications


### PR DESCRIPTION
In the "Problematic cases for hasOwnProperty" section, show how hasOwnProperty operates in the two cases as well as Object.hasOwn, and correct the expected output of the Object.hasOwn examples (it was logging the property value, which wouldn't result in true or false. Modified it to just log the Object.hasOwn result).

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Make clearer how hasOwnProperty works in the two cases and make it easy to compare with Object.hasOwn. Also correct the expected output of the console.logs in the Object.hasOwn cases.

### Motivation

Makes the difference between Object.hasOwn and hasOwnProperty clearer by having them in the same example, and fix the expected output in the Object.hasOwn cases.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

I was going to create an issue but it directed me to do this, so I did. Should I still create an issue, or is this sufficient?
