### PR TITLE
Resolve ReferenceError by updating Start Game button handler in the 2D_Breakout_game_pure_JavaScript tutorial.

### DIFF
--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -285,7 +285,7 @@ function draw() {
 
 const runButton = document.getElementById("runButton");
 runButton.addEventListener("click", () => {
-  startGame();
+  draw();
   runButton.disabled = true;
 });
 ```


### PR DESCRIPTION
### Description
Fix for "Uncaught ReferenceError: startGame is not defined" in the 2D_Breakout_game_pure_JavaScript tutorial.

### Motivation
In an earlier step, the game was started using a `startGame()` function that used `setInterval` to repeatedly call `draw()`.

In the final step, `setInterval` was replaced with `requestAnimationFrame` inside `draw()`, and the `startGame()` function was removed. However, the Start Game button still attempts to call `startGame()`, which no longer exists, resulting in a runtime error.

This PR updates the code to call `draw()` directly instead, aligning with the final step to improve rendering with `requestAnimationFrame`.