### PR TITLE
Replace Launch Handler API demo glitch links

### DIFF
--- a/files/en-us/web/api/launch_handler_api/index.md
+++ b/files/en-us/web/api/launch_handler_api/index.md
@@ -77,7 +77,7 @@ if ("launchQueue" in window) {
 
 This code is included in the PWA, and executed when the app loads, upon launch. The {{domxref("LaunchQueue.setConsumer", "window.launchQueue.setConsumer()")}}'s callback function extracts the search param out of the {{domxref("LaunchParams.targetURL")}} and, if it finds a `track` param, uses it to populate an {{htmlelement("audio")}} element's `src` and play the audio track that this points to.
 
-See the [Musicr 2.0](https://launch-handler.glitch.me/) demo app for full working code.
+See the [Musicr 2.0](https://mdn.github.io/dom-examples/launch-handler/) demo app for full working code.
 
 ## Specifications
 
@@ -90,4 +90,3 @@ See the [Musicr 2.0](https://launch-handler.glitch.me/) demo app for full workin
 ## See also
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app

--- a/files/en-us/web/api/launchparams/files/index.md
+++ b/files/en-us/web/api/launchparams/files/index.md
@@ -43,4 +43,3 @@ if ("launchQueue" in window) {
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
 - {{domxref("Window.launchQueue")}}
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app

--- a/files/en-us/web/api/launchparams/index.md
+++ b/files/en-us/web/api/launchparams/index.md
@@ -54,4 +54,4 @@ if ("launchQueue" in window) {
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
 - {{domxref("Window.launchQueue")}}
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app
+- [Musicr 2.0](https://mdn.github.io/dom-examples/launch-handler/) demo app

--- a/files/en-us/web/api/launchparams/targeturl/index.md
+++ b/files/en-us/web/api/launchparams/targeturl/index.md
@@ -48,4 +48,3 @@ if ("launchQueue" in window) {
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
 - {{domxref("Window.launchQueue")}}
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app

--- a/files/en-us/web/api/launchqueue/index.md
+++ b/files/en-us/web/api/launchqueue/index.md
@@ -50,4 +50,4 @@ if ("launchQueue" in window) {
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
 - {{domxref("Window.launchQueue")}}
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app
+- [Musicr 2.0](https://mdn.github.io/dom-examples/launch-handler/) demo app

--- a/files/en-us/web/api/launchqueue/setconsumer/index.md
+++ b/files/en-us/web/api/launchqueue/setconsumer/index.md
@@ -59,4 +59,3 @@ if ("launchQueue" in window) {
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
 - {{domxref("Window.launchQueue")}}
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app

--- a/files/en-us/web/api/window/launchqueue/index.md
+++ b/files/en-us/web/api/window/launchqueue/index.md
@@ -50,5 +50,4 @@ if ("launchQueue" in window) {
 
 - {{domxref("Launch Handler API", "Launch Handler API", "", "nocode")}}
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
-- `Window.launchQueue`
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app
+- [Musicr 2.0](https://mdn.github.io/dom-examples/launch-handler/) demo app

--- a/files/en-us/web/progressive_web_apps/manifest/reference/launch_handler/index.md
+++ b/files/en-us/web/progressive_web_apps/manifest/reference/launch_handler/index.md
@@ -52,4 +52,4 @@ The `launch_handler` member defines values that control the launch of a web appl
 
 - [Launch Handler API: Control how your app is launched](https://developer.chrome.com/docs/web-platform/launch-handler/)
 - {{domxref("Window.launchQueue")}}
-- [Musicr 2.0](https://launch-handler.glitch.me/) demo app
+- [Musicr 2.0](https://mdn.github.io/dom-examples/launch-handler/) demo app


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The MDN [Launch Handler API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Launch_Handler_API) has several pages that link to [this demo hosted on Glitch](https://launch-handler.glitch.me/).

Because Glitch is going away, we are re-hosting the demo on the `dom-examples` repo: see https://github.com/mdn/dom-examples/pull/316.

This PR updates all the remaining links to point to the new location. I've removed some of the links because, on reflection, it seemed over-the-top to link to the same demo from every page. The PR only links to those pages from the main landing page, the interface pages, the `Window.launchQueue` page, and the `launch_handler` manifest member page. 

We shouldn't merge this PR until the accompanying `dom-examples` PR is merged.


<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

- [x] https://github.com/mdn/dom-examples/pull/316
