### PR TITLE
Docs: Use && instead of | in padding syntax example

### DIFF
--- a/files/en-us/web/css/padding/index.md
+++ b/files/en-us/web/css/padding/index.md
@@ -74,13 +74,13 @@ This property is a shorthand for the following CSS properties:
 /* Apply to all four sides */
 padding: 1em;
 
-/* top and bottom | left and right */
+/* top and bottom && left and right */
 padding: 5% 10%;
 
-/* top | left and right | bottom */
+/* top && left and right && bottom */
 padding: 1em 2em 2em;
 
-/* top | right | bottom | left */
+/* top && right && bottom && left */
 padding: 5px 1em 0 2em;
 
 /* Global values */


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR corrects the syntax comment in a padding example, changing the incorrect | (OR) separator to && (AND) for better accuracy and clarity.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The previous comment used /* top and bottom | left and right */, which was misleading as it implied only one of the components could be used. Using && correctly signifies that these components are used together to form the padding value. This change aligns the example with formal CSS value syntax and reduces potential confusion for developers reading the documentation.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes #39659

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
