### PR TITLE
chore: Catching glitch.com links to de-noise external example cleanup

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
@@ -26,7 +26,7 @@ Alternatively, you can load Babylon.js from a CDN:
 <script src="https://cdn.babylonjs.com/v7.34.1/babylon.js"></script>
 ```
 
-If you don't want to develop locally, you can use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+If you don't want to develop locally, you can use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 With these editors, you can add `https://cdn.babylonjs.com/v7.34.1/babylon.js` as a JavaScript source so it's available in your code.
 
 ### HTML starter for Babylon.js

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -26,7 +26,7 @@ Alternatively, you can load PlayCanvas from a CDN:
 <script src="https://cdn.jsdelivr.net/npm/playcanvas@2.2.2/build/playcanvas.min.js"></script>
 ```
 
-If you don't want to develop locally, you can use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+If you don't want to develop locally, you can use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 With these editors, you can add `https://cdn.babylonjs.com/babylon.js` as a JavaScript source so it's available in your code.
 
 ### HTML starter for PlayCanvas

--- a/files/en-us/learn_web_development/core/accessibility/accessibility_troubleshooting/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/accessibility_troubleshooting/index.md
@@ -14,7 +14,7 @@ In the challenge for this module, we present to you a simple site with a number 
 
 To start this challenge, you should go and grab the [ZIP containing the files that comprise the example](https://raw.githubusercontent.com/mdn/learning-area/main/accessibility/assessment-start/assessment-files.zip). Decompress the contents into a new directory somewhere on your local computer.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 The finished challenge site should look like so:
 

--- a/files/en-us/learn_web_development/core/accessibility/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/index.md
@@ -15,7 +15,7 @@ Access to web content such as public services, education, e-commerce sites, and 
 You should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content), [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics), and [JavaScript](/en-US/docs/Learn_web_development/Core/Scripting) before starting this module.
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/accessibility/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/index.md
@@ -15,7 +15,7 @@ Access to web content such as public services, education, e-commerce sites, and 
 You should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content), [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics), and [JavaScript](/en-US/docs/Learn_web_development/Core/Scripting) before starting this module.
 
 > [!NOTE]
-> If you are working on a computer/tablet/other devices where you don't have the ability to create your own files, you can try out most of the code examples in an online coding program such as [JS Bin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/css_and_javascript/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/css_and_javascript/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [CSS and JavaScript accessibility best practices](/en-US/docs/Learn_web_development/Core/Accessibility/CSS_and_JavaScript) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [HTML: A good basis for accessibility](/en-US/docs/Learn_web_development/Core/Accessibility/HTML) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/wai-aria/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/wai-aria/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [WAI-ARIA basics](/en-US/docs/Learn_web_development/Core/Accessibility/WAI-ARIA_basics) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/css_layout/fundamental_layout_comprehension/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/fundamental_layout_comprehension/index.md
@@ -20,7 +20,7 @@ Save the HTML document and stylesheet into a directory on your computer, and add
 
 This starting point has all of the content of your layout as displayed by the browser in normal flow.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 If you use an online editor, you will need to upload the images and replace the values in the `src` attributes to point to the new image locations.
 
 > [!NOTE]

--- a/files/en-us/learn_web_development/core/css_layout/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/index.md
@@ -14,7 +14,7 @@ In previous modules we looked at how to style and manipulate the boxes that your
 Before starting this module, you should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content), the [basic fundamentals of CSS](/en-US/docs/Learn_web_development/Core/Styling_basics), and [CSS text styling](/en-US/docs/Learn_web_development/Core/Text_styling).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/css_layout/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/index.md
