### PR TITLE
Fix uncaught ReferenceError in example

### DIFF
--- a/files/en-us/web/api/keyboardevent/metakey/index.md
+++ b/files/en-us/web/api/keyboardevent/metakey/index.md
@@ -34,7 +34,7 @@ A boolean value.
 ```
 
 ```js
-document.querySelector("button").addEventListener("click", () => {
+document.querySelector("button").addEventListener("click", (e) => {
   document.querySelector("#output").textContent =
     `metaKey pressed? ${e.metaKey}`;
 });


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The `event` parameter was previously not accepted by the event handler, but used in its body, leading to a reference error.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
For the interactive playground to work

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
