### PR TITLE
fix(pr-test): add GITHUB_TOKEN env for `rari` related commands

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -69,6 +69,10 @@ jobs:
         env:
           GIT_DIFF_CONTENT: ${{ steps.check.outputs.GIT_DIFF_CONTENT }}
 
+          # Used by the `rari` cli to avoid rate limiting issues
+          # when fetching the latest releases info from the GitHub API.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
           CONTENT_ROOT: ${{ github.workspace }}/files
 
           # This is so that if there's a single 'unsafe_html' flaw, it


### PR DESCRIPTION
### Description

Add GITHUB_TOKEN env for `rari` related commands to avoid rate limiting issues when fetching the latest releases info from the GitHub API.

### Related issues and pull requests

Releated PR: mdn/rari#239
Downstream PR: mdn/translated-content#27745
