### PR TITLE
remove fetch request streams glitch demo links

### DIFF
--- a/files/en-us/web/api/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/index.md
@@ -30,8 +30,7 @@ It is the streaming equivalent of {{domxref("TextDecoder")}}.
 
 ## Examples
 
-- [Examples of streaming structured data and HTML](https://streams.spec.whatwg.org/demos/)
-- [An example of fetch request streams which uses `TextDecoderStream`](https://glitch.com/~fetch-request-stream).
+[Examples of streaming structured data and HTML](https://streams.spec.whatwg.org/demos/)
 
 ## Specifications
 
@@ -46,3 +45,4 @@ It is the streaming equivalent of {{domxref("TextDecoder")}}.
 - {{domxref("TextEncoderStream")}}
 - [Streams API Concepts](/en-US/docs/Web/API/Streams_API/Concepts)
 - [Experimenting with the Streams API](https://deanhume.com/experimenting-with-the-streams-api/)
+- [Streaming requests with the fetch API](https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests), developer.chrome.com (2020)

--- a/files/en-us/web/api/textencoderstream/index.md
+++ b/files/en-us/web/api/textencoderstream/index.md
@@ -25,8 +25,7 @@ The **`TextEncoderStream`** interface of the {{domxref('Encoding API','','',' ')
 
 ## Examples
 
-- [Examples of streaming structured data and HTML](https://streams.spec.whatwg.org/demos/)
-- [An example of fetch request streams which uses `TextEncoderStream` to upload the data](https://glitch.com/~fetch-request-stream).
+[Examples of streaming structured data and HTML](https://streams.spec.whatwg.org/demos/)
 
 ## Specifications
 
@@ -41,3 +40,4 @@ The **`TextEncoderStream`** interface of the {{domxref('Encoding API','','',' ')
 - {{domxref("TextDecoderStream")}}
 - [Streams API Concepts](/en-US/docs/Web/API/Streams_API/Concepts)
 - [Experimenting with the Streams API](https://deanhume.com/experimenting-with-the-streams-api/)
+- [Streaming requests with the fetch API](https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests), developer.chrome.com (2020)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description


The MDN [Encoding API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API) has a couple of pages that link to [this demo hosted on Glitch](https://fetch-request-stream.glitch.me/).

Because Glitch is going away, and this demo no longer works, I am removing these links from MDN. I've added a link to the DCC article that explains some of this stuff, as it is pretty useful.

This PR updates all the remaining links to point to the new location

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
