### PR TITLE
FF141 Relnote: Clear-Site-Data: cache clears bfcache

### DIFF
--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -35,7 +35,7 @@ Firefox 141 is the current [Nightly version of Firefox](https://www.mozilla.org/
 ### HTTP
 
 - The [`"cache"`](/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#cache) directive of the {{httpheader("Clear-Site-Data")}} response header now clears the {{glossary("bfcache")}} (backwards-forwards cache).
-  This allows a site to ensure that if a user navigates backward after a user has signed out, no private details visible during the initial session will be exposed. ([Firefox bug 1930501](https://bugzil.la/1930501)).
+  This allows a site to ensure that if anyone navigates backward after a user has signed out, private details that were visible during the initial session will not be exposed. ([Firefox bug 1930501](https://bugzil.la/1930501)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -34,6 +34,9 @@ Firefox 141 is the current [Nightly version of Firefox](https://www.mozilla.org/
 
 ### HTTP
 
+- The [`"cache"`](/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data#cache) directive of the {{httpheader("Clear-Site-Data")}} response header now clears the {{glossary("bfcache")}} (backwards-forwards cache).
+  This allows a site to ensure that if a user navigates backward after a user has signed out, no private details visible during the initial session will be exposed. ([Firefox bug 1930501](https://bugzil.la/1930501)).
+
 #### Removals
 
 ### Security

--- a/files/en-us/web/http/reference/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/reference/headers/clear-site-data/index.md
@@ -43,7 +43,8 @@ Clear-Site-Data: "*"
 > All directives must comply with the [quoted-string grammar](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6). A directive that does not include the double quotes is invalid.
 
 - `"cache"`
-  - : The server signals that the client should remove locally cached data (the browser cache, see [HTTP caching](/en-US/docs/Web/HTTP/Guides/Caching)) for the origin of the response URL. Depending on the browser, this might also clear out things like pre-rendered pages, script caches, WebGL shader caches, or address bar suggestions.
+  - : The server signals that the client should remove locally cached data (the browser cache, see [HTTP caching](/en-US/docs/Web/HTTP/Guides/Caching)) for the origin of the response URL.
+    Depending on the browser, this might also clear out things like pre-rendered pages, {{glossary("bfcache","backwards-forwards cache")}}, script caches, WebGL shader caches, or address bar suggestions.
 
 - `"clientHints"` {{Experimental_Inline}}
   - : Indicates that the server will remove all [client hints](/en-US/docs/Web/HTTP/Guides/Client_hints) (requested via {{HTTPHeader("Accept-CH")}}) stored for the origin of the response URL.


### PR DESCRIPTION
FF141 adds support for clearing `bfcache` using `Clear-Site-Data: cache` HTTP header in https://bugzilla.mozilla.org/show_bug.cgi?id=1930501

This adds a release note, and mentions that it might be cleared in the `cache` directive option.

Related docs work can be tracked in #40020

