### PR TITLE
Update file system API glitch demo links

### DIFF
--- a/files/en-us/web/api/filesystemfilehandle/createsyncaccesshandle/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createsyncaccesshandle/index.md
@@ -77,7 +77,7 @@ onmessage = async (e) => {
 
 ### Complete example with `mode` option
 
-Our [`createSyncAccessHandle()` mode test](https://createsyncaccesshandle-mode-test.glitch.me/) example provides an {{htmlelement("input")}} field to enter text into, and two buttons — one to write entered text to the end of a file in the origin private file system, and one to empty the file when it becomes too full.
+Our [`createSyncAccessHandle()` mode test](https://mdn.github.io/dom-examples/file-system-api/createsyncaccesshandle-mode/) example (see the [source code](https://github.com/mdn/dom-examples/tree/main/file-system-api/createsyncaccesshandle-mode)) provides an {{htmlelement("input")}} field to enter text into, and two buttons — one to write entered text to the end of a file in the origin private file system, and one to empty the file when it becomes too full.
 
 Try exploring the demo above, with the browser developer console open so you can see what is happening. If you try opening the demo in multiple browser tabs, you will find that multiple handles can be opened at once to write to the file at the same time. This is because `mode: "readwrite-unsafe"` is set on the `createSyncAccessHandle()` calls.
 

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -73,7 +73,7 @@ async function writeFile(fileHandle, contents) {
 
 ### Expanded usage with options
 
-Our [`createWritable()` mode test](https://createwritable-mode-test.glitch.me/) example provides a {{htmlelement("button")}} to select a file to write to, a text {{htmlelement("input")}} field into which you can enter some text to write to the file, and a second `<button>` to write the text to the file.
+Our [`createWritable()` mode test](https://mdn.github.io/dom-examples/file-system-api/createwritable-mode/) example (see the [source code](https://github.com/mdn/dom-examples/tree/main/file-system-api/createwritable-mode)) provides a {{htmlelement("button")}} to select a file to write to, a text {{htmlelement("input")}} field into which you can enter some text to write to the file, and a second `<button>` to write the text to the file.
 
 In the demo above, try selecting a text file on your file system (or entering a new file name), entering some text into the input field, and writing the text to the file. Open the file on your file system to check whether the write was successful.
 

--- a/files/en-us/web/api/filesystemhandle/remove/index.md
+++ b/files/en-us/web/api/filesystemhandle/remove/index.md
@@ -48,7 +48,7 @@ A {{jsxref("Promise")}} that fulfills with a value of `undefined`.
 
 ## Examples
 
-Our [`FileSystemHandle.remove()` demo](https://filesystemhandle-remove.glitch.me/) (see the [source code](https://glitch.com/edit/#!/filesystemhandle-remove)) is a file creator app. You can enter text into the {{htmlelement("textarea")}} and press the "Save file" {{htmlelement("button")}}, and the app will open a file picker allowing you to save that text onto your local file system in a text file of your choice. You can also choose to delete files you create.
+Our [`FileSystemHandle.remove()` demo](https://mdn.github.io/dom-examples/file-system-api/filesystemhandle-remove/) (see the [source code](https://github.com/mdn/dom-examples/tree/main/file-system-api/filesystemhandle-remove)) is a file creator app. You can enter text into the {{htmlelement("textarea")}} and press the "Save file" {{htmlelement("button")}}, and the app will open a file picker allowing you to save that text onto your local file system in a text file of your choice. You can also choose to delete files you create.
 
 It doesn't allow you to view the content of created files, and it doesn't stay in sync with the underlying file system on page reloads/closes. This means that files created by the app will still exist on the file system if you don't choose to delete them before reloading or closing the tab.
 
@@ -93,4 +93,3 @@ This feature is not part of any specification, but may become standard in the fu
 ## See also
 
 - [File System API](/en-US/docs/Web/API/File_System_API)
-- [FileSystemHandle.remove() demo](https://filesystemhandle-remove.glitch.me/)

--- a/files/en-us/web/api/filesystemobserver/filesystemobserver/index.md
+++ b/files/en-us/web/api/filesystemobserver/filesystemobserver/index.md
@@ -35,7 +35,7 @@ A new {{domxref("FileSystemObserver")}} object.
 ## Examples
 
 > [!NOTE]
-> For a complete working example, check out [File System Observer Demo](https://mdn.github.io/dom-examples/filesystemobserver/) ([source code](https://github.com/mdn/dom-examples/tree/main/filesystemobserver)).
+> For a complete working example, check out [File System Observer Demo](https://mdn.github.io/dom-examples/file-system-api/filesystemobserver/) ([source code](https://github.com/mdn/dom-examples/tree/main/file-system-api/filesystemobserver)).
 
 ### Initializing a `FileSystemObserver`
 

--- a/files/en-us/web/api/filesystemobserver/index.md
+++ b/files/en-us/web/api/filesystemobserver/index.md
@@ -27,7 +27,7 @@ The **`FileSystemObserver`** interface of the {{domxref("File System API", "File
 ## Examples
 
 > [!NOTE]
-> For a complete working example, check out [File System Observer Demo](https://mdn.github.io/dom-examples/filesystemobserver/) ([source code](https://github.com/mdn/dom-examples/tree/main/filesystemobserver)).
+> For a complete working example, check out [File System Observer Demo](https://mdn.github.io/dom-examples/file-system-api/filesystemobserver/) ([source code](https://github.com/mdn/dom-examples/tree/main/file-system-api/filesystemobserver)).
 
 ### Initialize a `FileSystemObserver`
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Our [File System API docs](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) have several Glitch demo links in them.

Because Glitch is going away, I have moved these to the dom-examples repo: see https://github.com/mdn/dom-examples/pull/323

This PR updates the glitch links to the new locations, and updates the links to the FileSystemObserver demo, which got moved during the dom-examples update.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
