### PR TITLE
docs(css): clarify that align-items: stretch also shrinks overflowing…

### DIFF
--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -121,7 +121,7 @@ align-items: unset;
   - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
 
 - `stretch`
-  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
+  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container. Likewise, if the items are larger than the container, they will be shrunk to fit, respecting the items' width and height limits.
 
 - `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the items to the center of the associated anchor element in the block direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).


### PR DESCRIPTION
… items (#39491)

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 Add details below to help us review your pull request (PR). Explain your changes and link to a related issue or pull request. Your PR may be delayed or closed if you don't provide enough information. -->

**Description**

Clarified the documentation for align-items: stretch to note that in addition to enlarging smaller items, it will also shrink overflowing items to fit the alignment container, respecting their width and height limits.

**Motivation**

This update addresses user confusion about the behavior of align-items: stretch when flex or grid items overflow the alignment container. It helps readers understand that the property will both enlarge and shrink items as needed, which aligns with expected behavior and resolves ambiguity in the docs.

**Additional details**

No code changes—only a documentation clarification. See discussion in issue #39491.

**Related issues and pull requests**

Fixes #39491