### PR TITLE
docs(glossary): Add short history about the hash routing

### DIFF
--- a/files/en-us/glossary/hash_function/index.md
+++ b/files/en-us/glossary/hash_function/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A hash function is a function that takes a variable-length input and produces a fixed-length output, also called a _digest_ (or just a "hash"). Hash functions should be quick to compute, and different inputs should as far as possible produce different outputs (this is called _collision-resistance_).
+A **hash function** is a function that takes a variable-length input and produces a fixed-length output, also called a _digest_ (or just a "hash"). Hash functions should be quick to compute, and different inputs should as far as possible produce different outputs (this is called _collision-resistance_).
 
 Hash functions have both {{glossary("cryptography", "cryptographic")}} and non-cryptographic uses. Outside cryptography, for example, hash functions can be used to generate the keys for an associative array such as a map or a dictionary.
 

--- a/files/en-us/glossary/hash_routing/index.md
+++ b/files/en-us/glossary/hash_routing/index.md
@@ -10,7 +10,7 @@ page-type: glossary-definition
 
 ## Historical context
 
-Early SPAs could not change the [path](/en-US/docs/Web/URI/Reference/Path) part of the URL without reloading the page. To work around this, developers used **hash-based SPA routing**, which stores the route in the "[fragment](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment)", the part of the URL that follows the symbol `#`. Common patterns included `#/profile` and `#!/profile`. Applications continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
+Early SPAs could not change the [path](/en-US/docs/Web/URI/Reference/Path) part of the URL without reloading the page. To work around this, developers used **hash-based SPA routing**, which stores the route in the "[fragment](/en-US/docs/Web/URI/Reference/Fragment)", the part of the URL that follows the symbol `#`. Common patterns included `#/profile` and `#!/profile`. Applications continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
 
 ## Limitations
 

--- a/files/en-us/glossary/hash_routing/index.md
+++ b/files/en-us/glossary/hash_routing/index.md
@@ -10,11 +10,11 @@ page-type: glossary-definition
 
 ## Historical context
 
-Early SPAs could not change the path part of the URL without reloading the page. To work around this, developers used **hash-based SPA routing**, which stores the route in the "fragment identifier", the part of the URL that follows the symbol `#`. Common patterns included `#/profile` and `#!/profile`. Applications continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
+Early SPAs could not change the [path](/en-US/docs/Web/URI/Reference/Path) part of the URL without reloading the page. To work around this, developers used **hash-based SPA routing**, which stores the route in the "[fragment](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment)", the part of the URL that follows the symbol `#`. Common patterns included `#/profile` and `#!/profile`. Applications continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
 
 ## Limitations
 
-Though this approach needed no server setup, it had limitations: Back/Forward support was limited, pages with hash-based URLs were not indexed properly (search engines ignored the fragment), and the resulting URLs were considered messy.
+Though this approach needed no server setup, it had limitations: {{glossary("bfcache", "back/forward")}} support was limited, pages with hash-based URLs were not indexed properly (search engines ignored the fragment), and the resulting URLs were considered messy.
 
 Hash-based routing is now considered a legacy technique. It is used, if at all, only as a fallback for very old browsers or for static hosts where server-side routing cannot be configured.
 

