### PR TITLE
FF141 Relnote Android: HTML webkitdirectory attribute

### DIFF
--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -15,6 +15,9 @@ Firefox 141 is the current [Nightly version of Firefox](https://www.mozilla.org/
 
 ### HTML
 
+- The HTML [`webkitdirectory`](/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) attribute and the corresponding {{domxref("HTMLInputElement.webkitdirectory")}} property are now supported on Firefox Android.
+  The attribute can be set to indicate that an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element should offer selection of directories instead of files. ([Firefox bug 1887878](https://bugzil.la/1887878)).
+
 #### Removals
 
 ### CSS

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -8,27 +8,26 @@ browser-compat: api.HTMLInputElement.webkitdirectory
 
 {{APIRef("File and Directory Entries API")}}
 
-The **`HTMLInputElement.webkitdirectory`** is a property
-that reflects the [`webkitdirectory`](/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) HTML attribute
-and indicates that the {{HTMLElement("input")}} element should let the user select directories instead of files.
+The **`webkitdirectory`** property of the {{domxref("HTMLInputElement")}} interface reflects the [`webkitdirectory`](/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) HTML attribute, which indicates that [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) elements should let the user select directories instead of files.
+
 When a directory is selected, the directory and its entire hierarchy of contents are included in the set of selected items.
 The selected file system entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} property.
 
 > [!NOTE]
-> This property is called `webkitdirectory` in the specification due to its
-> origins as a Google Chrome-specific API. It's likely to be renamed someday.
+> This property is called `webkitdirectory` in the specification due to its origins as a Google Chrome-specific API.
+> It's likely to be renamed someday.
 
 ## Value
 
-A Boolean; `true` if the {{HTMLElement("input")}} element should allow
-picking only directories or `false` if only files should be selectable.
+A Boolean; `true` if the {{HTMLElement("input")}} element should allow picking only directories or `false` if only files should be selectable.
 
-## Understanding the results
+## Description
 
-After the user makes a selection, each {{domxref("File")}} object in `files`
-has its {{domxref("File.webkitRelativePath")}} property set to the relative path within
-the selected directory at which the file is located. For example, consider this file
-system:
+Setting `webkitdirectory` true causes the input to offer users directories to select instead of files.
+
+After the user makes a selection, each {{domxref("File")}} object in `files` has its {{domxref("File.webkitRelativePath")}} property set to the relative path within the selected directory at which the file is located.
+
+For example, consider this file system:
 
 - PhotoAlbums
 
@@ -57,22 +56,18 @@ system:
       - PIC5684.jpg
       - PIC5712.jpg
 
-If the user chooses `PhotoAlbums`, then the list reported by files will
-contain {{domxref("File")}} objects for every file listed above—but not the directories.
-The entry for `PIC2343.jpg` will have a `webkitRelativePath` of
-`PhotoAlbums/Birthdays/Don's 40th birthday/PIC2343.jpg`. This makes it
-possible to know the hierarchy even though the {{domxref("FileList")}} is flat.
+If the user chooses `PhotoAlbums`, then the list reported by files will contain {{domxref("File")}} objects for every file listed above—but not the directories.
+The entry for `PIC2343.jpg` will have a `webkitRelativePath` of `PhotoAlbums/Birthdays/Don's 40th birthday/PIC2343.jpg`.
+This makes it possible to know the hierarchy even though the {{domxref("FileList")}} is flat.
 
 > [!NOTE]
-> The behavior of `webkitRelativePath` is different
-> in _Chromium < 72_. See [this bug](https://crbug.com/124187) for
-> further details.
+> The behavior of `webkitRelativePath` is different in _Chromium < 72_.
+> See [this bug](https://crbug.com/124187) for further details.
 
 ## Examples
 
-In this example, a directory picker is presented which lets the user choose one or more
-directories. When the {{domxref("HTMLElement/change_event", "change")}} event occurs, a list of all files contained
-within the selected directory hierarchies is generated and displayed.
+In this example, a directory picker is presented which lets the user choose one or more directories.
+When the {{domxref("HTMLElement/change_event", "change")}} event occurs, a list of all files contained within the selected directory hierarchies is generated and displayed.
 
 ### HTML
 

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -73,8 +73,6 @@ In addition to the attributes listed above, the following non-standard attribute
 
 The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
 
-Though originally implemented only for WebKit-based browsers, `webkitdirectory` is also usable in Firefox. However, even though it has relatively broad support, it is still not standard and should not be used unless you have no alternative.
-
 ## Unique file type specifiers
 
 A **unique file type specifier** is a string that describes a type of file that may be selected by the user in an {{HTMLElement("input")}} element of type `file`. Each unique file type specifier may take one of the following forms:


### PR DESCRIPTION
FF141 adds support for the HTML [`webkitdirectory`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) attribute (and corresponding API property), which can be used to indicate folder rather than file selection on an `<input type="file">` in https://bugzilla.mozilla.org/show_bug.cgi?id=1887878 

This adds a release note and tidies the associated docs a little for layout and current template.

Related docs work can be tracked in #40024