### PR TITLE
Fix: remove incorrect "form" attribute

### DIFF
--- a/files/en-us/web/html/reference/elements/meter/index.md
+++ b/files/en-us/web/html/reference/elements/meter/index.md
@@ -46,8 +46,6 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   - : The lower numeric bound of the high end of the measured range. This must be less than the maximum value (`max` attribute), and it also must be greater than the low value and minimum value (`low` attribute and `min` attribute, respectively), if any are specified. If unspecified, or if greater than the maximum value, the `high` value is equal to the maximum value.
 - `optimum`
   - : This attribute indicates the optimal numeric value. It must be within the range (as defined by the `min` attribute and `max` attribute). When used with the `low` attribute and `high` attribute, it gives an indication where along the range is considered preferable. For example, if it is between the `min` attribute and the `low` attribute, then the lower range is considered preferred. The browser may color the meter's bar differently depending on whether the value is less than or equal to the optimum value.
-- `form`
-  - : This optional attribute is used to explicitly set a {{HTMLElement("form")}} owner for the `<meter>` element. If omitted, the `<meter>` is associated with its ancestor `<form>` element or the form association set by the `form` attribute on another ancestor element, such as on a {{HTMLElement("fieldset")}}, if any. If included, the value must be the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) of a `<form>` in the same tree.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Removed the incorrect `form` attribute on the `<meter>` element.

### Motivation

The `form` attribute on `<meter>` is not not mentioned in the spec and, to my knowledge, is not supported in any current browser implementation.

[HTML Living Standard – meter element](https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element)

### Additional details

The only references to the `form` attribute on `<meter>` I could find are from W3C:

[www.w3.org | 4.10.17 The meter element — HTML5: Edition for Web Authors](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-meter-element.html)

The page list `form` and says:

> The form attribute is used to explicitly associate the meter element with its form owner.

But it does not list `name`.

On the w3schools website there is an example that uses both `form` and `name`:

`<meter id="anna" form="form1" name="anna" min="0" low="40" high="90" max="100" value="95"></meter>`

[www.w3schools.com | HTML meter form Attribute](https://www.w3schools.com/tags/att_meter_form.asp)

The same page indicates the form attribute is **Not supported** in all browsers.

My guess is this originated from a typo or misinterpretation in earlier W3C drafts.