### PR TITLE
Editorial review: Add docs for MediaTrackSettings.screenPixelRatio

### DIFF
--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -104,7 +104,11 @@ Tracks containing video shared from a user's screen (regardless of whether the s
       - : The stream contains a single window selected by the user for sharing.
 
 - {{domxref("MediaTrackSettings.logicalSurface", "logicalSurface")}}
+
   - : A Boolean value which, if `true`, indicates that the video contained in the stream's video track contains a background rendering context, rather than a user-visible one. This is `false` if the video being captured is coming from a foreground (user-visible) source.
+
+- {{domxref("MediaTrackSettings.screenPixelRatio", "screenPixelRatio")}}
+  - : A double-precision floating point value indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -50,9 +50,7 @@ Some or all of the following will be included in the object, either because it's
 - {{domxref("MediaTrackSettings.aspectRatio", "aspectRatio")}}
   - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.aspectRatio", "aspectRatio")}} property, specified precisely to 10 decimal places. This is the width of the image in pixels divided by its height in pixels. Common values include 1.3333333333 (for the classic television 4:3 "standard" {{glossary("aspect ratio")}}, also used on tablets such as Apple's iPad), 1.7777777778 (for the 16:9 high-definition widescreen aspect ratio), and 1.6 (for the 16:10 aspect ratio common among widescreen computers and tablets).
 - {{domxref("MediaTrackSettings.facingMode", "facingMode")}}
-
   - : A string indicating the current value of the {{domxref("MediaTrackConstraints.facingMode", "facingMode")}} property, specifying the direction the camera is facing. The value will be one of:
-
     - `"user"`
       - : A camera facing the user (commonly known as a "selfie cam"), used for self-portraiture and video calling.
     - `"environment"`
@@ -69,9 +67,7 @@ Some or all of the following will be included in the object, either because it's
 - {{domxref("MediaTrackSettings.width", "width")}}
   - : A long integer value indicating the current value of the {{domxref("MediaTrackSettings.width", "width")}} property, specifying the width of the track's video data in pixels.
 - {{domxref("MediaTrackSettings.resizeMode", "resizeMode")}}
-
   - : A string indicating the current value of the {{domxref("MediaTrackConstraints.resizeMode", "resizeMode")}} property, specifying the mode used by the user agent to derive the resolution of the track. The value will be one of:
-
     - `"none"`
       - : The track has the resolution offered by the camera, its driver or the OS.
     - `"crop-and-scale"`
@@ -82,9 +78,7 @@ Some or all of the following will be included in the object, either because it's
 Tracks containing video shared from a user's screen (regardless of whether the screen data comes from the entire screen or a portion of a screen, like a window or tab) are generally treated like video tracks, with the exception that they also support the following added settings:
 
 - {{domxref("MediaTrackSettings.cursor", "cursor")}}
-
   - : A string which indicates whether or not the mouse cursor is being included in the generated stream and under what conditions. Possible values are:
