### PR TITLE
Document pixelFormat for ImageData

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -48,7 +48,9 @@ getImageData(sx, sy, sw, sh, settings)
 - `settings` {{optional_inline}}
   - : An object with the following properties:
     - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
-    - `pixelFormat`: Specifies the pixel format. Can be set to `"rgba-unorm8"` for RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}, or to `"rgba-float16"` for RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
+    - `pixelFormat`: Specifies the pixel format. Possible values:
+      - `"rgba-unorm8"`, for RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}.
+      - `"rgba-float16"`, for RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
 
 ### Return value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -129,7 +129,9 @@ const context = canvas.getContext("2d");
 const imageData = context.getImageData(0, 0, 1, 1);
 console.log(imageData.pixelFormat); // "rgba-unorm8"
 
-const imageData = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
+const imageData = context.getImageData(0, 0, 1, 1, {
+  pixelFormat: "rgba-float16",
+});
 console.log(imageData.pixelFormat); // "rgba-float16"
 ```
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -48,6 +48,7 @@ getImageData(sx, sy, sw, sh, settings)
 - `settings` {{optional_inline}}
   - : An object with the following properties:
     - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+    - `pixelFormat`: Specifies the pixel format. Can be set to `"rgba-unorm8"` for RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}, or to `"rgba-float16"` for RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
 
 ### Return value
 
@@ -116,6 +117,20 @@ context.fillRect(0, 0, 10, 10);
 // Get ImageData converted to sRGB
 const imageData = context.getImageData(0, 0, 1, 1, { colorSpace: "srgb" });
 console.log(imageData.colorSpace); // "srgb"
+```
+
+### Getting data in different pixel formats
+
+The optional `pixelFormat` setting allows you to get image data in the desired pixel format.
+
+```js
+const context = canvas.getContext("2d");
+
+const imageData = context.getImageData(0, 0, 1, 1);
+console.log(imageData.pixelFormat); // "rgba-unorm8"
+
+const imageData = context.getImageData(0, 0, 1, 1, { pixelFormat: "rgba-float16" });
+console.log(imageData.pixelFormat); // "rgba-float16"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/imagedata/data/index.md
+++ b/files/en-us/web/api/imagedata/data/index.md
@@ -34,7 +34,7 @@ console.log(imageData.data); // Uint8ClampedArray[40000]
 console.log(imageData.data.length); // 40000
 ```
 
-If the `ImageData` object is set up for floating-point pixels, for example for high dynamic range (HDR) images, `data` will be a {{jsxref("Float16Array")}} instead.
+If the `ImageData` object is set up for floating-point pixels — for example, for high dynamic range (HDR) images —`data` will be a {{jsxref("Float16Array")}} instead.
 
 ```js
 let floatArray = new Float16Array(4 * 200 * 200);

--- a/files/en-us/web/api/imagedata/data/index.md
+++ b/files/en-us/web/api/imagedata/data/index.md
@@ -38,7 +38,9 @@ If the `ImageData` object is set up for floating-point pixels, for example for h
 
 ```js
 let floatArray = new Float16Array(4 * 200 * 200);
