### PR TITLE
http(cookies): document behavior of duplicate cookie names in Cookie header

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -55,7 +55,7 @@ This attribute is mandatory for the {{ HTMLElement("bdo") }} element where it ha
 
 This attribute is _not_ inherited by the {{ HTMLElement("bdi") }} element. If not set, its value is `auto`.
 
-Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields. In recent versions of Firefox on Windows, pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> inside a <code>&lt;textarea&gt;</code> toggles text direction and also updates the <code>dir</code> attribute value.
+Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields. In recent versions of Firefox on Windows, pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> inside a `<textarea>` toggles text direction and also updates the`dir` attribute value.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -55,7 +55,7 @@ This attribute is mandatory for the {{ HTMLElement("bdo") }} element where it ha
 
 This attribute is _not_ inherited by the {{ HTMLElement("bdi") }} element. If not set, its value is `auto`.
 
-Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields. Firefox uses <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> but does NOT update the `dir` attribute value.
+Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields. In recent versions of Firefox on Windows, pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> inside a <code>&lt;textarea&gt;</code> toggles text direction and also updates the <code>dir</code> attribute value.
 
 ## Specifications
 

--- a/files/en-us/web/http/reference/headers/cookie/index.md
+++ b/files/en-us/web/http/reference/headers/cookie/index.md
@@ -44,8 +44,7 @@ Cookies with the same name can coexist if they are set with different `Path`, `D
 
 However, if a cookie is set with the same name, path, domain, and partitioning context as an existing one, it will overwrite that cookie.
 
-{{Note("Some browsers isolate cookies by [partitioned contexts](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#partitioned_cookies), which can lead to cookies with the same name behaving independently based on their partition.")}}
-
+{{Note("Some browsers isolate cookies by [partitioned contexts](/en-US/docs/Web/API/Document/cookie#partitioned_cookies), which can lead to cookies with the same name behaving independently based on their partition.")}}
 
 ## Directives
 

--- a/files/en-us/web/http/reference/headers/cookie/index.md
+++ b/files/en-us/web/http/reference/headers/cookie/index.md
@@ -33,6 +33,20 @@ Cookie: name=value
 Cookie: name=value; name2=value2; name3=value3
 ```
 
+## Usage notes
+
+### Duplicate cookie names
+
+Cookies with the same name can coexist if they are set with different `Path`, `Domain`, or `Partitioned` attributes. For example, the following two `Set-Cookie` headers are valid and create distinct cookies:
+
+- `Set-Cookie: sessionId=abc123; Path=/app1`
+- `Set-Cookie: sessionId=xyz789; Path=/app2`
+
+However, if a cookie is set with the same name, path, domain, and partitioning context as an existing one, it will overwrite that cookie.
+
+{{Note("Some browsers isolate cookies by [partitioned contexts](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#partitioned_cookies), which can lead to cookies with the same name behaving independently based on their partition.")}}
+
+
 ## Directives
 
 - `<cookie-list>`


### PR DESCRIPTION
### Description

Added a "Duplicate cookie names" section under Usage notes on the `Cookie` header reference page. This explains how cookies with the same name can coexist if set with different `Path`, `Domain`, or `Partitioned` attributes, and how conflicts are resolved.

### Motivation

The MDN page lacked clarity about whether duplicate cookie names are allowed. This is a common point of confusion, and documenting it improves the accuracy and completeness of the HTTP Cookie reference.

### Additional details

Content is based on observed browser behavior and feedback from [issue #39562](https://github.com/mdn/content/issues/39562), including clarifications by MDN collaborators regarding cookie scope and overwriting rules.

### Related issues and pull requests

#39562