### PR TITLE
typo

### DIFF
--- a/files/en-us/web/api/shadowroot/mode/index.md
+++ b/files/en-us/web/api/shadowroot/mode/index.md
@@ -13,7 +13,7 @@ This defines whether or not the shadow root's internal features are accessible f
 
 When the `mode` of a shadow root is `"closed"`, the shadow root's implementation internals are inaccessible and unchangeable from JavaScript—in the same way the implementation internals of, for example, the {{HTMLElement("video")}} element are inaccessible and unchangeable from JavaScript.
 
-The property value is set using the `options.mode` property of the object passed to {{domxref("Element.attachShadow()")}}, or using the [`shadowrootmode`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode) attribute of the [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) element when a shadow root is created declaratively.
+The property value is set using the `mode` property of the object passed to {{domxref("Element.attachShadow()")}}, or using the [`shadowrootmode`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode) attribute of the [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) element when a shadow root is created declaratively.
 
 ## Value
 


### PR DESCRIPTION
The property's name is 'mode' not 'options.mode'