-let imageData = new ImageData(floatArray, 200, 200, { pixelFormat: "rgba-float16" });
+let imageData = new ImageData(floatArray, 200, 200, {
+  pixelFormat: "rgba-float16",
+});
 console.log(imageData.data); // Float16Array
 ```
 

--- a/files/en-us/web/api/imagedata/data/index.md
+++ b/files/en-us/web/api/imagedata/data/index.md
@@ -9,13 +9,16 @@ browser-compat: api.ImageData.data
 {{APIRef("Canvas API")}}{{AvailableInWorkers}}
 
 The readonly **`ImageData.data`** property returns a
-{{jsxref("Uint8ClampedArray")}} that contains the {{domxref("ImageData")}} object's
+{{jsxref("Uint8ClampedArray")}} or {{jsxref("Float16Array")}} that contains the {{domxref("ImageData")}} object's
 pixel data. Data is stored as a one-dimensional array in the RGBA order, with integer
 values between `0` and `255` (inclusive).
 
 ## Value
 
-A {{jsxref("Uint8ClampedArray")}}.
+The type depends on the {{domxref("ImageData.pixelFormat")}} used:
+
+- A {{jsxref("Uint8ClampedArray")}} if the `pixelFormat` is `"rgba-unorm8"`.
+- A {{jsxref("Float16Array")}} if the `pixelFormat` is `"rgba-float16"`.
 
 ## Examples
 
@@ -29,6 +32,14 @@ for each pixel, making 4 x 10,000, or 40,000 values in all.
 let imageData = new ImageData(100, 100);
 console.log(imageData.data); // Uint8ClampedArray[40000]
 console.log(imageData.data.length); // 40000
+```
+
+If the `ImageData` object is set up for floating-point pixels, for example for high dynamic range (HDR) images, `data` will be a {{jsxref("Float16Array")}} instead.
+
+```js
+let floatArray = new Float16Array(4 * 200 * 200);
+let imageData = new ImageData(floatArray, 200, 200, { pixelFormat: "rgba-float16" });
+console.log(imageData.data); // Float16Array
 ```
 
 ### Filling a blank ImageData object

--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -36,6 +36,8 @@ new ImageData(dataArray, width, height, settings)
 - `settings` {{optional_inline}}
   - : An object with the following properties:
     - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
+    - `pixelFormat`: Specifies the pixel format. Can be set to `"rgba-unorm8"` for RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}, or to `"rgba-float16"` for RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
+
 - `dataArray`
   - : A {{jsxref("Uint8ClampedArray")}} containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
 
@@ -46,7 +48,11 @@ A new {{domxref('ImageData')}} object.
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `array` is specified, but its length is not a multiple of `(4 * width)` or `(4 * width * height)`.
+  - : Thrown if `dataArray` is specified, but its length is not a multiple of `(4 * width)` or `(4 * width * height)`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `dataArray` is of type {{jsxref("Uint8ClampedArray")}} and `pixelFormat` is not set to `"rgba-unorm8"`.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `dataArray` is of type {{jsxref("Float16Array")}} and `pixelFormat` is not set to `"rgba-float16"`.
 
 ## Examples
 
@@ -66,6 +72,16 @@ This example creates an `ImageData` object with the [display-p3 color space](htt
 
 ```js
 let imageData = new ImageData(200, 100, { colorSpace: "display-p3" });
+```
+
+### Floating-point pixel data for wide gamuts and high dynamic range (HDR)
+
+Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR). You can set the `pixelFormat` setting to `"rgba-float16"` to use RGBA values with 16 bits per component. This requires the `dataArray` to be a {{jsxref("Float16Array")}}.
+
+```js
+let floatArray = new Float16Array(4 * 200 * 200);
+let imageData = new ImageData(floatArray, 200, 200, { pixelFormat: "rgba-float16" });
+console.log(imageData.pixelFormat); // "rgba-float16"
 ```
 
 ### Initializing ImageData with an array

--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -80,7 +80,9 @@ Floating-point pixel values allow representing colors in arbitrarily wide gamuts
 
 ```js
 let floatArray = new Float16Array(4 * 200 * 200);
-let imageData = new ImageData(floatArray, 200, 200, { pixelFormat: "rgba-float16" });
+let imageData = new ImageData(floatArray, 200, 200, {
+  pixelFormat: "rgba-float16",
+});
 console.log(imageData.pixelFormat); // "rgba-float16"
 ```
 

--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -36,7 +36,9 @@ new ImageData(dataArray, width, height, settings)
 - `settings` {{optional_inline}}
   - : An object with the following properties:
     - `colorSpace`: Specifies the color space of the image data. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3).
