### PR TITLE
Modernize CSS: consistently use rgb/hsl instead of rgba/hsla

### DIFF
--- a/files/en-us/web/css/attr/index.md
+++ b/files/en-us/web/css/attr/index.md
@@ -438,7 +438,7 @@ The cards are laid out in a flex container:
   .warning {
     padding: 1em;
     border: 1px solid #ccc;
-    background: rgba(255 255 205 / 0.8);
+    background: rgb(255 255 205 / 0.8);
     text-align: center;
     order: -1;
     margin: 1em;

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -28,7 +28,7 @@ color: hsl(30deg 82% 43%);
 ```
 
 ```css interactive-example-choice
-color: hsla(237deg 74% 33% / 61%);
+color: hsl(237deg 74% 33% / 61%);
 ```
 
 ```css interactive-example-choice

--- a/files/en-us/web/css/css_masking/masking/index.md
+++ b/files/en-us/web/css/css_masking/masking/index.md
@@ -66,10 +66,10 @@ In this case, the top-right corner of the mask is fully opaque, the top-left qua
 
 ```css live-sample___gradient1
 .applied-mask {
-  mask-image: conic-gradient(rgb(0 0 0 / 1) 90deg, rgba(0 0 0 / 0) 270deg);
+  mask-image: conic-gradient(rgb(0 0 0 / 1) 90deg, rgb(0 0 0 / 0) 270deg);
 }
 .mask-source {
-  background: conic-gradient(rgb(0 0 0 / 1) 90deg, rgba(0 0 0 / 0) 270deg);
+  background: conic-gradient(rgb(0 0 0 / 1) 90deg, rgb(0 0 0 / 0) 270deg);
 }
 ```
 


### PR DESCRIPTION
Our own user-facing documentation says:

> Note: The rgba() functional notation is an alias for rgb(). They are exactly equivalent. It is recommended to use rgb().

For reasons of consistency and terseness, we should fix the remaining few cases of `rgba`/`hsla`.