### PR TITLE
HTML best practices

### DIFF
--- a/files/en-us/glossary/csr/index.md
+++ b/files/en-us/glossary/csr/index.md
@@ -12,7 +12,7 @@ A pure CSR app may return the following HTML content:
 
 ```html
 <!doctype html>
-<html>
+<html lang="en-US">
   <head>
     <title>My App</title>
     <script src="bundle.js"></script>

--- a/files/en-us/learn_web_development/core/scripting/a_first_splash/index.md
+++ b/files/en-us/learn_web_development/core/scripting/a_first_splash/index.md
@@ -203,7 +203,7 @@ Let's now move forward, looking at how we can turn these steps into code, buildi
 To begin this tutorial, we'd like you to make a local copy of the following code in a new HTML file using your code editor.
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />

--- a/files/en-us/learn_web_development/core/scripting/conditionals/index.md
+++ b/files/en-us/learn_web_development/core/scripting/conditionals/index.md
@@ -607,7 +607,7 @@ h2 {
 }`;
   return `
 <!doctype html>
-<html>
+<html lang="en-US">
   <head>
     <style>${outputStyle}</style>
   </head>
@@ -798,7 +798,7 @@ function outputDocument(code) {
 
   return `
 <!doctype html>
-<html>
+<html lang="en-US">
   <head>
   </head>
   <body>

--- a/files/en-us/learn_web_development/core/scripting/debugging_javascript/index.md
+++ b/files/en-us/learn_web_development/core/scripting/debugging_javascript/index.md
@@ -205,8 +205,8 @@ HTML and CSS are permissive — errors and unrecognized features can often be ha
 
 Let's explore a common strategy for handling JavaScript errors in your code. The following sections are designed to be followed by making a copy of the below template file as `handling-errors.html` on your local machine, adding the code snippets in between the opening and closing `<script>` and `</script>` tags, then opening the file in a browser and looking at the output in the devtools JavaScript console.
 
-```html-nolint
-<!DOCTYPE html>
+```html
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
@@ -216,7 +216,6 @@ Let's explore a common strategy for handling JavaScript errors in your code. The
   <body>
     <script>
       // Code goes below this line
-
     </script>
   </body>
 </html>

--- a/files/en-us/learn_web_development/core/structuring_content/debugging_html/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/debugging_html/index.md
@@ -107,7 +107,7 @@ In this section, you'll study some code using the DOM inspector and see how the 
 1. First, save the following HTML file listing as `debug-example.html`, somewhere on your local machine. This demo is deliberately written with some built-in errors for us to explore.
 
    ```html-nolint
-   <!DOCTYPE html>
+   <!doctype html>
    <html lang="en-US">
      <head>
        <meta charset="utf-8">

--- a/files/en-us/learn_web_development/core/styling_basics/cool-looking_box/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/cool-looking_box/index.md
@@ -38,7 +38,7 @@ To get this assessment started, you should:
 ### HTML
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -136,7 +136,7 @@ The HTML file looks like this:
 
 ```html
 <!doctype html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="choose_beast.css" />

--- a/files/en-us/web/api/htmllinkelement/sheet/index.md
+++ b/files/en-us/web/api/htmllinkelement/sheet/index.md
@@ -20,12 +20,7 @@ A {{DOMxRef("StyleSheet")}} object, or `null` if none is associated with the ele
 ## Examples
 
 ```html
-<html>
-  <header>
-    <link rel="stylesheet" href="styles.css" />
-    …
-  </header>
-</html>
+<link rel="stylesheet" href="styles.css" />
 ```
 
 The `sheet` property of the `HTMLLinkElement` object will return the {{domxref("StyleSheet")}} object describing `styles.css`.

--- a/files/en-us/web/api/node/lookupnamespaceuri/index.md
+++ b/files/en-us/web/api/node/lookupnamespaceuri/index.md
@@ -38,7 +38,7 @@ A string containing the namespace URI corresponding to the prefix.
 ## Example
 
 ```html
-<div style="display: none">
+<div class="hidden">
   <div>Test HTML element</div>
   <svg>
     <text>Test SVG element</text>
@@ -57,6 +57,12 @@ A string containing the namespace URI corresponding to the prefix.
   </thead>
   <tbody></tbody>
 </table>
+```
+
+```css hidden
+.hidden {
+  display: none;
+}
 ```
 
 ```js

--- a/files/en-us/web/api/node/parentelement/index.md
+++ b/files/en-us/web/api/node/parentelement/index.md
@@ -35,7 +35,7 @@ if (node.parentElement) {
 
 ```html
 <!doctype html>
-<html>
+<html lang="en-US">
   <body>
     <script>
       const html = document.querySelector("html");

