### PR TITLE
chore: Move JavaScript sidebar into front matter

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -309,6 +309,7 @@ jsapi.h
 jscript
 jsdouble
 jspubtd.h
+jssidebar
 jsval
 kaios
 kawi

--- a/files/en-us/web/javascript/guide/closures/index.md
+++ b/files/en-us/web/javascript/guide/closures/index.md
@@ -2,9 +2,8 @@
 title: Closures
 slug: Web/JavaScript/Guide/Closures
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Intermediate")}}
 
 A **closure** is the combination of a function bundled together (enclosed) with references to its surrounding state (the **lexical environment**). In other words, a closure gives a function access to its outer scope. In JavaScript, closures are created every time a function is created, at function creation time.
 

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -2,9 +2,9 @@
 title: Control flow and error handling
 slug: Web/JavaScript/Guide/Control_flow_and_error_handling
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}}
 {{PreviousNext("Web/JavaScript/Guide/Grammar_and_types", "Web/JavaScript/Guide/Loops_and_iteration")}}
 
 JavaScript supports a compact set of statements, specifically

--- a/files/en-us/web/javascript/guide/data_structures/index.md
+++ b/files/en-us/web/javascript/guide/data_structures/index.md
@@ -2,9 +2,8 @@
 title: JavaScript data types and data structures
 slug: Web/JavaScript/Guide/Data_structures
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 Programming languages all have built-in data structures, but these often differ from one language to another. This article attempts to list the built-in data structures available in JavaScript and what properties they have. These can be used to build other data structures.
 

--- a/files/en-us/web/javascript/guide/enumerability_and_ownership_of_properties/index.md
+++ b/files/en-us/web/javascript/guide/enumerability_and_ownership_of_properties/index.md
@@ -2,9 +2,8 @@
 title: Enumerability and ownership of properties
 slug: Web/JavaScript/Guide/Enumerability_and_ownership_of_properties
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 Every property in JavaScript objects can be classified by three factors:
 

--- a/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
@@ -2,9 +2,8 @@
 title: Equality comparisons and sameness
 slug: Web/JavaScript/Guide/Equality_comparisons_and_sameness
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Intermediate")}}
 
 JavaScript provides three different value-comparison operations:
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -2,9 +2,10 @@
 title: Expressions and operators
 slug: Web/JavaScript/Guide/Expressions_and_operators
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_strings")}}
+{{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_strings")}}
 
 This chapter describes JavaScript's expressions and operators, including assignment, comparison, arithmetic, bitwise, logical, string, ternary and more.
 

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -2,9 +2,10 @@
 title: Functions
 slug: Web/JavaScript/Guide/Functions
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_operators")}}
+{{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_operators")}}
 
 Functions are one of the fundamental building blocks in JavaScript. A function in JavaScript is similar to a procedure—a set of statements that performs a task or calculates a value, but for a procedure to qualify as a function, it should take some input and return an output where there is some obvious relationship between the input and the output. To use a function, you must define it somewhere in the scope from which you wish to call it.
 

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -2,9 +2,10 @@
 title: Grammar and types
 slug: Web/JavaScript/Guide/Grammar_and_types
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Introduction", "Web/JavaScript/Guide/Control_flow_and_error_handling")}}
+{{PreviousNext("Web/JavaScript/Guide/Introduction", "Web/JavaScript/Guide/Control_flow_and_error_handling")}}
 
 This chapter discusses JavaScript's basic grammar, variable declarations, data types and literals.
 

--- a/files/en-us/web/javascript/guide/index.md
+++ b/files/en-us/web/javascript/guide/index.md
@@ -2,9 +2,8 @@
 title: JavaScript Guide
 slug: Web/JavaScript/Guide
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("JavaScript Guide")}}
 
 The JavaScript Guide shows you how to use [JavaScript](/en-US/docs/Web/JavaScript) and gives an overview of the language. If you need exhaustive information about a language feature, have a look at the [JavaScript reference](/en-US/docs/Web/JavaScript/Reference).
 

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -2,9 +2,10 @@
 title: Indexed collections
 slug: Web/JavaScript/Guide/Indexed_collections
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Regular_expressions", "Web/JavaScript/Guide/Keyed_collections")}}
+{{PreviousNext("Web/JavaScript/Guide/Regular_expressions", "Web/JavaScript/Guide/Keyed_collections")}}
 
 This chapter introduces collections of data which are ordered by an index value. This includes arrays and array-like constructs such as {{jsxref("Array")}} objects and {{jsxref("TypedArray")}} objects.
 

--- a/files/en-us/web/javascript/guide/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/guide/inheritance_and_the_prototype_chain/index.md
@@ -2,9 +2,8 @@
 title: Inheritance and the prototype chain
 slug: Web/JavaScript/Guide/Inheritance_and_the_prototype_chain
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Advanced")}}
 
 In programming, _inheritance_ refers to passing down characteristics from a parent to a child so that a new piece of code can reuse and build upon the features of an existing one. JavaScript implements inheritance by using [objects](/en-US/docs/Web/JavaScript/Guide/Data_structures#objects). Each object has an internal link to another object called its _prototype_. That prototype object has a prototype of its own, and so on until an object is reached with `null` as its prototype. By definition, `null` has no prototype and acts as the final link in this **prototype chain**. It is possible to mutate any member of the prototype chain or even swap out the prototype at runtime, so concepts like [static dispatching](https://en.wikipedia.org/wiki/Static_dispatch) do not exist in JavaScript.
 

--- a/files/en-us/web/javascript/guide/internationalization/index.md
+++ b/files/en-us/web/javascript/guide/internationalization/index.md
@@ -2,9 +2,10 @@
 title: Internationalization
 slug: Web/JavaScript/Guide/Internationalization
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Iterators_and_generators", "Web/JavaScript/Guide/Modules")}}
+{{PreviousNext("Web/JavaScript/Guide/Iterators_and_generators", "Web/JavaScript/Guide/Modules")}}
 
 The {{jsxref("Intl")}} object is the namespace for the ECMAScript Internationalization API, which provides a wide range of locale- and culture-sensitive data and operations.
 

--- a/files/en-us/web/javascript/guide/introduction/index.md
+++ b/files/en-us/web/javascript/guide/introduction/index.md
@@ -2,9 +2,10 @@
 title: Introduction
 slug: Web/JavaScript/Guide/Introduction
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide", "Web/JavaScript/Guide/Grammar_and_types")}}
+{{PreviousNext("Web/JavaScript/Guide", "Web/JavaScript/Guide/Grammar_and_types")}}
 
 This chapter introduces JavaScript and discusses some of its fundamental concepts.
 

--- a/files/en-us/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/en-us/web/javascript/guide/iterators_and_generators/index.md
@@ -2,9 +2,10 @@
 title: Iterators and generators
 slug: Web/JavaScript/Guide/Iterators_and_generators
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Typed_arrays", "Web/JavaScript/Guide/Internationalization")}}
+{{PreviousNext("Web/JavaScript/Guide/Typed_arrays", "Web/JavaScript/Guide/Internationalization")}}
 
 Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of {{jsxref("Statements/for...of", "for...of")}} loops.
 

--- a/files/en-us/web/javascript/guide/keyed_collections/index.md
+++ b/files/en-us/web/javascript/guide/keyed_collections/index.md
@@ -2,9 +2,10 @@
 title: Keyed collections
 slug: Web/JavaScript/Guide/Keyed_collections
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Indexed_collections", "Web/JavaScript/Guide/Working_with_objects")}}
+{{PreviousNext("Web/JavaScript/Guide/Indexed_collections", "Web/JavaScript/Guide/Working_with_objects")}}
 
 This chapter introduces collections of data which are indexed by a key; `Map` and `Set` objects contain elements which are iterable in the order of insertion.
 

--- a/files/en-us/web/javascript/guide/language_overview/index.md
+++ b/files/en-us/web/javascript/guide/language_overview/index.md
@@ -2,9 +2,8 @@
 title: JavaScript language overview
 slug: Web/JavaScript/Guide/Language_overview
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 JavaScript is a multi-paradigm, dynamic language with types and operators, standard built-in objects, and methods. Its syntax is based on the Java and C languages — many structures from those languages apply to JavaScript as well. JavaScript supports object-oriented programming with [object prototypes](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain) and classes. It also supports functional programming since functions are [first-class](/en-US/docs/Glossary/First-class_Function) objects that can be easily created via expressions and passed around like any other object.
 

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -2,9 +2,9 @@
 title: Loops and iteration
 slug: Web/JavaScript/Guide/Loops_and_iteration
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}}
 {{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling", "Web/JavaScript/Guide/Functions")}}
 
 Loops offer a quick and easy way to do something repeatedly. This

--- a/files/en-us/web/javascript/guide/memory_management/index.md
+++ b/files/en-us/web/javascript/guide/memory_management/index.md
@@ -2,9 +2,8 @@
 title: Memory management
 slug: Web/JavaScript/Guide/Memory_management
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Advanced")}}
 
 Low-level languages like C, have manual memory management primitives such as [`malloc()`](https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html) and [`free()`](https://en.wikipedia.org/wiki/C_dynamic_memory_allocation#Overview_of_functions). In contrast, JavaScript automatically allocates memory when objects are created and frees it when they are not used anymore (_garbage collection_). This automaticity is a potential source of confusion: it can give developers the false impression that they don't need to worry about memory management.
 

--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -2,9 +2,8 @@
 title: Meta programming
 slug: Web/JavaScript/Guide/Meta_programming
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Advanced")}}
 
 The {{jsxref("Proxy")}} and {{jsxref("Reflect")}} objects allow you to intercept and define custom behavior for fundamental language operations (e.g., property lookup, assignment, enumeration, function invocation, etc.). With the help of these two objects you are able to program at the meta level of JavaScript.
 

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -2,9 +2,10 @@
 title: JavaScript modules
 slug: Web/JavaScript/Guide/Modules
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Internationalization")}}
+{{Previous("Web/JavaScript/Guide/Internationalization")}}
 
 This guide gives you all you need to get started with JavaScript module syntax.
 

--- a/files/en-us/web/javascript/guide/numbers_and_strings/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_strings/index.md
@@ -2,9 +2,10 @@
 title: Numbers and strings
 slug: Web/JavaScript/Guide/Numbers_and_strings
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Expressions_and_operators", "Web/JavaScript/Guide/Representing_dates_times")}}
+{{PreviousNext("Web/JavaScript/Guide/Expressions_and_operators", "Web/JavaScript/Guide/Representing_dates_times")}}
 
 This chapter introduces the two most fundamental data types in JavaScript: numbers and strings. We will introduce their underlying representations, and functions used to work with and perform calculations on them.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/assertions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/assertions/index.md
@@ -2,9 +2,8 @@
 title: Assertions
 slug: Web/JavaScript/Guide/Regular_expressions/Assertions
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("JavaScript Guide")}}
 
 Assertions include boundaries, which indicate the beginnings and endings of lines and words, and other patterns indicating in some way that a match is possible (including look-ahead, look-behind, and conditional expressions).
 

--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -2,9 +2,8 @@
 title: Character classes
 slug: Web/JavaScript/Guide/Regular_expressions/Character_classes
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("JavaScript Guide")}}
 
 Character classes distinguish kinds of characters such as, for example, distinguishing between letters and digits.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -2,9 +2,8 @@
 title: Regular expression syntax cheat sheet
 slug: Web/JavaScript/Guide/Regular_expressions/Cheatsheet
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("JavaScript Guide")}}
 
 This page provides an overall cheat sheet of all the capabilities of `RegExp` syntax by aggregating the content of the articles in the `RegExp` guide. If you need more information on a specific topic, please follow the link on the corresponding heading to access the full article or head to [the guide](/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
 

--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -2,9 +2,8 @@
 title: Groups and backreferences
 slug: Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("JavaScript Guide")}}
 
 Groups group multiple patterns as a whole, and capturing groups provide extra submatch information when using a regular expression pattern to match against a string. Backreferences refer to a previously captured group in the same regular expression.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -2,9 +2,10 @@
 title: Regular expressions
 slug: Web/JavaScript/Guide/Regular_expressions
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Representing_dates_times", "Web/JavaScript/Guide/Indexed_collections")}}
+{{PreviousNext("Web/JavaScript/Guide/Representing_dates_times", "Web/JavaScript/Guide/Indexed_collections")}}
 
 Regular expressions are patterns used to match character combinations in strings.
 In JavaScript, regular expressions are also objects. These patterns are used with the {{jsxref("RegExp/exec", "exec()")}} and {{jsxref("RegExp/test", "test()")}} methods of {{jsxref("RegExp")}}, and with the {{jsxref("String/match", "match()")}}, {{jsxref("String/matchAll", "matchAll()")}}, {{jsxref("String/replace", "replace()")}}, {{jsxref("String/replaceAll", "replaceAll()")}}, {{jsxref("String/search", "search()")}}, and {{jsxref("String/split", "split()")}} methods of {{jsxref("String")}}.

--- a/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -2,9 +2,8 @@
 title: Quantifiers
 slug: Web/JavaScript/Guide/Regular_expressions/Quantifiers
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("JavaScript Guide")}}
 
 Quantifiers indicate numbers of characters or expressions to match.
 

--- a/files/en-us/web/javascript/guide/representing_dates_times/index.md
+++ b/files/en-us/web/javascript/guide/representing_dates_times/index.md
@@ -2,9 +2,10 @@
 title: Representing dates & times
 slug: Web/JavaScript/Guide/Representing_dates_times
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Numbers_and_strings", "Web/JavaScript/Guide/Regular_expressions")}}
+{{PreviousNext("Web/JavaScript/Guide/Numbers_and_strings", "Web/JavaScript/Guide/Regular_expressions")}}
 
 > [!NOTE]
 > The `Date` object is now considered legacy and should be avoided in new code. We will update this page with modern alternatives soon.

--- a/files/en-us/web/javascript/guide/typed_arrays/index.md
+++ b/files/en-us/web/javascript/guide/typed_arrays/index.md
@@ -2,9 +2,10 @@
 title: JavaScript typed arrays
 slug: Web/JavaScript/Guide/Typed_arrays
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Using_promises", "Web/JavaScript/Guide/Iterators_and_generators")}}
+{{PreviousNext("Web/JavaScript/Guide/Using_promises", "Web/JavaScript/Guide/Iterators_and_generators")}}
 
 JavaScript typed arrays are array-like objects that provide a mechanism for reading and writing raw binary data in memory buffers.
 

--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -2,9 +2,10 @@
 title: Using classes
 slug: Web/JavaScript/Guide/Using_classes
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Working_with_objects", "Web/JavaScript/Guide/Using_promises")}}
+{{PreviousNext("Web/JavaScript/Guide/Working_with_objects", "Web/JavaScript/Guide/Using_promises")}}
 
 JavaScript is a prototype-based language — an object's behaviors are specified by its own properties and its prototype's properties. However, with the addition of [classes](/en-US/docs/Web/JavaScript/Reference/Classes), the creation of hierarchies of objects and the inheritance of properties and their values are much more in line with other object-oriented languages such as Java. In this section, we will demonstrate how objects can be created from classes.
 

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -2,9 +2,10 @@
 title: Using promises
 slug: Web/JavaScript/Guide/Using_promises
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Using_classes", "Web/JavaScript/Guide/Typed_arrays")}}
+{{PreviousNext("Web/JavaScript/Guide/Using_classes", "Web/JavaScript/Guide/Typed_arrays")}}
 
 A {{jsxref("Promise")}} is an object representing the eventual completion or failure of an asynchronous operation. Since most people are consumers of already-created promises, this guide will explain consumption of returned promises before explaining how to create them.
 

--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -2,9 +2,10 @@
 title: Working with objects
 slug: Web/JavaScript/Guide/Working_with_objects
 page-type: guide
+sidebar: jssidebar
 ---
 
