### PR TITLE
FF141 IntersectionObserver scrollMargin property et al

### DIFF
--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -9,6 +9,8 @@ browser-compat: api.IntersectionObserver
 
 The Intersection Observer API provides a way to asynchronously observe changes in the intersection of a target element with an ancestor element or with a top-level document's {{Glossary("viewport")}}.
 
+## Overview
+
 Historically, detecting visibility of an element, or the relative visibility of two elements in relation to each other, has been a difficult task for which solutions have been unreliable and prone to causing the browser and the sites the user is accessing to become sluggish. As the web has matured, the need for this kind of information has grown. Intersection information is needed for many reasons, such as:
 
 - Lazy-loading of images or other content as a page is scrolled.
@@ -24,7 +26,7 @@ The Intersection Observer API lets code register a callback function that is exe
 
 One thing the Intersection Observer API can't do: trigger logic based on the exact number of pixels that overlap, or specifically on which ones they are. It only solves the common use case of "If they intersect by somewhere around _N_%, I need to do something."
 
-## Intersection observer concepts and usage
+## Concepts and usage
 
 The Intersection Observer API allows you to configure a callback that is called when either of these circumstances occur:
 
@@ -45,6 +47,7 @@ Create the intersection observer by calling its constructor and passing it a cal
 const options = {
   root: document.querySelector("#scrollArea"),
   rootMargin: "0px",
+  scrollMargin: "0px",
   threshold: 1.0,
 };
 
