### PR TITLE
Modernize CSS: use double colon for all pseudoelements

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/angular_item_component/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/angular_item_component/index.md
@@ -434,8 +434,8 @@ Adapted from https://css-tricks.com/the-checkbox-hack/#custom-designed-radio-but
 }
 
 /* checkbox aspect */
-[type="checkbox"]:not(:checked) + label:before,
-[type="checkbox"]:checked + label:before {
+[type="checkbox"]:not(:checked) + label::before,
+[type="checkbox"]:checked + label::before {
   content: "";
   position: absolute;
   left: 0;
@@ -447,8 +447,8 @@ Adapted from https://css-tricks.com/the-checkbox-hack/#custom-designed-radio-but
 }
 
 /* checked mark aspect */
-[type="checkbox"]:not(:checked) + label:after,
-[type="checkbox"]:checked + label:after {
+[type="checkbox"]:not(:checked) + label::after,
+[type="checkbox"]:checked + label::after {
   content: "\2713\0020";
   position: absolute;
   top: 0.15em;
@@ -460,18 +460,18 @@ Adapted from https://css-tricks.com/the-checkbox-hack/#custom-designed-radio-but
   font-family: "Lucida Sans Unicode", "Arial Unicode MS", Arial;
 }
 /* checked mark aspect changes */
-[type="checkbox"]:not(:checked) + label:after {
+[type="checkbox"]:not(:checked) + label::after {
   opacity: 0;
   transform: scale(0);
 }
-[type="checkbox"]:checked + label:after {
+[type="checkbox"]:checked + label::after {
   opacity: 1;
   transform: scale(1);
 }
 
 /* accessibility */
-[type="checkbox"]:checked:focus + label:before,
-[type="checkbox"]:not(:checked):focus + label:before {
+[type="checkbox"]:checked:focus + label::before,
+[type="checkbox"]:not(:checked):focus + label::before {
   border: 2px dotted blue;
 }
 ```

--- a/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
@@ -545,7 +545,7 @@ h1 {
 
 /* Handle specific elements nested in the DOM */
 div p,
-#id:first-line {
+#id::first-line {
   background-color: red;
   border-radius: 3px;
 }

--- a/files/en-us/learn_web_development/extensions/client-side_apis/video_and_audio_apis/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/video_and_audio_apis/index.md
@@ -148,7 +148,7 @@ Next, let's look at our button icons:
   font-style: normal;
 }
 
-button:before {
+button::before {
   font-family: HeydingsControlsRegular;
   font-size: 20px;
   position: relative;

--- a/files/en-us/learn_web_development/extensions/forms/html5_input_types/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/html5_input_types/index.md
@@ -252,11 +252,11 @@ A date and time control is created using the {{HTMLElement("input")}} element an
 ```
 
 ```css hidden live-sample___date1
-input:invalid + span:after {
+input:invalid + span::after {
   content: " ✖";
 }
 
-input:valid + span:after {
+input:valid + span::after {
   content: " ✓";
 }
 ```

--- a/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -356,7 +356,7 @@ button {
   transform: rotate(-1.5deg);
 }
 
-button:after {
+button::after {
   content: " >>>";
 }
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
@@ -104,8 +104,8 @@ So let's get started by setting up the basis for our WebRTC-powered phone app.
 
 ```css
 *,
-*:before,
-*:after {
+*::before,
+*::after {
   box-sizing: border-box;
 }
 

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -119,7 +119,7 @@ h3::after {
 
 ```js
 const h3 = document.querySelector("h3");
-const result = getComputedStyle(h3, ":after").content;
+const result = getComputedStyle(h3, "::after").content;
 
 console.log("the generated content is: ", result); // returns ' rocks!'
 ```

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -122,12 +122,12 @@ shadowRoot.appendChild(span);
 style.textContent =
   "span:hover { text-decoration: underline; }" +
   ":host-context(h1) { font-style: italic; }" +
-  ':host-context(h1):after { content: " - no links in headers!" }' +
+  ':host-context(h1)::after { content: " - no links in headers!" }' +
   ":host(.footer) { color : red; }" +
   ":host { background: rgb(0 0 0 / 10%); padding: 2px 5px; }";
 ```
 
-The `:host-context(h1) { font-style: italic; }` and `:host-context(h1):after { content: " - no links in headers!" }` rules style the instance of the `<context-span>` element (the shadow host in this instance) inside the `<h1>`. We've used it to make it clear that the custom element shouldn't appear inside the `<h1>` in our design.
+The `:host-context(h1) { font-style: italic; }` and `:host-context(h1)::after { content: " - no links in headers!" }` rules style the instance of the `<context-span>` element (the shadow host in this instance) inside the `<h1>`. We've used it to make it clear that the custom element shouldn't appear inside the `<h1>` in our design.
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -94,7 +94,7 @@ shadowRoot.appendChild(span);
 style.textContent =
   "span:hover { text-decoration: underline; }" +
   ":host-context(h1) { font-style: italic; }" +
-  ':host-context(h1):after { content: " - no links in headers!" }' +
+  ':host-context(h1)::after { content: " - no links in headers!" }' +
   ":host-context(article, aside) { color: gray; }" +
   ":host(.footer) { color : red; }" +
   ":host { background: rgb(0 0 0 / 10%); padding: 2px 5px; }";

--- a/files/en-us/web/css/_colon_host_function/index.md
+++ b/files/en-us/web/css/_colon_host_function/index.md
@@ -104,7 +104,7 @@ shadowRoot.appendChild(span);
 style.textContent =
   "span:hover { text-decoration: underline; }" +
   ":host-context(h1) { font-style: italic; }" +
-  ':host-context(h1):after { content: " - no links in headers!" }' +
+  ':host-context(h1)::after { content: " - no links in headers!" }' +
   ":host-context(article, aside) { color: gray; }" +
   ":host(.footer) { color : red; }" +
   ":host { background: rgb(0 0 0 / 10%); padding: 2px 5px; }";

--- a/files/en-us/web/css/contain/index.md
+++ b/files/en-us/web/css/contain/index.md
@@ -317,11 +317,11 @@ CSS quotes are similarly affected in that the [`content`](/en-US/docs/Web/CSS/co
 body {
   quotes: "[" "]" "‹" "›";
 }
-.open-quote:before {
+.open-quote::before {
   content: open-quote;
 }
 
-.close-quote:after {
+.close-quote::after {
   content: close-quote;
 }
 ```

--- a/files/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
@@ -26,9 +26,9 @@ To add a box shadow, click the "+" button at the top-left. This adds a shadow, a
 
 To add another shadow, click "+" again. Now any values you set will apply to this new shadow. Change the order in which these two shadows are applied using the ↑ and ↓ buttons at the top-left. Select the first shadow again by clicking it in column on the left. To update the element's own styles, select it by clicking the button labelled "element" along the top.
 
-You can add {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements to the element, and give them box shadows as well. To switch between the element and its pseudo-elements, use the buttons along the top labeled "element", ":before", and ":after".
+You can add {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements to the element, and give them box shadows as well. To switch between the element and its pseudo-elements, use the buttons along the top labeled "element", "::before", and "::after".
 
-The box at the bottom-right contains the CSS for the element and any `before::` or `::after` pseudo-elements.
+The box at the bottom-right contains the CSS for the element and any `::before` or `::after` pseudo-elements.
 
 ## See also
 

--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -177,8 +177,8 @@ div {
 .original {
   border: 1px dashed;
 }
-.original:before,
-.original:after {
+.original::before,
+.original::after {
   content: "";
   position: absolute;
   top: 100px;
@@ -187,7 +187,7 @@ div {
   height: 1px;
   border-top: 2px dotted;
 }
-.original:after {
+.original::after {
   transform: rotate(135deg);
 }
 .one {

--- a/files/en-us/web/html/reference/elements/input/url/index.md
+++ b/files/en-us/web/html/reference/elements/input/url/index.md
@@ -314,12 +314,12 @@ input + span {
   padding: 0 0.3rem;
 }
 
-input:invalid + span:after {
+input:invalid + span::after {
   content: "✖" / "Content is not valid";
   color: red;
 }
 
-input:valid + span:after {
+input:valid + span::after {
   content: "✓" / "Content is valid";
   color: green;
 }

--- a/files/en-us/web/html/reference/global_attributes/class/index.md
+++ b/files/en-us/web/html/reference/global_attributes/class/index.md
@@ -33,7 +33,7 @@ The **`class`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attribu
   padding: 10px;
 }
 
-.editorial:before {
+.editorial::before {
   content: "Editor: ";
 }
 ```

--- a/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
@@ -42,7 +42,7 @@ li {
   padding-bottom: 10px;
 }
 
-li:after {
+li::after {
   content: "Data ID: " attr(data-id);
   position: absolute;
   top: -22px;
@@ -55,7 +55,7 @@ li:after {
   transition: 0.5s opacity;
 }
 
-li:hover:after {
+li:hover::after {
   opacity: 1;
 }
 ```

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -27,7 +27,7 @@ The **`id`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes
   box-shadow: 2px 2px 1px black;
 }
 
-#exciting:before {
+#exciting::before {
   content: "ℹ️";
   margin-right: 5px;
 }


### PR DESCRIPTION
The single-colon versions are regarded as legacy, and these things are conceptually elements, not classes, so we should use the double colon version.