### PR TITLE
Handle various Chrome demo glitch links

### DIFF
--- a/files/en-us/web/api/background_fetch_api/index.md
+++ b/files/en-us/web/api/background_fetch_api/index.md
@@ -86,7 +86,7 @@ navigator.serviceWorker.ready.then(async (swReg) => {
 });
 ```
 
-You can find a demo application which implements Background Fetch [on Glitch](https://glitch.com/edit/#!/bgfetch-http203?path=public%2Fclient.js%3A191%3A45).
+You can find further code examples and a demo in [Introducing Background Fetch](https://developer.chrome.com/blog/background-fetch/).
 
 ## Specifications
 

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
@@ -142,7 +142,7 @@ perhaps for adding to a WebRTC call using {{domxref("RTCPeerConnection.addTrack(
 add the video track from the stream.
 
 > [!NOTE]
-> The [Screen sharing controls](https://screen-sharing-controls.glitch.me/) demo provides a complete implementation that allows you to create a screen capture with your choice of `getDisplayMedia()` constraints and options.
+> The [Screen sharing controls](https://chrome.dev/screen-sharing-controls/) demo provides a complete implementation that allows you to create a screen capture with your choice of `getDisplayMedia()` constraints and options.
 
 ## Specifications
 

--- a/files/en-us/web/api/otpcredential/code/index.md
+++ b/files/en-us/web/api/otpcredential/code/index.md
@@ -36,7 +36,7 @@ navigator.credentials
 ```
 
 > [!NOTE]
-> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
+> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://chrome.dev/web-otp-demo/).
 
 ## Specifications
 

--- a/files/en-us/web/api/otpcredential/index.md
+++ b/files/en-us/web/api/otpcredential/index.md
@@ -44,7 +44,7 @@ navigator.credentials
 ```
 
 > [!NOTE]
-> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
+> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://chrome.dev/web-otp-demo/).
 
 ## Specifications
 

--- a/files/en-us/web/api/screen_capture_api/element_region_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/element_region_capture/index.md
@@ -23,7 +23,7 @@ The Element Capture API captures the element itself (and its descendants), where
 There are legitimate use cases for both:
 
 - If you need to keep the capture specific to one DOM tree, and exclude anything outside it, then the Element Capture API is a better choice. For example, you don't want private content such as a set of message notifications or a speaker notes UI showing up in the capture.
-- However, if you really do want to capture a region of the browser tab, regardless of what is shown in it, the Region Capture API will serve you well. The [Region Capture Demo](https://region-capture-demo.glitch.me/) (see the [source code](https://glitch.com/edit/#!/region-capture-demo)) shows a useful possibility — zooming in on a particular area of the tab as you show multiple users an interactive walkthrough of some kind.
+- However, if you really do want to capture a region of the browser tab, regardless of what is shown in it, the Region Capture API will serve you well.
 
 In the next section we'll start with a basic Screen Capture API demo to illustrate the issues that the Element Capture and Region Capture APIs were created to solve.
 
@@ -291,5 +291,3 @@ However, there are still restrictions on the elements that can be used as crop t
 
 - [Capture a video stream from any element](https://developer.chrome.com/docs/web-platform/element-capture) on developer.chrome.com (2025)
 - [Better tab sharing with Region Capture](https://developer.chrome.com/docs/web-platform/region-capture) on developer.chrome.com (2023)
-- [Element Capture Demo](https://element-capture-demo.glitch.me/)
-- [Region Capture Demo](https://region-capture-demo.glitch.me/)

--- a/files/en-us/web/api/webotp_api/index.md
+++ b/files/en-us/web/api/webotp_api/index.md
@@ -114,7 +114,7 @@ Or you could specify it directly on the `<iframe>` like this:
 
 In this example, when an SMS message arrives and the user grants permission, an {{domxref("OTPCredential")}} object is returned with an OTP. This password is then prefilled into the verification form field, and the form is submitted.
 
-[Try this demo using a phone](https://web-otp.glitch.me/).
+[Try this demo using a phone](https://chrome.dev/web-otp-demo/).
 
 The form field includes an [`autocomplete`](/en-US/docs/Web/HTML/Reference/Attributes/autocomplete) attribute with the value of `one-time-code`. This is not needed for the WebOTP API to work, but it is worth including. As a result, Safari will prompt the user to autofill this field with the OTP when a correctly-formatted SMS is received, even though the WebOTP API isn't fully supported in Safari.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

This PR handles several links to Chrome dev rel demos that were on Glitch. Because Glitch is going away imminently, we need to do something with the links to avoid 404s on the site.

I've decided to start batching up a few at a time to cut down on the number of PRs.

Specifically, this PR does the following:

- Background Fetch demo - I've instead linked to the article where the demo comes from, which contains a bunch more useful code snippets. They'll hopefully fix the demo link soon. I didn't just remove this one because the demo seems quite important/valuable.
- getDisplayMedia() Screen Sharing controls demo - this one has been moved, so the link is updated to point to the new location.
- Web OTP demo - this one has been moved, so the link is updated to point to the new location.
- Element capture/Region capture demos. I just removed these ones - we already have full demos, and we already link to the article that they originate from.


<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
