### PR TITLE
correct buffer types for Descriptor and Characteristic

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -27,7 +27,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to an {{jsxref("DataView")}}.
+A {{jsxref("Promise")}} that resolves to a {{jsxref("DataView")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -12,18 +12,18 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValue
 
 Use {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}} and {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()")}} instead.
 
-The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, [writes the characteristic value with optional response](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
+The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}, [writes the characteristic value with optional response](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
 
 ## Syntax
 
 ```js-nolint
-writeValue(value)
+writeValue(buffer)
 ```
 
 ### Parameters
 
 - `value`
-  - : An {{jsxref("ArrayBuffer")}}.
+  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -10,7 +10,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, [writes the characteristic value without response](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
+The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}, [writes the characteristic value without response](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
 
 ## Syntax
 
@@ -21,7 +21,7 @@ writeValueWithoutResponse(value)
 ### Parameters
 
 - `value`
-  - : An {{jsxref("ArrayBuffer")}}.
+  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -10,7 +10,7 @@ browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithResponse
 
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, [writes the characteristic value with required response](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
+The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}, [writes the characteristic value with required response](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
 
 ## Syntax
 
@@ -21,7 +21,7 @@ writeValueWithResponse(value)
 ### Parameters
 
 - `value`
-  - : An {{jsxref("ArrayBuffer")}}.
+  - : An {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
@@ -13,7 +13,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.readValue
 The
 **`BluetoothRemoteGATTDescriptor.readValue()`**
 method returns a {{jsxref("Promise")}} that resolves to
-an {{jsxref("ArrayBuffer")}} holding a duplicate of the `value` property if
+a {{jsxref("DataView")}} holding a duplicate of the `value` property if
 it is available and supported. Otherwise it throws an error.
 
 ## Syntax
@@ -28,7 +28,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to an {{jsxref("ArrayBuffer")}}.
+A {{jsxref("Promise")}} that resolves to a {{jsxref("DataView")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.md
@@ -11,12 +11,12 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.value
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`BluetoothRemoteGATTDescriptor.value`**
-read-only property returns an {{jsxref("ArrayBuffer")}} containing the currently cached
+read-only property returns an {{jsxref("DataView")}} containing the currently cached
 descriptor value. This value gets updated when the value of the descriptor is read.
 
 ## Value
 
-An {{jsxref("ArrayBuffer")}}.
+A {{jsxref("DataView")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
@@ -12,18 +12,18 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.writeValue
 
 The **`BluetoothRemoteGATTDescriptor.writeValue()`**
 method sets the value property to the bytes contained in
-an {{jsxref("ArrayBuffer")}} and returns a {{jsxref("Promise")}}.
+an {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}} and returns a {{jsxref("Promise")}}.
 
 ## Syntax
 
 ```js-nolint
-writeValue(array)
+writeValue(buffer)
 ```
 
 ### Parameters
 
-- `array`
-  - : Sets the value with the bytes contained in the array.
+- `buffer`
+  - : Sets the value with the bytes contained in the buffer.
 
 ### Return value
 


### PR DESCRIPTION
### Description

The buffer types used for values in the documentation of Web Bluetooth's `BluetoothRemoteGATTDescriptor`  and `BluetoothRemoteGATTCharacteristic` are either incomplete or incorrect.

### Motivation

To provide developers information that matches the [draft standard](https://webbluetoothcg.github.io/web-bluetooth/) and the implementation in Chrome.
