### PR TITLE
Fix PublicKeyCredentialCreationOptions.pubKeyCredParams.alg

### DIFF
--- a/files/en-us/web/api/publickeycredentialcreationoptions/index.md
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/index.md
@@ -125,7 +125,7 @@ The **`PublicKeyCredentialCreationOptions`** dictionary represents the object pa
 
       - : A number that is equal to a [COSE Algorithm Identifier](https://www.iana.org/assignments/cose/cose.xhtml#algorithms), representing the cryptographic algorithm to use for this credential type. It is recommended that relying parties that wish to support a wide range of authenticators should include at least the following values in the provided choices:
 
-        - `-8`: Ed25519
+        - `-8`: EdDSA
         - `-7`: ES256
         - `-257`: RS256
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

This PR fixes the description for `PublicKeyCredentialCreationOptions.pubKeyCredParams.alg`.
The number `-8` does not identify the `Ed25519` algorithm but `EdDSA` (see the linked IANA document).
`Ed25519` has number `-19`.

### Motivation

This change was made to clarify which algorithm is referred to in the section.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
- https://www.iana.org/assignments/cose/cose.xhtml#algorithms

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
