### PR TITLE
Replaced incorrect "double integer" with "number" in CSS Typed OM docs

### DIFF
--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -25,7 +25,7 @@ new CSSMathSum(values)
 ### Parameters
 
 - `values`
-  - : One or more numbers or {{domxref('CSSNumericValue')}} objects.
+  - : One or more numbers (which are wrapped into {{domxref("CSSUnitValue")}}s of `unit: "number"`) or {{domxref("CSSNumericValue")}} objects.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -25,7 +25,7 @@ new CSSMathSum(values)
 ### Parameters
 
 - `values`
-  - : One or more double integers or {{domxref('CSSNumericValue')}} objects.
+  - : One or more numbers or {{domxref('CSSNumericValue')}} objects.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -21,14 +21,11 @@ new CSSRotate(x, y, z, angle)
 ### Parameters
 
 - {{domxref('CSSRotate.x','x')}}
-  - : A value for the x-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a number or a {{domxref('CSSNumericValue')}}.
+  - : A value for the x-axis of the {{domxref('CSSRotate')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
 - {{domxref('CSSRotate.y','y')}}
-  - : A value for the y-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a number or a {{domxref('CSSNumericValue')}}.
+  - : A value for the y-axis of the {{domxref('CSSRotate')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
 - {{domxref('CSSRotate.z','z')}}
-  - : A value for the z-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a number or a {{domxref('CSSNumericValue')}}.
+  - : A value for the z-axis of the {{domxref('CSSRotate')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
 - {{domxref('CSSRotate.angle','angle')}}
   - : A value for the angle of the {{domxref('CSSRotate')}} object to be constructed. This
     must be a {{domxref('CSSNumericValue')}}.

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -22,13 +22,13 @@ new CSSRotate(x, y, z, angle)
 
 - {{domxref('CSSRotate.x','x')}}
   - : A value for the x-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a double integer or a {{domxref('CSSNumericValue')}}.
+    This must either be a number or a {{domxref('CSSNumericValue')}}.
 - {{domxref('CSSRotate.y','y')}}
   - : A value for the y-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a double integer or a {{domxref('CSSNumericValue')}}.
+    This must either be a number or a {{domxref('CSSNumericValue')}}.
 - {{domxref('CSSRotate.z','z')}}
   - : A value for the z-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a double integer or a {{domxref('CSSNumericValue')}}.
+    This must either be a number or a {{domxref('CSSNumericValue')}}.
 - {{domxref('CSSRotate.angle','angle')}}
   - : A value for the angle of the {{domxref('CSSRotate')}} object to be constructed. This
     must be a {{domxref('CSSNumericValue')}}.

--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -14,8 +14,7 @@ translating vector.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
-{{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -14,7 +14,8 @@ translating vector.
 
 ## Value
 
-A number or a {{domxref("CSSNumericValue")}}
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
+{{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -14,7 +14,7 @@ translating vector.
 
 ## Value
 
-A double integer or a {{domxref("CSSNumericValue")}}
+A number or a {{domxref("CSSNumericValue")}}
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -14,8 +14,7 @@ translating vector.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
-{{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -14,7 +14,8 @@ translating vector.
 
 ## Value
 
-A number or a {{domxref("CSSNumericValue")}}
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
+{{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -14,7 +14,7 @@ translating vector.
 
 ## Value
 
-A double integer or a {{domxref("CSSNumericValue")}}
+A number or a {{domxref("CSSNumericValue")}}
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -15,8 +15,7 @@ farther away.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
-{{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -15,7 +15,8 @@ farther away.
 
 ## Value
 
-A number or a {{domxref("CSSNumericValue")}}
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
+{{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -15,7 +15,7 @@ farther away.
 
 ## Value
 
-A double integer or a {{domxref("CSSNumericValue")}}
+A number or a {{domxref("CSSNumericValue")}}
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/cssscale/index.md
@@ -23,13 +23,13 @@ new CSSScale(x, y, z)
 
 - {{domxref('CSSScale.x','x')}}
   - : A value for the x-axis of the {{domxref('CSSScale')}} object to be constructed. This
-    must either be a double integer or a {{domxref('CSSNumericValue')}}.
+    must either be a number or a {{domxref('CSSNumericValue')}}.
 - {{domxref('CSSScale.y','y')}}
   - : A value for the y-axis of the {{domxref('CSSScale')}} object to be constructed. This
-    must either be a double integer or a {{domxref('CSSNumericValue')}}.
+    must either be a number or a {{domxref('CSSNumericValue')}}.
 - {{domxref('CSSScale.z','z')}} {{optional_inline}}
   - : A value for the z-axis of the {{domxref('CSSScale')}} object to be constructed. This
-    must either be a double integer or a {{domxref('CSSNumericValue')}}. If a value is
+    must either be a number or a {{domxref('CSSNumericValue')}}. If a value is
     passed for the `z-axis` this is a 3d transform. The value of
     `is2D` will be set to false.
 

--- a/files/en-us/web/api/cssscale/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/cssscale/index.md
@@ -22,16 +22,11 @@ new CSSScale(x, y, z)
 ### Parameters
 
 - {{domxref('CSSScale.x','x')}}
-  - : A value for the x-axis of the {{domxref('CSSScale')}} object to be constructed. This
-    must either be a number or a {{domxref('CSSNumericValue')}}.
+  - : A value for the x-axis of the {{domxref('CSSScale')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
 - {{domxref('CSSScale.y','y')}}
-  - : A value for the y-axis of the {{domxref('CSSScale')}} object to be constructed. This
-    must either be a number or a {{domxref('CSSNumericValue')}}.
+  - : A value for the y-axis of the {{domxref('CSSScale')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
 - {{domxref('CSSScale.z','z')}} {{optional_inline}}
-  - : A value for the z-axis of the {{domxref('CSSScale')}} object to be constructed. This
-    must either be a number or a {{domxref('CSSNumericValue')}}. If a value is
-    passed for the `z-axis` this is a 3d transform. The value of
-    `is2D` will be set to false.
+  - : A value for the z-axis of the {{domxref('CSSScale')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}. If a value is passed, the value of `is2D` will be set to false.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/x/index.md
+++ b/files/en-us/web/api/cssscale/x/index.md
@@ -14,8 +14,7 @@ translating vector.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
-{{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/x/index.md
+++ b/files/en-us/web/api/cssscale/x/index.md
@@ -14,7 +14,8 @@ translating vector.
 
 ## Value
 
-A number or a {{domxref("CSSNumericValue")}}
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
+{{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/x/index.md
+++ b/files/en-us/web/api/cssscale/x/index.md
@@ -14,7 +14,7 @@ translating vector.
 
 ## Value
 
-A double integer or a {{domxref("CSSNumericValue")}}
+A number or a {{domxref("CSSNumericValue")}}
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -14,8 +14,7 @@ translating vector.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
-{{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -14,7 +14,8 @@ translating vector.
 
 ## Value
 
-A number or a {{domxref("CSSNumericValue")}}
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
+{{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -14,7 +14,7 @@ translating vector.
 
 ## Value
 
-A double integer or a {{domxref("CSSNumericValue")}}
+A number or a {{domxref("CSSNumericValue")}}
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -18,7 +18,8 @@ property will be set to false.
 
 ## Value
 
-A number or a {{domxref("CSSNumericValue")}}
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
+{{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -18,8 +18,7 @@ property will be set to false.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a
-{{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -18,7 +18,7 @@ property will be set to false.
 
 ## Value
 
-A double integer or a {{domxref("CSSNumericValue")}}
+A number or a {{domxref("CSSNumericValue")}}
 
 ## Examples
 


### PR DESCRIPTION
### Description

Replaced all incorrect mentions of **"double integer"** with **"number"** in affected MDN Web API pages (e.g., CSSMathSum). This improves accuracy and aligns with web specifications.

### Motivation

The term "double integer" is incorrect and confusing — it mixes two incompatible number types. The correct generic term per the [CSS Typed OM specification](https://drafts.css-houdini.org/css-typed-om/#typedefdef-cssnumberish) is **"number"**, which can represent either integers or floating-point values as appropriate. Using "number" ensures clarity for developers reading the documentation.

### Additional details

Example of original usage (now corrected):
https://developer.mozilla.org/en-US/docs/Web/API/CSSMathSum/CSSMathSum#values

### Related issues and pull requests

Fixes #39762
