### PR TITLE
Replace AudioContext.setSinkId glitch links

### DIFF
--- a/files/en-us/web/api/audiocontext/setsinkid/index.md
+++ b/files/en-us/web/api/audiocontext/setsinkid/index.md
@@ -48,7 +48,7 @@ Attempting to set the sink ID to its existing value (i.e., returned by {{domxref
 
 ## Examples
 
-In our [SetSinkId test example](https://set-sink-id.glitch.me/) (check out the [source code](https://glitch.com/edit/#!/set-sink-id)), we create an audio graph that generates a three-second burst of white noise via an {{domxref("AudioBufferSourceNode")}}, which we also run through a {{domxref("GainNode")}} to quiet things down a bit.
+In our [SetSinkId test example](https://mdn.github.io/dom-examples/audiocontext-setsinkid/) (check out the [source code](https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid)), we create an audio graph that generates a three-second burst of white noise via an {{domxref("AudioBufferSourceNode")}}, which we also run through a {{domxref("GainNode")}} to quiet things down a bit.
 
 ```js
 mediaDeviceBtn.addEventListener("click", async () => {
@@ -107,7 +107,6 @@ The output device can be changed during audio playback, as well as before, or be
 
 ## See also
 
-- [SetSinkId test example](https://set-sink-id.glitch.me/)
 - [Change the destination output device in Web Audio](https://developer.chrome.com/blog/audiocontext-setsinkid/)
 - {{domxref("AudioContext.sinkId")}}
 - {{domxref("AudioContext/sinkchange_event", "sinkchange")}}

--- a/files/en-us/web/api/audiocontext/sinkchange_event/index.md
+++ b/files/en-us/web/api/audiocontext/sinkchange_event/index.md
@@ -42,7 +42,7 @@ audioCtx.addEventListener("sinkchange", () => {
 });
 ```
 
-See our [SetSinkId test example](https://set-sink-id.glitch.me/) for working code.
+See our [SetSinkId test example](https://mdn.github.io/dom-examples/audiocontext-setsinkid/) for working code (also check out the [source code](https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid)).
 
 ## Specifications
 
@@ -54,7 +54,6 @@ See our [SetSinkId test example](https://set-sink-id.glitch.me/) for working cod
 
 ## See also
 
-- [SetSinkId test example](https://set-sink-id.glitch.me/)
 - [Change the destination output device in Web Audio](https://developer.chrome.com/blog/audiocontext-setsinkid/)
 - {{domxref("AudioContext.setSinkId()")}}
 - {{domxref("AudioContext.sinkId")}}

--- a/files/en-us/web/api/audiocontext/sinkid/index.md
+++ b/files/en-us/web/api/audiocontext/sinkid/index.md
@@ -26,7 +26,7 @@ This property returns one of the following values, depending on how the sink ID 
 
 ## Examples
 
-In our [SetSinkId test example](https://set-sink-id.glitch.me/), we create an audio graph that generates a three-second burst of white noise via an {{domxref("AudioBufferSourceNode")}}, which we also run through a {{domxref("GainNode")}} to quiet things down a bit. We also provide the user with a dropdown menu to allow them to change the audio output device.
+In our [SetSinkId test example](https://mdn.github.io/dom-examples/audiocontext-setsinkid/) (check out the [source code](https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid)), we create an audio graph that generates a three-second burst of white noise via an {{domxref("AudioBufferSourceNode")}}, which we also run through a {{domxref("GainNode")}} to quiet things down a bit. We also provide the user with a dropdown menu to allow them to change the audio output device.
 
 When the Play button is clicked, we assemble the audio graph and start it playing, and we also log information about the current device to the console based on the value of `sinkId`:
 
@@ -65,7 +65,6 @@ playBtn.addEventListener("click", () => {
 
 ## See also
 
-- [SetSinkId test example](https://set-sink-id.glitch.me/)
 - [Change the destination output device in Web Audio](https://developer.chrome.com/blog/audiocontext-setsinkid/)
 - {{domxref("AudioContext.setSinkId()")}}
 - {{domxref("AudioContext/sinkchange_event", "sinkchange")}}

--- a/files/en-us/web/api/audiosinkinfo/index.md
+++ b/files/en-us/web/api/audiosinkinfo/index.md
@@ -42,7 +42,7 @@ audioCtx.sinkId;
 
 ## See also
 
-- [SetSinkId test example](https://set-sink-id.glitch.me/)
+- [SetSinkId test example](https://mdn.github.io/dom-examples/audiocontext-setsinkid/) (check out the [source code](https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid))
 - {{domxref("AudioContext.setSinkId()")}}
 - {{domxref("AudioContext.sinkId")}}
 - {{domxref("AudioContext/sinkchange_event", "sinkchange")}}

--- a/files/en-us/web/api/audiosinkinfo/type/index.md
+++ b/files/en-us/web/api/audiosinkinfo/type/index.md
@@ -26,7 +26,7 @@ A string. Currently the only value is `none`.
 
 ## See also
 
-- [SetSinkId test example](https://set-sink-id.glitch.me/)
+- [SetSinkId test example](https://mdn.github.io/dom-examples/audiocontext-setsinkid/) (check out the [source code](https://github.com/mdn/dom-examples/tree/main/audiocontext-setsinkid))
 - {{domxref("AudioContext.setSinkId()")}}
 - {{domxref("AudioContext.sinkId")}}
 - {{domxref("AudioContext/sinkchange_event", "sinkchange")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The MDN AudioContext.setSinkId documentation [see this, and similar pages](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/setSinkId) has several links to [this demo hosted on Glitch](https://set-sink-id.glitch.me/).

Because Glitch is going away, I've filed this PR to update all the remaining links (I removed a few) to point to the same demo on `dom-examples`.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
