### PR TITLE
TRACE is not allowed in fetch

### DIFF
--- a/files/en-us/web/http/reference/methods/trace/index.md
+++ b/files/en-us/web/http/reference/methods/trace/index.md
@@ -99,8 +99,7 @@ Accept: */*
 
 ## Browser compatibility
 
-The browser doesn't use the `TRACE` method for user-initiated actions, so "browser compatibility" doesn't apply.
-Developers can't set this request method using [`fetch()`](/en-US/docs/Web/API/Window/fetch) because it's a [forbidden method](https://fetch.spec.whatwg.org/#forbidden-method).
+There's no browser compat
 
 ## See also
 

--- a/files/en-us/web/http/reference/methods/trace/index.md
+++ b/files/en-us/web/http/reference/methods/trace/index.md
@@ -100,7 +100,7 @@ Accept: */*
 ## Browser compatibility
 
 The browser doesn't use the `TRACE` method for user-initiated actions, so "browser compatibility" doesn't apply.
-Developers can set this request method using [`fetch()`](/en-US/docs/Web/API/Window/fetch).
+Developers can't set this request method using [`fetch()`](/en-US/docs/Web/API/Window/fetch) because it's a [forbidden method](https://fetch.spec.whatwg.org/#forbidden-method).
 
 ## See also
 

--- a/files/en-us/web/http/reference/methods/trace/index.md
+++ b/files/en-us/web/http/reference/methods/trace/index.md
@@ -99,7 +99,7 @@ Accept: */*
 
 ## Browser compatibility
 
-There's no browser compat
+The browser doesn't use the `TRACE` method for user-initiated actions, so "browser compatibility" doesn't apply.
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

According to [fetch.spec.whatwg.org/#forbidden-method](https://fetch.spec.whatwg.org/#forbidden-method), we can't set `TRACE` method in `fetch`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
