### PR TITLE
fix: Prettier 3.6.2 compat bug with MD031

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_stores/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_stores/index.md
@@ -577,6 +577,7 @@ Moreover, because web storage only supports saving string values, we will have t
      };
    };
    ```
+
    - Our `localStore` will be a function that when executed initially reads its content from web storage, and returns an object with three methods: `subscribe()`, `set()`, and `update()`.
    - When we create a new `localStore`, we'll have to specify the key of the web storage and an initial value. We then check if the value exists in web storage and, if not, we create it.
    - We use the [`localStorage.getItem(key)`](/en-US/docs/Web/API/Storage/getItem) and [`localStorage.setItem(key, value)`](/en-US/docs/Web/API/Storage/setItem) methods to read and write information to web storage, and the [`toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) and `toObj()` (which uses [`JSON.parse()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)) helper functions to convert the values.

--- a/files/en-us/learn_web_development/core/scripting/what_went_wrong/index.md
+++ b/files/en-us/learn_web_development/core/scripting/what_went_wrong/index.md
@@ -62,6 +62,7 @@ Earlier on in the course we got you to type some simple JavaScript commands into
    Uncaught TypeError: guessSubmit.addeventListener is not a function
    number-game-errors.html:87:19
    ```
+
    - The first part, `Uncaught TypeError: guessSubmit.addeventListener is not a function`, is telling us something about what went wrong.
    - The second part, `number-game-errors.html:87:19`, is telling us where in the code the error came from: line 87, character 19 of the file "number-game-errors.html".
 

--- a/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
@@ -376,6 +376,7 @@ It is possible to render external images onto your canvas. These can be simple i
    ```js
    ctx.drawImage(image, 20, 20, 185, 175, 50, 50, 185, 175);
    ```
+
    - The first parameter is the image reference, as before.
    - Parameters 2 and 3 define the coordinates of the top left corner of the area you want to cut out of the loaded image, relative to the top-left corner of the image itself. Nothing to the left of the first parameter or above the second will be drawn.
    - Parameters 4 and 5 define the width and height of the area we want to cut out from the original image we loaded.

--- a/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -67,6 +67,7 @@ It is important to clarify the current standardization status of such features t
   > [!WARNING]
   > This feature is currently opposed by <number> browser vendor(s). See the [Standards positions](#standards_positions) section below for details of opposition.
   ```
+
   - Replace `<number>` with the number of browser vendors opposing the feature.
   - Use `vendor` or `vendors` as appropriate.
 

--- a/files/en-us/web/api/topics_api/using/index.md
+++ b/files/en-us/web/api/topics_api/using/index.md
@@ -68,6 +68,7 @@ The following features all serve a dual purpose — they return the user's top t
   ```html
   <iframe browsingtopics src="ad-tech1.example"> ... </iframe>
   ```
+
   - Programmatically by setting the equivalent {{domxref("HTMLIFrameElement.browsingTopics")}} property to `true`:
 
   ```js

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "markdownlint-rule-search-replace": "1.2.0",
     "node-html-parser": "^7.0.1",
     "parse-diff": "^0.11.1",
-    "prettier": "^3.6.2",
+    "prettier": "3.6.2",
     "yaml": "^2.8.0",
     "yargs": "^18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "markdownlint-rule-search-replace": "1.2.0",
     "node-html-parser": "^7.0.1",
     "parse-diff": "^0.11.1",
-    "prettier": "3.6.1",
+    "prettier": "^3.6.2",
     "yaml": "^2.8.0",
     "yargs": "^18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8351,15 +8351,15 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
+prettier@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
+  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
+
 prettier@^3.2.5:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.1.tgz#cc3bce21c09a477b1e987b76ce9663925d86ae44"
   integrity sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==
-
-prettier@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
-  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
 
 pretty-format@30.0.2:
   version "30.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8351,10 +8351,15 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
-prettier@3.6.1, prettier@^3.2.5:
+prettier@^3.2.5:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.1.tgz#cc3bce21c09a477b1e987b76ce9663925d86ae44"
   integrity sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==
+
+prettier@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
+  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
 
 pretty-format@30.0.2:
   version "30.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8351,15 +8351,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
-prettier@3.6.2:
+prettier@3.6.2, prettier@^3.2.5:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
-
-prettier@^3.2.5:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.1.tgz#cc3bce21c09a477b1e987b76ce9663925d86ae44"
-  integrity sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==
 
 pretty-format@30.0.2:
   version "30.0.2"


### PR DESCRIPTION
### Description

Bump Prettier and format non-compliant files.

### Motivation

There was a compat bug with Prettier v3.6.1 and markdownlint causing dueling linters.

### Related

- https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md
- https://redirect.github.com/prettier/prettier/issues/17652
- https://github.com/prettier/prettier/releases/tag/3.6.2