### PR TITLE
Replace requestVideoFrameCallback() glitch demo link

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/requestvideoframecallback/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestvideoframecallback/index.md
@@ -77,26 +77,31 @@ You can compare the `now` callback parameter and the `expectedDisplayTime` metad
 
 ### Drawing video frames on a canvas
 
-This example shows how to use `requestVideoFrameCallback()` to draw the frames of a video onto a {{htmlelement("canvas")}} element at exactly the same frame rate as the video. It also logs the frame metadata to the DOM for debugging purposes.
+This example shows how to use `requestVideoFrameCallback()` to draw the frames of a video onto a {{htmlelement("canvas")}} element at exactly the same frame rate as the video. It also logs the frame metadata to the screen for debugging purposes.
 
 ```js
-if ("requestVideoFrameCallback" in HTMLVideoElement.prototype) {
-  const video = document.createElement("video");
-  const fpsInfo = document.createElement("div");
-  const metadataInfo = document.createElement("div");
-  const canvas = document.createElement("canvas");
+const startDrawing = () => {
+  const button = document.querySelector("button");
+  const video = document.querySelector("video");
+  const canvas = document.querySelector("canvas");
   const ctx = canvas.getContext("2d");
+  const fpsInfo = document.querySelector("#fps-info");
+  const metadataInfo = document.querySelector("#metadata-info");
 
-  // 'Big Buck Bunny' licensed under CC 3.0 by the Blender foundation. Hosted by archive.org
-  // Poster from peach.blender.org
-  video.src =
-    "https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4";
-  video.poster =
-    "https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217";
-  video.width = 640;
-  video.controls = true;
+  button.addEventListener("click", () =>
+    video.paused ? video.play() : video.pause(),
+  );
 
-  document.body.append(video, fpsInfo, metadataInfo, canvas);
+  video.addEventListener("play", () => {
+    if (!("requestVideoFrameCallback" in HTMLVideoElement.prototype)) {
+      return alert(
+        "Your browser does not support the `Video.requestVideoFrameCallback()` API.",
+      );
+    }
+  });
+
+  let width = canvas.width;
+  let height = canvas.height;
 
   let paintCount = 0;
   let startTime = 0.0;
@@ -106,25 +111,24 @@ if ("requestVideoFrameCallback" in HTMLVideoElement.prototype) {
       startTime = now;
     }
 
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.drawImage(video, 0, 0, width, height);
 
     const elapsed = (now - startTime) / 1000.0;
     const fps = (++paintCount / elapsed).toFixed(3);
-    fpsInfo.innerText = `video fps: ${fps}`;
+    fpsInfo.innerText = !isFinite(fps) ? 0 : fps;
     metadataInfo.innerText = JSON.stringify(metadata, null, 2);
 
-    // Re-register the callback to run on the next frame
     video.requestVideoFrameCallback(updateCanvas);
   };
 
-  // Initial registration of the callback to run on the first frame
+  video.src = "assets/bigbuckbunny.mp4";
   video.requestVideoFrameCallback(updateCanvas);
-} else {
-  alert("Your browser does not support requestVideoFrameCallback().");
-}
+};
+
+window.addEventListener("load", startDrawing);
 ```
 
-See [requestVideoFrameCallback Demo](https://requestvideoframecallback.glitch.me/) for a working implementation of the above code.
+See [requestVideoFrameCallback Demo](https://mdn.github.io/dom-examples/requestvideoframecallback/) for a working implementation of the above code.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlvideoelement/requestvideoframecallback/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestvideoframecallback/index.md
@@ -94,7 +94,7 @@ const startDrawing = () => {
 
   video.addEventListener("play", () => {
     if (!("requestVideoFrameCallback" in HTMLVideoElement.prototype)) {
-      return alert(
+      console.error(
         "Your browser does not support the `Video.requestVideoFrameCallback()` API.",
       );
     }
@@ -121,14 +121,32 @@ const startDrawing = () => {
     video.requestVideoFrameCallback(updateCanvas);
   };
 
-  video.src = "assets/bigbuckbunny.mp4";
+  video.src = "https://mdn.github.io/shared-assets/videos/flower.mp4";
   video.requestVideoFrameCallback(updateCanvas);
 };
 
 window.addEventListener("load", startDrawing);
 ```
 
-See [requestVideoFrameCallback Demo](https://mdn.github.io/dom-examples/requestvideoframecallback/) for a working implementation of the above code.
+```css
+video,
+canvas {
+  max-width: 49%;
+}
+```
+
+```html
+<p>
+  Start <button type="button">⏯</button> playing the video. Pause the video to read the metadata.
+  Drawing video frames on the canvas is synced with the actual video framerate.
+</p>
+<video controls playsinline></video>
+<canvas width="960" height="540"></canvas>
+<p><span id="fps-info">0</span>fps</p>
+<p><pre id="metadata-info"></pre></p>
+```
+
+{{embedlivesample("", , "540")}}
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The MDN [requestVideoFrameCallback() documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback) links to [this demo hosted on Glitch](https://requestvideoframecallback.glitch.me/).

Because Glitch is going away, we are re-hosting the demo on the `dom-examples` repo: see 

- [ ] https://github.com/mdn/dom-examples/pull/321.

This PR updates the demo link to point to the new location and makes sure the code is consistent with the demo.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
