### PR TITLE
Editorial review: Add information about pointer_composite_access WGSL extension

### DIFF
--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -30,7 +30,7 @@ The following WGSL language extensions are defined at [WGSL language extensions]
 - `pointer_composite_access`
   - : Enables WGSL shader code to access components of complex data types using the same dot (`.`) syntax whether you're working directly with the data or with a pointer to it.
 
-    Specifically, when `pointer_composite_access` is available:
+    When `pointer_composite_access` is available:
     - If `foo` is a pointer: `foo.bar` is available as a more convenient way to write `(*foo).bar`. The asterisk (`*`) would normally be needed to turn the pointer into a "reference" that can be dereferenced, but now both pointers and references are almost interchangeable.
     - If `foo` is not a pointer: The dot (`.`) operator works exactly as you're used to for directly accessing members.
     - if `pa` is a pointer that stores the starting address of an array, then `pa[i]` gives you direct access to the memory location where the `i`th element of that array is stored.

--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -28,7 +28,7 @@ The following WGSL language extensions are defined at [WGSL language extensions]
     - Packing and unpacking instructions with packed 4-component vectors of 8-bit integers (via built-in functions such as `pack4xI8()` and `pack4xI8Clamp()`).
 
 - `pointer_composite_access`
-  - : Enables syntactic sugar, allowing WGSL shader code to access components of complex data types using the same dot (`.`) syntax whether you're working directly with the data or with a pointer to it.
+  - : Enables WGSL shader code to access components of complex data types using the same dot (`.`) syntax whether you're working directly with the data or with a pointer to it.
 
     Specifically, when `pointer_composite_access` is available:
     - If `foo` is a pointer: `foo.bar` is available as a more convenient way to write `(*foo).bar`. The asterisk (`*`) would normally be needed to turn the pointer into a "reference" that can be dereferenced, but now both pointers and references are almost interchangeable.

--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -27,6 +27,16 @@ The following WGSL language extensions are defined at [WGSL language extensions]
     - 32-bit integer scalars packing 4-component vectors of 8-bit integers to be used as inputs to dot product instructions (via the `dot4U8Packed()` and `dot4I8Packed()` built-in functions).
     - Packing and unpacking instructions with packed 4-component vectors of 8-bit integers (via built-in functions such as `pack4xI8()` and `pack4xI8Clamp()`).
 
+- `pointer_composite_access`
+  - : Enables syntactic sugar, allowing WGSL shader code to access components of complex data types using the same dot (`.`) syntax whether you're working directly with the data or with a pointer to it.
+
+    Specifically, when `pointer_composite_access` is available:
+    - If `foo` is a pointer: `foo.bar` is available as a more convenient way to write `(*foo).bar`. The asterisk (`*`) would normally be needed to turn the pointer into a "reference" that can be dereferenced, but now both pointers and references are almost interchangeable.
+    - If `foo` is not a pointer: The dot (`.`) operator works exactly as you're used to for directly accessing members.
+    - if `pa` is a pointer that stores the starting address of an array, then `pa[i]` gives you direct access to the memory location where the `i`th element of that array is stored.
+
+    See [Syntax sugar for dereferencing composites in WGSL](https://developer.chrome.com/blog/new-in-webgpu-123#syntax_sugar_for_dereferencing_composites_in_wgsl) for further details and an example.
+
 - `readonly_and_readwrite_storage_textures`
   - : When available, allows the `"read-only"` and `"read-write"` [`storageTexture.access`](/en-US/docs/Web/API/GPUDevice/createBindGroupLayout#access) values to be set when specifying storage texture bind group entry types in a bind group layout. These enable WGSL code to read storage textures, and read/write storage textures, respectively.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Chrome 123 adds support for the `pointer_composite_access` WGSL extension. See https://developer.chrome.com/blog/new-in-webgpu-123#syntax_sugar_for_dereferencing_composites_in_wgsl.

This PR adds a brief description of the `pointer_composite_access` extension to the [WGSLLanguageFeatures](https://developer.mozilla.org/en-US/docs/Web/API/WGSLLanguageFeatures) reference page.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
