### PR TITLE
FF141 PointerEvent.persistentDeviceId - Relnote/layout

### DIFF
--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -21,8 +21,9 @@ Firefox 141 is the current [Beta version of Firefox](https://www.mozilla.org/en-
 ### HTML
 
 - The HTML [`webkitdirectory`](/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) attribute and the corresponding {{domxref("HTMLInputElement.webkitdirectory")}} property are now partially supported on Firefox Android ([Firefox bug 1887878](https://bugzil.la/1887878)).
-The attribute can be set to indicate that an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element should offer selection of directories instead of files.
-Note that the returned file entries for the selected folder always contain an empty string in ({{domxref("File.webkitRelativePath")}}), which means that using `webkitdirectory` is not suitable for use cases where information about the directory structure is needed ([Firefox bug 1973726](https://bugzil.la/1973726)).
+  The attribute can be set to indicate that an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element should offer selection of directories instead of files.
+  Note that the returned file entries for the selected folder always contain an empty string in ({{domxref("File.webkitRelativePath")}}), which means that using `webkitdirectory` is not suitable for use cases where information about the directory structure is needed ([Firefox bug 1973726](https://bugzil.la/1973726)).
+
 <!-- #### Removals -->
 
 <!-- ### CSS -->

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -52,7 +52,9 @@ Note that the returned file entries for the selected folder always contain an em
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
+
+- The {{domxref("PointerEvent/persistentDeviceId","persistentDeviceId")}} property of the {{domxref("PointerEvent")}} interface is now supported. This gives each pointing device that interacts with the screen a unique ID that persists for the session. It provides a reliable way to identify multiple pointing devices (such as pens) interacting with the screen simultaneously. ([Firefox bug 1968400](https://bugzil.la/1968400)).
 
 <!-- #### DOM -->
 

--- a/files/en-us/web/api/pointerevent/persistentdeviceid/index.md
+++ b/files/en-us/web/api/pointerevent/persistentdeviceid/index.md
@@ -31,7 +31,7 @@ An integer, or `0` if the device generating the `PointerEvent` could not be iden
 Assuming the following HTML:
 
 ```html
-<canvas id="inking-surface" width="300" height="200"></canvas>
+<canvas id="inking-surface" width="1280" height="720"></canvas>
 ```
 
 The following JavaScript assigns a different inking color to up to three unique pointers interacting with a canvas:

--- a/files/en-us/web/api/pointerevent/persistentdeviceid/index.md
+++ b/files/en-us/web/api/pointerevent/persistentdeviceid/index.md
@@ -8,10 +8,11 @@ browser-compat: api.PointerEvent.persistentDeviceId
 
 {{ APIRef("Pointer Events") }}
 
-The **`persistentDeviceId`** read-only property of the
-{{domxref("PointerEvent")}} interface is a unique identifier for the pointing device generating the `PointerEvent`. This provides a secure, reliable way to identify multiple pointing devices (such as pens) interacting with the screen simultaneously.
+The **`persistentDeviceId`** read-only property of the {{domxref("PointerEvent")}} interface is a unique identifier for the pointing device generating the `PointerEvent`.
+This provides a secure, reliable way to identify multiple pointing devices (such as pens) interacting with the screen simultaneously.
 
-A `persistentDeviceId` persists for the lifetime of a browsing session. To avoid the risk of fingerprinting/tracking, pointing devices are assigned a new `persistentDeviceId` at the start of each session.
+A `persistentDeviceId` persists for the lifetime of a browsing session.
+To avoid the risk of fingerprinting/tracking, pointing devices are assigned a new `persistentDeviceId` at the start of each session.
 
 Pointer events whose generating device could not be identified are assigned a `persistentDeviceId` value of `0`.
 
@@ -20,17 +21,20 @@ Pointer events whose generating device could not be identified are assigned a `p
 An integer, or `0` if the device generating the `PointerEvent` could not be identified.
 
 > [!NOTE]
-> Due to digitizer and pointing device hardware constraints, a `persistentDeviceId` may not be available for all pointer events, particularly with older hardware. For example, the pointing device might not report its hardware ID to the digitizer in time for `pointerdown` to receive a `persistentDeviceId`: it may initially be `0` and change to a valid value for later events in the stroke.
+> Due to digitizer and pointing device hardware constraints, a `persistentDeviceId` may not be available for all pointer events, particularly with older hardware.
+> For example, the pointing device might not report its hardware ID to the digitizer in time for `pointerdown` to receive a `persistentDeviceId`: it may initially be `0` and change to a valid value for later events in the stroke.
 
 ## Examples
+
+### Assign color for each persistentDeviceId
 
 Assuming the following HTML:
 
 ```html
-<canvas id="inking-surface" width="1280" height="720"></canvas>
+<canvas id="inking-surface" width="300" height="200"></canvas>
 ```
 
-The following JavaScript assigns a different inking color to unique pointers interacting with a canvas:
+The following JavaScript assigns a different inking color to up to three unique pointers interacting with a canvas:
 
 ```js
 const colorBlue = 0;


### PR DESCRIPTION
FF141 adds support for [`PointerEvent.persistentDeviceId`](http://localhost:5042/en-US/docs/Web/API/PointerEvent/persistentDeviceId) in https://bugzilla.mozilla.org/show_bug.cgi?id=1968400

This adds a release not and does minor formatting changes to the property page

Related docs work can be tracked in #40022
