### PR TITLE
Separate wat br pages into br, br_if, br_table, pages

### DIFF
--- a/files/en-us/webassembly/reference/control_flow/br/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br/index.md
@@ -7,6 +7,8 @@ sidebar: webassemblysidebar
 
 The **`br`** statement branches to a [`loop`](/en-US/docs/WebAssembly/Reference/Control_flow/loop), a [`block`](/en-US/docs/WebAssembly/Reference/Control_flow/block), or an [`if`](/en-US/docs/WebAssembly/Reference/Control_flow/if...else) statement.
 
+Other variants of `br` include [`br_if`](/en-us/WebAssembly/Reference/Control_flow/br_if) and [`br_table`](/en-us/WebAssembly/Reference/Control_flow/br_table).
+
 {{InteractiveExample("Wat Demo: br", "tabbed-taller")}}
 
 ```wat interactive-example

--- a/files/en-us/webassembly/reference/control_flow/br/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br/index.md
@@ -5,23 +5,23 @@ page-type: webassembly-instruction
 sidebar: webassemblysidebar
 ---
 
-The **`br`** statement branches to a loop, block, or if.
+The **`br`** statement branches to a [`loop`](/en-US/docs/WebAssembly/Reference/Control_flow/loop), a [`block`](/en-US/docs/WebAssembly/Reference/Control_flow/block), or an [`if`](/en-US/docs/WebAssembly/Reference/Control_flow/if...else) statement.
 
 {{InteractiveExample("Wat Demo: br", "tabbed-taller")}}
 
 ```wat interactive-example
 (module
-  ;; import the browser console object, you'll need to pass this in from JavaScript
+  ;; Import the browser console object, which you'll need to pass in from JavaScript
   (import "console" "log" (func $log (param i32)))
 
   (func
     (block $my_block
 
-      ;; break out fo the block.
-      ;; if this is removed the code will throw an error when it reaches `unreachable`
+      ;; Break out of the block
+      ;; If this is removed, the code will throw an error when it reaches `unreachable`
       br $my_block
 
-      ;; we'll never reach this point since we broke out of the block
+      ;; The code will never reach this point since we broke out of the block
       unreachable
 
     )

--- a/files/en-us/webassembly/reference/control_flow/br/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br/index.md
@@ -7,8 +7,6 @@ sidebar: webassemblysidebar
 
 The **`br`** statement branches to a loop, block, or if.
 
-Other variants of `br` are `br_if` for branching on condition, and `br_table` for branching to different blocks based on an argument.
-
 {{InteractiveExample("Wat Demo: br", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -16,27 +14,15 @@ Other variants of `br` are `br_if` for branching on condition, and `br_table` fo
   ;; import the browser console object, you'll need to pass this in from JavaScript
   (import "console" "log" (func $log (param i32)))
 
-  ;; create a global variable and initialize it to 0
-  (global $i (mut i32) (i32.const 0))
-
   (func
-    (loop $my_loop
+    (block $my_block
 
-      ;; add one to $i
-      global.get $i
-      i32.const 1
-      i32.add
-      global.set $i
+      ;; break out fo the block.
+      ;; if this is removed the code will throw an error when it reaches `unreachable`
+      br $my_block
 
-      ;; log the current value of $i
-      global.get $i
-      call $log
-
-      ;; if $i is less than 10 branch to loop
-      global.get $i
-      i32.const 10
-      i32.lt_s
-      br_if $my_loop
+      ;; we'll never reach this point since we broke out of the block
+      unreachable
 
     )
   )
@@ -67,5 +53,3 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `br`        | `0x0c`        |
-| `br_if`     | `0x0d`        |
-| `br_table`  | `0x0e`        |

--- a/files/en-us/webassembly/reference/control_flow/br_if/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_if/index.md
@@ -1,0 +1,68 @@
+---
+title: br_if
+slug: WebAssembly/Reference/Control_flow/br_if
+page-type: webassembly-instruction
+sidebar: webassemblysidebar
+---
+
+The **`br_if`** statement branches to a loop, block, or if, based on a boolean (0 or 1) condition.
+
+{{InteractiveExample("Wat Demo: br_if", "tabbed-taller")}}
+
+```wat interactive-example
+(module
+  ;; import the browser console object, you'll need to pass this in from JavaScript
+  (import "console" "log" (func $log (param i32)))
+
+  ;; create a global variable and initialize it to 0
+  (global $i (mut i32) (i32.const 0))
+
+  (func
+    (loop $my_loop
+
+      ;; add one to $i
+      global.get $i
+      i32.const 1
+      i32.add
+      global.set $i
+
+      ;; log the current value of $i
+      global.get $i
+      call $log
+
+      ;; if $i is less than 10 branch to loop
+      global.get $i
+      i32.const 10
+      i32.lt_s
+      br_if $my_loop
+
+    )
+  )
+
+  (start 1) ;; run the first function automatically
+)
+```
+
+```js interactive-example
+const url = "{%wasm-url%}";
+await WebAssembly.instantiateStreaming(fetch(url), { console });
+```
+
+## Syntax
+
+```wat
+;; label the loop so that it can be branched to
+(loop $my_loop
+
+  ;; add 1 (true) to the stack
+  i32.const 1
+
+  ;; branch to the loop if the top of the stack is 1
+  br_if $my_loop
+
+)
+```
+
+| Instruction | Binary opcode |
+| ----------- | ------------- |
+| `br_if`     | `0x0d`        |

--- a/files/en-us/webassembly/reference/control_flow/br_if/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_if/index.md
@@ -51,13 +51,13 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 ## Syntax
 
 ```wat
-;; label the loop so that it can be branched to
+;; Label the loop to enable branching to it later
 (loop $my_loop
 
-  ;; add 1 (true) to the stack
+  ;; Add 1 (true) to the stack
   i32.const 1
 
-  ;; branch to the loop if the top of the stack is 1
+  ;; Branch to the loop if the top of the stack is 1
   br_if $my_loop
 
 )

--- a/files/en-us/webassembly/reference/control_flow/br_if/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_if/index.md
@@ -5,32 +5,32 @@ page-type: webassembly-instruction
 sidebar: webassemblysidebar
 ---
 
-The **`br_if`** statement branches to a loop, block, or if, based on a boolean (0 or 1) condition.
+The **`br_if`** statement branches to a [`loop`](/en-US/docs/WebAssembly/Reference/Control_flow/loop), a [`block`](/en-US/docs/WebAssembly/Reference/Control_flow/block), or an [`if`](/en-US/docs/WebAssembly/Reference/Control_flow/if...else) statement, based on a boolean (`0` or `1`) condition.
 
 {{InteractiveExample("Wat Demo: br_if", "tabbed-taller")}}
 
 ```wat interactive-example
 (module
-  ;; import the browser console object, you'll need to pass this in from JavaScript
+  ;; Import the browser console object, which you'll need to pass in from JavaScript
   (import "console" "log" (func $log (param i32)))
 
-  ;; create a global variable and initialize it to 0
+  ;; Create a global variable and initialize it to 0
   (global $i (mut i32) (i32.const 0))
 
   (func
     (loop $my_loop
 
-      ;; add one to $i
+      ;; Add 1 to $i
       global.get $i
       i32.const 1
       i32.add
       global.set $i
 
-      ;; log the current value of $i
+      ;; Log the current value of $i
       global.get $i
       call $log
 
-      ;; if $i is less than 10 branch to loop
+      ;; If $i is less than 10, branch to loop
       global.get $i
       i32.const 10
       i32.lt_s
@@ -39,7 +39,7 @@ The **`br_if`** statement branches to a loop, block, or if, based on a boolean (
     )
   )
 
-  (start 1) ;; run the first function automatically
+  (start 1) ;; Run the first function automatically
 )
 ```
 

--- a/files/en-us/webassembly/reference/control_flow/br_table/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_table/index.md
@@ -71,7 +71,6 @@ i32.const 1
         ;; 0 = jump to `block`; since item 0 in br_table is 1, it jumps up one level
         ;; 1 = jump to `if`; since item 1 in br_table is 2, it jumps up two levels
         ;; 2 = jump to `loop`; since item 2 in br_table is 0, it doesn't jump any levels (causing an infinite loop)
-        
         ;; Create a br_table with the targets
         (br_table 1 2 0)
       )

--- a/files/en-us/webassembly/reference/control_flow/br_table/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_table/index.md
@@ -7,6 +7,8 @@ sidebar: webassemblysidebar
 
 The **`br_table`** statement branches to different loops, blocks, or ifs, based on an argument.
 
+You can think of if like a `switch` statement in some sense.
+
 {{InteractiveExample("Wat Demo: br_table", "tabbed-taller")}}
 
 ```wat interactive-example

--- a/files/en-us/webassembly/reference/control_flow/br_table/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_table/index.md
@@ -5,15 +5,15 @@ page-type: webassembly-instruction
 sidebar: webassemblysidebar
 ---
 
-The **`br_table`** statement branches to different loops, blocks, or ifs, based on an argument.
+The **`br_table`** statement branches to different [`loop`](/en-US/docs/WebAssembly/Reference/Control_flow/loop), [`block`](/en-US/docs/WebAssembly/Reference/Control_flow/block), or [`if`](/en-US/docs/WebAssembly/Reference/Control_flow/if...else) statements, based on an argument.
 
-You can think of if like a `switch` statement in some sense.
+In some ways, `br_table` is similar to the [`switch`](/en-US/docs/Web/JavaScript/Reference/Statements/switch) statement, branching to different code blocks depending on the argument.
 
 {{InteractiveExample("Wat Demo: br_table", "tabbed-taller")}}
 
 ```wat interactive-example
 (module
-  ;; import the browser console object, you'll need to pass this in from JavaScript
+  ;; Import the browser console object, which you'll need to pass in from JavaScript
   (import "console" "log" (func $log (param i32)))
 
   (func
@@ -58,13 +58,13 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 ## Syntax
 
 ```wat
-;; add true to the top of the stack so that the if is exectuted.
+;; Add true to the top of the stack so that the `if` statement is executed.
 i32.const 1
 (if ;; 2
   (then
     (block ;; 1
       (loop ;; 0
-        ;; add variable to top of the stack
+        ;; Add a variable to the top of the stack
         i32.const 2
 
         ;; 0 = jump to the block, item 0 in br_table is 1 so we jump to 1 level.

--- a/files/en-us/webassembly/reference/control_flow/br_table/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_table/index.md
@@ -1,0 +1,80 @@
+---
+title: br_table
+slug: WebAssembly/Reference/Control_flow/br_table
+page-type: webassembly-instruction
+sidebar: webassemblysidebar
+---
+
+The **`br_table`** statement branches to different loops, blocks, or ifs, based on an argument.
+
+{{InteractiveExample("Wat Demo: br_table", "tabbed-taller")}}
+
+```wat interactive-example
+(module
+  ;; import the browser console object, you'll need to pass this in from JavaScript
+  (import "console" "log" (func $log (param i32)))
+
+  (func
+    ;; label each block for easy reference.
+    ;; (could also be referenced by index)
+    (block $outer_block
+      (block $middle_block
+        (block $inner_block
+
+          ;; choose which block to break out of based on their order in the br_table
+          ;; 0 is `$inner_block`, 1 is `$outer_block`, 2 is `$middle_block`
+          i32.const 0
+
+          ;; create a br_table with three targets
+          (br_table $inner_block $outer_block $middle_block)
+
+          ;; we'll never reach this point since we broke out of the block
+          unreachable
+
+        )
+
+        ;; if you jump out of the `$inner_block` block but stay in `$middle_block`,
+        ;; 42 will be logged.
+        ;; if also jump out of the `$middle_block` block, either by jumping out of
+        ;; `$middle_block` or `$outer_block`, this will be skipped.
+        i32.const 42
+        call $log
+
+      )
+    )
+  )
+
+  (start 1) ;; run the first function automatically
+)
+```
+
+```js interactive-example
+const url = "{%wasm-url%}";
+await WebAssembly.instantiateStreaming(fetch(url), { console });
+```
+
+## Syntax
+
+```wat
+;; add true to the top of the stack so that the if is exectuted.
+i32.const 1
+(if ;; 2
+  (then
+    (block ;; 1
+      (loop ;; 0
+        ;; add variable to top of the stack
+        i32.const 2
+
+        ;; 0 = jump to the block, item 0 in br_table is 1 so we jump to 1 level.
+        ;; 1 = jump to the if, item 1 in br_table is 2 so we jump to 2 levels.
+        ;; 2 = jump to the loop, item 2 in br_table is 0 so we jump to 0 levels. (this will cuase an infinite loop)
+        (br_table 1 2 0)
+      )
+    )
+  )
+)
+```
+
+| Instruction | Binary opcode |
+| ----------- | ------------- |
+| `br_table`  | `0x0e`        |

--- a/files/en-us/webassembly/reference/control_flow/br_table/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_table/index.md
@@ -17,28 +17,29 @@ In some ways, `br_table` is similar to the [`switch`](/en-US/docs/Web/JavaScript
   (import "console" "log" (func $log (param i32)))
 
   (func
-    ;; label each block for easy reference.
-    ;; (could also be referenced by index)
+    ;; Label each block for easy reference
+    ;; (they can also be referenced by their index)
     (block $outer_block
       (block $middle_block
         (block $inner_block
 
-          ;; choose which block to break out of based on their order in the br_table
+          ;; Choose which block to break out of based on their order in the br_table
           ;; 0 is `$inner_block`, 1 is `$outer_block`, 2 is `$middle_block`
           i32.const 0
 
-          ;; create a br_table with three targets
+          ;; Create a br_table with three targets
           (br_table $inner_block $outer_block $middle_block)
 
-          ;; we'll never reach this point since we broke out of the block
+          ;; The code will never reach this point since we broke out of the block
           unreachable
 
         )
 
-        ;; if you jump out of the `$inner_block` block but stay in `$middle_block`,
-        ;; 42 will be logged.
-        ;; if also jump out of the `$middle_block` block, either by jumping out of
-        ;; `$middle_block` or `$outer_block`, this will be skipped.
+        ;; If you jump out of `$inner_block` but stay in `$middle_block`,
+        ;; 42 will be logged
+        ;; If you jump out of `$middle_block` also,
+        ;; by jumping out of either `$middle_block` or `$outer_block`,
+        ;; this will be skipped
         i32.const 42
         call $log
 
@@ -46,7 +47,7 @@ In some ways, `br_table` is similar to the [`switch`](/en-US/docs/Web/JavaScript
     )
   )
 
-  (start 1) ;; run the first function automatically
+  (start 1) ;; Run the first function automatically
 )
 ```
 
@@ -67,9 +68,11 @@ i32.const 1
         ;; Add a variable to the top of the stack
         i32.const 2
 
-        ;; 0 = jump to the block, item 0 in br_table is 1 so we jump to 1 level.
-        ;; 1 = jump to the if, item 1 in br_table is 2 so we jump to 2 levels.
-        ;; 2 = jump to the loop, item 2 in br_table is 0 so we jump to 0 levels. (this will cuase an infinite loop)
+        ;; 0 = jump to `block`; since item 0 in br_table is 1, it jumps up one level
+        ;; 1 = jump to `if`; since item 1 in br_table is 2, it jumps up two levels
+        ;; 2 = jump to `loop`; since item 2 in br_table is 0, it doesn't jump any levels (causing an infinite loop)
+        
+        ;; Create a br_table with the targets
         (br_table 1 2 0)
       )
     )

--- a/files/en-us/webassembly/reference/control_flow/index.md
+++ b/files/en-us/webassembly/reference/control_flow/index.md
@@ -14,7 +14,7 @@ WebAssembly control flow instructions.
 - [`br_if`](/en-US/docs/WebAssembly/Reference/Control_flow/br_if)
   - : Branches to a loop, block, or if, based on a boolean condition.
 - [`br_table`](/en-US/docs/WebAssembly/Reference/Control_flow/br_table)
-  - : Branches to a loop or block.
+  - : Branches to different loops, blocks, or ifs, based on an argument.
 - [`call`](/en-US/docs/WebAssembly/Reference/Control_flow/call)
   - : Calls a function.
 - [`drop`](/en-US/docs/WebAssembly/Reference/Control_flow/Drop)

--- a/files/en-us/webassembly/reference/control_flow/index.md
+++ b/files/en-us/webassembly/reference/control_flow/index.md
@@ -11,6 +11,10 @@ WebAssembly control flow instructions.
   - : Creates a label that can later be branched out of with a [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br).
 - [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br)
   - : Branches to a loop, block, or if.
+- [`br_if`](/en-US/docs/WebAssembly/Reference/Control_flow/br_if)
+  - : Branches to a loop, block, or if, based on a boolean condition.
+- [`br_table`](/en-US/docs/WebAssembly/Reference/Control_flow/br_table)
+  - : Branches to a loop or block.
 - [`call`](/en-US/docs/WebAssembly/Reference/Control_flow/call)
   - : Calls a function.
 - [`drop`](/en-US/docs/WebAssembly/Reference/Control_flow/Drop)

--- a/files/en-us/webassembly/reference/control_flow/index.md
+++ b/files/en-us/webassembly/reference/control_flow/index.md
@@ -10,11 +10,11 @@ WebAssembly control flow instructions.
 - [`block`](/en-US/docs/WebAssembly/Reference/Control_flow/block)
   - : Creates a label that can later be branched out of with a [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br).
 - [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br)
-  - : Branches to a loop, block, or if.
+- : Branches to a `loop`, `block`, or `if`.
 - [`br_if`](/en-US/docs/WebAssembly/Reference/Control_flow/br_if)
-  - : Branches to a loop, block, or if, based on a boolean condition.
+  - : Branches to a `loop`, `block`, or `if`, based on a boolean condition.
 - [`br_table`](/en-US/docs/WebAssembly/Reference/Control_flow/br_table)
-  - : Branches to different loops, blocks, or ifs, based on an argument.
+  - : Branches to different `loop`, `block`, or `if` statements, based on an argument.
 - [`call`](/en-US/docs/WebAssembly/Reference/Control_flow/call)
   - : Calls a function.
 - [`drop`](/en-US/docs/WebAssembly/Reference/Control_flow/Drop)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description
Separate wat `br` pages into `br`, `br_if`, `br_table`, into their own pages.
This let's each one have it's own example.

### Motivation
Clearer information especially around `br_table` which is a bit harder to wrap one's head around. 

### Related issues and pull requests
Fixes #40194
