### PR TITLE
fix(breadcrumb): double reference in breadcrumbs

### DIFF
--- a/files/en-us/web/index.md
+++ b/files/en-us/web/index.md
@@ -1,5 +1,6 @@
 ---
 title: Web technology for developers
+short-title: Web
 slug: Web
 page-type: landing-page
 ---


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Adds a short title to the index of the web folder - this should be picked up and breadcrumbs will then read 'Web > Technology > Reference" instead of "Reference > Technology > Reference"

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
