### PR TITLE
Modernize CSS: use media range syntax

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/media_queries/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/media_queries/index.md
@@ -90,7 +90,7 @@ To change the `width` of your screen, change the size of your browser or rotate 
 
 #### Width and height
 
-The feature we tend to detect most often in order to create responsive designs (and that has widespread browser support) is viewport width, and we can apply CSS if the viewport is above or below a certain width — or an exact width — using the `min-width`, `max-width`, and `width` media features.
+The feature we tend to detect most often in order to create responsive designs (and that has widespread browser support) is viewport width, and we can apply CSS if the viewport is above or below a certain width — or an exact width — using the `width` media feature, and prefix it with `min-` or `max-` as needed.
 
 These features are used to create layouts that respond to different screen sizes. For example, to set the body text color to red if the viewport is exactly 600 pixels, you would use the following media query.
 
@@ -235,10 +235,10 @@ As before, try testing the examples in this section by adjusting your browser wi
 
 ### "and" logic in media queries
 
-To combine media features you can use `and` in much the same way as we have used `and` above to combine a media type and feature. For example, we might want to test for a `min-width` and `orientation`. The body text will only be blue if the viewport is at least 600 pixels wide and the device is in landscape mode.
+To combine media features you can use `and` in much the same way as we have used `and` above to combine a media type and feature. For example, we might want to test for `width` and `orientation`. The body text will only be blue if the viewport is at least 600 pixels wide and the device is in landscape mode.
 
 ```css live-sample___and
-@media screen and (min-width: 600px) and (orientation: landscape) {
+@media screen and (width >= 600px) and (orientation: landscape) {
   body {
     color: blue;
   }
@@ -263,7 +263,7 @@ To combine media features you can use `and` in much the same way as we have used
 If you have a set of queries, any of which could match, then you can comma separate these queries. In the below example the text will be blue if the viewport is at least 600 pixels wide OR the device is in landscape orientation. If either of these things are true the query matches.
 
 ```css live-sample___or
