### PR TITLE
Mention the insertion of the approximately equals symbol in NumberFormat.formatRange

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.md
@@ -53,7 +53,7 @@ formatRange(startDate, endDate)
 
 ### Return value
 
-A string representing the given date range formatted according to the locale and formatting options of this {{jsxref("Intl.DateTimeFormat")}} object.
+A string representing the given date range formatted according to the locale and formatting options of this {{jsxref("Intl.DateTimeFormat")}} object. If the start and end dates are equivalent at the precision of the output, the output will only contain a single date.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrange/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrange/index.md
@@ -25,7 +25,7 @@ formatRange(startRange, endRange)
 
 ### Return value
 
-A string representing the given range of numbers formatted according to the locale and formatting options of this {{jsxref("Intl.NumberFormat")}} object.
+A string representing the given range of numbers formatted according to the locale and formatting options of this {{jsxref("Intl.NumberFormat")}} object. If the start and end values are formatted to the same string, the output will only contain a single value, possibly prefixed with an "approximately equals" symbol (e.g., "~$3"). The insertion of this symbol only depends on the locale settings, and is inserted even when `startRange === endRange`.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formatrangetoparts/index.md
@@ -25,7 +25,7 @@ formatRangeToParts(startRange, endRange)
 
 ### Return value
 
-An {{jsxref("Array")}} of objects containing the formatted range in parts. Each object has three properties, `type`, `value`, and `source`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/NumberFormat/formatRange", "formatRange()")}}. The `type` may have the same values as {{jsxref("Intl/NumberFormat/formatToParts", "formatToParts()")}}. The `source` can be one of the following:
+An {{jsxref("Array")}} of objects containing the formatted range in parts. Each object has three properties, `type`, `value`, and `source`, each containing a string. The string concatenation of `value`, in the order provided, will result in the same string as {{jsxref("Intl/NumberFormat/formatRange", "formatRange()")}}. The `type` may have the same values as {{jsxref("Intl/NumberFormat/formatToParts", "formatToParts()")}}, or the additional value `"approximatelySign"` (see below). The `source` can be one of the following:
 
 - `startRange`
   - : The token is a part of the start number.
@@ -34,7 +34,7 @@ An {{jsxref("Array")}} of objects containing the formatted range in parts. Each 
 - `shared`
   - : The token is shared between the start and end; for example, the currency symbol. All literals that are part of the range pattern itself, such as the `"–"` separator, are also marked as `shared`.
 
-If the start and end numbers are equivalent, then the output has the same list of tokens as calling {{jsxref("Intl/NumberFormat/formatToParts", "formatToParts()")}} on the start number, with all tokens marked as `source: "shared"`.
+If the start and end numbers are formatted to the same string, then the output has the same list of tokens as calling {{jsxref("Intl/NumberFormat/formatToParts", "formatToParts()")}} on the start number, with all tokens marked as `source: "shared"`. In addition, the first token may be an "approximately equals" symbol (e.g., "~") with `type: "approximatelySign"`. The insertion of this symbol only depends on the locale settings, and is inserted even when `startRange === endRange`.
 
 ### Exceptions
 


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/61960 reports that the existence of the `{ type: "approximatelySign" }` token is missing in MDN.