### PR TITLE
Fix link to Overview of scroll anchoring

### DIFF
--- a/files/en-us/web/css/css_scroll_anchoring/index.md
+++ b/files/en-us/web/css/css_scroll_anchoring/index.md
@@ -26,7 +26,7 @@ For scroll containers that are [snapped](/en-US/docs/Glossary/Scroll_snap) to an
 
 ## Guides
 
-- [Overview of scroll anchoring(/en-US/docs/Web/CSS/CSS_scroll_anchoring/Scroll_anchoring)
+- [Overview of scroll anchoring](/en-US/docs/Web/CSS/CSS_scroll_anchoring/Scroll_anchoring)
   - : What is scroll anchoring, suppression triggers, and when and how to enable and disable this browser feature.
 
 ## Related concepts


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The link to "Overview of scroll anchoring" is broken on the page:

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_anchoring#guides

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
