### PR TITLE
Fixing confusion around id versus name

### DIFF
--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -74,8 +74,8 @@ This example creates a password credential from a {{domxref("PasswordCredentialI
 
 ```js
 const credInit = {
-  id: "1234",
-  name: "Serpentina",
+  id: "serp1234", // "username" in a typical username/password pair
+  name: "Serpentina", // display name for credential
   origin: "https://example.org",
   password: "the last visible dog",
 };
@@ -88,6 +88,8 @@ makeCredential.addEventListener("click", async () => {
   });
   console.log(cred.name);
   // Serpentina
+  console.log(cred.id);
+  // serp1234
   console.log(cred.password);
   // the last visible dog
 });

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.md
@@ -28,9 +28,9 @@ Either of the following:
     - `iconURL` {{optional_inline}}
       - : A string representing the URL of an icon or avatar to be associated with the credential.
     - `id`
-      - : A string representing a unique ID for the credential.
+      - : A string representing the username portion of the username/password combination.
     - `name` {{optional_inline}}
-      - : A string representing the credential username.
+      - : A string representing a human-understandable name associated with the credential, intended to help the user select this credential in a user interface.
     - `origin`
       - : A string representing the credential's origin. {{domxref("PasswordCredential")}} objects are origin-bound, which means that they will only be usable on the specified origin they were intended to be used on.
     - `password`

--- a/files/en-us/web/api/passwordcredentialinit/index.md
+++ b/files/en-us/web/api/passwordcredentialinit/index.md
@@ -29,9 +29,9 @@ The `origin` property is set to the origin of the document the {{domxref("HTMLFo
 - `iconURL` {{optional_inline}}
   - : A string representing the URL of an icon or avatar to be associated with the credential.
 - `id`
-  - : A string representing a unique ID for the credential (e.g., the _username_ in a typical username/password credential pair).
+  - : A string representing the username portion of the username/password combination.
 - `name` {{optional_inline}}
-  - : A string representing the credential's display name (aka, nickname or label; may not be used by the browser).
+  - : A string representing a human-understandable name associated with the credential, intended to help the user select this credential in a user interface.
 - `origin`
   - : A string representing the credential's origin. {{domxref("PasswordCredential")}} objects are origin-bound, which means that they will only be usable on the specified origin they were intended to be used on.
 - `password`

--- a/files/en-us/web/api/passwordcredentialinit/index.md
+++ b/files/en-us/web/api/passwordcredentialinit/index.md
@@ -29,9 +29,9 @@ The `origin` property is set to the origin of the document the {{domxref("HTMLFo
 - `iconURL` {{optional_inline}}
   - : A string representing the URL of an icon or avatar to be associated with the credential.
 - `id`
-  - : A string representing a unique ID for the credential.
+  - : A string representing a unique ID for the credential (e.g., the _username_ in a typical username/password credential pair).
 - `name` {{optional_inline}}
-  - : A string representing the credential username.
+  - : A string representing the credential's display name (aka, nickname or label; may not be used by the browser).
 - `origin`
   - : A string representing the credential's origin. {{domxref("PasswordCredential")}} objects are origin-bound, which means that they will only be usable on the specified origin they were intended to be used on.
 - `password`
@@ -45,8 +45,8 @@ This example constructs an object literal to initialize a password credential.
 
 ```js
 const credInit = {
-  id: "1234",
-  name: "Serpentina",
+  id: "serp1234",  // "username" in a typical username/password pair
+  name: "Serpentina",  // display name for credential
   origin: "https://example.org",
   password: "the last visible dog",
 };
@@ -59,6 +59,8 @@ makeCredential.addEventListener("click", async () => {
   });
   console.log(cred.name);
   // Serpentina
+  console.log(cred.id);
+  // serp1234
   console.log(cred.password);
   // the last visible dog
 });
@@ -75,12 +77,12 @@ The HTML declares a {{HTMLElement("form")}} containing three submittable element
 ```html
 <form>
   <div>
-    <label for="userid">Enter your user ID: </label>
-    <input type="text" name="userid" id="userid" autocomplete="username" />
+    <label for="displayname">Enter your display name: </label>
+    <input type="text" name="displayname" id="displayname" autocomplete="name" />
   </div>
   <div>
     <label for="username">Enter your username: </label>
-    <input type="text" name="username" id="username" autocomplete="name" />
+    <input type="text" name="username" id="username" autocomplete="username" />
   </div>
   <div>
     <label for="password">Enter your password: </label>
@@ -139,7 +141,7 @@ makeCredential.addEventListener("click", async () => {
       password: formCreds,
     });
     log(
-      `New credential:\nname: ${credential.name}, password: ${credential.password}`,
+      `New credential:\ndisplay name: ${credential.name}, username: ${credential.id}, password: ${credential.password}`,
     );
   } catch (e) {
     if (e.name === "TypeError") {

--- a/files/en-us/web/api/passwordcredentialinit/index.md
+++ b/files/en-us/web/api/passwordcredentialinit/index.md
@@ -45,8 +45,8 @@ This example constructs an object literal to initialize a password credential.
 
 ```js
 const credInit = {
-  id: "serp1234",  // "username" in a typical username/password pair
-  name: "Serpentina",  // display name for credential
+  id: "serp1234", // "username" in a typical username/password pair
+  name: "Serpentina", // display name for credential
   origin: "https://example.org",
   password: "the last visible dog",
 };

--- a/files/en-us/web/api/passwordcredentialinit/index.md
+++ b/files/en-us/web/api/passwordcredentialinit/index.md
@@ -78,7 +78,11 @@ The HTML declares a {{HTMLElement("form")}} containing three submittable element
 <form>
   <div>
     <label for="displayname">Enter your display name: </label>
-    <input type="text" name="displayname" id="displayname" autocomplete="name" />
+    <input
+      type="text"
+      name="displayname"
+      id="displayname"
+      autocomplete="name" />
   </div>
   <div>
     <label for="username">Enter your username: </label>


### PR DESCRIPTION
### Description

Clarifying the roles of `id` (aka "username") vs `name` (aka "display name") in this credential type, aligning them to typical expectations for username/password credentials.

### Motivation

The existing documentation (and sample code) implies confusing/mixed things about the roles of `id` versus `name` in the creation and storage of this credential type. Some parts of this page were accurate (to spec) but other places implied an opposite relationship that contradicts the spec (and browser behavior).

I misunderstood after reading this page, and only figured it out after live testing -- including actually using `navigator.credentials.store()` to prompt to store the credential in the browser -- and reading the specification.

So I want to fix the page so other's aren't misled like I was. :)

### Additional details

n/a

### Related issues and pull requests

n/a