### PR TITLE
fix(typos): multiple repeated words

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
@@ -147,7 +147,7 @@ This is rendered as follows:
 
 {{EmbedLiveSample("form-anatomy", "100%", "200", , , , , "allow-forms")}}
 
-If you click click "Sign me up!" immediately, you'll see a validation error because no data was entered. If you fill out the fields with a name and email address then click "Sign me up!", you'll see a `404` error message.
+If you click "Sign me up!" immediately, you'll see a validation error because no data was entered. If you fill out the fields with a name and email address then click "Sign me up!", you'll see a `404` error message.
 
 We'll explain why later on. Before moving on, copy the previous HTML code listing into a new HTML file using your [code editor](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Code_editors) and open it in a new browser tab.
 

--- a/files/en-us/learn_web_development/getting_started/soft_skills/research_and_learning/index.md
+++ b/files/en-us/learn_web_development/getting_started/soft_skills/research_and_learning/index.md
@@ -106,7 +106,7 @@ An effective research network consists of several groups of people with differen
   - Ask them how they would prefer to communicate with you about the problem, to make the interaction as comfortable for them as possible.
   - If arranging a meeting, don't book more of their time than you need. If you are not sure how long you will need, timebox the session to say 30 minutes. You can always ask them for more help in the future.
 
-- Wider community network: This could consist of a dedicated online community such as forums or chat groups (for example the [The MDN Web Docs discord](/discord) or the [freeCodeCamp forums](https://forum.freecodecamp.org/)), or a physical meetup such as a conference or skill-share event.
+- Wider community network: This could consist of a dedicated online community such as forums or chat groups (for example the [MDN Web Docs discord](/discord) or the [freeCodeCamp forums](https://forum.freecodecamp.org/)), or a physical meetup such as a conference or skill-share event.
 - Global network: Sometimes you might be out of options, in which case you could try asking your question on a general global community like a social media network. Sometimes helpful answers can come from unexpected places.
 
 > [!NOTE]

--- a/files/en-us/mdn/community/discussions/index.md
+++ b/files/en-us/mdn/community/discussions/index.md
@@ -10,7 +10,7 @@ We ask that you keep each discussion focused on the topic at hand instead of cov
 
 > [!NOTE]
 > Don't use GitHub Discussions to report bugs.
-> If you see something wrong on MDN Web Docs, open a GitHub issue in the [the relevant GitHub repository](/en-US/docs/MDN/Community/Our_repositories).
+> If you see something wrong on MDN Web Docs, open a GitHub issue in a relevant [MDN GitHub repository](/en-US/docs/MDN/Community/Our_repositories).
 
 If you're not sure whether to open a GitHub issue or discussion, here's what each are for:
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -149,7 +149,7 @@ The `background` key can also contain this optional property:
             <code>document</code> requests that the browser use the extension's background scripts as documents, if supported.
           </li>
           <li>
-            <code>service_worker</code> requests that the the browser run the extension's background scripts as service workers, if supported.
+            <code>service_worker</code> requests that the browser run the extension's background scripts as service workers, if supported.
           </li>
         </ul>
         <p>Chrome only supports service workers, so it ignores this key. If omitted, Firefox and Safari run background scripts as documents. Safari uses a service worker context if the extension specifies <code>scripts</code> and <code>preferred_environment</code> is set to <code>service_worker</code>.</p>

--- a/files/en-us/mozilla/firefox/releases/130/index.md
+++ b/files/en-us/mozilla/firefox/releases/130/index.md
@@ -27,7 +27,7 @@ This article provides information about the changes in Firefox 130 that affect d
 
 #### Removals
 
-- {{domxref('WebGLRenderingContext.drawingBufferColorSpace')}} and [`WebGL2RenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGL2RenderingContext) were prematurely released (without an an implementation) in [Firefox 127](/en-US/docs/Mozilla/Firefox/Releases/127), and have been removed ([Firefox bug 1909559](https://bugzil.la/1909559)).
+- {{domxref('WebGLRenderingContext.drawingBufferColorSpace')}} and [`WebGL2RenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGL2RenderingContext) were prematurely released (without an implementation) in [Firefox 127](/en-US/docs/Mozilla/Firefox/Releases/127), and have been removed ([Firefox bug 1909559](https://bugzil.la/1909559)).
 
 ### WebAssembly
 

--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -62,14 +62,14 @@ Firefox 18 was released on January 8, 2013. This article lists key changes that 
 ### Interface changes
 
 - `nsIStreamListener`
-  - : The 4th parameter (aOffset) of `onDataAvailable()` method changes to unsigned long long. ([Firefox bug 784912](https://bugzil.la/784912))
+  - : The 4th parameter (`aOffset`) of `onDataAvailable()` method changes to `unsigned long long`. ([Firefox bug 784912](https://bugzil.la/784912))
 - `nsIUploadChannel`
   - : `setUploadStream()` supports over 2GB content-length ([Firefox bug 790617](https://bugzil.la/790617))
 - `nsIEditor`
   - : `addEditorObserver()` has been removed, use `setEditorObserver()` instead, `removeEditorObserver()` no longer takes a `nsIEditorObserver` parameter ([Firefox bug 785091](https://bugzil.la/785091))
 - `nsIHttpProtocolHandler`
   - : `http-on-modify-request` observers are no longer guaranteed to be called synchronously during `nsIChannel.asyncOpen()`.
-    For observers that need to be called during `asyncOpen()`, the new `http-on-opening-request` observer topic has been added. `See` ([Firefox bug 800799](https://bugzil.la/800799))
+    For observers that need to be called during `asyncOpen()`, the new `http-on-opening-request` observer topic has been added. See ([Firefox bug 800799](https://bugzil.la/800799))
 - `nsIProtocolProxyService`
   - : The `resolve` method has been removed. Now, only the `asyncResolve` method can be used. See ([Firefox bug 769764](https://bugzil.la/769764))
 

--- a/files/en-us/web/api/sanitizer/allowelement/index.md
+++ b/files/en-us/web/api/sanitizer/allowelement/index.md
@@ -156,7 +156,7 @@ function log(text) {
 The code first creates a new `Sanitizer` object that initially allows {{htmlelement("div")}} elements (removing attributes other than `id`) and also replaced {{htmlelement("span")}} elements with any child elements.
 
 It then calls `allowElement()`, firstly to add a {{htmlelement("div")}} element that removes `style` attributes.
-Since the `<div>` element is already allowed, it is removed from the [`elements` configuration](/en-US/docs/Web/API/SanitizerConfig#elements) and the `<div>` element definition is is appended.
+Since the `<div>` element is already allowed, it is removed from the [`elements` configuration](/en-US/docs/Web/API/SanitizerConfig#elements) and the `<div>` element definition is appended.
 
 A {{htmlelement("span")}} element is then added to the allow list, which removes it from the [`replaceWithChildrenElements` configuration list](/en-US/docs/Web/API/SanitizerConfig#replacewithchildrenelements).
 

--- a/files/en-us/web/api/sanitizer/removeunsafe/index.md
+++ b/files/en-us/web/api/sanitizer/removeunsafe/index.md
@@ -76,7 +76,7 @@ function log(text) {
 
 #### JavaScript
 
-The code first creates a new `Sanitizer` object that that allows the safe element {{htmlelement("p")}}, the unsafe elements {{htmlelement("script")}} and {{htmlelement("iframe")}}, and the unsafe `onwebkitanimationend` event handler attribute.
+The code first creates a new `Sanitizer` object that allows the safe element {{htmlelement("p")}}, the unsafe elements {{htmlelement("script")}} and {{htmlelement("iframe")}}, and the unsafe `onwebkitanimationend` event handler attribute.
 
 The code then calls `removeUnsafe()` on the sanitizer and logs its configuration.
 

--- a/files/en-us/web/api/sanitizer/replaceelementwithchildren/index.md
+++ b/files/en-us/web/api/sanitizer/replaceelementwithchildren/index.md
@@ -26,7 +26,7 @@ replaceElementWithChildren(element)
 
 - `element`
 
-  - : A string indicating the name of the element to be be replaced, or an object with the following properties:
+  - : A string indicating the name of the element to be replaced, or an object with the following properties:
 
     - `name`
       - : A string containing the name of the element.

--- a/files/en-us/web/api/sanitizerconfig/index.md
+++ b/files/en-us/web/api/sanitizerconfig/index.md
@@ -21,7 +21,7 @@ It can also be passed as the `option.sanitizer` parameter when calling the [sani
 - {{domxref("ShadowRoot/setHTMLUnsafe","setHTMLUnsafe()")}} or {{domxref("ShadowRoot/setHTMLUnsafe","setHTMLUnsafe()")}} on {{domxref("ShadowRoot")}}.
 - [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) or [`Document.parseHTML()`](/en-US/docs/Web/API/Document/parseHTML_static) static methods.
 
-Note that normally a {{domxref("Sanitizer")}} instance would be be passed as the option instead of `SanitizerConfig` in the above methods, in particular because `sanitizer` instances are more efficient to share and modify.
+Note that normally a {{domxref("Sanitizer")}} instance would be passed as the option instead of `SanitizerConfig` in the above methods, in particular because `sanitizer` instances are more efficient to share and modify.
 
 ## Instance properties
 

--- a/files/en-us/web/css/_doublecolon_scroll-marker-group/index.md
+++ b/files/en-us/web/css/_doublecolon_scroll-marker-group/index.md
@@ -106,7 +106,7 @@ ul {
 }
 ```
 
-Next, the list's `::scroll-marker-group` pseudo-element is laid out using flexbox, with a {{cssxref("justify-content")}} value of of `center` and a {{cssxref("gap")}} of `20px` so that its children (the {{cssxref("::scroll-marker")}} pseudo-elements) are centered inside the `::scroll-marker-group` with a gap between each one.
+Next, the list's `::scroll-marker-group` pseudo-element is laid out using flexbox, with a {{cssxref("justify-content")}} value of `center` and a {{cssxref("gap")}} of `20px` so that its children (the {{cssxref("::scroll-marker")}} pseudo-elements) are centered inside the `::scroll-marker-group` with a gap between each one.
 
 ```css live-sample___carousel-example live-sample___carousel-example_final
 ul::scroll-marker-group {

--- a/files/en-us/web/css/css_overflow/css_carousels/index.md
+++ b/files/en-us/web/css/css_overflow/css_carousels/index.md
@@ -257,7 +257,7 @@ ul {
 }
 ```
 
-Next, the list's `::scroll-marker-group` pseudo-element is positioned relative to the carousel using CSS anchor positioning, similar to the scroll button's, except that it is horizontally centered on the carousel using a {{cssxref("justify-self")}} value of `anchor-center`. The group is laid out using flexbox, with a {{cssxref("justify-content")}} value of of `center` and a {{cssxref("gap")}} of `20px` so that its children (the `::scroll-marker` pseudo-elements) are centered inside the `::scroll-marker-group` with a gap between each one.
+Next, the list's `::scroll-marker-group` pseudo-element is positioned relative to the carousel using CSS anchor positioning, similar to the scroll button's, except that it is horizontally centered on the carousel using a {{cssxref("justify-self")}} value of `anchor-center`. The group is laid out using flexbox, with a {{cssxref("justify-content")}} value of `center` and a {{cssxref("gap")}} of `20px` so that its children (the `::scroll-marker` pseudo-elements) are centered inside the `::scroll-marker-group` with a gap between each one.
 
 ```css live-sample___first-example
 ul::scroll-marker-group {

--- a/files/en-us/web/css/mask-repeat/index.md
+++ b/files/en-us/web/css/mask-repeat/index.md
@@ -58,7 +58,7 @@ The `<repeat-style>` values include:
 
 - `space`
 
-  - : The mask image is repeated as many times as possible without clipping. If the element's origin size is at least twice the size as the mask image's size in the associated dimension, the {{cssxref("mask-position")}} property is ignored and the first and last images are positioned at the edges of the mask origin container. If the the mask origin box is not an exact multiple of the mask image's size, whitespace is distributed evenly between the repeated mask images.
+  - : The mask image is repeated as many times as possible without clipping. If the element's origin size is at least twice the size as the mask image's size in the associated dimension, the {{cssxref("mask-position")}} property is ignored and the first and last images are positioned at the edges of the mask origin container. If the mask origin box is not an exact multiple of the mask image's size, whitespace is distributed evenly between the repeated mask images.
 
     If the origin box size is less than twice the mask image's size in the given dimension, only one mask image can be displayed. In this case, the image is positioned as defined by the `mask-position` property, which defaults to `0% 0%`. The mask image will only be clipped if the mask image is larger than the mask origin box.
 

--- a/files/en-us/web/svg/reference/attribute/mask-type/index.md
+++ b/files/en-us/web/svg/reference/attribute/mask-type/index.md
@@ -60,7 +60,7 @@ svg {
 
 ## mask
 
-For {{SVGElement("mask")}}, `mask-type` defines whether the content of the mask element is treated as luminance mask or alpha mask.
+For {{SVGElement("mask")}}, the `mask-type` defines whether the content of the mask element is treated as a luminance mask or an alpha mask.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/reference/attribute/mask-type/index.md
+++ b/files/en-us/web/svg/reference/attribute/mask-type/index.md
@@ -60,7 +60,7 @@ svg {
 
 ## mask
 
-For {{SVGElement("mask")}}, `mask-type` defines whether the content of the mask element is treated as as luminance mask or alpha mask.
+For {{SVGElement("mask")}}, `mask-type` defines whether the content of the mask element is treated as luminance mask or alpha mask.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
### Description

Fixing cases of:

* `be be` -> `be`
* `the [the` -> `the [`
* etc.

Found using Vale.Repetition rule.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/38839