### PR TITLE
feat: link crawl-related resources, robots.txt, HTTP headers, HTML meta

### DIFF
--- a/files/en-us/glossary/robots.txt/index.md
+++ b/files/en-us/glossary/robots.txt/index.md
@@ -6,20 +6,20 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **robots.txt** is a file which is usually placed in the root of a website (for example, `https://www.example.com/robots.txt`).
+A **robots.txt** is a file that is usually placed in the root of a website (for example, `https://www.example.com/robots.txt`).
 It specifies whether {{Glossary("crawler", "crawlers")}} are allowed or disallowed from accessing an entire website or to certain resources on a website.
 A restrictive `robots.txt` file can prevent bandwidth consumption by crawlers.
 
 A site owner can forbid crawlers to detect a certain path (and all files in that path) or a specific file.
 This is often done to prevent these resources from being indexed or served by search engines.
 
-If a crawler is allowed to access resources, you can define [indexing rules](/en-US/docs/Web/HTTP/Reference/Headers/X-Robots-Tag#directives) for those resources via `<meta name="robots">` elements and {{HTTPHeader("X-Robots-Tag")}} HTTP headers.
+If a crawler is allowed to access resources, you can define [indexing rules](/en-US/docs/Web/HTTP/Reference/Headers/X-Robots-Tag#directives) for those resources via [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) elements (commonly referred to as a "robots tag") and {{HTTPHeader("X-Robots-Tag")}} HTTP headers.
 Search-related crawlers use these rules to determine how to index and serve resources in search results, or to adjust the crawl rate for specific resources over time.
 
 ## See also
 
-- {{HTTPHeader("X-Robots-Tag")}}
-- {{Glossary("Search engine")}}
+- [robots.txt configuration](/en-US/docs/Web/Security/Practical_implementation_guides/Robots_txt) security guide
+- {{Glossary("Search engine")}} glossary term
 - {{RFC("9309", "Robots Exclusion Protocol")}}
 - [How Google interprets the robots.txt specification](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt) on developers.google.com
 - https://www.robotstxt.org

--- a/files/en-us/glossary/robots.txt/index.md
+++ b/files/en-us/glossary/robots.txt/index.md
@@ -7,7 +7,7 @@ page-type: glossary-definition
 {{GlossarySidebar}}
 
 A **robots.txt** is a file that is usually placed in the root of a website (for example, `https://www.example.com/robots.txt`).
-It specifies whether {{Glossary("crawler", "crawlers")}} are allowed or disallowed from accessing an entire website or to certain resources on a website.
+It specifies whether or not {{Glossary("crawler", "crawlers")}} are allowed access to an entire website, or to specified resources.
 A restrictive `robots.txt` file can prevent bandwidth consumption by crawlers.
 
 A site owner can forbid crawlers to detect a certain path (and all files in that path) or a specific file.

--- a/files/en-us/web/accessibility/guides/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/guides/seizure_disorders/index.md
@@ -178,11 +178,9 @@ Controlling exposure to the page is key to ensuring that someone susceptible to 
 
 If you believe you may have an image or animation that may cause seizures, control access to it by first displaying a warning about the content, and then putting it in a location where the user must opt in to it, such as clicking a button, or ensuring that the link to the page has a distinct and obvious warning.
 
-Consider using metadata such as `<meta name="robots" content="noindex, nofollow">` so that the page is not indexed by search engines.
-
-#### Do Not Index, Do Not Follow
-
-By not indexing the page, the likelihood that users will stumble upon it via search will be reduced.
+Consider setting crawl directives for search engines to hint that they shouldn't include potentially harmful resources in their search indexes.
+You can do this using metadata in a [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) element with restrictive rules like `noindex, nofollow`.
+By not indexing the page (`noindex`) and not following links on the page (`nofollow`), the likelihood that users will stumble upon it via search will be reduced:
 
 ```html
 <html lang="en">
@@ -191,6 +189,12 @@ By not indexing the page, the likelihood that users will stumble upon it via sea
     <meta name="robots" content="noindex, nofollow" />
   </head>
 </html>
+```
+
+For non-HTML resources, you can set crawl directives in a {{httpheader("X-Robots-Tag")}} HTTP response header:
+
+```http
+X-Robots-Tag: noindex
 ```
 
 ### Animated GIFs

--- a/files/en-us/web/html/reference/elements/meta/name/robots/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/robots/index.md
@@ -7,8 +7,8 @@ page-type: html-attribute-value
 
 {{HTMLSidebar}}
 
-The **`robots`** value for the [`name`](/en-US/docs/Web/HTML/Reference/Elements/meta/name) attribute of the {{htmlelement("meta")}} element defines the crawl behavior that cooperative crawlers (or "robots") should use with the page.
-If specified, you define crawl directives using a [`content`](/en-US/docs/Web/HTML/Reference/Elements/meta#content) attribute in the `<meta>` element as a comma-separated list of one or more rules.
+The **`robots`** value for the [`name`](/en-US/docs/Web/HTML/Reference/Elements/meta/name) attribute of the {{htmlelement("meta")}} element (often called a "robots tag") defines the crawl and indexing behavior that web {{glossary("Crawler", "crawlers")}} should use with the page.
+If specified, you define instructions for crawlers in the [`content`](/en-US/docs/Web/HTML/Reference/Elements/meta#content) attribute of the `<meta>` element as a comma-separated list of one or more rules.
 
 For example, to hint to crawlers that a page should be excluded from their search indexes, a `noindex` value can be used:
 

--- a/files/en-us/web/http/reference/headers/index.md
+++ b/files/en-us/web/http/reference/headers/index.md
@@ -503,7 +503,7 @@ See the [Topics API](/en-US/docs/Web/API/Topics_API) documentation for more info
 - {{HTTPHeader("X-DNS-Prefetch-Control")}} {{non-standard_inline}}
   - : Controls DNS prefetching, a feature by which browsers proactively perform domain name resolution on both links that the user may choose to follow as well as URLs for items referenced by the document, including images, CSS, JavaScript, and so forth.
 - {{HTTPHeader("X-Robots-Tag")}} {{non-standard_inline}}
-  - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is effectively equivalent to `<meta name="robots" content="…">`.
+  - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is effectively equivalent to [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) elements.
 
 ## Deprecated headers
 

--- a/files/en-us/web/http/reference/headers/index.md
+++ b/files/en-us/web/http/reference/headers/index.md
@@ -503,7 +503,7 @@ See the [Topics API](/en-US/docs/Web/API/Topics_API) documentation for more info
 - {{HTTPHeader("X-DNS-Prefetch-Control")}} {{non-standard_inline}}
   - : Controls DNS prefetching, a feature by which browsers proactively perform domain name resolution on both links that the user may choose to follow as well as URLs for items referenced by the document, including images, CSS, JavaScript, and so forth.
 - {{HTTPHeader("X-Robots-Tag")}} {{non-standard_inline}}
-  - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is effectively equivalent to [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) elements.
+  - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is equivalent to [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) elements.
 
 ## Deprecated headers
 

--- a/files/en-us/web/http/reference/headers/x-robots-tag/index.md
+++ b/files/en-us/web/http/reference/headers/x-robots-tag/index.md
@@ -13,12 +13,12 @@ The **`X-Robots-Tag`** {{Glossary("response header")}} defines how {{glossary("C
 While not part of any specification, it is a de-facto standard method for communicating with search bots, web crawlers, and similar user agents.
 Search-related crawlers use the rules from the `X-Robots-Tag` header to adjust how to present web pages or other resources in search results.
 
-Indexing rules defined via `<meta name="robots">` elements and `X-Robots-Tag` headers are discovered when a URL is crawled.
+Indexing rules are defined in a `X-Robots-Tag` header or a [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) HTML element (often called a "robots tag") and are discovered when a URL is crawled.
 Specifying indexing rules in a HTTP header is useful for non-HTML documents like images, PDFs, or other media.
 
 > [!NOTE]
-> Only cooperative robots follow these rules, and a crawler still needs to access the resource to read headers and meta elements (see [Interaction with robots.txt](#interaction_with_robots.txt)).
-> If you want to prevent bandwidth consumption by crawlers, a restrictive {{Glossary("robots.txt")}} file is more effective than indexing rules as it blocks resources from being crawled entirely.
+> Only cooperative robots follow these rules, and a crawler first needs to access the resource to read headers and meta elements (see [Interaction with robots.txt](#interaction_with_robots.txt)).
+> If you want to prevent bandwidth consumption by crawlers, a restrictive {{Glossary("robots.txt")}} file is more effective than indexing rules as it blocks resources from being crawled.
 
 <table class="properties">
   <tbody>
@@ -191,7 +191,9 @@ Not part of any current specification.
 
 ## See also
 
-- {{Glossary("Robots.txt")}}
+- {{Glossary("robots.txt")}}
 - {{Glossary("Search engine")}}
+- [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) HTML element ("robots tag")
+- [robots.txt configuration](/en-US/docs/Web/Security/Practical_implementation_guides/Robots_txt) security guide
 - {{RFC("9309", "Robots Exclusion Protocol")}}
 - [Using the X-Robots-Tag HTTP header](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag) on developers.google.com

--- a/files/en-us/web/security/practical_implementation_guides/robots_txt/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/robots_txt/index.md
@@ -37,4 +37,7 @@ Disallow: /secret/admin-interface
 
 ## See also
 
+- {{HTTPHeader("X-Robots-Tag")}} HTTP header
+- [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) HTML element ("robots tag")
+- {{RFC("9309", "Robots Exclusion Protocol")}}
 - [About /robots.txt](https://www.robotstxt.org/robotstxt.html) on `robotstxt.org`


### PR DESCRIPTION
### Description

Linking together multiple isolated resources about crawling.

### Motivation

We have a new page for https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots, this fills in part of the picture for website owners to be able to set directives for web crawlers. I hope this PR ties the docs together a bit more so we have less isolated docs per feature, and we have more of a concept of crawling, although a guide that mentions all of these together with pros / cons / use cases would be a good next step.
