### PR TITLE
Remove stream visualizer glitch demo links

### DIFF
--- a/files/en-us/web/api/readablebytestreamcontroller/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/index.md
@@ -67,5 +67,4 @@ The example in [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Usi
 - [Streams API concepts](/en-US/docs/Web/API/Streams_API)
 - [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams)
 - {{domxref("ReadableStream")}}
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
 - [Web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams) - polyfills

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -179,5 +179,4 @@ console.log(total);
 - [Streams API concepts](/en-US/docs/Web/API/Streams_API)
 - [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams)
 - [Using readable byte stream](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams)
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
 - [Web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams) - polyfills

--- a/files/en-us/web/api/readablestreambyobreader/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/index.md
@@ -137,5 +137,4 @@ reader.releaseLock();
 - [Streams API concepts](/en-US/docs/Web/API/Streams_API)
 - [Using readable byte stream](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams)
 - {{domxref("ReadableStream")}}
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
 - [Web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams) - polyfills

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.md
@@ -81,5 +81,4 @@ const stream = new ReadableStream({
 - [Streams API concepts](/en-US/docs/Web/API/Streams_API)
 - [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams)
 - {{domxref("ReadableStream")}}
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
 - [Web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams) - polyfills

--- a/files/en-us/web/api/readablestreamdefaultreader/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.md
@@ -83,5 +83,4 @@ fetch("https://www.example.org/").then((response) => {
 - [Streams API concepts](/en-US/docs/Web/API/Streams_API)
 - [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams)
 - {{domxref("ReadableStream")}}
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
 - [Web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill) or [sd-streams](https://github.com/stardazed/sd-streams) - polyfills

--- a/files/en-us/web/api/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/index.md
@@ -119,5 +119,4 @@ Note that this is not resilient to other influences.
 
 ## See also
 
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
 - [Streams—The Definitive Guide](https://web.dev/articles/streams)

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -72,4 +72,4 @@ This example does not support the [backpressure](/en-US/docs/Web/API/Streams_API
 
 ## See also
 
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/), for a basic visualization of readable, writable, and transform streams.
+- [Streams—The Definitive Guide](https://web.dev/articles/streams)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The MDN [Streams API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) has several pages that link to [this demo hosted on Glitch](https://whatwg-stream-visualizer.glitch.me/).

Because Glitch is going away, I've decided to remove these links. I don't see this demo as being vital to the documentation, plus it is fairly complicated, and I don't think we should take on the role of maintaining it.

If it gets moved somewhere else, we can always link to the new location in the future.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