-{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Keyed_collections", "Web/JavaScript/Guide/Using_classes")}}
+{{PreviousNext("Web/JavaScript/Guide/Keyed_collections", "Web/JavaScript/Guide/Using_classes")}}
 
 JavaScript is designed on an object-based paradigm. An object is a collection of [properties](/en-US/docs/Glossary/Property/JavaScript), and a property is an association between a name (or _key_) and a value. A property's value can be a function, in which case the property is known as a [method](/en-US/docs/Glossary/Method).
 

--- a/files/en-us/web/javascript/index.md
+++ b/files/en-us/web/javascript/index.md
@@ -2,9 +2,8 @@
 title: JavaScript
 slug: Web/JavaScript
 page-type: landing-page
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 **JavaScript** (**JS**) is a lightweight interpreted (or {{Glossary("Just_In_Time_Compilation", "just-in-time compiled")}}) programming language with {{Glossary("First-class Function", "first-class functions")}}. While it is most well-known as the scripting language for Web pages, [many non-browser environments](https://en.wikipedia.org/wiki/JavaScript#Other_usage) also use it, such as {{Glossary("Node.js")}}, [Apache CouchDB](https://couchdb.apache.org/) and [Adobe Acrobat](https://opensource.adobe.com/dc-acrobat-sdk-docs/acrobatsdk/). JavaScript is a [prototype-based](/en-US/docs/Glossary/Prototype-based_programming), [garbage-collected](/en-US/docs/Glossary/Garbage_collection), [dynamic](/en-US/docs/Glossary/Dynamic_typing) language, supporting multiple paradigms such as imperative, functional, and object-oriented.
 

--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -3,9 +3,8 @@ title: constructor
 slug: Web/JavaScript/Reference/Classes/constructor
 page-type: javascript-language-feature
 browser-compat: javascript.classes.constructor
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 The **`constructor`** method is a special method of a [class](/en-US/docs/Web/JavaScript/Reference/Classes) for creating and initializing an object instance of that class.
 

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -3,9 +3,8 @@ title: extends
 slug: Web/JavaScript/Reference/Classes/extends
 page-type: javascript-language-feature
 browser-compat: javascript.classes.extends
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 The **`extends`** keyword is used in [class declarations](/en-US/docs/Web/JavaScript/Reference/Statements/class) or [class expressions](/en-US/docs/Web/JavaScript/Reference/Operators/class) to create a class that is a child of another class.
 

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -3,9 +3,8 @@ title: Classes
 slug: Web/JavaScript/Reference/Classes
 page-type: guide
 browser-compat: javascript.classes
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on [prototypes](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain) but also have some syntax and semantics that are unique to classes.
 

--- a/files/en-us/web/javascript/reference/classes/private_elements/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_elements/index.md
@@ -6,9 +6,8 @@ browser-compat:
   - javascript.classes.private_class_fields
   - javascript.classes.private_class_fields_in
   - javascript.classes.private_class_methods
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 **Private elements** are counterparts of the regular class elements which are public, including [class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields), class methods, etc. Private elements get created by using a hash `#` prefix and cannot be legally referenced outside of the class. The privacy encapsulation of these class elements is enforced by JavaScript itself. The only way to access a private element is via [dot notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#dot_notation), and you can only do so within the class that defines the private element.
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -3,9 +3,8 @@ title: Public class fields
 slug: Web/JavaScript/Reference/Classes/Public_class_fields
 page-type: javascript-language-feature
 browser-compat: javascript.classes.public_class_fields
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 **Public fields** are writable, enumerable, and configurable properties defined on each class instance or class constructor.
 

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -3,9 +3,8 @@ title: static
 slug: Web/JavaScript/Reference/Classes/static
 page-type: javascript-language-feature
 browser-compat: javascript.classes.static
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 The **`static`** keyword defines a [static method or field](/en-US/docs/Web/JavaScript/Reference/Classes#static_methods_and_fields) for a class, or a [static initialization block](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) (see the link for more information about this usage). Static properties cannot be directly accessed on instances of the class. Instead, they're accessed on the class itself.
 

--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -3,9 +3,8 @@ title: Static initialization blocks
 slug: Web/JavaScript/Reference/Classes/Static_initialization_blocks
 page-type: javascript-language-feature
 browser-compat: javascript.classes.static_initialization_blocks
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Classes")}}
 
 **Static initialization blocks** are declared within a {{jsxref("Statements/class", "class")}}. It contains statements to be evaluated during class initialization. This permits more flexible initialization logic than {{jsxref("Classes/static", "static")}} properties, such as using `try...catch` or setting multiple fields from a single value. Initialization is performed in the context of the current class declaration, with access to private state, which allows the class to share information of its private elements with other classes or functions declared in the same scope (analogous to "friend" classes in C++).
 

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -2,9 +2,8 @@
 title: Deprecated and obsolete features
 slug: Web/JavaScript/Reference/Deprecated_and_obsolete_features
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 This page lists features of JavaScript that are deprecated (that is, still available but planned for removal) and obsolete (that is, no longer usable).
 

--- a/files/en-us/web/javascript/reference/errors/already_executing_generator/index.md
+++ b/files/en-us/web/javascript/reference/errors/already_executing_generator/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: already executing generator"
 slug: Web/JavaScript/Reference/Errors/Already_executing_generator
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "TypeError: already executing generator" occurs when a [generator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) is continued using one of its methods (such as {{jsxref("Generator/next", "next()")}}) while executing the generator function's body itself.
 

--- a/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
@@ -2,9 +2,8 @@
 title: "Warning: -file- is being assigned a //# sourceMappingURL, but already has one"
 slug: Web/JavaScript/Reference/Errors/Already_has_pragma
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript warning "-file- is being assigned a //# sourceMappingURL, but already has one." occurs when a source map has been specified more than once for a given JavaScript source.
 

--- a/files/en-us/web/javascript/reference/errors/arguments_not_allowed/index.md
+++ b/files/en-us/web/javascript/reference/errors/arguments_not_allowed/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: arguments is not valid in fields"
 slug: Web/JavaScript/Reference/Errors/Arguments_not_allowed
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "SyntaxError: arguments is not valid in fields" occurs when the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) identifier is read in a class field initializer or in a static initialization block, outside of a non-[arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 

--- a/files/en-us/web/javascript/reference/errors/array_sort_argument/index.md
+++ b/files/en-us/web/javascript/reference/errors/array_sort_argument/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: invalid Array.prototype.sort argument"
 slug: Web/JavaScript/Reference/Errors/Array_sort_argument
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid Array.prototype.sort argument" occurs when the argument of {{jsxref("Array.prototype.sort()")}} (and its related methods: {{jsxref("Array.prototype.toSorted()")}}, {{jsxref("TypedArray.prototype.sort()")}}, {{jsxref("TypedArray.prototype.toSorted()")}}) isn't either {{jsxref("undefined")}} or a function which compares its operands.
 

--- a/files/en-us/web/javascript/reference/errors/await_yield_in_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/await_yield_in_parameter/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: await/yield expression can't be used in parameter"
 slug: Web/JavaScript/Reference/Errors/await_yield_in_parameter
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "await expression can't be used in parameter" or "yield expression can't be used in parameter" occurs when the [default parameter](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) expression contains the {{jsxref("Operators/await", "await")}} or {{jsxref("Operators/yield", "yield")}} keyword and has the effect of pausing default parameter evaluation.
 

--- a/files/en-us/web/javascript/reference/errors/bad_await/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_await/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: await is only valid in async functions, async generators and modules"
 slug: Web/JavaScript/Reference/Errors/Bad_await
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "await is only valid in async functions, async generators and modules" occurs when an {{jsxref("Operators/await", "await")}} expression is used outside of [async functions](/en-US/docs/Web/JavaScript/Reference/Statements/async_function) or [modules](/en-US/docs/Web/JavaScript/Guide/Modules) or other async contexts.
 

--- a/files/en-us/web/javascript/reference/errors/bad_break/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_break/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: unlabeled break must be inside loop or switch"
 slug: Web/JavaScript/Reference/Errors/Bad_break
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "unlabeled break must be inside loop or switch" occurs when a {{jsxref("Statements/break", "break")}} statement is not inside a loop or a {{jsxref("Statements/switch", "switch")}} statement.
 

--- a/files/en-us/web/javascript/reference/errors/bad_continue/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_continue/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: continue must be inside loop"
 slug: Web/JavaScript/Reference/Errors/Bad_continue
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "continue must be inside loop" occurs when a {{jsxref("Statements/continue", "continue")}} statement is not inside a loop statement.
 

--- a/files/en-us/web/javascript/reference/errors/bad_new_optional/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_new_optional/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: new keyword cannot be used with an optional chain"
 slug: Web/JavaScript/Reference/Errors/Bad_new_optional
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "new keyword cannot be used with an optional chain" occurs when the constructor of a {{jsxref("Operators/new", "new")}} expression is an [optional chain](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), or if there's an optional chain between the constructor and the parenthesized list of arguments.
 

--- a/files/en-us/web/javascript/reference/errors/bad_optional_template/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_optional_template/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: tagged template cannot be used with optional chain"
 slug: Web/JavaScript/Reference/Errors/Bad_optional_template
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "tagged template cannot be used with optional chain" occurs when the tag expression of a [tagged template literal](/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) is an [optional chain](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), or if there's an optional chain between the tag and the template.
 

--- a/files/en-us/web/javascript/reference/errors/bad_radix/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_radix/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: radix must be an integer"
 slug: Web/JavaScript/Reference/Errors/Bad_radix
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "radix must be an integer at least 2 and no greater than 36"
 occurs when the optional `radix` parameter of the

--- a/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
@@ -2,9 +2,8 @@
 title: 'SyntaxError: invalid regular expression flag "x"'
 slug: Web/JavaScript/Reference/Errors/Bad_regexp_flag
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid regular expression flag" occurs when the flags in a regular expression contain any flag that is not one of: `d`, `g`, `i`, `m`, `s`, `u`, `v`, or `y`. It may also be raised if the expression contains more than one instance of a valid flag, or when the [`u`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode) and [`v`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) flags are used together.
 

--- a/files/en-us/web/javascript/reference/errors/bad_return/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_return/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: return not in function"
 slug: Web/JavaScript/Reference/Errors/Bad_return
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "return not in function" occurs when a [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) statement is called outside of a [function](/en-US/docs/Web/JavaScript/Guide/Functions).
 

--- a/files/en-us/web/javascript/reference/errors/bad_strict_arguments_eval/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_strict_arguments_eval/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: 'arguments'/'eval' can't be defined or assigned to in strict mode code"
 slug: Web/JavaScript/Reference/Errors/Bad_strict_arguments_eval
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception "'arguments' can't be defined or assigned to in strict mode code" or "'eval' can't be defined or assigned to in strict mode code" occurs when attempting to create a {{Glossary("binding")}} called `arguments` or `eval`, or assign to such a name.
 

--- a/files/en-us/web/javascript/reference/errors/bad_super_call/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_super_call/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: super() is only valid in derived class constructors"
 slug: Web/JavaScript/Reference/Errors/Bad_super_call
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "super() is only valid in derived class constructors" occurs when the {{jsxref("Operators/super", "super()")}} call is used somewhere that's not the body of a [constructor](/en-US/docs/Web/JavaScript/Reference/Classes/constructor) in a class with [`extends`](/en-US/docs/Web/JavaScript/Reference/Classes/extends) keyword.
 

--- a/files/en-us/web/javascript/reference/errors/bad_super_prop/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_super_prop/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: use of super property/member accesses only valid within methods or eval code within methods"
 slug: Web/JavaScript/Reference/Errors/Bad_super_prop
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "use of super property/member accesses only valid within methods or eval code within methods" occurs when the {{jsxref("Operators/super", "super.x")}} or `super[x]` syntax is used outside of a [method](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions).
 

--- a/files/en-us/web/javascript/reference/errors/bigint_division_by_zero/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_division_by_zero/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: BigInt division by zero"
 slug: Web/JavaScript/Reference/Errors/BigInt_division_by_zero
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "BigInt division by zero" occurs when a {{jsxref("BigInt")}} is divided by `0n`.
 

--- a/files/en-us/web/javascript/reference/errors/bigint_negative_exponent/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_negative_exponent/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: BigInt negative exponent"
 slug: Web/JavaScript/Reference/Errors/BigInt_negative_exponent
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "BigInt negative exponent" occurs when a {{jsxref("BigInt")}} is raised to the power of a negative BigInt value.
 

--- a/files/en-us/web/javascript/reference/errors/bigint_not_serializable/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_not_serializable/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: BigInt value can't be serialized in JSON"
 slug: Web/JavaScript/Reference/Errors/BigInt_not_serializable
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "BigInt value can't be serialized in JSON" occurs when a {{jsxref("BigInt")}} is encountered in {{jsxref("JSON.stringify")}} with no custom serialization method provided.
 

--- a/files/en-us/web/javascript/reference/errors/builtin_ctor_no_new/index.md
+++ b/files/en-us/web/javascript/reference/errors/builtin_ctor_no_new/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: calling a builtin X constructor without new is forbidden"
 slug: Web/JavaScript/Reference/Errors/Builtin_ctor_no_new
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "calling a builtin X constructor without new is forbidden" occurs when you try to call a builtin constructor without using the {{jsxref("Operators/new", "new")}} keyword. All modern constructors, such as {{jsxref("Promise")}} and {{jsxref("Map")}}, must be called with `new`.
 

--- a/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: X.prototype.y called on incompatible type"
 slug: Web/JavaScript/Reference/Errors/Called_on_incompatible_type
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "called on incompatible target (or object)" occurs when a
 function (on a given object), is called with a `this` not corresponding to

--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -2,9 +2,8 @@
 title: "ReferenceError: can't access lexical declaration 'X' before initialization"
 slug: Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't access lexical declaration 'X' before initialization" occurs when a lexical variable was accessed before it was initialized.
 This happens within any scope (global, module, function, or block) when [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) variables are accessed before the place where they are declared is executed.

--- a/files/en-us/web/javascript/reference/errors/cant_assign_to_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_assign_to_property/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: can''t assign to property "x" on "y": not an object'
 slug: Web/JavaScript/Reference/Errors/Cant_assign_to_property
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript strict mode exception "can't assign to property" occurs when attempting
 to create a property on [primitive](/en-US/docs/Glossary/Primitive) value

--- a/files/en-us/web/javascript/reference/errors/cant_be_converted_to_bigint_because_it_isnt_an_integer/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_be_converted_to_bigint_because_it_isnt_an_integer/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: x can't be converted to BigInt because it isn't an integer"
 slug: Web/JavaScript/Reference/Errors/Cant_be_converted_to_BigInt_because_it_isnt_an_integer
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "x can't be converted to BigInt because it isn't an integer" occurs when the [`BigInt()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt) function is used on a number that isn't an integer.
 

--- a/files/en-us/web/javascript/reference/errors/cant_convert_bigint_to_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_bigint_to_number/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: can't convert BigInt to number"
 slug: Web/JavaScript/Reference/Errors/Cant_convert_BigInt_to_number
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't convert BigInt to number" occurs when an arithmetic operation involves a mix of {{jsxref("BigInt")}} and {{jsxref("Number")}} values.
 

--- a/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: can't convert x to BigInt"
 slug: Web/JavaScript/Reference/Errors/Cant_convert_x_to_BigInt
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "x can't be converted to BigInt" occurs when attempting to convert a {{jsxref("Symbol")}}, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), or {{jsxref("undefined")}} value to a {{jsxref("BigInt")}}, or if an operation expecting a BigInt parameter receives a number.
 

--- a/files/en-us/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: can''t define property "x": "obj" is not extensible'
 slug: Web/JavaScript/Reference/Errors/Cant_define_property_object_not_extensible
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't define property "x": "obj" is not extensible" occurs
 when {{jsxref("Object.preventExtensions()")}} marked an object as no longer extensible,

--- a/files/en-us/web/javascript/reference/errors/cant_delete/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_delete/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: property "x" is non-configurable and can''t be deleted'
 slug: Web/JavaScript/Reference/Errors/Cant_delete
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "property is non-configurable and can't be deleted" occurs
 when it was attempted to delete a property, but that property is [non-configurable](/en-US/docs/Web/JavaScript/Guide/Data_structures#properties).

--- a/files/en-us/web/javascript/reference/errors/cant_delete_private_fields/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_delete_private_fields/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: private fields can't be deleted"
 slug: Web/JavaScript/Reference/Errors/Cant_delete_private_fields
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "SyntaxError: private fields can't be deleted" occurs when [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete) is used on a [private element](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements) of a class or an object.
 

--- a/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: can''t redefine non-configurable property "x"'
 slug: Web/JavaScript/Reference/Errors/Cant_redefine_property
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't redefine non-configurable property" occurs when it was
 attempted to redefine a property, but that property is [non-configurable](/en-US/docs/Web/JavaScript/Guide/Data_structures#properties).

--- a/files/en-us/web/javascript/reference/errors/cant_set_prototype/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_set_prototype/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: can't set prototype of this object"
 slug: Web/JavaScript/Reference/Errors/Cant_set_prototype
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't set prototype of this object" occurs when attempting to set the prototype of an object, but the object's prototype is frozen, either by being a built-in immutable prototype object, or by being [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible).
 

--- a/files/en-us/web/javascript/reference/errors/cant_use_nullish_coalescing_unparenthesized/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_use_nullish_coalescing_unparenthesized/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: cannot use `??` unparenthesized within `||` and `&&` expressions"
 slug: Web/JavaScript/Reference/Errors/Cant_use_nullish_coalescing_unparenthesized
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "cannot use `??` unparenthesized within `||` and `&&` expressions" occurs when an [nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) is used with a [logical OR](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR) or [logical AND](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) in the same expression without parentheses.
 

--- a/files/en-us/web/javascript/reference/errors/class_ctor_no_new/index.md
+++ b/files/en-us/web/javascript/reference/errors/class_ctor_no_new/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: class constructors must be invoked with 'new'"
 slug: Web/JavaScript/Reference/Errors/Class_ctor_no_new
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "class constructors must be invoked with 'new'" occurs when a [class constructor](/en-US/docs/Web/JavaScript/Reference/Classes) is called without the {{jsxref("Operators/new", "new")}} keyword. All class constructors must be called with `new`.
 

--- a/files/en-us/web/javascript/reference/errors/constructor_cant_be_used_directly/index.md
+++ b/files/en-us/web/javascript/reference/errors/constructor_cant_be_used_directly/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: Iterator/AsyncIterator constructor can't be used directly"
 slug: Web/JavaScript/Reference/Errors/Constructor_cant_be_used_directly
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "Iterator constructor can't be used directly" or "AsyncIterator constructor can't be used directly" occurs when you try to use the {{jsxref("Iterator/Iterator", "Iterator()")}} or {{jsxref("AsyncIterator/AsyncIterator", "AsyncIterator()")}} constructors directly to create instances. These constructors are _abstract classes_ and should only be inherited from.
 

--- a/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: cyclic object value"
 slug: Web/JavaScript/Reference/Errors/Cyclic_object_value
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "cyclic object value" occurs when object references were found
 in [JSON](https://www.json.org/). {{jsxref("JSON.stringify()")}} doesn't try

--- a/files/en-us/web/javascript/reference/errors/cyclic_prototype/index.md
+++ b/files/en-us/web/javascript/reference/errors/cyclic_prototype/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: can't set prototype: it would cause a prototype chain cycle"
 slug: Web/JavaScript/Reference/Errors/Cyclic_prototype
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "TypeError: can't set prototype: it would cause a prototype chain cycle" occurs when an object's prototype is set to an object such that the [prototype chain](/en-US/docs/Learn_web_development/Extensions/Advanced_JavaScript_objects/Object_prototypes#the_prototype_chain) becomes circular (`a` and `b` both have each other in their prototype chains).
 

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: applying the 'delete' operator to an unqualified name is deprecated"
 slug: Web/JavaScript/Reference/Errors/Delete_in_strict_mode
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception "applying the 'delete' operator to an unqualified name is deprecated" occurs when variables are attempted to be deleted using the [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete) operator.
 

--- a/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed"
 slug: Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception
 "'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them" occurs when the

--- a/files/en-us/web/javascript/reference/errors/deprecated_octal_escape_sequence/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_octal_escape_sequence/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: octal escape sequences can't be used in untagged template literals or in strict mode code"
 slug: Web/JavaScript/Reference/Errors/Deprecated_octal_escape_sequence
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "octal escape sequences can't be used in untagged template literals or in strict mode code" occurs when octal escape sequences are used in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) string literals or untagged template literals.
 

--- a/files/en-us/web/javascript/reference/errors/deprecated_octal_literal/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_octal_literal/index.md
@@ -2,9 +2,8 @@
 title: 'SyntaxError: "0"-prefixed octal literals are deprecated'
 slug: Web/JavaScript/Reference/Errors/Deprecated_octal_literal
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception "0-prefixed octal literals are deprecated; use the "0o" prefix instead" occurs when deprecated octal literals (`0` followed by digits) are used.
 

--- a/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //# instead"
 slug: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript warning "Using `//@` to indicate sourceURL pragmas is deprecated. Use `//#` instead" occurs when there is a deprecated source map syntax in a JavaScript source.
 

--- a/files/en-us/web/javascript/reference/errors/duplicate_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/duplicate_parameter/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: duplicate formal argument x"
 slug: Web/JavaScript/Reference/Errors/Duplicate_parameter
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "duplicate formal argument x" or "duplicate argument names not allowed in this context" occurs when a function creates two or more parameter {{Glossary("binding", "bindings")}} with the same name, and the function is not a [non-strict](/en-US/docs/Web/JavaScript/Reference/Strict_mode) function with only simple parameters.
 

--- a/files/en-us/web/javascript/reference/errors/duplicate_proto/index.md
+++ b/files/en-us/web/javascript/reference/errors/duplicate_proto/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: property name __proto__ appears more than once in object literal"
 slug: Web/JavaScript/Reference/Errors/Duplicate_proto
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "property name \_\_proto\_\_ appears more than once in object literal" occurs when an [object literal](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) contains multiple occurrences of the `__proto__` field, which is used to [set the prototype of this new object](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#prototype_setter).
 

--- a/files/en-us/web/javascript/reference/errors/either_be_both_static_or_non-static/index.md
+++ b/files/en-us/web/javascript/reference/errors/either_be_both_static_or_non-static/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: getter and setter for private name #x should either be both static or non-static"
 slug: Web/JavaScript/Reference/Errors/Either_be_both_static_or_non-static
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "mismatched placement" occurs when a private [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get) and [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set) are mismatched in whether or not they are {{jsxref("Classes/static", "static")}}.
 

--- a/files/en-us/web/javascript/reference/errors/form_must_be_one_of/index.md
+++ b/files/en-us/web/javascript/reference/errors/form_must_be_one_of/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: form must be one of 'NFC', 'NFD', 'NFKC', or 'NFKD'"
 slug: Web/JavaScript/Reference/Errors/Form_must_be_one_of
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "form must be one of 'NFC', 'NFD', 'NFKC', or 'NFKD'" occurs when an unrecognized string is passed to the {{jsxref("String.prototype.normalize()")}} method.
 

--- a/files/en-us/web/javascript/reference/errors/function_label/index.md
+++ b/files/en-us/web/javascript/reference/errors/function_label/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: functions cannot be labelled"
 slug: Web/JavaScript/Reference/Errors/Function_label
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "functions cannot be labelled" occurs when a {{jsxref("Statements/function", "function")}} declaration has a [label](/en-US/docs/Web/JavaScript/Reference/Statements/label) before it.
 

--- a/files/en-us/web/javascript/reference/errors/get_set_missing_private/index.md
+++ b/files/en-us/web/javascript/reference/errors/get_set_missing_private/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: can't access/set private field or method: object is not the right class"
 slug: Web/JavaScript/Reference/Errors/Get_set_missing_private
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't access private field or method: object is not the right class" or "can't set private field: object is not the right class" occurs when a private field or method is get or set on an object that does not have this [private element](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements) defined.
 

--- a/files/en-us/web/javascript/reference/errors/getter_no_arguments/index.md
+++ b/files/en-us/web/javascript/reference/errors/getter_no_arguments/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: getter functions must have no arguments"
 slug: Web/JavaScript/Reference/Errors/Getter_no_arguments
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "getter functions must have no arguments" occurs when a [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get) is declared and the parameter list is non-empty.
 

--- a/files/en-us/web/javascript/reference/errors/getter_only/index.md
+++ b/files/en-us/web/javascript/reference/errors/getter_only/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: setting getter-only property "x"'
 slug: Web/JavaScript/Reference/Errors/Getter_only
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception "setting getter-only property" occurs when there is an attempt to set a new value to a property for which only a [getter](/en-US/docs/Web/JavaScript/Reference/Functions/get) is specified, or when setting a [private accessor property](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements) that similarly only has a getter defined.
 

--- a/files/en-us/web/javascript/reference/errors/hash_outside_class/index.md
+++ b/files/en-us/web/javascript/reference/errors/hash_outside_class/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: Unexpected '#' used outside of class body"
 slug: Web/JavaScript/Reference/Errors/Hash_outside_class
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "Unexpected '#' used outside of class body" occurs when a hash
 ("#") is encountered in an unexpected context, most notably

--- a/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: identifier starts immediately after numeric literal"
 slug: Web/JavaScript/Reference/Errors/Identifier_after_number
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "identifier starts immediately after numeric literal" occurs
 when an identifier started with a digit. Identifiers can only start with a letter,

--- a/files/en-us/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/en-us/web/javascript/reference/errors/illegal_character/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: illegal character"
 slug: Web/JavaScript/Reference/Errors/Illegal_character
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "illegal character" occurs when the [lexer](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar) reads a character that's not part of a string literal, and the character cannot constitute a valid token in the language.
 

--- a/files/en-us/web/javascript/reference/errors/import_decl_module_top_level/index.md
+++ b/files/en-us/web/javascript/reference/errors/import_decl_module_top_level/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: import declarations may only appear at top level of a module"
 slug: Web/JavaScript/Reference/Errors/import_decl_module_top_level
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "import declarations may only appear at top level of a module" occurs when an import declaration is not at the top level of a module. This might be because the import declaration is nested in other constructs (functions, blocks, etc.), or more often because the current file is not treated as a module.
 

--- a/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: cannot use 'in' operator to search for 'x' in 'y'"
 slug: Web/JavaScript/Reference/Errors/in_operator_no_object
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "right-hand side of 'in' should be an object" occurs when the
 [`in` operator](/en-US/docs/Web/JavaScript/Reference/Operators/in)

--- a/files/en-us/web/javascript/reference/errors/index.md
+++ b/files/en-us/web/javascript/reference/errors/index.md
@@ -2,9 +2,8 @@
 title: JavaScript error reference
 slug: Web/JavaScript/Reference/Errors
 page-type: landing-page
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 Below, you'll find a list of errors which are thrown by JavaScript. These errors can be a helpful debugging aid, but the reported problem isn't always immediately clear. The pages below will provide additional details about these errors. Each error is an object based upon the {{jsxref("Error")}} object, and has a `name` and a `message`.
 

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: invalid array length"
 slug: Web/JavaScript/Reference/Errors/Invalid_array_length
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "Invalid array length" occurs when specifying an array length that is either negative, a floating number or exceeds the maximum supported by the platform (i.e., when creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}}, or when setting the {{jsxref("Array/length", "length")}} property).
 

--- a/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid assignment left-hand side"
 slug: Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid assignment left-hand side" occurs when there was an unexpected assignment somewhere. It may be triggered when a single `=` sign was used instead of `==` or `===`.
 

--- a/files/en-us/web/javascript/reference/errors/invalid_bigint_syntax/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_bigint_syntax/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid BigInt syntax"
 slug: Web/JavaScript/Reference/Errors/Invalid_BigInt_syntax
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid BigInt syntax" occurs when a string value is being coerced to a {{jsxref("BigInt")}} but it failed to be parsed as an integer.
 

--- a/files/en-us/web/javascript/reference/errors/invalid_const_assignment/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_const_assignment/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: invalid assignment to const "x"'
 slug: Web/JavaScript/Reference/Errors/Invalid_const_assignment
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid assignment to const" occurs when it was attempted to
 alter a constant value. JavaScript

--- a/files/en-us/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_date/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: invalid date"
 slug: Web/JavaScript/Reference/Errors/Invalid_date
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid date" occurs when an invalid date is attempted to be converted to an ISO date string.
 

--- a/files/en-us/web/javascript/reference/errors/invalid_derived_return/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_derived_return/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: derived class constructor returned invalid value x"
 slug: Web/JavaScript/Reference/Errors/Invalid_derived_return
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "derived class constructor returned invalid value x" occurs when a derived class constructor returns a value that is not an object or `undefined`.
 

--- a/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-in_initializer/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: for-in loop head declarations may not have initializers"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-in_initializer
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception
 "for-in loop head declarations may not have initializers"

--- a/files/en-us/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: a declaration in the head of a for-of loop can't have an initializer"
 slug: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "a declaration in the head of a for-of loop can't have an initializer" occurs when the head of a [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loop contains an initializer expression such as `for (const i = 0 of iterable)`. This is not allowed in for-of loops.
 

--- a/files/en-us/web/javascript/reference/errors/invalid_right_hand_side_instanceof_operand/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_right_hand_side_instanceof_operand/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: invalid 'instanceof' operand 'x'"
 slug: Web/JavaScript/Reference/Errors/invalid_right_hand_side_instanceof_operand
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid 'instanceof' operand" occurs when the right-hand side
 operands of the [`instanceof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof)

--- a/files/en-us/web/javascript/reference/errors/is_not_iterable/index.md
+++ b/files/en-us/web/javascript/reference/errors/is_not_iterable/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: 'x' is not iterable"
 slug: Web/JavaScript/Reference/Errors/is_not_iterable
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "is not iterable" occurs when the value which is [spread](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) into an array or function call, given as the
 right-hand side of [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement),

--- a/files/en-us/web/javascript/reference/errors/json_bad_parse/index.md
+++ b/files/en-us/web/javascript/reference/errors/json_bad_parse/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: JSON.parse: bad parsing"
 slug: Web/JavaScript/Reference/Errors/JSON_bad_parse
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exceptions thrown by {{jsxref("JSON.parse()")}} occur when string failed
 to be parsed as JSON.

--- a/files/en-us/web/javascript/reference/errors/key_not_weakly_held/index.md
+++ b/files/en-us/web/javascript/reference/errors/key_not_weakly_held/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: WeakSet key/WeakMap value 'x' must be an object or an unregistered symbol"
 slug: Web/JavaScript/Reference/Errors/Key_not_weakly_held
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "WeakSet key (or WeakMap value) 'x' must be an object or an unregistered symbol" occurs when an value of invalid type is used as a key in a {{jsxref("WeakSet")}} or as a value in a {{jsxref("WeakMap")}}.
 

--- a/files/en-us/web/javascript/reference/errors/label_not_found/index.md
+++ b/files/en-us/web/javascript/reference/errors/label_not_found/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: label not found"
 slug: Web/JavaScript/Reference/Errors/Label_not_found
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "label not found" occurs when a {{jsxref("Statements/break", "break")}} or {{jsxref("Statements/continue", "continue")}} statement references a label that does not exist on any statement that contains the `break` or `continue` statement.
 

--- a/files/en-us/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/en-us/web/javascript/reference/errors/malformed_uri/index.md
@@ -2,9 +2,8 @@
 title: "URIError: malformed URI sequence"
 slug: Web/JavaScript/Reference/Errors/Malformed_URI
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "malformed URI sequence" occurs when URI encoding or decoding
 wasn't successful.

--- a/files/en-us/web/javascript/reference/errors/missing_bracket_after_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_bracket_after_list/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing ] after element list"
 slug: Web/JavaScript/Reference/Errors/Missing_bracket_after_list
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing ] after element list" occurs when there is an error
 with the array initializer syntax somewhere. Likely there is a closing square bracket

--- a/files/en-us/web/javascript/reference/errors/missing_colon_after_property_id/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_colon_after_property_id/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing : after property id"
 slug: Web/JavaScript/Reference/Errors/Missing_colon_after_property_id
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing : after property id" occurs when objects are created
 using the [object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) syntax.

--- a/files/en-us/web/javascript/reference/errors/missing_curly_after_function_body/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_curly_after_function_body/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing } after function body"
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_function_body
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing } after function body" occurs when there is a syntax
 mistake when creating a function somewhere. Check if any closing curly braces or

--- a/files/en-us/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing } after property list"
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing } after property list" occurs when there is a mistake
 in the [object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) syntax somewhere.

--- a/files/en-us/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing formal parameter"
 slug: Web/JavaScript/Reference/Errors/Missing_formal_parameter
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing formal parameter" occurs when your function
 declaration is missing valid parameters.

--- a/files/en-us/web/javascript/reference/errors/missing_initializer_in_const/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_initializer_in_const/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing = in const declaration"
 slug: Web/JavaScript/Reference/Errors/Missing_initializer_in_const
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing = in const declaration" occurs when a const
 declaration was not given a value in the same statement (like

--- a/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing name after . operator"
 slug: Web/JavaScript/Reference/Errors/Missing_name_after_dot_operator
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing name after . operator" occurs when there is a problem
 with how the dot operator (`.`) is used

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing ) after argument list"
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing ) after argument list" occurs when there is an error
 with how a function is called. This might be a typo, a missing operator, or an unescaped

--- a/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing ) after condition"
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_condition
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing ) after condition" occurs when there is an error with
 how an

--- a/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: More arguments needed"
 slug: Web/JavaScript/Reference/Errors/More_arguments_needed
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "more arguments needed" occurs when there is an error with how
 a function is called. More arguments need to be provided.

--- a/files/en-us/web/javascript/reference/errors/negative_repetition_count/index.md
+++ b/files/en-us/web/javascript/reference/errors/negative_repetition_count/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: repeat count must be non-negative"
 slug: Web/JavaScript/Reference/Errors/Negative_repetition_count
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "repeat count must be non-negative" occurs when the
 {{jsxref("String.prototype.repeat()")}} method is used with a `count`

--- a/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: "x" is not a non-null object'
 slug: Web/JavaScript/Reference/Errors/No_non-null_object
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "is not a non-null object" occurs when an object is expected
 somewhere and wasn't provided. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is not an object and won't work.

--- a/files/en-us/web/javascript/reference/errors/no_properties/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_properties/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: null/undefined has no properties"
 slug: Web/JavaScript/Reference/Errors/No_properties
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "null (or undefined) has no properties" occurs when you
 attempt to access properties of [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}. They

--- a/files/en-us/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_variable_name/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: missing variable name"
 slug: Web/JavaScript/Reference/Errors/No_variable_name
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "missing variable name" is a common error.
 It is usually caused by omitting a variable name or a typographic error.

--- a/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.md
+++ b/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: can't delete non-configurable array element"
 slug: Web/JavaScript/Reference/Errors/Non_configurable_array_element
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "can't delete non-configurable array element" occurs when it
 was attempted to [shorten the length](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length#shortening_an_array)

--- a/files/en-us/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_constructor/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: "x" is not a constructor'
 slug: Web/JavaScript/Reference/Errors/Not_a_constructor
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "is not a constructor" occurs when there was an attempt to use
 an object or a variable as a constructor, but that object or variable is not a

--- a/files/en-us/web/javascript/reference/errors/not_a_function/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_function/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: "x" is not a function'
 slug: Web/JavaScript/Reference/Errors/Not_a_function
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "is not a function" occurs when there was an attempt to call a
 value from a function, but the value is not actually a function.

--- a/files/en-us/web/javascript/reference/errors/not_a_valid_code_point/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_a_valid_code_point/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: argument is not a valid code point"
 slug: Web/JavaScript/Reference/Errors/Not_a_valid_code_point
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "Invalid code point" occurs when {{jsxref("NaN")}} values,
 negative Integers (-1), non-Integers (5.4), or values larger than 0x10FFFF (1114111) are

--- a/files/en-us/web/javascript/reference/errors/not_defined/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_defined/index.md
@@ -2,9 +2,8 @@
 title: 'ReferenceError: "x" is not defined'
 slug: Web/JavaScript/Reference/Errors/Not_defined
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "_variable_ is not defined" occurs when there is a
 non-existent variable referenced somewhere.

--- a/files/en-us/web/javascript/reference/errors/parameter_after_rest_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/parameter_after_rest_parameter/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: parameter after rest parameter"
 slug: Web/JavaScript/Reference/Errors/Parameter_after_rest_parameter
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "parameter after rest parameter" occurs when a [rest parameter](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) is followed by anything else in a parameter list, including another rest parameter, a formal parameter, or a [trailing comma](/en-US/docs/Web/JavaScript/Reference/Trailing_commas).
 

--- a/files/en-us/web/javascript/reference/errors/precision_range/index.md
+++ b/files/en-us/web/javascript/reference/errors/precision_range/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: precision is out of range"
 slug: Web/JavaScript/Reference/Errors/Precision_range
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "precision is out of range" occurs when a number that's
 outside of the allowed range was passed into `toExponential`, `toFixed`, or `toPrecision`.

--- a/files/en-us/web/javascript/reference/errors/private_double_initialization/index.md
+++ b/files/en-us/web/javascript/reference/errors/private_double_initialization/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: Initializing an object twice is an error with private fields/methods"
 slug: Web/JavaScript/Reference/Errors/Private_double_initialization
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "Initializing an object twice is an error with private fields/methods" occurs when an object that was created via a class constructor goes through the class construction again, and the class contains a [private element](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements). This is usually caused by the [return override](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements#returning_overriding_object) trick.
 

--- a/files/en-us/web/javascript/reference/errors/private_setter_only/index.md
+++ b/files/en-us/web/javascript/reference/errors/private_setter_only/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: getting private setter-only property"
 slug: Web/JavaScript/Reference/Errors/Private_setter_only
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "getting private setter-only property" occurs when reading the value of a [private element](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements) for which only a [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set) is defined.
 

--- a/files/en-us/web/javascript/reference/errors/promise_any_all_rejected/index.md
+++ b/files/en-us/web/javascript/reference/errors/promise_any_all_rejected/index.md
@@ -2,9 +2,8 @@
 title: "AggregateError: No Promise in Promise.any was resolved"
 slug: Web/JavaScript/Reference/Errors/Promise_any_all_rejected
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "No Promise in Promise.any was resolved" occurs when all promises passed to {{jsxref("Promise.any()")}} are rejected. It is the only built-in usage of {{jsxref("AggregateError")}}.
 

--- a/files/en-us/web/javascript/reference/errors/property_access_denied/index.md
+++ b/files/en-us/web/javascript/reference/errors/property_access_denied/index.md
@@ -2,9 +2,8 @@
 title: 'Error: Permission denied to access property "x"'
 slug: Web/JavaScript/Reference/Errors/Property_access_denied
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "Permission denied to access property" occurs when there was
 an attempt to access an object for which you have no permission.

--- a/files/en-us/web/javascript/reference/errors/read-only/index.md
+++ b/files/en-us/web/javascript/reference/errors/read-only/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: "x" is read-only'
 slug: Web/JavaScript/Reference/Errors/Read-only
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception
 "is read-only" occurs when a global variable or object

--- a/files/en-us/web/javascript/reference/errors/redeclared_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/redeclared_parameter/index.md
@@ -2,9 +2,8 @@
 title: 'SyntaxError: redeclaration of formal parameter "x"'
 slug: Web/JavaScript/Reference/Errors/Redeclared_parameter
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "redeclaration of formal parameter" occurs when the same
 variable name occurs as a function parameter and is then redeclared using a

--- a/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: Reduce of empty array with no initial value"
 slug: Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "reduce of empty array with no initial value" occurs when a
 reduce function is used.

--- a/files/en-us/web/javascript/reference/errors/regex_backslash_at_end_of_pattern/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_backslash_at_end_of_pattern/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: \\ at end of pattern"
 slug: Web/JavaScript/Reference/Errors/Regex_backslash_at_end_of_pattern
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "\ at end of pattern" occurs when a regular expression pattern ends with an unescaped backslash (`\`). In a regex literal, the backslash would cause the closing slash `/` to be a literal character, so this can only appear when using the {{jsxref("RegExp/RegExp", "RegExp()")}} constructor.
 

--- a/files/en-us/web/javascript/reference/errors/regex_character_class_escape_in_class_range/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_character_class_escape_in_class_range/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: character class escape cannot be used in class range in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_character_class_escape_in_class_range
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "character class escape cannot be used in class range in regular expression" occurs when a [Unicode-aware](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode) regular expression pattern contains a [character class](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class) where a boundary of a character range is another character class, such as a [character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape).
 

--- a/files/en-us/web/javascript/reference/errors/regex_duplicate_capture_group_name/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_duplicate_capture_group_name/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: duplicate capture group name in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_duplicate_capture_group_name
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "duplicate capture group name in regular expression" occurs when a regular expression pattern contains two or more [named capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) with the same name, and these capture groups could be matched at the same time.
 

--- a/files/en-us/web/javascript/reference/errors/regex_incomplete_quantifier/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_incomplete_quantifier/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: incomplete quantifier in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_incomplete_quantifier
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "incomplete quantifier in regular expression" occurs when a regular expression pattern contains a `{`, but it does not start a valid [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier).
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_capture_group_name/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_capture_group_name/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid capture group name in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_capture_group_name
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid capture group name in regular expression" occurs when a [named capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) or [named backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference) contains an invalid [identifier](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers).
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_char_in_class/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_char_in_class/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid character in class in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_char_in_class
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid character in class in regular expression" occurs when a character appears in a [`v`-mode character class](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class) but it's not allowed to appear literally.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_class_set_operation/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_class_set_operation/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid class set operation in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_class_set_operation
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid class set operation in regular expression" occurs when a double punctuator sequence appears in a [`v`-mode character class](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class) but it is not recognized by the syntax.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_decimal_escape/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_decimal_escape/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid decimal escape in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_decimal_escape
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid decimal escape in regular expression" occurs when a legacy [octal escape sequence](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#escape_sequences) is used in a [Unicode-aware](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode) regular expression pattern.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_group/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_group/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid regexp group"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_group
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid regexp group" occurs when the sequence `(?` does not start a valid group syntax. Recognized group syntaxes that start with `(?` include:
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_identity_escape/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_identity_escape/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid identity escape in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_identity_escape
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid identity escape in regular expression" occurs when a [Unicode-aware](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode) regular expression pattern contains an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#escape_sequences) that does not represent a recognized escape sequence.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_named_capture_reference/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_named_capture_reference/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid named capture reference in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_named_capture_reference
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid named capture reference in regular expression" occurs when a regular expression pattern contains a [named backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference) that does not refer to a [named capture group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) before it. The similar error message "invalid named reference in regular expression" is thrown when the sequence `\k` is encountered but is not followed by `<`.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_property_name/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_property_name/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid property name in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_property_name
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid property name in regular expression" or "invalid class property name in regular expression" occurs when the `\p` and `\P` [Unicode character class escapes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) are not followed by a valid Unicode property name and/or value.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_range_in_character_class/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_range_in_character_class/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid range in character class"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_range_in_character_class
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid range in character class" occurs when a [character class](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class) in a regular expression uses a range, but the start of the range is greater than the end.
 

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_unicode_escape/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_unicode_escape/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: invalid unicode escape in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_invalid_unicode_escape
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "invalid unicode escape in regular expression" occurs when the `\c` and `\u` [character escapes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape) are not followed by valid characters.
 

--- a/files/en-us/web/javascript/reference/errors/regex_negated_char_class_with_strings/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_negated_char_class_with_strings/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: negated character class with strings in regular expression"
 slug: Web/JavaScript/Reference/Errors/Regex_negated_char_class_with_strings
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "negated character class with strings in regular expression" occurs when a [`v`-mode character class](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class) is negated and may be able to match a string (more than one character).
 

--- a/files/en-us/web/javascript/reference/errors/regex_nothing_to_repeat/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_nothing_to_repeat/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: nothing to repeat"
 slug: Web/JavaScript/Reference/Errors/Regex_nothing_to_repeat
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "nothing to repeat" or "invalid quantifier in regular expression" occurs when a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) in a regular expression is applied to nothing or applied to an [assertion](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#assertions).
 

--- a/files/en-us/web/javascript/reference/errors/regex_numbers_out_of_order_in_quantifier/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_numbers_out_of_order_in_quantifier/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: numbers out of order in {} quantifier."
 slug: Web/JavaScript/Reference/Errors/Regex_numbers_out_of_order_in_quantifier
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "numbers out of order in {} quantifier" occurs when a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) in a regular expression uses the `{n,m}` syntax but `m` is less than `n`.
 

--- a/files/en-us/web/javascript/reference/errors/regex_raw_bracket/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_raw_bracket/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: raw bracket is not allowed in regular expression with unicode flag"
 slug: Web/JavaScript/Reference/Errors/Regex_raw_bracket
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "raw bracket is not allowed in regular expression with unicode flag" occurs when a [Unicode-aware](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode) regular expression pattern contains a raw bracket (`{`, `}`, `]`) that is not part of a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) or [character class](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class).
 

--- a/files/en-us/web/javascript/reference/errors/requires_global_regexp/index.md
+++ b/files/en-us/web/javascript/reference/errors/requires_global_regexp/index.md
@@ -2,9 +2,8 @@
 title: "TypeError: matchAll/replaceAll must be called with a global RegExp"
 slug: Web/JavaScript/Reference/Errors/Requires_global_RegExp
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "TypeError: matchAll/replaceAll must be called with a global RegExp" occurs when the {{jsxref("String.prototype.matchAll()")}} or {{jsxref("String.prototype.replaceAll()")}} method is used with a {{jsxref("RegExp")}} object that does not have the {{jsxref("RegExp/global", "global")}} flag set.
 

--- a/files/en-us/web/javascript/reference/errors/reserved_identifier/index.md
+++ b/files/en-us/web/javascript/reference/errors/reserved_identifier/index.md
@@ -2,9 +2,8 @@
 title: 'SyntaxError: "x" is a reserved identifier'
 slug: Web/JavaScript/Reference/Errors/Reserved_identifier
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "_variable_ is a reserved identifier" occurs
 when [reserved keywords](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords) are used as identifiers.

--- a/files/en-us/web/javascript/reference/errors/rest_with_default/index.md
+++ b/files/en-us/web/javascript/reference/errors/rest_with_default/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: rest parameter may not have a default"
 slug: Web/JavaScript/Reference/Errors/Rest_with_default
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "rest parameter may not have a default" occurs when a [rest parameter](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) has a [default value](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters). Because the rest parameter always creates an array, the default value would never apply.
 

--- a/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -2,9 +2,8 @@
 title: "RangeError: repeat count must be less than infinity"
 slug: Web/JavaScript/Reference/Errors/Resulting_string_too_large
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "repeat count must be less than infinity" occurs when the
 {{jsxref("String.prototype.repeat()")}} method is used with a `count`

--- a/files/en-us/web/javascript/reference/errors/setter_one_argument/index.md
+++ b/files/en-us/web/javascript/reference/errors/setter_one_argument/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: setter functions must have one argument"
 slug: Web/JavaScript/Reference/Errors/Setter_one_argument
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "setter functions must have one argument" occurs when a [setter](/en-US/docs/Web/JavaScript/Reference/Functions/get) is declared and the parameter list is not consisted of exactly one formal parameter.
 

--- a/files/en-us/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/en-us/web/javascript/reference/errors/stmt_after_return/index.md
@@ -2,9 +2,8 @@
 title: "Warning: unreachable code after return statement"
 slug: Web/JavaScript/Reference/Errors/Stmt_after_return
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript warning "unreachable code after return statement" occurs when using an
 expression after a {{jsxref("Statements/return", "return")}} statement, or when using a

--- a/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
+++ b/files/en-us/web/javascript/reference/errors/strict_non_simple_params/index.md
@@ -2,9 +2,8 @@
 title: 'SyntaxError: "use strict" not allowed in function with non-simple parameters'
 slug: Web/JavaScript/Reference/Errors/Strict_non_simple_params
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "`"use strict"` not allowed in function" occurs
 when a `"use strict"` directive is used at the top of a function with

--- a/files/en-us/web/javascript/reference/errors/string_literal_eol/index.md
+++ b/files/en-us/web/javascript/reference/errors/string_literal_eol/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: string literal contains an unescaped line break"
 slug: Web/JavaScript/Reference/Errors/String_literal_EOL
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript error "string literal contains an unescaped line break" occurs when there is an unterminated
 [string literal](/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#string_literals) somewhere. String literals must be enclosed by single

--- a/files/en-us/web/javascript/reference/errors/super_called_twice/index.md
+++ b/files/en-us/web/javascript/reference/errors/super_called_twice/index.md
@@ -2,9 +2,8 @@
 title: "ReferenceError: super() called twice in derived class constructor"
 slug: Web/JavaScript/Reference/Errors/Super_called_twice
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "super() called twice in derived class constructor" occurs when the {{jsxref("Operators/super", "super()")}} is called a second time for a given derived class constructor.
 

--- a/files/en-us/web/javascript/reference/errors/super_not_called/index.md
+++ b/files/en-us/web/javascript/reference/errors/super_not_called/index.md
@@ -2,9 +2,8 @@
 title: "ReferenceError: must call super constructor before using 'this' in derived class constructor"
 slug: Web/JavaScript/Reference/Errors/Super_not_called
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "must call super constructor before using 'this' in derived class constructor" occurs when the {{jsxref("Operators/super", "super()")}} is not called for a given derived class constructor, and the derived constructor tries to access the value of {{jsxref("Operators/this", "this")}}, or the derived constructor has already returned and the return value is not an object.
 

--- a/files/en-us/web/javascript/reference/errors/too_much_recursion/index.md
+++ b/files/en-us/web/javascript/reference/errors/too_much_recursion/index.md
@@ -2,9 +2,8 @@
 title: "InternalError: too much recursion"
 slug: Web/JavaScript/Reference/Errors/Too_much_recursion
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "too much recursion" or "Maximum call stack size exceeded"
 occurs when there are too many function calls, or a function is missing a base case.

--- a/files/en-us/web/javascript/reference/errors/undeclared_private_field_or_method/index.md
+++ b/files/en-us/web/javascript/reference/errors/undeclared_private_field_or_method/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: reference to undeclared private field or method #x"
 slug: Web/JavaScript/Reference/Errors/Undeclared_private_field_or_method
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "reference to undeclared private field or method #x" occurs when a [private name](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements) is used, but this private name is not declared in the class scope.
 

--- a/files/en-us/web/javascript/reference/errors/undeclared_var/index.md
+++ b/files/en-us/web/javascript/reference/errors/undeclared_var/index.md
@@ -2,9 +2,8 @@
 title: 'ReferenceError: assignment to undeclared variable "x"'
 slug: Web/JavaScript/Reference/Errors/Undeclared_var
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-only exception "Assignment to undeclared variable" occurs when the value has been assigned to an undeclared variable.
 

--- a/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_token/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: Unexpected token"
 slug: Web/JavaScript/Reference/Errors/Unexpected_token
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exceptions "unexpected token" occur when the parser does not see a token it recognizes at the given position, so it cannot make sense of the structure of the program. This might be a simple typo.
 

--- a/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
@@ -2,9 +2,8 @@
 title: 'TypeError: "x" is (not) "y"'
 slug: Web/JavaScript/Reference/Errors/Unexpected_type
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "_x_ is (not) _y_" occurs when there was an
 unexpected type. Oftentimes, unexpected {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)

--- a/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: function statement requires a name"
 slug: Web/JavaScript/Reference/Errors/Unnamed_function_statement
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "function statement requires a name" occurs
 when there is a [function statement](/en-US/docs/Web/JavaScript/Reference/Statements/function)

--- a/files/en-us/web/javascript/reference/errors/unparenthesized_unary_expr_lhs_exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/errors/unparenthesized_unary_expr_lhs_exponentiation/index.md
@@ -2,9 +2,8 @@
 title: "SyntaxError: unparenthesized unary expression can't appear on the left-hand side of '**'"
 slug: Web/JavaScript/Reference/Errors/Unparenthesized_unary_expr_lhs_exponentiation
 page-type: javascript-error
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Errors")}}
 
 The JavaScript exception "unparenthesized unary expression can't appear on the left-hand side of '\*\*'" occurs when a unary operator (one of `typeof`, `void`, `delete`, `await`, `!`, `~`, `+`, `-`) is used on the left operand of the [exponentiation operator](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation) without parentheses.
 

--- a/files/en-us/web/javascript/reference/execution_model/index.md
+++ b/files/en-us/web/javascript/reference/execution_model/index.md
@@ -6,9 +6,8 @@ spec-urls:
   - https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html
   - https://tc39.es/ecma262/multipage/memory-model.html
   - https://html.spec.whatwg.org/multipage/webappapis.html
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 This page introduces the basic infrastructure of the JavaScript runtime environment. The model is largely theoretical and abstract, without any platform-specific or implementation-specific details. Modern JavaScript engines heavily optimize the described semantics.
 

--- a/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
@@ -6,9 +6,10 @@ page-type: javascript-instance-data-property
 status:
   - deprecated
 browser-compat: javascript.functions.arguments.callee
+sidebar: jssidebar
 ---
 
-{{jsSidebar("Functions")}}{{Deprecated_Header}}
+{{Deprecated_Header}}
 
 > [!NOTE]
 > Accessing `arguments.callee` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) will throw a {{jsxref("TypeError")}}. If a function must reference itself, either give the [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) a name or use a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function).

--- a/files/en-us/web/javascript/reference/functions/arguments/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.md
@@ -3,9 +3,8 @@ title: The arguments object
 slug: Web/JavaScript/Reference/Functions/arguments
 page-type: javascript-language-feature
 browser-compat: javascript.functions.arguments
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 **`arguments`** is an array-like object accessible inside [functions](/en-US/docs/Web/JavaScript/Guide/Functions) that contains the values of the arguments passed to that function.
 

--- a/files/en-us/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/length/index.md
@@ -4,9 +4,8 @@ short-title: length
 slug: Web/JavaScript/Reference/Functions/arguments/length
 page-type: javascript-instance-data-property
 browser-compat: javascript.functions.arguments.length
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 The **`arguments.length`** data property contains the number of arguments passed to the function.
 

--- a/files/en-us/web/javascript/reference/functions/arguments/symbol.iterator/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/symbol.iterator/index.md
@@ -4,9 +4,8 @@ short-title: "[Symbol.iterator]()"
 slug: Web/JavaScript/Reference/Functions/arguments/Symbol.iterator
 page-type: javascript-instance-method
 browser-compat: javascript.functions.arguments.@@iterator
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 The **`[Symbol.iterator]()`** method of {{jsxref("Functions/arguments", "arguments")}} objects implements the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) and allows `arguments` objects to be consumed by most syntaxes expecting iterables, such as the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and {{jsxref("Statements/for...of", "for...of")}} loops. It returns an [array iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields the value of each index in the `arguments` object.
 

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -3,9 +3,8 @@ title: Arrow function expressions
 slug: Web/JavaScript/Reference/Functions/Arrow_functions
 page-type: javascript-language-feature
 browser-compat: javascript.functions.arrow_functions
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 An **arrow function expression** is a compact alternative to a traditional [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function), with some semantic differences and deliberate limitations in usage:
 

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -3,9 +3,8 @@ title: Default parameters
 slug: Web/JavaScript/Reference/Functions/Default_parameters
 page-type: javascript-language-feature
 browser-compat: javascript.functions.default_parameters
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 **Default function parameters** allow named parameters to be initialized with default values if no value or `undefined` is passed.
 

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -3,9 +3,8 @@ title: get
 slug: Web/JavaScript/Reference/Functions/get
 page-type: javascript-language-feature
 browser-compat: javascript.functions.get
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 The **`get`** syntax binds an object property to a function that will be called when that property is looked up. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 

--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -3,9 +3,8 @@ title: Functions
 slug: Web/JavaScript/Reference/Functions
 page-type: guide
 browser-compat: javascript.functions
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 Generally speaking, a function is a "subprogram" that can be _called_ by code external (or internal, in the case of recursion) to the function. Like the program itself, a function is composed of a sequence of statements called the _function body_. Values can be _passed_ to a function as parameters, and the function will _return_ a value.
 

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -3,9 +3,8 @@ title: Method definitions
 slug: Web/JavaScript/Reference/Functions/Method_definitions
 page-type: javascript-language-feature
 browser-compat: javascript.functions.method_definitions
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 **Method definition** is a shorter syntax for defining a function property in an object initializer. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -3,9 +3,8 @@ title: Rest parameters
 slug: Web/JavaScript/Reference/Functions/rest_parameters
 page-type: javascript-language-feature
 browser-compat: javascript.functions.rest_parameters
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 The **rest parameter** syntax allows a function to accept an indefinite number of arguments as an array, providing a way to represent [variadic functions](https://en.wikipedia.org/wiki/Variadic_function) in JavaScript.
 

--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -3,9 +3,8 @@ title: set
 slug: Web/JavaScript/Reference/Functions/set
 page-type: javascript-language-feature
 browser-compat: javascript.functions.set
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Functions")}}
 
 The **`set`** syntax binds an object property to a function to be called when there is an attempt to set that property. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 

--- a/files/en-us/web/javascript/reference/global_objects/decodeuri/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/decodeuri/index.md
@@ -3,9 +3,8 @@ title: decodeURI()
 slug: Web/JavaScript/Reference/Global_Objects/decodeURI
 page-type: javascript-function
 browser-compat: javascript.builtins.decodeURI
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`decodeURI()`** function decodes a Uniform Resource Identifier (URI) previously created by {{jsxref("encodeURI()")}} or a similar routine.
 

--- a/files/en-us/web/javascript/reference/global_objects/decodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/decodeuricomponent/index.md
@@ -3,9 +3,8 @@ title: decodeURIComponent()
 slug: Web/JavaScript/Reference/Global_Objects/decodeURIComponent
 page-type: javascript-function
 browser-compat: javascript.builtins.decodeURIComponent
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`decodeURIComponent()`** function decodes a Uniform Resource Identifier (URI) component previously created by {{jsxref("encodeURIComponent()")}} or by a similar routine.
 

--- a/files/en-us/web/javascript/reference/global_objects/encodeuri/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuri/index.md
@@ -3,9 +3,8 @@ title: encodeURI()
 slug: Web/JavaScript/Reference/Global_Objects/encodeURI
 page-type: javascript-function
 browser-compat: javascript.builtins.encodeURI
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`encodeURI()`** function encodes a {{Glossary("URI")}} by replacing each instance of certain characters by one, two, three, or four escape sequences representing the {{Glossary("UTF-8")}} encoding of the character (will only be four escape sequences for characters composed of two surrogate characters). Compared to {{jsxref("encodeURIComponent()")}}, this function encodes fewer characters, preserving those that are part of the URI syntax.
 

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -3,9 +3,8 @@ title: encodeURIComponent()
 slug: Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 page-type: javascript-function
 browser-compat: javascript.builtins.encodeURIComponent
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`encodeURIComponent()`** function encodes a {{Glossary("URI")}} by replacing each instance of certain characters by one, two, three, or four escape sequences representing the {{Glossary("UTF-8")}} encoding of the character (will only be four escape sequences for characters composed of two surrogate characters). Compared to {{jsxref("encodeURI()")}}, this function encodes more characters, including those that are part of the URI syntax.
 

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.md
@@ -5,9 +5,10 @@ page-type: javascript-function
 status:
   - deprecated
 browser-compat: javascript.builtins.escape
+sidebar: jssidebar
 ---
 
-{{jsSidebar("Objects")}}{{Deprecated_Header}}
+{{Deprecated_Header}}
 
 > [!NOTE]
 > `escape()` is a non-standard function implemented by browsers and was only standardized for cross-engine compatibility. It is not required to be implemented by all JavaScript engines and may not work everywhere. Use {{jsxref("encodeURIComponent()")}} or {{jsxref("encodeURI()")}} if possible.

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -3,9 +3,8 @@ title: eval()
 slug: Web/JavaScript/Reference/Global_Objects/eval
 page-type: javascript-function
 browser-compat: javascript.builtins.eval
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 > [!WARNING]
 > Executing JavaScript from a string is an enormous security risk. It is far too easy for a bad actor to run arbitrary code when you use `eval()`. See [Never use direct eval()!](#never_use_direct_eval!), below.

--- a/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/globalthis/index.md
@@ -3,9 +3,8 @@ title: globalThis
 slug: Web/JavaScript/Reference/Global_Objects/globalThis
 page-type: javascript-global-property
 browser-compat: javascript.builtins.globalThis
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`globalThis`** global property contains the [global `this`](/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context) value, which is usually akin to the [global object](/en-US/docs/Glossary/Global_object).
 

--- a/files/en-us/web/javascript/reference/global_objects/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/index.md
@@ -2,9 +2,8 @@
 title: Standard built-in objects
 slug: Web/JavaScript/Reference/Global_Objects
 page-type: landing-page
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 This chapter documents all of JavaScript's standard, built-in objects, including their methods and properties.
 

--- a/files/en-us/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/infinity/index.md
@@ -3,9 +3,8 @@ title: Infinity
 slug: Web/JavaScript/Reference/Global_Objects/Infinity
 page-type: javascript-global-property
 browser-compat: javascript.builtins.Infinity
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`Infinity`** global property is a numeric value representing infinity.
 

--- a/files/en-us/web/javascript/reference/global_objects/isfinite/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/isfinite/index.md
@@ -3,9 +3,8 @@ title: isFinite()
 slug: Web/JavaScript/Reference/Global_Objects/isFinite
 page-type: javascript-function
 browser-compat: javascript.builtins.isFinite
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`isFinite()`** function determines whether a value is finite, first converting the value to a number if necessary. A finite number is one that's not {{jsxref("NaN")}} or ±{{jsxref("Infinity")}}. Because coercion inside the `isFinite()` function can be [surprising](/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description), you may prefer to use {{jsxref("Number.isFinite()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/isnan/index.md
@@ -3,9 +3,8 @@ title: isNaN()
 slug: Web/JavaScript/Reference/Global_Objects/isNaN
 page-type: javascript-function
 browser-compat: javascript.builtins.isNaN
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`isNaN()`** function determines whether a value is {{jsxref("NaN")}}, first converting the value to a number if necessary. Because coercion inside the `isNaN()` function can be [surprising](#description), you may prefer to use {{jsxref("Number.isNaN()")}}.
 

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -3,9 +3,8 @@ title: NaN
 slug: Web/JavaScript/Reference/Global_Objects/NaN
 page-type: javascript-global-property
 browser-compat: javascript.builtins.NaN
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`NaN`** global property is a value representing Not-A-Number.
 

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -3,9 +3,8 @@ title: parseFloat()
 slug: Web/JavaScript/Reference/Global_Objects/parseFloat
 page-type: javascript-function
 browser-compat: javascript.builtins.parseFloat
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`parseFloat()`** function parses a string argument and returns a floating point number.
 

--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.md
@@ -3,9 +3,8 @@ title: parseInt()
 slug: Web/JavaScript/Reference/Global_Objects/parseInt
 page-type: javascript-function
 browser-compat: javascript.builtins.parseInt
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`parseInt()`** function parses a string argument and returns an integer of the specified [radix](https://en.wikipedia.org/wiki/Radix) (the base in mathematical numeral systems).
 

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.md
@@ -3,9 +3,8 @@ title: undefined
 slug: Web/JavaScript/Reference/Global_Objects/undefined
 page-type: javascript-global-property
 browser-compat: javascript.builtins.undefined
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Objects")}}
 
 The **`undefined`** global property represents the primitive
 value [`undefined`](/en-US/docs/Web/JavaScript/Guide/Data_structures#undefined_type). It is one of JavaScript's

--- a/files/en-us/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/unescape/index.md
@@ -5,9 +5,10 @@ page-type: javascript-function
 status:
   - deprecated
 browser-compat: javascript.builtins.unescape
+sidebar: jssidebar
 ---
 
-{{jsSidebar("Objects")}}{{Deprecated_Header}}
+{{Deprecated_Header}}
 
 > [!NOTE]
 > `unescape()` is a non-standard function implemented by browsers and was only standardized for cross-engine compatibility. It is not required to be implemented by all JavaScript engines and may not work everywhere. Use {{jsxref("decodeURIComponent()")}} or {{jsxref("decodeURI()")}} if possible.

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -2,9 +2,8 @@
 title: JavaScript reference
 slug: Web/JavaScript/Reference
 page-type: landing-page
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 The JavaScript reference serves as a repository of facts about the JavaScript language. The entire language is described here in detail. As you write JavaScript code, you'll refer to these pages often (thus the title "JavaScript reference").
 

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -3,9 +3,8 @@ title: Iteration protocols
 slug: Web/JavaScript/Reference/Iteration_protocols
 page-type: guide
 spec-urls: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iteration
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 **Iteration protocols** aren't new built-ins or syntax, but _protocols_. These protocols can be implemented by any object by following some conventions.
 

--- a/files/en-us/web/javascript/reference/javascript_technologies_overview/index.md
+++ b/files/en-us/web/javascript/reference/javascript_technologies_overview/index.md
@@ -2,9 +2,8 @@
 title: JavaScript technologies overview
 slug: Web/JavaScript/Reference/JavaScript_technologies_overview
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Introductory")}}
 
 Whereas [HTML](/en-US/docs/Web/HTML) defines a webpage's structure and content and [CSS](/en-US/docs/Web/CSS) sets the formatting and appearance, [JavaScript](/en-US/docs/Web/JavaScript) adds interactivity to a webpage and creates rich web applications.
 

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -4,9 +4,8 @@ slug: Web/JavaScript/Reference/Lexical_grammar
 page-type: guide
 browser-compat: javascript.grammar
 spec-urls: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 This page describes JavaScript's lexical grammar. JavaScript source text is just a sequence of characters — in order for the interpreter to understand it, the string has to be _parsed_ to a more structured representation. The initial step of parsing is called [lexical analysis](https://en.wikipedia.org/wiki/Lexical_analysis), in which the text gets scanned from left to right and is converted into a sequence of individual, atomic input elements. Some input elements are insignificant to the interpreter, and will be stripped after this step — they include [white space](#white_space) and [comments](#comments). The others, including [identifiers](#identifiers), [keywords](#keywords), [literals](#literals), and punctuators (mostly [operators](/en-US/docs/Web/JavaScript/Reference/Operators)), will be used for further syntax analysis. [Line terminators](#line_terminators) and multiline comments are also syntactically insignificant, but they guide the process for [automatic semicolons insertion](#automatic_semicolon_insertion) to make certain invalid token sequences become valid.
 

--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -3,9 +3,8 @@ title: Addition (+)
 slug: Web/JavaScript/Reference/Operators/Addition
 page-type: javascript-operator
 browser-compat: javascript.operators.addition
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **addition (`+`)** operator produces the sum of numeric operands or string concatenation.
 

--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
@@ -3,9 +3,8 @@ title: Addition assignment (+=)
 slug: Web/JavaScript/Reference/Operators/Addition_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.addition_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **addition assignment (`+=`)** operator performs [addition](/en-US/docs/Web/JavaScript/Reference/Operators/Addition) (which is either numeric addition or string concatenation) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/assignment/index.md
@@ -3,9 +3,8 @@ title: Assignment (=)
 slug: Web/JavaScript/Reference/Operators/Assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **assignment (`=`)** operator is used to assign a value to a variable or property. The assignment expression itself has a value, which is the assigned value. This allows multiple assignments to be chained in order to assign a single value to multiple variables.
 

--- a/files/en-us/web/javascript/reference/operators/async_function/index.md
+++ b/files/en-us/web/javascript/reference/operators/async_function/index.md
@@ -3,9 +3,8 @@ title: async function expression
 slug: Web/JavaScript/Reference/Operators/async_function
 page-type: javascript-operator
 browser-compat: javascript.operators.async_function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`async function`** keywords can be used to define an async function inside an expression.
 

--- a/files/en-us/web/javascript/reference/operators/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/async_function_star_/index.md
@@ -3,9 +3,8 @@ title: async function* expression
 slug: Web/JavaScript/Reference/Operators/async_function*
 page-type: javascript-operator
 browser-compat: javascript.operators.async_generator_function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`async function*`** keywords can be used to define an async generator function inside an expression.
 

--- a/files/en-us/web/javascript/reference/operators/await/index.md
+++ b/files/en-us/web/javascript/reference/operators/await/index.md
@@ -3,9 +3,8 @@ title: await
 slug: Web/JavaScript/Reference/Operators/await
 page-type: javascript-operator
 browser-compat: javascript.operators.await
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`await`** operator is used to wait for a {{jsxref("Promise")}} and get its fulfillment value. It can only be used inside an [async function](/en-US/docs/Web/JavaScript/Reference/Statements/async_function) or at the top level of a [module](/en-US/docs/Web/JavaScript/Guide/Modules).
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
@@ -3,9 +3,8 @@ title: Bitwise AND (&)
 slug: Web/JavaScript/Reference/Operators/Bitwise_AND
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_and
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise AND (`&`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bits of both operands are `1`.
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -3,9 +3,8 @@ title: Bitwise AND assignment (&=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_AND_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_and_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise AND assignment (`&=`)** operator performs [bitwise AND](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_AND) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_not/index.md
@@ -3,9 +3,8 @@ title: Bitwise NOT (~)
 slug: Web/JavaScript/Reference/Operators/Bitwise_NOT
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_not
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise NOT (`~`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bit of the operand is `0`, and a `0` otherwise.
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
@@ -3,9 +3,8 @@ title: Bitwise OR (|)
 slug: Web/JavaScript/Reference/Operators/Bitwise_OR
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_or
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise OR (`|`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bits of either or both operands are `1`.
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -3,9 +3,8 @@ title: Bitwise OR assignment (|=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_OR_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_or_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise OR assignment (`|=`)** operator performs [bitwise OR](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
@@ -3,9 +3,8 @@ title: Bitwise XOR (^)
 slug: Web/JavaScript/Reference/Operators/Bitwise_XOR
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_xor
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise XOR (`^`)** operator returns a number or BigInt whose binary representation has a `1` in each bit position for which the corresponding bits of either but not both operands are `1`.
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
@@ -3,9 +3,8 @@ title: Bitwise XOR assignment (^=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.bitwise_xor_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **bitwise XOR assignment (`^=`)** operator performs [bitwise XOR](/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/class/index.md
+++ b/files/en-us/web/javascript/reference/operators/class/index.md
@@ -3,9 +3,8 @@ title: class expression
 slug: Web/JavaScript/Reference/Operators/class
 page-type: javascript-operator
 browser-compat: javascript.operators.class
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`class`** keyword can be used to define a class inside an expression.
 

--- a/files/en-us/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/comma_operator/index.md
@@ -3,9 +3,8 @@ title: Comma operator (,)
 slug: Web/JavaScript/Reference/Operators/Comma_operator
 page-type: javascript-operator
 browser-compat: javascript.operators.comma
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **comma (`,`)** operator evaluates each of its operands (from left to right) and returns the value of the last operand. This is commonly used to provide multiple updaters to a [`for`](/en-US/docs/Web/JavaScript/Reference/Statements/for) loop's afterthought.
 

--- a/files/en-us/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/conditional_operator/index.md
@@ -3,9 +3,8 @@ title: Conditional (ternary) operator
 slug: Web/JavaScript/Reference/Operators/Conditional_operator
 page-type: javascript-operator
 browser-compat: javascript.operators.conditional
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **conditional (ternary) operator** is the only JavaScript operator that takes three operands:
 a condition followed by a question mark (`?`), then an expression to execute if the condition is {{Glossary("truthy")}} followed by a colon (`:`), and finally the expression to execute if the condition is {{Glossary("falsy")}}.

--- a/files/en-us/web/javascript/reference/operators/decrement/index.md
+++ b/files/en-us/web/javascript/reference/operators/decrement/index.md
@@ -3,9 +3,8 @@ title: Decrement (--)
 slug: Web/JavaScript/Reference/Operators/Decrement
 page-type: javascript-operator
 browser-compat: javascript.operators.decrement
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **decrement (`--`)** operator decrements (subtracts one from) its operand and returns the value before or after the decrement, depending on where the operator is placed.
 

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -3,9 +3,8 @@ title: delete
 slug: Web/JavaScript/Reference/Operators/delete
 page-type: javascript-operator
 browser-compat: javascript.operators.delete
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`delete`** operator removes a property from an object. If the property's value is an object and there are no more references to the object, the object held by that property is eventually released automatically.
 

--- a/files/en-us/web/javascript/reference/operators/destructuring/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring/index.md
@@ -3,9 +3,8 @@ title: Destructuring
 slug: Web/JavaScript/Reference/Operators/Destructuring
 page-type: javascript-language-feature
 browser-compat: javascript.operators.destructuring
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **destructuring** syntax is a JavaScript syntax that makes it possible to unpack values from arrays, or properties from objects, into distinct variables. It can be used in locations that receive data (such as the left-hand side of an assignment or anywhere that creates new identifier bindings).
 

--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -3,9 +3,8 @@ title: Division (/)
 slug: Web/JavaScript/Reference/Operators/Division
 page-type: javascript-operator
 browser-compat: javascript.operators.division
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **division (`/`)** operator produces the quotient of its operands where the left operand is the dividend and the right operand is the divisor.
 

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.md
@@ -3,9 +3,8 @@ title: Division assignment (/=)
 slug: Web/JavaScript/Reference/Operators/Division_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.division_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **division assignment (`/=`)** operator performs [division](/en-US/docs/Web/JavaScript/Reference/Operators/Division) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/equality/index.md
@@ -3,9 +3,8 @@ title: Equality (==)
 slug: Web/JavaScript/Reference/Operators/Equality
 page-type: javascript-operator
 browser-compat: javascript.operators.equality
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **equality (`==`)** operator checks whether its two operands are equal,
 returning a Boolean result.

--- a/files/en-us/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation/index.md
@@ -3,9 +3,8 @@ title: Exponentiation (**)
 slug: Web/JavaScript/Reference/Operators/Exponentiation
 page-type: javascript-operator
 browser-compat: javascript.operators.exponentiation
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **exponentiation (`**`)** operator returns the result of raising the first operand to the power of the second operand. It is equivalent to {{jsxref("Math.pow()")}}, except it also accepts [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) as operands.
 

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -3,9 +3,8 @@ title: Exponentiation assignment (**=)
 slug: Web/JavaScript/Reference/Operators/Exponentiation_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.exponentiation_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **exponentiation assignment (`**=`)** operator performs [exponentiation](/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/function/index.md
+++ b/files/en-us/web/javascript/reference/operators/function/index.md
@@ -3,9 +3,8 @@ title: function expression
 slug: Web/JavaScript/Reference/Operators/function
 page-type: javascript-operator
 browser-compat: javascript.operators.function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`function`** keyword can be used to define a function inside an expression.
 

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.md
@@ -3,9 +3,8 @@ title: function* expression
 slug: Web/JavaScript/Reference/Operators/function*
 page-type: javascript-operator
 browser-compat: javascript.operators.generator_function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`function*`** keyword can be used to define a generator function inside an expression.
 

--- a/files/en-us/web/javascript/reference/operators/greater_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than/index.md
@@ -3,9 +3,8 @@ title: Greater than (>)
 slug: Web/JavaScript/Reference/Operators/Greater_than
 page-type: javascript-operator
 browser-compat: javascript.operators.greater_than
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **greater than (`>`)** operator returns `true` if the left
 operand is greater than the right operand, and `false` otherwise.

--- a/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/greater_than_or_equal/index.md
@@ -3,9 +3,8 @@ title: Greater than or equal (>=)
 slug: Web/JavaScript/Reference/Operators/Greater_than_or_equal
 page-type: javascript-operator
 browser-compat: javascript.operators.greater_than_or_equal
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **greater than or equal (`>=`)** operator returns `true` if
 the left operand is greater than or equal to the right operand, and `false`

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -3,9 +3,8 @@ title: Grouping operator ( )
 slug: Web/JavaScript/Reference/Operators/Grouping
 page-type: javascript-operator
 browser-compat: javascript.operators.grouping
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **grouping `( )`** operator controls the precedence of evaluation in expressions. It also acts as a container for arbitrary expressions in certain syntactic constructs, where ambiguity or syntax errors would otherwise occur.
 

--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -3,9 +3,8 @@ title: import.meta
 slug: Web/JavaScript/Reference/Operators/import.meta
 page-type: javascript-language-feature
 browser-compat: javascript.operators.import_meta
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`import.meta`** meta-property exposes context-specific metadata to a JavaScript module. It contains information about the module, such as the module's URL.
 

--- a/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
@@ -3,9 +3,8 @@ title: import.meta.resolve()
 slug: Web/JavaScript/Reference/Operators/import.meta/resolve
 page-type: javascript-language-feature
 browser-compat: javascript.operators.import_meta.resolve
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 **`import.meta.resolve()`** is a built-in function defined on the [`import.meta`](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta) object of a JavaScript module that resolves a module specifier to a URL using the current module's URL as base.
 

--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -3,9 +3,8 @@ title: import()
 slug: Web/JavaScript/Reference/Operators/import
 page-type: javascript-operator
 browser-compat: javascript.operators.import
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`import()`** syntax, commonly called _dynamic import_, is a function-like expression that allows loading an ECMAScript module asynchronously and dynamically into a potentially non-module environment.
 

--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -3,9 +3,8 @@ title: in
 slug: Web/JavaScript/Reference/Operators/in
 page-type: javascript-operator
 browser-compat: javascript.operators.in
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`in`** operator returns `true` if the specified property is in the specified object or its prototype chain.
 

--- a/files/en-us/web/javascript/reference/operators/increment/index.md
+++ b/files/en-us/web/javascript/reference/operators/increment/index.md
@@ -3,9 +3,8 @@ title: Increment (++)
 slug: Web/JavaScript/Reference/Operators/Increment
 page-type: javascript-operator
 browser-compat: javascript.operators.increment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **increment (`++`)** operator increments (adds one to) its operand and returns the value before or after the increment, depending on where the operator is placed.
 

--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -3,9 +3,8 @@ title: Expressions and operators
 slug: Web/JavaScript/Reference/Operators
 page-type: landing-page
 browser-compat: javascript.operators
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 This chapter documents all the JavaScript language operators, expressions and keywords.
 

--- a/files/en-us/web/javascript/reference/operators/inequality/index.md
+++ b/files/en-us/web/javascript/reference/operators/inequality/index.md
@@ -3,9 +3,8 @@ title: Inequality (!=)
 slug: Web/JavaScript/Reference/Operators/Inequality
 page-type: javascript-operator
 browser-compat: javascript.operators.inequality
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **inequality (`!=`)** operator checks whether its two operands are not
 equal, returning a Boolean result.

--- a/files/en-us/web/javascript/reference/operators/instanceof/index.md
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.md
@@ -3,9 +3,8 @@ title: instanceof
 slug: Web/JavaScript/Reference/Operators/instanceof
 page-type: javascript-operator
 browser-compat: javascript.operators.instanceof
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`instanceof`** operator tests to see if the `prototype` property of a constructor appears anywhere in the prototype chain of an object. The return value is a boolean value. Its behavior can be customized with [`Symbol.hasInstance`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance).
 

--- a/files/en-us/web/javascript/reference/operators/left_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift/index.md
@@ -3,9 +3,8 @@ title: Left shift (<<)
 slug: Web/JavaScript/Reference/Operators/Left_shift
 page-type: javascript-operator
 browser-compat: javascript.operators.left_shift
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **left shift (`<<`)** operator returns a number or BigInt whose binary representation is the first operand shifted by the specified number of bits to the left. Excess bits shifted off to the left are discarded, and zero bits are shifted in from the right.
 

--- a/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
@@ -3,9 +3,8 @@ title: Left shift assignment (<<=)
 slug: Web/JavaScript/Reference/Operators/Left_shift_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.left_shift_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **left shift assignment (`<<=`)** operator performs [left shift](/en-US/docs/Web/JavaScript/Reference/Operators/Left_shift) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -3,9 +3,8 @@ title: Less than (<)
 slug: Web/JavaScript/Reference/Operators/Less_than
 page-type: javascript-operator
 browser-compat: javascript.operators.less_than
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **less than (`<`)** operator returns `true` if the left operand is less than the right operand, and `false` otherwise.
 

--- a/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.md
@@ -3,9 +3,8 @@ title: Less than or equal (<=)
 slug: Web/JavaScript/Reference/Operators/Less_than_or_equal
 page-type: javascript-operator
 browser-compat: javascript.operators.less_than_or_equal
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **less than or equal (`<=`)** operator returns `true` if the left operand is less than or equal to the right operand, and `false` otherwise.
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.md
@@ -3,9 +3,8 @@ title: Logical AND (&&)
 slug: Web/JavaScript/Reference/Operators/Logical_AND
 page-type: javascript-operator
 browser-compat: javascript.operators.logical_and
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **logical AND (`&&`)** (logical conjunction) operator for a set of boolean operands will be `true` if and only if all the operands are `true`. Otherwise it will be `false`.
 

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.md
@@ -3,9 +3,8 @@ title: Logical AND assignment (&&=)
 slug: Web/JavaScript/Reference/Operators/Logical_AND_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.logical_and_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **logical AND assignment (`&&=`)** operator only evaluates the right operand and assigns to the left if the left operand is {{Glossary("truthy")}}.
 

--- a/files/en-us/web/javascript/reference/operators/logical_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_not/index.md
@@ -3,9 +3,8 @@ title: Logical NOT (!)
 slug: Web/JavaScript/Reference/Operators/Logical_NOT
 page-type: javascript-operator
 browser-compat: javascript.operators.logical_not
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **logical NOT (`!`)** (logical complement, negation) operator takes truth to
 falsity and vice versa. It is typically used with boolean (logical)

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.md
@@ -3,9 +3,8 @@ title: Logical OR (||)
 slug: Web/JavaScript/Reference/Operators/Logical_OR
 page-type: javascript-operator
 browser-compat: javascript.operators.logical_or
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **logical OR (`||`)** (logical disjunction) operator for a set of operands
 is true if and only if one or more of its operands is true. It is typically used with

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -3,9 +3,8 @@ title: Logical OR assignment (||=)
 slug: Web/JavaScript/Reference/Operators/Logical_OR_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.logical_or_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **logical OR assignment (`||=`)** operator only evaluates the right operand and assigns to the left if the left operand is {{Glossary("falsy")}}.
 

--- a/files/en-us/web/javascript/reference/operators/multiplication/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication/index.md
@@ -3,9 +3,8 @@ title: Multiplication (*)
 slug: Web/JavaScript/Reference/Operators/Multiplication
 page-type: javascript-operator
 browser-compat: javascript.operators.multiplication
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **multiplication (`*`)** operator produces the product of the operands.
 

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -3,9 +3,8 @@ title: Multiplication assignment (*=)
 slug: Web/JavaScript/Reference/Operators/Multiplication_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.multiplication_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **multiplication assignment (`*=`)** operator performs [multiplication](/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/new.target/index.md
+++ b/files/en-us/web/javascript/reference/operators/new.target/index.md
@@ -3,9 +3,8 @@ title: new.target
 slug: Web/JavaScript/Reference/Operators/new.target
 page-type: javascript-language-feature
 browser-compat: javascript.operators.new_target
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`new.target`** meta-property lets you detect whether a function or constructor was called using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. In constructors and functions invoked using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator, `new.target` returns a reference to the constructor or function that `new` was called upon. In normal function calls, `new.target` is {{jsxref("undefined")}}.
 

--- a/files/en-us/web/javascript/reference/operators/new/index.md
+++ b/files/en-us/web/javascript/reference/operators/new/index.md
@@ -3,9 +3,8 @@ title: new
 slug: Web/JavaScript/Reference/Operators/new
 page-type: javascript-operator
 browser-compat: javascript.operators.new
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`new`** operator lets developers create an instance of a user-defined object type or of one of the built-in object types that has a constructor function.
 

--- a/files/en-us/web/javascript/reference/operators/null/index.md
+++ b/files/en-us/web/javascript/reference/operators/null/index.md
@@ -3,9 +3,8 @@ title: "null"
 slug: Web/JavaScript/Reference/Operators/null
 page-type: javascript-language-feature
 browser-compat: javascript.operators.null
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`null`** value represents the intentional absence of any object value. It
 is one of JavaScript's [primitive values](/en-US/docs/Glossary/Primitive) and

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -3,9 +3,8 @@ title: Nullish coalescing operator (??)
 slug: Web/JavaScript/Reference/Operators/Nullish_coalescing
 page-type: javascript-operator
 browser-compat: javascript.operators.nullish_coalescing
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **nullish coalescing (`??`)** operator is a logical
 operator that returns its right-hand side operand when its left-hand side operand is

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_assignment/index.md
@@ -3,9 +3,8 @@ title: Nullish coalescing assignment (??=)
 slug: Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.nullish_coalescing_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **nullish coalescing assignment (`??=`)** operator, also known as the **logical nullish assignment** operator, only evaluates the right operand and assigns to the left if the left operand is {{Glossary("nullish")}} (`null` or `undefined`).
 

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.md
@@ -3,9 +3,8 @@ title: Object initializer
 slug: Web/JavaScript/Reference/Operators/Object_initializer
 page-type: javascript-language-feature
 browser-compat: javascript.operators.object_initializer
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 An **object initializer** is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces (`{}`). Objects can also be initialized using [`Object.create()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) or [by invoking a constructor function](/en-US/docs/Web/JavaScript/Guide/Working_with_objects#using_a_constructor_function) with the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.
 

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -2,9 +2,8 @@
 title: Operator precedence
 slug: Web/JavaScript/Reference/Operators/Operator_precedence
 page-type: guide
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 **Operator precedence** determines how operators are parsed concerning each other. Operators with higher precedence become the operands of operators with lower precedence.
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -3,9 +3,8 @@ title: Optional chaining (?.)
 slug: Web/JavaScript/Reference/Operators/Optional_chaining
 page-type: javascript-operator
 browser-compat: javascript.operators.optional_chaining
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **optional chaining (`?.`)** operator accesses an object's property or calls a function. If the object accessed or function called using this operator is {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), the expression short circuits and evaluates to {{jsxref("undefined")}} instead of throwing an error.
 

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -3,9 +3,8 @@ title: Property accessors
 slug: Web/JavaScript/Reference/Operators/Property_accessors
 page-type: javascript-operator
 browser-compat: javascript.operators.property_accessors
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 **Property accessors** provide access to an object's properties by using the dot notation or the bracket notation.
 

--- a/files/en-us/web/javascript/reference/operators/remainder/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder/index.md
@@ -3,9 +3,8 @@ title: Remainder (%)
 slug: Web/JavaScript/Reference/Operators/Remainder
 page-type: javascript-operator
 browser-compat: javascript.operators.remainder
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **remainder (`%`)** operator returns the remainder left over when one operand is divided by a second operand. It always takes the sign of the dividend.
 

--- a/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/remainder_assignment/index.md
@@ -3,9 +3,8 @@ title: Remainder assignment (%=)
 slug: Web/JavaScript/Reference/Operators/Remainder_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.remainder_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **remainder assignment (`%=`)** operator performs [remainder](/en-US/docs/Web/JavaScript/Reference/Operators/Remainder) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/right_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift/index.md
@@ -3,9 +3,8 @@ title: Right shift (>>)
 slug: Web/JavaScript/Reference/Operators/Right_shift
 page-type: javascript-operator
 browser-compat: javascript.operators.right_shift
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **right shift (`>>`)** operator returns a number or BigInt whose binary representation is the first operand shifted by the specified number of bits to the right. Excess bits shifted off to the right are discarded, and copies of the leftmost bit are shifted in from the left. This operation is also called "sign-propagating right shift" or "arithmetic right shift", because the sign of the resulting number is the same as the sign of the first operand.
 

--- a/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/right_shift_assignment/index.md
@@ -3,9 +3,8 @@ title: Right shift assignment (>>=)
 slug: Web/JavaScript/Reference/Operators/Right_shift_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.right_shift_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **right shift assignment (`>>=`)** operator performs [right shift](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -3,9 +3,8 @@ title: Spread syntax (...)
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 page-type: javascript-operator
 browser-compat: javascript.operators.spread
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **spread (`...`)** syntax allows an iterable, such as an array or string, to be expanded in places where zero or more arguments (for function calls) or elements (for array literals) are expected. In an object literal, the spread syntax enumerates the properties of an object and adds the key-value pairs to the object being created.
 

--- a/files/en-us/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_equality/index.md
@@ -3,9 +3,8 @@ title: Strict equality (===)
 slug: Web/JavaScript/Reference/Operators/Strict_equality
 page-type: javascript-operator
 browser-compat: javascript.operators.strict_equality
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **strict equality (`===`)** operator checks whether its two operands are
 equal, returning a Boolean result. Unlike the [equality](/en-US/docs/Web/JavaScript/Reference/Operators/Equality) operator,

--- a/files/en-us/web/javascript/reference/operators/strict_inequality/index.md
+++ b/files/en-us/web/javascript/reference/operators/strict_inequality/index.md
@@ -3,9 +3,8 @@ title: Strict inequality (!==)
 slug: Web/JavaScript/Reference/Operators/Strict_inequality
 page-type: javascript-operator
 browser-compat: javascript.operators.strict_inequality
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **strict inequality (`!==`)** operator checks whether its two operands are
 not equal, returning a Boolean result. Unlike the [inequality](/en-US/docs/Web/JavaScript/Reference/Operators/Inequality)

--- a/files/en-us/web/javascript/reference/operators/subtraction/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction/index.md
@@ -3,9 +3,8 @@ title: Subtraction (-)
 slug: Web/JavaScript/Reference/Operators/Subtraction
 page-type: javascript-operator
 browser-compat: javascript.operators.subtraction
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **subtraction (`-`)** operator subtracts the two operands, producing their difference.
 

--- a/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -3,9 +3,8 @@ title: Subtraction assignment (-=)
 slug: Web/JavaScript/Reference/Operators/Subtraction_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.subtraction_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **subtraction assignment (`-=`)** operator performs [subtraction](/en-US/docs/Web/JavaScript/Reference/Operators/Subtraction) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -3,9 +3,8 @@ title: super
 slug: Web/JavaScript/Reference/Operators/super
 page-type: javascript-language-feature
 browser-compat: javascript.operators.super
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`super`** keyword is used to access properties on an object literal or class's [[Prototype]], or invoke a superclass's constructor.
 

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -3,9 +3,8 @@ title: this
 slug: Web/JavaScript/Reference/Operators/this
 page-type: javascript-language-feature
 browser-compat: javascript.operators.this
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`this`** keyword refers to the context where a piece of code, such as a function's body, is supposed to run. Most typically, it is used in object methods, where `this` refers to the object that the method is attached to, thus allowing the same method to be reused on different objects.
 

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -3,9 +3,8 @@ title: typeof
 slug: Web/JavaScript/Reference/Operators/typeof
 page-type: javascript-operator
 browser-compat: javascript.operators.typeof
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`typeof`** operator returns a string indicating the type of the operand's value.
 

--- a/files/en-us/web/javascript/reference/operators/unary_negation/index.md
+++ b/files/en-us/web/javascript/reference/operators/unary_negation/index.md
@@ -3,9 +3,8 @@ title: Unary negation (-)
 slug: Web/JavaScript/Reference/Operators/Unary_negation
 page-type: javascript-operator
 browser-compat: javascript.operators.unary_negation
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **unary negation (`-`)** operator precedes its operand and negates it.
 

--- a/files/en-us/web/javascript/reference/operators/unary_plus/index.md
+++ b/files/en-us/web/javascript/reference/operators/unary_plus/index.md
@@ -3,9 +3,8 @@ title: Unary plus (+)
 slug: Web/JavaScript/Reference/Operators/Unary_plus
 page-type: javascript-operator
 browser-compat: javascript.operators.unary_plus
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **unary plus (`+`)** operator precedes its operand and evaluates to its
 operand but attempts to [convert it into a number](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion), if it isn't already.

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.md
@@ -3,9 +3,8 @@ title: Unsigned right shift (>>>)
 slug: Web/JavaScript/Reference/Operators/Unsigned_right_shift
 page-type: javascript-operator
 browser-compat: javascript.operators.unsigned_right_shift
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **unsigned right shift (`>>>`)** operator returns a number whose binary representation is the first operand shifted by the specified number of bits to the right. Excess bits shifted off to the right are discarded, and zero bits are shifted in from the left. This operation is also called "zero-filling right shift", because the sign bit becomes `0`, so the resulting number is always positive. Unsigned right shift does not accept [BigInt](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) values.
 

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
@@ -3,9 +3,8 @@ title: Unsigned right shift assignment (>>>=)
 slug: Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment
 page-type: javascript-operator
 browser-compat: javascript.operators.unsigned_right_shift_assignment
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **unsigned right shift assignment (`>>>=`)** operator performs [unsigned right shift](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift) on the two operands and assigns the result to the left operand.
 

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -3,9 +3,8 @@ title: void operator
 slug: Web/JavaScript/Reference/Operators/void
 page-type: javascript-operator
 browser-compat: javascript.operators.void
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`void`** operator evaluates the given
 `expression` and then returns {{jsxref("undefined")}}.

--- a/files/en-us/web/javascript/reference/operators/yield/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield/index.md
@@ -3,9 +3,8 @@ title: yield
 slug: Web/JavaScript/Reference/Operators/yield
 page-type: javascript-operator
 browser-compat: javascript.operators.yield
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`yield`** operator is used to pause and resume a [generator function](/en-US/docs/Web/JavaScript/Reference/Statements/function*).
 

--- a/files/en-us/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield_star_/index.md
@@ -3,9 +3,8 @@ title: yield*
 slug: Web/JavaScript/Reference/Operators/yield*
 page-type: javascript-operator
 browser-compat: javascript.operators.yield_star
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Operators")}}
 
 The **`yield*`** operator can be used within generator (sync or async) functions to delegate to another [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) object, such as a {{jsxref("Generator")}}. Inside async generator functions, it can additionally be used to delegate to another async iterable object, such as an {{jsxref("AsyncGenerator")}}.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/backreference/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/backreference/index.md
@@ -3,9 +3,8 @@ title: "Backreference: \\1, \\2"
 slug: Web/JavaScript/Reference/Regular_expressions/Backreference
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.backreference
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **backreference** refers to the submatch of a previous [capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) and matches the same text as that group. For [named capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group), you may prefer to use the [named backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference) syntax.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/capturing_group/index.md
@@ -3,9 +3,8 @@ title: "Capturing group: (...)"
 slug: Web/JavaScript/Reference/Regular_expressions/Capturing_group
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.capturing_group
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **capturing group** groups a subpattern, allowing you to apply a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) to the entire group or use [disjunctions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) within it. It memorizes information about the subpattern match, so that you can refer back to it later with a [backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference), or access the information through the [match results](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#return_value).
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
@@ -3,9 +3,8 @@ title: "Character class: [...], [^...]"
 slug: Web/JavaScript/Reference/Regular_expressions/Character_class
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.character_class
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **character class** matches any character in or not in a custom set of characters. When the [`v`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) flag is enabled, it can also be used to match finite-length strings.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_class_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class_escape/index.md
@@ -3,9 +3,8 @@ title: "Character class escape: \\d, \\D, \\w, \\W, \\s, \\S"
 slug: Web/JavaScript/Reference/Regular_expressions/Character_class_escape
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.character_class_escape
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **character class escape** is an escape sequence that represents a set of characters.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_escape/index.md
@@ -3,9 +3,8 @@ title: "Character escape: \\n, \\u{...}"
 slug: Web/JavaScript/Reference/Regular_expressions/Character_escape
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.character_escape
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **character escape** represents a character that may not be able to be conveniently represented in its literal form.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/disjunction/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/disjunction/index.md
@@ -3,9 +3,8 @@ title: "Disjunction: |"
 slug: Web/JavaScript/Reference/Regular_expressions/Disjunction
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.disjunction
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **disjunction** specifies multiple alternatives. Any alternative matching the input causes the entire disjunction to be matched.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/index.md
@@ -3,9 +3,8 @@ title: Regular expressions
 slug: Web/JavaScript/Reference/Regular_expressions
 page-type: landing-page
 browser-compat: javascript.regular_expressions
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **regular expression** (_regex_ for short) allow developers to match strings against a pattern, extract submatch information, or simply test if the string conforms to that pattern. Regular expressions are used in many programming languages, and JavaScript's syntax is inspired by [Perl](https://www.perl.org/).
 

--- a/files/en-us/web/javascript/reference/regular_expressions/input_boundary_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/input_boundary_assertion/index.md
@@ -3,9 +3,8 @@ title: "Input boundary assertion: ^, $"
 slug: Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.input_boundary_assertion
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 An **input boundary assertion** checks if the current position in the string is an input boundary. An input boundary is the start or end of the string; or, if the `m` flag is set, the start or end of a line.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/literal_character/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/literal_character/index.md
@@ -3,9 +3,8 @@ title: "Literal character: a, b"
 slug: Web/JavaScript/Reference/Regular_expressions/Literal_character
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.literal_character
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **literal character** specifies exactly itself to be matched in the input text.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
@@ -3,9 +3,8 @@ title: "Lookahead assertion: (?=...), (?!...)"
 slug: Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.lookahead_assertion
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **lookahead assertion** "looks ahead": it attempts to match the subsequent input with the given pattern, but it does not consume any of the input — if the match is successful, the current position in the input stays the same.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/lookbehind_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookbehind_assertion/index.md
@@ -3,9 +3,8 @@ title: "Lookbehind assertion: (?<=...), (?<!...)"
 slug: Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.lookbehind_assertion
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **lookbehind assertion** "looks behind": it attempts to match the previous input with the given pattern, but it does not consume any of the input — if the match is successful, the current position in the input stays the same. It matches each atom in its pattern in the reverse order.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/modifier/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/modifier/index.md
@@ -3,9 +3,8 @@ title: "Modifier: (?ims-ims:...)"
 slug: Web/JavaScript/Reference/Regular_expressions/Modifier
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.modifier
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **modifier** overrides [flag](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#regex_flags) settings in a specific part of a regular expression. It can be used to enable or disable flags that change the meanings of certain regex syntax elements. These flags are [`i`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase), [`m`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline), and [`s`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll).
 

--- a/files/en-us/web/javascript/reference/regular_expressions/named_backreference/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/named_backreference/index.md
@@ -3,9 +3,8 @@ title: "Named backreference: \\k<name>"
 slug: Web/JavaScript/Reference/Regular_expressions/Named_backreference
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.named_backreference
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **named backreference** refers to the submatch of a previous [named capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) and matches the same text as that group. For [unnamed capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group), you need to use the normal [backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference) syntax.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/named_capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/named_capturing_group/index.md
@@ -3,9 +3,8 @@ title: "Named capturing group: (?<name>...)"
 slug: Web/JavaScript/Reference/Regular_expressions/Named_capturing_group
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.named_capturing_group
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **named capturing group** is a particular kind of [capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) that allows to give a name to the group. The group's matching result can later be identified by this name instead of by its index in the pattern.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/non-capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/non-capturing_group/index.md
@@ -3,9 +3,8 @@ title: "Non-capturing group: (?:...)"
 slug: Web/JavaScript/Reference/Regular_expressions/Non-capturing_group
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.non_capturing_group
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **non-capturing group** groups a subpattern, allowing you to apply a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) to the entire group or use [disjunctions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) within it. It acts like the [grouping operator](/en-US/docs/Web/JavaScript/Reference/Operators/Grouping) in JavaScript expressions, and unlike [capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group), it does not memorize the matched text, allowing for better performance and avoiding confusion when the pattern also contains useful capturing groups.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/quantifier/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/quantifier/index.md
@@ -3,9 +3,8 @@ title: "Quantifier: *, +, ?, {n}, {n,}, {n,m}"
 slug: Web/JavaScript/Reference/Regular_expressions/Quantifier
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.quantifier
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **quantifier** repeats an [atom](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) a certain number of times. The quantifier is placed after the atom it applies to.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
@@ -3,9 +3,8 @@ title: "Unicode character class escape: \\p{...}, \\P{...}"
 slug: Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.unicode_character_class_escape
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **unicode character class escape** is a kind of [character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape) that matches a set of characters specified by a Unicode property. It's only supported in [Unicode-aware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode). When the [`v`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) flag is enabled, it can also be used to match finite-length strings.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/wildcard/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/wildcard/index.md
@@ -3,9 +3,8 @@ title: "Wildcard: ."
 slug: Web/JavaScript/Reference/Regular_expressions/Wildcard
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.wildcard
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **wildcard** matches all characters except line terminators. It also matches line terminators if the `s` flag is set.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/word_boundary_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/word_boundary_assertion/index.md
@@ -3,9 +3,8 @@ title: "Word boundary assertion: \\b, \\B"
 slug: Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion
 page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.word_boundary_assertion
+sidebar: jssidebar
 ---
-
-{{jsSidebar}}
 
 A **word boundary assertion** checks if the current position in the string is a word boundary. A word boundary is where the next character is a word character and the previous character is not a word character, or vice versa.
 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -3,9 +3,8 @@ title: async function
 slug: Web/JavaScript/Reference/Statements/async_function
 page-type: javascript-statement
 browser-compat: javascript.statements.async_function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`async function`** declaration creates a {{Glossary("binding")}} of a new async function to a given name. The `await` keyword is permitted within the function body, enabling asynchronous, promise-based behavior to be written in a cleaner style and avoiding the need to explicitly configure promise chains.
 

--- a/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
@@ -3,9 +3,8 @@ title: async function*
 slug: Web/JavaScript/Reference/Statements/async_function*
 page-type: javascript-statement
 browser-compat: javascript.statements.async_generator_function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`async function*`** declaration creates a {{Glossary("binding")}} of a new async generator function to a given name.
 

--- a/files/en-us/web/javascript/reference/statements/block/index.md
+++ b/files/en-us/web/javascript/reference/statements/block/index.md
@@ -3,9 +3,8 @@ title: Block statement
 slug: Web/JavaScript/Reference/Statements/block
 page-type: javascript-statement
 browser-compat: javascript.statements.block
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 A **block statement** is used to group zero or more statements. The block is delimited by a pair of braces ("curly braces") and contains a list of zero or more statements and declarations.
 

--- a/files/en-us/web/javascript/reference/statements/break/index.md
+++ b/files/en-us/web/javascript/reference/statements/break/index.md
@@ -3,9 +3,8 @@ title: break
 slug: Web/JavaScript/Reference/Statements/break
 page-type: javascript-statement
 browser-compat: javascript.statements.break
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`break`** statement terminates the current loop or {{jsxref("Statements/switch", "switch")}} statement and transfers program control to the statement following the terminated statement. It can also be used to jump past a [labeled statement](/en-US/docs/Web/JavaScript/Reference/Statements/label) when used within that labeled statement.
 

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -3,9 +3,8 @@ title: class
 slug: Web/JavaScript/Reference/Statements/class
 page-type: javascript-statement
 browser-compat: javascript.statements.class
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`class`** declaration creates a {{Glossary("binding")}} of a new [class](/en-US/docs/Web/JavaScript/Reference/Classes) to a given name.
 

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -3,9 +3,8 @@ title: const
 slug: Web/JavaScript/Reference/Statements/const
 page-type: javascript-statement
 browser-compat: javascript.statements.const
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`const`** declaration declares block-scoped local variables. The value of a constant can't be changed through reassignment using the [assignment operator](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment), but if a constant is an [object](/en-US/docs/Web/JavaScript/Guide/Data_structures#objects), its properties can be added, updated, or removed.
 

--- a/files/en-us/web/javascript/reference/statements/continue/index.md
+++ b/files/en-us/web/javascript/reference/statements/continue/index.md
@@ -3,9 +3,8 @@ title: continue
 slug: Web/JavaScript/Reference/Statements/continue
 page-type: javascript-statement
 browser-compat: javascript.statements.continue
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`continue`** statement terminates execution of the statements in the current iteration of the current or labeled loop, and continues execution of the loop with the next iteration.
 

--- a/files/en-us/web/javascript/reference/statements/debugger/index.md
+++ b/files/en-us/web/javascript/reference/statements/debugger/index.md
@@ -3,9 +3,8 @@ title: debugger
 slug: Web/JavaScript/Reference/Statements/debugger
 page-type: javascript-statement
 browser-compat: javascript.statements.debugger
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`debugger`** statement invokes any available debugging
 functionality, such as setting a breakpoint. If no debugging functionality is available,

--- a/files/en-us/web/javascript/reference/statements/do...while/index.md
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.md
@@ -3,9 +3,8 @@ title: do...while
 slug: Web/JavaScript/Reference/Statements/do...while
 page-type: javascript-statement
 browser-compat: javascript.statements.do_while
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`do...while`** statement creates a loop that executes a specified statement as long as the test condition evaluates to true. The condition is evaluated after executing the statement, resulting in the specified statement executing at least once.
 

--- a/files/en-us/web/javascript/reference/statements/empty/index.md
+++ b/files/en-us/web/javascript/reference/statements/empty/index.md
@@ -3,9 +3,8 @@ title: Empty statement
 slug: Web/JavaScript/Reference/Statements/Empty
 page-type: javascript-statement
 browser-compat: javascript.statements.empty
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 An **empty statement** is used to provide no statement, although the
 JavaScript syntax would expect one.

--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -3,9 +3,8 @@ title: export
 slug: Web/JavaScript/Reference/Statements/export
 page-type: javascript-statement
 browser-compat: javascript.statements.export
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`export`** declaration is used to export values from a JavaScript module. Exported values can then be imported into other programs with the {{jsxref("Statements/import", "import")}} declaration or [dynamic import](/en-US/docs/Web/JavaScript/Reference/Operators/import). The value of an imported binding is subject to change in the module that exports it — when a module updates the value of a binding that it exports, the update will be visible in its imported value.
 

--- a/files/en-us/web/javascript/reference/statements/expression_statement/index.md
+++ b/files/en-us/web/javascript/reference/statements/expression_statement/index.md
@@ -3,9 +3,8 @@ title: Expression statement
 slug: Web/JavaScript/Reference/Statements/Expression_statement
 page-type: javascript-statement
 spec-urls: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-expression-statement
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 An **expression statement** is an expression used in a place where a statement is expected. The expression is evaluated and its result is discarded — therefore, it makes sense only for expressions that have side effects, such as executing a function or updating a variable.
 

--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.md
@@ -3,9 +3,8 @@ title: for await...of
 slug: Web/JavaScript/Reference/Statements/for-await...of
 page-type: javascript-statement
 browser-compat: javascript.statements.for_await_of
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`for await...of`** statement creates a loop iterating over [async iterable objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) as well as [sync iterables](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol). This statement can only be used in contexts where [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) can be used, which includes inside an [async function](/en-US/docs/Web/JavaScript/Reference/Statements/async_function) body and in a [module](/en-US/docs/Web/JavaScript/Guide/Modules).
 

--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -3,9 +3,8 @@ title: for...in
 slug: Web/JavaScript/Reference/Statements/for...in
 page-type: javascript-statement
 browser-compat: javascript.statements.for_in
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`for...in`** statement iterates over all [enumerable string properties](/en-US/docs/Web/JavaScript/Guide/Enumerability_and_ownership_of_properties) of an object (ignoring properties keyed by [symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)), including inherited enumerable properties.
 

--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -3,9 +3,8 @@ title: for...of
 slug: Web/JavaScript/Reference/Statements/for...of
 page-type: javascript-statement
 browser-compat: javascript.statements.for_of
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`for...of`** statement executes a loop that operates on a sequence of values sourced from an [iterable object](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol). Iterable objects include instances of built-ins such as {{jsxref("Array")}}, {{jsxref("String")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}}, {{domxref("NodeList")}} (and other DOM collections), as well as the {{jsxref("Functions/arguments", "arguments")}} object, [generators](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) produced by [generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*), and user-defined iterables.
 

--- a/files/en-us/web/javascript/reference/statements/for/index.md
+++ b/files/en-us/web/javascript/reference/statements/for/index.md
@@ -3,9 +3,8 @@ title: for
 slug: Web/JavaScript/Reference/Statements/for
 page-type: javascript-statement
 browser-compat: javascript.statements.for
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`for`** statement creates a loop that consists of three optional expressions, enclosed in parentheses and separated by semicolons, followed by a statement (usually a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block)) to be executed in the loop.
 

--- a/files/en-us/web/javascript/reference/statements/function/index.md
+++ b/files/en-us/web/javascript/reference/statements/function/index.md
@@ -3,9 +3,8 @@ title: function
 slug: Web/JavaScript/Reference/Statements/function
 page-type: javascript-statement
 browser-compat: javascript.statements.function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`function`** declaration creates a {{Glossary("binding")}} of a new function to a given name.
 

--- a/files/en-us/web/javascript/reference/statements/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/function_star_/index.md
@@ -3,9 +3,8 @@ title: function*
 slug: Web/JavaScript/Reference/Statements/function*
 page-type: javascript-statement
 browser-compat: javascript.statements.generator_function
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`function*`** declaration creates a {{Glossary("binding")}} of a new generator function to a given name. A generator function can be exited and later re-entered, with its context (variable {{Glossary("binding", "bindings")}}) saved across re-entrances.
 

--- a/files/en-us/web/javascript/reference/statements/if...else/index.md
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.md
@@ -3,9 +3,8 @@ title: if...else
 slug: Web/JavaScript/Reference/Statements/if...else
 page-type: javascript-statement
 browser-compat: javascript.statements.if_else
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`if...else`** statement executes a statement if a specified condition is {{Glossary("truthy")}}. If the condition is {{Glossary("falsy")}}, another statement in the optional `else` clause will be executed.
 

--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -3,9 +3,8 @@ title: import
 slug: Web/JavaScript/Reference/Statements/import
 page-type: javascript-statement
 browser-compat: javascript.statements.import
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The static **`import`** declaration is used to import read-only live {{Glossary("binding", "bindings")}} which are [exported](/en-US/docs/Web/JavaScript/Reference/Statements/export) by another module. The imported bindings are called _live bindings_ because they are updated by the module that exported the binding, but cannot be re-assigned by the importing module.
 

--- a/files/en-us/web/javascript/reference/statements/import/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/with/index.md
@@ -3,9 +3,8 @@ title: Import attributes
 slug: Web/JavaScript/Reference/Statements/import/with
 page-type: javascript-language-feature
 browser-compat: javascript.statements.import.import_attributes
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 > [!NOTE]
 > A previous version of this proposal used the `assert` keyword instead of `with`. The assertion feature is now non-standard. Check the [browser compatibility table](#browser_compatibility) for details.

--- a/files/en-us/web/javascript/reference/statements/index.md
+++ b/files/en-us/web/javascript/reference/statements/index.md
@@ -3,9 +3,8 @@ title: Statements and declarations
 slug: Web/JavaScript/Reference/Statements
 page-type: landing-page
 browser-compat: javascript.statements
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 JavaScript applications consist of statements with an appropriate syntax. A single statement may span multiple lines. Multiple statements may occur on a single line if each statement is separated by a semicolon. This isn't a keyword, but a group of keywords.
 

--- a/files/en-us/web/javascript/reference/statements/label/index.md
+++ b/files/en-us/web/javascript/reference/statements/label/index.md
@@ -3,9 +3,8 @@ title: Labeled statement
 slug: Web/JavaScript/Reference/Statements/label
 page-type: javascript-statement
 browser-compat: javascript.statements.label
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 A **labeled statement** is any [statement](/en-US/docs/Web/JavaScript/Reference/Statements) that is prefixed with an identifier. You can jump to this label using a {{jsxref("Statements/break", "break")}} or {{jsxref("Statements/continue", "continue")}} statement nested within the labeled statement.
 

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -3,9 +3,8 @@ title: let
 slug: Web/JavaScript/Reference/Statements/let
 page-type: javascript-statement
 browser-compat: javascript.statements.let
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`let`** declaration declares re-assignable, block-scoped local variables, optionally initializing each to a value.
 

--- a/files/en-us/web/javascript/reference/statements/return/index.md
+++ b/files/en-us/web/javascript/reference/statements/return/index.md
@@ -3,9 +3,8 @@ title: return
 slug: Web/JavaScript/Reference/Statements/return
 page-type: javascript-statement
 browser-compat: javascript.statements.return
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`return`** statement ends function execution and specifies a value to be returned to the function caller.
 

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -3,9 +3,8 @@ title: switch
 slug: Web/JavaScript/Reference/Statements/switch
 page-type: javascript-statement
 browser-compat: javascript.statements.switch
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`switch`** statement evaluates an [expression](/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators), matching the expression's value against a series of `case` clauses, and executes [statements](/en-US/docs/Web/JavaScript/Reference/Statements) after the first `case` clause with a matching value, until a `break` statement is encountered. The `default` clause of a `switch` statement will be jumped to if no `case` matches the expression's value.
 

--- a/files/en-us/web/javascript/reference/statements/throw/index.md
+++ b/files/en-us/web/javascript/reference/statements/throw/index.md
@@ -3,9 +3,8 @@ title: throw
 slug: Web/JavaScript/Reference/Statements/throw
 page-type: javascript-statement
 browser-compat: javascript.statements.throw
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`throw`** statement throws a user-defined exception. Execution of the current function will stop (the statements after `throw` won't be executed), and control will be passed to the first [`catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block in the call stack. If no `catch` block exists among caller functions, the program will terminate.
 

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -3,9 +3,8 @@ title: try...catch
 slug: Web/JavaScript/Reference/Statements/try...catch
 page-type: javascript-statement
 browser-compat: javascript.statements.try_catch
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`try...catch`** statement is comprised of a `try` block and either a `catch` block, a `finally` block, or both. The code in the `try` block is executed first, and if it throws an exception, the code in the `catch` block will be executed. The code in the `finally` block will always be executed before control flow exits the entire construct.
 

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -3,9 +3,8 @@ title: var
 slug: Web/JavaScript/Reference/Statements/var
 page-type: javascript-statement
 browser-compat: javascript.statements.var
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`var`** statement declares function-scoped or globally-scoped variables, optionally initializing each to a value.
 

--- a/files/en-us/web/javascript/reference/statements/while/index.md
+++ b/files/en-us/web/javascript/reference/statements/while/index.md
@@ -3,9 +3,8 @@ title: while
 slug: Web/JavaScript/Reference/Statements/while
 page-type: javascript-statement
 browser-compat: javascript.statements.while
+sidebar: jssidebar
 ---
-
-{{jsSidebar("Statements")}}
 
 The **`while`** statement creates a loop that executes a specified statement as long as the test condition evaluates to true. The condition is evaluated before executing the statement.
 

--- a/files/en-us/web/javascript/reference/statements/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/with/index.md
@@ -5,9 +5,10 @@ page-type: javascript-statement
 status:
   - deprecated
 browser-compat: javascript.statements.with
+sidebar: jssidebar
 ---
 
-{{jsSidebar("Statements")}}{{Deprecated_Header}}
+{{Deprecated_Header}}
 
 > [!NOTE]
 > Use of the `with` statement is not recommended, as it may be the source of confusing bugs and compatibility issues, makes optimization impossible, and is forbidden in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode). The recommended alternative is to assign the object whose properties you want to access to a temporary variable.

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -3,9 +3,8 @@ title: Strict mode
 slug: Web/JavaScript/Reference/Strict_mode
 page-type: guide
 spec-urls: https://tc39.es/ecma262/multipage/strict-mode-of-ecmascript.html
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 > [!NOTE]
 > Sometimes you'll see the default, non-strict mode referred to as _[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)_. This isn't an official term, but be aware of it, just in case.

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -3,9 +3,8 @@ title: Template literals (Template strings)
 slug: Web/JavaScript/Reference/Template_literals
 page-type: javascript-language-feature
 browser-compat: javascript.grammar.template_literals
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 **Template literals** are literals delimited with backtick (`` ` ``) characters, allowing for [multi-line strings](#multi-line_strings), [string interpolation](#string_interpolation) with embedded expressions, and special constructs called [tagged templates](#tagged_templates).
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.md
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.md
@@ -3,9 +3,8 @@ title: Trailing commas
 slug: Web/JavaScript/Reference/Trailing_commas
 page-type: javascript-language-feature
 browser-compat: javascript.grammar.trailing_commas
+sidebar: jssidebar
 ---
-
-{{jsSidebar("More")}}
 
 **Trailing commas** (sometimes called "final commas") can be useful when adding new elements, parameters, or properties to JavaScript code. If you want to add a new property, you can add a new line without modifying the previously last line if that line already uses a trailing comma. This makes version-control diffs cleaner and editing code might be less troublesome.
 


### PR DESCRIPTION
### Description

__Changes:__
* Move `{{jsSidebar}}` to front matter `sidebar: jssidebar`
* Remove params, e.g., `{{jsSidebar("Intermediate")}}` -> these are not necessary in the current system to highlight the active page.

### Motivation

We are tidying up sidebar macros in favor of front matter now.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/39274
- [x] https://github.com/mdn/content/pull/39065
- [x] https://github.com/mdn/content/pull/40107
- [x] https://github.com/mdn/content/pull/40167 


### Reviewer hints

It's probably best to check each commit as they're grouped by type of change.