-
     - `always`
       - : The mouse is always visible in the video content of the {domxref("MediaStream"), unless the mouse has moved outside the area of the content.
     - `motion`
@@ -93,9 +87,7 @@ Tracks containing video shared from a user's screen (regardless of whether the s
       - : The mouse cursor is never included in the shared video.
 
 - {{domxref("MediaTrackSettings.displaySurface", "displaySurface")}}
-
   - : A string which specifies the type of source the track contains; one of:
-
     - `browser`
       - : The stream contains the contents of a single browser tab selected by the user.
     - `monitor`
@@ -104,11 +96,10 @@ Tracks containing video shared from a user's screen (regardless of whether the s
       - : The stream contains a single window selected by the user for sharing.
 
 - {{domxref("MediaTrackSettings.logicalSurface", "logicalSurface")}}
-
   - : A Boolean value which, if `true`, indicates that the video contained in the stream's video track contains a background rendering context, rather than a user-visible one. This is `false` if the video being captured is coming from a foreground (user-visible) source.
 
 - {{domxref("MediaTrackSettings.screenPixelRatio", "screenPixelRatio")}}
-  - : A double-precision floating point value indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
+  - : A number representing the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -99,7 +99,7 @@ Tracks containing video shared from a user's screen (regardless of whether the s
   - : A Boolean value which, if `true`, indicates that the video contained in the stream's video track contains a background rendering context, rather than a user-visible one. This is `false` if the video being captured is coming from a foreground (user-visible) source.
 
 - {{domxref("MediaTrackSettings.screenPixelRatio", "screenPixelRatio")}}
-  - : A number representing the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
+  - : A number representing the ratio of the physical size of a pixel on the captured display surface (displayed at its physical resolution) to the logical size of a CSS pixel on the capturing screen (displayed at its logical resolution). It cannot be used as a constraint or capability.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -104,7 +104,6 @@ Tracks containing video shared from a user's screen (regardless of whether the s
       - : The stream contains a single window selected by the user for sharing.
 
 - {{domxref("MediaTrackSettings.logicalSurface", "logicalSurface")}}
-
   - : A Boolean value which, if `true`, indicates that the video contained in the stream's video track contains a background rendering context, rather than a user-visible one. This is `false` if the video being captured is coming from a foreground (user-visible) source.
 
 - {{domxref("MediaTrackSettings.screenPixelRatio", "screenPixelRatio")}}

--- a/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
@@ -8,33 +8,40 @@ browser-compat: api.MediaTrackSettings.screenPixelRatio
 
 {{APIRef("Media Capture and Streams")}}
 
-The {{domxref("MediaTrackSettings")}} dictionary's **`screenPixelRatio`** property is a number representing the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
+The {{domxref("MediaTrackSettings")}} dictionary's **`screenPixelRatio`** property is a number representing the ratio of the physical size of a pixel on the captured display surface (displayed at its physical resolution) to the logical size of a CSS pixel on the capturing screen (displayed at its logical resolution). It cannot be used as a constraint or capability.
 
 This property allows applications using the [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API) to save resources by sending the video of a screen capture at its logical, or device independent, resolution.
 
 ## Value
 
-A number representing the screeen pixel ratio.
+A number representing the screen pixel ratio.
 
-This is calculated by dividing the size of a {{glossary("CSS pixel")}} at a page zoom of `1.0` and using a scale factor of `1.0` on the capturing screen by the vertical size of a pixel from the [display surface](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface).
+This is calculated by dividing the size of a {{glossary("CSS pixel")}} at a page zoom of `1.0` and using a scale factor of `1.0` on the capturing screen by the vertical size of a pixel from the captured [display surface](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface).
 
 ## Description
 
-It is common for a screen to have zoom applied via the operating system (OS), for example by the user zooming in. The resolution before applying the zoom is called the **logical resolution**, and the resolution after the zoom is applied is called the **physical resolution**.
+It is common for a screen to have zoom applied via the operating system (OS), for example when the display is a high-resolution display, and you want the graphics to be shown at the same physical size as they would on a standard resolution display. The resolution before applying the zoom is called the **logical resolution**, and the resolution after the zoom is applied is called the **physical resolution**.
 
-A video-conferencing app can save bandwidth and CPU when the captured screen is zoomed in on the sender side by:
+If the sender's captured screen is zoomed in, then the physical resolution is greater than the logical resolution, and a video-conferencing app can therefore save bandwidth and CPU by:
 
 1. Removing the zoom applied to the captured display surface by the OS.
 2. Sending the video of the screen capture at the logical resolution.
 3. Reapplying the zoom after receiving it on the remote client to size it back up to its physical resolution.
 
-The `screenPixelRatio` property describes the ratio of the physical size of a pixel to its logical size, and therefore enables the application to work out how much of a zoom has been applied, and then constrain the video to the logical size.
+The `screenPixelRatio` property describes the ratio of the physical size of a pixel to the logical size of a CSS pixel, and therefore enables the application to work out how much of a zoom factor has been applied, and then constrain the video to the logical size.
+
+For example:
+
+- If the captured display surface is being displayed on a standard resolution screen where physical pixel dimensions are about the same as CSS pixel dimensions, `screenPixelRatio` will return a value of `1`.
+- If, however, the captured display surface is being displayed on a high-dpi resolution screen where physical pixel dimensions are about double the CSS pixel dimensions, `screenPixelRatio` will return a value of `2`.
 
 ## Examples
 
 ### Basic `screenPixelRatio` usage
 
-The following snippet shows how an application may use `screenPixelRatio` to constrain a {{domxref("MediaStreamTrack")}}'s' [`width`](/en-US/docs/Web/API/MediaTrackConstraints/width) and [`height`](/en-US/docs/Web/API/MediaTrackConstraints/height) to the logical resolution when scaling exceeds an acceptable threshold (specified by an application-defined constant).
+In this example, the application defines a constant `RESOLUTION_LIMIT`, which represents the scaling factor beyond which which the sending application should send video at the logical resolution rather than the physical resolution.
+
+When `screenPixelRatio` exceeds this limit, the application uses the `screenPixelRatio` value to calculate the logical resolution from the physical resolution, and then constrains the captured {{domxref("MediaStreamTrack")}} to the logical resolution.
 
 ```js
 const RESOLUTION_LIMIT = 1.5;
@@ -47,11 +54,11 @@ async function startCapture() {
   const settings = track.getSettings();
   const capabilities = track.getCapabilities();
 
-  if (track.screenPixelRatio > RESOLUTION_LIMIT) {
-    let physicalWidth = capabilities.width.max;
-    let physicalHeight = capabilities.height.max;
-    let logicalWidth = physicalWidth / settings.screenPixelRatio;
-    let logicalHeight = physicalHeight / settings.screenPixelRatio;
+  if (settings.screenPixelRatio > RESOLUTION_LIMIT) {
+    const physicalWidth = capabilities.width.max;
+    const physicalHeight = capabilities.height.max;
+    const logicalWidth = physicalWidth / settings.screenPixelRatio;
+    const logicalHeight = physicalHeight / settings.screenPixelRatio;
     await track.applyConstraints({
       width: logicalWidth,
       height: logicalHeight,

--- a/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
@@ -1,0 +1,76 @@
+---
+title: "MediaTrackSettings: screenPixelRatio property"
+short-title: screenPixelRatio
+slug: Web/API/MediaTrackSettings/screenPixelRatio
+page-type: web-api-instance-property
+browser-compat: api.MediaTrackSettings.screenPixelRatio
+---
+
+{{APIRef("Media Capture and Streams")}}
+
+The {{domxref("MediaTrackSettings")}} dictionary's **`screenPixelRatio`** property is a double-precision floating point value indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
+
+This property allows applications using the [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API) to save resources by sending the video of a screen capture using their logical, or device independent, resolution.
+
+## Value
+
+A double-precision floating-point number indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface.
+
+Specifically, this is calculated by dividing the size of a {{glossary("CSS pixel")}} at a page zoom of `1.0` and using a scale factor of `1.0` on the capturing screen by the vertical size of a pixel from the [display surface](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface).
+
+## Description
+
+It is common for a screen to have zoom applied via the operating system (OS). The resolution before applying the zoom is called the **logical resolution**, and the resolution after the zoom is applied is called the **physical resolution**.
+
+The logical resolution is normally lower than the physical resolution, therefore a video-conferencing app can save bandwidth and CPU by:
+
+1. Removing the zoom applied to the captured display surface by the OS.
+2. Sending the video of the screen capture at the logical resolution.
+3. Reapplying the zoom after receiving it on the remote client to size it back up to its physical resolution.
+
+Since the logical resolution is normally lower than the actual/physical resolution, the application can save bandwidth and CPU when sending the video using this resolution.
+
+## Examples
+
+### Basic `screenPixelRatio` usage
+
+The following snippet shows how an application may use `screenPixelRatio` to constrain a {{domxref("MediaStreamTrack")}}'s' [`width`](/en-US/docs/Web/API/MediaTrackConstraints/width) and [`height`](/en-US/docs/Web/API/MediaTrackConstraints/height) to the logical resolution when scaling exceeds an acceptable threshold (specified by an application-defined constant).
+
+```js
+const RESOLUTION_LIMIT = 1.5;
+
+async function startCapture() {
+  const stream = await navigator.mediaDevices.getDisplayMedia({
+    video: true,
+  });
+  const track = stream.getVideoTracks()[0];
+  const settings = track.getSettings();
+  const capabilities = track.getCapabilities();
+
+  if (track.screenPixelRatio > RESOLUTION_LIMIT) {
+    let physicalWidth = capabilities.width.max;
+    let physicalHeight = capabilities.height.max;
+    let logicalWidth = physicalWidth / settings.screenPixelRatio;
+    let logicalHeight = physicalHeight / settings.screenPixelRatio;
+    await track.applyConstraints({
+      width: logicalWidth,
+      height: logicalHeight,
+    });
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API)
+- [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API)
+- [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Constraints)
+- {{domxref("MediaTrackSettings")}}

--- a/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
@@ -8,27 +8,27 @@ browser-compat: api.MediaTrackSettings.screenPixelRatio
 
 {{APIRef("Media Capture and Streams")}}
 
-The {{domxref("MediaTrackSettings")}} dictionary's **`screenPixelRatio`** property is a double-precision floating point value indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
+The {{domxref("MediaTrackSettings")}} dictionary's **`screenPixelRatio`** property is a number representing the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
 
-This property allows applications using the [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API) to save resources by sending the video of a screen capture using their logical, or device independent, resolution.
+This property allows applications using the [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API) to save resources by sending the video of a screen capture at its logical, or device independent, resolution.
 
 ## Value
 
-A double-precision floating-point number indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface.
+A number representing the screeen pixel ratio.
 
-Specifically, this is calculated by dividing the size of a {{glossary("CSS pixel")}} at a page zoom of `1.0` and using a scale factor of `1.0` on the capturing screen by the vertical size of a pixel from the [display surface](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface).
+This is calculated by dividing the size of a {{glossary("CSS pixel")}} at a page zoom of `1.0` and using a scale factor of `1.0` on the capturing screen by the vertical size of a pixel from the [display surface](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface).
 
 ## Description
 
-It is common for a screen to have zoom applied via the operating system (OS). The resolution before applying the zoom is called the **logical resolution**, and the resolution after the zoom is applied is called the **physical resolution**.
+It is common for a screen to have zoom applied via the operating system (OS), for example by the user zooming in. The resolution before applying the zoom is called the **logical resolution**, and the resolution after the zoom is applied is called the **physical resolution**.
 
-The logical resolution is normally lower than the physical resolution, therefore a video-conferencing app can save bandwidth and CPU by:
+A video-conferencing app can save bandwidth and CPU when the captured screen is zoomed in on the sender side by:
 
 1. Removing the zoom applied to the captured display surface by the OS.
 2. Sending the video of the screen capture at the logical resolution.
 3. Reapplying the zoom after receiving it on the remote client to size it back up to its physical resolution.
 
-Since the logical resolution is normally lower than the actual/physical resolution, the application can save bandwidth and CPU when sending the video using this resolution.
+The `screenPixelRatio` property describes the ratio of the physical size of a pixel to its logical size, and therefore enables the application to work out how much of a zoom has been applied, and then constrain the video to the logical size.
 
 ## Examples
 

--- a/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/screenpixelratio/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackSettings: screenPixelRatio property"
 short-title: screenPixelRatio
 slug: Web/API/MediaTrackSettings/screenPixelRatio
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.screenPixelRatio
+spec-urls: https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksettings-screenpixelratio
 ---
 
 {{APIRef("Media Capture and Streams")}}
@@ -70,10 +70,6 @@ async function startCapture() {
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/screen_capture_api/index.md
+++ b/files/en-us/web/api/screen_capture_api/index.md
@@ -78,7 +78,7 @@ The Screen Capture API adds properties to the following dictionaries defined by 
 - {{domxref("MediaTrackSettings.suppressLocalAudioPlayback")}}
   - : A boolean value, which is `true` if the audio being captured is not played out of the user's local speakers.
 - {{domxref("MediaTrackSettings.screenPixelRatio")}}
-  - : A double-precision floating point value indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
+  - : A number representing the ratio of the physical size of a pixel on the captured display surface (displayed at its physical resolution) to the logical size of a CSS pixel on the capturing screen (displayed at its logical resolution). It cannot be used as a constraint or capability.
 
 ### MediaTrackSupportedConstraints
 

--- a/files/en-us/web/api/screen_capture_api/index.md
+++ b/files/en-us/web/api/screen_capture_api/index.md
@@ -77,6 +77,8 @@ The Screen Capture API adds properties to the following dictionaries defined by 
   - : A boolean value, which is `true` if the video being captured doesn't directly correspond to a single onscreen display area.
 - {{domxref("MediaTrackSettings.suppressLocalAudioPlayback")}}
   - : A boolean value, which is `true` if the audio being captured is not played out of the user's local speakers.
+- {{domxref("MediaTrackSettings.screenPixelRatio")}}
+  - : A double-precision floating point value indicating the ratio of the size of a CSS pixel on the capturing screen by the vertical size of a pixel on the captured display surface. It cannot be used as a constraint or capability.
 
 ### MediaTrackSupportedConstraints
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Chrome 136+ supports the `MediaTrackSettings.screenPixelRatio` property, on desktop only. See https://chromestatus.com/feature/6738236535472128 for details.

This PR adds a ref page for the new property.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
