### PR TITLE
Fix <pre> typo

### DIFF
--- a/files/en-us/web/html/reference/elements/pre/index.md
+++ b/files/en-us/web/html/reference/elements/pre/index.md
@@ -28,8 +28,8 @@ By default, `<pre>` is a [block-level](/en-US/docs/Glossary/Block-level_content)
             O N
             D  E
             DONT
-           E SUIS
-           LA LAN
+          JE SUIS
+          LA  LAN
           G U E  É
          L O Q U E N
         TE      QUESA


### PR DESCRIPTION
`<pre>` First example from Apollinaire poem is missing a J. 
See source here https://www.paris-a-nu.fr/wp-content/uploads/2018/04/guillaume_apollinaire_calligramme.jpg

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