@@ -14,7 +14,7 @@ In previous modules we looked at how to style and manipulate the boxes that your
 Before starting this module, you should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content), the [basic fundamentals of CSS](/en-US/docs/Learn_web_development/Core/Styling_basics), and [CSS text styling](/en-US/docs/Learn_web_development/Core/Text_styling).
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/flexbox/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/flexbox/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand how [flexbox and 
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/floats/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/floats/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand [floats in CSS](/
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/grid/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/grid/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand how a [grid and g
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/position/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/position/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand [positioning in C
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/responsive_design/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/responsive_design/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand [how to use media
 
 > [!NOTE]
 > Because you need to test your design in multiple screen sizes, we do not have interactive editors on this page.
-> Download the code and work locally, or use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> Download the code and work locally, or use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/design_for_developers/index.md
+++ b/files/en-us/learn_web_development/core/design_for_developers/index.md
@@ -19,7 +19,7 @@ In addition, front-end developers are often tasked with doing various bits of de
 Before starting this module, you should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Lessons
 

--- a/files/en-us/learn_web_development/core/design_for_developers/index.md
+++ b/files/en-us/learn_web_development/core/design_for_developers/index.md
@@ -19,7 +19,7 @@ In addition, front-end developers are often tasked with doing various bits of de
 Before starting this module, you should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Lessons
 

--- a/files/en-us/learn_web_development/core/scripting/image_gallery/index.md
+++ b/files/en-us/learn_web_development/core/scripting/image_gallery/index.md
@@ -13,7 +13,7 @@ Now that we've looked at the fundamental building blocks of JavaScript, we'll te
 
 To start this challenge, you should go and [grab the ZIP](https://raw.githubusercontent.com/mdn/learning-area/main/javascript/building-blocks/gallery/gallery-start.zip) file for the example, unzip it somewhere on your computer, and do the exercise locally to begin with.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 > [!NOTE]
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/index.md
+++ b/files/en-us/learn_web_development/core/scripting/index.md
@@ -15,7 +15,7 @@ JavaScript is a huge topic, with so many different features, styles, and techniq
 Before starting this module, you don't need any previous JavaScript knowledge, but you should have worked through the previous modules in the course. You should at least know [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and the [basic fundamentals of CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/scripting/index.md
+++ b/files/en-us/learn_web_development/core/scripting/index.md
@@ -15,7 +15,7 @@ JavaScript is a huge topic, with so many different features, styles, and techniq
 Before starting this module, you don't need any previous JavaScript knowledge, but you should have worked through the previous modules in the course. You should at least know [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and the [basic fundamentals of CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/scripting/silly_story_generator/index.md
+++ b/files/en-us/learn_web_development/core/scripting/silly_story_generator/index.md
@@ -17,7 +17,8 @@ To get this challenge started, you should:
 - Go and [grab the HTML file](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/assessment-start/index.html) for the example, save a local copy of it as `index.html` in a new directory somewhere on your computer, and do the challenge locally to begin with. This also has the CSS to style the example contained within it.
 - Go to the [page containing the raw text](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/assessment-start/raw-text.txt) and keep this open in a separate browser tab somewhere. You'll need it later.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/). You could paste the HTML, CSS and JavaScript into one of these online editors. If the online editor you are using doesn't have a separate JavaScript panel, feel free to put it inline in a `<script>` element inside the HTML page.
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+If the online editor you are using doesn't have a separate JavaScript panel, you can put it inline in a `<script>` element inside the HTML page.
 
 > [!NOTE]
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/arrays/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/arrays/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Arrays](/en-US/docs/Learn_web_development/Core/Scripting/Arrays) article.
 
 > [!NOTE]
-> For tasks 1–4, you can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> For Tasks 1–4, you can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Interactive challenge

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/arrays/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/arrays/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Arrays](/en-US/docs/Learn_web_development/Core/Scripting/Arrays) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/conditionals/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/conditionals/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Making decisions in your code — conditionals](/en-US/docs/Learn_web_development/Core/Scripting/Conditionals) article.
 
 > [!NOTE]
-> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/events/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/events/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Introduction to events](/en-US/docs/Learn_web_development/Core/Scripting/Events) article.
 
 > [!NOTE]
-> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/functions/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/functions/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Functions — reusable blocks of code](/en-US/docs/Learn_web_development/Core/Scripting/Functions), [Build your own function](/en-US/docs/Learn_web_development/Core/Scripting/Build_your_own_function), and [Function return values](/en-US/docs/Learn_web_development/Core/Scripting/Return_values) articles.
 
 > [!NOTE]
-> For tasks 1–4, you can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> For Tasks 1–4, you can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/functions/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/functions/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Functions — reusable blocks of code](/en-US/docs/Learn_web_development/Core/Scripting/Functions), [Build your own function](/en-US/docs/Learn_web_development/Core/Scripting/Build_your_own_function), and [Function return values](/en-US/docs/Learn_web_development/Core/Scripting/Return_values) articles.
 
 > [!NOTE]
-> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/json/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/json/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Working with JSON](/en-US/docs/Learn_web_development/Core/Scripting/JSON) article.
 
 > [!NOTE]
-> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/loops/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/loops/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Looping code](/en-US/docs/Learn_web_development/Core/Scripting/Loops) article.
 
 > [!NOTE]
-> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/math/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/math/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of the tests on this page is to assess whether you've understood the [Basic math in JavaScript — numbers and operators](/en-US/docs/Learn_web_development/Core/Scripting/Math) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error in your code, it will be logged into the results panel on this page or in the JavaScript console.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/object_basics/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/object_basics/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [JavaScript object basics](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error in your code, it will be logged into the results panel on this page or in the JavaScript console.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/strings/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/strings/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Handling text — strings in JavaScript](/en-US/docs/Learn_web_development/Core/Scripting/Strings) and [Useful string methods](/en-US/docs/Learn_web_development/Core/Scripting/Useful_string_methods) articles.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/variables/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/variables/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Storing the information you need — Variables](/en-US/docs/Learn_web_development/Core/Scripting/Variables) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error in your code, it will be logged into the results panel on this page or in the JavaScript console.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/variables/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/variables/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Storing the information you need — Variables](/en-US/docs/Learn_web_development/Core/Scripting/Variables) article.
 
 > [!NOTE]
