### PR TITLE
doc[http/guides/authentication/index.md]: Removed outdated description about firefox

### DIFF
--- a/files/en-us/web/http/guides/authentication/index.md
+++ b/files/en-us/web/http/guides/authentication/index.md
@@ -153,8 +153,7 @@ Many clients also let you avoid the login prompt by using an encoded URL contain
 https://username:password@www.example.com/
 ```
 
-**The use of these URLs is deprecated**.
-In Chrome, the `username:password@` part in URLs is [removed from subresource URLs](https://codereview.chromium.org/2651943002) for security reasons. In Firefox, it is checked if the site actually requires authentication and if not, Firefox will warn the user with a prompt "You are about to log in to the site `www.example.com` with the username `username`, but the website does not require authentication. This may be an attempt to trick you." In case the site does require authentication, Firefox will still ask for user confirmation "You are about to log in to the site `www.example.com` with the username `username`." before sending the credentials to the site. Note that Firefox sends the request without credentials in both cases before showing the prompt in order to determine whether the site requires authentication.
+**The use of these URLs is deprecated across modern browsers**.
 
 ## See also
 

--- a/files/en-us/web/http/guides/authentication/index.md
+++ b/files/en-us/web/http/guides/authentication/index.md
@@ -147,13 +147,13 @@ location /status {
 
 ### Access using credentials in the URL
 
-Many clients also let you avoid the login prompt by using an encoded URL containing the username and the password like this:
+Historically some sites would allow you to login using an encoded URL containing the username and the password as shown:
 
 ```plain example-bad
 https://username:password@www.example.com/
 ```
 
-**The use of these URLs is deprecated across modern browsers**.
+This syntax is no longer allowed in modern browsers; the username and password are stripped from the request before it is sent.
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Test Locally with firefox 140.0.2, firefox does not show any warning message.

https://github.com/user-attachments/assets/2c284b21-d218-4999-b225-99ac272267cd

```
Firefox will warn the user with a prompt "You are about to log in to the site www.example.com with the username username, but the website does not require authentication. This may be an attempt to trick you."
```

This seems outdated, but I can't find the exact version firefox changed this behavior.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
