### PR TITLE
fix: clarify comment on intentional misspelling for spell-check demon…

### DIFF
--- a/files/en-us/web/css/text-decoration-line/index.md
+++ b/files/en-us/web/css/text-decoration-line/index.md
@@ -142,7 +142,7 @@ The `text-decoration-line` property is specified as `none`, or **one or more** s
 
 In this example, the first paragraph contains a spelling mistake and uses the browser's styling for spelling errors on the misspelled word. The second paragraph uses the browser's styling for grammar errors. There is no styling change in browsers that do not support these `text-decoration-line` values.
 
-<!-- cSpell:ignore speling -->
+<!-- cSpell:ignore speling --> <!-- 'speling' is intentionally misspelled below to demonstrate spell-check styling. -->
 
 ```html
 <p>This text contains a <span class="spelling">speling</span> mistake.</p>


### PR DESCRIPTION
## Fix: Clarify Intentional Misspelling in Example

### Summary

This PR clarifies the use of the intentionally misspelled word `speling` in the `text-decoration-line` documentation example. A comment was added to explicitly state that the misspelling is deliberate and used to demonstrate browser spell-check styling. No functional or content changes were made.

### Motivation

- Ensures future contributors and reviewers understand that the misspelling is intentional, not an error.
- Improves documentation clarity and maintainability.
- Fully complies with the MDN contribution guidelines regarding spelling, documentation, and code comments.

### Checklist

- [x] Change is limited to documentation/comment improvement.
- [x] No intentional example or demo was altered beyond clarifying comments.
- [x] All contribution guidelines have been followed.
- [x] Linting and spell-checking are passing.

---

Thank you for reviewing!