--- a/files/en-us/glossary/hash_routing/index.md
+++ b/files/en-us/glossary/hash_routing/index.md
@@ -1,0 +1,23 @@
+---
+title: Hash routing
+slug: Glossary/Hash_routing
+page-type: glossary-definition
+---
+
+{{GlossarySidebar}}
+
+**Hash routing** is a client-side technique used in single-page applications (SPAs) to manage navigation and state changes without reloading the entire page.
+
+## Historical context
+
+Early SPAs could not change the path part of the URL without reloading the page. To work around this, developers used **hash-based SPA routing**, which stores the route in the "fragment identifier", the part of the URL that follows the symbol `#`. Common patterns included `#/profile` and `#!/profile`. Applications continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
+
+## Limitations
+
+Though this approach needed no server setup, it had limitations: Back/Forward support was limited, pages with hash-based URLs were not indexed properly (search engines ignored the fragment), and the resulting URLs were considered messy.
+
+Hash-based routing is now considered a legacy technique. It is used, if at all, only as a fallback for very old browsers or for static hosts where server-side routing cannot be configured.
+
+## Modern alternatives
+
+By 2012, all major browsers (Chrome 5, Safari 5, Firefox 4) supported the [History API](/en-US/docs/Web/API/History_API). SPAs could now call [`pushState()`](/en-US/docs/Web/API/History/pushState), [`replaceState()`](/en-US/docs/Web/API/History/replaceState), and the [`popstate`](/en-US/docs/Web/API/PopStateEvent) event to manipulate the browser's history stack, switch to paths such as `/profile` directly, and update the view without a full reload. This also allowed for cleaner URLs without hash fragments.