@@ -61,8 +64,24 @@ The `options` object passed into the {{domxref("IntersectionObserver.Intersectio
   - : The element that is used as the viewport for checking visibility of the target. Must be the ancestor of the target. Defaults to the browser viewport if not specified or if `null`.
 - `rootMargin`
   - : Margin around the root. A string of one to four values similar to the CSS {{cssxref("margin")}} property, e.g., `"10px 20px 30px 40px"` (top, right, bottom, left). The values can only be [absolute lengths](/en-US/docs/Learn_web_development/Core/Styling_basics/Values_and_units#absolute_length_units) or percentages. This set of values serves to grow or shrink each side of the root element's bounding box before computing intersections. Negative values will shrink the bounding box of the root element and positive values will expand it. The default value, if not specified, is `"0px 0px 0px 0px"`.
+- `scrollMargin`
+  - : Margin around nested {{glossary("scroll container","scroll containers")}} that takes the same values/has same default as `rootMargin`.
+    The margins are applied to nested scrollable containers before computing intersections.
+    Positive values grow the clipping rectangle of the container, allowing targets to intersect before they becomes visible, while negative values shrink the clipping rectangle.
 - `threshold`
   - : Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. If you want the callback to run every time visibility passes another 25%, you would specify the array \[0, 0.25, 0.5, 0.75, 1]. The default is 0 (meaning as soon as even one pixel is visible, the callback will be run). A value of 1.0 means that the threshold isn't considered passed until every pixel is visible.
+- `delay`
+  - : When tracking target visibility ([trackVisibility](#trackvisibility) is `true`), this can be used to set the minimum delay in millisecond between notifications from this observer.
+    Limiting the notification rate is desirable because the visibility calculation is computationally intensive.
+    If tracking visibility, the value will be set to 100 for any value less than 100, and you should use the largest tolerable value.
+    The value is 0 by default.
+- `trackVisibility`
+  - : A boolean indicating whether this `IntersectionObserver` is tracking changes in a target's visibility.
+
+    When `false` the browser will report intersections when the target element scrolls into the root element's viewport.
+    When `true`, the browser will additionally check that the target is actually visible, and hasn't been covered by other elements or potentially been distorted or hidden by a filter, reduced opacity, or some transform.
+    The value is `false` by default as tracking visibility is computationally intensive.
+    If this is set, a [`delay`](#delay) should also be set.
 
 #### Intersection change callbacks
 
@@ -138,10 +157,14 @@ The **_root intersection rectangle_** is the rectangle used to check against the
 
 The root intersection rectangle can be adjusted further by setting the **root margin**, `rootMargin`, when creating the {{domxref("IntersectionObserver")}}. The values in `rootMargin` define offsets added to each side of the intersection root's bounding box to create the final intersection root bounds (which are disclosed in {{domxref("IntersectionObserverEntry.rootBounds")}} when the callback is executed). Positive values grow the box, while negative values shrink it.
 
-In the example below, we have a scrollable box and an element that's initially out of view. You can adjust the root right margin, and see that:
+The effect of growing the box using the root margin is to allow overflow targets to intersect with the root before they become visible.
+This can be used, for example, to start loading images just before they come into view, rather than at the point they become visible.
 
-- If the margin is negative, then even when the red element starts to become visible, it's still not considered intersecting with the root because the root's bounding box is shrunk.
+In the example below, we have a scrollable box and an element that's initially out of view.
+You can adjust the root right margin, and see that:
+
 - If the margin is positive, the red element is considered intersecting with the root even if it's not visible, because it's intersecting with the root's margin area.
+- If the margin is negative, then even when the red element starts to become visible, it's still not considered intersecting with the root because the root's bounding box is shrunk.
 
 ```html hidden
 <div class="demo">
@@ -224,6 +247,7 @@ function createObserver() {
   if (margin.valueAsNumber < 0) {
     marginIndicator.style.width = `${-margin.valueAsNumber}px`;
     marginIndicator.style.left = `${margin.valueAsNumber}px`;
+
     marginIndicator.style.backgroundColor = "blue";
   } else {
     marginIndicator.style.width = `${margin.valueAsNumber}px`;
@@ -241,7 +265,216 @@ scrollAmount.addEventListener("input", () => {
 });
 ```
 
-{{EmbedLiveSample("the intersection root and root margin", "", 300)}}
+{{EmbedLiveSample("the intersection root and root margin", "", 200)}}
+
+#### The intersection root and scroll margin
+
+Consider the case where you have an root element that contains nested {{glossary("scroll container","scroll containers")}}, and you want to observe intersections with a target inside one of those scrollable containers.
+Intersections with the target element start being observable, by default, when the target is visible within the area defined by the root.
+In other words, when the container is scrolled into view in the root and the target is scrolled into view within the clipping rectangle of its container.
+
+You can use a scroll margin to start observing intersections before or after the target is scrolled into view within its scroll container.
+The margin is added to all nested scroll containers in the root, including the root element if it also a scroll container, and has the effect of either growing (positive margins) or shrinking (negative margin) the clipping region used for calculating intersections.
+
+> [!NOTE]
+> You could alternatively create an intersection observer on the scroll container (instead of the root) and set a root margin.
+> Using a scroll margin on the root is more ergonomic, as in most cases you can have just one intersection observer for all nested targets.
+
+In the example below, we have a scrollable box and an image carousel that is initially out of view.
+An observer on the root element observes the image element targets within the carousel.
+When an image element starts to intersect with the root element, the image is loaded, the intersection is logged, and the observer is removed.
+
+Scroll the down to display the carousel.
+The visible images should immediately load.
+If you scroll the carousel right, you should observe that the images are loaded as soon as the element becomes visible.
+
+After resetting the example you can use the provided control to change the scroll margin percentage.
+If you set a positive value like 20% the clip rectangle of the scroll container will be increased by 20%, and you should observe that images are detected and loaded before they come into view.
+Similarly, a negative value will mean that the intersection is detected once images are already in view.
+
+```html hidden
+<button id="reset" type="button">Reset</button>
+```
+
+```html hidden
+<div id="root_container">
+  <p>content before (scroll down to carousel)</p>
+
+  <div class="flexcontainer">
+    <div class="carousel">
+      <img
+        data-src="ballon-portrait.jpg"
+        class="lazy-carousel-img"
+        alt="Balloon portrait" />
+      <img
+        data-src="balloon-small.jpg"
+        class="lazy-carousel-img"
+        alt="balloon-small" />
+      <img data-src="surfer.jpg" class="lazy-carousel-img" alt="surfer" />
+      <img
+        data-src="border-diamonds.png"
+        class="lazy-carousel-img"
+        alt="border-diamonds" />
+      <img data-src="fire.png" class="lazy-carousel-img" alt="fire" />
+      <img data-src="puppy-header.jpg" class="lazy-carousel-img" alt="puppy" />
+      <img data-src="moon.jpg" class="lazy-carousel-img" alt="moon" />
+      <img data-src="rhino.jpg" class="lazy-carousel-img" alt="rhino" />
+    </div>
+    <div id="marginIndicator"></div>
+  </div>
+  <p>content after</p>
+</div>
+```
+
+```html hidden
+<div class="controls">
+  <label>
+    Set the right margin of the scroll root:
+    <input id="margin" type="number" value="0" step="5" />%
+  </label>
+</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#root_container {
+  height: 250px;
+  overflow-y: auto;
+  border: solid blue;
+}
+
+.controls {
+  margin-top: 10px;
+}
+
+p {
+  height: 50vh;
+}
+
+.flexcontainer {
+  display: flex;
+}
+
+#marginIndicator {
+  position: relative;
+  height: 100px;
+  width: 1px;
+  background-color: red;
+  opacity: 0.5;
+  display: flex;
+}
+
+.carousel {
+  width: 300px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  display: flex;
+  border: solid;
+  /* outline: 200px solid rgba(0, 0, 0, 0.1); */
+}
+.carousel img {
+  scroll-snap-stop: always;
+  scroll-snap-align: start;
+  display: block;
+  width: 195px;
+  height: 99px;
+  min-width: 195px;
+  min-height: 99px;
+  margin-right: 10px;
+  background-color: #eee; /* Placeholder background */
+}
+
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js hidden
+let imageObserver;
+
+function createImageObserver() {
+  const carousel = document.querySelector(".carousel");
+  const lazyImages = carousel.querySelectorAll(".lazy-carousel-img");
+
+  if (imageObserver) {
+    imageObserver.disconnect();
+  }
+
+  let observerOptions = {
+    root: root_container,
+    rootMargin: "0px", // No extra margin
+    scrollMargin: `${margin.valueAsNumber}%`, // No extra margin / Can be set
+    threshold: 0.01, // Trigger when 1% of the image is visible
+  };
+
+  imageObserver = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        log(`intersect: ${img.dataset.src}`); // Only on first intersection
+        img.src = `https://mdn.github.io/shared-assets/images/examples/${img.dataset.src}`; // Load image by setting src
+        img.classList.remove("lazy-carousel-img"); // Remove the class
+        observer.unobserve(img); // Stop observing once loaded
+      }
+    });
+  }, observerOptions);
+
+  if (margin.valueAsNumber < 0) {
+    marginIndicator.style.width = `${-margin.valueAsNumber}px`;
+    marginIndicator.style.left = `${margin.valueAsNumber}px`;
+    marginIndicator.style.backgroundColor = "blue";
+  } else {
+    marginIndicator.style.width = `${margin.valueAsNumber}px`;
+    marginIndicator.style.left = "0px";
+    marginIndicator.style.backgroundColor = "green";
+  }
+
+  lazyImages.forEach((image) => {
+    imageObserver.observe(image); // Start observing each image
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  if ("IntersectionObserver" in window) {
+    createImageObserver();
+    margin.addEventListener("input", () => {
+      createImageObserver();
+    });
+  } else {
+    // Fallback for browsers that don't support Intersection Observer
+    // Loads all images immediately if Intersection Observer is not supported.
+    lazyImages.forEach((img) => {
+      img.src = img.dataset.src;
+      img.classList.remove("lazy-carousel-img");
+    });
+    console.warn(
+      "Intersection Observer not supported. All carousel images loaded.",
+    );
+  }
+});
+```
+
+{{EmbedLiveSample("The intersection root and scroll margin","100%","500px")}}
 
 #### Thresholds
 
@@ -427,12 +660,27 @@ startup();
 
 {{EmbedLiveSample("Thresholds", 500, 500)}}
 
+#### Tracking visibility and delay
+
+By default the observer provides notifications when the target element is scrolled into the root element's viewport.
+While this is all that is needed in many situations, sometimes it is important that intersections are not reported when the target has been "visually compromised".
+For example, when measuring analytics or ad impressions, it is important that target elements are not hidden or or distorted, in whole or in part.
+
+The `trackVisibility` setting tells the observer to only report intersections for targets that the browser does not consider to be visually compromised, such as by altering the opacity, or applying a filter or transform.
+The algorithm is conservative, and may omit elements that are technically visible, such as those with only a slight opacity reduction.
+
+The visibility calculation is computationally expensive and should only be used when necessary.
+When tracking visibility a {{domxref("IntersectionObserver/delay","delay")}} should also be set to limit the minimum reporting period.
+The recommendation is that you set the delay to the largest tolerable value (the minimum delay when tracking visibility is100 milliseconds).
+
 #### Clipping and the intersection rectangle
 
 The browser computes the final intersection rectangle as follows; this is all done for you, but it can be helpful to understand these steps in order to better grasp exactly when intersections will occur.
 
-1. The target element's bounding rectangle (that is, the smallest rectangle that fully encloses the bounding boxes of every component that makes up the element) is obtained by calling {{domxref("Element.getBoundingClientRect", "getBoundingClientRect()")}} on the target. This is the largest the intersection rectangle may be. The remaining steps will remove any portions that don't intersect.
-2. Starting at the target's immediate parent block and moving outward, each containing block's clipping (if any) is applied to the intersection rectangle. A block's clipping is determined based on the intersection of the two blocks and the clipping mode (if any) specified by the {{cssxref("overflow")}} property. Setting `overflow` to anything but `visible` causes clipping to occur.
+1. The target element's bounding rectangle (that is, the smallest rectangle that fully encloses the bounding boxes of every component that makes up the element) is obtained by calling {{domxref("Element.getBoundingClientRect", "getBoundingClientRect()")}} on the target.
+   This is the largest the intersection rectangle may be. The remaining steps will remove any portions that don't intersect.
+2. Starting at the target's immediate parent block and moving outward, each containing block's clipping (if any) is applied to the intersection rectangle.
+   A block's clipping is determined based on the intersection of the two blocks and the clipping mode (if any) specified by the {{cssxref("overflow")}} property. Setting `overflow` to anything but `visible` causes clipping to occur.
 3. If one of the containing elements is the root of a nested browsing context (such as the document contained in an {{HTMLElement("iframe")}}), the intersection rectangle is clipped to the containing context's viewport, and recursion upward through the containers continues with the container's containing block. So if the top level of an `<iframe>` is reached, the intersection rectangle is clipped to the frame's viewport, then the frame's parent element is the next block recursed through toward the intersection root.
 4. When recursion upward reaches the intersection root, the resulting rectangle is mapped to the intersection root's coordinate space.
 5. The resulting rectangle is then updated by intersecting it with the [root intersection rectangle](#the_intersection_root_and_root_margin).

--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -71,7 +71,7 @@ The `options` object passed into the {{domxref("IntersectionObserver.Intersectio
 - `threshold`
   - : Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. If you want the callback to run every time visibility passes another 25%, you would specify the array \[0, 0.25, 0.5, 0.75, 1]. The default is 0 (meaning as soon as even one pixel is visible, the callback will be run). A value of 1.0 means that the threshold isn't considered passed until every pixel is visible.
 - `delay`
-  - : When tracking target visibility ([trackVisibility](#trackvisibility) is `true`), this can be used to set the minimum delay in millisecond between notifications from this observer.
+  - : When tracking target visibility ([trackVisibility](#trackvisibility) is `true`), this can be used to set the minimum delay in milliseconds between notifications from this observer.
     Limiting the notification rate is desirable because the visibility calculation is computationally intensive.
     If tracking visibility, the value will be set to 100 for any value less than 100, and you should use the largest tolerable value.
     The value is 0 by default.
@@ -269,12 +269,12 @@ scrollAmount.addEventListener("input", () => {
 
 #### The intersection root and scroll margin
 
-Consider the case where you have an root element that contains nested {{glossary("scroll container","scroll containers")}}, and you want to observe intersections with a target inside one of those scrollable containers.
-Intersections with the target element start being observable, by default, when the target is visible within the area defined by the root.
-In other words, when the container is scrolled into view in the root and the target is scrolled into view within the clipping rectangle of its container.
+Consider the case where you have a root element that contains nested {{glossary("scroll container","scroll containers")}}, and you want to observe intersections with a target inside one of those scrollable containers.
+Intersections with the target element start being observable, by default, when the target is visible within the area defined by the root;
+in other words, when the container is scrolled into view in the root and the target is scrolled into view within the clipping rectangle of its container.
 
 You can use a scroll margin to start observing intersections before or after the target is scrolled into view within its scroll container.
-The margin is added to all nested scroll containers in the root, including the root element if it also a scroll container, and has the effect of either growing (positive margins) or shrinking (negative margin) the clipping region used for calculating intersections.
+The margin is added to all nested scroll containers in the root, including the root element if it is also a scroll container, and has the effect of either growing (positive margins) or shrinking (negative margin) the clipping region used for calculating intersections.
 
 > [!NOTE]
 > You could create an intersection observer on each scroll container for which you want a scroll margin, and use the root margin property to achieve a similar effect.
@@ -284,7 +284,7 @@ In the example below, we have a scrollable box and an image carousel that is ini
 An observer on the root element observes the image element targets within the carousel.
 When an image element starts to intersect with the root element, the image is loaded, the intersection is logged, and the observer is removed.
 
-Scroll the down to display the carousel.
+Scroll down to display the carousel.
 The visible images should immediately load.
 If you scroll the carousel, you should observe that the images are loaded as soon as the element becomes visible.
 
@@ -664,14 +664,14 @@ startup();
 
 By default the observer provides notifications when the target element is scrolled into the root element's viewport.
 While this is all that is needed in many situations, sometimes it is important that intersections are not reported when the target has been "visually compromised".
-For example, when measuring analytics or ad impressions, it is important that target elements are not hidden or or distorted, in whole or in part.
+For example, when measuring analytics or ad impressions, it is important that target elements are not hidden or distorted, in whole or in part.
 
 The `trackVisibility` setting tells the observer to only report intersections for targets that the browser does not consider to be visually compromised, such as by altering the opacity, or applying a filter or transform.
 The algorithm is conservative, and may omit elements that are technically visible, such as those with only a slight opacity reduction.
 
 The visibility calculation is computationally expensive and should only be used when necessary.
 When tracking visibility a {{domxref("IntersectionObserver/delay","delay")}} should also be set to limit the minimum reporting period.
-The recommendation is that you set the delay to the largest tolerable value (the minimum delay when tracking visibility is100 milliseconds).
+The recommendation is that you set the delay to the largest tolerable value (the minimum delay when tracking visibility is 100 milliseconds).
 
 #### Clipping and the intersection rectangle
 

--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -286,7 +286,7 @@ When an image element starts to intersect with the root element, the image is lo
 
 Scroll the down to display the carousel.
 The visible images should immediately load.
-If you scroll the carousel right, you should observe that the images are loaded as soon as the element becomes visible.
+If you scroll the carousel, you should observe that the images are loaded as soon as the element becomes visible.
 
 After resetting the example you can use the provided control to change the scroll margin percentage.
 If you set a positive value like 20% the clip rectangle of the scroll container will be increased by 20%, and you should observe that images are detected and loaded before they come into view.

--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -277,8 +277,8 @@ You can use a scroll margin to start observing intersections before or after the
 The margin is added to all nested scroll containers in the root, including the root element if it also a scroll container, and has the effect of either growing (positive margins) or shrinking (negative margin) the clipping region used for calculating intersections.
 
 > [!NOTE]
-> You could alternatively create an intersection observer on the scroll container (instead of the root) and set a root margin.
-> Using a scroll margin on the root is more ergonomic, as in most cases you can have just one intersection observer for all nested targets.
+> You could create an intersection observer on each scroll container for which you want a scroll margin, and use the root margin property to achieve a similar effect.
+> Using a scroll margin is more ergonomic, as in most cases you can have just one intersection observer for all nested targets.
 
 In the example below, we have a scrollable box and an image carousel that is initially out of view.
 An observer on the root element observes the image element targets within the carousel.

--- a/files/en-us/web/api/intersectionobserver/delay/index.md
+++ b/files/en-us/web/api/intersectionobserver/delay/index.md
@@ -1,0 +1,33 @@
+---
+title: "IntersectionObserver: delay property"
+short-title: delay
+slug: Web/API/IntersectionObserver/delay
+page-type: web-api-instance-property
+browser-compat: api.IntersectionObserver.delay
+---
+
+{{APIRef("Intersection Observer API")}}
+
+The **`delay`** read-only property of the {{domxref("IntersectionObserver")}} interface indicates the minimum delay between notifications from this observer for a given target.
+
+The delay is used to limit the rate at which notifications should be provided when [tracking visibility](/en-US/docs/Web/API/IntersectionObserver/trackVisibility), as this is a computationally intensive operation.
+The recommendation when tracking visibility is that you set the delay to the largest tolerable value.
+
+## Value
+
+A positive number in milliseconds.
+
+The value is set using the [`option.delay`](/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#delay) argument to the `IntersectionObserver()` constructor.
+The value is clamped to 100 or greater if {{domxref("IntersectionObserver/trackVisibility","trackVisibility")}} is `true`, but otherwise defaults to 0.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Timing element visibility with the Intersection Observer API](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility)

--- a/files/en-us/web/api/intersectionobserver/delay/index.md
+++ b/files/en-us/web/api/intersectionobserver/delay/index.md
@@ -8,7 +8,7 @@ browser-compat: api.IntersectionObserver.delay
 
 {{APIRef("Intersection Observer API")}}
 
-The **`delay`** read-only property of the {{domxref("IntersectionObserver")}} interface indicates the minimum delay between notifications from this observer for a given target.
+The **`delay`** read-only property of the {{domxref("IntersectionObserver")}} interface indicates the minimum delay between notifications from this observer.
 
 The delay is used to limit the rate at which notifications should be provided when [tracking visibility](/en-US/docs/Web/API/IntersectionObserver/trackVisibility), as this is a computationally intensive operation.
 The recommendation when tracking visibility is that you set the delay to the largest tolerable value.

--- a/files/en-us/web/api/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/index.md
@@ -18,12 +18,19 @@ When an `IntersectionObserver` is created, it's configured to watch for given ra
 
 ## Instance properties
 
+- {{domxref("IntersectionObserver.delay")}} {{ReadOnlyInline}}
+  - : An integer indicating the minimum delay between notifications from this observer for a given target.
 - {{domxref("IntersectionObserver.root")}} {{ReadOnlyInline}}
   - : The {{domxref("Element")}} or {{domxref("Document")}} whose bounds are used as the bounding box when testing for intersection. If no `root` value was passed to the constructor or its value is `null`, the top-level document's viewport is used.
 - {{domxref("IntersectionObserver.rootMargin")}} {{ReadOnlyInline}}
   - : An offset rectangle applied to the root's {{Glossary('bounding box')}} when calculating intersections, effectively shrinking or growing the root for calculation purposes. The value returned by this property may not be the same as the one specified when calling the constructor as it may be changed to match internal requirements. Each offset can be expressed in pixels (`px`) or as a percentage (`%`). The default is "0px 0px 0px 0px".
+- {{domxref("IntersectionObserver.scrollMargin")}} {{ReadOnlyInline}}
+  - : An offset rectangle applied to each {{glossary("scroll container")}} on the path from intersection root to target, effectively shrinking or growing the clip rectangles used to calculate intersections.
+    The value returned by this property may not be the same as the one specified when calling the constructor.
 - {{domxref("IntersectionObserver.thresholds")}} {{ReadOnlyInline}}
   - : A list of thresholds, sorted in increasing numeric order, where each threshold is a ratio of intersection area to bounding box area of an observed target. Notifications for a target are generated when any of the thresholds are crossed for that target. If no value was passed to the constructor, 0 is used.
+- {{domxref("IntersectionObserver.trackVisibility")}} {{ReadOnlyInline}}
+  - : A boolean indicating whether this `IntersectionObserver` is tracking changes in a target's visibility.
 
 ## Instance methods
 

--- a/files/en-us/web/api/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/index.md
@@ -19,7 +19,7 @@ When an `IntersectionObserver` is created, it's configured to watch for given ra
 ## Instance properties
 
 - {{domxref("IntersectionObserver.delay")}} {{ReadOnlyInline}}
-  - : An integer indicating the minimum delay between notifications from this observer for a given target.
+  - : An integer indicating the minimum delay between notifications from this observer.
 - {{domxref("IntersectionObserver.root")}} {{ReadOnlyInline}}
   - : The {{domxref("Element")}} or {{domxref("Document")}} whose bounds are used as the bounding box when testing for intersection. If no `root` value was passed to the constructor or its value is `null`, the top-level document's viewport is used.
 - {{domxref("IntersectionObserver.rootMargin")}} {{ReadOnlyInline}}
@@ -30,7 +30,7 @@ When an `IntersectionObserver` is created, it's configured to watch for given ra
 - {{domxref("IntersectionObserver.thresholds")}} {{ReadOnlyInline}}
   - : A list of thresholds, sorted in increasing numeric order, where each threshold is a ratio of intersection area to bounding box area of an observed target. Notifications for a target are generated when any of the thresholds are crossed for that target. If no value was passed to the constructor, 0 is used.
 - {{domxref("IntersectionObserver.trackVisibility")}} {{ReadOnlyInline}}
-  - : A boolean indicating whether this `IntersectionObserver` is tracking changes in a target's visibility.
+  - : A boolean indicating whether this `IntersectionObserver` is checking that the target does not have compromised visibility.
 
 ## Instance methods
 

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
@@ -68,8 +68,8 @@ new IntersectionObserver(callback, options)
     - `trackVisibility`
       - : A boolean indicating whether the observer should track visibility.
 
-        When `true`, the browser will check that the target does not have compromised visibility when calculating intersections.
-        For example, that it hasn't been covered by other elements or potentially been distorted or hidden by a filter, reduced opacity, or some transform.
+        When `true`, the browser will check that the target does not have compromised visibility when calculating intersections;
+        for example, that it hasn't been covered by other elements or potentially been distorted or hidden by a filter, reduced opacity, or some transform.
 
         Tracking visibility is an expensive operation, and should only be done when necessary.
         A [`delay`](#delay) should also be set when this value is `true`.

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
@@ -10,12 +10,6 @@ browser-compat: api.IntersectionObserver.IntersectionObserver
 
 The **`IntersectionObserver()`** constructor creates and returns a new {{domxref("IntersectionObserver")}} object.
 
-The `rootMargin`, if specified, is checked to ensure it's syntactically correct.
-If not specified, or an empty string, the default is `0px 0px 0px 0px`.
-
-The `threshold`s, if specified, are checked to ensure that they're all in the range 0.0 and 1.0 inclusive, and the threshold list is sorted in ascending numeric order.
-If the threshold list is empty, it's set to the array `[0.0]`.
-
 ## Syntax
 
 ```js-nolint
@@ -29,16 +23,30 @@ new IntersectionObserver(callback, options)
   - : A function which is called when the percentage of the target element is visible crosses a threshold.
     The callback receives as input two parameters:
     - `entries`
-      - : An array of {{domxref("IntersectionObserverEntry")}} objects, each representing one threshold which was crossed, either becoming more or less visible than the percentage specified by that threshold. You should not assume the number of entries, because multiple threshold-crossing events may be reported in a single callback invocation. The entries are dispatched using a queue, so they should be ordered by the time they were generated, but you should preferably use {{domxref("IntersectionObserverEntry.time")}} to correctly order them.
+      - : An array of {{domxref("IntersectionObserverEntry")}} objects, each representing one threshold which was crossed, either becoming more or less visible than the percentage specified by that threshold.
+        You should not assume the number of entries, because multiple threshold-crossing events may be reported in a single callback invocation.
+        The entries are dispatched using a queue, so they should be ordered by the time they were generated, but you should preferably use {{domxref("IntersectionObserverEntry.time")}} to correctly order them.
     - `observer`
       - : The {{domxref("IntersectionObserver")}} for which the callback is being invoked.
 
 - `options` {{optional_inline}}
-  - : An optional object which customizes the observer. All properties are optional.
-    You can provide any combination of the following options:
+  - : An optional object which customizes the observer.
+
+    You can provide any combination (or none) of the following options:
+    - `delay`
+      - : A number specifying the minimum permitted delay between notifications from the observer for a given target, in milliseconds.
+
+        The delay is used to limit the rate at which notifications should be provided when tracking visibility, as this is a computationally intensive operation.
+        The recommendation when tracking visibility is that you set the delay to the largest tolerable value.
+
+        When [`trackVisibility`](#trackvisibility) is `true` the minimum value will be 100.
+        The browser will set the value to 100 if any smaller value is used, or if the value is not specified.
+        The default value is 0.
+
     - `root`
       - : An {{domxref("Element")}} or {{domxref("Document")}} object which is an ancestor of the intended target, whose bounding rectangle will be considered the viewport.
-        Any part of the target not visible in the visible area of the `root` is not considered visible. If not specified, the observer uses the document's
+        Any part of the target not visible in the visible area of the `root` is not considered visible.
+        If not specified, the observer uses the document's
         viewport as the root, with no margin, and a 0% threshold (meaning that even a one-pixel change is enough to trigger a callback).
     - `rootMargin`
       - : A string which specifies a set of offsets to add to the root's {{Glossary('bounding_box')}} when calculating intersections, effectively shrinking
@@ -46,23 +54,33 @@ new IntersectionObserver(callback, options)
         The syntax is approximately the same as that for the CSS {{cssxref("margin")}} property;
         see [The intersection root and root margin](/en-US/docs/Web/API/Intersection_Observer_API#the_intersection_root_and_root_margin) for more information on how the margin works and the syntax.
         The default is "0px 0px 0px 0px".
+    - `scrollMargin`
+      - : A string that specifies the offsets to add to every {{glossary("scroll container")}} on path to the target when calculating intersections, effectively shrinking or growing the clip rectangles used to calculate intersections.
+        This allows, for example, better observation of targets inside nested scroll containers that are currently clipped away by the scroll containers.
+        The syntax is approximately the same as that for the CSS {{cssxref("margin")}} property.
+        The default is "0px 0px 0px 0px".
     - `threshold`
       - : Either a single number or an array of numbers between 0.0 and 1.0, specifying a ratio of intersection area to total bounding box area for the observed target.
         A value of 0.0 means that even a single visible pixel counts as the target being visible.
         1.0 means that the entire target element is visible.
         See [Thresholds](/en-US/docs/Web/API/Intersection_Observer_API#thresholds) for a more in-depth description of how thresholds are used.
-        The default is a threshold of 0.0.
+        The default is a threshold of "0".
+    - `trackVisibility`
+      - : A boolean indicating whether the observer should track visibility.
+        Tracking visibility is an expensive operation, and should only be done when necessary.
+        A [`delay`](#delay) should also be set when this value is `true`.
+        The default is `false`.
 
 ### Return value
 
-A new {{domxref("IntersectionObserver")}} which can be used to watch for the visibility of a target element within the specified `root` crossing through any of the
-specified visibility `threshold`s.
+A new {{domxref("IntersectionObserver")}} which can be used to watch for the visibility of a target element within the specified `root` crossing through any of the specified visibility `threshold`s.
+
 Call its {{domxref("IntersectionObserver.observe", "observe()")}} method to begin watching for the visibility changes on a given target.
 
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
-  - : The specified `rootMargin` is invalid.
+  - : The specified `rootMargin` or `scrollMargin` is invalid.
 - {{jsxref("RangeError")}}
   - : One or more of the values in `threshold` is outside the range 0.0 to 1.0.
 

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
@@ -34,12 +34,12 @@ new IntersectionObserver(callback, options)
 
     You can provide any combination (or none) of the following options:
     - `delay`
-      - : A number specifying the minimum permitted delay between notifications from the observer for a given target, in milliseconds.
+      - : A number specifying the minimum permitted delay between notifications from the observer, in milliseconds.
 
-        The delay is used to limit the rate at which notifications should be provided when tracking visibility, as this is a computationally intensive operation.
+        The delay is used to limit the rate at which notifications will be provided when tracking visibility, as this is a computationally intensive operation.
         The recommendation when tracking visibility is that you set the delay to the largest tolerable value.
 
-        When [`trackVisibility`](#trackvisibility) is `true` the minimum value will be 100.
+        When [`trackVisibility`](#trackvisibility) is `true` the minimum value is 100.
         The browser will set the value to 100 if any smaller value is used, or if the value is not specified.
         The default value is 0.
 
@@ -67,6 +67,10 @@ new IntersectionObserver(callback, options)
         The default is a threshold of "0".
     - `trackVisibility`
       - : A boolean indicating whether the observer should track visibility.
+
+        When `true`, the browser will check that the target does not have compromised visibility when calculating intersections.
+        For example, that it hasn't been covered by other elements or potentially been distorted or hidden by a filter, reduced opacity, or some transform.
+
         Tracking visibility is an expensive operation, and should only be done when necessary.
         A [`delay`](#delay) should also be set when this value is `true`.
         The default is `false`.

--- a/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
@@ -11,7 +11,7 @@ browser-compat: api.IntersectionObserver.scrollMargin
 The **`scrollMargin`** read-only property of the {{domxref("IntersectionObserver")}} interface adds a margin to all nested {{glossary("scroll container","scroll containers")}} within the root element, including the root element if it is a scroll container.
 
 This grows or shrinks the clipping rectangle of the scrollable containers before calculating intersections.
-This lets you, for example, adjust the bounds of the scroll container so that the target element is considered visible even if a pixels are not yet displayed in the container's viewport, or to treat the target as partially hidden if an edge is too close to the edge of the container's bounding box.
+This lets you, for example, adjust the bounds of the scroll container so that the target element is considered visible even if its pixels are not yet displayed in the container's viewport, or to treat the target as partially hidden if an edge is too close to the edge of the container's bounding box.
 
 Note that if the root element is also a scrollable container, then the `scrollMargin` and {{domxref("IntersectionObserver/rootMargin","rootMargin")}} are combined to determine the effective bounding rectangle used for calculating intersections with the target.
 
@@ -165,7 +165,7 @@ function log(text) {
 }
 ```
 
-The first part of the code defines function `createImageObserver()` that we use to create `IntersectionObserver` objects and assign to the `imageObserver` variable.
+The first part of the code defines the function `createImageObserver()` that we use to create `IntersectionObserver` objects and assign to the `imageObserver` variable.
 We use a function because observer options can't be changed after construction, and we want to be able to demonstrate the effects of different `scrollMargin` values.
 
 The `IntersectionObserver` is created with no `rootMargin`, a near-zero `threshold`, and a `scrollMargin` that takes its value from the `margin` input, and that will be applied to all sides of the scroll container.
@@ -247,7 +247,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 #### Results
 
-Scroll the down to display the carousel.
+Scroll down to display the carousel.
 The visible images should immediately load.
 If you scroll the carousel right, you should observe that the images are loaded as soon as the element becomes visible.
 

--- a/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
@@ -24,11 +24,6 @@ A string, formatted similarly to the CSS {{cssxref("margin")}} property's value.
 The specified margin defines offsets for one or more sides of a scroll container clipping rectangle.
 If `scrollMargin` isn't specified when the object was instantiated, it defaults to the string `"0px 0px 0px 0px"`.
 
-<!--
-The string returned by this property may not match the one specified when the {{domxref("IntersectionObserver")}} was instantiated.
-The browser is permitted to alter the values.
--->
-
 ## Example
 
 ### Carousel with scroll margin

--- a/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
@@ -1,0 +1,271 @@
+---
+title: "IntersectionObserver: scrollMargin property"
+short-title: scrollMargin
+slug: Web/API/IntersectionObserver/scrollMargin
+page-type: web-api-instance-property
+browser-compat: api.IntersectionObserver.scrollMargin
+---
+
+{{APIRef("Intersection Observer API")}}
+
+The **`scrollMargin`** read-only property of the {{domxref("IntersectionObserver")}} interface adds a margin to all nested {{glossary("scroll container","scroll containers")}} within the root element, including the root element if it is a scroll container.
+
+This grows or shrinks the clipping rectangle of the scrollable containers before calculating intersections.
+This lets you, for example, adjust the bounds of the scroll container so that the target element is considered visible even if a pixels are not yet displayed in the container's viewport, or to treat the target as partially hidden if an edge is too close to the edge of the container's bounding box.
+
+Note that if the root element is also a scrollable container, then the `scrollMargin` and {{domxref("IntersectionObserver/rootMargin","rootMargin")}} are combined to determine the effective bounding rectangle used for calculating intersections with the target.
+
+For more information see [The intersection root and root margin](/en-US/docs/Web/API/Intersection_Observer_API#the_intersection_root_and_scroll_margin) in the API overview.
+
+## Value
+
+A string, formatted similarly to the CSS {{cssxref("margin")}} property's value.
+
+The specified margin defines offsets for one or more sides of a scroll container clipping rectangle.
+If `scrollMargin` isn't specified when the object was instantiated, it defaults to the string `"0px 0px 0px 0px"`.
+
+<!--
+The string returned by this property may not match the one specified when the {{domxref("IntersectionObserver")}} was instantiated.
+The browser is permitted to alter the values.
+-->
+
+## Example
+
+### Carousel with scroll margin
+
+This example defines a scrollable box (the root element), which contains an image carousel that is initially out of view.
+An observer on the root element observes the image element targets within the carousel.
+When an image element starts to intersect with the root element, the image is loaded, the intersection is logged, and the observer is removed.
+
+The example allows you to modify the `scrollMargin` in order to see how this changes when targets within the carousel scrollable container start to intersect.
+
+#### HTML
+
+```html hidden
+<button id="reset" type="button">Reset</button>
+```
+
+The code below defines the `root_container` {{htmlelement("div")}} element, which we will use as the root element of the intersection observer.
+This in turn contains a {{htmlelement("p")}} element that is used to push the other elements out of view "by default", a `carousel` `<div>` , and a `marginIndicator` (used to indicate the size of the margin applied to scrollable elements within the root element).
+
+The {{htmlelement("img")}} elements within the carousel have a `data-src` attribute that contains a file name.
+In our observer code, we will use this attribute to set the `img.src` when each image starts to intersect with the root element, which will load the image.
+
+```html
+<div id="root_container">
+  <p>content before (scroll down to carousel)</p>
+
+  <div class="flexcontainer">
+    <div class="carousel">
+      <img
+        data-src="ballon-portrait.jpg"
+        class="lazy-carousel-img"
+        alt="Balloon portrait" />
+      <img
+        data-src="balloon-small.jpg"
+        class="lazy-carousel-img"
+        alt="balloon-small" />
+      <img data-src="surfer.jpg" class="lazy-carousel-img" alt="surfer" />
+      <img
+        data-src="border-diamonds.png"
+        class="lazy-carousel-img"
+        alt="border-diamonds" />
+      <img data-src="fire.png" class="lazy-carousel-img" alt="fire" />
+      <img data-src="puppy-header.jpg" class="lazy-carousel-img" alt="puppy" />
+      <img data-src="moon.jpg" class="lazy-carousel-img" alt="moon" />
+      <img data-src="rhino.jpg" class="lazy-carousel-img" alt="rhino" />
+    </div>
+    <div id="marginIndicator"></div>
+  </div>
+  <p>content after</p>
+</div>
+```
+
+```html
+<div class="controls">
+  <label>
+    Set the right margin of the scroll root:
+    <input id="margin" type="number" value="0" step="5" />px
+  </label>
+</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+```css
+#root_container {
+  height: 250px;
+  overflow-y: auto;
+  border: solid blue;
+}
+
+p {
+  height: 50vh;
+}
+
+.flexcontainer {
+  display: flex;
+}
+
+#marginIndicator {
+  position: relative;
+  height: 100px;
+  width: 1px;
+  background-color: red;
+  opacity: 0.5;
+  display: flex;
+}
+
+.carousel {
+  width: 300px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  display: flex;
+  border: solid;
+  /* outline: 200px solid rgba(0, 0, 0, 0.1); */
+}
+.carousel img {
+  scroll-snap-stop: always;
+  scroll-snap-align: start;
+  display: block;
+  width: 195px;
+  height: 99px;
+  min-width: 195px;
+  min-height: 99px;
+  margin-right: 10px;
+  background-color: #eee; /* Placeholder background */
+}
+
+.controls {
+  margin-top: 10px;
+}
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
+
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+The first part of the code defines function `createImageObserver()` that we use to create `IntersectionObserver` objects and assign to the `imageObserver` variable.
+We use a function because observer options can't be changed after construction, and we want to be able to demonstrate the effects of different `scrollMargin` values.
+
+The `IntersectionObserver` is created with no `rootMargin`, a near-zero `threshold`, and a `scrollMargin` that takes its value from the `margin` input, and that will be applied to all sides of the scroll container.
+
+The callback is called for all observed targets.
+For intersecting targets it sets the `img.src` to the name of the image to be loaded (from the `img.dataset.src`), logs the intersection, and then stops observing the image.
+
+The code at the end of the function calls {{domxref("IntersectionObserver.observe()")}} on each image to start the observer.
+
+```js
+let imageObserver;
+
+function createImageObserver() {
+  const carousel = document.querySelector(".carousel");
+  const lazyImages = carousel.querySelectorAll(".lazy-carousel-img");
+
+  if (imageObserver) {
+    imageObserver.disconnect();
+  }
+
+  let observerOptions = {
+    root: root_container,
+    rootMargin: "0px", // No extra margin
+    scrollMargin: `${margin.valueAsNumber}px`, // No extra margin / Can be set
+    threshold: 0.01, // Trigger when 1% of the image is visible
+  };
+
+  imageObserver = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        log(`intersect: ${img.dataset.src}`); // Only on first intersection
+        img.src = `https://mdn.github.io/shared-assets/images/examples/${img.dataset.src}`; // Load image by setting src
+        img.classList.remove("lazy-carousel-img"); // Remove the class
+        observer.unobserve(img); // Stop observing once loaded
+      }
+    });
+  }, observerOptions);
+
+  if (margin.valueAsNumber < 0) {
+    marginIndicator.style.width = `${-margin.valueAsNumber}px`;
+    marginIndicator.style.left = `${margin.valueAsNumber}px`;
+    marginIndicator.style.backgroundColor = "blue";
+  } else {
+    marginIndicator.style.width = `${margin.valueAsNumber}px`;
+    marginIndicator.style.left = "0px";
+    marginIndicator.style.backgroundColor = "green";
+  }
+
+  lazyImages.forEach((image) => {
+    imageObserver.observe(image); // Start observing each image
+  });
+}
+```
+
+The following code waits until the page is ready, and creates the observer using `createImageObserver()` on start and whenever the `margin` input value is changed.
+If the `IntersectionObserver` interface isn't supported, it loads all the images immediately.
+
+```js
+document.addEventListener("DOMContentLoaded", () => {
+  if ("IntersectionObserver" in window) {
+    createImageObserver();
+    margin.addEventListener("input", () => {
+      createImageObserver();
+    });
+  } else {
+    // Fallback for browsers that don't support Intersection Observer
+    // Loads all images immediately if Intersection Observer is not supported.
+    lazyImages.forEach((img) => {
+      img.src = img.dataset.src;
+      img.classList.remove("lazy-carousel-img");
+    });
+    console.warn(
+      "Intersection Observer not supported. All carousel images loaded.",
+    );
+  }
+});
+```
+
+#### Results
+
+Scroll the down to display the carousel.
+The visible images should immediately load.
+If you scroll the carousel right, you should observe that the images are loaded as soon as the element becomes visible.
+
+You can use the provided control to change the scroll margin percentage (after resetting the example)
+If you set a positive value like 20px the clip rectangle of the scroll container will be increased by 20px, and you should observe that images are detected and loaded before they come into view.
+Similarly, a negative value will mean that the intersection is detected once images are already in view.
+
+{{EmbedLiveSample("Carousel with scroll margin","100%","500px")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/intersectionobserver/trackvisibility/index.md
+++ b/files/en-us/web/api/intersectionobserver/trackvisibility/index.md
@@ -19,7 +19,7 @@ The value is set using the [`option.trackVisibility`](/en-US/docs/Web/API/Inters
 ## Description
 
 When not tracking visibility, the observer provides notifications when the target element is scrolled into the root element's viewport.
-However this doesn't tell you if the element is visible or has compromised visibility — it might be partially covered by another element, have reduced opacity, or be distorted by a filter, transform, or other modification.
+However this doesn't tell you if the target element has compromised visibility — it might be partially covered by another element, have reduced opacity, or be distorted by a filter, transform, or other modification.
 
 When tracking visibility, only elements that the browser considers to be visible are shown as intersecting.
 The algorithm is conservative, and may omit elements that are technically visible, such as those with only a slight opacity reduction.

--- a/files/en-us/web/api/intersectionobserver/trackvisibility/index.md
+++ b/files/en-us/web/api/intersectionobserver/trackvisibility/index.md
@@ -18,11 +18,11 @@ The value is set using the [`option.trackVisibility`](/en-US/docs/Web/API/Inters
 
 ## Description
 
-When not tracking visibility, the observer provides notifications when the element is scrolled into the window's viewport.
-However this doesn't tell you if the element is actually visible: it might be scrolled out of view inside a scrollable container or behind another element, or it might be "effectively invisible" due to an opacity change, filter, transform, or other modification.
+When not tracking visibility, the observer provides notifications when the target element is scrolled into the root element's viewport.
+However this doesn't tell you if the element is visible or has compromised visibility — it might be partially covered by another element, have reduced opacity, or be distorted by a filter, transform, or other modification.
 
 When tracking visibility, only elements that the browser considers to be visible are shown as intersecting.
-The algorithm is conservative, and may omit elements that are technically be visible, such as those with only a slight opacity reduction.
+The algorithm is conservative, and may omit elements that are technically visible, such as those with only a slight opacity reduction.
 
 Note that the calculation of visibility is computationally expensive.
 To avoid the operation running too often, a {{domxref("IntersectionObserver/delay","delay")}} is used to limit the minimum reporting period.

--- a/files/en-us/web/api/intersectionobserver/trackvisibility/index.md
+++ b/files/en-us/web/api/intersectionobserver/trackvisibility/index.md
@@ -1,0 +1,40 @@
+---
+title: "IntersectionObserver: trackVisibility property"
+short-title: trackVisibility
+slug: Web/API/IntersectionObserver/trackVisibility
+page-type: web-api-instance-property
+browser-compat: api.IntersectionObserver.trackVisibility
+---
+
+{{APIRef("Intersection Observer API")}}
+
+The **`trackVisibility`** read-only property of the {{domxref("IntersectionObserver")}} interface indicates whether the observer is tracking target visibility in addition to element intersections.
+
+## Value
+
+`true` if visibility is being tracked for intersection calculations, and `false` otherwise.
+
+The value is set using the [`option.trackVisibility`](/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#trackvisibility) argument to the `IntersectionObserver()` constructor.
+
+## Description
+
+When not tracking visibility, the observer provides notifications when the element is scrolled into the window's viewport.
+However this doesn't tell you if the element is actually visible: it might be scrolled out of view inside a scrollable container or behind another element, or it might be "effectively invisible" due to an opacity change, filter, transform, or other modification.
+
+When tracking visibility, only elements that the browser considers to be visible are shown as intersecting.
+The algorithm is conservative, and may omit elements that are technically be visible, such as those with only a slight opacity reduction.
+
+Note that the calculation of visibility is computationally expensive.
+To avoid the operation running too often, a {{domxref("IntersectionObserver/delay","delay")}} is used to limit the minimum reporting period.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Timing element visibility with the Intersection Observer API](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility)


### PR DESCRIPTION
FF141 adds support for [`IntersectionObserver.scrollMargin`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) in https://https://bugzilla.mozilla.org/show_bug.cgi?id=1860030.

This adds documentation for that property, and also for the `delay` and `trackVisibility` properties that now have implementations in some browsers.

Related docs work can be tracked in #40026
