### PR TITLE
feat: PoC move APIRef macro into front matter

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -39,6 +39,7 @@ animalfound
 anonid
 apacheconf
 apachectl
+apiref
 appcache
 APPCOMMAND
 APPCOMMAND_MEDIA_PREVIOUSTRACK

--- a/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
@@ -6,9 +6,7 @@ page-type: web-api-constructor
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.AudioProcessingEvent
-sidebar:
-  - apiref:
-      - Web Audio API
+sidebar: apiref
 ---
 
 {{Deprecated_header}}

--- a/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
@@ -6,7 +6,9 @@ page-type: web-api-constructor
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.AudioProcessingEvent
-sidebar: apiref
+sidebar:
+  - apiref:
+      - Web Audio API
 ---
 
 {{Deprecated_header}}

--- a/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
@@ -6,9 +6,10 @@ page-type: web-api-constructor
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.AudioProcessingEvent
+sidebar: apiref
 ---
 
-{{APIRef}}{{Deprecated_header}}
+{{Deprecated_header}}
 
 The **`AudioProcessingEvent()`** constructor creates a new {{domxref("AudioProcessingEvent")}} object.
 

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -5,9 +5,12 @@ page-type: web-api-interface
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent
+sidebar:
+  - apiref:
+      - Web Audio API
 ---
 
-{{APIRef("Web Audio API")}}{{deprecated_header}}
+{{deprecated_header}}
 
 The `AudioProcessingEvent` interface of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.
 

--- a/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
@@ -6,7 +6,9 @@ page-type: web-api-instance-property
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.inputBuffer
-sidebar: apiref
+sidebar:
+  - apiref:
+      - Web Audio API
 ---
 
 {{Deprecated_header}}

--- a/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
@@ -6,9 +6,7 @@ page-type: web-api-instance-property
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.inputBuffer
-sidebar:
-  - apiref:
-      - Web Audio API
+sidebar: apiref
 ---
 
 {{Deprecated_header}}

--- a/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/inputbuffer/index.md
@@ -6,9 +6,10 @@ page-type: web-api-instance-property
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.inputBuffer
+sidebar: apiref
 ---
 
-{{APIRef}}{{Deprecated_header}}
+{{Deprecated_header}}
 
 The **`inputBuffer`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the input buffer of an audio processing event.
 

--- a/files/en-us/web/api/audioprocessingevent/outputbuffer/index.md
+++ b/files/en-us/web/api/audioprocessingevent/outputbuffer/index.md
@@ -6,9 +6,10 @@ page-type: web-api-instance-property
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.outputBuffer
+sidebar: apiref
 ---
 
-{{APIRef}}{{Deprecated_header}}
+{{Deprecated_header}}
 
 The **`outputBuffer`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the output buffer of an audio processing event.
 

--- a/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
+++ b/files/en-us/web/api/audioprocessingevent/playbacktime/index.md
@@ -6,9 +6,10 @@ page-type: web-api-instance-property
 status:
   - deprecated
 browser-compat: api.AudioProcessingEvent.playbackTime
+sidebar: apiref
 ---
 
-{{APIRef}}{{Deprecated_header}}
+{{Deprecated_header}}
 
 The **`playbackTime`** read-only property of the {{domxref("AudioProcessingEvent")}} interface represents the time when the audio will be played. It is in the same coordinate system as the time used by the {{domxref("AudioContext")}}.
 

--- a/files/en-us/web/api/idbdatabase/close/index.md
+++ b/files/en-us/web/api/idbdatabase/close/index.md
@@ -4,9 +4,12 @@ short-title: close()
 slug: Web/API/IDBDatabase/close
 page-type: web-api-instance-method
 browser-compat: api.IDBDatabase.close
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`close()`** method of the {{domxref("IDBDatabase")}}
 interface returns immediately and closes the connection in a separate thread.

--- a/files/en-us/web/api/idbdatabase/close_event/index.md
+++ b/files/en-us/web/api/idbdatabase/close_event/index.md
@@ -4,9 +4,10 @@ short-title: close
 slug: Web/API/IDBDatabase/close_event
 page-type: web-api-event
 browser-compat: api.IDBDatabase.close_event
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
-
-{{ APIRef("IndexedDB") }}
 
 The `close` event is fired on `IDBDatabase` when the database connection is unexpectedly closed. This could happen, for example, if the underlying storage is removed or if the user clears the database in the browser's history preferences.
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -4,9 +4,12 @@ short-title: createObjectStore()
 slug: Web/API/IDBDatabase/createObjectStore
 page-type: web-api-instance-method
 browser-compat: api.IDBDatabase.createObjectStore
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`createObjectStore()`** method of the
 {{domxref("IDBDatabase")}} interface creates and returns a new {{domxref("IDBObjectStore")}}.

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
@@ -4,9 +4,12 @@ short-title: deleteObjectStore()
 slug: Web/API/IDBDatabase/deleteObjectStore
 page-type: web-api-instance-method
 browser-compat: api.IDBDatabase.deleteObjectStore
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`deleteObjectStore()`** method of the
 {{domxref("IDBDatabase")}} interface destroys the object store with the given name in

