### PR TITLE
Avoid duplicate code in interactive example

### DIFF
--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -15,7 +15,7 @@ The **grouping `( )`** operator controls the precedence of evaluation in express
 console.log(1 + 2 * 3); // 1 + 6
 // Expected output: 7
 
-console.log(1 + 2 * 3); // 1 + 6
+console.log(1 + (2 * 3)); // 1 + 6
 // Expected output: 7
 
 console.log((1 + 2) * 3); // 3 * 3

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -11,7 +11,7 @@ The **grouping `( )`** operator controls the precedence of evaluation in express
 
 {{InteractiveExample("JavaScript Demo: Grouping operator")}}
 
-```js interactive-example
+```js-nolint interactive-example
 console.log(1 + 2 * 3); // 1 + 6
 // Expected output: 7
 


### PR DESCRIPTION
### Description

Instead of having two identical lines in the example, add grouping parentheses to one of the code locations.
Thus make the interactive example more consistent with an example further down in the same page.

### Motivation

I think the duplicate code is not helpful to readers of this interactive example. 

### Additional details

I think the duplicate code may have been introduced by some automated formatting that removed unnecessary grouping. 

Not sure, if the proposed change will pass linting.
Would it help to use `js-nolint` instead of `js` for the changed code block?
Would `js-nolint` play nicely `interactive-example`?

### Related issues and pull requests

Not aware of any. Since this is a minor/cosmetic change, I have not raised a corresponding issue yet.