--- a/files/en-us/web/api/svgcircleelement/cy/index.md
+++ b/files/en-us/web/api/svgcircleelement/cy/index.md
@@ -26,7 +26,7 @@ An {{domxref("SVGAnimatedLength")}} representing the y-coordinate of the circle'
   viewBox="0 0 100 100"
   width="200"
   height="200">
-  <circle cy="50" cy="50" r="50" fill="gold" id="circle" />
+  <circle cx="50" cy="50" r="50" fill="gold" id="circle" />
 </svg>
 ```
 

--- a/files/en-us/web/api/svgcircleelement/r/index.md
+++ b/files/en-us/web/api/svgcircleelement/r/index.md
@@ -26,7 +26,7 @@ An {{domxref("SVGAnimatedLength")}} representing the radius of the circle.
   viewBox="0 0 100 100"
   width="200"
   height="200">
-  <circle r="50" r="50" r="50" fill="gold" id="circle" />
+  <circle r="50" fill="gold" id="circle" />
 </svg>
 ```
 

--- a/files/en-us/web/api/svgelement/attributestylemap/index.md
+++ b/files/en-us/web/api/svgelement/attributestylemap/index.md
@@ -26,8 +26,6 @@ The following code snippet shows the relationship between the `style` attribute 
 
 ```html
 <svg
-  width="50"
-  height="50"
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 250 250"
   width="250"

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -39,8 +39,6 @@ The following code snippet demonstrates how the `style` attribute is translated 
 
 ```html
 <svg
