### PR TITLE
Elaborated on use of Service Workers on http://localhost

### DIFF
--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -17,7 +17,10 @@ Service workers run in a worker context: they therefore have no DOM access and r
 
 Service workers can't import JavaScript modules dynamically, and [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility) will throw an error if it is called in a service worker global scope. Static imports using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) statement are allowed.
 
-Service workers only run over HTTPS, for security reasons. Most significantly, HTTP connections are susceptible to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
+Service workers only run over HTTPS for security reasons (with the exception of `http://localhost`, see the note below). Most significantly, HTTP connections are susceptible to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
+
+> [!NOTE]
+> To facilitate local development, most modern browsers treat `http://localhost` as a secure context, thus allowing for the use of service workers without an SSL certificate.
 
 > [!NOTE]
 > On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the **Enable Service Workers over HTTP (when toolbox is open)** option in the Firefox DevTools options/gear menu.

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -17,10 +17,7 @@ Service workers run in a worker context: they therefore have no DOM access and r
 
 Service workers can't import JavaScript modules dynamically, and [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility) will throw an error if it is called in a service worker global scope. Static imports using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) statement are allowed.
 
-Service workers only run over HTTPS for security reasons (with the exception of `http://localhost`, see the note below). Most significantly, HTTP connections are susceptible to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
-
-> [!NOTE]
-> To facilitate local development, most modern browsers treat `http://localhost` as a secure context, thus allowing for the use of service workers without an SSL certificate.
+Service workers are only available in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts): this means that their document is served over HTTPS, although browsers also treat `http://localhost` as a secure context, to facilitate local development. HTTP connections are susceptible to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs.
 
 > [!NOTE]
 > On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the **Enable Service Workers over HTTP (when toolbox is open)** option in the Firefox DevTools options/gear menu.


### PR DESCRIPTION
### Description

Mentioned that there is an exception allowing use of service workers on http://localhost and added a note explaining that in more detail.

### Motivation

The document is mentioning that Service Workers only run in secure contexts, but did not mention how to develop service workers on localhost, which by default does not come with an SSL Certificate.

### Additional details

none

### Related issues and pull requests

none
