### PR TITLE
Fixed incorrect reference from "current" to "previous" document on unload

### DIFF
--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
@@ -8,13 +8,13 @@ browser-compat: api.PerformanceNavigationTiming.unloadEventEnd
 
 {{APIRef("Performance API")}}
 
-The **`unloadEventEnd`** read-only property returns a {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the current document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler completes.
+The **`unloadEventEnd`** read-only property returns a {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the previous document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler completes.
 
 ## Value
 
 The `unloadEventEnd` property can have the following values:
 
-- A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the current document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler completes.
+- A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the previous document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler completes.
 - `0` if there is no previous document.
 - `0` if the previous page was on another origin.
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
@@ -8,13 +8,13 @@ browser-compat: api.PerformanceNavigationTiming.unloadEventStart
 
 {{APIRef("Performance API")}}
 
-The **`unloadEventStart`** read-only property returns a {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the current document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler starts.
+The **`unloadEventStart`** read-only property returns a {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the previous document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler starts.
 
 ## Value
 
 The `unloadEventStart` property can have the following values:
 
-- A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the current document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler starts.
+- A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the previous document's [`unload`](/en-US/docs/Web/API/Window/unload_event) event handler starts.
 - `0` if there is no previous document.
 - `0` if the previous page was on another origin.
 


### PR DESCRIPTION
### Description

Fixed incorrect reference from "current" to "previous" document on unload.

### Motivation

I had to look up the spec as to why our validations against navigation timings fails so often since we implemented it based on MDN. The "current" document is a bit of an ambiguous description regarding the unload event (the description below correctly mensions "previous").

### Additional details

[PerformanceNavigationTiming unloadeventstart spec](https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-unloadeventstart)

