### PR TITLE
fix(glossary): Add cross linking between image format entries

### DIFF
--- a/files/en-us/glossary/favicon/index.md
+++ b/files/en-us/glossary/favicon/index.md
@@ -16,7 +16,7 @@ They are used to improve user experience and enforce brand consistency. When a f
 
 ## See also
 
-- [link rel="icon"](/en-US/docs/Web/HTML/Reference/Attributes/rel#icon) to add a favicon to a page
+- Using [link rel="icon"](/en-US/docs/Web/HTML/Reference/Attributes/rel#icon) to add a favicon to a page
 - [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - Tools:
   - [Free favicon generator](https://favicon.io/)

--- a/files/en-us/glossary/favicon/index.md
+++ b/files/en-us/glossary/favicon/index.md
@@ -16,7 +16,7 @@ They are used to improve user experience and enforce brand consistency. When a f
 
 ## See also
 
-- Using [link rel="icon"](/en-US/docs/Web/HTML/Reference/Attributes/rel#icon) to add a favicon to a page
+- Using [`<link rel="icon">`](/en-US/docs/Web/HTML/Reference/Attributes/rel#icon) to add a favicon to a page
 - [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - Tools:
   - [Free favicon generator](https://favicon.io/)

--- a/files/en-us/glossary/favicon/index.md
+++ b/files/en-us/glossary/favicon/index.md
@@ -16,9 +16,9 @@ They are used to improve user experience and enforce brand consistency. When a f
 
 ## See also
 
-- [Favicon](https://en.wikipedia.org/wiki/Favicon) on Wikipedia
-- The [link rel="icon"](/en-US/docs/Web/HTML/Reference/Attributes/rel#icon) element documentation, used to add a favicon to a page.
-- Tools
-
+- [link rel="icon"](/en-US/docs/Web/HTML/Reference/Attributes/rel#icon) to add a favicon to a page
+- [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
+- Tools:
   - [Free favicon generator](https://favicon.io/)
   - [Favicon.ico and & app icon generator](https://www.favicon-generator.org/)
+- [Favicon](https://en.wikipedia.org/wiki/Favicon) on Wikipedia

--- a/files/en-us/glossary/gif/index.md
+++ b/files/en-us/glossary/gif/index.md
@@ -10,4 +10,8 @@ GIF (Graphics Interchange Format) is an image format that uses lossless compress
 
 ## See also
 
+- [GIF section in the Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types#gif_graphics_interchange_format)
+- Other image formats (glossary terms): {{Glossary("JPEG")}}, {{Glossary("PNG")}}, {{Glossary("SVG")}}, {{Glossary("WebP")}}
+- [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
+- [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - [GIF](https://en.wikipedia.org/wiki/GIF) on Wikipedia

--- a/files/en-us/glossary/jpeg/index.md
+++ b/files/en-us/glossary/jpeg/index.md
@@ -12,4 +12,8 @@ JPEG compression is composed of three compression techniques applied in successi
 
 ## See also
 
+- [JPEG section in the Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_joint_photographic_experts_group_image)
+- Other image formats (glossary terms): {{Glossary("GIF")}}, {{Glossary("PNG")}}, {{Glossary("SVG")}}, {{Glossary("WebP")}}
+- [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
+- [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - [JPEG](https://en.wikipedia.org/wiki/JPEG) on Wikipedia

--- a/files/en-us/glossary/png/index.md
+++ b/files/en-us/glossary/png/index.md
@@ -10,4 +10,8 @@ page-type: glossary-definition
 
 ## See also
 
+- [PNG section in the Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types#png_portable_network_graphics)
+- Other image formats (glossary terms): {{Glossary("GIF")}}, {{Glossary("JPEG")}}, {{Glossary("SVG")}}, {{Glossary("WebP")}}
+- [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
+- [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics) on Wikipedia

--- a/files/en-us/glossary/svg/index.md
+++ b/files/en-us/glossary/svg/index.md
@@ -20,5 +20,6 @@ As a [vector image format](https://en.wikipedia.org/wiki/Vector_graphics), SVG g
 - [SVG documentation on MDN](/en-US/docs/Web/SVG)
 - Other image formats (glossary terms): {{Glossary("GIF")}}, {{Glossary("JPEG")}}, {{Glossary("PNG")}}, {{Glossary("WebP")}}
 - [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
+- [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - [SVG](https://en.wikipedia.org/wiki/SVG) on Wikipedia
 - [SVG Primer](https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html) on w3.org

--- a/files/en-us/glossary/svg/index.md
+++ b/files/en-us/glossary/svg/index.md
@@ -21,5 +21,6 @@ As a [vector image format](https://en.wikipedia.org/wiki/Vector_graphics), SVG g
 - Other image formats (glossary terms): {{Glossary("GIF")}}, {{Glossary("JPEG")}}, {{Glossary("PNG")}}, {{Glossary("WebP")}}
 - [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
 - [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
+- [Including vector graphics in HTML](/en-US/docs/Learn_web_development/Core/Structuring_content/Including_vector_graphics_in_HTML)
 - [SVG](https://en.wikipedia.org/wiki/SVG) on Wikipedia
 - [SVG Primer](https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html) on w3.org

--- a/files/en-us/glossary/svg/index.md
+++ b/files/en-us/glossary/svg/index.md
@@ -16,7 +16,9 @@ As a [vector image format](https://en.wikipedia.org/wiki/Vector_graphics), SVG g
 
 ## See also
 
-- [SVG](https://en.wikipedia.org/wiki/SVG) on Wikipedia
-- [W3.org's SVG Primer](https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html)
+- [SVG section in the Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics)
 - [SVG documentation on MDN](/en-US/docs/Web/SVG)
-- [Latest SVG specification](https://svgwg.org/svg2-draft/)
+- Other image formats (glossary terms): {{Glossary("GIF")}}, {{Glossary("JPEG")}}, {{Glossary("PNG")}}, {{Glossary("WebP")}}
+- [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
+- [SVG](https://en.wikipedia.org/wiki/SVG) on Wikipedia
+- [SVG Primer](https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html) on w3.org

--- a/files/en-us/glossary/webp/index.md
+++ b/files/en-us/glossary/webp/index.md
@@ -10,4 +10,7 @@ page-type: glossary-definition
 
 ## See also
 
+- [WebP section in the Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image)
+- Other image formats (glossary terms): {{Glossary("GIF")}}, {Glossary("JPEG")}}, {{Glossary("PNG")}}, {{Glossary("SVG")}}
+- [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
 - [WebP](https://en.wikipedia.org/wiki/WebP) on Wikipedia

--- a/files/en-us/glossary/webp/index.md
+++ b/files/en-us/glossary/webp/index.md
@@ -13,4 +13,5 @@ page-type: glossary-definition
 - [WebP section in the Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image)
 - Other image formats (glossary terms): {{Glossary("GIF")}}, {Glossary("JPEG")}}, {{Glossary("PNG")}}, {{Glossary("SVG")}}
 - [HTML images](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images) (Learn web development)
+- [Adding custom icons to your site](/en-US/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#adding_custom_icons_to_your_site)
 - [WebP](https://en.wikipedia.org/wiki/WebP) on Wikipedia


### PR DESCRIPTION
### Description

This PR adds cross links between different image format entries in the Glossary (PNG, GIF, JPEG, WebP, SVG).
Additionally, it adds links to relevant guides.

### Motivation

To improve discoverability of content and help readers explore other image formats
