### PR TITLE
chore: Fix misleading explanation

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
@@ -624,7 +624,7 @@ margin: 0auto;
 padding- left: 10px;
 ```
 
-Do you see the spacing errors? First, `0auto` is not recognized as a valid value for the `margin` property. The entry `0auto` is meant to be two separate values: `0` and `auto`. Second, the browser does not recognize `padding-` as a valid property. The correct property name (`padding-left`) doesn't have a space inserted in it.
+Do you see the spacing errors? First, `0auto` is not recognized as a valid value for the `margin` property. The entry `0auto` is meant to be two separate values: `0` and `auto`. Second, the browser does not recognize `padding-` as a valid property. The correct property name (`padding-left`) doesn't have a space in it.
 
 You should always make sure to separate distinct values from one another by at least one space. Keep property names and property values together as single unbroken strings.
 

--- a/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
@@ -624,7 +624,7 @@ margin: 0auto;
 padding- left: 10px;
 ```
 
-Do you see the spacing errors? First, `0auto` is not recognized as a valid value for the `margin` property. The entry `0auto` is meant to be two separate values: `0` and `auto`. Second, the browser does not recognize `padding-` as a valid property. The correct property name (`padding-left`) has a space inserted in it.
+Do you see the spacing errors? First, `0auto` is not recognized as a valid value for the `margin` property. The entry `0auto` is meant to be two separate values: `0` and `auto`. Second, the browser does not recognize `padding-` as a valid property. The correct property name (`padding-left`) doesn't have a space inserted in it.
 
 You should always make sure to separate distinct values from one another by at least one space. Keep property names and property values together as single unbroken strings.
 


### PR DESCRIPTION
### Description

Fixes misleading explanation about spacing error in the `padding-left` property example. Clarifies that the correct property name should *not* contain a space.

### Motivation

The original sentence may lead readers to believe that the correct property (`padding-left`) includes a space, which is incorrect. This change clarifies that the space was mistakenly inserted and does not belong in the valid property name.

### Additional details

None.

### Related issues and pull requests

None.
