### PR TITLE
ci(pr-rebase-needed): use branch for push concurrency group

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-rebase-needed-${{ github.event.pull_request.number }}
+  group: pr-rebase-needed-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description

Improves the `pr-rebase-needed` workflow by separating workflow runs triggered by push events into different concurrency groups per branch.

### Motivation

Previously, any push to any origin branch was cancelling any running workflow run caused by another push, including the main branch.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Same as: https://github.com/mdn/browser-compat-data/pull/27163