### PR TITLE
fix(document.forms): Convert text to warning

### DIFF
--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -13,11 +13,12 @@ The **`forms`** read-only property of the {{domxref("Document")}} interface retu
 > [!NOTE]
 > Similarly, you can access a list of a form's component user input elements using the {{domxref("HTMLFormElement.elements")}} property.
 
+You can also access named `<form>` elements as properties of the `document` object.
+For example, `document["login-form"]` and `document.forms["login-form"]` can both be used to access the form named `login-form`.
+
 > [!WARNING]
-> Though you can access named `<form>` elements as properties of the `document` object itself, relying on this behavior is dangerous and discouraged.
-> For example, `document["login-form"]` and `document.forms["login-form"]` can both access the form named `login-form`.
-> However, using `document["login-form"]` can lead to unexpected conflicts with existing or future APIs in the browser.
-> For example, if a browser introduces a built-in `document["login-form"]` property in the future, your code will no longer be able to access your form element.
+> Relying on the `document["form-name"]` pattern is dangerous and discouraged because it can lead to unexpected conflicts with existing or future APIs in the browser.
+> For example, if a browser introduces a built-in `document["login-form"]` property in the future, your code may no longer be able to access the form element.
 > To avoid such conflicts, always use `document.forms` to access named forms.
 
 ## Value

--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -15,7 +15,7 @@ The **`forms`** read-only property of the {{domxref("Document")}} interface retu
 
 > [!WARNING]
 > Though you can access named `<form>` elements as properties of the `document` object itself, relying on this behavior is dangerous and discouraged.
-> For example, `document["login-form"]` and `document.forms["login-form"]` can both access the form named `login-form`. 
+> For example, `document["login-form"]` and `document.forms["login-form"]` can both access the form named `login-form`.
 > However, using `document["login-form"]` can lead to unexpected conflicts with existing or future APIs in the browser.
 > For example, if a browser introduces a built-in `document["login-form"]` property in the future, your code will no longer be able to access your form element.
 > To avoid such conflicts, always use `document.forms` to access named forms.

--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -13,10 +13,12 @@ The **`forms`** read-only property of the {{domxref("Document")}} interface retu
 > [!NOTE]
 > Similarly, you can access a list of a form's component user input elements using the {{domxref("HTMLFormElement.elements")}} property.
 
-Named `<form>` elements are also exposed as properties of the `document` object itself.
-For example, `document["login-form"]` and `document.forms["login-form"]` can both access the form named `login-form`. Relying on this behavior is dangerous and discouraged.
-It can lead to unexpected conflicts with some existing or future APIs in the browser.
-For example, if browsers introduce a new `document` property with the same name as your form, then the same code will no longer be able to access the form element. Always use `document.forms` instead.
+> [!WARNING]
+> Though you can access named `<form>` elements as properties of the `document` object itself, relying on this behavior is dangerous and discouraged.
+> For example, `document["login-form"]` and `document.forms["login-form"]` can both access the form named `login-form`. 
+> However, using `document["login-form"]` can lead to unexpected conflicts with existing or future APIs in the browser.
+> For example, if a browser introduces a built-in `document["login-form"]` property in the future, your code will no longer be able to access your form element.
+> To avoid such conflicts, always use `document.forms` to access named forms.
 
 ## Value
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -8,7 +8,7 @@ browser-compat: html.global_attributes.id
 
 {{HTMLSidebar("Global_attributes")}}
 
-The **`id`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) defines an identifier (ID) which must be unique in the whole document.
+The **`id`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) defines an identifier (ID) that must be unique within the entire document.
 
 {{InteractiveExample("HTML Demo: id", "tabbed-shorter")}}
 
@@ -47,20 +47,22 @@ Also, not all valid ID attribute values are valid JavaScript identifiers. For ex
 
 The purpose of the ID attribute is to identify a single element when linking (using a [fragment identifier](/en-US/docs/Web/URI/Reference/Fragment)), scripting, or styling (with {{glossary("CSS")}}).
 
-Elements with ID attributes are available as global properties. The property name is the ID attribute, and the property value is the element. For example, given markup like:
+You can access elements with ID attributes as global properties of the `window` object, where the property name is the ID value, and the property value is the corresponding element. For example, given this markup:
 
 ```html
 <p id="preamble"></p>
 ```
 
-You could access the paragraph element in JavaScript using code like:
+You can access this paragraph element in JavaScript using the following code:
 
 ```js
 const content = window.preamble.textContent;
 ```
 
 > [!WARNING]
-> Relying on this behavior is dangerous and discouraged. It can lead to unexpected conflicts with some existing or future APIs in the browser. For example, if browsers introduce a new global property named `preamble`, then the same code will no longer be able to access the HTML element. Use `document.getElementById()` or `document.querySelector()` instead.
+> Relying on the `window["id-value"]` or `window.idValue` pattern is dangerous and discouraged because it can lead to unexpected conflicts with existing or future APIs in the browser.
+> For example, if a browser introduces a built-in global property named `preamble` in the future, your code may no longer be able to access the HTML element.
+> To avoid such conflicts, always use `document.getElementById()` or `document.querySelector()` to access elements by ID.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -62,7 +62,7 @@ const content = window.preamble.textContent;
 > [!WARNING]
 > Relying on the `window["id-value"]` or `window.idValue` pattern is dangerous and discouraged because it can lead to unexpected conflicts with existing or future APIs in the browser.
 > For example, if a browser introduces a built-in global property named `preamble` in the future, your code may no longer be able to access the HTML element.
-> To avoid such conflicts, always use `document.getElementById()` or `document.querySelector()` to access elements by ID.
+> To avoid such conflicts, always use the {{domxref("Document.getElementById()")}} or {domxref("Document.querySelector()")}} method to access elements by ID.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

This is a follow-up to https://github.com/mdn/content/pull/40001.

@Josh-Cena @hamishwillee can you take look?
I think with the phrasing "dangerous and discouraged" in the para, we should ideally change the text into a "Warning" callout.

I've also rephrased the text to follow this format: "though `<this is possible>`, don't do it `<because>`. always `<do this>`."