### PR TITLE
Replace navigation api glitch demo links

### DIFF
--- a/files/en-us/web/api/navigateevent/canintercept/index.md
+++ b/files/en-us/web/api/navigateevent/canintercept/index.md
@@ -65,4 +65,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/destination/index.md
+++ b/files/en-us/web/api/navigateevent/destination/index.md
@@ -57,4 +57,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/downloadrequest/index.md
+++ b/files/en-us/web/api/navigateevent/downloadrequest/index.md
@@ -56,4 +56,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/formdata/index.md
+++ b/files/en-us/web/api/navigateevent/formdata/index.md
@@ -56,4 +56,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/hashchange/index.md
+++ b/files/en-us/web/api/navigateevent/hashchange/index.md
@@ -56,4 +56,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/hasuavisualtransition/index.md
+++ b/files/en-us/web/api/navigateevent/hasuavisualtransition/index.md
@@ -69,5 +69,4 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
 - [Same-document view transitions for single-page applications](https://developer.chrome.com/docs/web-platform/view-transitions/same-document)

--- a/files/en-us/web/api/navigateevent/index.md
+++ b/files/en-us/web/api/navigateevent/index.md
@@ -122,4 +122,4 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))

--- a/files/en-us/web/api/navigateevent/info/index.md
+++ b/files/en-us/web/api/navigateevent/info/index.md
@@ -60,5 +60,4 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
 - Methods that allow info to be passed — {{domxref("Navigation.back()")}}, {{domxref("Navigation.forward()")}}, {{domxref("Navigation.navigate()")}}, {{domxref("Navigation.reload()")}}, and {{domxref("Navigation.traverseTo()")}}