-> For tasks 1 and 2, you can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> For Tasks 1 and 2, you can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error in your code, it will be logged into the results panel on this page or in the JavaScript console.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/structuring_content/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/index.md
@@ -15,7 +15,7 @@ HTML is the technology that defines the content and structure of any website. Wr
 Before starting this module, you don't need any previous HTML knowledge, but you should have at least basic familiarity with using computers and using the web passively (i.e., just looking at it and consuming content). You should have a basic work environment set up (as detailed in [Installing basic software](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software)), and understand how to create and manage files (as detailed in [Dealing with files](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files)). Both are parts of our [Getting started with the web](/en-US/docs/Learn_web_development/Getting_started/Your_first_website) complete beginner's module.
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/structuring_content/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/index.md
@@ -15,7 +15,7 @@ HTML is the technology that defines the content and structure of any website. Wr
 Before starting this module, you don't need any previous HTML knowledge, but you should have at least basic familiarity with using computers and using the web passively (i.e., just looking at it and consuming content). You should have a basic work environment set up (as detailed in [Installing basic software](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software)), and understand how to create and manage files (as detailed in [Dealing with files](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files)). Both are parts of our [Getting started with the web](/en-US/docs/Learn_web_development/Getting_started/Your_first_website) complete beginner's module.
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/structuring_content/marking_up_a_letter/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/marking_up_a_letter/index.md
@@ -13,7 +13,7 @@ We all learn to write a letter sooner or later; it is also a useful example to t
 ## Starting point
 
 To begin, get the [raw text you need to mark up](https://github.com/mdn/learning-area/blob/main/html/introduction-to-html/marking-up-a-letter-start/letter-text.txt), and the [CSS to style the HTML](https://github.com/mdn/learning-area/blob/main/html/introduction-to-html/marking-up-a-letter-start/css.txt).
-Create a new `.html` file using your text editor or use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Create a new `.html` file using your text editor or use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 > [!NOTE]
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/structuring_content/mozilla_splash_page/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/mozilla_splash_page/index.md
@@ -15,7 +15,7 @@ To start off this assessment, you need to grab the HTML and all the images avail
 
 Access the different images in the [originals](https://github.com/mdn/learning-area/tree/main/html/multimedia-and-embedding/mdn-splash-page-start/originals) directory and save them in the same way; you'll want to save them in a different directory for now, as you'll need to manipulate (some of) them using a graphics editor before they're ready to be used.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 > [!NOTE]
 > The example HTML file contains quite a lot of CSS, to style the page. You don't need to touch the CSS, just the HTML inside the {{htmlelement("body")}} element — as long as you insert the correct markup, the styling will make it look correct.

--- a/files/en-us/learn_web_development/core/structuring_content/planet_data_table/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/planet_data_table/index.md
@@ -15,7 +15,7 @@ In this challenge, we provide you with some data on the planets in our solar sys
 To start the assessment, make local copies of [blank-template.html](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/blank-template.html), [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/minimal-table.css), and [planets-data.txt](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/planets-data.txt) in a new directory in your local computer.
 
 > [!NOTE]
-> You can try solutions in your code editor or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in your code editor or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
@@ -20,7 +20,7 @@ The zip file contains:
 - CSS to style your markup.
 - Images that are used on the page.
 
-Create the example on your local computer, or alternatively use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Create the example on your local computer, or alternatively use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 > [!NOTE]
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/advanced_html_text/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/advanced_html_text/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you understand how to use [lesser-known HTML elements to mark up advanced semantic features](/en-US/docs/Learn_web_development/Core/Structuring_content/Advanced_text_features).
 
 > [!NOTE]
-> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/audio_and_video/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/audio_and_video/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you understand how to [embed video and audio content in HTML](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_video_and_audio).
 
 > [!NOTE]
-> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/html_text_basics/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/html_text_basics/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you understand how to mark up text in HTML to give it structure and meaning.
 
 > [!NOTE]
-> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/images/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/images/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you understand [images and how to embed them in HTML](/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images).
 
 > [!NOTE]
-> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/links/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you understand how to [implement links in HTML](/en-US/docs/Learn_web_development/Core/Structuring_content/Creating_links).
 
 > [!NOTE]
-> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the MDN Playground or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/core/styling_basics/cool-looking_box/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/cool-looking_box/index.md
@@ -62,7 +62,7 @@ html {
 /* Your CSS below here */
 ```
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 You could paste the HTML and fill in the CSS into one of these online editors.
 
 > [!NOTE]

--- a/files/en-us/learn_web_development/core/styling_basics/fancy_letterheaded_paper/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/fancy_letterheaded_paper/index.md
@@ -17,7 +17,7 @@ To start this challenge, you should:
 - Make local copies of the [HTML](https://github.com/mdn/learning-area/blob/main/css/styling-boxes/letterheaded-paper-start/index.html) and [CSS](https://github.com/mdn/learning-area/blob/main/css/styling-boxes/letterheaded-paper-start/style.css) — save them as `index.html` and `style.css` in a new directory.
 - Save local copies of the [top](https://raw.githubusercontent.com/mdn/learning-area/master/css/styling-boxes/letterheaded-paper-start/top-image.png), [bottom](https://raw.githubusercontent.com/mdn/learning-area/master/css/styling-boxes/letterheaded-paper-start/bottom-image.png) and [logo](https://raw.githubusercontent.com/mdn/learning-area/master/css/styling-boxes/letterheaded-paper-start/logo.png) images in the same directory as your code files.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 You could paste the HTML and fill in the CSS into one of these online editors.
 
 > [!NOTE]

--- a/files/en-us/learn_web_development/core/styling_basics/fundamental_css_comprehension/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/fundamental_css_comprehension/index.md
@@ -17,7 +17,7 @@ To start this challenge, you should:
 - Go and grab the [HTML file for the exercise](https://github.com/mdn/learning-area/blob/main/css/introduction-to-css/fundamental-css-comprehension/index.html), and the [associated image file](https://github.com/mdn/learning-area/blob/main/css/introduction-to-css/fundamental-css-comprehension/chris.jpg), and save them in a new directory on your local computer. If you want to use your own image file and fill your own name in, you are welcome to — just make sure the image is square.
 - Grab the [CSS resources text file](https://github.com/mdn/learning-area/blob/main/css/introduction-to-css/fundamental-css-comprehension/style-resources.txt) — this contains a set of raw selectors and rulesets that you'll need to study and combine to answer part of this challenge.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 You could paste the HTML and fill in the CSS into one of these online editors, and use [this URL](https://mdn.github.io/learning-area/css/introduction-to-css/fundamental-css-comprehension/chris.jpg) to point the `<img>` element to the image file.
 
 > [!NOTE]

--- a/files/en-us/learn_web_development/core/styling_basics/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/index.md
@@ -14,7 +14,7 @@ CSS (Cascading Style Sheets) is used to style and layout web pages — for examp
 Before starting this module, you should have a basic work environment set up (as detailed in [Installing basic software](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software)), and understand how to create and manage files (as detailed in [Dealing with files](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files)). You should also be familiar with HTML (work through our [Structuring content with HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) module if not).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/styling_basics/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/index.md
@@ -14,7 +14,7 @@ CSS (Cascading Style Sheets) is used to style and layout web pages — for examp
 Before starting this module, you should have a basic work environment set up (as detailed in [Installing basic software](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software)), and understand how to create and manage files (as detailed in [Dealing with files](/en-US/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files)). You should also be familiar with HTML (work through our [Structuring content with HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) module if not).
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/styling_basics/styling_a_bio_page/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/styling_a_bio_page/index.md
@@ -11,7 +11,7 @@ sidebar: learnsidebar
 In this challenge you will style a simple bio page, testing you on some of the skills you learned in the last couple of lessons including writing selectors and text styling.
 
 > [!NOTE]
-> You can click "Play" in the live samples below to open the code in the MDN Playground, or you can copy and paste the code into your own IDE or an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can click "Play" in the live samples below to open the code in the MDN Playground, or you can copy and paste the code into your own IDE or an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Project brief

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/backgrounds_and_borders/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/backgrounds_and_borders/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand [backgrounds and 
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/box_model/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/box_model/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand the [CSS box mode
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/cascade/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/cascade/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand universal propert
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/images/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/images/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand how special eleme
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/overflow/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand [overflow in CSS 
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand [CSS selectors](/
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/sizing/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/sizing/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand the different way
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/values/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/values/index.md
@@ -10,7 +10,7 @@ The aim of this skill test is to assess whether you understand different types o
 
 > [!NOTE]
 > Click **"Play"** in the code blocks below to edit the examples in the MDN Playground.
-> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can also copy the code (click the clipboard icon) and paste it into an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
 ## Task 1

--- a/files/en-us/learn_web_development/core/text_styling/index.md
+++ b/files/en-us/learn_web_development/core/text_styling/index.md
@@ -14,7 +14,7 @@ With the basics of the CSS language covered, the next CSS topic for you to conce
 Before starting this module, you should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and the [basic fundamentals of CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/text_styling/index.md
+++ b/files/en-us/learn_web_development/core/text_styling/index.md
@@ -14,7 +14,7 @@ With the basics of the CSS language covered, the next CSS topic for you to conce
 Before starting this module, you should be familiar with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and the [basic fundamentals of CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/core/text_styling/typesetting_a_homepage/index.md
+++ b/files/en-us/learn_web_development/core/text_styling/typesetting_a_homepage/index.md
@@ -17,7 +17,7 @@ To start this challenge, you should:
 - Go and grab the [HTML](https://github.com/mdn/learning-area/blob/main/css/styling-text/typesetting-a-homepage-start/index.html) and [CSS](https://github.com/mdn/learning-area/blob/main/css/styling-text/typesetting-a-homepage-start/style.css) files for the exercise, and the provided [external link icon](https://github.com/mdn/learning-area/blob/main/css/styling-text/typesetting-a-homepage-start/external-link-52.png).
 - Make a copy of them on your local computer.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 You could paste the HTML and fill in the CSS into one of these online editors, and use [this external link icon](https://mdn.github.io/learning-area/css/styling-text/typesetting-a-homepage-start/external-link-52.png) as a background image.
 
 > [!NOTE]

--- a/files/en-us/learn_web_development/extensions/advanced_javascript_objects/adding_bouncing_balls_features/index.md
+++ b/files/en-us/learn_web_development/extensions/advanced_javascript_objects/adding_bouncing_balls_features/index.md
@@ -14,7 +14,8 @@ In this challenge, you are expected to use the bouncing balls demo from the prev
 
 To start this challenge, make a local copy of [index-finished.html](https://github.com/mdn/learning-area/blob/main/javascript/oojs/bouncing-balls/index-finished.html), [style.css](https://github.com/mdn/learning-area/blob/main/javascript/oojs/bouncing-balls/style.css), and [main-finished.js](https://github.com/mdn/learning-area/blob/main/javascript/oojs/bouncing-balls/main-finished.js) from our last article in a new directory in your local computer.
 
-Alternatively, you could use an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/). You could paste the HTML, CSS and JavaScript into one of these online editors. If the online editor you are using doesn't have a separate JavaScript panel, feel free to put it inline in a `<script>` element inside the HTML page.
+Alternatively, you could use an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+If the online editor you are using doesn't have a separate JavaScript panel, you can put it inline in a `<script>` element inside the HTML page.
 
 > [!NOTE]
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/extensions/advanced_javascript_objects/index.md
+++ b/files/en-us/learn_web_development/extensions/advanced_javascript_objects/index.md
@@ -16,7 +16,7 @@ Having a deeper knowledge of how JavaScript objects work is useful as you build 
 Before starting this module, You should really have learnt the fundamentals of [JavaScript](/en-US/docs/Learn_web_development/Core/Scripting), especially [JavaScript object basics](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics). It would also be helpful to have some familiarity with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer/tablet/other devices where you are not able to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/extensions/advanced_javascript_objects/index.md
+++ b/files/en-us/learn_web_development/extensions/advanced_javascript_objects/index.md
@@ -16,7 +16,7 @@ Having a deeper knowledge of how JavaScript objects work is useful as you build 
 Before starting this module, You should really have learnt the fundamentals of [JavaScript](/en-US/docs/Learn_web_development/Core/Scripting), especially [JavaScript object basics](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics). It would also be helpful to have some familiarity with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/extensions/advanced_javascript_objects/test_your_skills/object-oriented_javascript/index.md
+++ b/files/en-us/learn_web_development/extensions/advanced_javascript_objects/test_your_skills/object-oriented_javascript/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Classes in JavaScript](/en-US/docs/Learn_web_development/Extensions/Advanced_JavaScript_objects/Classes_in_JavaScript) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 > If there is an error in your code, it will be logged into the results panel on this page or in the JavaScript console.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn_web_development/extensions/async_js/index.md
+++ b/files/en-us/learn_web_development/extensions/async_js/index.md
@@ -14,7 +14,7 @@ In this module, we take a look at {{Glossary("asynchronous")}} {{Glossary("JavaS
 Asynchronous JavaScript is a fairly advanced topic, and you are advised to work through [Dynamic scripting with JavaScript](/en-US/docs/Learn_web_development/Core/Scripting) modules before attempting this.
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you can try out (most of) the code examples in an online coding program such as [JS Bin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/extensions/async_js/index.md
+++ b/files/en-us/learn_web_development/extensions/async_js/index.md
@@ -14,7 +14,7 @@ In this module, we take a look at {{Glossary("asynchronous")}} {{Glossary("JavaS
 Asynchronous JavaScript is a fairly advanced topic, and you are advised to work through [Dynamic scripting with JavaScript](/en-US/docs/Learn_web_development/Core/Scripting) modules before attempting this.
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials and challenges
 

--- a/files/en-us/learn_web_development/extensions/client-side_apis/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/index.md
@@ -16,7 +16,7 @@ Before starting this module, You should really have learnt the fundamentals of [
 It would also be helpful to have some familiarity with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials
 

--- a/files/en-us/learn_web_development/extensions/client-side_apis/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/index.md
@@ -16,7 +16,7 @@ Before starting this module, You should really have learnt the fundamentals of [
 It would also be helpful to have some familiarity with [HTML](/en-US/docs/Learn_web_development/Core/Structuring_content) and [CSS](/en-US/docs/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
-> If you are working on a device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JSBin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Tutorials
 

--- a/files/en-us/learn_web_development/extensions/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/index.md
@@ -18,7 +18,7 @@ Mastering forms however requires more than just HTML knowledge — you also need
 The above text is a good indicator as to why we've put web forms into its own standalone module, rather than trying to mix bits of it into the HTML, CSS, and JavaScript topic areas — form elements are more complex than most other HTML elements, and they also require a close marriage of related CSS and JavaScript techniques to get the most out of them.
 
 > [!NOTE]
-> If you are working on a computer/tablet/other device where you don't have the ability to create your own files, you could try out (most of) the code examples in an online coding program such as [JS Bin](https://jsbin.com/) or [Glitch](https://glitch.com/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Introductory tutorials
 

--- a/files/en-us/learn_web_development/extensions/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/index.md
@@ -18,7 +18,7 @@ Mastering forms however requires more than just HTML knowledge — you also need
 The above text is a good indicator as to why we've put web forms into its own standalone module, rather than trying to mix bits of it into the HTML, CSS, and JavaScript topic areas — form elements are more complex than most other HTML elements, and they also require a close marriage of related CSS and JavaScript techniques to get the most out of them.
 
 > [!NOTE]
-> If you are working on a computer, tablet, or another device where you can't create files, you can try an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
+> If you are working on a computer, tablet, or another device where you can't create files, you can try running the code in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 ## Introductory tutorials
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/advanced_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/advanced_styling/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Advanced form styling](/en-US/docs/Learn_web_development/Extensions/Forms/Advanced_form_styling) and [UI pseudo-classes](/en-US/docs/Learn_web_development/Extensions/Forms/UI_pseudo-classes) articles.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/basic_controls/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/basic_controls/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Basic native form controls](/en-US/docs/Learn_web_development/Extensions/Forms/Basic_native_form_controls) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/form_structure/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/form_structure/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [How to structure a web form](/en-US/docs/Learn_web_development/Extensions/Forms/How_to_structure_a_web_form) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/form_validation/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Client-side form validation](/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/input_types/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/input_types/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [The HTML5 input types](/en-US/docs/Learn_web_development/Extensions/Forms/HTML5_input_types) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/other_controls/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/other_controls/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Other form controls](/en-US/docs/Learn_web_development/Extensions/Forms/Other_form_controls) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/forms/test_your_skills/styling_basics/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/test_your_skills/styling_basics/index.md
@@ -9,7 +9,7 @@ sidebar: learnsidebar
 The aim of this skill test is to assess whether you've understood our [Styling web forms](/en-US/docs/Learn_web_development/Extensions/Forms/Styling_web_forms) article.
 
 > [!NOTE]
-> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> You can try solutions in the interactive editors on this page or in an online editor such as [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
@@ -86,7 +86,7 @@ Some of the things to consider when choosing a host:
 The good news when you're starting out is that there are quite a few sites that provide "free" computing environments that are intended for evaluation and testing.
 These are usually fairly resource constrained/limited environments, and you do need to be aware that they may expire after some introductory period or have other constraints.
 They are however great for testing low-traffic sites in a hosted environment, and can provide an easy migration to paying for more resources when your site gets busier.
-Popular choices in this category include [Glitch](https://glitch.com/), [Python Anywhere](https://www.pythonanywhere.com/), [Amazon Web Services](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-free-tier.html), [Microsoft Azure](https://azure.microsoft.com/en-us/pricing/details/app-service/linux/), etc.
+Popular choices in this category include [Python Anywhere](https://www.pythonanywhere.com/), [Amazon Web Services](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-free-tier.html), [Microsoft Azure](https://azure.microsoft.com/en-us/pricing/details/app-service/linux/), etc.
 
 Most providers also offer a "basic" or "hobby" tier that is intended for small production sites, and which provide more useful levels of computing power and fewer limitations.
 [Railway](https://railway.com/), [Heroku](https://www.heroku.com/), [DigitalOcean](https://www.digitalocean.com/) and [Python Anywhere](https://www.pythonanywhere.com/) are examples of popular hosting providers that have a relatively inexpensive basic computing tier (in the $5 to $10 USD per month range).

--- a/files/en-us/learn_web_development/getting_started/environment_setup/command_line/index.md
+++ b/files/en-us/learn_web_development/getting_started/environment_setup/command_line/index.md
@@ -240,7 +240,7 @@ One good habit to get into is to write your terminal command out inside a text e
 If you're not comfortable trying terminal commands out on your own machine, there are hosted online terminals available that provide safe places to practice entering commands, without risking breaking your own machine:
 
 - Our learning partner, [Scrimba](https://scrimba.com/home?via=mdn), features a terminal for entering commands in their learning environment. A great place to see this in action is their [Command Line Basics](https://scrimba.com/command-line-basics-c08b87ogl0/~05hu?via=mdn) <sup>[_MDN learning partner_](/en-US/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> course, which also provides a fun interactive introduction to navigating around the file tree and manipulating files and directories via the terminal.
-- [Glitch.com](https://glitch.com/) is a great place to try out web development code, and Glitch projects also include a terminal for running commands.
+- [Command-line playground](https://sandbox.bio/playgrounds/terminal) on sandbox.bio is a great place to try out terminal commands so you can familiarize yourself with command line interfaces and common shells like Bash.
 
 A great resource for getting a quick overview of specific terminal commands is [tldr.sh](https://tldr.sh/). This is a community-driven documentation service, similar to MDN, but specific to terminal commands.
 

--- a/files/en-us/learn_web_development/getting_started/environment_setup/command_line/index.md
+++ b/files/en-us/learn_web_development/getting_started/environment_setup/command_line/index.md
@@ -240,7 +240,7 @@ One good habit to get into is to write your terminal command out inside a text e
 If you're not comfortable trying terminal commands out on your own machine, there are hosted online terminals available that provide safe places to practice entering commands, without risking breaking your own machine:
 
 - Our learning partner, [Scrimba](https://scrimba.com/home?via=mdn), features a terminal for entering commands in their learning environment. A great place to see this in action is their [Command Line Basics](https://scrimba.com/command-line-basics-c08b87ogl0/~05hu?via=mdn) <sup>[_MDN learning partner_](/en-US/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> course, which also provides a fun interactive introduction to navigating around the file tree and manipulating files and directories via the terminal.
-- [Command-line playground](https://sandbox.bio/playgrounds/terminal) on sandbox.bio is a great place to try out terminal commands so you can familiarize yourself with command line interfaces and common shells like Bash.
+- The [Command-line playground](https://sandbox.bio/playgrounds/terminal) on sandbox.bio is a great place to try out terminal commands so you can familiarize yourself with command line interfaces and common shells like Bash.
 
 A great resource for getting a quick overview of specific terminal commands is [tldr.sh](https://tldr.sh/). This is a community-driven documentation service, similar to MDN, but specific to terminal commands.
 

--- a/files/en-us/learn_web_development/getting_started/environment_setup/installing_software/index.md
+++ b/files/en-us/learn_web_development/getting_started/environment_setup/installing_software/index.md
@@ -109,7 +109,7 @@ While version control tools are essential for web development teams, you don't n
 
 After you've finished developing a website or app (on your local computer, or perhaps on a development server), you'll want to put it onto a remote web server so that your users can type in the web address associated with it and view it on the web!
 
-There are various ways you can do this, from buying hosting and using an [SFTP app](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/Upload_files_to_a_web_server#sftp), using a service like [GitHub Pages](https://pages.github.com/) or [Netlify](https://www.netlify.com/), or even setting up a quick demo to share with others using something like [Glitch](https://glitch.com/) or [CodePen](https://codepen.io/).
+There are various ways you can do this, from buying hosting and using an [SFTP app](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/Upload_files_to_a_web_server#sftp), using a service like [GitHub Pages](https://pages.github.com/) or [Netlify](https://www.netlify.com/), or even putting together a quick demo to share with others using something like [CodePen](https://codepen.io/) or [JSFiddle](https://jsfiddle.net/).
 
 Such a list of options might seem overwhelming, but don't worry — you don't need to know anything about publishing websites right now. We'll look at this topic many times later in the course. You'll get practical experience of it soon enough, in our [Your first website](/en-US/docs/Learn_web_development/Getting_started/Your_first_website) module.
 

--- a/files/en-us/learn_web_development/getting_started/your_first_website/publishing_your_website/index.md
+++ b/files/en-us/learn_web_development/getting_started/your_first_website/publishing_your_website/index.md
@@ -79,8 +79,7 @@ Try playing with some of these examples to find out which one works best for you
 
 - [Scrimba](https://scrimba.com/new?via=mdn) <sup>[_MDN learning partner_](/en-US/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup>
 - [JSFiddle](https://jsfiddle.net/)
-- [Glitch](https://glitch.com/)
-- [JS Bin](https://jsbin.com/)
+- [JSBin](https://jsbin.com/)
 - [CodePen](https://codepen.io/)
 
 ## Publishing via GitHub


### PR DESCRIPTION
## Description

This PR removes `[Glitch](https://glitch.com/)` occurrences.

### Motivation

I'm helping @chrisdavidmills remove some of the Glitch demos.

## Related

- [x] https://github.com/mdn/content/pull/40148
- [x] https://github.com/mdn/content/pull/40170