### PR TITLE
fix: use correct number in lesson

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/math/index.md
+++ b/files/en-us/learn_web_development/core/scripting/math/index.md
@@ -399,7 +399,7 @@ Open the above example in the MDN Playground by clicking the **"Play"** button, 
 
 - Change the line that calculates `x` so the box is still `50px` wide, but the 50 is calculated using the numbers 43 and 7 and an arithmetic operator.
 - Change the line that calculates `y` so the box is `75px` high, but the 75 is calculated using the numbers 25 and 3 and an arithmetic operator.
-- Change the line that calculates `x` so the box is `100px` wide, but the 150 is calculated using three numbers and the subtraction and division operators.
+- Change the line that calculates `x` so the box is `100px` wide, but the 100 is calculated using three numbers and the subtraction and division operators.
 - Change the line that calculates `y` so the box is `200px` high, but the 200 is calculated using the numbers 2 and `x`, and the multiplication operator.
 
 Don't worry if you mess the code up. You can always press the Reset button and start again.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
The lesson reads (emphasis mine):
> Change the line that calculates x so the box is 100px wide, but the **150** is calculated using three numbers and the subtraction and division operators.

However, I updated it to (emphasis not added):
> Change the line that calculates x so the box is 100px wide, but the **100** is calculated using three numbers and the subtraction and division operators. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It seems to be a typo, as it was talking about making a `100px` adjustment, but then referred to 150 which is nowhere in that sentence.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #40102 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
