### PR TITLE
Clarify errors thrown by insertRule

### DIFF
--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.md
@@ -34,10 +34,9 @@ The index of the new rule.
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if _index_ is greater than the number of child CSS rules.
 - `HierarchyRequestError` {{domxref("DOMException")}}
-  - : Thrown if, due to constraints specified by CSS, the new rule cannot be inserted into
-    the list at the (zero-index) index position given.
-- `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the new rule is an `@namespace` at-rule, and the list of child CSS rules contains anything other than `@import` at-rules and `@namespace` at-rules.
+  - : Thrown if `rule` cannot be inserted at the specified index due to some CSS constraint.
+- `HierarchyRequestError` {{domxref("DOMException")}}
+  - : Thrown if the `rule` is a valid statement but not a [nested statement](/en-US/docs/Web/CSS/CSS_syntax/Syntax#nested_statements).
 
 ## Examples
 

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -52,7 +52,7 @@ The newly inserted rule's index within the stylesheet's rule-list.
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `index` > `{{domxref("CSSRuleList", "", "", "1")}}.length`.
 - `HierarchyRequestError` {{domxref("DOMException")}}
-  - : Thrown if `rule` cannot be inserted at the specified index due to some CSS constraint; for instance trying to insert an {{cssxref("@import")}} at-rule after a style rule.
+  - : Thrown if `rule` cannot be inserted at the specified index due to some CSS constraint; for instance: trying to insert an {{cssxref("@import")}} at-rule after a style rule.
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if more than one rule is given in the `rule` parameter.
 - `InvalidStateError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -52,7 +52,7 @@ The newly inserted rule's index within the stylesheet's rule-list.
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `index` > `{{domxref("CSSRuleList", "", "", "1")}}.length`.
 - `HierarchyRequestError` {{domxref("DOMException")}}
-  - : Thrown if `rule` cannot be inserted at the specified index due to some CSS constraint, for instance trying to insert an {{cssxref("@import")}} at-rule after a style rule.
+  - : Thrown if `rule` cannot be inserted at the specified index due to some CSS constraint; for instance trying to insert an {{cssxref("@import")}} at-rule after a style rule.
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if more than one rule is given in the `rule` parameter.
 - `InvalidStateError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -52,11 +52,9 @@ The newly inserted rule's index within the stylesheet's rule-list.
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `index` > `{{domxref("CSSRuleList", "", "", "1")}}.length`.
 - `HierarchyRequestError` {{domxref("DOMException")}}
-  - : Thrown if `rule` cannot be inserted at `index` `0` due to some CSS constraint.
+  - : Thrown if `rule` cannot be inserted at the specified index due to some CSS constraint, for instance trying to insert an {{cssxref("@import")}} at-rule after a style rule.
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if more than one rule is given in the `rule` parameter.
-- `HierarchyRequestError` {{domxref("DOMException")}}
-  - : Thrown if trying to insert an {{cssxref("@import")}} at-rule after a style rule.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if `rule` is {{cssxref("@namespace")}} and the rule-list has more than just `@import` at-rules and/or `@namespace` at-rules.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Clarify the errors thrown by `CSSStyleSheet.insertRule` and `CSSGroupingRule.insertRule`

### Motivation
Clarity and alignment with the spec.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
The previous assertion that HierarchyRequestError is thrown if the rule cannot be inserted at index 0 (rather than the specified index) was incorrect and seems to have been caused by a typo in the spec that has been fixed in a [recent commit](https://github.com/w3c/csswg-drafts/commit/52fb649).
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
