### PR TITLE
Add information about SVG transform support on <svg> root

### DIFF
--- a/files/en-us/web/svg/reference/attribute/transform/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform/index.md
@@ -17,7 +17,6 @@ In SVG 2, you can use the `transform` attribute on any element, including the {{
 Note that using `transform` on the `<svg>` root is a newer feature, and you should check [browser compatibility](#browser_compatibility) for support.
 Using `transform` on the `<svg>` root is convenient for applying transforms to an entire SVG image without the need for extra wrapper elements or CSS workarounds.
 
-
 In SVG 1.1, only these 16 elements were allowed to have a `transform` applied: {{SVGElement('a')}}, {{SVGElement('circle')}}, {{SVGElement('clipPath')}}, {{SVGElement('defs')}}, {{SVGElement('ellipse')}}, {{SVGElement('foreignObject')}}, {{SVGElement('g')}}, {{SVGElement('image')}}, {{SVGElement('line')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('switch')}}, {{SVGElement('text')}}, and {{SVGElement('use')}}.
 
 Also, as a legacy from SVG 1.1, {{SVGElement('linearGradient')}} and {{SVGElement('radialGradient')}} support the `gradientTransform` attribute, and {{SVGElement('pattern')}} supports the `patternTransform` attribute, both of which behave exactly like the `transform` attribute.

--- a/files/en-us/web/svg/reference/attribute/transform/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform/index.md
@@ -9,7 +9,7 @@ sidebar: svgref
 The **`transform`** attribute defines a list of transform definitions that are applied to an element and the element's children.
 
 > [!NOTE]
-> As a presentation attribute, `transform` also has a CSS property counterpart: {{cssxref("transform")}}. When both are specified, the CSS property takes priority. However, be aware that there are some differences in syntax between the CSS property and the attribute. See the documentation for the CSS property {{cssxref('transform')}} for the specific syntax to use in that case.
+> As a presentation attribute, `transform` also has a CSS property counterpart: {{cssxref("transform")}}. When both are specified, the CSS property takes priority. Note that there are some differences in syntax between the CSS property and the attribute!
 
 ## Elements
 

--- a/files/en-us/web/svg/reference/attribute/transform/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform/index.md
@@ -46,9 +46,13 @@ Also, as a legacy from SVG 1.1, {{SVGElement('linearGradient')}} and {{SVGElemen
   </tbody>
 </table>
 
-## Example
+## Examples
 
-```css hidden
+### Apply a transform to a single SVG element
+
+In this example, we apply a `transform` to a single {{svgelement("g")}} element inside an SVG document:
+
+```css hidden live-sample___transform-single-element live-sample___transform-svg-document
 html,
 body,
 svg {
@@ -56,7 +60,7 @@ svg {
 }
 ```
 
-```html
+```html live-sample___transform-single-element
 <svg
   viewBox="-40 0 150 100"
   xmlns="http://www.w3.org/2000/svg"
@@ -76,7 +80,32 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", '100%', 200)}}
+{{EmbedLiveSample("transform-single-element", '100%', 200)}}
+
+### Apply a transform to an entire SVG document
+
+In this example, we apply a `transform` to the {{svgelement("svg")}} root element, meaning that the transform is applied to the entire SVG document:
+
+```html live-sample___transform-svg-document
+<svg
+  viewBox="-40 0 150 100"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  transform="rotate(-10 50 100)
+               translate(-36 15.5)
+               skewX(40)
+               scale(1 0.5)">
+  <g fill="grey">
+    <path
+      id="heart"
+      d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
+  </g>
+
+  <use href="#heart" fill="none" stroke="red" />
+</svg>
+```
+
+{{EmbedLiveSample("transform-svg-document", '100%', 200)}}
 
 ## Transform functions
 

--- a/files/en-us/web/svg/reference/attribute/transform/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform/index.md
@@ -11,7 +11,38 @@ The **`transform`** attribute defines a list of transform definitions that are a
 > [!NOTE]
 > As a presentation attribute, `transform` also has a CSS property counterpart: {{cssxref("transform")}}. When both are specified, the CSS property takes priority. However, be aware that there are some differences in syntax between the CSS property and the attribute. See the documentation for the CSS property {{cssxref('transform')}} for the specific syntax to use in that case.
 
-You can use this attribute with any SVG element.
+## Elements
+
+In SVG 2, you can use the `transform` attribute on any SVG element inside the {{SVGElement('svg')}} root. In addition, some browsers support using `transform` on the `<svg>` root itself, which is convenient for applying transforms to an entire SVG image without the need for extra wrapper elements or CSS workarounds.
+
+In SVG 1.1, only these 16 elements were allowed to have a `transform` applied: {{SVGElement('a')}}, {{SVGElement('circle')}}, {{SVGElement('clipPath')}}, {{SVGElement('defs')}}, {{SVGElement('ellipse')}}, {{SVGElement('foreignObject')}}, {{SVGElement('g')}}, {{SVGElement('image')}}, {{SVGElement('line')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('switch')}}, {{SVGElement('text')}}, and {{SVGElement('use')}}.
+
+Also, as a legacy from SVG 1.1, {{SVGElement('linearGradient')}} and {{SVGElement('radialGradient')}} support the `gradientTransform` attribute, and {{SVGElement('pattern')}} supports the `patternTransform` attribute, both of which behave exactly like the `transform` attribute.
+
+## Value
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Value</th>
+      <td>
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Guides/Content_type#transform-list"
+            ><code>&#x3C;transform-list></code></a
+          ></strong
+        >
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Default value</th>
+      <td><em>none</em></td>
+    </tr>
+    <tr>
+      <th scope="row">Animatable</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Example
 
@@ -45,36 +76,9 @@ svg {
 
 {{EmbedLiveSample("Example", '100%', 200)}}
 
-In SVG 1.1, only these 16 elements were allowed to use it: {{SVGElement('a')}}, {{SVGElement('circle')}}, {{SVGElement('clipPath')}}, {{SVGElement('defs')}}, {{SVGElement('ellipse')}}, {{SVGElement('foreignObject')}}, {{SVGElement('g')}}, {{SVGElement('image')}}, {{SVGElement('line')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('switch')}}, {{SVGElement('text')}}, and {{SVGElement('use')}}.
-
-Also, as a legacy from SVG 1.1, {{SVGElement('linearGradient')}} and {{SVGElement('radialGradient')}} support the `gradientTransform` attribute, and {{SVGElement('pattern')}} supports the `patternTransform` attribute, both of which act exactly like the `transform` attribute.
-
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Value</th>
-      <td>
-        <strong
-          ><a href="/en-US/docs/Web/SVG/Guides/Content_type#transform-list"
-            ><code>&#x3C;transform-list></code></a
-          ></strong
-        >
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Default value</th>
-      <td><em>none</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Animatable</th>
-      <td>Yes</td>
-    </tr>
-  </tbody>
-</table>
-
 ## Transform functions
 
-The following transform functions can be used by the `transform` attribute `<transform-list>`
+The following transform functions can be used by the `transform` attribute `<transform-list>`.
 
 > [!WARNING]
 > As per the spec, you should be able to also use CSS [transform functions](/en-US/docs/Web/CSS/transform-function). However, the compatibility isn't guaranteed.

--- a/files/en-us/web/svg/reference/attribute/transform/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform/index.md
@@ -13,7 +13,10 @@ The **`transform`** attribute defines a list of transform definitions that are a
 
 ## Elements
 
-In SVG 2, you can use the `transform` attribute on any SVG element inside the {{SVGElement('svg')}} root. In addition, some browsers support using `transform` on the `<svg>` root itself, which is convenient for applying transforms to an entire SVG image without the need for extra wrapper elements or CSS workarounds.
+In SVG 2, you can use the `transform` attribute on any element, including the {{SVGElement('svg')}} root.
+Note that using `transform` on the `<svg>` root is a newer feature, and you should check [browser compatibility](#browser_compatibility) for support.
+Using `transform` on the `<svg>` root is convenient for applying transforms to an entire SVG image without the need for extra wrapper elements or CSS workarounds.
+
 
 In SVG 1.1, only these 16 elements were allowed to have a `transform` applied: {{SVGElement('a')}}, {{SVGElement('circle')}}, {{SVGElement('clipPath')}}, {{SVGElement('defs')}}, {{SVGElement('ellipse')}}, {{SVGElement('foreignObject')}}, {{SVGElement('g')}}, {{SVGElement('image')}}, {{SVGElement('line')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('switch')}}, {{SVGElement('text')}}, and {{SVGElement('use')}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Chrome 137+ supports setting an SVG `transform` attribute on the root `<svg>` element. See https://chromestatus.com/feature/6129368025530368 for details.

This PR updates the `transform` attribute page to mention this, and to clean up the structure a bit.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
