### PR TITLE
BFCache now also has the state partitioning concept

### DIFF
--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -105,7 +105,7 @@ As such, the following network APIs and caches are **permanently** partitioned b
 - Preconnect
 - [CORS-preflight](/en-US/docs/Glossary/Preflight_request) Cache
 - WebRTC deviceID
-- [BFCache](/en-US/docs/Glossary/bfcache)
+- {{glossary("bfcache","Backward/forward cache (bfcache)")}}
 
 ## Dynamic partitioning
 

--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -105,6 +105,7 @@ As such, the following network APIs and caches are **permanently** partitioned b
 - Preconnect
 - [CORS-preflight](/en-US/docs/Glossary/Preflight_request) Cache
 - WebRTC deviceID
+- [BFCache](/en-US/docs/Glossary/bfcache)
 
 ## Dynamic partitioning
 


### PR DESCRIPTION
With [Bug 1930501] making the bfcache clearable programmatically from website context, it is now also partitioned within Firefox.

[Bug 1930501]: https://bugzilla.mozilla.org/show_bug.cgi?id=1930501
