### PR TITLE
Omitting roundingInterval

### DIFF
--- a/files/en-us/web/css/round/index.md
+++ b/files/en-us/web/css/round/index.md
@@ -48,7 +48,7 @@ The `valueToRound` is rounded according to the rounding strategy, to the nearest
 
 - `roundingInterval`
   - : The rounding interval.
-    This is a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}}, or a mathematical expression that resolves to one of those values.
+    This is a {{CSSxREF("&lt;number&gt;")}}, {{CSSxREF("&lt;dimension&gt;")}}, or {{CSSxREF("&lt;percentage&gt;")}}, or a mathematical expression that resolves to one of those values. If `valueToRound` is a {{CSSxREF("&lt;number&gt;")}}, `roundingInterval` may be omitted and defaults to `1`. Otherwise, omitting it results in an invalid expression.
 
 ### Return value
 


### PR DESCRIPTION
### Description

Improved the description of the `roundingInterval` argument of the CSS `round` function. I explained what happens when you omit the value.

### Motivation

In the syntax definition the argument is optional so I was wondering what would happen. Had to look at the spec to find out.

### Additional details

Source (from the spec):
> If the [type](https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-type) of A matches [<number>](https://drafts.csswg.org/css-values/#number-value), then B may be omitted, and defaults to 1; omitting B is otherwise invalid.

https://drafts.csswg.org/css-values/#round-func