--- a/files/en-us/web/api/navigateevent/intercept/index.md
+++ b/files/en-us/web/api/navigateevent/intercept/index.md
@@ -120,4 +120,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/navigateevent/index.md
+++ b/files/en-us/web/api/navigateevent/navigateevent/index.md
@@ -93,4 +93,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/navigationtype/index.md
+++ b/files/en-us/web/api/navigateevent/navigationtype/index.md
@@ -78,4 +78,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/scroll/index.md
+++ b/files/en-us/web/api/navigateevent/scroll/index.md
@@ -75,4 +75,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/signal/index.md
+++ b/files/en-us/web/api/navigateevent/signal/index.md
@@ -50,4 +50,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/sourceelement/index.md
+++ b/files/en-us/web/api/navigateevent/sourceelement/index.md
@@ -44,4 +44,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigateevent/userinitiated/index.md
+++ b/files/en-us/web/api/navigateevent/userinitiated/index.md
@@ -40,4 +40,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/activation/index.md
+++ b/files/en-us/web/api/navigation/activation/index.md
@@ -36,4 +36,3 @@ if (navigation.activation) {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/back/index.md
+++ b/files/en-us/web/api/navigation/back/index.md
@@ -78,4 +78,3 @@ async function forwardHandler() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/cangoback/index.md
+++ b/files/en-us/web/api/navigation/cangoback/index.md
@@ -57,4 +57,3 @@ async function forwardHandler() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/cangoforward/index.md
+++ b/files/en-us/web/api/navigation/cangoforward/index.md
@@ -55,4 +55,3 @@ async function forwardHandler() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/currententry/index.md
+++ b/files/en-us/web/api/navigation/currententry/index.md
@@ -52,4 +52,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/currententrychange_event/index.md
+++ b/files/en-us/web/api/navigation/currententrychange_event/index.md
@@ -69,4 +69,3 @@ navigation.addEventListener("currententrychange", () => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/entries/index.md
+++ b/files/en-us/web/api/navigation/entries/index.md
@@ -70,4 +70,3 @@ backButtonEl.addEventListener("click", () => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/forward/index.md
+++ b/files/en-us/web/api/navigation/forward/index.md
@@ -78,4 +78,3 @@ async function forwardHandler() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/index.md
+++ b/files/en-us/web/api/navigation/index.md
@@ -139,4 +139,4 @@ navigation.updateCurrentEntry({ state: newState });
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))

--- a/files/en-us/web/api/navigation/navigate/index.md
+++ b/files/en-us/web/api/navigation/navigate/index.md
@@ -128,4 +128,3 @@ async function navigateHandler() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/navigate_event/index.md
+++ b/files/en-us/web/api/navigation/navigate_event/index.md
@@ -100,4 +100,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/navigateerror_event/index.md
+++ b/files/en-us/web/api/navigation/navigateerror_event/index.md
@@ -61,4 +61,3 @@ navigation.addEventListener("navigateerror", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/navigatesuccess_event/index.md
+++ b/files/en-us/web/api/navigation/navigatesuccess_event/index.md
@@ -59,4 +59,3 @@ navigation.addEventListener("navigateerror", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/reload/index.md
+++ b/files/en-us/web/api/navigation/reload/index.md
@@ -86,4 +86,3 @@ async function handleReload() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/transition/index.md
+++ b/files/en-us/web/api/navigation/transition/index.md
@@ -40,4 +40,3 @@ async function handleTransition() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/traverseto/index.md
+++ b/files/en-us/web/api/navigation/traverseto/index.md
@@ -81,4 +81,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation/updatecurrententry/index.md
+++ b/files/en-us/web/api/navigation/updatecurrententry/index.md
@@ -58,4 +58,3 @@ detailsElem.addEventListener("toggle", () => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigation_api/index.md
+++ b/files/en-us/web/api/navigation_api/index.md
@@ -113,7 +113,7 @@ There are a few perceived limitations with the Navigation API:
 ## Examples
 
 > [!NOTE]
-> Check out Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/).
+> Check out the [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api)).
 
 ### Handling a navigation using `intercept()`
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/from/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/from/index.md
@@ -36,4 +36,3 @@ navigation.addEventListener("currententrychange", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationcurrententrychangeevent/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/index.md
@@ -62,4 +62,4 @@ navigation.addEventListener("currententrychange", () => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
@@ -55,4 +55,3 @@ navigation.addEventListener("currententrychange", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
@@ -43,4 +43,3 @@ navigation.addEventListener("currententrychange", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationdestination/getstate/index.md
+++ b/files/en-us/web/api/navigationdestination/getstate/index.md
@@ -53,5 +53,4 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
 - Methods that allow state to be updated — {{domxref("Navigation.navigate()")}}, {{domxref("Navigation.reload()")}}, and {{domxref("Navigation.updateCurrentEntry()")}}

--- a/files/en-us/web/api/navigationdestination/id/index.md
+++ b/files/en-us/web/api/navigationdestination/id/index.md
@@ -39,4 +39,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationdestination/index.md
+++ b/files/en-us/web/api/navigationdestination/index.md
@@ -75,4 +75,4 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))

--- a/files/en-us/web/api/navigationdestination/index/index.md
+++ b/files/en-us/web/api/navigationdestination/index/index.md
@@ -37,4 +37,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationdestination/key/index.md
+++ b/files/en-us/web/api/navigationdestination/key/index.md
@@ -39,4 +39,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationdestination/samedocument/index.md
+++ b/files/en-us/web/api/navigationdestination/samedocument/index.md
@@ -39,4 +39,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationdestination/url/index.md
+++ b/files/en-us/web/api/navigationdestination/url/index.md
@@ -59,4 +59,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationhistoryentry/dispose_event/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/dispose_event/index.md
@@ -52,4 +52,3 @@ navigation.addEventListener("currententrychange", () => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationhistoryentry/getstate/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/getstate/index.md
@@ -59,5 +59,4 @@ async function handleReload() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
 - Methods that allow state to be updated — {{domxref("Navigation.navigate()")}}, {{domxref("Navigation.reload()")}}, and {{domxref("Navigation.updateCurrentEntry()")}}

--- a/files/en-us/web/api/navigationhistoryentry/id/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/id/index.md
@@ -37,4 +37,3 @@ console.log(current.id);
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationhistoryentry/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/index.md
@@ -79,4 +79,4 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))

--- a/files/en-us/web/api/navigationhistoryentry/index/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/index/index.md
@@ -35,4 +35,3 @@ console.log(current.index);
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationhistoryentry/key/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/key/index.md
@@ -62,4 +62,3 @@ navigation.addEventListener("navigate", (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationhistoryentry/samedocument/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/samedocument/index.md
@@ -36,4 +36,3 @@ console.log(current.sameDocument);
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationhistoryentry/url/index.md
+++ b/files/en-us/web/api/navigationhistoryentry/url/index.md
@@ -35,4 +35,3 @@ console.log(current.url);
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationtransition/finished/index.md
+++ b/files/en-us/web/api/navigationtransition/finished/index.md
@@ -39,4 +39,3 @@ async function cleanupNavigation() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationtransition/from/index.md
+++ b/files/en-us/web/api/navigationtransition/from/index.md
@@ -35,4 +35,3 @@ console.log(navigation.transition.from);
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/navigationtransition/index.md
+++ b/files/en-us/web/api/navigationtransition/index.md
@@ -46,4 +46,4 @@ async function cleanupNavigation() {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))

--- a/files/en-us/web/api/navigationtransition/navigationtype/index.md
+++ b/files/en-us/web/api/navigationtransition/navigationtype/index.md
@@ -42,4 +42,3 @@ console.log(navigation.transition.navigationType);
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)

--- a/files/en-us/web/api/popstateevent/hasuavisualtransition/index.md
+++ b/files/en-us/web/api/popstateevent/hasuavisualtransition/index.md
@@ -50,5 +50,4 @@ window.addEventListener("popstate", async (event) => {
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
 - [Same-document view transitions for single-page applications](https://developer.chrome.com/docs/web-platform/view-transitions/same-document)

--- a/files/en-us/web/api/window/navigation/index.md
+++ b/files/en-us/web/api/window/navigation/index.md
@@ -36,4 +36,4 @@ let currentNavEntries = window.navigation.entries();
 
 - [Modern client-side routing: the Navigation API](https://developer.chrome.com/docs/web-platform/navigation-api/)
 - [Navigation API explainer](https://github.com/WICG/navigation-api/blob/main/README.md)
-- Domenic Denicola's [Navigation API live demo](https://gigantic-honored-octagon.glitch.me/)
+- [Navigation API live demo](https://mdn.github.io/dom-examples/navigation-api/) ([view demo source](https://github.com/mdn/dom-examples/tree/main/navigation-api))


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The MDN [Navigation API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) has several pages that link to [this demo hosted on Glitch](https://gigantic-honored-octagon.glitch.me/).

Because Glitch is going away, we are re-hosting the demo on the `dom-examples` repo: see https://github.com/mdn/dom-examples/pull/315.

This PR updates all the remaining links to point to the new location. I've removed many of the links because, on reflection, it seemed over-the-top to link to the same demo from every page. The PR only links to those pages from the main landing page, the interface pages, and the `Window.navigation` page.

We shouldn't merge this PR until the accompanying `dom-examples` PR is merged.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

- [x] https://github.com/mdn/dom-examples/pull/315
