### PR TITLE
Document MediaSession.setScreenshareActive

### DIFF
--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -28,6 +28,8 @@ For example, a smartphone might have a standard panel in its lock screen that pr
   - : Indicates to the user agent whether the user's microphone is considered to be currently muted.
 - {{domxref("MediaSession.setPositionState", "setPositionState()")}}
   - : Sets the current playback position and speed of the media currently being presented.
+- {{domxref("MediaSession.setScreenshareActive", "setScreenshareActive()")}}
+  - : Indicates to the user agent the screenshare capture state desired by the page.
 
 ## Examples
 

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -56,6 +56,8 @@ setActionHandler(type, callback)
       - : Turn the user's active camera on or off.
     - `togglemicrophone`
       - : Mute or unmute the user's microphone.
+    - `togglescreenshare`
+      - : Turn the user's active screenshare on or off.
 - `callback`
   - : A function to call when the specified action type is invoked. The callback should not return a value. The callback receives a dictionary containing the following properties:
     - `action`

--- a/files/en-us/web/api/mediasession/setscreenshareactive/index.md
+++ b/files/en-us/web/api/mediasession/setscreenshareactive/index.md
@@ -1,0 +1,54 @@
+---
+title: "MediaSession: setScreenshareActive() method"
+short-title: setScreenshareActive()
+slug: Web/API/MediaSession/setScreenshareActive
+page-type: web-api-instance-method
+browser-compat: api.MediaSession.setScreenshareActive
+---
+
+{{APIRef("Media Session API")}}
+
+The **`setScreenshareActive()`** method of the {{domxref("MediaSession")}} interface is used to indicate to the user agent whether the user's screenshare is considered to be active.
+
+Call this method on the `navigator` object's {{domxref("navigator.mediaSession", "mediaSession")}} object.
+
+Note that the status of the screenshare is not tracked in the {{domxref("MediaSession")}} itself, but must be tracked separately.
+
+## Syntax
+
+```js-nolint
+setScreenshareActive(active)
+```
+
+### Parameters
+
+- `active`
+  - : A boolean indicating whether the screenshare is considered active or not.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+Below is an example of updating the screenshare active state of the current
+{{domxref('MediaSession')}}, as well as listening to requests to change the screenshare status with {{domxref("MediaSession.setActionHandler", "setActionHandler()")}}.
+
+```js
+let screenshareActive = false;
+
+navigator.mediaSession.setCameraActive(cameraActive);
+
+navigator.mediaSession.setActionHandler("togglescreenshare", () => {
+  screenshareActive = !screenshareActive;
+  navigator.mediaSession.setCameraActive(screenshareActive);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
### Description

Document https://w3c.github.io/mediasession/#dom-mediasession-setscreenshareactive

### Motivation

Adding missing docs.

### Additional details

I just created a cheap copy of the MediaSession.setCameraActive page. This is the same thing but for screenshare.

### Related issues and pull requests

None.