### PR TITLE
Remove all JS syntax errors caused by split code blocks

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
@@ -92,36 +92,23 @@ A popup on the toolbar button provides the extension's user interface. [context.
 
 All the extension's features are implemented through [context.js](https://github.com/mdn/webextensions-examples/blob/main/contextual-identities/context.js), which is invoked whenever the toolbar popup is displayed.
 
-The script first gets the 'identity-list' `<div>` from context.html.
-
-```js
-let div = document.getElementById("identity-list");
-```
-
-It then checks whether the contextual identities feature is turned on in the browser. If it's not on, information on how to activate it is added to the popup.
-
-```js
-if (browser.contextualIdentities === undefined) {
-  div.innerText =
-    "browser.contextualIdentities not available. Check that the privacy.userContext.enabled pref is set to true, and reload the add-on.";
-} else {
-```
+The script first gets the 'identity-list' `<div>` from context.html. It then checks whether the contextual identities feature is turned on in the browser. If it's not on, information on how to activate it is added to the popup.
 
 Firefox installs with the contextual identity feature turned off. It's turned on when an extension using the `contextualIdentities` API is installed. However, the user can turn the feature off using an option on the preferences page (about:preferences), hence the need for the check.
 
 The script now uses {{WebExtAPIRef("contextualIdentities.query")}} to determine whether any contextual identities are defined in the browser. If there are none, a message is added to the popup and the script stops.
 
 ```js
+const div = document.getElementById("identity-list");
+if (browser.contextualIdentities === undefined) {
+  div.innerText =
+    "browser.contextualIdentities not available. Check that the privacy.userContext.enabled pref is set to true, and reload the add-on.";
+} else {
   browser.contextualIdentities.query({}).then((identities) => {
     if (!identities.length) {
       div.innerText = "No identities returned from the API.";
       return;
     }
-```
-
-If there are contextual identities present—Firefox comes with four default identities—the script loops through each one adding its name, styled in its chosen color, to the `<div>` element. The function `createOptions()` then adds the options to "create" or "close all" to the `<div>` before it's added to the popup.
-
-```js
     for (const identity of identities) {
       const row = document.createElement("div");
       const span = document.createElement("span");
@@ -135,7 +122,11 @@ If there are contextual identities present—Firefox comes with four default ide
     }
   });
 }
+```
 
