### PR TITLE
Docs: Use && instead of | in text-shadow syntax example

### DIFF
--- a/files/en-us/web/css/text-shadow/index.md
+++ b/files/en-us/web/css/text-shadow/index.md
@@ -58,19 +58,19 @@ p {
 ## Syntax
 
 ```css
-/* offset-x | offset-y | blur-radius | color */
+/* offset-x && offset-y && blur-radius && color */
 text-shadow: 1px 1px 2px black;
 
-/* color | offset-x | offset-y | blur-radius */
+/* color && offset-x && offset-y && blur-radius */
 text-shadow: #fc0 1px 0 10px;
 
-/* offset-x | offset-y | color */
+/* offset-x && offset-y && color */
 text-shadow: 5px 5px #558abb;
 
-/* color | offset-x | offset-y */
+/* color && offset-x && offset-y */
 text-shadow: white 2px 5px;
 
-/* offset-x | offset-y
+/* offset-x && offset-y */
 /* Use defaults for color and blur-radius */
 text-shadow: 5px 10px;
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR corrects the syntax comment in a text-shadow example, changing the incorrect | (OR) separator to && (AND) for better accuracy and clarity.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The previous comment used /* offset-x | offset-y */, which was misleading as it implied only one of the components could be used. Using && correctly signifies that these components are used together to form the text-shadow value. This change aligns the example with formal CSS value syntax and reduces potential confusion for developers reading the documentation.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes #39659

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
