### PR TITLE
Bug-1888486 `browser.i18n.getPreferredSystemLanguages` doc and release note

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getpreferredsystemlanguages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getpreferredsystemlanguages/index.md
@@ -1,0 +1,30 @@
+---
+title: i18n.getPreferredSystemLanguages()
+slug: Mozilla/Add-ons/WebExtensions/API/i18n/getPreferredSystemLanguages
+page-type: webextension-api-function
+browser-compat: webextensions.api.i18n.getPreferredSystemLanguages
+---
+
+{{AddonSidebar}}
+
+Returns the preferred locales of the operating system. This is different from the locales set in the browser; to get those, use {{WebExtAPIRef('i18n.getAcceptLanguages')}}.
+
+## Syntax
+
+```js-nolint
+let preferredSystemLanguages = await browser.i18n.getPreferredSystemLanguages()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with an array of {{WebExtAPIRef("i18n.LanguageCode")}} strings.
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getsystemuilanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getsystemuilanguage/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.i18n.getSystemUILanguage
 
 {{AddonSidebar}}
 
-Returns the current UI locale of the operating system. This is different from {{WebExtAPIRef('i18n.getUILanguage')}}, which returns the UI locale of the web browser. 
+Returns the current UI locale of the operating system. This is different from {{WebExtAPIRef('i18n.getUILanguage')}}, which returns the UI locale of the web browser.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getsystemuilanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getsystemuilanguage/index.md
@@ -1,0 +1,30 @@
+---
+title: i18n.getSystemUILanguage()
+slug: Mozilla/Add-ons/WebExtensions/API/i18n/getSystemUILanguage
+page-type: webextension-api-function
+browser-compat: webextensions.api.i18n.getSystemUILanguage
+---
+
+{{AddonSidebar}}
+
+Returns the current UI locale of the operating system. This is different from {{WebExtAPIRef('i18n.getUILanguage')}}, which returns the UI locale of the web browser. 
+
+## Syntax
+
+```js-nolint
+let systemUILanguage = await browser.i18n.getSystemUILanguage()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with a {{WebExtAPIRef("i18n.LanguageCode")}}.
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -18,14 +18,19 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 
 ## Functions
 
-- {{WebExtAPIRef("i18n.getAcceptLanguages()")}}
-  - : Gets the [accept-languages](/en-US/docs/Web/HTTP/Guides/Content_negotiation#the_accept-language_header) of the browser. This is different from the locale used by the browser. To get the locale, use {{WebExtAPIRef('i18n.getUILanguage')}}.
-- {{WebExtAPIRef("i18n.getMessage()")}}
-  - : Gets the localized string for the specified message.
-- {{WebExtAPIRef("i18n.getUILanguage()")}}
-  - : Gets the UI language of the browser. This is different from {{WebExtAPIRef('i18n.getAcceptLanguages')}} which returns the preferred user languages.
 - {{WebExtAPIRef("i18n.detectLanguage()")}}
   - : Detects the language of the provided text using the [Compact Language Detector](https://github.com/CLD2Owners/cld2).
+- {{WebExtAPIRef("i18n.getMessage()")}}
+  - : Gets the localized string for the specified message.
+- {{WebExtAPIRef("i18n.getAcceptLanguages()")}}
+  - : Gets the [accept-languages](/en-US/docs/Web/HTTP/Guides/Content_negotiation#the_accept-language_header) of the browser. This is different from the locale used by the browser. To get the locale, use {{WebExtAPIRef('i18n.getUILanguage')}}.
+- {{WebExtAPIRef("i18n.getUILanguage()")}}
+  - : Gets the UI language of the browser. This is different from {{WebExtAPIRef('i18n.getAcceptLanguages')}} which returns the preferred user languages.
+- {{WebExtAPIRef("i18n.getPreferredSystemLanguages()")}}
+  - : Returns the preferred locales of the operating system.
+- {{WebExtAPIRef("i18n.getSystemUILanguage()")}}
+  - : Returns the current UI locale of the operating system.
+
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -31,7 +31,6 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 - {{WebExtAPIRef("i18n.getSystemUILanguage()")}}
   - : Returns the current UI locale of the operating system.
 
-
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -60,6 +60,7 @@ Firefox 141 is the current [Nightly version of Firefox](https://www.mozilla.org/
 ## Changes for add-on developers
 
 - Adds the {{WebExtAPIRef('i18n.getPreferredSystemLanguages')}} method to retrieve the preferred locales of the operating system. This complements {{WebExtAPIRef('i18n.getAcceptLanguages')}} which return details of the locales set in the browser. ([Firefox bug 1888486](https://bugzil.la/1888486))
+
 ### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -60,7 +60,6 @@ Firefox 141 is the current [Nightly version of Firefox](https://www.mozilla.org/
 ## Changes for add-on developers
 
 - Adds the {{WebExtAPIRef('i18n.getPreferredSystemLanguages')}} method to retrieve the preferred locales of the operating system. This complements {{WebExtAPIRef('i18n.getAcceptLanguages')}} which return details of the locales set in the browser. ([Firefox bug 1888486](https://bugzil.la/1888486))
- 
 ### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -59,6 +59,8 @@ Firefox 141 is the current [Nightly version of Firefox](https://www.mozilla.org/
 
 ## Changes for add-on developers
 
+- Adds the {{WebExtAPIRef('i18n.getPreferredSystemLanguages')}} method to retrieve the preferred locales of the operating system. This complements {{WebExtAPIRef('i18n.getAcceptLanguages')}} which return details of the locales set in the browser. ([Firefox bug 1888486](https://bugzil.la/1888486))
+ 
 ### Removals
 
 ### Other


### PR DESCRIPTION


### Description

Add details of `i18n.getSystemUILanguage` and `i18n.getPreferredSystemLanguages`. The latter of these has been implemented in Firefox in [Bug 1888486](https://bugzilla.mozilla.org/show_bug.cgi?id=1888486) and therefore is also included in release notes.

### Related issues and pull requests

- BCD for the Safari implementation included in https://github.com/mdn/browser-compat-data/pull/27058.
- BCD for the Firefox implementation of `i18n.getPreferredSystemLanguages` included in https://github.com/mdn/browser-compat-data/pull/27075.