-@media screen and (min-width: 600px), screen and (orientation: landscape) {
+@media screen and (width >= 600px), screen and (orientation: landscape) {
   body {
     color: blue;
   }
@@ -288,7 +288,7 @@ If you have a set of queries, any of which could match, then you can comma separ
 You can negate an entire media query by using the `not` operator. This reverses the meaning of the entire media query. Therefore in this next example the text will only be blue if the viewport is _not_ at least 600 pixels wide.
 
 ```css live-sample___not
-@media not (min-width: 600px) {
+@media not (width >= 600px) {
   body {
     color: blue;
   }
@@ -509,7 +509,7 @@ Drag the window wider until you can see that the line lengths are becoming quite
 Add the following to the bottom of your CSS:
 
 ```css
-@media screen and (min-width: 40em) {
+@media screen and (width >= 40em) {
   article {
     display: grid;
     grid-template-columns: 3fr 1fr;
@@ -535,7 +535,7 @@ Let's continue to expand the width until we feel there is enough room for the si
 Add the following to the bottom of your CSS:
 
 ```css
-@media screen and (min-width: 70em) {
+@media screen and (width >= 70em) {
   main {
     display: grid;
     grid-template-columns: 3fr 1fr;

--- a/files/en-us/learn_web_development/core/css_layout/responsive_design/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/responsive_design/index.md
@@ -77,7 +77,7 @@ The rest of this article will explain the various web platform features you migh
 For example, the following media query tests to see if the current web page is being displayed as screen media (therefore not a printed document) and the viewport is at least `80rem` wide. The `.container` rule will only be applied if these two things are true.
 
 ```css
-@media screen and (min-width: 80rem) {
+@media screen and (width >= 80rem) {
   .container {
     margin: 1em 2em;
   }
@@ -168,7 +168,7 @@ body {
 ```
 
 ```css live-sample___flex-based-rwd
-@media screen and (min-width: 600px) {
+@media screen and (width >= 600px) {
   .wrapper {
     display: flex;
   }
@@ -246,7 +246,7 @@ body {
 ```
 
 ```css live-sample___grid-based-rwd
-@media screen and (min-width: 600px) {
+@media screen and (width >= 600px) {
   .wrapper {
     display: grid;
     grid-template-columns: 1fr 2fr;
@@ -299,7 +299,7 @@ h1 {
   font-size: 2rem;
 }
 
-@media (min-width: 1200px) {
+@media (width >= 1200px) {
   h1 {
     font-size: 4rem;
   }
@@ -364,7 +364,7 @@ h1 {
   background-color: #fff;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (width >= 600px) {
   .wrapper {
     display: grid;
     grid-template-columns: 1fr 2fr;
@@ -450,7 +450,7 @@ h1 {
   background-color: #fff;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (width >= 600px) {
   .wrapper {
     display: grid;
     grid-template-columns: 1fr 2fr;

--- a/files/en-us/learn_web_development/core/frameworks_libraries/angular_styling/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/angular_styling/index.md
@@ -120,7 +120,7 @@ In `app.component.css`, add the following styles:
     0 2.5rem 5rem 0 rgb(0 0 0 / 10%);
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (width >= 600px) {
   .main {
     width: 70%;
   }

--- a/files/en-us/learn_web_development/core/frameworks_libraries/react_todo_list_beginning/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/react_todo_list_beginning/index.md
@@ -320,7 +320,7 @@ body {
   max-width: 68rem;
   width: 100%;
 }
-@media screen and (min-width: 620px) {
+@media screen and (width >= 620px) {
   body {
     font-size: 1.9rem;
     line-height: 1.31579;
@@ -391,7 +391,7 @@ body {
 .stack-large > * + * {
   margin-top: 2.5rem;
 }
-@media screen and (min-width: 550px) {
+@media screen and (width >= 550px) {
   .stack-small > * + * {
     margin-top: 1.4rem;
   }
@@ -413,7 +413,7 @@ body {
   padding: 1rem;
   position: relative;
 }
-@media screen and (min-width: 550px) {
+@media screen and (width >= 550px) {
   .todoapp {
     padding: 4rem;
   }
@@ -456,7 +456,7 @@ body {
 [class*="__lg"]:not(:last-child) {
   margin-bottom: 1rem;
 }
-@media screen and (min-width: 620px) {
+@media screen and (width >= 620px) {
   [class*="__lg"] {
     font-size: 2.4rem;
   }

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
@@ -215,7 +215,7 @@ With this in mind, let's have a look at the `src/App.svelte` file that came with
     font-weight: 100;
   }
 
-  @media (min-width: 640px) {
+  @media (width >= 640px) {
     main {
       max-width: none;
     }
@@ -271,7 +271,7 @@ If you have experience working with CSS, the following snippet should make sense
     font-weight: 100;
   }
 
-  @media (min-width: 640px) {
+  @media (width >= 640px) {
     main {
       max-width: none;
     }

--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
@@ -459,7 +459,7 @@ body {
   background-color: #f5f5f5;
   color: #4d4d4d;
 }
-@media screen and (min-width: 620px) {
+@media screen and (width >= 620px) {
   body {
     font-size: 1.9rem;
     line-height: 1.31579;
@@ -535,7 +535,7 @@ body {
 .stack-large > * + * {
   margin-top: 2.5rem;
 }
-@media screen and (min-width: 550px) {
+@media screen and (width >= 550px) {
   .stack-small > * + * {
     margin-top: 1.4rem;
   }
@@ -557,7 +557,7 @@ body {
     0 2px 4px 0 rgb(0 0 0 / 20%),
     0 2.5rem 5rem 0 rgb(0 0 0 / 10%);
 }
-@media screen and (min-width: 550px) {
+@media screen and (width >= 550px) {
   .todoapp {
     padding: 4rem;
   }
@@ -600,7 +600,7 @@ body {
 [class*="__lg"]:not(:last-child) {
   margin-bottom: 1rem;
 }
-@media screen and (min-width: 620px) {
+@media screen and (width >= 620px) {
   [class*="__lg"] {
     font-size: 2.4rem;
   }

--- a/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
@@ -131,7 +131,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
 }
-@media screen and (min-width: 620px) {
+@media screen and (width >= 620px) {
   body {
     font-size: 1.9rem;
     line-height: 1.31579;
@@ -215,7 +215,7 @@ Update your `App.vue` file's `<style>` element so it looks like so:
 [class*="__lg"]:not(:last-child) {
   margin-bottom: 1rem;
 }
-@media screen and (min-width: 620px) {
+@media screen and (width >= 620px) {
   [class*="__lg"] {
     font-size: 2.4rem;
   }
@@ -239,7 +239,7 @@ Update your `App.vue` file's `<style>` element so it looks like so:
 .stack-large > * + * {
   margin-top: 2.5rem;
 }
-@media screen and (min-width: 550px) {
+@media screen and (width >= 550px) {
   .stack-small > * + * {
     margin-top: 1.4rem;
   }
@@ -258,7 +258,7 @@ Update your `App.vue` file's `<style>` element so it looks like so:
     0 2px 4px 0 rgb(0 0 0 / 20%),
     0 2.5rem 5rem 0 rgb(0 0 0 / 10%);
 }
-@media screen and (min-width: 550px) {
+@media screen and (width >= 550px) {
   #app {
     padding: 4rem;
   }
@@ -445,7 +445,7 @@ Next, copy the following CSS into the newly created `<style>` element:
 .custom-checkbox > input[type="checkbox"]:checked + label::after {
   opacity: 1;
 }
-@media only screen and (min-width: 40rem) {
+@media only screen and (width >= 40rem) {
   label,
   input,
   .custom-checkbox {

--- a/files/en-us/learn_web_development/core/styling_basics/cascade_layers/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/cascade_layers/index.md
@@ -269,7 +269,7 @@ If you define a layer using [media](/en-US/docs/Web/CSS/CSS_media_queries/Using_
 ```
 
 ```css live-sample___media-order
-@media (min-width: 50em) {
+@media (width >= 50em) {
   @layer site;
 }
 

--- a/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
@@ -464,7 +464,7 @@ body {
   background-color: pink;
 }
 
-@media (min-width: 30em) {
+@media (width >= 30em) {
   body {
     background-color: blue;
   }
@@ -531,7 +531,7 @@ body {
   max-width: 33em;
 }
 
-@media (min-width: 70em) {
+@media (width >= 70em) {
   /* Increase the global font size on larger screens or windows
      for better readability */
   body {
@@ -591,7 +591,7 @@ body {
   max-width: 33em;
 }
 
-@media (min-width: 70em) {
+@media (width >= 70em) {
   body {
     font-size: 130%;
   }
@@ -606,7 +606,7 @@ The next example shows the same CSS in a more compressed format, with all extra 
 
 ```css-nolint
 body{font:1em/150% Helvetica,Arial,sans-serif;padding:1em;margin:0 auto;max-width:33em;}
-@media(min-width:70em){body{font-size:130%;}}
+@media(width>=70em){body{font-size:130%;}}
 h1{font-size:1.5em;}
 ```
 

--- a/files/en-us/learn_web_development/extensions/performance/css/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/css/index.md
@@ -63,7 +63,7 @@ To optimize the CSSOM construction and improve page performance, you can do one 
   <link
     rel="stylesheet"
     href="mobile.css"
-    media="screen and (max-width: 480px)" />
+    media="screen and (width <= 480px)" />
   ```
 
   The above example provides three sets of styles — default styles that will always load, styles that will only be loaded when the document is being printed, and styles that will be loaded only by devices with narrow screens. By default, the browser assumes that each specified style sheet is render-blocking. You can tell the browser when a style sheet should be applied by adding a `media` attribute containing a [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries). When the browser sees a style sheet that it only needs to apply in a specific scenario, it still downloads the stylesheet, but doesn't render-block. By separating the CSS into multiple files, the main render-blocking file, in this case `styles.css`, is much smaller, reducing the time for which rendering is blocked.
@@ -116,7 +116,7 @@ To optimize the CSSOM construction and improve page performance, you can do one 
     rel="preload"
     href="bg-image-wide.png"
     as="image"
-    media="(min-width: 601px)" />
+    media="(width > 600px)" />
   ```
 
   With `preload`, the browser will fetch the referenced resources as soon as possible and make them available in the browser cache so that they will be ready for use sooner when they are referenced in subsequent code. It is useful to preload high-priority resources that the user will encounter early on in a page so that the experience is as smooth as possible. Note how you can also use `media` attributes to create responsive preloaders.
@@ -184,10 +184,7 @@ CSS can scope styles to particular conditions with media queries. Media queries 
 <link rel="stylesheet" href="print.css" media="print" />
 
 <!-- Loading and parsing mobile.css is not render-blocking on large screens -->
-<link
-  rel="stylesheet"
-  href="mobile.css"
-  media="screen and (max-width: 480px)" />
+<link rel="stylesheet" href="mobile.css" media="screen and (width <= 480px)" />
 ```
 
 By default, the browser assumes that each specified style sheet is render blocking. Tell the browser when the style sheet should be applied by adding a `media` attribute with the [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries). When the browser sees a style sheet it knows that it only needs to apply it for a specific scenario, it still downloads the stylesheet, but doesn't render block. By separating out the CSS into multiple files, the main render-blocking file, in this case `styles.css`, is much smaller, reducing the time that rendering is blocked.

--- a/files/en-us/learn_web_development/extensions/performance/html/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/html/index.md
@@ -68,13 +68,13 @@ This example provides different size images for different screen widths:
 ```html
 <img
   srcset="480w.jpg 480w, 800w.jpg 800w"
-  sizes="(max-width: 600px) 480px,
+  sizes="(width <= 600px) 480px,
          800px"
   src="800w.jpg"
   alt="Family portrait" />
 ```
 
-`srcset` provides the intrinsic size of the source images along with their filenames, and `sizes` provides media queries alongside image slot widths that need to be filled in each case. The browser then decides which images makes sense to load for each slot. As an example, if the screen width is `600px` or less, then `max-width: 600px` is true, and therefore, the slot to fill is said to be `480px`. In this case, the browser will likely choose to load the 480w.jpg file (480px-wide image). This helps with performance because browsers don't load larger images than they need.
+`srcset` provides the intrinsic size of the source images along with their filenames, and `sizes` provides media queries alongside image slot widths that need to be filled in each case. The browser then decides which images makes sense to load for each slot. As an example, if the screen width is `600px` or less, then `width <= 600px` is true, and therefore, the slot to fill is said to be `480px`. In this case, the browser will likely choose to load the 480w.jpg file (480px-wide image). This helps with performance because browsers don't load larger images than they need.
 
 This example provides different resolution images for different screen resolutions:
 
@@ -99,13 +99,13 @@ An example is as follows:
 
 ```html
 <picture>
-  <source media="(max-width: 799px)" srcset="narrow-banner-480w.jpg" />
-  <source media="(min-width: 800px)" srcset="wide-banner-800w.jpg" />
+  <source media="(width < 800px)" srcset="narrow-banner-480w.jpg" />
+  <source media="(width >= 800px)" srcset="wide-banner-800w.jpg" />
   <img src="large-banner-800w.jpg" alt="Dense forest scene" />
 </picture>
 ```
 
-The {{htmlelement("source")}} elements contain media queries inside `media` attributes. If a media query returns true, the image referenced in its `<source>` element's `srcset` attribute is loaded. In the above example, if the viewport width is `799px` or less, the `narrow-banner-480w.jpg` image is loaded. Also note how the `<picture>` element includes an `<img>` element, which provides a default image to load in the case of browsers that don't support `<picture>`.
+The {{htmlelement("source")}} elements contain media queries inside `media` attributes. If a media query returns true, the image referenced in its `<source>` element's `srcset` attribute is loaded. In the above example, if the viewport width is less than `800px`, the `narrow-banner-480w.jpg` image is loaded. Also note how the `<picture>` element includes an `<img>` element, which provides a default image to load in the case of browsers that don't support `<picture>`.
 
 Note the use of the `srcset` attribute in this example. As shown in the previous section, you can provide different resolutions for each image source.
 
@@ -115,11 +115,8 @@ Note the use of the `srcset` attribute in this example. As shown in the previous
 <video controls>
   <source src="video/smaller.mp4" type="video/mp4" />
   <source src="video/smaller.webm" type="video/webm" />
-  <source src="video/larger.mp4" type="video/mp4" media="(min-width: 800px)" />
-  <source
-    src="video/larger.webm"
-    type="video/webm"
-    media="(min-width: 800px)" />
+  <source src="video/larger.mp4" type="video/mp4" media="(width >= 800px)" />
+  <source src="video/larger.webm" type="video/webm" media="(width >= 800px)" />
 
   <!-- fallback for browsers that don't support video element -->
   <a href="video/larger.mp4">download video</a>

--- a/files/en-us/learn_web_development/extensions/testing/feature_detection/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/feature_detection/index.md
@@ -182,7 +182,7 @@ if (window.matchMedia("(width <= 480px)").matches) {
 As an example, our [Snapshot](https://github.com/chrisdavidmills/snapshot) demo makes use of it to selectively apply the Brick JavaScript library and use it to handle the UI layout, but only for the small screen layout (480px wide or less). We first use the `media` attribute to only apply the Brick CSS to the page if the page width is 480px or less:
 
 ```html
-<link href="dist/brick.css" rel="stylesheet" media="all and (width <= 480px)" />
+<link href="dist/brick.css" rel="stylesheet" media="(width <= 480px)" />
 ```
 
 We then use `matchMedia()` in the JavaScript several times, to only run Brick navigation functions if we are on the small screen layout (in wider screen layouts, everything can be seen at once, so we don't need to navigate between different views).

--- a/files/en-us/learn_web_development/extensions/testing/feature_detection/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/feature_detection/index.md
@@ -174,7 +174,7 @@ Bear in mind that some features are, however, known to be undetectable. In these
 We also wanted to mention the {{domxref("Window.matchMedia")}} JavaScript feature at this point too. This is a property that allows you to run media query tests inside JavaScript. It looks like this:
 
 ```js
-if (window.matchMedia("(max-width: 480px)").matches) {
+if (window.matchMedia("(width <= 480px)").matches) {
   // run JavaScript in here.
 }
 ```
@@ -182,16 +182,13 @@ if (window.matchMedia("(max-width: 480px)").matches) {
 As an example, our [Snapshot](https://github.com/chrisdavidmills/snapshot) demo makes use of it to selectively apply the Brick JavaScript library and use it to handle the UI layout, but only for the small screen layout (480px wide or less). We first use the `media` attribute to only apply the Brick CSS to the page if the page width is 480px or less:
 
 ```html
-<link
-  href="dist/brick.css"
-  rel="stylesheet"
-  media="all and (max-width: 480px)" />
+<link href="dist/brick.css" rel="stylesheet" media="all and (width <= 480px)" />
 ```
 
 We then use `matchMedia()` in the JavaScript several times, to only run Brick navigation functions if we are on the small screen layout (in wider screen layouts, everything can be seen at once, so we don't need to navigate between different views).
 
 ```js
-if (window.matchMedia("(max-width: 480px)").matches) {
+if (window.matchMedia("(width <= 480px)").matches) {
   deck.shuffleTo(1);
 }
 ```

--- a/files/en-us/mdn/writing_guidelines/code_style_guide/css/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/css/index.md
@@ -129,15 +129,15 @@ In a stylesheet that contains [media query](/en-US/docs/Web/CSS/CSS_media_querie
 ```css example-good
 /* Default CSS layout for narrow screens */
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   /* CSS for medium width screens */
 }
 
-@media (min-width: 800px) {
+@media (width >= 800px) {
   /* CSS for wide screens */
 }
 
-@media (min-width: 1100px) {
+@media (width >= 1100px) {
   /* CSS for really wide screens */
 }
 ```

--- a/files/en-us/web/api/cssconditionrule/conditiontext/index.md
+++ b/files/en-us/web/api/cssconditionrule/conditiontext/index.md
@@ -23,7 +23,7 @@ The following example demonstrates reading the value of
 {{domxref("CSSConditionRule")}} interface.
 
 ```css
-@media (min-width: 500px) {
+@media (width >= 500px) {
   body {
     color: blue;
   }
@@ -32,7 +32,7 @@ The following example demonstrates reading the value of
 
 ```js
 const targetRule = document.styleSheets[0].cssRules[0];
-console.log(targetRule.conditionText); // "(min-width: 500px)"
+console.log(targetRule.conditionText); // "(width >= 500px)"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/csscontainerrule/containername/index.md
+++ b/files/en-us/web/api/csscontainerrule/containername/index.md
@@ -13,7 +13,7 @@ The read-only **`containerName`** property of the {{domxref("CSSContainerRule")}
 For example, the value of `containerName` for the {{cssxref("@container")}} below is `sidebar`:
 
 ```css
-@container sidebar (min-width: 700px) {
+@container sidebar (width >= 700px) {
   .card {
     font-size: 2em;
   }
@@ -61,7 +61,7 @@ First we define the HTML for a `card` (`<div>`) contained within a `post`.
 ```
 
 The CSS for the container element specifies the type of the container, and may also specify a name.
-The card has a default font size, which is overridden for the `@container` named `sidebar` if the minimum width is greater than 700px.
+The card has a default font size, which is overridden for the `@container` named `sidebar` if the width is greater than 700px.
 
 ```html
 <style id="example-styles">
@@ -75,7 +75,7 @@ The card has a default font size, which is overridden for the `@container` named
     font-size: 1em;
   }
 
-  @container sidebar (min-width: 700px) {
+  @container sidebar (width >= 700px) {
     .card {
       font-size: 2em;
     }

--- a/files/en-us/web/api/csscontainerrule/containerquery/index.md
+++ b/files/en-us/web/api/csscontainerrule/containerquery/index.md
@@ -10,10 +10,10 @@ browser-compat: api.CSSContainerRule.containerQuery
 
 The read-only **`containerQuery`** property of the {{domxref("CSSContainerRule")}} interface returns a string representing the container conditions that are evaluated when the container changes size in order to determine if the styles in the associated {{cssxref("@container")}} are applied.
 
-For example, the value of `containerQuery` for the {{cssxref("@container")}} below is `(min-width: 700px)`:
+For example, the value of `containerQuery` for the {{cssxref("@container")}} below is `(width >= 700px)`:
 
 ```css
-@container sidebar (min-width: 700px) {
+@container sidebar (width >= 700px) {
   .card {
     font-size: 2em;
   }

--- a/files/en-us/web/api/csscontainerrule/index.md
+++ b/files/en-us/web/api/csscontainerrule/index.md
@@ -163,7 +163,7 @@ The card has a default font size, which is overridden for the `@container` named
     font-size: 1em;
   }
 
-  @container sidebar (min-width: 700px) {
+  @container sidebar (width >= 700px) {
     .card {
       font-size: 2em;
     }

--- a/files/en-us/web/api/cssmediarule/index.md
+++ b/files/en-us/web/api/cssmediarule/index.md
@@ -33,7 +33,7 @@ As this rule lives in the last stylesheet added to the document, it will be the 
 ```
 
 ```css
-@media (min-width: 500px) {
+@media (width >= 500px) {
   body {
     color: blue;
   }

--- a/files/en-us/web/api/cssmediarule/media/index.md
+++ b/files/en-us/web/api/cssmediarule/media/index.md
@@ -24,7 +24,7 @@ Calling `myRules[0].media` therefore returns a {{domxref("MediaList")}}
 object representing the media query.
 
 ```css
-@media (min-width: 500px) {
+@media (width >= 500px) {
   body {
     color: blue;
   }

--- a/files/en-us/web/api/cssrule/parentrule/index.md
+++ b/files/en-us/web/api/cssrule/parentrule/index.md
@@ -19,7 +19,7 @@ A {{domxref("CSSRule")}} which is the type of the containing rules. If the curre
 ## Examples
 
 ```css
-@media (min-width: 500px) {
+@media (width >= 500px) {
   .box {
     width: 100px;
     height: 200px;

--- a/files/en-us/web/api/htmlimageelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlimageelement/currentsrc/index.md
@@ -39,7 +39,7 @@ document.
     /en-US/docs/Web/HTML/Reference/Elements/img/clock-demo-200px.png 200w,
     /en-US/docs/Web/HTML/Reference/Elements/img/clock-demo-400px.png 400w
   "
-  sizes="(max-width: 400px) 50%, 90%" />
+  sizes="(width <= 400px) 50%, 90%" />
 ```
 
 ### JavaScript

--- a/files/en-us/web/api/htmlimageelement/height/index.md
+++ b/files/en-us/web/api/htmlimageelement/height/index.md
@@ -46,7 +46,7 @@ otherwise, it's drawn at 300px.
     /en-US/docs/Web/HTML/Reference/Elements/img/clock-demo-200px.png 200w,
     /en-US/docs/Web/HTML/Reference/Elements/img/clock-demo-400px.png 400w
   "
-  sizes="(max-width: 400px) 200px, 300px" />
+  sizes="(width <= 400px) 200px, 300px" />
 ```
 
 ### JavaScript

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -62,9 +62,9 @@ and 50em.
       new-york-skyline-4by3.jpg 1961w,
       new-york-skyline-tall.jpg 1060w
     "
-    sizes="((min-width: 50em) and (max-width: 60em)) 50em,
-              ((min-width: 30em) and (max-width: 50em)) 30em,
-              (max-width: 30em) 20em"
+    sizes="(50em <= width <= 60em) 50em,
+              (30em <= width < 50em) 30em,
+              (width < 30em) 20em"
     alt="The New York City skyline on a beautiful day, with the One World Trade Center building in the middle." />
   <p>
     Then there's even more amazing stuff to say down here. Can you believe it? I

--- a/files/en-us/web/api/htmlimageelement/width/index.md
+++ b/files/en-us/web/api/htmlimageelement/width/index.md
@@ -47,7 +47,7 @@ drawn at 400px.
     /en-US/docs/Web/HTML/Reference/Elements/img/clock-demo-200px.png 200w,
     /en-US/docs/Web/HTML/Reference/Elements/img/clock-demo-400px.png 400w
   "
-  sizes="(max-width: 400px) 200px, 400px" />
+  sizes="(width <= 400px) 200px, 400px" />
 ```
 
 ### JavaScript

--- a/files/en-us/web/api/htmllinkelement/imagesizes/index.md
+++ b/files/en-us/web/api/htmllinkelement/imagesizes/index.md
@@ -27,7 +27,7 @@ Given the following `<link>` element:
   rel="preload"
   as="image"
   imagesrcset="narrow.png, medium.png 600w, wide.png 1200w"
-  imagesizes="(max-width: 400px) 200px, (width < 600px) 75vw, 50vw" />
+  imagesizes="(width < 400px) 200px, (400px <= width < 600px) 75vw, 50vw" />
 ```
 
 ```html hidden

--- a/files/en-us/web/api/htmllinkelement/media/index.md
+++ b/files/en-us/web/api/htmllinkelement/media/index.md
@@ -23,13 +23,13 @@ A string.
   id="el"
   href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
   rel="stylesheet"
-  media="screen and (min-width: 600px)"
+  media="screen and (width >= 600px)"
   crossorigin="anonymous" />
 ```
 
 ```js
 const el = document.getElementById("el");
-console.log(el.media); // Output: "screen and (min-width: 600px)"
+console.log(el.media); // Output: "screen and (width >= 600px)"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlmetaelement/media/index.md
+++ b/files/en-us/web/api/htmlmetaelement/media/index.md
@@ -50,7 +50,7 @@ document.head.appendChild(meta1);
 // Add a theme-color for small devices
 const meta2 = document.createElement("meta");
 meta2.name = "theme-color";
-meta2.media = "(max-width: 600px)";
+meta2.media = "(width <= 600px)";
 meta2.content = "#000000";
 document.head.appendChild(meta2);
 ```

--- a/files/en-us/web/api/htmlsourceelement/height/index.md
+++ b/files/en-us/web/api/htmlsourceelement/height/index.md
@@ -24,17 +24,17 @@ A non-negative number indicating the height of the image resource in CSS pixels.
 <picture id="img">
   <source
     srcset="landscape.png"
-    media="(min-width: 1000px)"
+    media="(width >= 1000px)"
     width="1000"
     height="400" />
   <source
     srcset="square.png"
-    media="(min-width: 800px)"
+    media="(width >= 800px)"
     width="800"
     height="800" />
   <source
     srcset="portrait.png"
-    media="(min-width: 600px)"
+    media="(width >= 600px)"
     width="600"
     height="800" />
   <img

--- a/files/en-us/web/api/htmlsourceelement/media/index.md
+++ b/files/en-us/web/api/htmlsourceelement/media/index.md
@@ -23,13 +23,13 @@ A string.
   id="el"
   src="largeVideo.mov"
   type="video/quicktime"
-  media="screen and (min-width: 600px)" />
+  media="screen and (width >= 600px)" />
 ```
 
 ```js
 const el = document.getElementById("el");
-console.log(el.media); // Output: "screen and (min-width: 600px)"
-el.media = "(min-width: 800px)"; // Updates the media value
+console.log(el.media); // Output: "screen and (width >= 600px)"
+el.media = "(width >= 800px)"; // Updates the media value
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlsourceelement/sizes/index.md
+++ b/files/en-us/web/api/htmlsourceelement/sizes/index.md
@@ -23,15 +23,14 @@ A string.
   id="el"
   src="mediumVideo.mov"
   type="video/quicktime"
-  sizes="((min-width: 50em) and (max-width: 60em)) 50em,
-         ((min-width: 30em) and (max-width: 50em)) 30em" />
+  sizes="(50em <= width <= 60px) 50em,
+         (30em <= width < 50em) 30em" />
 ```
 
 ```js
 const el = document.getElementById("el");
-console.log(el.sizes); // Output: "((min-width: 50em) and (max-width: 60em)) 50em, ((min-width: 30em) and (max-width: 50em)) 30em"
-el.sizes =
-  "((min-width: 50em) and (max-width: 60em)) 50em, ((min-width: 30em) and (max-width: 50em)) 30em"; // Updates the sizes value
+console.log(el.sizes); // Output: "(50em <= width <= 60px) 50em, (30em <= width < 50em) 30em"
+el.sizes = "(50em <= width <= 60px) 100em, (30em <= width < 50em) 60em"; // Updates the sizes value
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlsourceelement/type/index.md
+++ b/files/en-us/web/api/htmlsourceelement/type/index.md
@@ -23,7 +23,7 @@ A string.
   id="el"
   src="large.webp"
   type="video/webp"
-  media="screen and (min-width: 600px)" />
+  media="screen and (width >= 600px)" />
 ```
 
 ```js

--- a/files/en-us/web/api/htmlsourceelement/width/index.md
+++ b/files/en-us/web/api/htmlsourceelement/width/index.md
@@ -24,17 +24,17 @@ A non-negative number indicating the width of the image resource in CSS pixels.
 <picture id="img">
   <source
     srcset="landscape.png"
-    media="(min-width: 1000px)"
+    media="(width >= 1000px)"
     width="1000"
     height="400" />
   <source
     srcset="square.png"
-    media="(min-width: 800px)"
+    media="(width >= 800px)"
     width="800"
     height="800" />
   <source
     srcset="portrait.png"
-    media="(min-width: 600px)"
+    media="(width >= 600px)"
     width="600"
     height="800" />
   <img

--- a/files/en-us/web/api/medialist/mediatext/index.md
+++ b/files/en-us/web/api/medialist/mediatext/index.md
@@ -16,7 +16,7 @@ interface is a {{Glossary("stringifier")}} that returns a string representing th
 
 A string representing the media queries of a stylesheet. Each one is
 separated by a comma, for example
-`screen and (min-width: 480px), print`.
+`screen and (width >= 480px), print`.
 
 If you wish to set new media queries on the document, the string value must have the
 different queries separated by commas, e.g., `screen, print`. Note that the

--- a/files/en-us/web/api/medialist/tostring/index.md
+++ b/files/en-us/web/api/medialist/tostring/index.md
@@ -34,17 +34,13 @@ const mediaList = firstStyleSheet.media; // the mediaList of the stylesheet
 mediaList.mediaText = "SCREEN AND (140PX <= WIDTH <= 380PX)";
 
 // add a second media value
-mediaList.appendMedium(
-  "SCREEN AND (MAX-HEIGHT: 400PX) AND (ORIENTATION: LANDSCAPE))",
-);
+mediaList.appendMedium("SCREEN AND (ORIENTATION: LANDSCAPE))");
 
 // erroneously, add the same media query again
-mediaList.appendMedium(
-  "SCREEN AND (MAX-HEIGHT: 400PX) AND (ORIENTATION: LANDSCAPE))",
-);
+mediaList.appendMedium("SCREEN AND (ORIENTATION: LANDSCAPE))");
 
 console.log(mediaList.toString());
-// "screen and (140px <= width <= 380px), screen and (max-height: 400px) and (orientation: landscape)"
+// "screen and (140px <= width <= 380px), screen and (orientation: landscape)"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/mediaquerylist/addlistener/index.md
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.md
@@ -40,7 +40,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 const paragraph = document.querySelector("p");
-const mediaQueryList = window.matchMedia("(max-width: 600px)");
+const mediaQueryList = window.matchMedia("(width <= 600px)");
 
 function screenTest(e) {
   if (e.matches) {

--- a/files/en-us/web/api/mediaquerylist/change_event/index.md
+++ b/files/en-us/web/api/mediaquerylist/change_event/index.md
@@ -38,7 +38,7 @@ _The `MediaQueryListEvent` interface inherits properties from its parent interfa
 ## Example
 
 ```js
-const mql = window.matchMedia("(max-width: 600px)");
+const mql = window.matchMedia("(width <= 600px)");
 
 mql.onchange = (e) => {
   if (e.matches) {

--- a/files/en-us/web/api/mediaquerylist/index.md
+++ b/files/en-us/web/api/mediaquerylist/index.md
@@ -38,7 +38,7 @@ _The `MediaQueryList` interface inherits methods from its parent interface, {{DO
 _The following events are delivered to `MediaQueryList` objects:_
 
 - {{DOMxRef("MediaQueryList.change_event", "change")}}
-  - : Sent to the `MediaQueryList` when the result of running the media query against the document changes. For example, if the media query is `(min-width: 400px)`, the `change` event is fired any time the width of the document's {{Glossary("viewport")}} changes such that its width moves across the 400px boundary in either direction.
+  - : Sent to the `MediaQueryList` when the result of running the media query against the document changes. For example, if the media query is `(width >= 400px)`, the `change` event is fired any time the width of the document's {{Glossary("viewport")}} changes such that its width moves across the 400px boundary in either direction.
 
 ## Examples
 
@@ -46,7 +46,7 @@ This example creates a `MediaQueryList` and then sets up a listener to detect wh
 
 ```js
 const para = document.querySelector("p");
-const mql = window.matchMedia("(max-width: 600px)");
+const mql = window.matchMedia("(width <= 600px)");
 
 function screenTest(e) {
   if (e.matches) {

--- a/files/en-us/web/api/mediaquerylist/media/index.md
+++ b/files/en-us/web/api/mediaquerylist/media/index.md
@@ -18,14 +18,14 @@ A string representing a serialized media query.
 
 ## Examples
 
-This example runs the media query `(max-width: 600px)` and displays the
+This example runs the media query `(width <= 600px)` and displays the
 value of the resulting `MediaQueryList`'s `media` property in a
 {{HTMLElement("span")}}.
 
 ### JavaScript
 
 ```js
-let mql = window.matchMedia("(max-width: 600px)");
+let mql = window.matchMedia("(width <= 600px)");
 
 document.querySelector(".mq-value").innerText = mql.media;
 ```

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.md
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.md
@@ -39,7 +39,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 const paragraph = document.querySelector("p");
-const mediaQueryList = window.matchMedia("(max-width: 600px)");
+const mediaQueryList = window.matchMedia("(width <= 600px)");
 
 function screenTest(e) {
   if (e.matches) {

--- a/files/en-us/web/api/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/index.md
@@ -33,7 +33,7 @@ _The `MediaQueryListEvent` interface inherits methods from its parent interface,
 
 ```js
 const para = document.querySelector("p"); // This is the UI element where to display the text
-const mql = window.matchMedia("(max-width: 600px)");
+const mql = window.matchMedia("(width <= 600px)");
 
 mql.addEventListener("change", (event) => {
   if (event.matches) {

--- a/files/en-us/web/api/mediaquerylistevent/matches/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/matches/index.md
@@ -22,7 +22,7 @@ currently matches the media query list, `false` if not.
 
 ```js
 const para = document.querySelector("p"); // This is the UI element where to display the text
-const mql = window.matchMedia("(max-width: 600px)");
+const mql = window.matchMedia("(width <= 600px)");
 
 mql.addEventListener("change", (event) => {
   if (event.matches) {

--- a/files/en-us/web/api/mediaquerylistevent/media/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/media/index.md
@@ -20,7 +20,7 @@ A string representing a serialized media query.
 
 ```js
 const para = document.querySelector("p"); // This is the UI element where to display the text
-const mql = window.matchMedia("(max-width: 600px)");
+const mql = window.matchMedia("(width <= 600px)");
 
 mql.addEventListener("change", (event) => {
   if (event.matches) {

--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.md
@@ -36,7 +36,7 @@ A new {{domxref("MediaQueryListEvent")}} object.
 ## Examples
 
 ```js
-const media = "(max-width: 600px)";
+const media = "(width <= 600px)";
 const matches = true;
 
 const myMediaQueryListEvent = new MediaQueryListEvent("change", {

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -124,7 +124,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Refer
 <svg
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <style id="circle_style_id" media="all and (min-width: 600px)">
+  <style id="circle_style_id" media="all and (width >= 600px)">
     circle {
       fill: gold;
       stroke: green;

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -124,7 +124,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Refer
 <svg
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <style id="circle_style_id" media="all and (width >= 600px)">
+  <style id="circle_style_id" media="(width >= 600px)">
     circle {
       fill: gold;
       stroke: green;

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -25,7 +25,7 @@ This example demonstrates programmatically getting and setting the media propert
 
 ### HTML
 
-The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Reference/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Reference/Element/style) element that is conditional on the media query `"all and (width >= 600px)"`.
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Reference/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Reference/Element/style) element that is conditional on the media query `"(width >= 600px)"`.
 We also define a `button` that will be used to display the current style and change the style.
 
 ```html
@@ -67,7 +67,7 @@ addEventListener("resize", () => {
 });
 
 button.addEventListener("click", () => {
-  style.media = "all and (width >= 700px)";
+  style.media = "(width >= 700px)";
   setButtonText();
 });
 ```

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -25,7 +25,7 @@ This example demonstrates programmatically getting and setting the media propert
 
 ### HTML
 
-The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Reference/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Reference/Element/style) element that is conditional on the media query `"all and (min-width: 600px)"`.
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Reference/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Reference/Element/style) element that is conditional on the media query `"all and (width >= 600px)"`.
 We also define a `button` that will be used to display the current style and change the style.
 
 ```html
@@ -67,7 +67,7 @@ addEventListener("resize", () => {
 });
 
 button.addEventListener("click", () => {
-  style.media = "all and (min-width: 700px)";
+  style.media = "all and (width >= 700px)";
   setButtonText();
 });
 ```

--- a/files/en-us/web/api/view_transition_api/using/index.md
+++ b/files/en-us/web/api/view_transition_api/using/index.md
@@ -549,10 +549,10 @@ This could be achieved with the following HTML:
   rel="expect"
   href="#lead-content"
   blocking="render"
-  media="screen and (min-width: 641px)" />
+  media="screen and (width > 640px)" />
 <link
   rel="expect"
   href="#first-section"
   blocking="render"
-  media="screen and (max-width: 640px)" />
+  media="screen and (width <= 640px)" />
 ```

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -25,7 +25,7 @@ matchMedia(mediaQueryString)
 - `mediaQueryString`
   - : A string specifying the media query to parse into a {{domxref("MediaQueryList")}}.
 
-    Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia("(max-width: 600px)")` works, whereas `matchMedia("max-width: 600px")` does not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
+    Just like in CSS, any [media feature](/en-US/docs/Web/CSS/@media#media_features) must be wrapped in parentheses inside the expression. For example: `matchMedia("(width <= 600px)")` or `matchMedia("(orientation: landscape)")` work, whereas `matchMedia("width < 600px")` or `matchMedia("orientation: landscape")` do not. Keywords for media types (`all`, `print`, `screen`) and logical operators (`and`, `or`, `not`, `only`) do not need to be wrapped in parentheses.
 
 ### Return value
 
@@ -50,7 +50,7 @@ in the article on {{domxref("Window.devicePixelRatio")}}.
 
 ## Examples
 
-This example runs the media query `(max-width: 600px)` and displays the
+This example runs the media query `(width <= 600px)` and displays the
 value of the resulting `MediaQueryList`'s `matches` property in a
 {{HTMLElement("span")}}; as a result, the output will say "true" if the viewport is less
 than or equal to 600 pixels wide, and will say "false" if the window is wider than that.
@@ -58,7 +58,7 @@ than or equal to 600 pixels wide, and will say "false" if the window is wider th
 ### JavaScript
 
 ```js
-let mql = window.matchMedia("(max-width: 600px)");
+let mql = window.matchMedia("(width <= 600px)");
 
 document.querySelector(".mq-value").innerText = mql.matches;
 ```

--- a/files/en-us/web/css/@container/index.md
+++ b/files/en-us/web/css/@container/index.md
@@ -383,7 +383,7 @@ The shorthand syntax for this declaration is described in the {{cssxref("contain
 Next, target that container by adding the name to the container query:
 
 ```css
-@container summary (min-width: 400px) {
+@container summary (width >= 400px) {
   .card {
     font-size: 1.5em;
   }
@@ -398,8 +398,8 @@ It is possible to nest container queries which has the same effect.
 The following query evaluates to true and applies the declared style if the container named `summary` is wider than `400px` and has an ancestor container wider than `800px`:
 
 ```css
-@container summary (min-width: 400px) {
-  @container (min-width: 800px) {
+@container summary (width > 400px) {
+  @container (width > 800px) {
     /* <stylesheet> */
   }
 }

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -102,9 +102,9 @@ The `@import` rules in the above examples show media-dependent conditions that w
 ### Importing CSS rules conditional on feature support
 
 ```css
-@import url("grid.css") supports(display: grid) screen and (max-width: 400px);
+@import url("grid.css") supports(display: grid) screen and (width <= 400px);
 @import url("flex.css") supports((not (display: grid)) and (display: flex))
-  screen and (max-width: 400px);
+  screen and (width <= 400px);
 ```
 
 The `@import` rules above illustrate how you might import a layout that uses a grid if `display: grid` is supported, and otherwise imports CSS that uses `display: flex`.

--- a/files/en-us/web/css/@media/color-index/index.md
+++ b/files/en-us/web/css/@media/color-index/index.md
@@ -55,7 +55,7 @@ This HTML will apply a special stylesheet for devices that have at least 256 col
 <link rel="stylesheet" href="http://foo.bar.com/base.css" />
 <link
   rel="stylesheet"
-  media="all and (min-color-index: 256)"
+  media="(color-index >= 256)"
   href="http://foo.bar.com/color-stylesheet.css" />
 ```
 

--- a/files/en-us/web/css/@media/display-mode/index.md
+++ b/files/en-us/web/css/@media/display-mode/index.md
@@ -39,7 +39,7 @@ The `display-mode` feature is specified as a keyword value chosen from the list 
 ### Apply CSS if the application is in fullscreen mode
 
 ```css
-@media all and (display-mode: fullscreen) {
+@media (display-mode: fullscreen) {
   body {
     margin: 0;
     border: 5px solid black;

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -47,7 +47,7 @@ abbr {
 
 ```css
 /* At the top level of your code */
-@media screen and (min-width: 900px) {
+@media screen and (width >= 900px) {
   article {
     padding: 1rem 3rem;
   }
@@ -55,7 +55,7 @@ abbr {
 
 /* Nested within another conditional at-rule */
 @supports (display: flex) {
-  @media screen and (min-width: 900px) {
+  @media screen and (width >= 900px) {
     article {
       display: flex;
     }
@@ -197,7 +197,7 @@ You can also combine multiple media queries into a single rule by separating the
 - `only`
   - : Applies a style only if an entire query matches.
     It is useful for preventing older browsers from applying selected styles.
-    When not using `only`, older browsers would interpret the query `screen and (max-width: 500px)` as `screen`, ignoring the remainder of the query, and applying its styles on all screens.
+    When not using `only`, older browsers would interpret the query `screen and (width <= 500px)` as `screen`, ignoring the remainder of the query, and applying its styles on all screens.
     If you use the `only` operator, you _must also_ specify a media type.
 - `,` (comma)
   - : Commas are used to combine multiple media queries into a single rule.
@@ -252,12 +252,6 @@ Because of this potential, a browser may opt to fudge the returned values in som
 @media screen, print {
   body {
     line-height: 1.2;
-  }
-}
-
-@media only screen and (min-width: 320px) and (max-width: 480px) and (resolution: 150dpi) {
-  body {
-    line-height: 1.4;
   }
 }
 ```

--- a/files/en-us/web/css/container-name/index.md
+++ b/files/en-us/web/css/container-name/index.md
@@ -95,13 +95,13 @@ Writing a container query via the {{Cssxref("@container")}} at-rule will apply s
 The following example has two container queries, one that will apply only to the contents of the `.post-excerpt` element and one that will apply to both the `.post-meta` and `.post-excerpt` contents:
 
 ```css
-@container excerpt (min-width: 400px) {
+@container excerpt (width >= 400px) {
   p {
     visibility: hidden;
   }
 }
 
-@container (min-width: 400px) {
+@container (width >= 400px) {
   p {
     font-size: 2rem;
   }
@@ -125,13 +125,13 @@ This will allow you to target the container using either name in the {{cssxref("
 This is useful if you want to target the same container with multiple container queries where either condition could be true:
 
 ```css
-@container meta (max-width: 500px) {
+@container meta (width <= 500px) {
   p {
     visibility: hidden;
   }
 }
 
-@container card (max-height: 200px) {
+@container card (width <= 200px) {
   h2 {
     font-size: 1.5em;
   }

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -157,7 +157,7 @@ h3 {
 Writing a container query via the {{Cssxref("@container")}} at-rule will apply styles to the elements of the container when it is wider than 400px:
 
 ```css
-@container (min-width: 400px) {
+@container (width > 400px) {
   .card {
     display: grid;
     grid-template-columns: 1fr 2fr;

--- a/files/en-us/web/css/container/index.md
+++ b/files/en-us/web/css/container/index.md
@@ -85,7 +85,7 @@ The `container` shorthand is intended to make this simpler to define in a single
 You can then target that container by name using the {{cssxref("@container")}} at-rule:
 
 ```css
-@container sidebar (min-width: 400px) {
+@container sidebar (width >= 400px) {
   /* <stylesheet> */
 }
 ```

--- a/files/en-us/web/css/css_containment/container_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_queries/index.md
@@ -65,7 +65,7 @@ Specifically, this query will apply a larger font size for the card title if the
 }
 
 /* If the container is larger than 700px */
-@container (min-width: 700px) {
+@container (width > 700px) {
   .card h2 {
     font-size: 2em;
   }
@@ -93,7 +93,7 @@ The following example creates a containment context with the name `sidebar`:
 You can then target this containment context using the `@container` at-rule:
 
 ```css
-@container sidebar (min-width: 700px) {
+@container sidebar (width > 700px) {
   .card {
     font-size: 2em;
   }
@@ -134,7 +134,7 @@ The container query length units are:
 The following example uses the `cqi` unit to set the font size of a heading based on the inline size of the container:
 
 ```css
-@container (min-width: 700px) {
+@container (width > 700px) {
   .card h2 {
     font-size: max(1.5em, 1.23em + 2cqi);
   }
@@ -158,7 +158,7 @@ The following example uses a {{cssxref("grid-template-columns")}} declaration to
 If you want to use a single-column layout for devices with a smaller viewport, you can use a media query to change the grid template:
 
 ```css
-@media (max-width: 700px) {
+@media (width <= 700px) {
   .card {
     grid-template-columns: 1fr;
   }

--- a/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
@@ -96,11 +96,11 @@ After you add names to your `@container` at rules, you can use the {{cssxref("co
 In the above example, the styles within the container query block will apply to the descendants of all {{htmlelement("li")}} elements with a width that is greater than their height. Note that other elements with `container-name: card` applied to them that match the size query will also have these styles applied to their elements' descendants.
 
 ```css
-@container wide (min-width: 20em) {
+@container wide (width >= 20em) {
   /* styles applied to descendants of wide .sizeContainer */
 }
 
-@container narrow (max-width: 20em) {
+@container narrow (width < 20em) {
   /* styles applied to descendants of narrow .sizeContainer */
 }
 
@@ -110,7 +110,7 @@ In the above example, the styles within the container query block will apply to 
 }
 ```
 
-In the above example, the element has two container names, `wide` and `narrow`. The descendants of any elements with `class="sizeContainer"` will get the styles from the `wide` or `narrow` query applied (or both if an element is precisely 20em wide).
+In the above example, the element has two container names, `wide` and `narrow`. The descendants of any elements with `class="sizeContainer"` will get the styles from the `wide` or `narrow` query applied.
 
 The default value `container-type: normal` prevents the container from being a size container, but it can still be a [style container](#container_style_queries). The default value `container-name: none` states the container has no name, but it does not prevent the element from matching unnamed queries.
 
@@ -141,12 +141,12 @@ In the future, we'll be able to write style queries like so:
     not style(background-color: red),
     style(--themeBackground),
     style(--themeColor: blue) or style(--themeColor: purple),
-    (max-width: 100vw) and style(max-width: 600px) {
+    (width <= 100vw) and style(max-width: 600px) {
   /* <stylesheet> */
 }
 ```
 
-The `style()` functional notation is used to differentiate style queries from size queries. While not yet supported, we will eventually be able to query regular CSS declarations such as `max-width: 100vw`. Querying `@container (max-width: 100vw)` is a size query; containment with {{cssxref("container-type")}}, or the {{cssxref("container")}} shorthand, is needed. That query will return true if the container is 100vw or less. That is different from querying `@container style(max-width: 100vw)`, which is a style query; when supported, this query will return true if the container has a {{cssxref("max-width")}} value of `100vw`.
+The `style()` functional notation is used to differentiate style queries from size queries. While not yet supported, we will eventually be able to query regular CSS declarations such as `max-width: 600px`. Querying `@container (max-width: 600px)` is a size query; containment with {{cssxref("container-type")}}, or the {{cssxref("container")}} shorthand, is needed. That query will return true if the container is 600px or less. That is different from querying `@container style(max-width: 600px)`, which is a style query; when supported, this query will return true if the container has a {{cssxref("max-width")}} value of `600px`.
 
 Until style queries for regular CSS declarations and properties are supported, we are limited to including only custom properties as the `style()` parameter, with or without a value:
 

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
@@ -290,7 +290,7 @@ For our layout above, we might like to have a very basic layout at narrow widths
 We can then redefine that layout inside [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to go to our two columns layout, and perhaps take it to a three column layout if the available space is even wider. Note that for the wide layout, we keep the nine-column track grid, redefining where items are placed using `grid-template-areas`.
 
 ```css
-@media (min-width: 30em) {
+@media (width >= 30em) {
   .wrapper {
     grid-template-columns: repeat(9, 1fr);
     grid-template-areas:
@@ -299,7 +299,7 @@ We can then redefine that layout inside [media queries](/en-US/docs/Web/CSS/CSS_
       "sd sd sd  ft  ft   ft   ft   ft   ft";
   }
 }
-@media (min-width: 60em) {
+@media (width >= 60em) {
   .wrapper {
     grid-template-areas:
       "hd hd hd   hd   hd   hd   hd   hd hd"

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
@@ -113,7 +113,7 @@ This does not create a layout. Rather, the items now have names we can use to do
 With our mobile layout in place, we can now proceed to add a {{cssxref("@media")}} query to adapt this layout for bigger screens with enough real estate to display two columns.
 
 ```css
-@media (min-width: 500px) {
+@media (width >= 500px) {
   .wrapper {
     grid-template-columns: 1fr 3fr;
     grid-template-areas:
@@ -134,7 +134,7 @@ You can see the layout taking shape in the value of {{cssxref("grid-template-are
 We can now add a final breakpoint for wider screens able to display a three-column layout.
 
 ```css
-@media (min-width: 700px) {
+@media (width >= 700px) {
   .wrapper {
     grid-template-columns: 1fr 4fr 1fr;
     grid-template-areas:
@@ -312,7 +312,7 @@ At the next breakpoint, we want a two-column layout. Our header and navigation s
 The `ad` panel is below the sidebar, starting at grid row line 4. Then we have the content and footer starting at col-start 4 and spanning nine tracks, taking both to the end of the grid.
 
 ```css
-@media (min-width: 500px) {
+@media (width >= 500px) {
   .side {
     grid-column: col-start / span 3;
     grid-row: 3;
@@ -335,7 +335,7 @@ The `ad` panel is below the sidebar, starting at grid row line 4. Then we have t
 Finally, for screens larger than our largest breakpoint, we define a three-column version of this layout. The header continues to span right across the grid, but now the navigation moves down to become the first sidebar, with the content and then the sidebar next to it. The footer now also spans across the full layout.
 
 ```css
-@media (min-width: 700px) {
+@media (width >= 700px) {
   .main-nav {
     grid-column: col-start / span 2;
     grid-row: 2 / 4;

--- a/files/en-us/web/css/css_media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/using_media_queries/index.md
@@ -205,7 +205,7 @@ The `and` keyword combines a media feature with a media type _or_ other media fe
 This example combines two media features to restrict styles to landscape-oriented devices with a width of at least 30 ems:
 
 ```css
-@media (min-width: 30em) and (orientation: landscape) {
+@media (width >= 30em) and (orientation: landscape) {
   /* … */
 }
 ```
@@ -213,7 +213,7 @@ This example combines two media features to restrict styles to landscape-oriente
 To limit the styles to devices with a screen, you can chain the media features to the `screen` media type:
 
 ```css
-@media screen and (min-width: 30em) and (orientation: landscape) {
+@media screen and (width >= 30em) and (orientation: landscape) {
   /* … */
 }
 ```
@@ -225,7 +225,7 @@ You can use a comma-separated list of media queries to apply styles when the use
 The following rule contains two media queries. The block's styles will apply if either the user's device has a height of 680px or more _or_ if the browser viewport is in portrait mode (the viewport height is greater than the viewport width):
 
 ```css
-@media (min-height: 680px), screen and (orientation: portrait) {
+@media (height >= 680px), screen and (orientation: portrait) {
   /* … */
 }
 ```

--- a/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_overflow_in_multicol_layout/index.md
@@ -138,7 +138,7 @@ body {
 
 One issue with multicol on the web is that if the columns are taller than the viewport, the reader will need to scroll the page up and down to read, which is not a good user experience. One way to avoid this is to only apply the column properties if you know there is enough vertical space.
 
-In the example below, we used a {{CSSXref("min-height")}} [@media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to ensure there is enough vertical space before applying the column properties.
+In the example below, we used a `height` [@media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to ensure there is enough vertical space before applying the column properties.
 
 ```html hidden live-sample___min-height
 <div class="container">
@@ -165,7 +165,7 @@ body {
   font: 1.2em / 1.5 sans-serif;
 }
 
-@media (min-height: 300px) {
+@media (height >= 300px) {
   .container {
     column-width: 200px;
   }

--- a/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
@@ -73,7 +73,7 @@ At-rules can be nested within other at-rules. Below you can see an example of th
   display: grid;
   @media (orientation: landscape) {
     grid-auto-flow: column;
-    @media (min-width: 1024px) {
+    @media (width >= 1024px) {
       max-inline-size: 1024px;
     }
   }
@@ -91,7 +91,7 @@ At-rules can be nested within other at-rules. Below you can see an example of th
     grid-auto-flow: column;
   }
 }
-@media (orientation: landscape) and (min-width: 1024px) {
+@media (orientation: landscape) and (width >= 1024px) {
   .foo {
     max-inline-size: 1024px;
   }

--- a/files/en-us/web/css/cssom_view/viewport_concepts/index.md
+++ b/files/en-us/web/css/cssom_view/viewport_concepts/index.md
@@ -108,7 +108,7 @@ If the iframe is set to 50vw, it will be 50% of the width of the `1200px` parent
 A width-based media query within the iframe document is relative to the iframe's viewport.
 
 ```css
-@media screen and (min-width: 500px) {
+@media screen and (width >= 500px) {
   p {
     color: red;
   }
@@ -132,7 +132,7 @@ SVG also has an internal [coordinate system](/en-US/docs/Web/CSS/CSSOM_view/Coor
 If you include an SVG file in your HTML, the viewport of the SVG is the initial containing block, or the width and height of the SVG container. Using the {{CSSxRef("@media")}} query in your SVG's CSS is relative to that container, not the browser.
 
 ```css
-@media screen and (min-width: 400px) and (max-width: 500px) {
+@media screen and (400px <= width <= 500px) {
   /* CSS goes here */
 }
 ```

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.md
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.md
@@ -135,7 +135,7 @@ p {
   margin: 0 0 1em 0;
 }
 
-@media (min-width: 500px) {
+@media (width >= 500px) {
   .media {
     display: grid;
     grid-template-columns: fit-content(200px) 1fr;
@@ -176,7 +176,7 @@ I have chosen to use [grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) for the 
 
 Another reason to use grid layout is in order that I can use {{cssxref("fit-content")}} for the track sizing of the image. By using `fit-content` with a maximum size of 200 pixels, when we have a small image such as the icon, the track only gets as large as the size of that image — the `max-content` size. If the image is larger, the track stops growing at 200 pixels and as the image has a {{cssxref("max-width")}} of 100% applied, it scales down so that it continues to fit inside the column.
 
-By using {{cssxref("grid-template-areas")}} to achieve the layout, I can see the pattern in the CSS. I define my grid once we have a max-width of 500 pixels, so on smaller devices the media object stacks.
+By using {{cssxref("grid-template-areas")}} to achieve the layout, I can see the pattern in the CSS. I define my grid once the viewport is 500 pixels wide, so on smaller devices the media object stacks.
 
 An option for the pattern is to flip it to switch the image to the other side — this is done by adding the `media-flip` class, which defines a flipped grid template causing the layout to be mirrored.
 

--- a/files/en-us/web/css/ratio/index.md
+++ b/files/en-us/web/css/ratio/index.md
@@ -34,7 +34,7 @@ Two ratios are compared using the quotients' numeric values. For example, 16/16 
 ### Use in a media query
 
 ```css
-@media screen and (min-aspect-ratio: 16/9) {
+@media screen and (aspect-ratio >= 16/9) {
   /* … */
 }
 ```

--- a/files/en-us/web/css/resolution/index.md
+++ b/files/en-us/web/css/resolution/index.md
@@ -34,7 +34,7 @@ The `<resolution>` data type consists of a strictly positive {{cssxref("&lt;numb
 ### Use in a media query
 
 ```css
-@media print and (min-resolution: 300dpi) {
+@media print and (resolution >= 300dpi) {
   /* … */
 }
 
@@ -42,7 +42,7 @@ The `<resolution>` data type consists of a strictly positive {{cssxref("&lt;numb
   /* … */
 }
 
-@media (min-resolution: 2dppx) {
+@media (resolution >= 2dppx) {
   /* … */
 }
 

--- a/files/en-us/web/html/guides/responsive_images/index.md
+++ b/files/en-us/web/html/guides/responsive_images/index.md
@@ -55,7 +55,7 @@ We can however use two attributes — [`srcset`](/en-US/docs/Web/HTML/Reference/
 ```html
 <img
   srcset="elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w"
-  sizes="(max-width: 600px) 480px,
+  sizes="(width <= 600px) 480px,
          800px"
   src="elva-fairy-800w.jpg"
   alt="Elva dressed as a fairy" />
@@ -71,7 +71,7 @@ The `srcset` and `sizes` attributes look complicated, but they're not too hard t
 
 **`sizes`** defines a set of media conditions (e.g., screen widths) and indicates what image size would be best to choose, when certain media conditions are true — these are the hints we talked about earlier. In this case, before each comma we write:
 
-1. A **media condition** (`(max-width:600px)`) — you'll learn more about these in the [CSS topic](/en-US/docs/Learn_web_development/Core/Styling_basics), but for now let's just say that a media condition describes a possible state that the screen can be in. In this case, we are saying "when the viewport width is 600 pixels or less".
+1. A **media condition** (`(width <= 600px)`) — you'll learn more about these in the [CSS topic](/en-US/docs/Learn_web_development/Core/Styling_basics), but for now let's just say that a media condition describes a possible state that the screen can be in. In this case, we are saying "when the viewport width is 600 pixels or less".
 2. A space
 3. The **width of the slot** the image will fill when the media condition is true (`480px`)
 
@@ -85,7 +85,7 @@ So, with these attributes in place, the browser will:
 3. Look at the slot size given to that media query.
 4. Load the image referenced in the `srcset` list that has the same size as the slot or, if there isn't one, the first image that is bigger than the chosen slot size.
 
-And that's it! At this point, if a supporting browser with a viewport width of 480px loads the page, the `(max-width: 600px)` media condition will be true, and so the browser chooses the `480px` slot. The `elva-fairy-480w.jpg` will be loaded, as its inherent width (`480w`) is closest to the slot size. The 800px picture is 128KB on disk, whereas the 480px version is only 63KB — a saving of 65KB. Now, imagine if this was a page that had many pictures on it. Using this technique could save mobile users a lot of bandwidth.
+And that's it! At this point, if a supporting browser with a viewport width of 480px loads the page, the `(width <= 600px)` media condition will be true, and so the browser chooses the `480px` slot. The `elva-fairy-480w.jpg` will be loaded, as its inherent width (`480w`) is closest to the slot size. The 800px picture is 128KB on disk, whereas the 480px version is only 63KB — a saving of 65KB. Now, imagine if this was a page that had many pictures on it. Using this technique could save mobile users a lot of bandwidth.
 
 > [!NOTE]
 > When testing this with a desktop browser, if the browser fails to load the narrower images when you've got its window set to the narrowest width, have a look at what the viewport is (you can approximate it by going into the browser's JavaScript console and typing in `document.querySelector('html').clientWidth`). Different browsers have minimum sizes that they'll let you reduce the window width to, and they might be wider than you'd think. When testing it with a mobile browser, you can use tools like Firefox's `about:debugging` page to inspect the page loaded on the mobile using the desktop developer tools.
@@ -138,13 +138,13 @@ Let's fix this, with {{htmlelement("picture")}}! Like [`<video>` and `<audio>`](
 
 ```html
 <picture>
-  <source media="(max-width: 799px)" srcset="elva-480w-close-portrait.jpg" />
-  <source media="(min-width: 800px)" srcset="elva-800w.jpg" />
+  <source media="(width < 800px)" srcset="elva-480w-close-portrait.jpg" />
+  <source media="(width >= 800px)" srcset="elva-800w.jpg" />
   <img src="elva-800w.jpg" alt="Chris standing up holding his daughter Elva" />
 </picture>
 ```
 
-- The `<source>` elements include a `media` attribute that contains a media condition — as with the first `srcset` example, these conditions are tests that decide which image is shown — the first one that returns true will be displayed. In this case, if the viewport width is 799px wide or less, the first `<source>` element's image will be displayed. If the viewport width is 800px or more, it'll be the second one.
+- The `<source>` elements include a `media` attribute that contains a media condition — as with the first `srcset` example, these conditions are tests that decide which image is shown — the first one that returns true will be displayed. In this case, if the viewport width is less than 800px wide, the first `<source>` element's image will be displayed. If the viewport width is 800px or more, it'll be the second one.
 - The `srcset` attributes contain the path to the image to display. Just as we saw with `<img>` above, `<source>` can take a `srcset` attribute with multiple images referenced, as well as a `sizes` attribute. So, you could offer multiple images via a `<picture>` element, but then also offer multiple resolutions of each one. Realistically, you probably won't want to do this kind of thing very often.
 - In all cases, you must provide an `<img>` element, with `src` and `alt`, right before `</picture>`, otherwise no images will appear. This provides a default case that will apply when none of the media conditions return true (you could actually remove the second `<source>` element in this example), and a fallback for browsers that don't support the `<picture>` element.
 

--- a/files/en-us/web/html/reference/attributes/rel/preload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/preload/index.md
@@ -151,12 +151,12 @@ Let's look at an example (see it on GitHub — [source code](https://github.com/
     rel="preload"
     href="bg-image-narrow.png"
     as="image"
-    media="(max-width: 600px)" />
+    media="(width <= 600px)" />
   <link
     rel="preload"
     href="bg-image-wide.png"
     as="image"
-    media="(min-width: 601px)" />
+    media="(width > 600px)" />
 
   <link rel="stylesheet" href="main.css" />
 </head>
@@ -166,7 +166,7 @@ Let's look at an example (see it on GitHub — [source code](https://github.com/
   </header>
 
   <script>
-    const mediaQueryList = window.matchMedia("(max-width: 600px)");
+    const mediaQueryList = window.matchMedia("(width <= 600px)");
     const header = document.querySelector("header");
 
     if (mediaQueryList.matches) {

--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -202,7 +202,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
     1. A [media condition](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax). This must be omitted for the last item in the list.
     2. A source size value.
 
-    Media Conditions describe properties of the _viewport_, not of the _image_. For example, `(max-height: 500px) 1000px` proposes to use a source of 1000px width, if the _viewport_ is not higher than 500px. Because a source size descriptor is used to specify the width to use for the image during layout of the page, the media condition is typically (but not necessarily) based on the [width](/en-US/docs/Web/CSS/@media/width) information.
+    Media Conditions describe properties of the _viewport_, not of the _image_. For example, `(height <= 500px) 1000px` proposes to use a source of 1000px width, if the _viewport_ is not higher than 500px. Because a source size descriptor is used to specify the width to use for the image during layout of the page, the media condition is typically (but not necessarily) based on the [width](/en-US/docs/Web/CSS/@media/width) information.
 
     Source size values specify the intended display size of the image. {{glossary("User agent", "User agents")}} use the current source size to select one of the sources supplied by the `srcset` attribute, when those sources are described using width (`w`) descriptors. The selected source size affects the {{glossary("intrinsic size")}} of the image (the image's display size if no {{glossary("CSS")}} styling is applied). If the `srcset` attribute is absent, or contains no values with a width descriptor, then the `sizes` attribute has no effect.
 
@@ -366,14 +366,14 @@ In this example we include a `srcset` attribute with a reference to a high-resol
 
 ### Using the srcset and sizes attributes
 
-The `src` attribute is ignored in {{glossary("User agent", "user agents")}} that support `srcset` when `w` descriptors are included. When the `(max-width: 600px)` media condition matches, the 200 pixel-wide image will load (it is the one that matches `200px` most closely), otherwise the other image will load.
+The `src` attribute is ignored in {{glossary("User agent", "user agents")}} that support `srcset` when `w` descriptors are included. When the `(width <= 600px)` media condition matches, the 200 pixel-wide image will load (it is the one that matches `200px` most closely), otherwise the other image will load.
 
 ```html
 <img
   src="clock-demo-200px.png"
   alt="The time is 12:45."
   srcset="clock-demo-200px.png 200w, clock-demo-400px.png 400w"
-  sizes="(max-width: 600px) 200px, 50vw" />
+  sizes="(width <= 600px) 200px, 50vw" />
 ```
 
 {{EmbedLiveSample("Using_the_srcset_and_sizes_attributes", "100%", 350)}}

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -52,10 +52,7 @@ You can also provide a media type or query inside a `media` attribute; this reso
 
 ```html
 <link href="print.css" rel="stylesheet" media="print" />
-<link
-  href="mobile.css"
-  rel="stylesheet"
-  media="screen and (max-width: 600px)" />
+<link href="mobile.css" rel="stylesheet" media="screen and (width <= 600px)" />
 ```
 
 Some interesting new performance and security features have been added to the `<link>` element too. Take this example:
@@ -354,14 +351,11 @@ this resource will then only be loaded if the media condition is true. For examp
 ```html
 <link href="print.css" rel="stylesheet" media="print" />
 <link href="mobile.css" rel="stylesheet" media="all" />
-<link
-  href="desktop.css"
-  rel="stylesheet"
-  media="screen and (min-width: 600px)" />
+<link href="desktop.css" rel="stylesheet" media="screen and (width >= 600px)" />
 <link
   href="highres.css"
   rel="stylesheet"
-  media="screen and (min-resolution: 300dpi)" />
+  media="screen and (resolution >= 300dpi)" />
 ```
 
 ### Stylesheet load events

--- a/files/en-us/web/html/reference/elements/picture/index.md
+++ b/files/en-us/web/html/reference/elements/picture/index.md
@@ -66,7 +66,7 @@ If the {{HTMLElement("source")}}'s media condition evaluates to `false`, the bro
 
 ```html
 <picture>
-  <source srcset="mdn-logo-wide.png" media="(min-width: 600px)" />
+  <source srcset="mdn-logo-wide.png" media="(width >= 600px)" />
   <img src="mdn-logo-narrow.png" alt="MDN" />
 </picture>
 ```

--- a/files/en-us/web/html/reference/elements/source/index.md
+++ b/files/en-us/web/html/reference/elements/source/index.md
@@ -98,7 +98,7 @@ This example demonstrates how to offer an alternate source file for viewports ab
 
 ```html
 <video controls>
-  <source src="foo-large.webm" media="(min-width: 800px)" />
+  <source src="foo-large.webm" media="(width >= 800px)" />
   <source src="foo.webm" />
   I'm sorry; your browser doesn't support HTML video.
 </video>
@@ -112,8 +112,8 @@ In this example, two `<source>` elements are included within {{HTMLElement("pict
 
 ```html
 <picture>
-  <source srcset="mdn-logo-wide.png" media="(min-width: 800px)" />
-  <source srcset="mdn-logo-medium.png" media="(min-width: 600px)" />
+  <source srcset="mdn-logo-wide.png" media="(width >= 800px)" />
+  <source srcset="mdn-logo-medium.png" media="(width >= 600px)" />
   <img src="mdn-logo-narrow.png" alt="MDN Web Docs" />
 </picture>
 ```
@@ -129,17 +129,17 @@ A [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) allow
 <picture>
   <source
     srcset="landscape.png"
-    media="(min-width: 1000px)"
+    media="(width >= 1000px)"
     width="1000"
     height="400" />
   <source
     srcset="square.png"
-    media="(min-width: 800px)"
+    media="(width >= 800px)"
     width="800"
     height="800" />
   <source
     srcset="portrait.png"
-    media="(min-width: 600px)"
+    media="(width >= 600px)"
     width="600"
     height="800" />
   <img

--- a/files/en-us/web/html/reference/elements/style/index.md
+++ b/files/en-us/web/html/reference/elements/style/index.md
@@ -143,7 +143,7 @@ In this example we build on the previous one, including a `media` attribute on t
         border: 1px solid black;
       }
     </style>
-    <style media="all and (max-width: 500px)">
+    <style media="(width < 500px)">
       p {
         color: blue;
         background-color: yellow;

--- a/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -374,7 +374,7 @@ Now that the player has its basic look and feel taken care of, some other stylin
 The player currently works fairly well until displayed on a "medium" screen (e.g., 1024px/64em) or smaller. In this case, the margins and padding on the {{ htmlelement("figure") }} element need to be removed so that all the available space is taken advantage of, and the buttons are a bit too small so this needs to be altered by setting a new height on the element that has the `.controls` class set on it:
 
 ```css
-@media screen and (max-width: 64em) {
+@media screen and (width <= 64em) {
   figure {
     padding-left: 0;
     padding-right: 0;
@@ -390,7 +390,7 @@ The player currently works fairly well until displayed on a "medium" screen (e.g
 This works well enough until it is viewed on a smaller screen (680px/42.5em), so another breakpoint is made here. Since the height of the `.controls` class element will now vary, a fixed height is no longer required — it is therefore set to `auto`. The definitions for the elements within the `.controls` element now also need to be changed:
 
 ```css
-@media screen and (max-width: 42.5em) {
+@media screen and (width <= 42.5em) {
   .controls {
     height: auto;
   }

--- a/files/en-us/web/svg/reference/attribute/media/index.md
+++ b/files/en-us/web/svg/reference/attribute/media/index.md
@@ -29,7 +29,7 @@ svg {
       fill: black;
     }
   </style>
-  <style media="all and (min-width: 600px)">
+  <style media="all and (width >= 600px)">
     rect {
       fill: seagreen;
     }

--- a/files/en-us/web/svg/reference/attribute/media/index.md
+++ b/files/en-us/web/svg/reference/attribute/media/index.md
@@ -29,7 +29,7 @@ svg {
       fill: black;
     }
   </style>
-  <style media="all and (width >= 600px)">
+  <style media="(width >= 600px)">
     rect {
       fill: seagreen;
     }


### PR DESCRIPTION
The range syntax is almost always better than using `min-` or `max-`:

- It allows specifying exclusive ranges, and inclusive ranges are more obvious
- It's shorter and more straightforward to read
- It avoids the pitfall where if you have two queries like `min-width: 600px` and `max-width: 599px`, neither query would apply if the device is 599.5px wide. In fact we have quite a few cases like this!