### PR TITLE
chore(fx): active-fx-release -> firefox-release-notes-active page type

### DIFF
--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -2,7 +2,7 @@
 title: Firefox 139 for developers
 short-title: Firefox 139 (Stable)
 slug: Mozilla/Firefox/Releases/139
-page-type: active-fx-release
+page-type: firefox-release-notes-active
 sidebar: firefoxsidebar
 ---
 

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -2,7 +2,7 @@
 title: Firefox 140 for developers
 short-title: Firefox 140 (Beta)
 slug: Mozilla/Firefox/Releases/140
-page-type: active-fx-release
+page-type: firefox-release-notes-active
 sidebar: firefoxsidebar
 ---
 

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -2,7 +2,7 @@
 title: Firefox 141 for developers
 short-title: Firefox 141 (Nightly)
 slug: Mozilla/Firefox/Releases/141
-page-type: active-fx-release
+page-type: firefox-release-notes-active
 sidebar: firefoxsidebar
 ---
 

--- a/files/sidebars/firefoxsidebar.yaml
+++ b/files/sidebars/firefoxsidebar.yaml
@@ -6,7 +6,7 @@ sidebar:
     title: Firefox
   - type: listSubPages
     path: /Mozilla/Firefox/Releases
-    tags: unknown
+    tags: firefox-release-notes-active
     link: /Mozilla/Firefox/Releases
   - /Mozilla/Firefox/Experimental_features
   - type: listSubPages

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -161,8 +161,8 @@
               "enum": [
                 "guide",
                 "landing-page",
-                "active-fx-release",
-                "firefox-release-notes"
+                "firefox-release-notes",
+                "firefox-release-notes-active"
               ]
             }
           }


### PR DESCRIPTION
### Description

Rari formats unknown page types to `unknown` in sidebars. Now that this new page type is supported, I'm tidying up the references in places where it should be. There's no visible effect, but it's not nice to have `unknown` page types in sidebars.

### Motivation

The page type has been renamed / added to allow list in rari.

### Related issues and pull requests

- [x] https://github.com/mdn/rari/pull/226
- [x] https://github.com/mdn/content/pull/39761 