### PR TITLE
Align HTML with speech-color-changer (39977)

### DIFF
--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -31,6 +31,7 @@ The HTML and CSS for the app is really trivial. We have a title, instructions pa
 ```html
 <h1>Speech color changer</h1>
 <p>Tap/click then say a color to change the background color of the app.</p>
+<div class="hints"></div>
 <div>
   <p class="output"><em>…diagnostic messages</em></p>
 </div>

--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -30,8 +30,7 @@ The HTML and CSS for the app is really trivial. We have a title, instructions pa
 
 ```html
 <h1>Speech color changer</h1>
-<p>Tap/click then say a color to change the background color of the app.</p>
-<div class="hints"></div>
+<p class="hints"></p>
 <div>
   <p class="output"><em>…diagnostic messages</em></p>
 </div>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

This PR updates the Web Speech API example to ensure consistency with the live demo. Specifically, it assigns the correct class (`hints`) to the appropriate element used for diagnostic messaging.

### Motivation

The issue #39977 indicated confusion about the `hints` class. The fix aligns the MDN documentation with the corresponding code sample in [mdn/dom-examples](https://github.com/mdn/dom-examples/blob/main/web-speech-api/speech-color-changer/index.html), ensuring clarity for developers and preventing runtime issues.

### Additional details

- Verified usage of `document.querySelector('.hints')` in the demo JavaScript.

### Related issues and pull requests
Fixes #39977

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->