### PR TITLE
Remove Summary a11y warning

### DIFF
--- a/files/en-us/web/html/reference/elements/summary/index.md
+++ b/files/en-us/web/html/reference/elements/summary/index.md
@@ -114,9 +114,6 @@ You can use heading elements in `<summary>`, like this:
 
 This currently has some spacing issues that could be addressed using CSS.
 
-> [!WARNING]
-> Because the `<summary>` element has a default role of [button](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role) (which strips all roles from child elements), this example will not work for users of assistive technologies such as screen readers. The `<h4>` will have its role removed and thus will not be treated as a heading for these users.
-
 ### HTML in summaries
 
 This example adds some semantics to the `<summary>` element to indicate the label as important:

--- a/files/en-us/web/html/reference/elements/summary/index.md
+++ b/files/en-us/web/html/reference/elements/summary/index.md
@@ -114,6 +114,9 @@ You can use heading elements in `<summary>`, like this:
 
 This currently has some spacing issues that could be addressed using CSS.
 
+> [!WARNING]
+> The role assigned to the `<summary>` element varies across browsers. Some still assign it a default [`button`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role) role, which removes all roles from its children. This inconsistency can cause issues for users of assistive technologies such as screen readers (`<h4>` in the previous example will have its role removed and will not be treated as a heading for these users). You should test your `<summary>` implementation on multiple platforms to ensure there's consistent accessibility support.
+
 ### HTML in summaries
 
 This example adds some semantics to the `<summary>` element to indicate the label as important:


### PR DESCRIPTION

### Description

Remove outdated warning on accessibility roles in the `<summary>` element.

### Motivation

The implicit role of the element was changed from `button` to `no corresponding role` in the aria specifications at the end of 2022:

- https://github.com/w3c/html-aria/pull/434
- https://github.com/w3c/html-aria/pull/435

Seems like the `implicit role` was corrected on mdn in 2023 (https://github.com/mdn/content/pull/28602), but this specific warning was forgotten.

Although the specifications still contain [a warning](https://w3c.github.io/html-aria/#el-summary) that browsers will still use a button role, I tested this and found it to not be the case at least in Chromium, Firefox and Safari. So perhaps the specs also need to be updated.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Relates to #28602 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
