### PR TITLE
Ensure that syntax sections start with a code block

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -11,24 +11,12 @@ browser-compat: api.Document.cookie
 The {{domxref("Document")}} property `cookie` lets you read and write [cookies](/en-US/docs/Web/HTTP/Guides/Cookies) associated with the document.
 It serves as a getter and setter for the actual values of the cookies.
 
-## Syntax
+## Value
 
-### Read all cookies accessible from this location
-
-```js
-allCookies = document.cookie;
-```
-
-In the code above `allCookies` is a string containing a semicolon-separated list of all cookies (i.e., `key=value` pairs).
+A string containing a semicolon-separated list of all cookies (i.e., `key=value` pairs).
 Note that each _key_ and _value_ may be surrounded by whitespace (space and tab characters): in fact, {{RFC(6265)}} mandates a single space after each semicolon, but some user agents may not abide by this.
 
-### Write a new cookie
-
-```js
-document.cookie = newCookie;
-```
-
-In the code above, `newCookie` is a string of form `key=value`, specifying the cookie to set/update. Note that you can only set/update a single cookie at a time using this method. Consider also that:
+You can also assign to this property a string of the form `"key=value"`, specifying the cookie to set/update. Note that you can only set/update a single cookie at a time using this method. Consider also that:
 
 - Any of the following cookie attribute values can optionally follow the key-value pair, each preceded by a semicolon separator:
   - `;domain=domain` (e.g., `example.com` or `subdomain.example.com`): The host to which the cookie will be sent.
