### PR TITLE
Fix duplicated content in `<a>` 'Strong link text' example

### DIFF
--- a/files/en-us/web/html/reference/elements/a/index.md
+++ b/files/en-us/web/html/reference/elements/a/index.md
@@ -157,7 +157,7 @@ A sadly common mistake is to only link the words "click here" or "here":
 
 {{EmbedLiveSample('Inaccessible, weak link text')}}
 
-#### Strong link text
+#### Accessible, strong link text
 
 Luckily, this is an easy fix, and it's actually shorter than the inaccessible version!
 
@@ -167,7 +167,7 @@ Luckily, this is an easy fix, and it's actually shorter than the inaccessible ve
 
 ##### Result
 
-{{EmbedLiveSample('Strong link text')}}
+{{EmbedLiveSample('Accessible, strong link text')}}
 
 Assistive software has shortcuts to list all links on a page. However, strong link text benefits all users — the "list all links" shortcut emulates how sighted users quickly scan pages.
 

--- a/files/en-us/web/html/reference/elements/a/index.md
+++ b/files/en-us/web/html/reference/elements/a/index.md
@@ -155,7 +155,7 @@ A sadly common mistake is to only link the words "click here" or "here":
 
 ##### Result
 
-{{EmbedLiveSample('Inaccessible, weak link text')}}
+{{EmbedLiveSample('Inaccessible, weak link text', '100%', '50')}}
 
 #### Accessible, strong link text
 
@@ -167,7 +167,7 @@ Luckily, this is an easy fix, and it's actually shorter than the inaccessible ve
 
 ##### Result
 
-{{EmbedLiveSample('Accessible, strong link text')}}
+{{EmbedLiveSample('Accessible, strong link text', '100%', '50')}}
 
 Assistive software has shortcuts to list all links on a page. However, strong link text benefits all users — the "list all links" shortcut emulates how sighted users quickly scan pages.
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Updates [Accessibility / Strong link text](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#strong_link_text) example header to fix duplicated content in the EmbedLiveSample.

This also makes the header consistent with the weak example, which is "Inaccessible, weak link text".

Link: 

Example HTML: 

```
<p>Learn more <a href="/products">about our products</a>.</p>
```

Displayed example:
> Learn more about our products [here](https://44e1d5f9b44daf128070b2aca959480c668bebc5.mdnplay.dev/products).
>
> Learn more [about our products](https://44e1d5f9b44daf128070b2aca959480c668bebc5.mdnplay.dev/products).
