### PR TITLE
CSS best practice: always specify generic font family as fallback

### DIFF
--- a/files/en-us/learn_web_development/extensions/performance/css/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/css/index.md
@@ -210,7 +210,7 @@ h1,
 h2,
 h3 {
   /* It is actually loaded here */
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
 }
 ```
 

--- a/files/en-us/web/api/cssfontpalettevaluesrule/basepalette/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/basepalette/index.md
@@ -42,7 +42,7 @@ This example adds rules in an extra stylesheet added to the document, returned a
 @import url("https://fonts.googleapis.com/css2?family=Nabla&display=swap");
 
 h2 {
-  font-family: "Nabla";
+  font-family: "Nabla", fantasy;
 }
 
 @font-palette-values --two {

--- a/files/en-us/web/api/cssfontpalettevaluesrule/overridecolors/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/overridecolors/index.md
@@ -42,7 +42,7 @@ This example first defines a few at-rules, among them two {{cssxref("@font-palet
 }
 
 .emoji {
-  font-family: "Noto Color Emoji";
+  font-family: "Noto Color Emoji", emoji;
   font-size: 3rem;
 }
 

--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -158,7 +158,6 @@ button {
 kbd {
   border: 2px solid #cdcdcd;
   border-radius: 3px;
-  box-shadow: #cdcdcd;
   box-shadow: inset 0 -1px 0 0 #cdcdcd;
   font-size: 0.825rem;
   padding: 0.25rem;

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -57,7 +57,7 @@ This is fairly well documented already, but we thought we'd give a mention to th
 
 ```css
 label {
-  font-family: "NotoColorEmoji";
+  font-family: "Noto Color Emoji", emoji;
   font-size: 3rem;
   position: absolute;
   top: 2px;

--- a/files/en-us/web/css/@font-face/font-feature-settings/index.md
+++ b/files/en-us/web/css/@font-face/font-feature-settings/index.md
@@ -74,10 +74,10 @@ p {
   margin: 0.7rem 3rem;
 }
 .swash-off {
-  font-family: MonteCarlo;
+  font-family: MonteCarlo, cursive;
 }
 .swash-on {
-  font-family: MonteCarlo2;
+  font-family: MonteCarlo2, cursive;
 }
 ```
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -192,7 +192,7 @@ The example below shows how to define two font faces with the same font family. 
 
 /* Using the regular font face */
 p {
-  font-family: MainText;
+  font-family: MainText, sans-serif;
 }
 
 /* Font-family is inherited, but bold fonts are used */
@@ -217,7 +217,7 @@ A color font will be activated if the user agent supports it, and an `opentype` 
 
 /* Using the font face */
 p {
-  font-family: "Trickster";
+  font-family: "Trickster", fantasy;
 }
 ```
 
@@ -268,7 +268,7 @@ The block of CSS inside `@supports` will be applied if the user agent supports `
   }
 
   .colored_text {
-    font-family: "Trickster";
+    font-family: "Trickster", fantasy;
   }
 }
 ```

--- a/files/en-us/web/css/@font-palette-values/base-palette/index.md
+++ b/files/en-us/web/css/@font-palette-values/base-palette/index.md
@@ -55,7 +55,7 @@ Using the [Rocher Color Font](https://www.harbortype.com/fonts/rocher-color/), t
 }
 
 h2 {
-  font-family: "Rocher";
+  font-family: "Rocher", fantasy;
 }
 
 @font-palette-values --two {

--- a/files/en-us/web/css/@font-palette-values/font-family/index.md
+++ b/files/en-us/web/css/@font-palette-values/font-family/index.md
@@ -58,7 +58,7 @@ In this example, when the `font-family` descriptor is used in the [@font-palette
 }
 
 h2 {
-  font-family: "Bungee Spice";
+  font-family: "Bungee Spice", fantasy;
 }
 
 h2.extra-spicy {
@@ -91,11 +91,11 @@ h2 {
 }
 
 h1 {
-  font-family: "Bungee Spice";
+  font-family: "Bungee Spice", fantasy;
 }
 
 h2 {
-  font-family: Bixa;
+  font-family: Bixa, fantasy;
 }
 ```
 

--- a/files/en-us/web/css/@font-palette-values/index.md
+++ b/files/en-us/web/css/@font-palette-values/index.md
@@ -53,7 +53,7 @@ This example shows how you can change some or all of the colors in a color font.
 ```css
 @import url(https://fonts.googleapis.com/css2?family=Bungee+Spice);
 p {
-  font-family: "Bungee Spice";
+  font-family: "Bungee Spice", fantasy;
   font-size: 2rem;
 }
 @font-palette-values --Alternate {

--- a/files/en-us/web/css/@font-palette-values/override-colors/index.md
+++ b/files/en-us/web/css/@font-palette-values/override-colors/index.md
@@ -87,7 +87,7 @@ This example shows how to override colors in the [Noto Color Emoji](https://font
 }
 ```
 
-```css-nolint
+```css
 @font-face {
   font-family: "Noto Color Emoji";
   font-style: normal;
@@ -97,7 +97,7 @@ This example shows how to override colors in the [Noto Color Emoji](https://font
 }
 
 .emoji {
-  font-family: "Noto Color Emoji";
+  font-family: "Noto Color Emoji", emoji;
   font-size: 3rem;
 }
 @font-palette-values --red {
@@ -137,7 +137,7 @@ Using [Rocher Color Font](https://www.harbortype.com/fonts/rocher-color/), this 
   src: url("[path-to-font]/RocherColorGX.woff2") format("woff2");
 }
 h2 {
-  font-family: "Rocher";
+  font-family: "Rocher", fantasy;
 }
 @font-palette-values --override-palette {
   font-family: "Rocher";

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -282,7 +282,9 @@ The following example applies the CSS style if the browser supports the `COLRv1`
 @import url("https://fonts.googleapis.com/css2?family=Bungee+Spice");
 
 @supports font-tech(color-COLRv1) {
-  font-family: "Bungee Spice";
+  p {
+    font-family: "Bungee Spice", fantasy;
+  }
 }
 ```
 
@@ -305,8 +307,10 @@ The following example applies the CSS style if the browser supports the `woff2` 
 
 ```css
 @supports font-format(woff2) {
-  font-family: "Open Sans";
-  src: url("open-sans.woff2") format("woff2");
+  p {
+    font-family: "Open Sans", sans-serif;
+    src: url("open-sans.woff2") format("woff2");
+  }
 }
 ```
 

--- a/files/en-us/web/css/_colon_-moz-drag-over/index.md
+++ b/files/en-us/web/css/_colon_-moz-drag-over/index.md
@@ -55,7 +55,7 @@ target.addEventListener(
 
 ```css
 body {
-  font-family: arial;
+  font-family: Arial;
 }
 div {
   display: inline-block;

--- a/files/en-us/web/css/css_colors/color_values/index.md
+++ b/files/en-us/web/css/css_colors/color_values/index.md
@@ -98,7 +98,7 @@ The HTML creates a box containing a color picker control (with a label created u
     16px "Lucida Grande",
     "Helvetica",
     "Arial",
-    "sans-serif";
+    sans-serif;
 }
 ```
 

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -408,7 +408,7 @@ In the following live example, you can adjust the slant.
 }
 
 p {
-  font-family: "SlantFont";
+  font-family: "SlantFont", sans-serif;
   display: inline-block;
   margin: 1rem;
   font-size: 4rem;

--- a/files/en-us/web/css/font-feature-settings/index.md
+++ b/files/en-us/web/css/font-feature-settings/index.md
@@ -166,7 +166,7 @@ td.tabular {
 
 /* enable stylistic set 7 */
 .fancy-style {
-  font-family: Gabriola;
+  font-family: Gabriola, cursive;
   font-feature-settings: "ss07";
 }
 ```

--- a/files/en-us/web/css/font-optical-sizing/index.md
+++ b/files/en-us/web/css/font-optical-sizing/index.md
@@ -41,7 +41,7 @@ font-optical-sizing: none;
 }
 
 #example-element {
-  font-family: Amstelvar;
+  font-family: Amstelvar, serif;
   text-align: left;
 }
 
@@ -114,7 +114,7 @@ When optical sizing is used, small text sizes are often rendered with thicker st
 
 p {
   font-size: 36px;
-  font-family: Amstelvar;
+  font-family: Amstelvar, serif;
 }
 
 .no-optical-sizing {

--- a/files/en-us/web/css/font-palette/index.md
+++ b/files/en-us/web/css/font-palette/index.md
@@ -100,7 +100,7 @@ In the CSS, we import a [color font](https://www.colorfonts.wtf/) called [Nabla]
 }
 
 p {
-  font-family: "Nabla";
+  font-family: "Nabla", fantasy;
   font-size: 5rem;
   margin: 0;
   text-align: center;

--- a/files/en-us/web/css/font-palette/palette-mix/index.md
+++ b/files/en-us/web/css/font-palette/palette-mix/index.md
@@ -89,7 +89,7 @@ In the CSS, we import a color font from Google Fonts, and define two custom `fon
 }
 
 p {
-  font-family: "Nabla";
+  font-family: "Nabla", fantasy;
   font-size: 4rem;
   text-align: center;
   margin: 0;

--- a/files/en-us/web/css/font-size-adjust/index.md
+++ b/files/en-us/web/css/font-size-adjust/index.md
@@ -190,7 +190,7 @@ div {
 }
 
 p {
-  font-family: Futura;
+  font-family: Futura, sans-serif;
   font-size: 50px;
 }
 

--- a/files/en-us/web/css/font-stretch/index.md
+++ b/files/en-us/web/css/font-stretch/index.md
@@ -162,7 +162,9 @@ td {
     sans-serif;
 }
 #anek-malayalam td {
-  font: 90px "Anek Malayalam";
+  font:
+    90px "Anek Malayalam",
+    sans-serif;
 }
 #inconsolata td:nth-child(2),
 #anek-malayalam td:nth-child(2) {

--- a/files/en-us/web/css/font-style/index.md
+++ b/files/en-us/web/css/font-style/index.md
@@ -48,7 +48,7 @@ font-style: oblique 40deg;
 
 section {
   font-size: 1.2em;
-  font-family: Amstelvar;
+  font-family: Amstelvar, serif;
 }
 ```
 

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -111,12 +111,12 @@ font-synthesis: position;
 
 .english {
   font-size: 1.2em;
-  font-family: Oxygen;
+  font-family: Oxygen, sans-serif;
 }
 
 .chinese {
   font-size: 1.2em;
-  font-family: "Ma Shan Zheng";
+  font-family: "Ma Shan Zheng", cursive;
 }
 
 .bold {
@@ -261,7 +261,7 @@ This example shows the browser's default font-synthesis behavior and compares it
   font-family: "Montserrat", sans-serif;
 }
 .chinese {
-  font-family: "Ma Shan Zheng";
+  font-family: "Ma Shan Zheng", cursive;
 }
 .no-syn {
   font-synthesis: none;

--- a/files/en-us/web/css/font-variant-alternates/index.md
+++ b/files/en-us/web/css/font-variant-alternates/index.md
@@ -103,7 +103,7 @@ We can then use that name inside `font-variant-alternates` to switch on swashes 
 }
 
 p {
-  font-family: "MonteCarlo";
+  font-family: "MonteCarlo", cursive;
   font-size: 3rem;
   margin: 0.7rem 3rem;
 }

--- a/files/en-us/web/css/font-variant-east-asian/index.md
+++ b/files/en-us/web/css/font-variant-east-asian/index.md
@@ -139,7 +139,7 @@ tbody {
 }
 
 td {
-  font-family: "Yu Gothic";
+  font-family: "Yu Gothic", fantasy;
   font-size: 20px;
 }
 th {

--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -152,7 +152,7 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground:
 }
 
 .ordinal {
-  font-family: "Source Sans Pro";
+  font-family: "Source Sans Pro", sans-serif;
   font-size: 2rem;
   font-variant-numeric: ordinal;
 }

--- a/files/en-us/web/css/font-variation-settings/index.md
+++ b/files/en-us/web/css/font-variation-settings/index.md
@@ -45,7 +45,7 @@ font-variation-settings: "wdth" 75;
 
 p {
   font-size: 1.5rem;
-  font-family: Amstelvar;
+  font-family: Amstelvar, serif;
 }
 ```
 

--- a/files/en-us/web/css/font/index.md
+++ b/files/en-us/web/css/font/index.md
@@ -413,7 +413,7 @@ p {
 ```css hidden
 body,
 input {
-  font: 14px arial;
+  font: 14px Arial;
   overflow: hidden;
 }
 

--- a/files/en-us/web/css/letter-spacing/index.md
+++ b/files/en-us/web/css/letter-spacing/index.md
@@ -46,7 +46,7 @@ letter-spacing: -1px;
 
 section {
   font-size: 1.2em;
-  font-family: Amstelvar;
+  font-family: Amstelvar, serif;
 }
 ```
 

--- a/files/en-us/web/css/page/index.md
+++ b/files/en-us/web/css/page/index.md
@@ -198,7 +198,7 @@ The `break-after: page;` is used to split them up, which splits each chapter int
   }
   section {
     font-size: 2rem;
-    font-family: Roboto;
+    font-family: Roboto, sans-serif;
   }
   .chapter {
     border: tomato 2px solid;

--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -499,7 +499,7 @@ div {
   overflow: scroll;
   scrollbar-width: thin;
   font-size: 16px;
-  font-family: verdana;
+  font-family: Verdana;
   border: 1px solid;
 }
 

--- a/files/en-us/web/css/selector_list/index.md
+++ b/files/en-us/web/css/selector_list/index.md
@@ -47,7 +47,7 @@ This example shows grouping selectors in a single line using a comma-separated l
 
 ```css-nolint
 h1, h2, h3, h4, h5, h6 {
-  font-family: helvetica;
+  font-family: Helvetica, Arial;
 }
 ```
 

--- a/files/en-us/web/css/word-spacing/index.md
+++ b/files/en-us/web/css/word-spacing/index.md
@@ -46,7 +46,7 @@ word-spacing: -0.4ch;
 
 section {
   font-size: 1.2em;
-  font-family: Amstelvar;
+  font-family: Amstelvar, serif;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/caption/index.md
+++ b/files/en-us/web/html/reference/elements/caption/index.md
@@ -77,14 +77,18 @@ tr:nth-child(odd) td {
 }
 
 .heman {
-  font: 1.4rem molot;
+  font:
+    1.4rem molot,
+    sans-serif;
   text-shadow:
     1px 1px 1px #fff,
     2px 2px 1px #000;
 }
 
 .skeletor {
-  font: 1.7rem rapscallion;
+  font:
+    1.7rem rapscallion,
+    fantasy;
   letter-spacing: 3px;
   text-shadow:
     1px 1px 0 #fff,

--- a/files/en-us/web/html/reference/elements/input/index.md
+++ b/files/en-us/web/html/reference/elements/input/index.md
@@ -946,7 +946,7 @@ input.custom {
   font:
     16px "Helvetica",
     "Arial",
-    "sans-serif";
+    sans-serif;
 }
 ```
 

--- a/files/en-us/web/mathml/tutorials/for_beginners/fractions_and_roots/index.md
+++ b/files/en-us/web/mathml/tutorials/for_beginners/fractions_and_roots/index.md
@@ -186,7 +186,8 @@ Here is an exercise to verify whether you understood the relation between a Math
 math {
   font-family:
     Latin Modern Math,
-    STIX Two Math;
+    STIX Two Math,
+    math;
   font-size: 200%;
 }
 math .highlight {

--- a/files/en-us/web/mathml/tutorials/for_beginners/text_containers/index.md
+++ b/files/en-us/web/mathml/tutorials/for_beginners/text_containers/index.md
@@ -34,7 +34,9 @@ Since most of these characters are not part of Basic Latin Unicode block, it is 
 
 ```css
 p {
-  font-family: Latin Modern Math;
+  font-family:
+    Latin Modern Math,
+    math;
 }
 ```
 
@@ -281,7 +283,9 @@ div {
 }
 
 .text {
-  font-family: Latin Modern Math;
+  font-family:
+    Latin Modern Math,
+    math;
 }
 ```
 


### PR DESCRIPTION
We should always specify a generic fallback so the displayed font is not Times New Roman. Even when the font-face is explicitly declared in the code, it may fail to load.