### PR TITLE
Fix dir attribute firefox

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/floats/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/floats/index.md
@@ -325,7 +325,7 @@ You should see that the second paragraph now clears the floated element and no l
 
 ## Clearing boxes wrapped around a float
 
-You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box wrapped around _both_ elements.
+You now know how to clear something following a floated element, but let's see what happens if you have a tall float and a short paragraph, with a box containing around _both_ elements.
 
 ### The problem
 

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -55,7 +55,7 @@ This attribute is mandatory for the {{ HTMLElement("bdo") }} element where it ha
 
 This attribute is _not_ inherited by the {{ HTMLElement("bdi") }} element. If not set, its value is `auto`.
 
-Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields. Firefox uses <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> but does NOT update the `dir` attribute value.
+Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields. In recent versions of Firefox on Windows, pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> inside a <code>&lt;textarea&gt;</code> toggles text direction and also updates the <code>dir</code> attribute value.
 
 ## Specifications
 


### PR DESCRIPTION
Description
Updated the usage note regarding Firefox behavior with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> to reflect that recent versions now update the dir attribute when used inside a <textarea>.

Motivation
The previous note incorrectly stated that Firefox does not update the dir attribute. This fix improves accuracy for developers referencing MDN when handling text direction and writing modes.

Additional details
Behavior verified in recent versions of Firefox on Windows, where toggling text direction in a <textarea> using the shortcut also updates the dir attribute on the element.

Related issues and pull requests
Fixes #40016