### PR TITLE
doc[sec-websocket-extensions]: change from `comma-separated` to `semicolon-separated`

### DIFF
--- a/files/en-us/web/http/guides/protocol_upgrade_mechanism/index.md
+++ b/files/en-us/web/http/guides/protocol_upgrade_mechanism/index.md
@@ -74,7 +74,7 @@ Sec-WebSocket-Extensions: extensions
 - `extensions`
   - : A comma-separated list of extensions to request (or agree to support). These should be selected from the [IANA WebSocket Extension Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#extension-name). Extensions which take parameters do so by using semicolon delineation.
 
-For example:
+For example, this header indicates two custom extensions: `superspeed` and `colormode` (which additionally has the parameter `depth=16`):
 
 ```http
 Sec-WebSocket-Extensions: superspeed, colormode; depth=16

--- a/files/en-us/web/http/guides/protocol_upgrade_mechanism/index.md
+++ b/files/en-us/web/http/guides/protocol_upgrade_mechanism/index.md
@@ -77,7 +77,7 @@ Sec-WebSocket-Extensions: extensions
 For example:
 
 ```http
-Sec-WebSocket-Extensions: superspeed, colormode; depth=16
+Sec-WebSocket-Extensions: superspeed; colormode; depth=16
 ```
 
 #### {{HTTPHeader("Sec-WebSocket-Key")}}

--- a/files/en-us/web/http/guides/protocol_upgrade_mechanism/index.md
+++ b/files/en-us/web/http/guides/protocol_upgrade_mechanism/index.md
@@ -77,7 +77,7 @@ Sec-WebSocket-Extensions: extensions
 For example:
 
 ```http
-Sec-WebSocket-Extensions: superspeed; colormode; depth=16
+Sec-WebSocket-Extensions: superspeed, colormode; depth=16
 ```
 
 #### {{HTTPHeader("Sec-WebSocket-Key")}}

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -57,7 +57,7 @@ Sec-WebSocket-Extensions: <selected-extension>
 
 ### WebSocket opening handshake
 
-The HTTP request below shows the opening handshake where a client supports the `permessage-deflate` and `client_max_window_bits` extensions.
+The HTTP request below shows the opening handshake where a client supports the `permessage-deflate` extension with `client_max_window_bits` parameter.
 
 ```http
 GET /chat HTTP/1.1
@@ -66,7 +66,7 @@ Upgrade: websocket
 Connection: Upgrade
 Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
 Sec-WebSocket-Version: 13
-Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
+Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits, bbf-usp-protocol
 ```
 
 The request below with separate headers for each extension is equivalent:
@@ -78,8 +78,8 @@ Upgrade: websocket
 Connection: Upgrade
 Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
 Sec-WebSocket-Version: 13
-Sec-WebSocket-Extensions: permessage-deflate
-Sec-WebSocket-Extensions: client_max_window_bits
+Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
+Sec-WebSocket-Extensions: bbf-usp-protocol
 ```
 
 The response below might be sent from a server to indicate that it will support the `permessage-deflate` extension:

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -50,7 +50,7 @@ Sec-WebSocket-Extensions: <selected-extension>
 
 - `<extensions>`
   - : A semicolon-separated list of extensions to request (or for the server to agree to support).
-    These should be selected from the [IANA WebSocket Extension Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#extension-name).
+    These are commonly selected from the [IANA WebSocket Extension Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#extension-name) (custom extensions may also be used).
     Extensions which take parameters delineate them with semicolons.
 
 ## Examples

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -12,7 +12,8 @@ spec-urls: https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.2
 The HTTP **Sec-WebSocket-Extensions** {{glossary("request header", "request")}} and {{glossary("response header")}} is used in the [WebSocket](/en-US/docs/Web/API/WebSockets_API) opening [handshake](/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#the_websocket_handshake) to negotiate a protocol extension used by the client and server.
 
 In a request the header specifies one or more extensions that the web application would like to use, in order of preference.
-These can be added as in multiple headers, or as semicolon separate values added to a single header.
+These can be added as in multiple headers, or as comma separated values added to a single header.
+Each extension can also have one or more parameters — these are semicolon-separated values listed after the extension.
 
 In a response the header can only appear once, where it specifies the extension selected by the server from the client's preferences.
 This value must be the first extension that the server supports from the list provided in the request header.

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -12,7 +12,7 @@ spec-urls: https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.2
 The HTTP **Sec-WebSocket-Extensions** {{glossary("request header", "request")}} and {{glossary("response header")}} is used in the [WebSocket](/en-US/docs/Web/API/WebSockets_API) opening [handshake](/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#the_websocket_handshake) to negotiate a protocol extension used by the client and server.
 
 In a request the header specifies one or more extensions that the web application would like to use, in order of preference.
-These can be added as in multiple headers, or as comma separate values added to a single header.
+These can be added as in multiple headers, or as semicolon separate values added to a single header.
 
 In a response the header can only appear once, where it specifies the extension selected by the server from the client's preferences.
 This value must be the first extension that the server supports from the list provided in the request header.
@@ -49,7 +49,7 @@ Sec-WebSocket-Extensions: <selected-extension>
 ## Directives
 
 - `<extensions>`
-  - : A comma-separated list of extensions to request (or for the server to agree to support).
+  - : A semicolon-separated list of extensions to request (or for the server to agree to support).
     These should be selected from the [IANA WebSocket Extension Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#extension-name).
     Extensions which take parameters delineate them with semicolons.
 

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -50,7 +50,7 @@ Sec-WebSocket-Extensions: <selected-extension>
 ## Directives
 
 - `<extensions>`
-  - : A semicolon-separated list of extensions to request (or for the server to agree to support).
+  - : A comma-separated list of extensions to request (or for the server to agree to support).
     These are commonly selected from the [IANA WebSocket Extension Name Registry](https://www.iana.org/assignments/websocket/websocket.xml#extension-name) (custom extensions may also be used).
     Extensions which take parameters delineate them with semicolons.
 

--- a/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
+++ b/files/en-us/web/http/reference/headers/sec-websocket-extensions/index.md
@@ -58,7 +58,7 @@ Sec-WebSocket-Extensions: <selected-extension>
 
 ### WebSocket opening handshake
 
-The HTTP request below shows the opening handshake where a client supports the `permessage-deflate` extension with `client_max_window_bits` parameter.
+The HTTP request below shows the opening handshake where a client supports the `permessage-deflate` extension (with `client_max_window_bits` parameter), and the `bbf-usp-protocol` extension.
 
 ```http
 GET /chat HTTP/1.1


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The value of `Sec-WebSocket-Extensions` is semicolon-separated, like `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits`, which is described in this document.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