@@ -316,27 +304,27 @@ Read more about [Cookies and Security](https://humanwhocodes.com/blog/2009/05/12
 - [RFC 2965](https://datatracker.ietf.org/doc/html/rfc2965) (Section 5.3, "Implementation Limits") specifies that there should be **no maximum length** of a cookie's key or value size, and encourages implementations to support **arbitrarily large cookies**.
   Each browser's implementation maximum will necessarily be different, so consult individual browser documentation.
 
-The reason for the [syntax](#syntax) of the `document.cookie` accessor property is due to the client-server nature of cookies, which differs from other client-client storage methods (like, for instance, [localStorage](/en-US/docs/Web/API/Web_Storage_API)):
+The reason for the asymmetry between getting and setting the `document.cookie` accessor property is due to the client-server nature of cookies, which differs from other client-client storage methods (like, for instance, [localStorage](/en-US/docs/Web/API/Web_Storage_API)):
 
-### The server tells the client to store a cookie
+- The server tells the client to store a cookie:
 
-```bash
-HTTP/1.0 200 OK
-Content-type: text/html
-Set-Cookie: cookie_name1=cookie_value1
-Set-Cookie: cookie_name2=cookie_value2; expires=Sun, 16 Jul 3567 06:23:41 GMT
+  ```http
+  HTTP/1.0 200 OK
+  Content-type: text/html
+  Set-Cookie: cookie_name1=cookie_value1
+  Set-Cookie: cookie_name2=cookie_value2; expires=Sun, 16 Jul 3567 06:23:41 GMT
 
-[content of the page here]
-```
+  [content of the page here]
+  ```
 
-### The client sends back to the server its cookies previously stored
+- The client sends back to the server its cookies previously stored:
 
-```bash
-GET /sample_page.html HTTP/1.1
-Host: www.example.org
-Cookie: cookie_name1=cookie_value1; cookie_name2=cookie_value2
-Accept: */*
-```
+  ```http
+  GET /sample_page.html HTTP/1.1
+  Host: www.example.org
+  Cookie: cookie_name1=cookie_value1; cookie_name2=cookie_value2
+  Accept: */*
+  ```
 
 ## Specifications
 

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.md
@@ -14,13 +14,7 @@ object that is associated with the context. It might be [`null`](/en-US/docs/Web
 associated with a {{HTMLElement("canvas")}} element or an {{domxref("OffscreenCanvas")}}
 object.
 
-## Syntax
-
-```js-nolint
-gl.canvas
-```
-
-### Return value
+## Value
 
 Either a {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}} object or
 [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).

--- a/files/en-us/web/api/xrwebgllayer/antialias/index.md
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.md
@@ -17,13 +17,7 @@ property's value is `false`. The specific anti-aliasing technique used is left
 to the {{Glossary("user agent", "user agent's")}} discretion and cannot be specified by
 the website or web app.
 
-## Syntax
-
-```js-nolint
-xrWebGLLayer.antialias
-```
-
-### Value
+## Value
 
 A Boolean value which is `true` if the WebGL rendering layer's frame buffer
 is configured to support anti-aliasing. Otherwise, this property is `false`.

--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -26,14 +26,18 @@ As there are several ways to define the character encoding of a style sheet, the
 @charset "iso-8859-15";
 ```
 
-### Formal syntax
+### Parameters
+
+- _charset_
+  - : A {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the [IANA-registry](https://www.iana.org/assignments/character-sets/character-sets.xhtml), and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with _preferred_ must be used.
+
+## Formal syntax
+
+Note that the `@charset` rule is not parsed via syntax, but via a specific byte sequence of the following form:
 
 ```plain
 @charset "<charset>";
 ```
-
-- _charset_
-  - : A {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the [IANA-registry](https://www.iana.org/assignments/character-sets/character-sets.xhtml), and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with _preferred_ must be used.
 
 ## Examples
 

--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -17,6 +17,11 @@ The **`@color-profile`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CS
 }
 ```
 
+### Parameters
+
+- profile name
+  - : Either a {{cssxref("&lt;dashed-ident&gt;")}} or the identifier `device-cmyk`.
+
 ### Descriptors
 
 - `src`

--- a/files/en-us/web/css/@container/index.md
+++ b/files/en-us/web/css/@container/index.md
@@ -17,14 +17,6 @@ Once an eligible query container has been selected for an element, each containe
 
 ## Syntax
 
-```plain
-@container <container-condition># {
-  <stylesheet>
-}
-```
-
-For example:
-
 ```css
 /* With a <size-query> */
 @container (width > 400px) {
@@ -70,7 +62,7 @@ For example:
 }
 ```
 
-### Values
+### Parameters
 
 - `<container-condition>`
   - : An optional `<container-name>` and a `<container-query>`. Styles defined in the `<stylesheet>` are applied if the condition is true.
@@ -78,9 +70,6 @@ For example:
       - : Optional. The name of the container that the styles will be applied to when the query evaluates to true, specified as an {{cssxref("ident")}}.
     - `<container-query>`
       - : A set of features that are evaluated against the query container when the size, [`<style-feature>`](#container_style_queries), or scroll-state of the container changes.
-
-- `<stylesheet>`
-  - : A set of CSS rules or declarations.
 
 ### Logical keywords in container queries
 

--- a/files/en-us/web/css/@counter-style/index.md
+++ b/files/en-us/web/css/@counter-style/index.md
@@ -9,21 +9,17 @@ browser-compat: css.at-rules.counter-style
 
 The **`@counter-style`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/CSS_syntax/At-rule) lets you extend predefined list styles and define your own counter styles that are not part of the predefined set of styles. The `@counter-style` rule contains [descriptors](#descriptors) defining how the counter value is converted into a string representation.
 
+While CSS provides many useful predefined counter styles, the `@counter-style` at-rule offers an open-ended method for creating counters. This at-rule caters to the needs of worldwide typography by allowing authors to define their own counter styles when the predefined styles don't fit their requirements.
+
+## Syntax
+
 ```css
 @counter-style thumbs {
   system: cyclic;
   symbols: "\1F44D";
   suffix: " ";
 }
-
-ul {
-  list-style: thumbs;
-}
 ```
-
-While CSS provides many useful predefined counter styles, the `@counter-style` at-rule offers an open-ended method for creating counters. This at-rule caters to the needs of worldwide typography by allowing authors to define their own counter styles when the predefined styles don't fit their requirements.
-
-## Syntax
 
 The `@counter-style` at-rule is identified by a [counter style name](#counter_style_name), and the style of the named counter can be fine-tuned using a `<declaration-list>` consisting of one or more [descriptors](#descriptors) and their values.
 

--- a/files/en-us/web/css/@document/index.md
+++ b/files/en-us/web/css/@document/index.md
@@ -12,6 +12,8 @@ browser-compat: css.at-rules.document
 
 The **`@document`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/CSS_syntax/At-rule) restricts the style rules contained within it based on the URL of the document. It is designed primarily for user-defined style sheets (see [userchrome.org](https://www.userchrome.org/) for more information), though it can be used on author-defined style sheets, too.
 
+## Syntax
+
 ```css
 @document url("https://www.example.com/")
 {
@@ -20,8 +22,6 @@ The **`@document`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/CSS
   }
 }
 ```
-
-## Syntax
 
 An `@document` rule can specify one or more matching functions. If any of the functions apply to a given URL, the rule will take effect on that URL. The functions available are:
 

--- a/files/en-us/web/css/@font-feature-values/index.md
+++ b/files/en-us/web/css/@font-feature-values/index.md
@@ -53,8 +53,6 @@ Each `@font-feature-values` block contains a list of either feature value blocks
   }
 }
 
-…
-
 /* Apply the at-rules with a single declaration */
 .nice-look {
   font-variant-alternates: styleset(nice-style);

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -45,8 +45,6 @@ abbr {
 
 ## Syntax
 
-The `@media` at-rule may be placed at the top level of your code or nested inside any other conditional group at-rule.
-
 ```css
 /* At the top level of your code */
 @media screen and (min-width: 900px) {
@@ -64,6 +62,8 @@ The `@media` at-rule may be placed at the top level of your code or nested insid
   }
 }
 ```
+
+The `@media` at-rule may be placed at the top level of your code or nested inside any other conditional group at-rule.
 
 For a discussion of media query syntax, please see [Using media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax).
 

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -14,12 +14,6 @@ The **`prefers-reduced-motion`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-
 
 Such animations can trigger discomfort for those with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations such as scaling or panning large objects can be vestibular motion triggers.
 
-```css
-@media (prefers-reduced-motion: reduce) {
-  /* styles to apply if a user's device settings are set to reduced motion */
-}
-```
-
 ## Syntax
 
 - `no-preference`

--- a/files/en-us/web/css/@media/update/index.md
+++ b/files/en-us/web/css/@media/update/index.md
@@ -9,15 +9,7 @@ browser-compat: css.at-rules.media.update
 
 The **`update`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) can be used to test how frequently (if at all) the output device is able to modify the appearance of content once rendered.
 
-```css
-@media (update: < none | slow | fast >) {
-  /* styles to apply if the update frequency of the output device is a match */
-}
-```
-
 ## Syntax
-
-The `update` feature is specified as a single keyword value chosen from the list below.
 
 - `none`
   - : Once it has been rendered, the layout can no longer be updated. Example: documents printed on paper.

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -45,24 +45,20 @@ In JavaScript, `@supports` can be accessed via the CSS object model interface {{
 
 ## Syntax
 
-The `@supports` at-rule consists of a block of statements with a _supports condition._
-The supports condition is a set of one or more name-value pairs (e.g., `<property>: <value>`).
-
 ```css
 @supports (<supports-condition>) {
   /* If the condition is true, use the CSS in this block. */
 }
-```
 
-The conditions can be combined by conjunctions (`and`), disjunctions (`or`), and/or negations (`not`).
-
-```css
 @supports (<supports-condition>) and (<supports-condition>) {
   /* If both conditions are true, use the CSS in this block. */
 }
 ```
 
+The `@supports` at-rule consists of a block of statements with a _supports condition._
+The conditions can be combined by conjunctions (`and`), disjunctions (`or`), and/or negations (`not`).
 The precedence of operators can be defined with parentheses.
+
 Supports conditions can use either a `<property>: <value>` declaration syntax or a `<function()>` syntax.
 The following sections describe the use of each type of supports condition.
 

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -9,6 +9,8 @@ browser-compat: css.selectors.attribute
 
 The CSS **attribute selector** matches elements based on the element having a given attribute explicitly set, with options for defining an attribute value or substring value match.
 
+## Syntax
+
 ```css
 /* <a> elements with a title attribute */
 a[title] {
@@ -36,8 +38,6 @@ a[class~="logo"] {
   padding: 2px;
 }
 ```
-
-## Syntax
 
 - `[attr]`
   - : Represents elements with an attribute name of _attr_.

--- a/files/en-us/web/css/css_conditional_rules/index.md
+++ b/files/en-us/web/css/css_conditional_rules/index.md
@@ -52,7 +52,7 @@ There are plans to further extend possible queries by adding the generalized con
 
 ### data types
 
-- [`<container-name>`](/en-US/docs/Web/CSS/@container#values)
+- [`<container-name>`](/en-US/docs/Web/CSS/@container#container-name)
 - [`<style-feature>`](/en-US/docs/Web/CSS/@container#container_style_queries)
 - [Container relative `<length>` units](/en-US/docs/Web/CSS/length#container_query_length_units)
 - [`<media-query>`](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax)

--- a/files/en-us/web/http/reference/headers/available-dictionary/index.md
+++ b/files/en-us/web/http/reference/headers/available-dictionary/index.md
@@ -12,11 +12,11 @@ browser-compat: http.headers.Available-Dictionary
 
 The HTTP **`Available-Dictionary`** request header allows the browser to specify the best matching dictionary it has to allow the server to use {{glossary("Compression Dictionary Transport")}} for a resource request.
 
+Clients can send an `Available-Dictionary` header when they support `dcb` or `dcz` encodings. The header is a colon-surrounded base-64 encoded SHA-256 {{glossary("Hash_function", "hash")}} of the dictionary contents.
+
 See the [Compression Dictionary Transport guide](/en-US/docs/Web/HTTP/Guides/Compression_dictionary_transport) for more information.
 
 ## Syntax
-
-Clients can send an `Available-Dictionary` header when they support `dcb` or `dcz` encodings. The header is a colon-surrounded base-64 encoded SHA-256 {{glossary("Hash_function", "hash")}} of the dictionary contents.
 
 ```http
 Available-Dictionary: :<base64-hash>:

--- a/files/en-us/web/http/reference/headers/cache-control/index.md
+++ b/files/en-us/web/http/reference/headers/cache-control/index.md
@@ -34,6 +34,10 @@ The HTTP **`Cache-Control`** header holds _directives_ (instructions) in both re
 
 ## Syntax
 
+```http
+Cache-Control: <directive>, <directive>, ...
+```
+
 Cache directives follow these rules:
 
 - Caching directives are case-insensitive. However, lowercase is recommended because some implementations do not recognize uppercase directives.

--- a/files/en-us/web/http/reference/headers/content-security-policy/fenced-frame-src/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/fenced-frame-src/index.md
@@ -36,18 +36,15 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 
 ## Syntax
 
-One or more sources can be allowed for the `fenced-frame-src` policy:
-
 ```http
-Content-Security-Policy: fenced-frame-src <source>;
-Content-Security-Policy: fenced-frame-src <source> <source>;
+Content-Security-Policy: fenced-frame-src <source-expression-list>;
 ```
 
-A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions. For this directive, the following source expression values are applicable:
-
-- The [`<host-source>`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#host-source) value `"https:"`
-- The [`<scheme-source>`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#scheme-source) value `"https:"`
-- The string `"*"`
+- `<source-expression-list>`
+  - : A space-separated list of _source expression_ values. Resources of this type may be loaded if they match any of the given source expressions. For this directive, the following source expression values are applicable:
+    - The [`<host-source>`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#host-source) value `"https:"`
+    - The [`<scheme-source>`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#scheme-source) value `"https:"`
+    - The string `"*"`
 
 ## Examples
 

--- a/files/en-us/web/http/reference/headers/forwarded/index.md
+++ b/files/en-us/web/http/reference/headers/forwarded/index.md
@@ -34,12 +34,11 @@ The alternative and de-facto standard versions of this header are the {{HTTPHead
 
 ## Syntax
 
-The syntax for the forwarding header from a single proxy is shown below.
-Directives are `key=value` pairs, separated by a semicolon.
-
 ```http
 Forwarded: by=<identifier>;for=<identifier>;host=<host>;proto=<http|https>
 ```
+
+Directives are `key=value` pairs, separated by a semicolon.
 
 If there are multiple proxy servers between the client and server, they may each specify their own forwarding information.
 This can be done by adding a new `Forwarded` header to the end of the header block, or by appending the information to the end of the last `Forwarded` header in a comma-separated list.

--- a/files/en-us/web/http/reference/headers/proxy-authenticate/index.md
+++ b/files/en-us/web/http/reference/headers/proxy-authenticate/index.md
@@ -26,13 +26,11 @@ It is sent in a {{HTTPStatus("407", "407 Proxy Authentication Required")}} respo
 
 ## Syntax
 
-A comma-separated list of one or more authentication challenges:
-
 ```http
-Proxy-Authenticate: <challenge>
+Proxy-Authenticate: <challenge>, …
 ```
 
-Where a `<challenge>` is comprised of an `<auth-scheme>`, followed by an optional `<token68>` or a comma-separated list of `<auth-params>`:
+The value is a comma-separated list of challenges, where a `<challenge>` is comprised of an `<auth-scheme>`, followed by an optional `<token68>` or a comma-separated list of `<auth-params>`:
 
 ```plain
 challenge = <auth-scheme> <auth-param>, …, <auth-paramN>

--- a/files/en-us/web/http/reference/headers/sec-ch-ua-full-version-list/index.md
+++ b/files/en-us/web/http/reference/headers/sec-ch-ua-full-version-list/index.md
@@ -38,12 +38,11 @@ This is a feature designed to prevent servers from rejecting unknown user agents
 
 ## Syntax
 
-A comma separated list of brands in the user agent brand list, and their associated full version number.
-The syntax for a single entry has the following format:
-
 ```http
-Sec-CH-UA-Full-Version-List: "<brand>";v="<full version>", ...
+Sec-CH-UA-Full-Version-List: "<brand>";v="<full version>", …
 ```
+
+The value is a comma separated list of brands in the user agent brand list, and their associated full version number.
 
 ### Directives
 

--- a/files/en-us/web/http/reference/headers/sec-ch-ua/index.md
+++ b/files/en-us/web/http/reference/headers/sec-ch-ua/index.md
@@ -42,12 +42,11 @@ This is a feature designed to prevent servers from rejecting unknown user agents
 
 ## Syntax
 
-A comma separated list of brands in the user agent brand list, and their associated significant version number.
-The syntax for a single entry has the following format:
-
 ```http
 Sec-CH-UA: "<brand>";v="<significant version>", …
 ```
+
+The value is a comma separated list of brands in the user agent brand list, and their associated significant version number.
 
 ### Directives
 

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -34,16 +34,8 @@ The request header is automatically added by the browser based on its own capabi
 
 ## Syntax
 
-Request
-
 ```http
 Sec-WebSocket-Extensions: <extensions>
-```
-
-Response
-
-```http
-Sec-WebSocket-Extensions: <selected-extension>
 ```
 
 ## Directives

--- a/files/en-us/web/http/reference/headers/sec-websocket-protocol/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-protocol/index.md
@@ -46,7 +46,7 @@ Sec-WebSocket-Protocol: <sub-protocols>
   - : A comma-separated list of sub-protocol names, in the order of preference.
     The sub-protocols may be selected from the [IANA WebSocket Subprotocol Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name), or may be a custom name jointly understood by the client and the server.
 
-    As a response header, this should be a single sub-protocol selected by the server.
+    As a response header, this is a single sub-protocol that the server selected.
 
 ## Examples
 

--- a/files/en-us/web/http/reference/headers/sec-websocket-protocol/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-protocol/index.md
@@ -36,16 +36,8 @@ The sub-protocol selected by the server is made available to the web application
 
 ## Syntax
 
-Request:
-
 ```http
 Sec-WebSocket-Protocol: <sub-protocols>
-```
-
-Response:
-
-```http
-Sec-WebSocket-Protocol: <selected-sub-protocol>
 ```
 
 ## Directives
@@ -53,6 +45,8 @@ Sec-WebSocket-Protocol: <selected-sub-protocol>
 - `<sub-protocols>`
   - : A comma-separated list of sub-protocol names, in the order of preference.
     The sub-protocols may be selected from the [IANA WebSocket Subprotocol Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name), or may be a custom name jointly understood by the client and the server.
+
+    As a response header, this should be a single sub-protocol selected by the server.
 
 ## Examples
 

--- a/files/en-us/web/http/reference/headers/upgrade/index.md
+++ b/files/en-us/web/http/reference/headers/upgrade/index.md
@@ -32,8 +32,6 @@ For example, it can be used by a client to upgrade a connection from HTTP/1.1 to
 
 ## Syntax
 
-A comma-separated list of one or more protocols:
-
 ```http
 Upgrade: <protocol>[/<protocol_version>]
 Upgrade: <protocol>[/<protocol_version>], …, <protocolN>[/<protocol_versionN>]

--- a/files/en-us/web/http/reference/headers/vary/index.md
+++ b/files/en-us/web/http/reference/headers/vary/index.md
@@ -29,8 +29,6 @@ The same `Vary` header value should be used on all responses for a given URL, in
 
 ## Syntax
 
-Either `*` as a wildcard, or one or more header names in a comma-separated list:
-
 ```http
 Vary: *
 Vary: <header-name>, …, <header-nameN>

--- a/files/en-us/web/http/reference/headers/want-content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/want-content-digest/index.md
@@ -30,8 +30,6 @@ Some implementations may send unsolicited `Content-Digest` headers without requi
 
 ## Syntax
 
-A comma-separated list of one or more hashing algorithms:
-
 ```http
 Want-Content-Digest: <algorithm>=<preference>
 Want-Content-Digest: <algorithm>=<preference>, …, <algorithmN>=<preferenceN>

--- a/files/en-us/web/http/reference/headers/want-repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/want-repr-digest/index.md
@@ -30,8 +30,6 @@ Some implementations may send unsolicited `Repr-Digest` headers without requirin
 
 ## Syntax
 
-A comma-separated list of one or more hashing algorithms:
-
 ```http
 Want-Repr-Digest: <algorithm>=<preference>
 Want-Repr-Digest: <algorithm>=<preference>, …, <algorithmN>=<preferenceN>

--- a/files/en-us/web/http/reference/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/reference/headers/x-frame-options/index.md
@@ -30,8 +30,6 @@ The added security is provided only if the user accessing the document is using 
 
 ## Syntax
 
-There are two possible directives for `X-Frame-Options`:
-
 ```http
 X-Frame-Options: DENY
 X-Frame-Options: SAMEORIGIN
@@ -39,12 +37,10 @@ X-Frame-Options: SAMEORIGIN
 
 ### Directives
 
-If you specify `DENY`, not only will the browser attempt to load the page in a frame fail when loaded from other sites, attempts to do so will fail when loaded from the same site. On the other hand, if you specify `SAMEORIGIN`, you can still use the page in a frame as long as the site including it in a frame is the same as the one serving the page.
-
 - `DENY`
-  - : The page cannot be displayed in a frame, regardless of the site attempting to do so.
+  - : The page cannot be displayed in a frame, regardless of the site attempting to do so. Not only will the browser attempt to load the page in a frame fail when loaded from other sites, attempts to do so will fail when loaded from the same site.
 - `SAMEORIGIN`
-  - : The page can only be displayed if all ancestor frames are same origin to the page itself.
+  - : The page can only be displayed if all ancestor frames are same origin to the page itself. You can still use the page in a frame as long as the site including it in a frame is the same as the one serving the page.
 - `ALLOW-FROM origin` {{deprecated_inline}}
   - : This is an obsolete directive. Modern browsers that encounter response headers with this directive will ignore the header completely. The {{HTTPHeader("Content-Security-Policy")}} HTTP header has a {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} directive which you should use instead.
 

--- a/files/en-us/web/http/reference/headers/x-robots-tag/index.md
+++ b/files/en-us/web/http/reference/headers/x-robots-tag/index.md
@@ -35,8 +35,6 @@ Specifying indexing rules in a HTTP header is useful for non-HTML documents like
 
 ## Syntax
 
-One or more indexing rules as a comma-separated list:
-
 ```http
 X-Robots-Tag: <indexing-rule>
 X-Robots-Tag: <indexing-rule>, …, <indexing-ruleN>

--- a/files/en-us/web/uri/reference/fragment/text_fragments/index.md
+++ b/files/en-us/web/uri/reference/fragment/text_fragments/index.md
@@ -34,13 +34,11 @@ If the ID is changed or removed, the document fragment is ignored, and the link 
 
 ## Syntax
 
-In a similar manner to document fragments, text fragments are appended onto a URL after a hash symbol (`#`). The syntax however is a bit different:
-
 ```url
 https://example.com#:~:text=[prefix-,]textStart[,textEnd][,-suffix]
 ```
 
-The key parts to understand are as follows:
+Text fragments are a kind of URL fragment, and is written after the `#`. The key parts to understand are as follows:
 
 - `:~:`
   - : Otherwise known as _the fragment directive_, this sequence of characters tells the browser that what comes next is one or more user-agent instructions, which are stripped from the URL during loading so that author scripts cannot directly interact with them. User-agent instructions are also called directives.

--- a/files/en-us/web/uri/reference/path/index.md
+++ b/files/en-us/web/uri/reference/path/index.md
@@ -12,12 +12,12 @@ It contains data, usually organized in hierarchical form, to identify a resource
 
 ## Syntax
 
-A path consists of a sequence of path segments separated by a slash (`/`) character:
-
-```plain
+```url
 http://example.com:80<path>
 urn:<path>
 ```
+
+The path can contain nearly all characters, except `?` and `#` (which start the [query](/en-US/docs/Web/URI/Reference/Path) and [fragment](/en-US/docs/Web/URI/Reference/Fragment) respectively), and other characters reserved by the URI scheme. Some schemes (known as _hierarchical schemes_) further parse the path as a sequence of segments separated by slash (`/`) characters; others treat it as a single opaque string.
 
 ## Description
 

--- a/files/en-us/web/uri/reference/query/index.md
+++ b/files/en-us/web/uri/reference/query/index.md
@@ -12,11 +12,13 @@ It contains non-hierarchical data to identify a resource within the scope of the
 
 ## Syntax
 
-The query is indicated by the first question mark (`?`) character and is terminated by a number sign (`#`) or the end of the URI:
-
-```plain
-https://example.com/collection?<query>
+```url
+?query
 ```
+
+- `fragment`
+  - : A sequence of any characters, except for the `#` character, which starts the [fragment](/en-US/docs/Web/URI/Reference/Fragment).
+    The exact format of the query is defined by the resource itself.
 
 ## Description
 

--- a/files/en-us/web/uri/reference/schemes/data/index.md
+++ b/files/en-us/web/uri/reference/schemes/data/index.md
@@ -14,17 +14,18 @@ sidebar: urlsidebar
 
 ## Syntax
 
-Data URLs are composed of four parts: a prefix (`data:`), a [MIME type](/en-US/docs/Web/HTTP/Guides/MIME_types) indicating the type of data, an optional `base64` token if non-textual, and the data itself:
-
-```plain
+```url
 data:[<media-type>][;base64],<data>
 ```
 
-The `media-type` is a [MIME type](/en-US/docs/Web/HTTP/Guides/MIME_types) string, such as `'image/jpeg'` for a JPEG image file. If omitted, defaults to `text/plain;charset=US-ASCII`
-
-If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be {{Glossary("Percent-encoding", "percent-encoded")}}.
-
-If the data is textual, you can embed the text (using the appropriate entities or escapes based on the enclosing document's type). Otherwise, you can specify `base64` to embed base64-encoded binary data. You can find [a full dissection of MIME type structure](/en-US/docs/Web/HTTP/Guides/MIME_types) and [a table of common MIME types on the web](/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types).
+- `data:`
+  - : The scheme of the URL.
+- `<media-type>` {{optional_inline}}
+  - : The [MIME type](/en-US/docs/Web/HTTP/Guides/MIME_types) indicating the type of data, such as `image/jpeg` for a JPEG image file. If omitted, defaults to `text/plain;charset=US-ASCII`. You can find [a full dissection of MIME type structure](/en-US/docs/Web/HTTP/Guides/MIME_types) and [a table of common MIME types on the web](/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types).
+- `;base64` {{optional_inline}}
+  - : Indicates that the data should be base64-decoded; see [encoding data into base64 format](#encoding_data_into_base64_format).
+- `<data>`
+  - : The data itself. If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be {{Glossary("Percent-encoding", "percent-encoded")}}. If the data is textual, you can embed the text (using the appropriate entities or escapes based on the enclosing document's type). Otherwise, you can specify `base64` to embed base64-encoded binary data.
 
 A few examples:
 

--- a/files/en-us/web/uri/reference/schemes/javascript/index.md
+++ b/files/en-us/web/uri/reference/schemes/javascript/index.md
@@ -14,11 +14,14 @@ sidebar: urlsidebar
 
 ## Syntax
 
-JavaScript URLs start with the `javascript:` scheme and are followed by JavaScript code. The code will be parsed as a script.
-
 ```url
 javascript:<script>
 ```
+
+- `javascript:`
+  - : The scheme of the URL.
+- `<script>`
+  - : The JavaScript code to execute. The code will be parsed as a script.
 
 ## Description
 

--- a/files/en-us/web/uri/reference/schemes/resource/index.md
+++ b/files/en-us/web/uri/reference/schemes/resource/index.md
@@ -14,12 +14,14 @@ information is available to sites the browser connects to as well.
 
 ## Syntax
 
-Resource URLs are composed of two parts: a prefix (`resource:`), and a path
-pointing to the resource you want to load:
-
 ```url
 resource://<path>
 ```
+
+- `resource:`
+  - : The scheme of the URL.
+- `<path>`
+  - : A path pointing to the resource you want to load.
 
 An example:
 

--- a/files/en-us/web/uri/reference/schemes/urn/index.md
+++ b/files/en-us/web/uri/reference/schemes/urn/index.md
@@ -12,13 +12,9 @@ URNs provide globally-unique names for resources as opposed to providing informa
 
 ## Syntax
 
-An URN minimally consists of a Namespace Identifier (NID) and a Namespace Specific String (NSS):
-
 ```url
 urn:<NID>:<NSS>
 ```
-
-## Components
 
 - `<NID>`
   - : A NID (Namespace Identifier) is a case insensitive identifier for the namespace (e.g., `ISBN` and `isbn` are equivalent).


### PR DESCRIPTION
My checker parses all code blocks and lints them. However, most syntax blocks are not actually meant to be linted. To work around this, I added a rule that says "if the syntax section immediately starts with a code block, treat that code as pseudocode and do not lint it". It works really well, and there are only a few outliers where there's preceding text.

I checked through them, and found out that most of them is better off removing the introductory text. This results in a terser syntax section, and overall adheres to the general editorial conventions better.