-  width="50"
-  height="50"
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 250 250"
   width="250"

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.md
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.md
@@ -26,7 +26,7 @@ This example demonstrates how to return the value of the `width` set for the {{S
       viewBox="0 0 10 10"
       refX="5"
       refY="5"
-      viewBox="xMidYMid meet"
+      preserveAspectRatio="xMidYMid meet"
       markerWidth="6"
       markerHeight="6"
       orient="auto-start-reverse">

--- a/files/en-us/web/api/svgrectelement/ry/index.md
+++ b/files/en-us/web/api/svgrectelement/ry/index.md
@@ -22,8 +22,8 @@ Given the following SVG:
 
 ```html
 <svg viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
-  <rect x="0" y="0" width="60" height="60" ry="15" ry="15" />
-  <rect x="60" y="0" width="60" height="60" ry="15%" ry="15%" />
+  <rect x="0" y="0" width="60" height="60" rx="15" ry="15" />
+  <rect x="60" y="0" width="60" height="60" rx="15%" ry="15%" />
 </svg>
 ```
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
@@ -42,7 +42,7 @@ So let's get started by setting up the basis for our WebRTC-powered phone app.
 4. To finish the setup, you should copy the following HTML and CSS files into the root of your project folder. You can name both files `index`, so the HTML file will be `index.html` and the CSS file will be `index.css`. You won't need to modify these much in the articles that follow.
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -36,21 +36,11 @@ Which element(s) `:scope` matches depends on the context in which it is used:
 
 This example shows that `:scope` is equivalent to `:root` when used at the root level of a stylesheet. In this case, the provided CSS colors the background of the `<html>` element orange.
 
-#### HTML
-
-```html
-<html></html>
-```
-
-#### CSS
-
 ```css
 :scope {
   background-color: orange;
 }
 ```
-
-#### Result
 
 {{ EmbedLiveSample("Using :scope as an alternative to :root", "100%", 50) }}
 

--- a/files/en-us/web/css/isolation/index.md
+++ b/files/en-us/web/css/isolation/index.md
@@ -88,7 +88,7 @@ The `isolation` property is specified as one of the keyword values listed below.
 #### HTML
 
 ```html
-<div class="big-square ">
+<div class="big-square">
   <div class="isolation-auto">
     <div class="small-square">auto</div>
   </div>

--- a/files/en-us/web/css/ray/index.md
+++ b/files/en-us/web/css/ray/index.md
@@ -274,7 +274,7 @@ body {
 ```html hidden
 <div>
   <div class="container">
-    <div class=" shape shape1">&mdash;</div>
+    <div class="shape shape1">&mdash;</div>
   </div>
 </div>
 

--- a/files/en-us/web/css/text-box-trim/index.md
+++ b/files/en-us/web/css/text-box-trim/index.md
@@ -134,50 +134,41 @@ We also import a font from the Google Fonts service to apply to our demo's text.
 We have hidden the exact HTML code for brevity.
 
 ```html hidden
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>text-box demo</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
-      rel="stylesheet" />
-  </head>
-  <body>
-    <section>
-      <div>
-        <label for="box-trim">Select edge(s) to trim:</label>
-        <select id="box-trim">
-          <option>none</option>
-          <option>trim-start</option>
-          <option>trim-end</option>
-          <option selected>trim-both</option>
-        </select>
-      </div>
-      <div>
-        <label for="trim-over">Select trim over (start) value:</label>
-        <select id="trim-over">
-          <option>text</option>
-          <option selected>cap</option>
-          <option>ex</option>
-        </select>
-      </div>
-    </section>
-    <p class="display" contenteditable="">Holly Golightly</p>
-    <section>
-      <div>
-        <label for="trim-under">Select trim under (end) value:</label>
-        <select id="trim-under">
-          <option>text</option>
-          <option selected>alphabetic</option>
-        </select>
-      </div>
-    </section>
-    <output></output>
-  </body>
-</html>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
+  rel="stylesheet" />
+<section>
+  <div>
+    <label for="box-trim">Select edge(s) to trim:</label>
+    <select id="box-trim">
+      <option>none</option>
+      <option>trim-start</option>
+      <option>trim-end</option>
+      <option selected>trim-both</option>
+    </select>
+  </div>
+  <div>
+    <label for="trim-over">Select trim over (start) value:</label>
+    <select id="trim-over">
+      <option>text</option>
+      <option selected>cap</option>
+      <option>ex</option>
+    </select>
+  </div>
+</section>
+<p class="display" contenteditable="">Holly Golightly</p>
+<section>
+  <div>
+    <label for="trim-under">Select trim under (end) value:</label>
+    <select id="trim-under">
+      <option>text</option>
+      <option selected>alphabetic</option>
+    </select>
+  </div>
+</section>
+<output></output>
 ```
 
 #### CSS

--- a/files/en-us/web/http/guides/csp/index.md
+++ b/files/en-us/web/http/guides/csp/index.md
@@ -376,7 +376,7 @@ The `strict-dynamic` keyword is provided to help with this problem. It is a keyw
 For example, consider a document like this:
 
 ```html
-<html>
+<html lang="en-US">
   <head>
     <script
       src="./main.js"

--- a/files/en-us/web/http/reference/methods/delete/index.md
+++ b/files/en-us/web/http/reference/methods/delete/index.md
@@ -83,7 +83,7 @@ Content-Type: text/html; charset=UTF-8
 Date: Fri, 21 Jun 2024 14:18:33 GMT
 Content-Length: 1234
 
-<html>
+<html lang="en-US">
   <body>
     <h1>File "file.html" deleted.</h1>
   </body>
@@ -98,7 +98,7 @@ Date: Wed, 26 Jun 2024 12:00:00 GMT
 Content-Type: text/html; charset=UTF-8
 Content-Length: 1234
 
-<html>
+<html lang="en-US">
   <body>
     <h1>Deletion of "file.html" accepted.</h1>
     <p>See <a href="http://example.com/tasks/123/status">the status monitor</a> for details.</p>

--- a/files/en-us/web/http/reference/status/410/index.md
+++ b/files/en-us/web/http/reference/status/410/index.md
@@ -35,7 +35,7 @@ HTTP/1.1 410 Gone
 Content-Type: text/html
 Content-Length: 212
 
-<html>
+<html lang="en-US">
   <head>
     <title>Promotion expired</title>
   </head>

--- a/files/en-us/web/http/reference/status/429/index.md
+++ b/files/en-us/web/http/reference/status/429/index.md
@@ -40,7 +40,7 @@ HTTP/1.1 429 Too Many Requests
 Content-Type: text/html
 Retry-After: 3600
 
-<html>
+<html lang="en-US">
   <head>
     <title>Too Many Requests</title>
   </head>

--- a/files/en-us/web/http/reference/status/511/index.md
+++ b/files/en-us/web/http/reference/status/511/index.md
@@ -37,7 +37,7 @@ Host: example.com
 HTTP/1.1 511 Network Authentication Required
 Content-Type: text/html
 
-<html>
+<html lang="en-US">
   <head>
     <title>Network Authentication Required</title>
     <meta http-equiv="refresh" content="10; url=https://login.example.net/">

--- a/files/en-us/web/security/attacks/xs-leaks/index.md
+++ b/files/en-us/web/security/attacks/xs-leaks/index.md
@@ -108,8 +108,8 @@ In the attack described here, the attacker uses the [Content Security Policy (CS
 - Finally, they create an {{htmlelement("iframe")}} element and set its `src` attribute to `https://admin.example.org/`.
 
 ```html
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en-US">
   <head>
     <meta
       http-equiv="Content-Security-Policy"


### PR DESCRIPTION
- Make sure `html` elements have `lang="en-US"`
- `doctype` should be lowercase
- Remove duplicate attributes