### PR TITLE
Fix content issues

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/useful_string_methods/index.md
+++ b/files/en-us/learn_web_development/core/scripting/useful_string_methods/index.md
@@ -234,7 +234,7 @@ const greetings = [
   "Happy Birthday!",
   "Merry Christmas my love",
   "A happy Christmas to all the family",
-  "You\'re all I want for Christmas",
+  "You're all I want for Christmas",
   "Get well soon",
 ];
 

--- a/files/en-us/web/api/document/createtouchlist/index.md
+++ b/files/en-us/web/api/document/createtouchlist/index.md
@@ -24,7 +24,7 @@ createTouchList(touch1, touch2, /* …, */ touchN)
 ### Parameters
 
 - `touch1`, …, `touchN`
-  - : Zero or more {{DOMxRef("Touch")}} objects. **Note:** Firefox also
+  - : Zero or more {{DOMxRef("Touch")}} objects. Firefox also
     accepts an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of
     {{DOMxRef("Touch")}} objects.
 

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -64,7 +64,7 @@ The passed objects may be {{domxref("TrustedHTML")}} instances or strings.
 It is much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 The guarantees that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
-Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document (without first calling {{domxref("document.open()")}}) automatically calls {{domxref("document.open()")}}, which will [clear the document](/en-US/docs/Web/API/Document/open#description).
+Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document (without first calling {{domxref("document.open()")}}) automatically calls {{domxref("document.open()")}}, which will clear the document.
 
 The exception is that if the `document.write()` call is embedded within an inline HTML `<script>` tag, then it will not automatically call `document.open()`:
 

--- a/files/en-us/web/api/domrectlist/index.md
+++ b/files/en-us/web/api/domrectlist/index.md
@@ -9,7 +9,8 @@ browser-compat: api.DOMRectList
 
 The **`DOMRectList`** interface represents a collection of {{domxref("DOMRect")}} objects, typically used to hold the rectangles associated with a particular element, like bounding boxes returned by methods such as {{domxref("Element.getClientRects", "getClientRects()")}}. It provides access to each rectangle in the list via its index, along with a `length` property that indicates the total number of rectangles in the list.
 
-> **Note**: `DOMRectList` exists for compatibility with legacy Web content and is not recommended to be used when creating new APIs.
+> [!NOTE]
+> `DOMRectList` exists for compatibility with legacy Web content and is not recommended to be used when creating new APIs.
 
 ## Instance properties
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/selected/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/selected/index.md
@@ -11,7 +11,7 @@ browser-compat: api.RTCStatsReport.type_candidate-pair.selected
 The **`selected`** property of the {{domxref("RTCIceCandidatePairStats")}} dictionary indicates whether or not the candidate pair described by the object is the one currently being used to communicate with the remote peer.
 
 This property is non-standard and is only supported by Firefox.
-The standard way to determine the selected candidate pair is to look at the [`selectedCandidatePairId`](/en-US/docs/Web/API/RTCTransportStats#selectedcandidatepairid) property of the stats object of type `transport`.
+The standard way to determine the selected candidate pair is to look at the [`selectedCandidatePairId`](/en-US/docs/Web/API/RTCTransportStats/selectedCandidatePairId) property of the stats object of type `transport`.
 
 ## Value
 

--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -58,7 +58,7 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
 - {{domxref("ShadowRoot.elementsFromPoint()")}} {{Non-standard_Inline}}
   - : Returns an array of all elements at the specified coordinates.
 - {{DOMxRef("ShadowRoot.setHTML()")}}
-  - : Provides an XSS-safe method to parse and sanitize a string of HTML into a {{domxref("DocumentFragment")}}, which then replaces the existing tree in the Shadow DOM.
+  - : Provides an XSS-safe method to parse and sanitize a string of HTML into a {{domxref("DocumentFragment")}}, which then replaces the existing tree in the shadow DOM.
 - {{DOMxRef("ShadowRoot.setHTMLUnsafe()")}}
   - : Parses a string of HTML into a document fragment, without sanitization, which then replaces the shadowroot's original subtree. The HTML string may include declarative shadow roots, which would be parsed as template elements the HTML was set using [`ShadowRoot.innerHTML`](/en-US/docs/Web/API/ShadowRoot/innerHTML).
 

--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -57,6 +57,8 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
   - : Returns the topmost element at the specified coordinates.
 - {{domxref("ShadowRoot.elementsFromPoint()")}} {{Non-standard_Inline}}
   - : Returns an array of all elements at the specified coordinates.
+- {{DOMxRef("ShadowRoot.setHTML()")}}
+  - : Provides an XSS-safe method to parse and sanitize a string of HTML into a {{domxref("DocumentFragment")}}, which then replaces the existing tree in the Shadow DOM.
 - {{DOMxRef("ShadowRoot.setHTMLUnsafe()")}}
   - : Parses a string of HTML into a document fragment, without sanitization, which then replaces the shadowroot's original subtree. The HTML string may include declarative shadow roots, which would be parsed as template elements the HTML was set using [`ShadowRoot.innerHTML`](/en-US/docs/Web/API/ShadowRoot/innerHTML).
 

--- a/files/en-us/web/api/webgl_api/index.md
+++ b/files/en-us/web/api/webgl_api/index.md
@@ -131,6 +131,8 @@ Below, you'll find an assortment of guides to help you learn WebGL concepts and 
 
 ### Advanced tutorials
 
+- [Compressed texture formats](/en-US/docs/Web/API/WebGL_API/Compressed_texture_formats)
+  - : How to enable and use compressed texture formats for better memory performance.
 - [WebGL model view projection](/en-US/docs/Web/API/WebGL_API/WebGL_model_view_projection)
   - : A detailed explanation of the three core matrices that are typically used to represent a 3D object view: the model, view and projection matrices.
 - [Matrix math for the web](/en-US/docs/Web/API/WebGL_API/Matrix_math_for_the_web)

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
@@ -29,7 +29,8 @@ Before you get started, you'll want to make sure you've [installed node](https:/
 ### Table of Contents
 
 1. [Setup](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup)
-2. [Connect Peers](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers)
+2. [Building the server](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Build_the_server)
+3. [Connect Peers](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers)
    1. [Get Microphone Permission](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission)
    2. [Showing and hiding HTML](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Show_hide_html)
    3. [Create a Peer Connection](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection)
@@ -37,6 +38,6 @@ Before you get started, you'll want to make sure you've [installed node](https:/
    5. [Answer a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call)
    6. [End a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/End_a_call)
 
-3. [Deployment and Further Reading](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading)
+4. [Deployment and Further Reading](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading)
 
 {{NextMenu("Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup")}}

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
@@ -26,18 +26,18 @@ Before you get started, you'll want to make sure you've [installed node](https:/
 > [!NOTE]
 > If you learn better by following step-by-step code, we've also provided this [tutorial in code](https://github.com/SamsungInternet/WebPhone/tree/master/tutorial), which you can use instead.
 
-### Table of Contents
+### Table of contents
 
 1. [Setup](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup)
 2. [Building the server](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Build_the_server)
-3. [Connect Peers](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers)
-   1. [Get Microphone Permission](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission)
+3. [Connecting the peers](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers)
+   1. [Getting browser microphone permission](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission)
    2. [Showing and hiding HTML](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Show_hide_html)
-   3. [Create a Peer Connection](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection)
-   4. [Creating a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Creating_a_call)
-   5. [Answer a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call)
-   6. [End a Call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/End_a_call)
+   3. [Creating a peer connection](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection)
+   4. [Creating a call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Creating_a_call)
+   5. [Answering a call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call)
+   6. [Ending a call](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/End_a_call)
 
-4. [Deployment and Further Reading](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading)
+4. [Deployment and further reading](/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading)
 
 {{NextMenu("Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup")}}

--- a/files/en-us/web/api/webrtc_api/index.md
+++ b/files/en-us/web/api/webrtc_api/index.md
@@ -173,6 +173,8 @@ These interfaces and events are used to process incoming and outgoing encoded vi
 
 ## Guides
 
+- [Introduction to the Real-time Transport Protocol (RTP)](/en-US/docs/Web/API/WebRTC_API/Intro_to_RTP)
+  - : The Real-time Transport Protocol (RTP), defined in {{RFC(3550)}}, is an IETF standard protocol to enable real-time connectivity for exchanging data that needs real-time priority. This article provides an overview of what RTP is and how it functions in the context of WebRTC.
 - [Introduction to WebRTC protocols](/en-US/docs/Web/API/WebRTC_API/Protocols)
   - : This article introduces the protocols on top of which the WebRTC API is built.
 - [WebRTC connectivity](/en-US/docs/Web/API/WebRTC_API/Connectivity)

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -170,7 +170,8 @@ function simulateClick() {
 <section id="Quick_links">
   <ol>
     <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
-    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
     <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
   </ol>
 </section>

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -171,7 +171,7 @@ function simulateClick() {
   <ol>
     <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
     <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
-    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a></li>
     <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
   </ol>
 </section>

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -90,7 +90,7 @@ controller.abort(); // removes any/all event handlers associated with this contr
   <ol>
     <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
     <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
-    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a></li>
     <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
   </ol>
 </section>

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -90,5 +90,7 @@ controller.abort(); // removes any/all event handlers associated with this contr
   <ol>
     <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
     <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
   </ol>
 </section>

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -827,5 +827,8 @@ This topic provides an index to the main _sorts_ of events you might be interest
 <section id="Quick_links">
   <ol>
     <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
-  </ol>{{ListSubpages}}
+    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
+  </ol>
 </section>

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -828,7 +828,7 @@ This topic provides an index to the main _sorts_ of events you might be interest
   <ol>
     <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
     <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
-    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Event reference</a></li>
+    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a></li>
     <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
   </ol>
 </section>

--- a/files/en-us/web/html/reference/attributes/index.md
+++ b/files/en-us/web/html/reference/attributes/index.md
@@ -278,7 +278,7 @@ Elements in HTML have **attributes**; these are additional values that configure
     </tr>
     <tr>
       <td>
-        <code><a href="/en-US/docs/Web/HTML/Reference/Elements/meta#content">content</a></code>
+        <code><a href="/en-US/docs/Web/HTML/Reference/Attributes/content">content</a></code>
       </td>
       <td>{{ HTMLElement("meta") }}</td>
       <td>

--- a/files/en-us/web/http/reference/headers/index.md
+++ b/files/en-us/web/http/reference/headers/index.md
@@ -159,7 +159,7 @@ For more information, refer to the [CORS documentation](/en-US/docs/Web/HTTP/Gui
 - {{HTTPHeader("Integrity-Policy")}}
   - : Ensures that all resources the user agent loads (of a certain type) have [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees.
 - {{HTTPHeader("Integrity-Policy-Report-Only")}}
-  - : Report on resources that the user agent loads that would violate [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees if the integrity policy was enforced (using the `Integrity-Policy` header).
+  - : Reports on resources that the user agent loads that would violate [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees if the integrity policy were enforced (using the `Integrity-Policy` header).
 
 ## Message body information
 

--- a/files/en-us/web/http/reference/headers/index.md
+++ b/files/en-us/web/http/reference/headers/index.md
@@ -154,6 +154,13 @@ For more information, refer to the [CORS documentation](/en-US/docs/Web/HTTP/Gui
   - : States the wish for a {{HTTPHeader("Repr-Digest")}} header.
     It is the `Repr-` analogue of {{HTTPHeader("Want-Content-Digest")}}.
 
+## Integrity policy
+
+- {{HTTPHeader("Integrity-Policy")}}
+  - : Ensures that all resources the user agent loads (of a certain type) have [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees.
+- {{HTTPHeader("Integrity-Policy-Report-Only")}}
+  - : Report on resources that the user agent loads that would violate [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees if the integrity policy was enforced (using the `Integrity-Policy` header).
+
 ## Message body information
 
 - {{HTTPHeader("Content-Length")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.md
@@ -40,9 +40,10 @@ Array(arrayLength)
 - `arrayLength`
   - : If the only argument passed to the `Array` constructor is an integer
     between 0 and 2<sup>32</sup> - 1 (inclusive), this returns a new JavaScript array with
-    its `length` property set to that number (**Note:** this
-    implies an array of `arrayLength` empty slots, not slots with actual
-    `undefined` values — see [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays)).
+    its `length` property set to that number.
+
+    > [!NOTE]
+    > This implies an array of `arrayLength` empty slots, not slots with actual `undefined` values — see [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays)).
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/statements/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/function_star_/index.md
@@ -234,18 +234,6 @@ function* f() {}
 const obj = new f(); // throws "TypeError: f is not a constructor
 ```
 
-### Generator defined in an expression
-
-```js
-const foo = function* () {
-  yield 10;
-  yield 20;
-};
-
-const bar = foo();
-console.log(bar.next()); // {value: 10, done: false}
-```
-
 ### Generator example
 
 ```js

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -70,6 +70,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 
 ### F
 
+- {{SVGAttr("fetchpriority")}}
 - {{SVGAttr("fill")}}
 - {{SVGAttr("fill-opacity")}}
 - {{SVGAttr("fill-rule")}}


### PR DESCRIPTION
Fix the following issues:

- Unnecessary string escape
- Remove unnecessary `**Note:**` or migrate to proper note
- Replace DT with its target
- Add some links to subpages