### PR TITLE
IntersectionObserver/Entry layout/template changes

### DIFF
--- a/files/en-us/web/api/intersectionobserver/disconnect/index.md
+++ b/files/en-us/web/api/intersectionobserver/disconnect/index.md
@@ -8,9 +8,7 @@ browser-compat: api.IntersectionObserver.disconnect
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} method
-**`disconnect()`** stops watching all of its target elements
-for visibility changes.
+The **`disconnect()`** method of the {{domxref("IntersectionObserver")}} interface stops the observer watching all of its target elements for visibility changes.
 
 ## Syntax
 

--- a/files/en-us/web/api/intersectionobserver/observe/index.md
+++ b/files/en-us/web/api/intersectionobserver/observe/index.md
@@ -8,21 +8,14 @@ browser-compat: api.IntersectionObserver.observe
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} method
-**`observe()`** adds an element to the set of target elements
-being watched by the `IntersectionObserver`. One observer has one set of
-thresholds and one root, but can watch multiple target elements for visibility changes
-in keeping with those.
+The **`observe()`** method of the {{domxref("IntersectionObserver")}} interface adds an element to the set of target elements being watched by the `IntersectionObserver`.
+One observer has one set of thresholds and one root, but can watch multiple target elements for visibility changes in keeping with those.
 
-To stop observing the element, call
-{{domxref("IntersectionObserver.unobserve()")}}.
+To stop observing the element, call {{domxref("IntersectionObserver.unobserve()")}}.
 
