### PR TITLE
Replace worker playground glitch links

### DIFF
--- a/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -35,7 +35,7 @@ The following functions are **only** available to workers:
 ## Web APIs available in workers
 
 > [!NOTE]
-> If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
+> If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can test support for a particular object or function using the [Worker Playground](https://mdn.github.io/dom-examples/web-workers/worker-playground/).
 
 The following Web APIs are available to workers:
 

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -817,7 +817,7 @@ You can use most standard JavaScript features inside a web worker, including:
 The main thing you _can't_ do in a Worker is directly affect the parent page. This includes manipulating the DOM and using that page's objects. You have to do it indirectly, by sending a message back to the main script via {{domxref("DedicatedWorkerGlobalScope.postMessage()")}}, then doing the changes in event handler.
 
 > [!NOTE]
-> You can test whether a method is available to workers using the site: <https://worker-playground.glitch.me/>. For example, if you enter {{domxref("EventSource")}} into the site on Firefox 84 you'll see that this is not supported in service workers, but is in dedicated and shared workers.
+> You can test whether a method or interface is available to workers using the [Worker Playground](https://mdn.github.io/dom-examples/web-workers/worker-playground/).
 
 > [!NOTE]
 > For a complete list of functions available to workers, see [Functions and interfaces available to workers](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

A couple of our worker pages link to the [Worker playground app](https://worker-playground.glitch.me/), which is published on Glitch.

Since Glitch is going away, I have moved the app to dom-examples: see 

- [x] https://github.com/mdn/dom-examples/pull/322.

This PR updates links to the Glitch version to point to the new location and improves the surrounding text.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