--- a/files/en-us/web/api/idbdatabase/index.md
+++ b/files/en-us/web/api/idbdatabase/index.md
@@ -3,9 +3,12 @@ title: IDBDatabase
 slug: Web/API/IDBDatabase
 page-type: web-api-interface
 browser-compat: api.IDBDatabase
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{APIRef("IndexedDB")}} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`IDBDatabase`** interface of the IndexedDB API provides a [connection to a database](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection); you can use an `IDBDatabase` object to open a [transaction](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction) on your database then create, manipulate, and delete objects (data) in that database. The interface provides the only way to get and manage versions of the database.
 

--- a/files/en-us/web/api/idbdatabase/name/index.md
+++ b/files/en-us/web/api/idbdatabase/name/index.md
@@ -4,9 +4,12 @@ short-title: name
 slug: Web/API/IDBDatabase/name
 page-type: web-api-instance-property
 browser-compat: api.IDBDatabase.name
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`name`** read-only property of the
 `IDBDatabase` interface is a string that contains the

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.md
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.md
@@ -4,9 +4,12 @@ short-title: objectStoreNames
 slug: Web/API/IDBDatabase/objectStoreNames
 page-type: web-api-instance-property
 browser-compat: api.IDBDatabase.objectStoreNames
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`objectStoreNames`** read-only property of the
 {{domxref("IDBDatabase")}} interface is a {{ domxref("DOMStringList") }} containing a

--- a/files/en-us/web/api/idbdatabase/transaction/index.md
+++ b/files/en-us/web/api/idbdatabase/transaction/index.md
@@ -4,9 +4,12 @@ short-title: transaction()
 slug: Web/API/IDBDatabase/transaction
 page-type: web-api-instance-method
 browser-compat: api.IDBDatabase.transaction
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`transaction`** method of the {{domxref("IDBDatabase")}} interface immediately returns a transaction object ({{domxref("IDBTransaction")}}) containing the {{domxref("IDBTransaction.objectStore")}} method, which you can use to access your object store.
 

--- a/files/en-us/web/api/idbdatabase/version/index.md
+++ b/files/en-us/web/api/idbdatabase/version/index.md
@@ -4,9 +4,12 @@ short-title: version
 slug: Web/API/IDBDatabase/version
 page-type: web-api-instance-property
 browser-compat: api.IDBDatabase.version
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
 
-{{ APIRef("IndexedDB") }} {{AvailableInWorkers}}
+{{AvailableInWorkers}}
 
 The **`version`** property of the {{domxref("IDBDatabase")}}
 interface is a 64-bit integer

--- a/files/en-us/web/api/idbdatabase/versionchange_event/index.md
+++ b/files/en-us/web/api/idbdatabase/versionchange_event/index.md
@@ -4,9 +4,10 @@ short-title: versionchange
 slug: Web/API/IDBDatabase/versionchange_event
 page-type: web-api-event
 browser-compat: api.IDBDatabase.versionchange_event
+sidebar:
+  - apiref:
+      - IndexedDB
 ---
-
-{{APIRef("IndexedDB")}}
 
 The `versionchange` event is fired when a database structure change ([`upgradeneeded`](/en-US/docs/Web/API/IDBOpenDBRequest/upgradeneeded_event) event send on an [`IDBOpenDBRequest`](/en-US/docs/Web/API/IDBOpenDBRequest) or [`IDBFactory.deleteDatabase`](/en-US/docs/Web/API/IDBFactory/deleteDatabase)) was requested elsewhere (most probably in
 another window/tab on the same computer).

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -33,14 +33,28 @@
         "description": "Sidebar navigation(s) to show, defined as YAML in /files/en-us/sidebars",
         "type": ["array", "string"],
         "items": {
-          "type": "string",
-          "enum": [
-            "mediasidebar",
-            "urlsidebar",
-            "xmlsidebar",
-            "xpathsidebar",
-            "xsltsidebar",
-            "exsltsidebar"
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "mediasidebar",
+                "urlsidebar",
+                "xmlsidebar",
+                "xpathsidebar",
+                "xsltsidebar",
+                "exsltsidebar"
+              ]
+            },
+            {
+              "type": "object",
+              "propertyNames": {
+                "enum": ["apiref"]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
           ]
         }
       },


### PR DESCRIPTION
### Description

This PR is a demo of moving the `{{apiref(.*)}}` macro into front matter.

__Changes:__
* Move `APIRef` into front matter
* Update front matter schema to allow for both strings or a list of items which accept string args

### Motivation

I have made the replacements across the entire `files/en-us/web/api/**/*` section for `APIRef`, which touches 7,000+ files. This PR is a small example on a subset of files so we can show that it works as expected with different parameter formats (with/without whitespace, without params).

For the full `APIRef` changes, see:

https://github.com/mdn/content/compare/main...bsmth:content:api-sidebar?expand=1

### Related issues and pull requests

- [x] https://github.com/mdn/rari/pull/237 (landed in [rari v0.1.41](https://github.com/mdn/rari/releases/tag/v0.1.41))