--- a/files/en-us/glossary/router/index.md
+++ b/files/en-us/glossary/router/index.md
@@ -11,7 +11,7 @@ On the web, the term **router** can refer to different concepts depending on the
 - For the network layer, a router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
 - For a {{Glossary("SPA", "single-page application (SPA)")}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
 
-  The concept of routing in SPAs has evolved significantly over the years. See the {{Glossary"hash_routing", "hash routing}} glossary entry to learn more.
+  The concept of routing in SPAs has evolved significantly over the years. See the {{Glossary("hash routing")}} glossary entry to learn more.
 
 - In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
 

--- a/files/en-us/glossary/router/index.md
+++ b/files/en-us/glossary/router/index.md
@@ -6,20 +6,29 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-There are three definitions for **routers** on the web:
+On the web, the term **router** can refer to different concepts depending on the context:
 
-1. For the network layer, the router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
-2. For a {{Glossary('SPA', 'Single-page application')}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
-3. In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
+- For the network layer, a router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
+- For a {{Glossary("SPA", "single-page application (SPA)")}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
+
+  The concept of routing in SPAs has evolved significantly over the years. See the [Brief history of hash-based SPA routing](#brief_history_of_hash-based_spa_routing) section.
+
+- In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
+
+## Brief history of hash-based SPA routing
+
+Early SPAs could not change the path part of the URL without reloading the page. To work around this, developers used hash-based routing, which stores the route in the "fragment identifier", the portion of the URL that follows the symbol `#`. The part following `#` was used to determine the view to render. Common patterns included `#/profile` and `#!/profile`. The code continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
+
+Though this approach needed no server setup, it had limitations: Back/Forward support was limited, pages with hash-based URLs were not indexed properly (search engines ignored the fragment), and the URLs looked messy.
+
+By 2012, all major browsers (Chrome 5, Safari 5, Firefox 4) supported the [History API](/en-US/docs/Web/API/History_API). SPAs could now call [`pushState()`](/en-US/docs/Web/API/History/pushState), [`replaceState()`](/en-US/docs/Web/API/History/replaceState), and the [`popstate`](/en-US/docs/Web/API/PopStateEvent) event to manipulate the browser's history stack, switch to paths such as `/profile` directly, and update the view without a full reload. This also allowed for cleaner URLs without hash fragments.
+
+Hash-based routing is now considered a legacy technique. It is used, if at all, only as a fallback for very old browsers or for static hosts where server-side routing cannot be configured.
 
 ## See also
 
-For network layer context:
-
-- [Router (computing)](<https://en.wikipedia.org/wiki/Router_(computing)>) on Wikipedia
-
-For SPA in application layer context, most of the popular SPA frameworks have their routing libraries:
-
-- [Angular router](https://angular.dev/guide/routing/common-router-tasks)
-- [React router](https://reactrouter.com/)
-- [Vue router](https://router.vuejs.org/)
+- For the network layer context, see [Router (computing)](<https://en.wikipedia.org/wiki/Router_(computing)>) on Wikipedia.
+- In the application layer context, most of the popular SPA frameworks include built-in routing libraries, such as:
+  - [Angular router](https://angular.dev/guide/routing/common-router-tasks)
+  - [React router](https://reactrouter.com/)
+  - [Vue router](https://router.vuejs.org/)

--- a/files/en-us/glossary/router/index.md
+++ b/files/en-us/glossary/router/index.md
@@ -11,19 +11,9 @@ On the web, the term **router** can refer to different concepts depending on the
 - For the network layer, a router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
 - For a {{Glossary("SPA", "single-page application (SPA)")}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
 
-  The concept of routing in SPAs has evolved significantly over the years. See the [Brief history of hash-based SPA routing](#brief_history_of_hash-based_spa_routing) section.
+  The concept of routing in SPAs has evolved significantly over the years. See the {{Glossary"hash_routing", "hash routing}} glossary entry to learn more.
 
 - In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
-
-## Brief history of hash-based SPA routing
-
-Early SPAs could not change the path part of the URL without reloading the page. To work around this, developers used hash-based routing, which stores the route in the "fragment identifier", the portion of the URL that follows the symbol `#`. The part following `#` was used to determine the view to render. Common patterns included `#/profile` and `#!/profile`. The code continually checked [`window.location.hash`](/en-US/docs/Web/API/Location/hash) (or listened for the [`hashchange`](/en-US/docs/Web/API/Window/hashchange_event) event when it was supported later) to detect fragment changes during user navigation; the SPA then updated the view whenever the fragment changed.
-
-Though this approach needed no server setup, it had limitations: Back/Forward support was limited, pages with hash-based URLs were not indexed properly (search engines ignored the fragment), and the URLs looked messy.
-
-By 2012, all major browsers (Chrome 5, Safari 5, Firefox 4) supported the [History API](/en-US/docs/Web/API/History_API). SPAs could now call [`pushState()`](/en-US/docs/Web/API/History/pushState), [`replaceState()`](/en-US/docs/Web/API/History/replaceState), and the [`popstate`](/en-US/docs/Web/API/PopStateEvent) event to manipulate the browser's history stack, switch to paths such as `/profile` directly, and update the view without a full reload. This also allowed for cleaner URLs without hash fragments.
-
-Hash-based routing is now considered a legacy technique. It is used, if at all, only as a fallback for very old browsers or for static hosts where server-side routing cannot be configured.
 
 ## See also
 

--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.md
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.md
@@ -19,7 +19,7 @@ The main interface defined in the History API is the {{domxref("History")}} inte
    - {{domxref("History.pushState()")}}
    - {{domxref("History.replaceState()")}}
 
-In this guide we'll be concerned only with the second set of methods, as these have more complex behavior.
+In this guide, we'll cover only the second set of methods.
 
 The `pushState()` method adds a new entry to the session history, while the `replaceState()` method updates the session history entry for the current page. Both these methods take a `state` parameter which can contain any {{Glossary("Serializable_object", "serializable object")}}. When the browser navigates to this history entry, the browser fires a {{domxref("Window.popstate_event", "popstate")}} event, which contains the state object associated with that entry.
 
@@ -32,13 +32,13 @@ Traditionally, websites are implemented as a collection of pages. When users nav
 While this is great for many sites, it can have some disadvantages:
 
 - It can be inefficient to load a whole page every time, when only part of the page needs to be updated.
-- It is hard to maintain application state when navigating across pages
+- It is hard to maintain application state when navigating across pages.
 
-For these reasons, a popular pattern for web apps is the {{Glossary("SPA", "single-page application")}} (SPA), in which the site consists of a single page, and when the user clicks links, the page:
+For these reasons, a popular pattern for web apps is the {{Glossary("SPA", "single-page application")}} (SPA). When a user clicks a link, the SPA performs the following steps:
 
-1. Prevents the default behavior of loading a new page
-2. {{domxref("Window/fetch", "Fetches", "", "nocode")}} new content to display
-3. Updates the page with the new content
+1. Prevents the default behavior of loading a new page.
+2. {{domxref("Window/fetch", "Fetches", "", "nocode")}} new content to display.
+3. Updates the page with the new content.
 
 For example:
 
@@ -125,17 +125,17 @@ document.addEventListener("click", async (event) => {
 
 Here, we're calling `pushState()` with three arguments:
 
-- `json`: this is the content we just fetched. It will be stored with the history entry, and later included as the {{domxref("PopStateEvent.state", "state")}} property of the argument passed to the `popstate` event handler.
-- `""`: this is needed for backward compatibility with legacy sites, and should always be an empty string
-- `creature`: this will be used as the URL for the entry. It will be shown in the browser's URL bar, and will be used as the value of the {{httpheader("Referer")}} header in any HTTP requests that the page makes. Note that this must be {{Glossary("Same-origin policy", "same-origin")}} with the page.
+- `json`: This is the content we just fetched. It will be stored with the history entry, and later included as the {{domxref("PopStateEvent.state", "state")}} property of the argument passed to the `popstate` event handler.
+- `""`: This is needed for backward compatibility with legacy sites, and should always be an empty string.
+- `creature`: This will be used as the URL for the entry. It will be shown in the browser's URL bar, and will be used as the value of the {{httpheader("Referer")}} header in any HTTP requests that the page makes. Note that this must be {{Glossary("Same-origin policy", "same-origin")}} with the page.
 
 ## Using the `popstate` event
 
-Suppose the user:
+Suppose the user performs the following steps:
 
-1. Clicks a link in our SPA, so we update the page and add history entry A using `pushState()`
-2. Clicks another link in our SPA, so we update the page and add history entry B using `pushState()`
-3. Presses the "Back" button
+1. Clicks a link in our SPA, so we update the page and add history entry A using `pushState()`.
+2. Clicks another link in our SPA, so we update the page and add history entry B using `pushState()`.
+3. Presses the "Back" button.
 
 Now the new current history entry is A, so the browser fires the `popstate` event, and the event handler argument includes the JSON that we passed to `pushState()` when we handled the navigation to A. This means we can restore the correct content with an event handler like this:
 
@@ -153,11 +153,11 @@ window.addEventListener("popstate", (event) => {
 
 ## Using `replaceState()`
 
-There's one more piece we need to add. When the user loads the SPA, the browser adds a history entry. Because this was an actual page load, the entry has no state associated with it. So suppose the user:
+There's one more piece we need to add. When the user loads the SPA, the browser adds a history entry. Because this was an actual page load, the entry has no state associated with it. So suppose the user does the following:
 
-1. Loads the SPA: the browser adds a history entry
-2. Clicks a link inside the SPA: the click handler updates the page and adds a history entry with `pushState()`
-3. Presses the "Back" button
+1. Loads the SPA, so the browser adds a history entry.
+2. Clicks a link inside the SPA, so the click handler updates the page and adds a history entry with `pushState()`.
+3. Presses the "Back" button.
 
 Now we want to go back to the SPA's initial state, but since this is a navigation in the same document, the page will not be reloaded, and since the history entry for the initial page has no state, we can't use `popstate` to restore it.
 
@@ -181,7 +181,7 @@ On page load, we collect all the parts of the page that we need to restore when 
 
 When the user returns to our starting point, the `popstate` event will contain this initial state, and we can use our `displayContent()` function to update the page.
 
-## A complete example
+## Complete History API example
 
 You can find this complete example at <https://github.com/mdn/dom-examples/tree/main/history-api>, and see the demo live at <https://mdn.github.io/dom-examples/history-api/>.
 


### PR DESCRIPTION
### Description

This PR primarily adds the "Brief history of hash-based SPA routing" section to the [Router](https://developer.mozilla.org/en-US/docs/Glossary/Router) glossary page.

Other changes are minor edits for formatting, punctuation, and clarity on the "Router" and [Working with the History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API) pages.

### Motivation

We were missing historical context for hash routing. The new section informs developers why `#/` and `#!/` routing practices came about, why they are obsolete now, and what to use instead.

/cc @tantek