### PR TITLE
doc[glossary/site/index.md]: Improve wording for same-site example

### DIFF
--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -26,7 +26,7 @@ These are the same site because the registrable domain of `mozilla.org` is the s
 - `https://developer.mozilla.org/en-US/docs/`
 - `https://support.mozilla.org/en-US/`
 
-These are the same site because the port is not relevant:
+These are the same site despite using different ports:
 
 - `https://example.com:8080`
 - `https://example.com`

--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -26,7 +26,7 @@ These are the same site because the registrable domain of `mozilla.org` is the s
 - `https://developer.mozilla.org/en-US/docs/`
 - `https://support.mozilla.org/en-US/`
 
-These are the same site despite using different ports:
+These are considered the same site because the port number is ignored when determining the site:
 
 - `https://example.com:8080`
 - `https://example.com`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Reworded explanation to use "despite" instead of "because" to more accurately reflect that different ports do not affect same-site status.

Before:

These are the same site because the port is not relevant:

- `https://example.com:8080`
- `https://example.com`

After:

These are the same site despite using different ports:

- `https://example.com:8080`
- `https://example.com`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
