### PR TITLE
Add info about calling `remove()` on nodes that have no parent node

### DIFF
--- a/files/en-us/web/api/characterdata/remove/index.md
+++ b/files/en-us/web/api/characterdata/remove/index.md
@@ -8,7 +8,8 @@ browser-compat: api.CharacterData.remove
 
 {{APIRef("DOM")}}
 
-The **`remove()`** method of the {{domxref("CharacterData")}} removes the text contained in the node.
+The **`remove()`** method of the {{domxref("CharacterData")}} removes it from its parent node.
+If it has no parent node, calling `remove()` does nothing.
 
 ## Syntax
 

--- a/files/en-us/web/api/documenttype/remove/index.md
+++ b/files/en-us/web/api/documenttype/remove/index.md
@@ -9,6 +9,7 @@ browser-compat: api.DocumentType.remove
 {{APIRef("DOM")}}
 
 The **`DocumentType.remove()`** method removes a document's `doctype`.
+If it is already detached from the document, calling `remove()` does nothing.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/remove/index.md
+++ b/files/en-us/web/api/element/remove/index.md
@@ -8,7 +8,8 @@ browser-compat: api.Element.remove
 
 {{APIRef("DOM")}}
 
-The **`Element.remove()`** method removes the element from the DOM.
+The **`Element.remove()`** method removes the element from its parent node.
+If it has no parent node, calling `remove()` does nothing.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Add info about calling `remove()` on nodes that have no parent node.

Also tightened up wording:
* `Element.remove` doesn't always "remove the element from the DOM" (e.g. if the parent is already detached from the DOM)
* `CharacterData.remove` doesn't "remove the text contained in the node", rather it removes the text node it from its parent, without altering its internal text data.

### Motivation

Currently this info is missing.

### Additional details

https://dom.spec.whatwg.org/#dom-childnode-remove
1. If [this](https://webidl.spec.whatwg.org/#this)’s [parent](https://dom.spec.whatwg.org/#concept-tree-parent) is null, then return.
2. [Remove](https://dom.spec.whatwg.org/#concept-node-remove) [this](https://webidl.spec.whatwg.org/#this).

### Related issues and pull requests

N/A