-When the visibility of the specified element crosses over one of the observer's
-visibility thresholds (as listed in {{domxref("IntersectionObserver.thresholds")}}), the
-observer's callback is executed with an array of
-{{domxref("IntersectionObserverEntry")}} objects representing the intersection changes
-which occurred. Note that this design allows multiple elements' intersection changes to
-be processed by a single call to the callback.
+When the visibility of the specified element crosses over one of the observer's visibility thresholds (as listed in {{domxref("IntersectionObserver.thresholds")}}), the observer's callback is executed with an array of {{domxref("IntersectionObserverEntry")}} objects representing the intersection changes
+which occurred.
+Note that this design allows multiple elements' intersection changes to be processed by a single call to the callback.
 
 > [!NOTE]
 > The observer [callback](/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#callback) will always fire the first render cycle after `observe()` is called, even if the observed element has not yet moved with respect to the viewport.
@@ -38,9 +31,8 @@ observe(targetElement)
 ### Parameters
 
 - `targetElement`
-  - : An {{domxref("element")}} whose visibility within the root is to be monitored. This
-    element must be a descendant of the root element (or contained within the current
-    document, if the root is the document's viewport).
+  - : An {{domxref("element")}} whose visibility within the root is to be monitored.
+    This element must be a descendant of the root element (or contained within the current document, if the root is the document's viewport).
 
 ### Return value
 

--- a/files/en-us/web/api/intersectionobserver/root/index.md
+++ b/files/en-us/web/api/intersectionobserver/root/index.md
@@ -8,33 +8,20 @@ browser-compat: api.IntersectionObserver.root
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} interface's read-only
-**`root`** property identifies the {{domxref("Element")}} or
-{{domxref("Document")}} whose bounds are treated as the {{Glossary("bounding box")}}
-of the {{Glossary("viewport")}} for the element which is the observer's target.
+The **`root`** read-only property of the {{domxref("IntersectionObserver")}} interface identifies the {{domxref("Element")}} or {{domxref("Document")}} whose bounds are treated as the {{Glossary("bounding box")}} of the {{Glossary("viewport")}} for the element which is the observer's target.
 
-If the `root` is `null`, then the bounds of the actual document
-viewport are used.
+If the `root` is `null`, then the bounds of the actual document viewport are used.
 
 ## Value
 
-A {{domxref("Element")}} or {{domxref("Document")}} object whose bounding box is used
-as the bounds of the viewport for the purposes of determining how much of the target
-element is visible. The intersection of this bounding rectangle, offset by any margins
-specified in the options passed to the
-{{domxref("IntersectionObserver.IntersectionObserver", "IntersectionObserver()")}}
-constructor, the target element's bounds, minus the bounds of every element or other
-object which overlaps the target element, is considered to be the visible area of the
-target element.
+A {{domxref("Element")}} or {{domxref("Document")}} object whose bounding box is used as the bounds of the viewport for the purposes of determining how much of the target element is visible.
+The intersection of this bounding rectangle, offset by any margins specified in the options passed to the {{domxref("IntersectionObserver.IntersectionObserver", "IntersectionObserver()")}} constructor, the target element's bounds, minus the bounds of every element or other object which overlaps the target element, is considered to be the visible area of the target element.
 
-If `root` is `null`, then the owning document is used as the
-root, and the bounds its viewport (that is, the visible area of the document) are used
-as the root bounds.
+If `root` is `null`, then the owning document is used as the root, and the bounds its viewport (that is, the visible area of the document) are used as the root bounds.
 
 ## Examples
 
-This example sets the {{cssxref("border")}} of the intersection observer's root element
-to be a 2-pixel medium green line.
+This example sets the {{cssxref("border")}} of the intersection observer's root element to be a 2-pixel medium green line.
 
 ```js
 observer.root.style.border = "2px solid #44aa44";

--- a/files/en-us/web/api/intersectionobserver/rootmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/rootmargin/index.md
@@ -8,36 +8,23 @@ browser-compat: api.IntersectionObserver.rootMargin
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} interface's read-only
-**`rootMargin`** property is a string with syntax similar to
-that of the CSS {{cssxref("margin")}} property. Each side of the rectangle represented
-by `rootMargin` is added to the corresponding side in the
-{{domxref("IntersectionObserver.root", "root")}} element's {{Glossary("bounding box")}}
-before the intersection test is performed. This lets you, for example, adjust the bounds
-outward so that the target element is considered 100% visible even if a certain number
-of pixels worth of width or height is clipped away, or treat the target as partially
-hidden if an edge is too close to the edge of the root's bounding box.
+The **`rootMargin`** read-only property of the {{domxref("IntersectionObserver")}} interface is a string with syntax similar to that of the CSS {{cssxref("margin")}} property.
 
-See [how intersections are calculated](/en-US/docs/Web/API/Intersection_Observer_API#how_intersection_is_calculated)
-for a more in-depth look at the root margin and how it works with
-the root's bounding box.
+Each side of the rectangle represented by `rootMargin` is added to the corresponding side in the {{domxref("IntersectionObserver.root", "root")}} element's {{Glossary("bounding box")}} before the intersection test is performed.
+This lets you, for example, adjust the bounds outward so that the target element is considered 100% visible even if a certain number of pixels worth of width or height is clipped away, or treat the target as partially hidden if an edge is too close to the edge of the root's bounding box.
+
+See [how intersections are calculated](/en-US/docs/Web/API/Intersection_Observer_API#how_intersection_is_calculated) for a more in-depth look at the root margin and how it works with the root's bounding box.
 
 ## Value
 
-A string, formatted similarly to the CSS {{cssxref("margin")}} property's value, which
-contains offsets for one or more sides of the root's bounding box. These offsets are
-added to the corresponding values in the root's bounding box before the intersection
-between the resulting rectangle and the target element's bounds.
+A string, formatted similarly to the CSS {{cssxref("margin")}} property's value, which contains offsets for one or more sides of the root's bounding box.
+These offsets are added to the corresponding values in the root's bounding box before the intersection between the resulting rectangle and the target element's bounds.
 
-The string returned by this property may not match the one specified when the
-{{domxref("IntersectionObserver")}} was instantiated. The browser is permitted to alter
-the values
+The string returned by this property may not match the one specified when the {{domxref("IntersectionObserver")}} was instantiated.
+The browser is permitted to alter the values
 
-If `rootMargin` isn't specified when the object was instantiated, it
-defaults to the string `"0px 0px 0px 0px"`, meaning that the intersection
-will be computed between the root element's unmodified bounds rectangle and the target's
-bounds. [How intersections are calculated](/en-US/docs/Web/API/Intersection_Observer_API#how_intersection_is_calculated)
-describes how the `rootMargin` is used in more detail.
+If `rootMargin` isn't specified when the object was instantiated, it defaults to the string `"0px 0px 0px 0px"`, meaning that the intersection will be computed between the root element's unmodified bounds rectangle and the target's bounds.
+[How intersections are calculated](/en-US/docs/Web/API/Intersection_Observer_API#how_intersection_is_calculated) describes how the `rootMargin` is used in more detail.
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserver/takerecords/index.md
+++ b/files/en-us/web/api/intersectionobserver/takerecords/index.md
@@ -8,17 +8,11 @@ browser-compat: api.IntersectionObserver.takeRecords
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} method
-**`takeRecords()`** returns an array of
-{{domxref("IntersectionObserverEntry")}} objects, one for each targeted element which
-has experienced an intersection change since the last time the intersections were
-checked, either explicitly through a call to this method or implicitly by an automatic
-call to the observer's callback.
+The **`takeRecords()`** method of the {{domxref("IntersectionObserver")}} interface returns an array of {{domxref("IntersectionObserverEntry")}} objects, one for each targeted element which has experienced an intersection change since the last time the intersections were checked, either explicitly through a call to this method or implicitly by an automatic call to the observer's callback.
 
 > [!NOTE]
-> If you use the callback to monitor these changes, you don't
-> need to call this method. Calling this method clears the pending intersection list, so
-> the callback will not be run.
+> If you use the callback to monitor these changes, you don't need to call this method.
+> Calling this method clears the pending intersection list, so the callback will not be run.
 
 ## Syntax
 
@@ -32,9 +26,7 @@ None.
 
 ### Return value
 
-An array of {{domxref("IntersectionObserverEntry")}} objects, one for each target
-element whose intersection with the root has changed since the last time the
-intersections were checked.
+An array of {{domxref("IntersectionObserverEntry")}} objects, one for each target element whose intersection with the root has changed since the last time the intersections were checked.
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserver/thresholds/index.md
+++ b/files/en-us/web/api/intersectionobserver/thresholds/index.md
@@ -8,36 +8,23 @@ browser-compat: api.IntersectionObserver.thresholds
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} interface's read-only
-**`thresholds`** property returns the list of intersection
-thresholds that was specified when the observer was instantiated with
-{{domxref("IntersectionObserver.IntersectionObserver", "IntersectionObserver()")}}. If
-only one threshold ratio was provided when instantiating the object, this will be an
-array containing that single value.
+The **`thresholds`** read-only property of the {{domxref("IntersectionObserver")}} interface returns the list of intersection thresholds that was specified when the observer was instantiated with {{domxref("IntersectionObserver.IntersectionObserver", "IntersectionObserver()")}}.
 
-See the [Intersection Observer](/en-US/docs/Web/API/Intersection_Observer_API#thresholds) page to
-learn how thresholds work.
+If only one threshold ratio was provided when instantiating the object, this will be an array containing that single value.
+
+See the [Intersection Observer](/en-US/docs/Web/API/Intersection_Observer_API#thresholds) page to learn how thresholds work.
 
 ## Value
 
-An array of intersection thresholds, originally specified using the
-`threshold` property when instantiating the observer. If only one observer
-was specified, without being in an array, this value is a one-entry array containing
-that threshold. Regardless of the order your original `threshold` array was
-in, this one is always sorted in numerically increasing order.
+An array of intersection thresholds, originally specified using the `threshold` property when instantiating the observer.
+If only one observer was specified, without being in an array, this value is a one-entry array containing that threshold.
+Regardless of the order your original `threshold` array was in, this one is always sorted in numerically increasing order.
 
-If no `threshold` option was included when
-`IntersectionObserver()` was used to instantiate the observer, the value of
-`thresholds` is `[0]`.
+If no `threshold` option was included when `IntersectionObserver()` was used to instantiate the observer, the value of `thresholds` is `[0]`.
 
 > [!NOTE]
-> Although the `options` object you can specify when creating an
-> {{domxref("IntersectionObserver")}} has a field named
-> `threshold`, this property is called
-> `thresholds`. Confusing? Yes. If you accidentally use
-> `thresholds` as the name of the field in your `options`, the
-> `thresholds` array will wind up being `[0.0]`, which is likely
-> not what you expect. Debugging chaos may ensue.
+> Although the `options` object you can specify in the {{domxref("IntersectionObserver/IntersectionObserver","IntersectionObserver()")}} constructor has a field named `threshold`, this property is called `thresholds`.
+> If you accidentally use `thresholds` as the name of the field in your `options`, the `thresholds` array will wind up being `[0.0]`, which is likely not what you expect.
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserver/unobserve/index.md
+++ b/files/en-us/web/api/intersectionobserver/unobserve/index.md
@@ -8,10 +8,7 @@ browser-compat: api.IntersectionObserver.unobserve
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserver")}} method
-**`unobserve()`** instructs the
-`IntersectionObserver` to stop observing the specified target
-element.
+The **`unobserve()`** method of the {{domxref("IntersectionObserver")}} interface instructs the `IntersectionObserver` to stop observing the specified target element.
 
 ## Syntax
 
@@ -22,8 +19,8 @@ unobserve(target)
 ### Parameters
 
 - `target`
-  - : The {{domxref("Element")}} to cease observing. If the specified element isn't being
-    observed, this method does nothing and no exception is thrown.
+  - : The {{domxref("Element")}} to cease observing.
+    If the specified element isn't being observed, this method does nothing and no exception is thrown.
 
 ### Return value
 

--- a/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.md
@@ -8,22 +8,14 @@ browser-compat: api.IntersectionObserverEntry.boundingClientRect
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's read-only
-**`boundingClientRect`** property returns a
-{{domxref("DOMRectReadOnly")}} which in essence describes a rectangle describing the
-smallest rectangle that contains the entire target element.
+The **`boundingClientRect`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface returns a {{domxref("DOMRectReadOnly")}} which in essence describes a rectangle describing the smallest rectangle that contains the entire target element.
 
 ## Value
 
-A {{domxref("DOMRectReadOnly")}} which describes the smallest rectangle that contains
-every part of the target element whose intersection change is being described. This
-value is obtained using the same algorithm as
-{{domxref("Element.getBoundingClientRect()")}}, so refer to that article for details on
-precisely what is done to obtain this rectangle and what is and is not included within
-its bounds.
+A {{domxref("DOMRectReadOnly")}} which describes the smallest rectangle that contains every part of the target element whose intersection change is being described.
+This value is obtained using the same algorithm as {{domxref("Element.getBoundingClientRect()")}}, so refer to that article for details on precisely what is done to obtain this rectangle and what is and is not included within its bounds.
 
-In the general case, however, it's safe to think of this as the bounds rectangle of the
-target element.
+In the general case, however, it's safe to think of this as the bounds rectangle of the target element.
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserverentry/intersectionratio/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/intersectionratio/index.md
@@ -8,28 +8,18 @@ browser-compat: api.IntersectionObserverEntry.intersectionRatio
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's
-read-only **`intersectionRatio`** property tells you how much
-of the target element is currently visible within the root's intersection ratio, as a
-value between 0.0 and 1.0.
+The **`intersectionRatio`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface tells you how much of the target element is currently visible within the root's intersection ratio, as a value between 0.0 and 1.0.
 
 ## Value
 
-A number between 0.0 and 1.0 which indicates how much of the target element is actually
-visible within the root's intersection rectangle. More precisely, this value is the
-ratio of the area of the intersection rectangle
-({{domxref("IntersectionObserverEntry.intersectionRect", "intersectionRect")}}) to the
-area of the target's bounds rectangle
-({{domxref("IntersectionObserverEntry.boundingClientRect", "boundingClientRect")}}).
+A number between 0.0 and 1.0 which indicates how much of the target element is actually visible within the root's intersection rectangle.
+More precisely, this value is the ratio of the area of the intersection rectangle ({{domxref("IntersectionObserverEntry.intersectionRect", "intersectionRect")}}) to the area of the target's bounds rectangle ({{domxref("IntersectionObserverEntry.boundingClientRect", "boundingClientRect")}}).
 
-If the area of the target's bounds rectangle is zero, the returned value is 1 if
-{{domxref("IntersectionObserverEntry.isIntersecting", "isIntersecting")}} is
-`true` or 0 if not.
+If the area of the target's bounds rectangle is zero, the returned value is 1 if {{domxref("IntersectionObserverEntry.isIntersecting", "isIntersecting")}} is `true` or 0 if not.
 
 ## Examples
 
-In this simple example, an intersection callback sets each target element's
-{{cssxref("opacity")}} to the intersection ratio of that element with the root.
+In this simple example, an intersection callback sets each target element's {{cssxref("opacity")}} to the intersection ratio of that element with the root.
 
 ```js
 function intersectionCallback(entries) {
@@ -39,8 +29,7 @@ function intersectionCallback(entries) {
 }
 ```
 
-To see a more concrete example, take a look at
-[Handling intersection changes](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility#handling_intersection_changes).
+To see a more concrete example, take a look at [Handling intersection changes](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility#handling_intersection_changes).
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserverentry/intersectionrect/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/intersectionrect/index.md
@@ -8,28 +8,17 @@ browser-compat: api.IntersectionObserverEntry.intersectionRect
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's
-read-only **`intersectionRect`** property is a
-{{domxref("DOMRectReadOnly")}} object which describes the smallest rectangle that
-contains the entire portion of the target element which is currently visible within
-the intersection root.
+The **`intersectionRect`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface is a {{domxref("DOMRectReadOnly")}} object which describes the smallest rectangle that contains the entire portion of the target element which is currently visible within the intersection root.
 
 ## Value
 
-A {{domxref("DOMRectReadOnly")}} which describes the part of the target element that's
-currently visible within the root's intersection rectangle.
+A {{domxref("DOMRectReadOnly")}} which describes the part of the target element that's currently visible within the root's intersection rectangle.
 
-This rectangle is computed by taking the intersection of
-{{domxref("IntersectionObserverEntry", "boundingClientRect")}} with each of the
-{{domxref("IntersectionObserverEntry.target", "target")}}'s ancestors' clip rectangles,
-with the exception of the intersection {{domxref("IntersectionObserver.root", "root")}}
-itself.
+This rectangle is computed by taking the intersection of {{domxref("IntersectionObserverEntry", "boundingClientRect")}} with each of the {{domxref("IntersectionObserverEntry.target", "target")}}'s ancestors' clip rectangles, with the exception of the intersection {{domxref("IntersectionObserver.root", "root")}} itself.
 
 ## Examples
 
-In this simple example, an intersection callback stores the intersection rectangle for
-later use by the code that draws the target elements' contents, so that only the visible
-area is redrawn.
+In this simple example, an intersection callback stores the intersection rectangle for later use by the code that draws the target elements' contents, so that only the visible area is redrawn.
 
 ```js
 function intersectionCallback(entries) {

--- a/files/en-us/web/api/intersectionobserverentry/isintersecting/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/isintersecting/index.md
@@ -8,7 +8,7 @@ browser-compat: api.IntersectionObserverEntry.isIntersecting
 
 {{APIRef("Intersection Observer API")}}
 
-The *`isIntersecting`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface is a Boolean value which is `true` if the target element intersects with the intersection observer's root.
+The **`isIntersecting`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface is a Boolean value which is `true` if the target element intersects with the intersection observer's root.
 
 If this is `true`, then, the `IntersectionObserverEntry` describes a transition into a state of intersection; if it's `false`, then you know the transition is from intersecting to not-intersecting.
 

--- a/files/en-us/web/api/intersectionobserverentry/isintersecting/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/isintersecting/index.md
@@ -8,26 +8,17 @@ browser-compat: api.IntersectionObserverEntry.isIntersecting
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's
-read-only **`isIntersecting`** property is a Boolean value
-which is `true` if the target element intersects with the intersection
-observer's root. If this is `true`, then, the
-`IntersectionObserverEntry` describes a transition into a state of
-intersection; if it's `false`, then you know the transition is from
-intersecting to not-intersecting.
+The *`isIntersecting`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface is a Boolean value which is `true` if the target element intersects with the intersection observer's root.
+
+If this is `true`, then, the `IntersectionObserverEntry` describes a transition into a state of intersection; if it's `false`, then you know the transition is from intersecting to not-intersecting.
 
 ## Value
 
-A Boolean value which indicates whether the
-{{domxref("IntersectionObserverEntry.target", "target")}} element has transitioned into
-a state of intersection (`true`) or out of a state of intersection
-(`false`).
+A Boolean value which indicates whether the {{domxref("IntersectionObserverEntry.target", "target")}} element has transitioned into a state of intersection (`true`) or out of a state of intersection (`false`).
 
 ## Examples
 
-In this simple example, an intersection callback is used to update a counter of how
-many targeted elements are currently intersecting with the
-{{domxref("IntersectionObserver.root", "intersection root", "", 1)}}.
+In this simple example, an intersection callback is used to update a counter of how many targeted elements are currently intersecting with the {{domxref("IntersectionObserver.root", "intersection root", "", 1)}}.
 
 ```js
 function intersectionCallback(entries) {
@@ -41,8 +32,7 @@ function intersectionCallback(entries) {
 }
 ```
 
-To see a more concrete example, take a look at
-[Handling intersection changes](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility#handling_intersection_changes).
+To see a more concrete example, take a look at [Handling intersection changes](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility#handling_intersection_changes).
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserverentry/rootbounds/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/rootbounds/index.md
@@ -8,21 +8,15 @@ browser-compat: api.IntersectionObserverEntry.rootBounds
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's
-read-only **`rootBounds`** property is a
-{{domxref("DOMRectReadOnly")}} corresponding to the
-{{domxref("IntersectionObserverEntry.target", "target")}}'s root intersection
-rectangle, offset by the {{domxref("IntersectionObserver.rootMargin")}} if one is
-specified.
+The **`rootBounds`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface is a {{domxref("DOMRectReadOnly")}} corresponding to the {{domxref("IntersectionObserverEntry.target", "target")}}'s root intersection rectangle, offset by the {{domxref("IntersectionObserver.rootMargin")}} if one is specified.
 
 ## Value
 
-A {{domxref("DOMRectReadOnly")}} which describes the root intersection rectangle. For
-roots which are the {{domxref("Document")}}'s viewport, this rectangle is the bounds
-rectangle of the entire document. Otherwise, it's the bounds of the root element.
+A {{domxref("DOMRectReadOnly")}} which describes the root intersection rectangle.
+For roots which are the {{domxref("Document")}}'s viewport, this rectangle is the bounds rectangle of the entire document.
+Otherwise, it's the bounds of the root element.
 
-This rectangle is offset by the values in
-{{domxref("IntersectionObserver.rootMargin")}}.
+This rectangle is offset by the values in {{domxref("IntersectionObserver.rootMargin")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserverentry/target/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/target/index.md
@@ -8,22 +8,15 @@ browser-compat: api.IntersectionObserverEntry.target
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's
-read-only **`target`** property indicates which targeted
-{{domxref("Element")}} has changed its amount of intersection with the intersection
-root.
+The **`target`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface indicates which targeted {{domxref("Element")}} has changed its amount of intersection with the intersection root.
 
 ## Value
 
-The `IntersectionObserverEntry`'s `target` property specifies
-which {{domxref("Element")}} previously targeted by calling
-{{domxref("IntersectionObserver.observe()")}} experienced a change in intersection with
-the root.
+The `IntersectionObserverEntry`'s `target` property specifies which {{domxref("Element")}} previously targeted by calling {{domxref("IntersectionObserver.observe()")}} experienced a change in intersection with the root.
 
 ## Examples
 
-In this simple example, each targeted element's {{cssxref("opacity")}} is set to its
-{{domxref("IntersectionObserverEntry.intersectionRatio", "intersectionRatio")}}.
+In this simple example, each targeted element's {{cssxref("opacity")}} is set to its {{domxref("IntersectionObserverEntry.intersectionRatio", "intersectionRatio")}}.
 
 ```js
 function intersectionCallback(entries) {
@@ -33,8 +26,7 @@ function intersectionCallback(entries) {
 }
 ```
 
-To see a more concrete example, take a look at
-[Handling intersection changes](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility#handling_intersection_changes).
+To see a more concrete example, take a look at [Handling intersection changes](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility#handling_intersection_changes).
 
 ## Specifications
 

--- a/files/en-us/web/api/intersectionobserverentry/time/index.md
+++ b/files/en-us/web/api/intersectionobserverentry/time/index.md
@@ -8,22 +8,17 @@ browser-compat: api.IntersectionObserverEntry.time
 
 {{APIRef("Intersection Observer API")}}
 
-The {{domxref("IntersectionObserverEntry")}} interface's
-read-only **`time`** property is a
-{{domxref("DOMHighResTimeStamp")}} that indicates the time at which the intersection
-change occurred relative to the time at which the document was created.
+The **`time`** read-only property of the {{domxref("IntersectionObserverEntry")}} interface is a {{domxref("DOMHighResTimeStamp")}} that indicates the time at which the intersection change occurred relative to the time at which the document was created.
 
 ## Value
 
-A {{domxref("DOMHighResTimeStamp")}} which indicates the time at which the
-{{domxref("IntersectionObserverEntry.target", "target")}} element experienced the
-intersection change described by the `IntersectionObserverEntry`. The time is
-specified in milliseconds since the creation of the containing document.
+A {{domxref("DOMHighResTimeStamp")}} which indicates the time at which the {{domxref("IntersectionObserverEntry.target", "target")}} element experienced the
+intersection change described by the `IntersectionObserverEntry`.
+The time is specified in milliseconds since the creation of the containing document.
 
 ## Examples
 
-See [Timing element visibility with the Intersection Observer API](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility) for a complete example which
-uses the `time` property to track how long elements are visible to the user.
+See [Timing element visibility with the Intersection Observer API](/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility) for a complete example which uses the `time` property to track how long elements are visible to the user.
 
 ## Specifications
 


### PR DESCRIPTION
I'm doing some changes to the in Intersection API in #40040 for #40026

This does a bunch of pure layout changes to match the web API template, to make the other review easier.

There are no content changes.