### PR TITLE
Fix bug in the second code example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
@@ -77,10 +77,10 @@ Here is one example of an atomic adder (same functionality as {{jsxref("Atomics.
 function add(mem, index, value) {
   let done = false;
   while (!done) {
-    const value = Atomics.load(mem, index);
-    done = Atomics.compareExchange(p, value, value + a) === value;
+    const currentValue = Atomics.load(mem, index);
+    done = Atomics.compareExchange(mem, index, currentValue, currentValue + value) === currentValue;
   }
-  return value + a;
+  return value + currentValue;
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.md
@@ -74,13 +74,13 @@ Atomics.load(ta, 0); // 12
 Here is one example of an atomic adder (same functionality as {{jsxref("Atomics.add()")}}), adapted from the linked Wikipedia article:
 
 ```js
-function add(mem, index, value) {
+function add(mem, index, a) {
   let done = false;
   while (!done) {
-    const currentValue = Atomics.load(mem, index);
-    done = Atomics.compareExchange(mem, index, currentValue, currentValue + value) === currentValue;
+    const value = Atomics.load(mem, index);
+    done = Atomics.compareExchange(mem, index, value, value + a) === value;
   }
-  return value + currentValue;
+  return value + a;
 }
 ```
 


### PR DESCRIPTION
In the second code example, the call to Atomics.compareExchange method used undeclared variables and wrong numbers of arguments.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
