### PR TITLE
Link to color-scheme from Options page

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
@@ -40,7 +40,7 @@ To create an options page, write an HTML file defining the page. This page can i
 </html>
 ```
 
-Note the use of `<meta name="color-scheme" content="dark light">`. This enables automatic switching between light and dark themes in the embedded UI based on the user's browser preferences.
+Note the use of `<meta name="color-scheme" content="dark light">`. This enables automatic switching between light and dark themes in the embedded UI based on the user's browser preferences. For more information, see [color-scheme](/en-US/docs/Web/HTML/Reference/Elements/meta/name/color-scheme).
 
 JavaScript running in the page can use all the [WebExtension APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) that the add-on has [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for. In particular, you can use the [`storage`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage) API to persist preferences.
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
@@ -40,7 +40,7 @@ To create an options page, write an HTML file defining the page. This page can i
 </html>
 ```
 
-Note the use of `<meta name="color-scheme" content="dark light">`. This enables automatic switching between light and dark themes in the embedded UI based on the user's browser preferences. For more information, see [color-scheme](/en-US/docs/Web/HTML/Reference/Elements/meta/name/color-scheme).
+Note the use of `<meta name="color-scheme" content="dark light">`. This enables automatic switching between light and dark themes in the embedded UI based on the user's browser preferences. For more information, see [`<meta name="color-scheme">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/color-scheme).
 
 JavaScript running in the page can use all the [WebExtension APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) that the add-on has [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for. In particular, you can use the [`storage`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage) API to persist preferences.
 


### PR DESCRIPTION
### Description

Add a link to the new page describing `<meta name="color-scheme">` from the description of the options page UI component.

### Related issues and pull requests

Fixes #35801 (main fix for this request was completed in feat(html): Move meta element name attrs out into separate pages #39804, however, this changed didn't include the link from the option page description.)
