### PR TITLE
Add important note explaining why `navigator.vibrate()` may not work

### DIFF
--- a/files/en-us/web/api/navigator/vibrate/index.md
+++ b/files/en-us/web/api/navigator/vibrate/index.md
@@ -17,6 +17,8 @@ If the method was unable to vibrate because of invalid parameters, it will retur
 `false`, else it returns `true`. If the pattern leads to a too
 long vibration, it is truncated: the max length depends on the implementation.
 
+On some Android devices, `navigator.vibrate()` will not work if the device is in **Silent Mode** or **Do Not Disturb (DND)** mode. Ensure these modes are disabled and vibration is enabled in your system settings.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/navigator/vibrate/index.md
+++ b/files/en-us/web/api/navigator/vibrate/index.md
@@ -17,7 +17,7 @@ If the method was unable to vibrate because of invalid parameters, it will retur
 `false`, else it returns `true`. If the pattern leads to a too
 long vibration, it is truncated: the max length depends on the implementation.
 
-On some Android devices, `navigator.vibrate()` will not work if the device is in **Silent Mode** or **Do Not Disturb (DND)** mode. Ensure these modes are disabled and vibration is enabled in your system settings.
+The `vibrate()` method may have no effect if the device is in Silent Mode or Do Not Disturb (DND) mode. Make sure these modes are disabled and that vibration is enabled in the device's system settings.
 
 ## Syntax
 

--- a/files/en-us/web/api/navigator/vibrate/index.md
+++ b/files/en-us/web/api/navigator/vibrate/index.md
@@ -17,7 +17,7 @@ If the method was unable to vibrate because of invalid parameters, it will retur
 `false`, else it returns `true`. If the pattern leads to a too
 long vibration, it is truncated: the max length depends on the implementation.
 
-The `vibrate()` method may have no effect if the device is in Silent Mode or Do Not Disturb (DND) mode. Make sure these modes are disabled and that vibration is enabled in the device's system settings.
+Some devices may not vibrate if they are in Silent mode or Do Not Disturb (DND) mode. To ensure vibration works, make sure these modes are turned off and that vibration is enabled in the system settings.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Added a usage note to the [`navigator.vibrate()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate) page, explaining that vibration may not work when a device is in Silent Mode or Do Not Disturb (DND) mode.

### Motivation

Many developers encounter issues where `navigator.vibrate()` appears to do nothing, even though the API is supported and called correctly. After extensive debugging, I found that the root cause was that my phone was in Silent Mode, which disables vibration for web APIs. This behavior is undocumented and non-obvious, so this note will save other developers time and confusion.
