### PR TITLE
chore: remove Screen Wake Lock API Glitch link

### DIFF
--- a/files/en-us/web/api/screen_wake_lock_api/index.md
+++ b/files/en-us/web/api/screen_wake_lock_api/index.md
@@ -155,5 +155,4 @@ The [Permissions API](/en-US/docs/Web/API/Permissions_API) `screen-wake-lock` pe
 
 ## See also
 
-- [Stay awake with the Screen Wake Lock API](https://developer.chrome.com/docs/capabilities/web-apis/wake-lock/)
-- [A Screen Wake Lock API demo on glitch](https://wake-lock-demo.glitch.me/)
+- [Stay awake with the Screen Wake Lock API](https://developer.chrome.com/docs/capabilities/web-apis/wake-lock/) on developer.chrome.com


### PR DESCRIPTION
### Description

Small PR to remove the Glitch link. The contents are the same as in-page and at https://github.com/mdn/dom-examples/tree/main/screen-wake-lock-api minus some styles and prose.

__Related:__

- [x] https://github.com/mdn/content/pull/40171