### PR TITLE
Document URLPattern.hasRegExpGroups

### DIFF
--- a/files/en-us/web/api/installevent/addroutes/index.md
+++ b/files/en-us/web/api/installevent/addroutes/index.md
@@ -37,7 +37,7 @@ addRoutes(routerRules)
         - `runningStatus` {{optional_inline}}
           - : An enumerated value representing the required running status of the service worker for a request to match the rule. Values can be `"running"` or `"not-running"`.
         - `urlPattern` {{optional_inline}}
-          - : A {{domxref("URLPattern")}} instance, or a `URLPattern()` constructor [`input`](/en-US/docs/Web/API/URLPattern/URLPattern#input) pattern representing the URLs that match the rule.
+          - : A {{domxref("URLPattern")}} instance, or a `URLPattern()` constructor [`input`](/en-US/docs/Web/API/URLPattern/URLPattern#input) pattern representing the URLs that match the rule. Regular expression capturing groups are not allowed, so {{domxref("URLPattern.hasRegExpGroups")}} must be `false`.
 
     - `source`
       - : An enumerated value or an object specifying the source from which matching resources will be loaded. Possible enumerated values are:

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -8,25 +8,21 @@ spec-urls: https://urlpattern.spec.whatwg.org/
 
 {{DefaultAPISidebar("URL Pattern API")}} {{AvailableInWorkers}}
 
-The **URL Pattern API** defines a syntax that is used to create URL pattern
-matchers. These patterns can be matched against URLs or individual URL
-components. The URL Pattern API is used by the {{domxref("URLPattern")}}
-interface.
+The **URL Pattern API** defines a syntax that is used to create URL pattern matchers.
+These patterns can be matched against URLs or individual URL components.
+The URL Pattern API is used by the {{domxref("URLPattern")}} interface.
 
 ## Concepts and usage
 
-The pattern syntax is based on the syntax from the
-[path-to-regexp](https://github.com/pillarjs/path-to-regexp) library. Patterns
-can contain:
+The pattern syntax is based on the syntax from the [path-to-regexp](https://github.com/pillarjs/path-to-regexp) library.
+Patterns can contain:
 
 - Literal strings which will be matched exactly.
 - Wildcards (`/posts/*`) that match any character.
 - Named groups (`/books/:id`) which extract a part of the matched URL.
-- Non-capturing groups (`/books{/old}?`) which make parts of a pattern optional
-  or be matched multiple times.
-- {{jsxref("RegExp")}} groups (`/books/(\\d+)`) which make arbitrarily complex
-  regex matches with a few [limitations](#regex_matchers_limitations). _Note that the
-  parentheses are not part of the regex but instead define their contents as a regex._
+- Non-capturing groups (`/books{/old}?`) which make parts of a pattern optional or be matched multiple times.
+- {{jsxref("RegExp")}} groups (`/books/(\\d+)`) which make arbitrarily complex regex matches with a few [limitations](#regex_matchers_limitations).
+  _Note that the parentheses are not part of the regex but instead define their contents as a regex._
   Some APIs prohibit the use of regular expression groups in `URLPattern` objects.
   The {{domxref("URLPattern.hasRegExpGroups", "hasRegExpGroups")}} property indicates whether or not regular expression groups are used.
 
@@ -42,18 +38,15 @@ The URL Pattern API only has a single related interface:
 
 ## Pattern syntax
 
-The syntax for patterns is based on the
-[path-to-regexp](https://github.com/pillarjs/path-to-regexp) JavaScript library.
-This syntax is similar to the one used in
-[Ruby on Rails](https://rubyonrails.org/), or JavaScript frameworks like
-[Express](https://expressjs.com/) or [Next.js](https://nextjs.org/).
+The syntax for patterns is based on the [path-to-regexp](https://github.com/pillarjs/path-to-regexp) JavaScript library.
+This syntax is similar to the one used in [Ruby on Rails](https://rubyonrails.org/), or JavaScript frameworks like [Express](https://expressjs.com/) or [Next.js](https://nextjs.org/).
 
 ### Fixed text and capture groups
 
-Each pattern can contain a combination of fixed text and groups. The fixed text
-is a sequence of characters that is matched exactly. Groups match an arbitrary
-string based on matching rules. Each URL part has its own default rules that are
-explained below, but they can be overwritten.
+Each pattern can contain a combination of fixed text and groups.
+The fixed text is a sequence of characters that is matched exactly.
+Groups match an arbitrary string based on matching rules.
+Each URL part has its own default rules that are explained below, but they can be overwritten.
 
 ```js
 // A pattern matching some fixed text
@@ -71,18 +64,14 @@ console.log(pattern.exec("https://example.com/books/123").pathname.groups); // {
 
 ### Segment wildcard
 
-By default, a group matching the `pathname` part of the URL will match all
-characters but the forward slash (`/`). In the `hostname` part, the group will
-match all characters except the dot (`.`). In all other parts, the group will
-match all characters. The segment wildcard is non-greedy, meaning that it will
-match the shortest possible string.
+By default, a group matching the `pathname` part of the URL will match all characters but the forward slash (`/`). In the `hostname` part, the group will match all characters except the dot (`.`).
+In all other parts, the group will match all characters.
+The segment wildcard is non-greedy, meaning that it will match the shortest possible string.
 
 ### Regex matchers
 
-Instead of using the default match rules for a group, you can use a regex for
-each group by including a regex in parentheses. This regex defines the matching
-rules for the group. Below is an example of a regex matcher on a named group
-that constrains the group to only match if it contains one or more digits:
+Instead of using the default match rules for a group, you can use a regex for each group by including a regex in parentheses.
+This regex defines the matching rules for the group. Below is an example of a regex matcher on a named group that constrains the group to only match if it contains one or more digits:
 
 ```js
 const pattern = new URLPattern("/books/:id(\\d+)", "https://example.com");
@@ -183,10 +172,8 @@ Some regex patterns do not work as you may expect:
 
 ### Unnamed and named groups
 
-Groups can either be named or unnamed. Named groups are specified by prefixing
-the group name with a colon (`:`). Regexp groups that are not prefixed by a
-colon and a name are unnamed. Unnamed groups are numerically indexed in the match
-result based on their order in the pattern.
+Groups can either be named or unnamed. Named groups are specified by prefixing the group name with a colon (`:`).
+Regexp groups that are not prefixed by a colon and a name are unnamed. Unnamed groups are numerically indexed in the match result based on their order in the pattern.
 
 ```js
 // A named group
@@ -239,13 +226,10 @@ console.log(pattern.test("https://example.com/books/123/456/789")); // true
 
 ### Group delimiters
 
-Patterns can also contain group delimiters. These are pieces of a pattern that
-are surrounded by curly braces (`{}`). These group delimiters are not captured
-in the match result like capturing groups, but can still have modifiers applied
-to them, just like groups. If group delimiters are not modified by a modifier,
-they are treated as if the items in them were just part of the parent pattern.
-Group delimiters may not contain other group delimiters, but may contain any
-other pattern items (capturing groups, regex, wildcard, or fixed text).
+Patterns can also contain group delimiters. These are pieces of a pattern that are surrounded by curly braces (`{}`).
+These group delimiters are not captured in the match result like capturing groups, but can still have modifiers applied to them, just like groups.
+If group delimiters are not modified by a modifier, they are treated as if the items in them were just part of the parent pattern.
+Group delimiters may not contain other group delimiters, but may contain any other pattern items (capturing groups, regex, wildcard, or fixed text).
 
 ```js
 // A group delimiter with a ? (optional) modifier
@@ -273,14 +257,11 @@ console.log(pattern.test("https://example.com/blog/my-blog")); // false
 
 ### Automatic group prefixing in pathnames
 
-In patterns that match against the `pathname` part of a URL, groups get an
-automatic slash (`/`) prefix added if the group definition is preceded by a
-slash (`/`). This is useful for groups with modifiers, as it allows for
-repeating groups to work as expected.
+In patterns that match against the `pathname` part of a URL, groups get an automatic slash (`/`) prefix added if the group definition is preceded by a slash (`/`).
+This is useful for groups with modifiers, as it allows for repeating groups to work as expected.
 
-If you do not want automatic prefixing, you can disable it by surrounding the
-group with group delimiters (`{}`). Group delimiters do not have automatic
-prefixing behavior.
+If you do not want automatic prefixing, you can disable it by surrounding the group with group delimiters (`{}`).
+Group delimiters do not have automatic prefixing behavior.
 
 ```js
 // A pattern with an optional group, preceded by a slash
@@ -317,10 +298,9 @@ console.log(pattern.test("https://example.com/books/")); // true
 
 ### Wildcard tokens
 
-The wildcard token (`*`) is a shorthand for an unnamed capturing group that
-matches all characters zero or more times. You can place this anywhere in the
-pattern. The wildcard is greedy, meaning that it will match the longest possible
-string.
+The wildcard token (`*`) is a shorthand for an unnamed capturing group that matches all characters zero or more times.
+You can place this anywhere in the pattern.
+The wildcard is greedy, meaning that it will match the longest possible string.
 
 ```js
 // A wildcard at the end of a pattern
@@ -352,7 +332,9 @@ In this case `{foo}` gets changed to `foo`.
 
 ## Case sensitivity
 
-The URL Pattern API treats many parts of the URL as case-sensitive by default when matching. In contrast, many client-side JavaScript frameworks use case-insensitive URL matching. An `ignoreCase` option is available on the {{domxref("URLPattern.URLPattern", "URLPattern()")}} constructor to enable case-insensitive matching if desired.
+The URL Pattern API treats many parts of the URL as case-sensitive by default when matching.
+In contrast, many client-side JavaScript frameworks use case-insensitive URL matching.
+An `ignoreCase` option is available on the {{domxref("URLPattern.URLPattern", "URLPattern()")}} constructor to enable case-insensitive matching if desired.
 
 ```js
 // Case-sensitive matching by default
@@ -377,8 +359,7 @@ console.log(pattern.test("https://example.com/2022/Feb/xc44rsz")); // true
 ### Filter on a specific URL component
 
 The following example shows how a `URLPattern` filters a specific URL component.
-When the `URLPattern()` constructor is called with a structured object of
-component patterns any missing components default to the `*` wildcard value.
+When the `URLPattern()` constructor is called with a structured object of component patterns any missing components default to the `*` wildcard value.
 
 ```js
 // Construct a URLPattern that matches a specific domain and its subdomains.
@@ -408,11 +389,9 @@ console.log(pattern.test("https://cdn-example.com/foo/bar"));
 
 ### Construct a URLPattern from a full URL string
 
-The following example shows how to construct a `URLPattern` from a full URL
-string with embedded patterns. For example, a `:` can be both the URL protocol
-suffix, like `https:`, and the beginning of a named pattern group, like `:foo`.
-It "just works" if there is no ambiguity between whether a character is part of
-the URL syntax or part of the pattern syntax.
+The following example shows how to construct a `URLPattern` from a full URL string with embedded patterns.
+For example, a `:` can be both the URL protocol suffix, like `https:`, and the beginning of a named pattern group, like `:foo`.
+It "just works" if there is no ambiguity between whether a character is part of the URL syntax or part of the pattern syntax.
 
 ```js
 // Construct a URLPattern that matches URLs to CDN servers loading jpg images.
@@ -444,13 +423,10 @@ console.log(
 
 ### Constructing a URLPattern with an ambiguous URL string
 
-The following example shows how a `URLPattern` constructed from an ambiguous
-string will favor treating characters as part of the pattern syntax. In this
-case the `:` character could be the protocol component suffix or it could be the
-prefix for a named group in the pattern. The constructor chooses to treat this
-as part of the pattern and therefore determines this is a relative pathname
-pattern. Since there is no base URL the relative pathname cannot be resolved and
-it throws an error.
+The following example shows how a `URLPattern` constructed from an ambiguous string will favor treating characters as part of the pattern syntax.
+In this case the `:` character could be the protocol component suffix or it could be the prefix for a named group in the pattern.
+The constructor chooses to treat this as part of the pattern and therefore determines this is a relative pathname pattern.
+Since there is no base URL the relative pathname cannot be resolved and it throws an error.
 
 ```js
 // Throws because this is interpreted as a single relative pathname pattern
@@ -460,9 +436,8 @@ const pattern = new URLPattern("data:foo*");
 
 ### Escaping characters to disambiguate URLPattern constructor strings
 
-The following example shows how an ambiguous constructor string character can be
-escaped to be treated as a URL separator instead of a pattern character. Here
-`:` is escaped as `\\:`.
+The following example shows how an ambiguous constructor string character can be escaped to be treated as a URL separator instead of a pattern character.
+Here `:` is escaped as `\\:`.
 
 ```js
 // Constructs a URLPattern treating the `:` as the protocol suffix.
@@ -518,13 +493,11 @@ console.log(result.hostname.input); // 'example.com'
 
 ### Using base URLs in the URLPattern constructor
 
-The follow example shows how base URLs can also be used to construct the
-`URLPattern`. Note that the base URL in these cases is treated strictly as a URL
-and cannot contain any pattern syntax itself.
+The follow example shows how base URLs can also be used to construct the `URLPattern`.
+Note that the base URL in these cases is treated strictly as a URL and cannot contain any pattern syntax itself.
 
-Also, since the base URL provides a value for every component the resulting
-`URLPattern` will also have a value for every component, even if it's the empty
-string. This means you do not get the "default to wildcard" behavior.
+Also, since the base URL provides a value for every component the resulting `URLPattern` will also have a value for every component, even if it's the empty string.
+This means you do not get the "default to wildcard" behavior.
 
 ```js
 const pattern1 = new URLPattern({
@@ -554,9 +527,8 @@ try {
 
 ### Accessing matched group values
 
-The following example shows how input values that match pattern groups can later
-be accessed from the `exec()` result object. Unnamed groups are assigned index
-numbers sequentially.
+The following example shows how input values that match pattern groups can later be accessed from the `exec()` result object.
+Unnamed groups are assigned index numbers sequentially.
 
 ```js
 const pattern = new URLPattern({ hostname: "*.example.com" });
@@ -571,8 +543,7 @@ console.log(result.inputs); // [{ hostname: 'cdn.example.com' }]
 
 ### Accessing matched group values using custom names
 
-The following example shows how groups can be given custom names which can be
-used to accessed the matched value in the result object.
+The following example shows how groups can be given custom names which can be used to accessed the matched value in the result object.
 
 ```js
 // Construct a URLPattern using matching groups with custom names. These
@@ -592,8 +563,7 @@ console.log(result.inputs); // [{ pathname: '/store/wanderview/view' }]
 
 ### Custom regular expression groups
 
-The following example shows how a matching group can use a custom regular
-expression.
+The following example shows how a matching group can use a custom regular expression.
 
 ```js
 const pattern = new URLPattern({ pathname: "/(foo|bar)" });
@@ -609,8 +579,7 @@ console.log(result.pathname.groups[0]); // 'foo'
 
 ### Named group with a custom regular expression
 
-The following example shows how to use a custom regular expression with a named
-group.
+The following example shows how to use a custom regular expression with a named group.
 
 ```js
 const pattern = new URLPattern({ pathname: "/:type(foo|bar)" });
@@ -621,9 +590,8 @@ console.log(result.pathname.groups.type); // 'foo'
 
 ### Making matching groups optional
 
-The following example shows how to make a matching group optional by placing a
-`?` modifier after it. For the pathname component this also causes any preceding
-`/` character to be treated as an optional prefix to the group.
+The following example shows how to make a matching group optional by placing a `?` modifier after it.
+For the pathname component this also causes any preceding `/` character to be treated as an optional prefix to the group.
 
 ```js
 const pattern = new URLPattern({ pathname: "/product/(index.html)?" });
@@ -648,9 +616,9 @@ console.log(pattern3.test({ pathname: "/product/" })); // true
 
 ### Making matching groups repeated
 
-The following example shows how a matching group can be made repeated by placing
-`+` modifier after it. In the `pathname` component this also treats the `/`
-prefix as special. It is repeated with the group.
+The following example shows how a matching group can be made repeated by placing `+` modifier after it.
+In the `pathname` component this also treats the `/` prefix as special.
+It is repeated with the group.
 
 ```js
 const pattern = new URLPattern({ pathname: "/product/:action+" });
@@ -663,10 +631,10 @@ console.log(pattern.test({ pathname: "/product" })); // false
 
 ### Making matching groups optional and repeated
 
-The following example shows how to make a matching group that is both optional
-and repeated. Do this by placing a `*` modifier after the group. Again, the
-pathname component treats the `/` prefix as special. It both becomes optional
-and is also repeated with the group.
+The following example shows how to make a matching group that is both optional and repeated.
+Do this by placing a `*` modifier after the group.
+Again, the pathname component treats the `/` prefix as special.
+It both becomes optional and is also repeated with the group.
 
 ```js
 const pattern = new URLPattern({ pathname: "/product/:action*" });
@@ -679,9 +647,7 @@ console.log(pattern.test({ pathname: "/product" })); // true
 
 ### Using a custom prefix or suffix for an optional or repeated modifier
 
-The following example shows how curly braces can be used to denote a custom
-prefix and/or suffix to be operated on by a subsequent `?`, `*`, or `+`
-modifier.
+The following example shows how curly braces can be used to denote a custom prefix and/or suffix to be operated on by a subsequent `?`, `*`, or `+` modifier.
 
 ```js
 const pattern = new URLPattern({ hostname: "{:subdomain.}*example.com" });
@@ -697,8 +663,7 @@ console.log(result.hostname.groups.subdomain); // 'foo.bar'
 
 ### Making text optional or repeated without a matching group
 
-The following example shows how curly braces can be used to denote fixed text
-values as optional or repeated without using a matching group.
+The following example shows how curly braces can be used to denote fixed text values as optional or repeated without using a matching group.
 
 ```js
 const pattern = new URLPattern({ pathname: "/product{/}?" });
@@ -713,8 +678,7 @@ console.log(result.pathname.groups); // {}
 
 ### Using multiple components and features at once
 
-The following example shows how many features can be combined across multiple
-URL components.
+The following example shows how many features can be combined across multiple URL components.
 
 ```js
 const pattern = new URLPattern({
@@ -745,7 +709,5 @@ console.log(result.pathname.groups.action); // 'view'
 
 ## See also
 
-- A polyfill of `URLPattern` is available
-  [on GitHub](https://github.com/kenchris/urlpattern-polyfill)
-- The pattern syntax used by URLPattern is similar to the syntax used by
-  [path-to-regexp](https://github.com/pillarjs/path-to-regexp)
+- A polyfill of `URLPattern` is available [on GitHub](https://github.com/kenchris/urlpattern-polyfill)
+- The pattern syntax used by URLPattern is similar to the syntax used by [path-to-regexp](https://github.com/pillarjs/path-to-regexp)

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -27,6 +27,8 @@ can contain:
 - {{jsxref("RegExp")}} groups (`/books/(\\d+)`) which make arbitrarily complex
   regex matches with a few [limitations](#regex_matchers_limitations). _Note that the
   parentheses are not part of the regex but instead define their contents as a regex._
+  Some APIs prohibit the use of regular expression groups in `URLPattern` objects.
+  The {{domxref("URLPattern.hasRegExpGroups", "hasRegExpGroups")}} property indicates whether or not regular expression groups are used.
 
 You can find details about the syntax in the [pattern syntax](#pattern_syntax)
 section below.

--- a/files/en-us/web/api/urlpattern/hasregexpgroups/index.md
+++ b/files/en-us/web/api/urlpattern/hasregexpgroups/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.hasRegExpGroups
 
 The **`hasRegExpGroups`** read-only property of the {{domxref("URLPattern")}} interface is a boolean indicating whether or not any of the `URLPattern` components contain [regular expression capturing groups](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences).
 
-You can use `hasRegExpGroups` property to check if a `URLPattern` object is usable with certain web platform APIs which do not allow regular expression capturing groups. For example:
+You can use the `hasRegExpGroups` property to check if a `URLPattern` object is usable with certain web platform APIs which do not allow regular expression capturing groups. For example:
 
 - The `match` directive in the {{HTTPHeader("Use-As-Dictionary")}} HTTP header prohibits regular expression capturing groups, as well as
 - the `urlPattern` condition when adding static routes using the {{domxref("InstallEvent.addRoutes()")}} method.

--- a/files/en-us/web/api/urlpattern/hasregexpgroups/index.md
+++ b/files/en-us/web/api/urlpattern/hasregexpgroups/index.md
@@ -1,0 +1,59 @@
+---
+title: "URLPattern: hasRegExpGroups property"
+short-title: hasRegExpGroups
+slug: Web/API/URLPattern/hasRegExpGroups
+page-type: web-api-instance-property
+browser-compat: api.URLPattern.hasRegExpGroups
+---
+
+{{APIRef("URL Pattern API")}} {{AvailableInWorkers}}
+
+The **`hasRegExpGroups`** read-only property of the {{domxref("URLPattern")}} interface is a boolean indicating whether or not any of the `URLPattern` components contain [regular expression capturing groups](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences).
+
+You can use `hasRegExpGroups` property to check if a `URLPattern` object is usable with certain web platform APIs which do not allow regular expression capturing groups. For example:
+
+- The `match` directive in the {{HTTPHeader("Use-As-Dictionary")}} HTTP header prohibits regular expression capturing groups, as well as
+- the `urlPattern` condition when adding static routes using the {{domxref("InstallEvent.addRoutes()")}} method.
+
+## Value
+
+A boolean.
+
+## Examples
+
+### Using `hasRegExpGroups`
+
+In the following example, a {{domxref("URLPattern")}} object is used with a group delimiter containing named capturing groups called "id" and "title". The `hasRegExpGroups` property returns `true`in this case.
+
+```js
+const pattern = new URLPattern({ pathname: "/blog/:id(\\d+){-:title}?" });
+console.log(pattern.hasRegExpGroups); // true
+const result = pattern.exec({ pathname: "/blog/123-some-article" });
+console.log(result.pathname.groups) // {id: '123', title: 'some-article'}
+```
+
+It also works with anonymous capturing groups.
+
+```js
+const pattern = new URLPattern({ pathname: "/blog/(\\d+)" });
+console.log(pattern.hasRegExpGroups); // true
+const result = pattern.exec({ pathname: "/blog/123" });
+console.log(result.pathname.groups) // {0: '123'}
+```
+
+For other non-capturing groups, for example when using wildcard tokes (`*`), `hasRegExpGroups` will return `false`.
+
+```js
+const pattern = new URLPattern({ pathname: "/blog/*" });
+console.log(pattern.hasRegExpGroups); // false
+const result = pattern.exec({ pathname: "/blog/123" });
+console.log(result.pathname.groups) // {0: '123'}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/urlpattern/hasregexpgroups/index.md
+++ b/files/en-us/web/api/urlpattern/hasregexpgroups/index.md
@@ -29,7 +29,7 @@ In the following example, a {{domxref("URLPattern")}} object is used with a grou
 const pattern = new URLPattern({ pathname: "/blog/:id(\\d+){-:title}?" });
 console.log(pattern.hasRegExpGroups); // true
 const result = pattern.exec({ pathname: "/blog/123-some-article" });
-console.log(result.pathname.groups) // {id: '123', title: 'some-article'}
+console.log(result.pathname.groups); // {id: '123', title: 'some-article'}
 ```
 
 It also works with anonymous capturing groups.
@@ -38,7 +38,7 @@ It also works with anonymous capturing groups.
 const pattern = new URLPattern({ pathname: "/blog/(\\d+)" });
 console.log(pattern.hasRegExpGroups); // true
 const result = pattern.exec({ pathname: "/blog/123" });
-console.log(result.pathname.groups) // {0: '123'}
+console.log(result.pathname.groups); // {0: '123'}
 ```
 
 For other non-capturing groups, for example when using wildcard tokes (`*`), `hasRegExpGroups` will return `false`.
@@ -47,7 +47,7 @@ For other non-capturing groups, for example when using wildcard tokes (`*`), `ha
 const pattern = new URLPattern({ pathname: "/blog/*" });
 console.log(pattern.hasRegExpGroups); // false
 const result = pattern.exec({ pathname: "/blog/123" });
-console.log(result.pathname.groups) // {0: '123'}
+console.log(result.pathname.groups); // {0: '123'}
 ```
 
 ## Specifications

--- a/files/en-us/web/api/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/index.md
@@ -22,6 +22,8 @@ page: {{domxref("URL Pattern API", "", "", "nocode")}}.
 - {{domxref("URLPattern.hash", "hash")}} {{ReadOnlyInline}}
   - : A string containing a pattern to match the _hash_ part
     of a URL.
+- {{domxref("URLPattern.hasRegExpGroups", "hasRegExpGroups")}} {{ReadOnlyInline}}
+  - : A boolean indicating whether or not any of the `URLPattern` components contain [regular expression capturing groups](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences).
 - {{domxref("URLPattern.hostname", "hostname")}} {{ReadOnlyInline}}
   - : A string containing a pattern to match the _hostname_
     part of a URL.

--- a/files/en-us/web/http/reference/headers/use-as-dictionary/index.md
+++ b/files/en-us/web/http/reference/headers/use-as-dictionary/index.md
@@ -29,7 +29,7 @@ Content-Encoding: match="<url-pattern>", match-dest=("<destination1>")
 ## Directives
 
 - `match`
-  - : A string value containing a [URL Pattern](/en-US/docs/Web/API/URL_Pattern_API): only resources whose URLs match this pattern may use this resource as a dictionary.
+  - : A string value containing a [URL Pattern](/en-US/docs/Web/API/URL_Pattern_API): only resources whose URLs match this pattern may use this resource as a dictionary. Regular expression capturing groups are not allowed, so {{domxref("URLPattern.hasRegExpGroups")}} must be `false`.
 - `match-dest`
   - : A space-separated list of strings, with each string in quotes and the whole value enclosed in parentheses, that provides a list of [Fetch request destinations](/en-US/docs/Web/API/Request/destination) that requests must match if they are to use this dictionary.
 - `id`


### PR DESCRIPTION
### Description

Document https://urlpattern.spec.whatwg.org/#dom-urlpattern-hasregexpgroups

### Motivation

Add missing docs

### Additional details

Chromestatus: https://chromestatus.com/feature/4761338127843328

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/30640
