### PR TITLE
add missing country code in the postal code validation example

### DIFF
--- a/files/en-us/web/html/guides/constraint_validation/index.md
+++ b/files/en-us/web/html/guides/constraint_validation/index.md
@@ -294,7 +294,7 @@ Basically, the idea is to trigger JavaScript on some form field event (like **on
 
 ### Constraint combining several fields: Postal code validation
 
-The postal code format varies from one country to another. Not only do most countries allow an optional prefix with the country code (like `D-` in Germany, `F-` in France or Switzerland), but some countries have postal codes with only a fixed number of digits; others, like the UK, have more complex structures, allowing letters at some specific positions.
+The postal code format varies from one country to another. Not only do most countries allow an optional prefix with the country code (like `D-` in Germany, `F-` in France or `CH-` in Switzerland), but some countries have postal codes with only a fixed number of digits; others, like the UK, have more complex structures, allowing letters at some specific positions.
 
 > [!NOTE]
 > This is not a comprehensive postal code validation library, but rather a demonstration of the key concepts.

--- a/files/en-us/web/html/guides/constraint_validation/index.md
+++ b/files/en-us/web/html/guides/constraint_validation/index.md
@@ -294,7 +294,7 @@ Basically, the idea is to trigger JavaScript on some form field event (like **on
 
 ### Constraint combining several fields: Postal code validation
 
-The postal code format varies from one country to another. Not only do most countries allow an optional prefix with the country code (like `D-` in Germany, `F-` in France or `CH-` in Switzerland), but some countries have postal codes with only a fixed number of digits; others, like the UK, have more complex structures, allowing letters at some specific positions.
+The postal code format varies from one country to another. Many countries allow an optional prefix with the country code (like `D-` in Germany, `F-` in France, and `CH-` in Switzerland). Some countries use only a fixed number of digits in postal codes, while others, like the UK, have more complex formats that allow letters at some specific positions.
 
 > [!NOTE]
 > This is not a comprehensive postal code validation library, but rather a demonstration of the key concepts.


### PR DESCRIPTION
### Description

I edited the paragraph explaining postal code validation example. Switzerland was mentioned there as an example county but its county code wasn't, so I added it.

### Motivation

It was confusing, as from the text it seems that swiss country code is `F-` but in reality it is `CH-` (which is reflected correctly in the provided code).

### Additional details

None.

### Related issues and pull requests

I didn't find a open issue that mentions this. This edit doesn't have dependencies. 