+If there are contextual identities present—Firefox comes with four default identities—the script loops through each one adding its name, styled in its chosen color, to the `<div>` element. The function `createOptions()` then adds the options to "create" or "close all" to the `<div>` before it's added to the popup.
+
+```js
 function createOptions(node, identity) {
   for (const option of ["Create", "Close All"]) {
     const a = document.createElement("a");
@@ -151,24 +142,19 @@ function createOptions(node, identity) {
 
 The script now waits for the user to select an option in the popup.
 
-```js
-function eventHandler(event) {
-```
-
 If the user clicks the option to create a tab for an identity, one is opened using {{WebExtAPIRef("tabs.create")}} by passing the identity's cookie store ID.
-
-```js
-if (event.target.dataset.action === "create") {
-  browser.tabs.create({
-    url: "about:blank",
-    cookieStoreId: event.target.dataset.identity,
-  });
-}
-```
 
 If the user selects the option to close all tabs for the identity, the script performs a {{WebExtAPIRef("tabs.query")}} to get all the tabs using the identity's cookie store. The script then passes this list of tabs to {{WebExtAPIRef("tabs.remove")}}.
 
 ```js
+function eventHandler(event) {
+  if (event.target.dataset.action === "create") {
+    browser.tabs.create({
+      url: "about:blank",
+      cookieStoreId: event.target.dataset.identity,
+    });
+  }
+
   if (event.target.dataset.action === "close-all") {
     browser.tabs
       .query({

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
@@ -118,7 +118,7 @@ let gettingActiveTab = browser.tabs.query({
 gettingActiveTab.then(updateTab);
 ```
 
-`updateTab()` first passes the active tab's URL to `isSupportedProtocol()`. If the protocol is one supported by bookmarks, the extension determines if the tab's URL is already bookmarked and if it is, calls `updateIcon()`.
+`updateTab()` first passes the active tab's URL to `isSupportedProtocol()`. If the protocol is supported by bookmarks, the extension determines whether the tab's URL is bookmarked and, if it is, calls `updateIcon()`.
 
 ```js
 function updateTab(tabs) {

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
@@ -118,13 +118,23 @@ let gettingActiveTab = browser.tabs.query({
 gettingActiveTab.then(updateTab);
 ```
 
-`updateTab()` first passes the active tab's URL to `isSupportedProtocol()`:
+`updateTab()` first passes the active tab's URL to `isSupportedProtocol()`. If the protocol is one supported by bookmarks, the extension determines if the tab's URL is already bookmarked and if it is, calls `updateIcon()`.
 
 ```js
-  function updateTab(tabs) {
-    if (tabs[0]) {
-      currentTab = tabs[0];
-      if (isSupportedProtocol(currentTab.url)) {
+function updateTab(tabs) {
+  if (tabs[0]) {
+    currentTab = tabs[0];
+    if (isSupportedProtocol(currentTab.url)) {
+      let searching = browser.bookmarks.search({ url: currentTab.url });
+      searching.then((bookmarks) => {
+        currentBookmark = bookmarks[0];
+        updateIcon();
+      });
+    } else {
+      console.log(`Bookmark it! does not support the '${currentTab.url}' URL.`);
+    }
+  }
+}
 ```
 
 `isSupportedProtocol()` determines if the URL displayed in the active tab is one that can be bookmarked. To extract the protocol from the tab's URL, the extension takes advantage of the [HTMLAnchorElement](/en-US/docs/Web/API/HTMLAnchorElement) by adding the tab's URL to an `<a>` element and then getting the protocol using the `protocol` property.
@@ -136,15 +146,6 @@ function isSupportedProtocol(urlString) {
   url.href = urlString;
   return supportedProtocols.includes(url.protocol);
 }
-```
-
-If the protocol is one supported by bookmarks, the extension determines if the tab's URL is already bookmarked and if it is, calls `updateIcon()`:
-
-```js
-      let searching = browser.bookmarks.search({ url: currentTab.url });
-      searching.then((bookmarks) => {
-        currentBookmark = bookmarks[0];
-        updateIcon();
 ```
 
 `updateIcon()` sets the toolbar button's icon and title, depending on whether the URL is bookmarked or not.

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_cookies_api/index.md
@@ -126,21 +126,20 @@ The extension's UI uses a toolbar button ({{WebExtAPIRef("browserAction")}}) imp
 
 [bgpicker.js](https://github.com/mdn/webextensions-examples/blob/main/cookie-bg-picker/popup/bgpicker.js) handles the selection of icon or entry of a color for the background in separate functions.
 
-To handle the icon buttons the script first gathers all the class names used for the buttons in the HTML file:
+To handle the icon buttons the script first gathers all the class names used for the buttons in the HTML file. It then loops through all the buttons assigning them their image and creating an `onclick` listener for each button:
 
 ```js
 let bgBtns = document.querySelectorAll(".bg-container button");
-```
 
-It then loops through all the buttons assigning them their image and creating an onclick listener for each button:
-
-```js
 for (let i = 0; i < bgBtns.length; i++) {
   let imgName = bgBtns[i].getAttribute("class");
   let bgImg = `url('images/${imgName}.png')`;
   bgBtns[i].style.backgroundImage = bgImg;
 
   bgBtns[i].onclick = (e) => {
+    // ...
+  };
+}
 ```
 
 When a button is clicked, its corresponding listener function gets the button class name and then the icon path which it passes to the page's content script ([updatebg.js](https://github.com/mdn/webextensions-examples/blob/main/cookie-bg-picker/content_scripts/updatebg.js)) using a message. The content script then applies the icon to the web page's background. Meanwhile, [bgpicker.js](https://github.com/mdn/webextensions-examples/blob/main/cookie-bg-picker/popup/bgpicker.js) stores the details of the icon applied to the background in a cookie:

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -158,6 +158,9 @@ function listTabs() {
     let counter = 0;
 
     tabsList.textContent = "";
+    // ...
+  });
+}
 ```
 
 Next, we'll create the links for each tab:
@@ -168,24 +171,33 @@ Next, we'll create the links for each tab:
    - The link's address is set using the tab's `id`.
 
 ```js
-for (const tab of tabs) {
-  if (!tab.active && counter <= limit) {
-    const tabLink = document.createElement("a");
+function listTabs() {
+  getCurrentWindowTabs().then((tabs) => {
+    // ...
+    for (const tab of tabs) {
+      if (!tab.active && counter <= limit) {
+        const tabLink = document.createElement("a");
 
-    tabLink.textContent = tab.title || tab.id;
+        tabLink.textContent = tab.title || tab.id;
 
-    tabLink.setAttribute("href", tab.id);
-    tabLink.classList.add("switch-tabs");
-    currentTabs.appendChild(tabLink);
-  }
+        tabLink.setAttribute("href", tab.id);
+        tabLink.classList.add("switch-tabs");
+        currentTabs.appendChild(tabLink);
+      }
 
-  counter += 1;
+      counter += 1;
+    }
+    // ...
+  });
 }
 ```
 
 Finally, the document fragment is written to the `<div id="tabs-list">` element:
 
 ```js
+function listTabs() {
+  getCurrentWindowTabs().then((tabs) => {
+    // ...
     tabsList.appendChild(currentTabs);
   });
 }
@@ -196,7 +208,8 @@ Finally, the document fragment is written to the `<div id="tabs-list">` element:
 Another related example feature is the "Alert active tab" info option that dumps all the {{WebExtAPIRef("tabs.Tab")}} object properties for the active tab into an alert:
 
 ```js
-else if (e.target.id === "tabs-alert-info") {
+// Other if conditions...
+if (e.target.id === "tabs-alert-info") {
   callOnActiveTab((tab) => {
     let props = "";
     for (const item in tab) {
@@ -389,22 +402,23 @@ Let's take a look at how the zoom in is implemented.
     For the zoom in feature, this runs:
 
     ```js
-      else if (e.target.id === "tabs-add-zoom") {
-        callOnActiveTab((tab) => {
-          browser.tabs.getZoom(tab.id).then((zoomFactor) => {
-            // The maximum zoomFactor is 5, it can't go higher
-            if (zoomFactor >= MAX_ZOOM) {
-              alert("Tab zoom factor is already at max!");
-            } else {
-              let newZoomFactor = zoomFactor + ZOOM_INCREMENT;
-              // If the newZoomFactor is set to higher than the max accepted
-              // it won't change, and will never alert that it's at maximum
-              newZoomFactor = newZoomFactor > MAX_ZOOM ? MAX_ZOOM : newZoomFactor;
-              browser.tabs.setZoom(tab.id, newZoomFactor);
-            }
-          });
+    // Other if conditions...
+    if (e.target.id === "tabs-add-zoom") {
+      callOnActiveTab((tab) => {
+        browser.tabs.getZoom(tab.id).then((zoomFactor) => {
+          // The maximum zoomFactor is 5, it can't go higher
+          if (zoomFactor >= MAX_ZOOM) {
+            alert("Tab zoom factor is already at max!");
+          } else {
+            let newZoomFactor = zoomFactor + ZOOM_INCREMENT;
+            // If the newZoomFactor is set to higher than the max accepted
+            // it won't change, and will never alert that it's at maximum
+            newZoomFactor = newZoomFactor > MAX_ZOOM ? MAX_ZOOM : newZoomFactor;
+            browser.tabs.setZoom(tab.id, newZoomFactor);
+          }
         });
-      }
+      });
+    }
     ```
 
     This code uses `callOnActiveTab()` to get the details of the active tab, then {{WebExtAPIRef("tabs.getZoom")}} gets the tab's current zoom factor. The current zoom is compared to the defined maximum (`MAX_ZOOM`) and an alert issued if the tab is already at the maximum zoom. Otherwise, the zoom level is incremented but limited to the maximum zoom, then the zoom is set with {{WebExtAPIRef("tabs.getZoom")}}.

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -412,7 +412,7 @@ Let's take a look at how the zoom in is implemented.
           } else {
             let newZoomFactor = zoomFactor + ZOOM_INCREMENT;
             // If the newZoomFactor is set to higher than the max accepted
-            // it won't change, and will never alert that it's at maximum
+            // it won't change, and does not alert that it's at maximum
             newZoomFactor = newZoomFactor > MAX_ZOOM ? MAX_ZOOM : newZoomFactor;
             browser.tabs.setZoom(tab.id, newZoomFactor);
           }

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -280,46 +280,11 @@ Let's add the class to a button (a button which does nothing).
 <button>Styled Button</button>
 ```
 
-```js hidden
-// get the element
-const button = document.querySelector("button");
-
-// Retrieve all computed styles with computedStyleMap()
-const allComputedStyles = button.computedStyleMap();
-
-// CSSMathSum Example
-let btnWidth = allComputedStyles.get("width");
-
-console.log(btnWidth); // CSSMathSum
-console.log(btnWidth.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
-console.log(btnWidth.operator); // 'sum'
-
-// CSSTransformValue
-let transform = allComputedStyles.get("transform");
-
-console.log(transform); // CSSTransformValue {0: CSSScale, 1: CSSTranslate, length: 2, is2D: true}
-console.log(transform.length); // 1
-console.log(transform[0]); // CSSScale {x: CSSUnitValue, y: CSSUnitValue, z: CSSUnitValue, is2D: true}
-console.log(transform[0].x); // CSSUnitValue {value: 0.95, unit: "number"}
-console.log(transform[0].y); // CSSUnitValue {value: 0.95, unit: "number"}
-console.log(transform[0].z); // CSSUnitValue {value: 1, unit: "number"}
-console.log(transform.is2D); // true
-
-// CSSImageValue
-let bgImage = allComputedStyles.get("background-image");
-
-console.log(bgImage); // CSSImageValue
-console.log(bgImage.toString()); // url("magic-wand.png")
-
-// CSSUnparsedValue
-let unit = allComputedStyles.get("--unit");
-
-console.log(unit);
-
-let parsedUnit = CSSNumericValue.parse(unit);
-console.log(parsedUnit);
-console.log(parsedUnit.unit);
-console.log(parsedUnit.value);
+```html hidden
+<p>
+  There is nothing to see here. Please open your browser console to see the
+  output!
+</p>
 ```
 
 We grab our `StylePropertyMapReadOnly` with the following JavaScript:
@@ -404,7 +369,11 @@ When we `get()` the `'background-image'`, a {{domxref('CSSImageValue')}} is retu
 
 Notice that the value returned is the absolute path to the image — this is returned even if the original `url()` value was relative. Had the background image been a gradient or multiple background images, `.get('background-image')` would have returned a `CSSStyleValue`. The `CSSImageValue` is returned only if there is a single image, and only if that single image declaration is a URL.
 
-### Summary
+Finally, we put all this together in one live sample. Remember to use your browser's console to inspect the output.
+
+{{EmbedLiveSample("CSSStyleValue", 120, 300)}}
+
+## Summary
 
 This should get you started with understanding the CSS Typed OM. Take a look at all the [CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API) interfaces to learn more.
 

--- a/files/en-us/web/api/document_object_model/examples/index.md
+++ b/files/en-us/web/api/document_object_model/examples/index.md
@@ -59,28 +59,28 @@ objOutput.innerHTML = strHtml;
 
 {{EmbedLiveSample("example_1_height_and_width", "", "300")}}
 
-## Example 2: Image Attributes
+## Example 2: border styles
 
 ```html
-<p>
-  <img id="img1" src="image1.gif" width="100" height="100" alt="border test" />
-</p>
+<div id="box"></div>
 
 <form name="FormName">
-  <input type="button" id="btn1" value="Make border 20px-wide" />
-  <input type="button" id="btn2" value="Make border 5px-wide" />
+  <button id="btn1">Make border 20px-wide</button>
+  <button id="btn2">Make border 5px-wide</button>
 </form>
 ```
 
 ```css
-#img1 {
+#box {
   border: 5px solid green;
+  width: 100px;
+  height: 100px;
 }
 ```
 
 ```js
 function setBorderWidth(width) {
-  document.getElementById("img1").style.borderWidth = `${width}px`;
+  document.getElementById("box").style.borderWidth = `${width}px`;
 }
 
 document.getElementById("btn1").addEventListener("click", () => {
@@ -91,7 +91,7 @@ document.getElementById("btn2").addEventListener("click", () => {
 });
 ```
 
-{{EmbedLiveSample("example_2_image_attributes", "", "200")}}
+{{EmbedLiveSample("example_2_border_styles", "", "200")}}
 
 ## Example 3: Manipulating Styles
 

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -46,43 +46,49 @@ function addData(e) {
       "Data not submitted — form incomplete.";
     return;
   }
+  // ...
+}
 ```
 
 In this segment, we check to see if the form fields have all been filled in. If not, we drop a message into our developer notifications pane (see the bottom left of the app UI) to tell the user what is going on, and exit out of the function. This step is mainly for browsers that don't support HTML form validation (I have used the `required` attribute in my HTML to force validation, in those that do.)
 
 ```js
-  else {
-    const newItem = [
-      {
-        taskTitle: title.value,
-        hours: hours.value,
-        minutes: minutes.value,
-        day: day.value,
-        month: month.value,
-        year: year.value,
-        notified: "no",
-      },
-    ];
+function addData(e) {
+  // ...
+  const newItem = [
+    {
+      taskTitle: title.value,
+      hours: hours.value,
+      minutes: minutes.value,
+      day: day.value,
+      month: month.value,
+      year: year.value,
+      notified: "no",
+    },
+  ];
 
-    // open a read/write db transaction, ready for adding the data
-    const transaction = db.transaction(["toDoList"], "readwrite");
+  // open a read/write db transaction, ready for adding the data
+  const transaction = db.transaction(["toDoList"], "readwrite");
 
-    // report on the success of opening the transaction
-    transaction.oncomplete = (event) => {
-      note.appendChild(document.createElement("li")).textContent =
-        "Transaction opened for task addition.";
-    };
+  // report on the success of opening the transaction
+  transaction.oncomplete = (event) => {
+    note.appendChild(document.createElement("li")).textContent =
+      "Transaction opened for task addition.";
+  };
 
-    transaction.onerror = (event) => {
-      note.appendChild(document.createElement("li")).textContent =
-        "Transaction not opened due to error. Duplicate items not allowed.";
-    };
+  transaction.onerror = (event) => {
+    note.appendChild(document.createElement("li")).textContent =
+      "Transaction not opened due to error. Duplicate items not allowed.";
+  };
 
-    // create an object store on the transaction
-    const objectStore = transaction.objectStore("toDoList");
+  // create an object store on the transaction
+  const objectStore = transaction.objectStore("toDoList");
 
-    // add our newItem object to the object store
-    const request = objectStore.add(newItem[0]);
+  // add our newItem object to the object store
+  const request = objectStore.add(newItem[0]);
+
+  // ...
+}
 ```
 
 In this section we create an object called `newItem` that stores the data in the format required to insert it into the database. The next few lines open the database transaction and provide messages to notify the user if this was successful or failed. Then an `objectStore` is created into which the new item is added. The `notified` property of the data object indicates that the to-do list item's deadline has not yet come up and been notified - more on this later!
@@ -91,29 +97,25 @@ In this section we create an object called `newItem` that stores the data in the
 > The `db` variable stores a reference to the IndexedDB database instance; we can then use various properties of this variable to manipulate the data.
 
 ```js
-    request.onsuccess = (event) => {
-      note.appendChild(document.createElement("li")).textContent =
-        "New item added to database.";
+function addData(e) {
+  // ...
+  request.onsuccess = (event) => {
+    note.appendChild(document.createElement("li")).textContent =
+      "New item added to database.";
 
-      title.value = "";
-      hours.value = null;
-      minutes.value = null;
-      day.value = "01";
-      month.value = "January";
-      year.value = 2020;
-    };
-  }
-```
-
-This next section creates a log message to say the new item addition is successful, and resets the form so it's ready for the next task to be entered.
-
-```js
+    title.value = "";
+    hours.value = null;
+    minutes.value = null;
+    day.value = "01";
+    month.value = "January";
+    year.value = 2020;
+  };
   // update the display of data to show the newly added item, by running displayData() again.
   displayData();
 }
 ```
 
-Last of all, we run the `displayData()` function, which updates the display of data in the app to show the new task that was just entered.
+This next section creates a log message to say the new item addition is successful, and resets the form so it's ready for the next task to be entered. Last of all, we run the `displayData()` function, which updates the display of data in the app to show the new task that was just entered.
 
 ### Checking whether a deadline has been reached
 
@@ -122,21 +124,20 @@ At this point our data is in the database; now we want to check whether any of t
 ```js
 function checkDeadlines() {
   const now = new Date();
+  const minuteCheck = now.getMinutes();
+  const hourCheck = now.getHours();
+  const dayCheck = now.getDate();
+  const monthCheck = now.getMonth();
+  const yearCheck = now.getFullYear();
+  // ...
+}
 ```
 
-First we grab the current date and time by creating a blank `Date` object. Easy huh? It's about to get a bit more complex.
+First we grab the current date and time by creating a blank `Date` object. The `Date` object has a number of methods to extract various parts of the date and time inside it. Here we fetch the current minutes (gives an easy numerical value), hours (gives an easy numerical value), day of the month (`getDate()` is needed for this, as `getDay()` returns the day of the week, 1-7), month (returns a number from 0-11, see below), and year (`getFullYear()` is needed; `getYear()` is deprecated, and returns a weird value that is not much use to anyone!)
 
 ```js
-const minuteCheck = now.getMinutes();
-const hourCheck = now.getHours();
-const dayCheck = now.getDate();
-const monthCheck = now.getMonth();
-const yearCheck = now.getFullYear();
-```
-
-The `Date` object has a number of methods to extract various parts of the date and time inside it. Here we fetch the current minutes (gives an easy numerical value), hours (gives an easy numerical value), day of the month (`getDate()` is needed for this, as `getDay()` returns the day of the week, 1-7), month (returns a number from 0-11, see below), and year (`getFullYear()` is needed; `getYear()` is deprecated, and returns a weird value that is not much use to anyone!)
-
-```js
+function checkDeadlines() {
+  // ...
   const objectStore = db
     .transaction(["toDoList"], "readwrite")
     .objectStore("toDoList");
@@ -145,91 +146,72 @@ The `Date` object has a number of methods to extract various parts of the date a
     const cursor = event.target.result;
     let monthNumber;
 
-    if (cursor) {
+    if (!cursor) return;
+    // ...
+    cursor.continue();
+  };
+}
 ```
 
-Next we create another IndexedDB `objectStore`, and use the `openCursor()` method to open a cursor, which is basically a way in IndexedDB to iterate through all the items in the store. We then loop through all the items in the cursor for as long as there is a valid item left in the cursor.
+Next we create another IndexedDB `objectStore`, and use the `openCursor()` method to open a cursor, which is basically a way in IndexedDB to iterate through all the items in the store. We then loop through all the items in the cursor for as long as there is a valid item left in the cursor. The last line of the function moves the cursor on, which causes the above deadline checking mechanism to be run for the next task stored in the IndexedDB.
+
+Now we start filling in the code in the `onsuccess` handler for checking deadlines.
 
 ```js
-switch (cursor.value.month) {
-  case "January":
-    monthNumber = 0;
-    break;
-  case "February":
-    monthNumber = 1;
-    break;
-
-  // other lines removed from listing for brevity
-
-  case "December":
-    monthNumber = 11;
-    break;
-  default:
-    alert("Incorrect month entered in database.");
-}
+const { hours, minutes, day, month, year, notified, taskTitle } = cursor.value;
+const monthNumber = MONTHS.indexOf(month);
+if (monthNumber === -1) throw new Error("Incorrect month entered in database.");
 ```
 
 The first thing we do is convert the month names we have stored in the database into a month number that JavaScript will understand. As we saw before, the JavaScript `Date` object creates month values as a number between 0 and 11.
 
-```js
-if (
-  Number(cursor.value.hours) === hourCheck &&
-  Number(cursor.value.minutes) === minuteCheck &&
-  Number(cursor.value.day) === dayCheck &&
-  monthNumber === monthCheck &&
-  cursor.value.year === yearCheck &&
-  notified === "no"
-) {
-  // If the numbers all do match, run the createNotification()
-  // function to create a system notification
-  createNotification(cursor.value.taskTitle);
-}
-```
-
-With the current time and date segments that we want to check against the IndexedDB stored values all assembled, it is time to perform the checks. We want all the values to match before we show the user some kind of notification to tell them their deadline is up.
-
-The `+` operator in this case converts numbers with leading zeros into their non leading zero equivalents, e.g., 09 -> 9. This is needed because JavaScript `Date` number values never have leading zeros, but our data might.
-
-The `notified === "no"` check is designed to make sure you will only get one notification per to-do item. When a notification is fired for each item object, its `notification` property is set to `"yes"` so this check will not pass on the next iteration, via the following code inside the `createNotification()` function (read [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) for an explanation):
+With the current time and date segments that we want to check against the IndexedDB stored values all assembled, it is time to perform the checks. We want all the values to match before we show the user some kind of notification to tell them their deadline is up. If the checks all match, we then run the `createNotification()` function to provide a notification to the user.
 
 ```js
-    // now we need to update the value of notified to "yes" in this particular data object, so the
-    // notification won't be set off on it again
-
-    // first open up a transaction as usual
-    const objectStore = db
-      .transaction(["toDoList"], "readwrite")
-      .objectStore("toDoList");
-
-    // get the to-do list object that has this title as its title
-    const request = objectStore.get(title);
-
-    request.onsuccess = () => {
-      // grab the data object returned as the result
-      const data = request.result;
-
-      // update the notified value in the object to "yes"
-      data.notified = "yes";
-
-      // create another request that inserts the item back into the database
-      const requestUpdate = objectStore.put(data);
-
-      // when this new request succeeds, run the displayData() function again to update the display
-      requestUpdate.onsuccess = () => {
-        displayData();
-      };
-```
-
-If the checks all match, we then run the `createNotification()` function to provide a notification to the user.
-
-```js
-      cursor.continue();
-    }
+let matched = parseInt(hours, 10) === hourCheck;
+matched &&= parseInt(minutes, 10) === minuteCheck;
+matched &&= parseInt(day, 10) === dayCheck;
+matched &&= monthNumber === monthCheck;
+matched &&= parseInt(year, 10) === yearCheck;
+if (matched && notified === "no") {
+  // If the numbers all do match, run the createNotification() function to create a system notification
+  // but only if the permission is set
+  if (Notification.permission === "granted") {
+    createNotification(taskTitle);
   }
 }
 ```
 
-The last line of the function moves the cursor on, which causes the above deadline checking mechanism to be run for the next task stored in the IndexedDB.
+The `notified === "no"` check is designed to make sure you will only get one notification per to-do item. When a notification is fired for each item object, its `notification` property is set to `"yes"` so this check will not pass on the next iteration, via the following code inside the `createNotification()` function (read [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) for an explanation):
+
+```js
+// now we need to update the value of notified to "yes" in this particular data object, so the
+// notification won't be set off on it again
+
+// first open up a transaction as usual
+const objectStore = db
+  .transaction(["toDoList"], "readwrite")
+  .objectStore("toDoList");
+
+// Get the to-do list object that has this title as its title
+const objectStoreTitleRequest = objectStore.get(title);
+
+objectStoreTitleRequest.onsuccess = () => {
+  // Grab the data object returned as the result
+  const data = objectStoreTitleRequest.result;
+
+  // Update the notified value in the object to 'yes'
+  data.notified = "yes";
+
+  // Create another request that inserts the item back into the database
+  const updateTitleRequest = objectStore.put(data);
+
+  // When this new request succeeds, run the displayData() function again to update the display
+  updateTitleRequest.onsuccess = () => {
+    displayData();
+  };
+};
+```
 
 ### Keep on checking!
 

--- a/files/en-us/web/api/media_capture_and_streams_api/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/index.md
@@ -22,7 +22,7 @@ It provides the interfaces and methods for working with the streams and their co
 
 ## Concepts and usage
 
-The API is based on the manipulation of a {{domxref("MediaStream")}} object representing a flux of audio- or video-related data. See an example in [Get the media stream](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos#the_startup_function).
+The API is based on the manipulation of a {{domxref("MediaStream")}} object representing a flux of audio- or video-related data. See an example in [Get the media stream](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos#demo).
 
 A `MediaStream` consists of zero or more {{domxref("MediaStreamTrack")}} objects, representing various audio or video **tracks**. Each `MediaStreamTrack` may have one or more **channels**. The channel represents the smallest unit of a media stream, such as an audio signal associated with a given speaker, like _left_ or _right_ in a stereo audio track.
 

--- a/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -14,11 +14,23 @@ You can also jump straight to the [Demo](#demo) if you like.
 
 ## The HTML markup
 
-[Our HTML interface](#html) has two main operational sections: the stream and capture panel and the presentation panel. Each of these is presented side-by-side in its own {{HTMLElement("div")}} to facilitate styling and control.
+Our HTML interface has two main operational sections: the stream and capture panel and the presentation panel. Each of these is presented side-by-side in its own {{HTMLElement("div")}} to facilitate styling and control.
+
+```html-nolint hidden live-sample___photo-capture live-sample___photo-capture-with-filters
+<div class="content-area">
+```
+
+```html hidden live-sample___photo-capture live-sample___photo-capture-with-filters
+<h1>MDN - navigator.mediaDevices.getUserMedia(): Still photo capture demo</h1>
+<p>
+  This example demonstrates how to set up a media stream using your built-in
+  webcam, fetch an image from that stream, and create a PNG using that image.
+</p>
+```
 
 The first panel on the left contains two components: a {{HTMLElement("video")}} element, which will receive the stream from `navigator.mediaDevices.getUserMedia()`, and a {{HTMLElement("button")}} the user clicks to capture a video frame.
 
-```html
+```html live-sample___photo-capture live-sample___photo-capture-with-filters
 <div class="camera">
   <video id="video">Video stream not available.</video>
   <button id="start-button">Take photo</button>
@@ -31,7 +43,7 @@ Next, we have a {{HTMLElement("canvas")}} element into which the captured frames
 
 We also have an {{HTMLElement("img")}} element into which we will draw the image — this is the final display shown to the user.
 
-```html
+```html live-sample___photo-capture live-sample___photo-capture-with-filters
 <canvas id="canvas"> </canvas>
 <div class="output">
   <img id="photo" alt="The screen capture will appear in this box." />
@@ -40,25 +52,39 @@ We also have an {{HTMLElement("img")}} element into which we will draw the image
 
 That's all of the relevant HTML. The rest is just some page layout fluff and a bit of text offering a link back to this page.
 
+```html hidden live-sample___photo-capture live-sample___photo-capture-with-filters
+<p>
+  Visit our article
+  <a
+    href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos">
+    Taking still photos with WebRTC
+  </a>
+  to learn more about the technologies used here.
+</p>
+```
+
+```html-nolint hidden live-sample___photo-capture live-sample___photo-capture-with-filters
+</div>
+```
+
 ## The JavaScript code
 
-Now let's take a look at the [JavaScript code](#javascript). We'll break it up into a few bite-sized pieces to make it easier to explain.
+Now let's take a look at the JavaScript code. We'll break it up into a few bite-sized pieces to make it easier to explain.
 
 ### Initialization
 
-We start by wrapping the whole script in an anonymous function to avoid global variables, then setting up various variables we'll be using.
+We start by setting up various variables we'll be using.
 
-```js
-(() => {
-  const width = 320;    // We will scale the photo width to this
-  const height = 0;     // This will be computed based on the input stream
+```js live-sample___photo-capture live-sample___photo-capture-with-filters
+const width = 320; // We will scale the photo width to this
+let height = 0; // This will be computed based on the input stream
 
-  const streaming = false;
+let streaming = false;
 
-  let video = null;
-  let canvas = null;
-  let photo = null;
-  let startButton = null;
+const video = document.getElementById("video");
+const canvas = document.getElementById("canvas");
+const photo = document.getElementById("photo");
+const startButton = document.getElementById("start-button");
 ```
 
 Those variables are:
@@ -70,35 +96,21 @@ Those variables are:
 - `streaming`
   - : Indicates whether or not there is currently an active stream of video running.
 - `video`
-  - : This will be a reference to the {{HTMLElement("video")}} element after the page is done loading.
+  - : A reference to the {{HTMLElement("video")}} element.
 - `canvas`
-  - : This will be a reference to the {{HTMLElement("canvas")}} element after the page is done loading.
+  - : A reference to the {{HTMLElement("canvas")}} element.
 - `photo`
-  - : This will be a reference to the {{HTMLElement("img")}} element after the page is done loading.
+  - : A reference to the {{HTMLElement("img")}} element.
 - `startButton`
-  - : This will be a reference to the {{HTMLElement("button")}} element that's used to trigger capture. We'll get that after the page is done loading.
+  - : A reference to the {{HTMLElement("button")}} element that's used to trigger capture.
 
-### The startup() function
-
-The `startup()` function is run when the page has finished loading, courtesy of {{domxref("EventTarget.addEventListener")}}. This function's job is to request access to the user's webcam, initialize the output {{HTMLElement("img")}} to a default state, and to establish the event listeners needed to receive each frame of video from the camera and react when the button is clicked to capture an image.
-
-#### Getting element references
-
-First, we grab references to the major elements we need to be able to access.
-
-```js
-  function startup() {
-    video = document.getElementById("video");
-    canvas = document.getElementById("canvas");
-    photo = document.getElementById("photo");
-    startButton = document.getElementById("start-button");
-```
+As part of the initial setup, we request access to the user's webcam, initialize the output {{HTMLElement("img")}} to a default state, and establish the event listeners needed to receive each frame of video from the camera and react when the button is clicked to capture an image.
 
 #### Get the media stream
 
 The next task is to get the media stream:
 
-```js
+```js live-sample___photo-capture live-sample___photo-capture-with-filters
 navigator.mediaDevices
   .getUserMedia({ video: true, audio: false })
   .then((stream) => {
@@ -122,12 +134,12 @@ The error callback is called if opening the stream doesn't work. This will happe
 
 After calling [`HTMLMediaElement.play()`](/en-US/docs/Web/API/HTMLMediaElement/play_event) on the {{HTMLElement("video")}}, there's a (hopefully brief) period of time that elapses before the stream of video begins to flow. To avoid blocking until that happens, we add an event listener to `video` for the {{domxref("HTMLMediaElement/canplay_event", "canplay")}} event, which is delivered when the video playback actually begins. At that point, all the properties in the `video` object have been configured based on the stream's format.
 
-```js
+```js live-sample___photo-capture live-sample___photo-capture-with-filters
 video.addEventListener(
   "canplay",
   (ev) => {
     if (!streaming) {
-      height = (video.videoHeight / video.videoWidth) * width;
+      height = video.videoHeight / (video.videoWidth / width);
 
       video.setAttribute("width", width);
       video.setAttribute("height", height);
@@ -150,7 +162,7 @@ Finally, the `width` and `height` of both the video and the canvas are set to ma
 
 To capture a still photo each time the user clicks the `startButton`, we need to add an event listener to the button, to be called when the {{domxref("Element/click_event", "click")}} event is issued:
 
-```js
+```js live-sample___photo-capture live-sample___photo-capture-with-filters
 startButton.addEventListener(
   "click",
   (ev) => {
@@ -163,22 +175,11 @@ startButton.addEventListener(
 
 This method is simple enough: it just calls our `takePicture()` function, defined below in the section [Capturing a frame from the stream](#capturing_a_frame_from_the_stream), then calls {{domxref("Event.preventDefault()")}} on the received event to prevent the click from being handled more than once.
 
-#### Wrapping up the startup() method
-
-There are only two more lines of code in the `startup()` method:
-
-```js
-    clearPhoto();
-  }
-```
-
-This is where we call the `clearPhoto()` method we'll describe below in the section [Clearing the photo box](#clearing_the_photo_box).
-
 ### Clearing the photo box
 
 Clearing the photo box involves creating an image, then converting it into a format usable by the {{HTMLElement("img")}} element that displays the most recently captured frame. That code looks like this:
 
-```js
+```js live-sample___photo-capture live-sample___photo-capture-with-filters
 function clearPhoto() {
   const context = canvas.getContext("2d");
   context.fillStyle = "#AAA";
@@ -187,6 +188,8 @@ function clearPhoto() {
   const data = canvas.toDataURL("image/png");
   photo.setAttribute("src", data);
 }
+
+clearPhoto();
 ```
 
 We start by getting a reference to the hidden {{HTMLElement("canvas")}} element that we use for offscreen rendering. Next we set the `fillStyle` to `#AAA` (a fairly light grey), and fill the entire canvas with that color by calling {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
@@ -197,7 +200,7 @@ Last in this function, we convert the canvas into a PNG image and call {{domxref
 
 There's one last function to define, and it's the point to the entire exercise: the `takePicture()` function, whose job it is to capture the currently displayed video frame, convert it into a PNG file, and display it in the captured frame box. The code looks like this:
 
-```js
+```js live-sample___photo-capture
 function takePicture() {
   const context = canvas.getContext("2d");
   if (width && height) {
@@ -226,35 +229,7 @@ If there isn't a valid image available (that is, the `width` and `height` are bo
 
 ## Demo
 
-### HTML
-
-```html live-sample___photo-capture
-<div class="content-area">
-  <h1>MDN - navigator.mediaDevices.getUserMedia(): Still photo capture demo</h1>
-  <p>
-    This example demonstrates how to set up a media stream using your built-in
-    webcam, fetch an image from that stream, and create a PNG using that image.
-  </p>
-  <div class="camera">
-    <video id="video">Video stream not available.</video>
-    <button id="start-button">Take photo</button>
-  </div>
-  <canvas id="canvas"> </canvas>
-  <div class="output">
-    <img id="photo" alt="The screen capture will appear in this box." />
-  </div>
-  <p>
-    Visit our article
-    <a
-      href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos">
-      Taking still photos with WebRTC
-    </a>
-    to learn more about the technologies used here.
-  </p>
-</div>
-```
-
-```css hidden live-sample___photo-capture
+```css hidden live-sample___photo-capture live-sample___photo-capture-with-filters
 #video {
   border: 1px solid black;
   box-shadow: 2px 2px 3px black;
@@ -308,136 +283,6 @@ If there isn't a valid image available (that is, the `width` and `height` are bo
 }
 ```
 
-### JavaScript
-
-```js live-sample___photo-capture
-(() => {
-  // The width and height of the captured photo. We will set the
-  // width to the value defined here, but the height will be
-  // calculated based on the aspect ratio of the input stream.
-  const width = 320; // We will scale the photo width to this
-  let height = 0; // This will be computed based on the input stream
-
-  // |streaming| indicates whether or not we're currently streaming
-  // video from the camera. Obviously, we start at false.
-  let streaming = false;
-
-  // The various HTML elements we need to configure or control. These
-  // will be set by the startup() function.
-  let video = null;
-  let canvas = null;
-  let photo = null;
-  let startButton = null;
-
-  function showViewLiveResultButton() {
-    if (window.self !== window.top) {
-      // Ensure that if our document is in a frame, we get the user
-      // to first open it in its own tab or window. Otherwise, it
-      // won't be able to request permission for camera access.
-      document.querySelector(".content-area").remove();
-      const button = document.createElement("button");
-      button.textContent = "Open example in new window";
-      document.body.append(button);
-      button.addEventListener("click", () =>
-        window.open(
-          location.href,
-          "MDN",
-          "width=850,height=700,left=150,top=150",
-        ),
-      );
-      return true;
-    }
-    return false;
-  }
-
-  function startup() {
-    if (showViewLiveResultButton()) {
-      return;
-    }
-    video = document.getElementById("video");
-    canvas = document.getElementById("canvas");
-    photo = document.getElementById("photo");
-    startButton = document.getElementById("start-button");
-
-    navigator.mediaDevices
-      .getUserMedia({ video: true, audio: false })
-      .then((stream) => {
-        video.srcObject = stream;
-        video.play();
-      })
-      .catch((err) => {
-        console.error(`An error occurred: ${err}`);
-      });
-
-    video.addEventListener(
-      "canplay",
-      (ev) => {
-        if (!streaming) {
-          height = video.videoHeight / (video.videoWidth / width);
-
-          // Firefox currently has a bug where the height can't be read from
-          // the video, so we will make assumptions if this happens.
-          if (isNaN(height)) {
-            height = width / (4 / 3);
-          }
-
-          video.setAttribute("width", width);
-          video.setAttribute("height", height);
-          canvas.setAttribute("width", width);
-          canvas.setAttribute("height", height);
-          streaming = true;
-        }
-      },
-      false,
-    );
-
-    startButton.addEventListener(
-      "click",
-      (ev) => {
-        takePicture();
-        ev.preventDefault();
-      },
-      false,
-    );
-
-    clearPhoto();
-  }
-
-  // Fill the photo with an indication that none has been captured.
-  function clearPhoto() {
-    const context = canvas.getContext("2d");
-    context.fillStyle = "#AAA";
-    context.fillRect(0, 0, canvas.width, canvas.height);
-
-    const data = canvas.toDataURL("image/png");
-    photo.setAttribute("src", data);
-  }
-
-  // Capture a photo by fetching the current contents of the video
-  // and drawing it into a canvas, then converting that to a PNG
-  // format data URL. By drawing it on an offscreen canvas and then
-  // drawing that to the screen, we can change its size and/or apply
-  // other changes before drawing it.
-  function takePicture() {
-    const context = canvas.getContext("2d");
-    if (width && height) {
-      canvas.width = width;
-      canvas.height = height;
-      context.drawImage(video, 0, 0, width, height);
-
-      const data = canvas.toDataURL("image/png");
-      photo.setAttribute("src", data);
-    } else {
-      clearPhoto();
-    }
-  }
-
-  // Set up our event listener to run the startup process
-  // once loading is complete.
-  window.addEventListener("load", startup, false);
-})();
-```
-
 {{EmbedLiveSample('photo-capture', '100%', '30', , , , , 'allow-popups')}}
 
 ## Fun with filters
@@ -446,7 +291,7 @@ Since we're capturing images from the user's webcam by grabbing frames from a {{
 
 For the video filters to be applied to the photo, the `takePicture()` function needs the following changes. Note that, while CSS {{cssxref("filter")}} effects applied to the video element affect its display, they do not automatically apply to the captured photo unless handled in the canvas drawing process.
 
-```js
+```js live-sample___photo-capture-with-filters
 function takePicture() {
   const context = canvas.getContext("2d");
   if (width && height) {
@@ -470,219 +315,6 @@ function takePicture() {
     clearPhoto();
   }
 }
-```
-
-```html hidden live-sample___photo-capture-with-filters
-<div class="content-area">
-  <h1>MDN - navigator.mediaDevices.getUserMedia(): Still photo capture demo</h1>
-  <p>
-    This example demonstrates how to set up a media stream using your built-in
-    webcam, fetch an image from that stream, and create a PNG using that image.
-  </p>
-  <div class="camera">
-    <video id="video">Video stream not available.</video>
-    <button id="start-button">Take photo</button>
-  </div>
-  <canvas id="canvas"> </canvas>
-  <div class="output">
-    <img id="photo" alt="The screen capture will appear in this box." />
-  </div>
-  <p>
-    Visit our article
-    <a
-      href="https://developer.mozilla.org/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos">
-      Taking still photos with WebRTC
-    </a>
-    to learn more about the technologies used here.
-  </p>
-</div>
-```
-
-```css hidden live-sample___photo-capture-with-filters
-#video {
-  border: 1px solid black;
-  box-shadow: 2px 2px 3px black;
-  width: 320px;
-  height: 240px;
-  filter: grayscale(100%);
-}
-
-#photo {
-  border: 1px solid black;
-  box-shadow: 2px 2px 3px black;
-  width: 320px;
-  height: 240px;
-}
-
-#canvas {
-  display: none;
-}
-
-.camera {
-  width: 340px;
-  display: inline-block;
-}
-
-.output {
-  width: 340px;
-  display: inline-block;
-  vertical-align: top;
-}
-
-#start-button {
-  display: block;
-  position: relative;
-  margin-left: auto;
-  margin-right: auto;
-  bottom: 32px;
-  background-color: rgb(0 150 0 / 50%);
-  border: 1px solid rgb(255 255 255 / 70%);
-  box-shadow: 0px 0px 1px 2px rgb(0 0 0 / 20%);
-  font-size: 14px;
-  font-family: "Lucida Grande", "Arial", sans-serif;
-  color: rgb(255 255 255 / 100%);
-}
-
-.content-area {
-  font:
-    1.2rem "Lucida Grande",
-    "Arial",
-    sans-serif;
-  width: 760px;
-  padding: 2rem;
-}
-```
-
-```js hidden live-sample___photo-capture-with-filters
-(() => {
-  // The width and height of the captured photo. We will set the
-  // width to the value defined here, but the height will be
-  // calculated based on the aspect ratio of the input stream.
-  const width = 320; // We will scale the photo width to this
-  let height = 0; // This will be computed based on the input stream
-
-  // |streaming| indicates whether or not we're currently streaming
-  // video from the camera. Obviously, we start at false.
-  let streaming = false;
-
-  // The various HTML elements we need to configure or control. These
-  // will be set by the startup() function.
-  let video = null;
-  let canvas = null;
-  let photo = null;
-  let startButton = null;
-
-  function showViewLiveResultButton() {
-    if (window.self !== window.top) {
-      // Ensure that if our document is in a frame, we get the user
-      // to first open it in its own tab or window. Otherwise, it
-      // won't be able to request permission for camera access.
-      document.querySelector(".content-area").remove();
-      const button = document.createElement("button");
-      button.textContent = "Open example in new window";
-      document.body.append(button);
-      button.addEventListener("click", () =>
-        window.open(
-          location.href,
-          "MDN",
-          "width=850,height=700,left=150,top=150",
-        ),
-      );
-      return true;
-    }
-    return false;
-  }
-
-  function startup() {
-    if (showViewLiveResultButton()) {
-      return;
-    }
-    video = document.getElementById("video");
-    canvas = document.getElementById("canvas");
-    photo = document.getElementById("photo");
-    startButton = document.getElementById("start-button");
-
-    navigator.mediaDevices
-      .getUserMedia({ video: true, audio: false })
-      .then((stream) => {
-        video.srcObject = stream;
-        video.play();
-      })
-      .catch((err) => {
-        console.error(`An error occurred: ${err}`);
-      });
-
-    video.addEventListener(
-      "canplay",
-      (ev) => {
-        if (!streaming) {
-          height = video.videoHeight / (video.videoWidth / width);
-
-          // Firefox currently has a bug where the height can't be read from
-          // the video, so we will make assumptions if this happens.
-          if (isNaN(height)) {
-            height = width / (4 / 3);
-          }
-
-          video.setAttribute("width", width);
-          video.setAttribute("height", height);
-          canvas.setAttribute("width", width);
-          canvas.setAttribute("height", height);
-          streaming = true;
-        }
-      },
-      false,
-    );
-
-    startButton.addEventListener(
-      "click",
-      (ev) => {
-        takePicture();
-        ev.preventDefault();
-      },
-      false,
-    );
-
-    clearPhoto();
-  }
-
-  // Fill the photo with an indication that none has been captured.
-  function clearPhoto() {
-    const context = canvas.getContext("2d");
-    context.fillStyle = "#AAA";
-    context.fillRect(0, 0, canvas.width, canvas.height);
-
-    const data = canvas.toDataURL("image/png");
-    photo.setAttribute("src", data);
-  }
-
-  // Capture a photo by fetching the current contents of the video
-  // and drawing it into a canvas, then converting that to a PNG
-  // format data URL. By drawing it on an offscreen canvas and then
-  // drawing that to the screen, we can change its size and/or apply
-  // other changes before drawing it.
-  function takePicture() {
-    const context = canvas.getContext("2d");
-    if (width && height) {
-      canvas.width = width;
-      canvas.height = height;
-
-      const videoStyles = window.getComputedStyle(video);
-      const filterValue = videoStyles.getPropertyValue("filter");
-      context.filter = filterValue !== "none" ? filterValue : "none";
-      context.drawImage(video, 0, 0, width, height);
-
-      const data = canvas.toDataURL("image/png");
-      photo.setAttribute("src", data);
-    } else {
-      clearPhoto();
-    }
-  }
-
-  // Set up our event listener to run the startup process
-  // once loading is complete.
-  window.addEventListener("load", startup, false);
-})();
 ```
 
 {{EmbedLiveSample('photo-capture-with-filters', '100%', '30', , , , , 'allow-popups')}}

--- a/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
+++ b/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
@@ -283,7 +283,7 @@ Note that we won't show the CSS for this example, as none of it is relevant to u
 
 In our script, we start off by grabbing references to the `<form>`, `<textarea>`, submit `<button>`, translation output `<p>`, and language detection `<output>` elements. We also declare a variable called `detectedLanguage` to contain results of language detection operations.
 
-```js
+```js live-sample___translator-example
 const form = document.querySelector("form");
 const textarea = document.querySelector("textarea");
 const submitBtn = document.querySelector("button");
@@ -298,7 +298,7 @@ Next, we use the {{domxref("EventTarget.addEventListener()")}} method to listen 
 - `submit` events on the `<form>` element; when the form is submitted, the `handleTranslation()` function is called.
 - `input` events on the `<textarea>` element; when the current `<textarea>` value is changed, the `detectLanguage()` function is called.
 
-```js
+```js live-sample___translator-example
 form.addEventListener("submit", handleTranslation);
 textarea.addEventListener("input", detectLanguage);
 ```
@@ -309,7 +309,7 @@ When detecting the language of the entered text, we create a `LanguageDetector` 
 
 Finally, we set the submit button to not be disabled, so the form can be submitted to start the translation.
 
-```js
+```js live-sample___translator-example
 async function detectLanguage() {
   if (textarea.value.length > 20) {
     const detector = await LanguageDetector.create({
@@ -338,7 +338,7 @@ async function detectLanguage() {
 
 Now we define the `handleTranslation()` function. After preventing the form's default submission, we create a new {{domxref("FormData")}} object instance containing our `<form>` data name/value pairs. We then run a data validation test, checking whether the detected `<textarea>` content language is the same as the language chosen to translate into (`translateLanguage`). If it is, we print an error message inside the `<p>` with class `translate-output`.
 
-```js
+```js live-sample___translator-example
 async function handleTranslation(e) {
   e.preventDefault();
 
@@ -358,7 +358,7 @@ If the test passes, we open a [`try { ... }`](/en-US/docs/Web/JavaScript/Referen
 - If it returns `available`, we create a translator using the {{domxref("Translator.create_static", "create()")}} method, passing it the detected input and chosen output languages. The required AI model is available, so we can use it immediately.
 - If it returns a different value (that is, `downloadable` or `downloading`), we run the same `create()` method call, but this time we include a `monitor` that prints out the percentage of the model downloaded to the `translate-output` `<p>` each time the {{domxref("CreateMonitor/downloadprogress_event", "downloadprogress")}} event fires.
 
-```js
+```js live-sample___translator-example
   try {
     const availability = await Translator.availability({
       sourceLanguage: detectedLanguage,
@@ -391,7 +391,7 @@ If the test passes, we open a [`try { ... }`](/en-US/docs/Web/JavaScript/Referen
 
 Next, we set the output `<p>` content to a pending message and disable the submit button before calling {{domxref("Translator.translate()")}} to perform the actual translation, passing it the `<textarea>` value. Once the translation is done, we display it inside the output `<p>` before making the submit button not disabled again.
 
-```js
+```js live-sample___translator-example
 translateOutput.textContent = "...generating translation...";
 submitBtn.disabled = true;
 
@@ -403,100 +403,7 @@ submitBtn.disabled = false;
 
 Finally, we include the `try` block's counterpart `catch() { ... }` block. If the `try` content throws any kind of exception, we display it inside the output `<p>`.
 
-```js
-  } catch (e) {
-    translateOutput.innerHTML = `<span class="error">${e}</span>`;
-  }
-}
-```
-
-```js hidden live-sample___translator-example
-const form = document.querySelector("form");
-const textarea = document.querySelector("textarea");
-const submitBtn = document.querySelector("button");
-
-const translateOutput = document.querySelector(".translate-output");
-const detectedLanguageOutput = document.querySelector(".detected-language");
-let detectedLanguage = "";
-
-form.addEventListener("submit", handleTranslation);
-textarea.addEventListener("input", detectLanguage);
-
-async function detectLanguage() {
-  if (textarea.value.length > 20) {
-    const detector = await LanguageDetector.create({
-      monitor(monitor) {
-        monitor.addEventListener("downloadprogress", (e) => {
-          console.log(`Downloaded ${e.loaded * 100}%`);
-        });
-      },
-    });
-
-    const results = await detector.detect(textarea.value);
-    detectedLanguageOutput.textContent = `Detected language: ${
-      results[0].detectedLanguage
-    }. Confidence: ${results[0].confidence.toFixed(4)}`;
-    detectedLanguage = results[0].detectedLanguage;
-
-    submitBtn.disabled = false;
-  } else {
-    detectedLanguageOutput.textContent = `Text too short to accurately detect language.`;
-    detectedLanguage = "";
-
-    submitBtn.disabled = true;
-  }
-}
-
-async function handleTranslation(e) {
-  e.preventDefault();
-
-  const formData = new FormData(form);
-
-  if (formData.get("translateLanguage") === detectedLanguage) {
-    translateOutput.innerHTML = `<span class="error">Input language and translation language are the same.</span>`;
-    return;
-  }
-  translateOutput.innerHTML = "";
-
-  try {
-    const availability = await Translator.availability({
-      sourceLanguage: detectedLanguage,
-      targetLanguage: formData.get("translateLanguage"),
-    });
-    let translator;
-
-    if (availability === "unavailable") {
-      translateOutput.innerHTML = `<span class="error">Translation not available; try a different language combination.</span>`;
-      return;
-    }
-    if (availability === "available") {
-      translator = await Translator.create({
-        sourceLanguage: detectedLanguage,
-        targetLanguage: formData.get("translateLanguage"),
-      });
-    } else {
-      translator = await Translator.create({
-        sourceLanguage: detectedLanguage,
-        targetLanguage: formData.get("translateLanguage"),
-        monitor(monitor) {
-          monitor.addEventListener("downloadprogress", (e) => {
-            translateOutput.textContent = `Downloaded ${Math.floor(
-              e.loaded * 100,
-            )}%`;
-          });
-        },
-      });
-    }
-
-    translateOutput.textContent = "...generating translation...";
-    submitBtn.disabled = true;
-
-    const translation = await translator.translate(
-      formData.get("translateText"),
-    );
-
-    translateOutput.textContent = translation;
-    submitBtn.disabled = false;
+```js live-sample___translator-example
   } catch (e) {
     translateOutput.innerHTML = `<span class="error">${e}</span>`;
   }

--- a/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
+++ b/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
@@ -347,9 +347,8 @@ async function handleTranslation(e) {
   if (formData.get("translateLanguage") === detectedLanguage) {
     translateOutput.innerHTML = `<span class="error">Input language and translation language are the same.</span>`;
     return;
-  } else {
-    translateOutput.innerHTML = "";
   }
+  translateOutput.innerHTML = "";
 ```
 
 If the test passes, we open a [`try { ... }`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block. We start by checking the availability of the model for translating between the detected input and chosen output languages using the {{domxref("Translator.availability_static", "availability()")}} method:

--- a/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
@@ -75,66 +75,44 @@ Next, we clear the canvas of what had been drawn on it before to get ready for t
 canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
 ```
 
-We now define the `draw()` function:
+We now define the `draw()` function. In here, we do the following:
+
+1. Use `requestAnimationFrame()` to keep looping the drawing function once it has been started.
+2. Grab the time domain data and copy it into our array.
+3. Fill the canvas with a solid color to start.
+4. Set a line width and stroke color for the wave we will draw, then begin drawing a path.
+5. Determine the width of each segment of the line to be drawn by dividing the canvas width by the array length (equal to the FrequencyBinCount, as defined earlier on), then define an x variable to define the position to move to for drawing each segment of the line.
+6. Now we run through a loop, defining the position of a small segment of the wave for each point in the buffer at a certain height based on the data point value from the array, then moving the line across to the place where the next wave segment should be drawn.
+7. Finally, we finish the line in the middle of the right-hand side of the canvas, then draw the stroke we've defined.
 
 ```js
 function draw() {
-```
+  const drawVisual = requestAnimationFrame(draw);
+  analyser.getByteTimeDomainData(dataArray);
+  // Fill solid color
+  canvasCtx.fillStyle = "rgb(200 200 200)";
+  canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
+  // Begin the path
+  canvasCtx.lineWidth = 2;
+  canvasCtx.strokeStyle = "rgb(0 0 0)";
+  canvasCtx.beginPath();
+  // Draw each point in the waveform
+  const sliceWidth = WIDTH / bufferLength;
+  let x = 0;
+  for (let i = 0; i < bufferLength; i++) {
+    const v = dataArray[i] / 128.0;
+    const y = v * (HEIGHT / 2);
 
-In here, we use `requestAnimationFrame()` to keep looping the drawing function once it has been started:
+    if (i === 0) {
+      canvasCtx.moveTo(x, y);
+    } else {
+      canvasCtx.lineTo(x, y);
+    }
 
-```js
-const drawVisual = requestAnimationFrame(draw);
-```
-
-Next, we grab the time domain data and copy it into our array
-
-```js
-analyser.getByteTimeDomainData(dataArray);
-```
-
-Next, fill the canvas with a solid color to start
-
-```js
-canvasCtx.fillStyle = "rgb(200 200 200)";
-canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
-```
-
-Set a line width and stroke color for the wave we will draw, then begin drawing a path
-
-```js
-canvasCtx.lineWidth = 2;
-canvasCtx.strokeStyle = "rgb(0 0 0)";
-canvasCtx.beginPath();
-```
-
-Determine the width of each segment of the line to be drawn by dividing the canvas width by the array length (equal to the FrequencyBinCount, as defined earlier on), then define an x variable to define the position to move to for drawing each segment of the line.
-
-```js
-const sliceWidth = WIDTH / bufferLength;
-let x = 0;
-```
-
-Now we run through a loop, defining the position of a small segment of the wave for each point in the buffer at a certain height based on the data point value from the array, then moving the line across to the place where the next wave segment should be drawn:
-
-```js
-for (let i = 0; i < bufferLength; i++) {
-  const v = dataArray[i] / 128.0;
-  const y = v * (HEIGHT / 2);
-
-  if (i === 0) {
-    canvasCtx.moveTo(x, y);
-  } else {
-    canvasCtx.lineTo(x, y);
+    x += sliceWidth;
   }
 
-  x += sliceWidth;
-}
-```
-
-Finally, we finish the line in the middle of the right-hand side of the canvas, then draw the stroke we've defined:
-
-```js
+  // Finish the line
   canvasCtx.lineTo(WIDTH, HEIGHT / 2);
   canvasCtx.stroke();
 }
@@ -174,6 +152,9 @@ function draw() {
 
   canvasCtx.fillStyle = "rgb(0 0 0)";
   canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
+
+  // ...
+}
 ```
 
 Now we set our `barWidth` to be equal to the canvas width divided by the number of bars (the buffer length). However, we are also multiplying that width by 2.5, because most of the frequencies will come back as having no audio in them, as most of the sounds we hear every day are in a certain lower frequency range. We don't want to display loads of empty bars, therefore we shift the ones that will display regularly at a noticeable height across so they fill the canvas display.
@@ -181,9 +162,13 @@ Now we set our `barWidth` to be equal to the canvas width divided by the number 
 We also set a `barHeight` variable, and an `x` variable to record how far across the screen to draw the current bar.
 
 ```js
-const barWidth = (WIDTH / bufferLength) * 2.5;
-let barHeight;
-let x = 0;
+function draw() {
+  // ...
+  const barWidth = (WIDTH / bufferLength) * 2.5;
+  let barHeight;
+  let x = 0;
+  // ...
+}
 ```
 
 As before, we now start a for loop and cycle through each value in the `dataArray`. For each one, we make the `barHeight` equal to the array value, set a fill color based on the `barHeight` (taller bars are brighter), and draw a bar at `x` pixels across the canvas, which is `barWidth` wide and `barHeight / 2` tall (we eventually decided to cut each bar in half so they would all fit on the canvas better.)
@@ -191,13 +176,17 @@ As before, we now start a for loop and cycle through each value in the `dataArra
 The one value that needs explaining is the vertical offset position we are drawing each bar at: `HEIGHT - barHeight / 2`. I am doing this because I want each bar to stick up from the bottom of the canvas, not down from the top, as it would if we set the vertical position to 0. Therefore, we instead set the vertical position each time to the height of the canvas minus `barHeight / 2`, so therefore each bar will be drawn from partway down the canvas, down to the bottom.
 
 ```js
-for (let i = 0; i < bufferLength; i++) {
-  barHeight = dataArray[i] / 2;
+function draw() {
+  // ...
+  for (let i = 0; i < bufferLength; i++) {
+    barHeight = dataArray[i] / 2;
 
-  canvasCtx.fillStyle = `rgb(${barHeight + 100} 50 50)`;
-  canvasCtx.fillRect(x, HEIGHT - barHeight / 2, barWidth, barHeight);
+    canvasCtx.fillStyle = `rgb(${barHeight + 100} 50 50)`;
+    canvasCtx.fillRect(x, HEIGHT - barHeight / 2, barWidth, barHeight);
 
-  x += barWidth + 1;
+    x += barWidth + 1;
+  }
+  // ...
 }
 ```
 

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
@@ -99,25 +99,14 @@ Let's briefly explain these:
 
 ### Getting a reference to our VR display
 
-One of the major functions inside our code is `start()` — we run this function when the body has finished loading:
+To begin with, we retrieve a WebGL context to use to render 3D graphics into the {{htmlelement("canvas")}} element in [our HTML](https://github.com/mdn/webvr-tests/blob/main/webvr/raw-webgl-example/index.html). We then check whether the `gl` context is available — if so, we run a number of functions to set up the scene for display.
 
 ```js
-// start
-//
-// Called when the body has loaded is created to get the ball rolling.
+const canvas = document.getElementById("gl-canvas");
 
-document.body.onload = start;
-```
+initWebGL(canvas); // Initialize the GL context
 
-To begin with, `start()` retrieves a WebGL context to use to render 3D graphics into the {{htmlelement("canvas")}} element in [our HTML](https://github.com/mdn/webvr-tests/blob/main/webvr/raw-webgl-example/index.html). We then check whether the `gl` context is available — if so, we run a number of functions to set up the scene for display.
-
-```js
-function start() {
-  canvas = document.getElementById("gl-canvas");
-
-  initWebGL(canvas); // Initialize the GL context
-
-  // WebGL setup code here
+// WebGL setup code here
 ```
 
 Next, we start the process of actually rendering the scene onto the canvas, by setting the canvas to fill the entire browser viewport, and running the rendering loop (`drawScene()`) for the first time. This is the non-WebVR — normal — rendering loop.
@@ -130,29 +119,37 @@ canvas.height = window.innerHeight;
 drawScene();
 ```
 
-Now onto our first WebVR-specific code. First of all, we check to see if {{domxref("Navigator.getVRDisplays")}} exists — this is the entry point into the API, and therefore good basic feature detection for WebVR. You'll see at the end of the block (inside the `else` clause) that if this doesn't exist, we log a message to indicate that WebVR 1.1 isn't supported by the browser.
+Now onto our first WebVR-specific code. First of all, we check to see if {{domxref("Navigator.getVRDisplays")}} exists — this is the entry point into the API, and therefore good basic feature detection for WebVR. If this doesn't exist, we log a message to indicate that WebVR 1.1 isn't supported by the browser.
 
 ```js
-  // WebVR: Check to see if WebVR is supported
-  if (navigator.getVRDisplays) {
-    console.log("WebVR 1.1 supported");
+// WebVR: Check to see if WebVR is supported
+if (navigator.getVRDisplays) {
+  console.log("WebVR 1.1 supported");
+  // ...
+} else {
+  console.log("WebVR API not supported by this browser.");
+}
 ```
 
-Inside our `if () { }` block, we run the {{domxref("Navigator.getVRDisplays()")}} function. This returns a promise, which is fulfilled with an array containing all the VR display devices connected to the computer. If none are connected, the array will be empty.
+The rest of the code goes inside the `if (navigator.getVRDisplays) { }` block, so that it only runs if WebVR is supported.
 
-```js
-    // Then get the displays attached to the computer
-    navigator.getVRDisplays().then((displays) => {
-```
+We first run the {{domxref("Navigator.getVRDisplays()")}} function. This returns a promise, which is fulfilled with an array containing all the VR display devices connected to the computer. If none are connected, the array will be empty.
 
 Inside the promise `then()` block, we check whether the array length is more than 0; if so, we set the value of our `vrDisplay` variable to the 0 index item inside the array. `vrDisplay` now contains a {{domxref("VRDisplay")}} object representing our connected display!
 
 ```js
-      // If a display is available, use it to present the scene
-      if (displays.length > 0) {
-        vrDisplay = displays[0];
-        console.log("Display found");
+// Then get the displays attached to the computer
+navigator.getVRDisplays().then((displays) => {
+  // If a display is available, use it to present the scene
+  if (displays.length > 0) {
+    vrDisplay = displays[0];
+    console.log("Display found");
+    // ...
+  }
+});
 ```
+
+The rest of the code goes inside the `if (displays.length > 0) { }` block, so that it only runs if there's at least one VR display available.
 
 > [!NOTE]
 > It is unlikely that you'll have multiple VR displays connected to your computer, and this is just a simple demo, so this will do for now.
@@ -165,16 +162,22 @@ Continuing on with the previous code block, we now add an event listener to our 
 
 If the display is not already presenting, we use the {{domxref("VRDisplay.requestPresent()")}} method to request that the browser start presenting content to the display. This takes as a parameter an array of the {{domxref("VRLayerInit")}} objects representing the layers you want to present in the display.
 
-Since the maximum number of layers you can display is currently 1, and the only required object member is the {{domxref("VRLayerInit.source")}} property (which is a reference to the {{htmlelement("canvas")}} you want to present in that layer; the other parameters are given sensible defaults — see {{domxref("VRLayerInit.leftBounds", "leftBounds")}} and {{domxref("VRLayerInit.rightBounds", "rightBounds")}})), the parameter is \[{ source: canvas }].
+Since the maximum number of layers you can display is currently 1, and the only required object member is the {{domxref("VRLayerInit.source")}} property (which is a reference to the {{htmlelement("canvas")}} you want to present in that layer; the other parameters are given sensible defaults — see {{domxref("VRLayerInit.leftBounds", "leftBounds")}} and {{domxref("VRLayerInit.rightBounds", "rightBounds")}})), the parameter is `[{ source: canvas }]`.
 
 `requestPresent()` returns a promise that is fulfilled when the presentation begins successfully.
 
 ```js
-        // Starting the presentation when the button is clicked: It can only be called in response to a user gesture
-        btn.addEventListener("click", () => {
-          if (btn.textContent === "Start VR display") {
-            vrDisplay.requestPresent([{ source: canvas }]).then(() => {
-              console.log("Presenting to WebVR display");
+// Starting the presentation when the button is clicked: It can only be called in response to a user gesture
+btn.addEventListener("click", () => {
+  if (btn.textContent === "Start VR display") {
+    vrDisplay.requestPresent([{ source: canvas }]).then(() => {
+      console.log("Presenting to WebVR display");
+      // ...
+    });
+  } else {
+    // ...
+  }
+});
 ```
 
 With our presentation request successful, we now want to start setting up to render content to present to the VRDisplay. First of all we set the canvas to the same size as the VR display area. We do this by getting the {{domxref("VREyeParameters")}} for both eyes using {{domxref("VRDisplay.getEyeParameters()")}}.
@@ -182,49 +185,54 @@ With our presentation request successful, we now want to start setting up to ren
 We then do some simple math to calculate the total width of the VRDisplay rendering area based on the eye {{domxref("VREyeParameters.renderWidth")}} and {{domxref("VREyeParameters.renderHeight")}}.
 
 ```js
-// Set the canvas size to the size of the vrDisplay viewport
+vrDisplay.requestPresent([{ source: canvas }]).then(() => {
+  // ...
+  // Set the canvas size to the size of the vrDisplay viewport
 
-const leftEye = vrDisplay.getEyeParameters("left");
-const rightEye = vrDisplay.getEyeParameters("right");
+  const leftEye = vrDisplay.getEyeParameters("left");
+  const rightEye = vrDisplay.getEyeParameters("right");
 
-canvas.width = Math.max(leftEye.renderWidth, rightEye.renderWidth) * 2;
-canvas.height = Math.max(leftEye.renderHeight, rightEye.renderHeight);
+  canvas.width = Math.max(leftEye.renderWidth, rightEye.renderWidth) * 2;
+  canvas.height = Math.max(leftEye.renderHeight, rightEye.renderHeight);
+  // ...
+});
 ```
 
 Next, we [cancel the animation loop](/en-US/docs/Web/API/Window/cancelAnimationFrame) previously set in motion by the {{domxref("Window.requestAnimationFrame()")}} call inside the `drawScene()` function, and instead invoke `drawVRScene()`. This function renders the same scene as before, but with some special WebVR magic going on. The loop inside here is maintained by WebVR's special {{domxref("VRDisplay.requestAnimationFrame")}} method.
 
 ```js
-// stop the normal presentation, and start the vr presentation
-window.cancelAnimationFrame(normalSceneFrame);
-drawVRScene();
+vrDisplay.requestPresent([{ source: canvas }]).then(() => {
+  // ...
+  // stop the normal presentation, and start the vr presentation
+  window.cancelAnimationFrame(normalSceneFrame);
+  drawVRScene();
+  // ...
+});
 ```
 
 Finally, we update the button text so that the next time it is pressed, it will stop presentation to the VR display.
 
 ```js
-              btn.textContent = "Exit VR display";
-            });
+vrDisplay.requestPresent([{ source: canvas }]).then(() => {
+  // ...
+  btn.textContent = "Exit VR display";
+});
 ```
 
 To stop the VR presentation when the button is subsequently pressed, we call {{domxref("VRDisplay.exitPresent()")}}. We also reverse the button's text content, and swap over the `requestAnimationFrame` calls. You can see here that we are using {{domxref("VRDisplay.cancelAnimationFrame")}} to stop the VR rendering loop, and starting the normal rendering loop off again by calling `drawScene()`.
 
 ```js
-          } else {
-            vrDisplay.exitPresent();
-            console.log("Stopped presenting to WebVR display");
+if (btn.textContent === "Start VR display") {
+  // ...
+} else {
+  vrDisplay.exitPresent();
+  console.log("Stopped presenting to WebVR display");
 
-            btn.textContent = "Start VR display";
+  btn.textContent = "Start VR display";
 
-            // Stop the VR presentation, and start the normal presentation
-            vrDisplay.cancelAnimationFrame(vrSceneFrame);
-            drawScene();
-          }
-        });
-      }
-    });
-  } else {
-    console.log("WebVR API not supported by this browser.");
-  }
+  // Stop the VR presentation, and start the normal presentation
+  vrDisplay.cancelAnimationFrame(vrSceneFrame);
+  drawScene();
 }
 ```
 
@@ -250,6 +258,8 @@ First of all, we begin the definition of our rendering loop function — `drawVR
 function drawVRScene() {
   // WebVR: Request the next frame of the animation
   vrSceneFrame = vrDisplay.requestAnimationFrame(drawVRScene);
+  // ...
+}
 ```
 
 Next, we call {{domxref("VRDisplay.getFrameData()")}}, passing it the name of the variable that we want to use to contain the frame data. We initialized this earlier on — `frameData`. After the call completes, this variable will contain the data need to render the next frame to the VR device, packaged up as a {{domxref("VRFrameData")}} object. This contains things like projection and view matrices for rendering the scene correctly for the left and right eye view, and the current {{domxref("VRPose")}} object, which contains data on the VR display such as orientation, position, etc.
@@ -257,42 +267,58 @@ Next, we call {{domxref("VRDisplay.getFrameData()")}}, passing it the name of th
 This has to be called on every frame so the rendered view is always up-to-date.
 
 ```js
-// Populate frameData with the data of the next frame to display
-vrDisplay.getFrameData(frameData);
+function drawVRScene() {
+  // ...
+  // Populate frameData with the data of the next frame to display
+  vrDisplay.getFrameData(frameData);
+  // ...
+}
 ```
 
 Now we retrieve the current {{domxref("VRPose")}} from the {{domxref("VRFrameData.pose")}} property, store the position and orientation for use later on, and send the current pose to the pose stats box for display, if the `poseStatsDisplayed` variable is set to true.
 
 ```js
-// You can get the position, orientation, etc. of the display from the current frame's pose
+function drawVRScene() {
+  // ...
+  // You can get the position, orientation, etc. of the display from the current frame's pose
 
-const curFramePose = frameData.pose;
-const curPos = curFramePose.position;
-const curOrient = curFramePose.orientation;
-if (poseStatsDisplayed) {
-  displayPoseStats(curFramePose);
+  const curFramePose = frameData.pose;
+  const curPos = curFramePose.position;
+  const curOrient = curFramePose.orientation;
+  if (poseStatsDisplayed) {
+    displayPoseStats(curFramePose);
+  }
+  // ...
 }
 ```
 
 We now clear the canvas before we start drawing on it, so that the next frame is clearly seen, and we don't also see previous rendered frames:
 
 ```js
-// Clear the canvas before we start drawing on it.
+function drawVRScene() {
+  // ...
+  // Clear the canvas before we start drawing on it.
 
-gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  // ...
+}
 ```
 
 We now render the view for both the left and right eyes. First of all we need to create projection and view locations for use in the rendering. These are {{domxref("WebGLUniformLocation")}} objects, created using the {{domxref("WebGLRenderingContext.getUniformLocation()")}} method, passing it the shader program's identifier and an identifying name as parameters.
 
 ```js
-// WebVR: Create the required projection and view matrix locations needed
-// for passing into the uniformMatrix4fv methods below
+function drawVRScene() {
+  // ...
+  // WebVR: Create the required projection and view matrix locations needed
+  // for passing into the uniformMatrix4fv methods below
 
-const projectionMatrixLocation = gl.getUniformLocation(
-  shaderProgram,
-  "projMatrix",
-);
-const viewMatrixLocation = gl.getUniformLocation(shaderProgram, "viewMatrix");
+  const projectionMatrixLocation = gl.getUniformLocation(
+    shaderProgram,
+    "projMatrix",
+  );
+  const viewMatrixLocation = gl.getUniformLocation(shaderProgram, "viewMatrix");
+  // ...
+}
 ```
 
 The next rendering step involves:
@@ -302,29 +328,37 @@ The next rendering step involves:
 - Running the `drawGeometry()` function, which renders the actual scene — because of what we specified in the previous two steps, we will render it for the left eye only.
 
 ```js
-// WebVR: Render the left eye's view to the left half of the canvas
-gl.viewport(0, 0, canvas.width * 0.5, canvas.height);
-gl.uniformMatrix4fv(
-  projectionMatrixLocation,
-  false,
-  frameData.leftProjectionMatrix,
-);
-gl.uniformMatrix4fv(viewMatrixLocation, false, frameData.leftViewMatrix);
-drawGeometry();
+function drawVRScene() {
+  // ...
+  // WebVR: Render the left eye's view to the left half of the canvas
+  gl.viewport(0, 0, canvas.width * 0.5, canvas.height);
+  gl.uniformMatrix4fv(
+    projectionMatrixLocation,
+    false,
+    frameData.leftProjectionMatrix,
+  );
+  gl.uniformMatrix4fv(viewMatrixLocation, false, frameData.leftViewMatrix);
+  drawGeometry();
+  // ...
+}
 ```
 
 We now do exactly the same thing, but for the right eye:
 
 ```js
-// WebVR: Render the right eye's view to the right half of the canvas
-gl.viewport(canvas.width * 0.5, 0, canvas.width * 0.5, canvas.height);
-gl.uniformMatrix4fv(
-  projectionMatrixLocation,
-  false,
-  frameData.rightProjectionMatrix,
-);
-gl.uniformMatrix4fv(viewMatrixLocation, false, frameData.rightViewMatrix);
-drawGeometry();
+function drawVRScene() {
+  // ...
+  // WebVR: Render the right eye's view to the right half of the canvas
+  gl.viewport(canvas.width * 0.5, 0, canvas.width * 0.5, canvas.height);
+  gl.uniformMatrix4fv(
+    projectionMatrixLocation,
+    false,
+    frameData.rightProjectionMatrix,
+  );
+  gl.uniformMatrix4fv(viewMatrixLocation, false, frameData.rightViewMatrix);
+  drawGeometry();
+  // ...
+}
 ```
 
 Next we define our `drawGeometry()` function. Most of this is just general WebGL code required to draw our 3D cube. You'll see some WebVR-specific parts in the `mvTranslate()` and `mvRotate()` function calls — these pass matrices into the WebGL program that define the translation and rotation of the cube for the current frame
@@ -384,19 +418,25 @@ function drawGeometry() {
 The next bit of the code has nothing to do with WebVR — it just updates the rotation of the cube on each frame:
 
 ```js
-// Update the rotation for the next draw, if it's time to do so.
-let currentTime = new Date().getTime();
-if (lastCubeUpdateTime) {
-  const delta = currentTime - lastCubeUpdateTime;
+function drawVRScene() {
+  // ...
+  // Update the rotation for the next draw, if it's time to do so.
+  let currentTime = new Date().getTime();
+  if (lastCubeUpdateTime) {
+    const delta = currentTime - lastCubeUpdateTime;
 
-  cubeRotation += (30 * delta) / 1000.0;
+    cubeRotation += (30 * delta) / 1000.0;
+  }
+  lastCubeUpdateTime = currentTime;
+  // ...
 }
-lastCubeUpdateTime = currentTime;
 ```
 
 The last part of the rendering loop involves us calling {{domxref("VRDisplay.submitFrame()")}} — now all the work has been done and we've rendered the display on the {{htmlelement("canvas")}}, this method then submits the frame to the VR display so it is displayed on there as well.
 
 ```js
+function drawVRScene() {
+  // ...
   // WebVR: Indicate that we are ready to present the rendered frame to the VR display
   vrDisplay.submitFrame();
 }
@@ -416,6 +456,8 @@ function displayPoseStats(pose) {
   const linAcc = pose.linearAcceleration;
   const angVel = pose.angularVelocity;
   const angAcc = pose.angularAcceleration;
+  // ...
+}
 ```
 
 We then write out the data into the information box, updating it on every frame. We've clamped each value to three decimal places using [`toFixed()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed), as the values are hard to read otherwise.
@@ -423,39 +465,47 @@ We then write out the data into the information box, updating it on every frame.
 You should note that we've used a conditional expression to detect whether the linear acceleration and angular acceleration arrays are successfully returned before we display the data. These values are not reported by most VR hardware as yet, so the code would throw an error if we did not do this (the arrays return `null` if they are not successfully reported).
 
 ```js
-  posStats.textContent = `Position: ` +
+function displayPoseStats(pose) {
+  // ...
+  posStats.textContent =
+    `Position: ` +
     `x ${pos[0].toFixed(3)}, ` +
     `y ${pos[1].toFixed(3)}, ` +
     `z ${pos[2].toFixed(3)}`;
-  orientStats.textContent = `Orientation: ` +
+  orientStats.textContent =
+    `Orientation: ` +
     `x ${orient[0].toFixed(3)}, ` +
     `y ${orient[1].toFixed(3)}, ` +
     `z ${orient[2].toFixed(3)}`;
-  linVelStats.textContent = `Linear velocity: ` +
+  linVelStats.textContent =
+    `Linear velocity: ` +
     `x ${linVel[0].toFixed(3)}, ` +
     `y ${linVel[1].toFixed(3)}, ` +
     `z ${linVel[2].toFixed(3)}`;
-  angVelStats.textContent = `Angular velocity: ` +
+  angVelStats.textContent =
+    `Angular velocity: ` +
     `x ${angVel[0].toFixed(3)}, ` +
     `y ${angVel[1].toFixed(3)}, ` +
     `z ${angVel[2].toFixed(3)}`;
 
   if (linAcc) {
-    linAccStats.textContent = `Linear acceleration: ` +
+    linAccStats.textContent =
+      `Linear acceleration: ` +
       `x ${linAcc[0].toFixed(3)}, ` +
       `y ${linAcc[1].toFixed(3)}, ` +
       `z ${linAcc[2].toFixed(3)}`;
   } else {
-    linAccStats.textContent = 'Linear acceleration not reported';
+    linAccStats.textContent = "Linear acceleration not reported";
   }
 
   if (angAcc) {
-    angAccStats.textContent = `Angular acceleration: ` +
-    `x ${angAcc[0].toFixed(3)}, ` +
-    `y ${angAcc[1].toFixed(3)}, ` +
-    `z ${angAcc[2].toFixed(3)}`;
+    angAccStats.textContent =
+      `Angular acceleration: ` +
+      `x ${angAcc[0].toFixed(3)}, ` +
+      `y ${angAcc[1].toFixed(3)}, ` +
+      `z ${angAcc[2].toFixed(3)}`;
   } else {
-    angAccStats.textContent = 'Angular acceleration not reported';
+    angAccStats.textContent = "Angular acceleration not reported";
   }
 }
 ```

--- a/files/en-us/web/html/reference/elements/object/index.md
+++ b/files/en-us/web/html/reference/elements/object/index.md
@@ -64,7 +64,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   data="/shared-assets/videos/flower.webm"
   width="600"
   height="140">
-  <img src="path/image.jpg" alt="useful image description" />
+  <img src="/mdn/shared-assets/blob/main/images/examples/flowers.jpg" alt="Some beautiful flowers" />
 </object>
 ```
 

--- a/files/en-us/web/html/reference/elements/object/index.md
+++ b/files/en-us/web/html/reference/elements/object/index.md
@@ -64,7 +64,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   data="/shared-assets/videos/flower.webm"
   width="600"
   height="140">
-  <img src="/mdn/shared-assets/blob/main/images/examples/flowers.jpg" alt="Some beautiful flowers" />
+  <img
+    src="/mdn/shared-assets/blob/main/images/examples/flowers.jpg"
+    alt="Some beautiful flowers" />
 </object>
 ```
 

--- a/files/en-us/web/html/reference/elements/object/index.md
+++ b/files/en-us/web/html/reference/elements/object/index.md
@@ -65,7 +65,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   width="600"
   height="140">
   <img
-    src="/mdn/shared-assets/blob/main/images/examples/flowers.jpg"
+    src="/shared-assets/images/examples/flowers.jpg"
     alt="Some beautiful flowers" />
 </object>
 ```


### PR DESCRIPTION
I am working on fixing all parser errors so that code examples can be linted. This PR fixes the rest of the problems with code blocks with interspersed prose. They are fixed by either adding the surrounding context, or migrating to live samples (which are concatenated at build time and can be picked up by my tool)