-    - `pixelFormat`: Specifies the pixel format. Can be set to `"rgba-unorm8"` for RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}, or to `"rgba-float16"` for RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
+    - `pixelFormat`: Specifies the pixel format. Possible values:
+      - `"rgba-unorm8"`, for RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}.
+      - `"rgba-float16"`, for RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
 
 - `dataArray`
   - : A {{jsxref("Uint8ClampedArray")}} containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.

--- a/files/en-us/web/api/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/index.md
@@ -26,6 +26,8 @@ It is created using the {{domxref("ImageData.ImageData", "ImageData()")}} constr
   - : An `unsigned long` representing the actual height, in pixels, of the `ImageData`.
 - {{domxref("ImageData.width")}} {{ReadOnlyInline}}
   - : An `unsigned long` representing the actual width, in pixels, of the `ImageData`.
+- {{domxref("ImageData.pixelFormat")}} {{ReadOnlyInline}}
+  - : A string indicating the format to use for the `ImageData`.
 
 ## Specifications
 

--- a/files/en-us/web/api/imagedata/pixelformat/index.md
+++ b/files/en-us/web/api/imagedata/pixelformat/index.md
@@ -1,0 +1,47 @@
+---
+title: "ImageData: pixelFormat property"
+short-title: pixelFormat
+slug: Web/API/ImageData/pixelFormat
+page-type: web-api-instance-property
+browser-compat: api.ImageData.pixelFormat
+---
+
+{{APIRef("Canvas API")}}{{AvailableInWorkers}}
+
+The read-only **`ImageData.pixelFormat`** property is a string indicating the pixel format of the image data.
+
+The pixel format can be set during `ImageData` initialization using either the [`ImageData()`](/en-US/docs/Web/API/ImageData/ImageData) constructor or the [`createImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData) method.
+
+## Value
+
+This property can have the following values:
+
+- `"rgba-unorm8"` representing RGBA with 8 bit per component unsigned normalized format, using a {{jsxref("Uint8ClampedArray")}}.
+- `"rgba-float16"` representing RGBA with 16 bits per component, using a {{jsxref("Float16Array")}}. Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR).
+
+## Examples
+
+### Floating-point pixel data for wide gamuts and high dynamic range (HDR)
+
+Floating-point pixel values allow representing colors in arbitrarily wide gamuts and high dynamic range (HDR). You can set the `pixelFormat` setting to `"rgba-float16"` to use RGBA values with 16 bits per component. This requires the `dataArray` to be a {{jsxref("Float16Array")}}.
+
+```js
+let floatArray = new Float16Array(4 * 200 * 200);
+let imageData = new ImageData(floatArray, 200, 200, { pixelFormat: "rgba-float16" });
+console.log(imageData.pixelFormat); // "rgba-float16"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ImageData")}}
+- {{jsxref("Float16Array")}}
+- {{domxref("CanvasRenderingContext2D.createImageData()")}}
+- {{domxref("CanvasRenderingContext2D.putImageData()")}}

--- a/files/en-us/web/api/imagedata/pixelformat/index.md
+++ b/files/en-us/web/api/imagedata/pixelformat/index.md
@@ -27,7 +27,9 @@ Floating-point pixel values allow representing colors in arbitrarily wide gamuts
 
 ```js
 let floatArray = new Float16Array(4 * 200 * 200);
-let imageData = new ImageData(floatArray, 200, 200, { pixelFormat: "rgba-float16" });
+let imageData = new ImageData(floatArray, 200, 200, {
+  pixelFormat: "rgba-float16",
+});
 console.log(imageData.pixelFormat); // "rgba-float16"
 ```
 


### PR DESCRIPTION
### Description

Document floating-point pixel support in 2D canvas which ships in Chromium-based browsers as of v137.

### Motivation

I like to document the web platform.

### Additional details

Explainer: https://github.com/ccameron-chromium/ColorWeb-CG/blob/image_data_float/image_data_float.md
Chromestatus: https://chromestatus.com/feature/5086141338877952

### Related issues and pull requests

Fix https://github.com/mdn/content/issues/39023
