### PR TITLE
Docs: Use && instead of | in box-shadow syntax example

### DIFF
--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -62,19 +62,19 @@ The `box-shadow` property enables you to cast a drop shadow from the frame of al
 box-shadow: none;
 
 /* A color and two length values */
-/* <color> | <length> | <length> */
+/* <color> && <length> && <length> */
 box-shadow: red 60px -16px;
 
 /* Three length values and a color */
-/* <length> | <length> | <length> | <color> */
+/* <length> && <length> && <length> && <color> */
 box-shadow: 10px 5px 5px black;
 
 /* Four length values and a color */
-/* <length> | <length> | <length> | <length> | <color> */
+/* <length> && <length> && <length> && <length> && <color> */
 box-shadow: 2px 2px 2px 1px rgb(0 0 0 / 20%);
 
 /* inset, length values, and a color */
-/* <inset> | <length> | <length> | <color> */
+/* <inset> && <length> && <length> && <color> */
 box-shadow: inset 5em 1em gold;
 
 /* Any number of shadows, separated by commas */


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR corrects the syntax comment in a box-shadow example, changing the incorrect | (OR) separator to && (AND) for better accuracy and clarity.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The previous comment used /* <color> | <length> | <length> */, which was misleading as it implied only one of the components could be used. Using && correctly signifies that these components are used together to form the shadow value. This change aligns the example with formal CSS value syntax and reduces potential confusion for developers reading the documentation.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes #39659

Related PRs:
- https://github.com/mdn/content/pull/40299
- https://github.com/mdn/content/pull/40300
- https://github.com/mdn/content/pull/40301

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
