### PR TITLE
Improve word choice

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/floats/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/floats/index.md
@@ -325,7 +325,7 @@ You should see that the second paragraph now clears the floated element and no l
 
 ## Clearing boxes wrapped around a float
 
-You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box containing around _both_ elements.
+You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box containing _both_ elements.
 
 ### The problem
 

--- a/files/en-us/learn_web_development/core/css_layout/floats/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/floats/index.md
@@ -325,7 +325,7 @@ You should see that the second paragraph now clears the floated element and no l
 
 ## Clearing boxes wrapped around a float
 
-You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box wrapped around _both_ elements.
+You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box containing around _both_ elements.
 
 ### The problem
 


### PR DESCRIPTION
### Description

Replaced the structural use of “wrapped around” with “containing” in the float layout tutorial. This improves clarity and prevents confusion with the visual "wrap around" effect caused by floats.

### Motivation

This change aligns with the consistent use of terminology throughout the tutorial. Using “containing” for structural context avoids misleading overlap with the visual concept of "wrap around", making the explanation more accurate for beginners.

### Additional details

N/A

### Related issues and pull requests

Fixes #40070