### PR TITLE
Additions to "Content with images must be labelled"

### DIFF
--- a/files/en-us/web/accessibility/guides/understanding_wcag/text_labels_and_names/index.md
+++ b/files/en-us/web/accessibility/guides/understanding_wcag/text_labels_and_names/index.md
@@ -228,7 +228,7 @@ As a best practice, also provide a {{htmlelement("title")}} for the document tha
 
 ## Content with images must be labeled
 
-Provide descriptive text for all contentful (that is, non-decorative) images and image-like elements. This includes SVG images, {{htmlelement("img")}}, {{htmlelement("canvas")}}, {{htmlelement("map")}}, and {{htmlelement("area")}} elements, as well as {{htmlelement("input")}} elements where `type=image` and {{htmlelement("object")}} elements where the `type` starts with `image/`. The typical way to do this is with the `alt` attribute, but for the {{htmlelement("canvas")}} element the `aria-label` attribute is needed instead. Be sure that the description conveys what is shown in the image.
+Provide descriptive text for all contentful (that is, non-decorative) images and image-like elements. This includes SVG images, {{htmlelement("img")}}, {{htmlelement("canvas")}}, {{htmlelement("map")}}, and {{htmlelement("area")}} elements, as well as {{htmlelement("input")}} elements where `type=image` and {{htmlelement("object")}} elements where the `type` starts with `image/`. The typical way to do this is with the `alt` attribute, but for elements that don't allow the `alt` attribute, such as {{htmlelement("canvas")}}, use [`role="img"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role) and [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) instead. Be sure that the description conveys what is shown in the image.
 
 For `alt` attributes on images which _are_ purely decorative, an empty value can be used to signal to accessibility tools that the element should be ignored.
 

--- a/files/en-us/web/accessibility/guides/understanding_wcag/text_labels_and_names/index.md
+++ b/files/en-us/web/accessibility/guides/understanding_wcag/text_labels_and_names/index.md
@@ -228,7 +228,9 @@ As a best practice, also provide a {{htmlelement("title")}} for the document tha
 
 ## Content with images must be labeled
 
-Provide descriptive text for all contentful (that is, non-decorative) images and image-like elements. This includes SVG images, {{htmlelement("img")}}, {{htmlelement("canvas")}}, {{htmlelement("map")}}, and {{htmlelement("area")}} elements, as well as {{htmlelement("input")}} elements where `type=image` and {{htmlelement("object")}} elements where the `type` starts with `image/`. The typical way to do this is with the `alt` attribute. Be sure that the description conveys what is shown in the image.
+Provide descriptive text for all contentful (that is, non-decorative) images and image-like elements. This includes SVG images, {{htmlelement("img")}}, {{htmlelement("canvas")}}, {{htmlelement("map")}}, and {{htmlelement("area")}} elements, as well as {{htmlelement("input")}} elements where `type=image` and {{htmlelement("object")}} elements where the `type` starts with `image/`. The typical way to do this is with the `alt` attribute, but for the {{htmlelement("canvas")}} element the `aria-label` attribute is needed instead. Be sure that the description conveys what is shown in the image.
+
+For `alt` attributes on images which *are* purely decorative, an empty value can be used to signal to accessibility tools that the element should be ignored.
 
 ### Example
 

--- a/files/en-us/web/accessibility/guides/understanding_wcag/text_labels_and_names/index.md
+++ b/files/en-us/web/accessibility/guides/understanding_wcag/text_labels_and_names/index.md
@@ -230,7 +230,7 @@ As a best practice, also provide a {{htmlelement("title")}} for the document tha
 
 Provide descriptive text for all contentful (that is, non-decorative) images and image-like elements. This includes SVG images, {{htmlelement("img")}}, {{htmlelement("canvas")}}, {{htmlelement("map")}}, and {{htmlelement("area")}} elements, as well as {{htmlelement("input")}} elements where `type=image` and {{htmlelement("object")}} elements where the `type` starts with `image/`. The typical way to do this is with the `alt` attribute, but for the {{htmlelement("canvas")}} element the `aria-label` attribute is needed instead. Be sure that the description conveys what is shown in the image.
 
-For `alt` attributes on images which *are* purely decorative, an empty value can be used to signal to accessibility tools that the element should be ignored.
+For `alt` attributes on images which _are_ purely decorative, an empty value can be used to signal to accessibility tools that the element should be ignored.
 
 ### Example
 


### PR DESCRIPTION
### Description

Mention that `canvas` needs `aria-label` rather than `alt`, and mention the use of `alt=""` to signal that an image is purely decorative.

### Motivation

I'm new to `canvas` and was confused when  the accessibility checker complained but the linked section only mentioned `alt`.

The existing text mentions that a label is needed for contentful images, but doesn't say how to stop the checker complaining for images that aren't contentful.

### Additional details

N/A

### Related issues and pull requests

N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
