### PR TITLE
Fix element name `marker` with `mask`

### DIFF
--- a/files/en-us/web/api/svgmaskelement/height/index.md
+++ b/files/en-us/web/api/svgmaskelement/height/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGMaskElement.height
 
 {{APIRef("SVG")}}
 
-The read-only **`height`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("height")}} attribute of the {{SVGElement("marker")}}.
+The read-only **`height`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("height")}} attribute of the {{SVGElement("mask")}}.
 
 > [!NOTE]
 > Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.

--- a/files/en-us/web/api/svgmaskelement/width/index.md
+++ b/files/en-us/web/api/svgmaskelement/width/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGMaskElement.width
 
 {{APIRef("SVG")}}
 
-The read-only **`width`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("width")}} attribute of the {{SVGElement("marker")}}.
+The read-only **`width`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("width")}} attribute of the {{SVGElement("mask")}}.
 
 > [!NOTE]
 > Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.

--- a/files/en-us/web/api/svgmaskelement/y/index.md
+++ b/files/en-us/web/api/svgmaskelement/y/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGMaskElement.y
 
 {{APIRef("SVG")}}
 
-The read-only **`y`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("y")}} attribute of the {{SVGElement("marker")}}. It represents the y-axis coordinate of the _top-left_ corner of the masking area.
+The read-only **`y`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("y")}} attribute of the {{SVGElement("mask")}}. It represents the y-axis coordinate of the _top-left_ corner of the masking area.
 
 > [!NOTE]
 > Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.


### PR DESCRIPTION
### Description

Fix element name `marker` with `mask` because the `SVGMaskElement` interface is `<mask>`'s, not `<marker>`'s.

### Motivation

To get correct information

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
