### PR TITLE
Restructure display property values for better clarity

### DIFF
--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -77,34 +77,66 @@ code {
 ## Syntax
 
 ```css
-/* precomposed values */
-display: block;
-display: inline;
+/* Two Keyword values */
+display: block flow;
+display: block flow-root;
+display: block table;
+display: block flex;
+display: block grid;
+display: block ruby;
+
+display: inline flow;
+display: inline flow-root;
+display: inline table;
+display: inline flex;
+display: inline grid;
+display: inline ruby;
+
+
+display: run-in flow;
+display: run-in flow-root;
+display: run-in table;
+display: run-in flex;
+display: run-in grid;
+display: run-in ruby;
+
+
+/* List Item values */
+
+display: block flow list-item;
+display: block flow-root list-item;
+
+display: inline flow list-item;
+display: inline flow-root list-item;
+
+
+/* Precomposed Inline-level values */
+
 display: inline-block;
-display: flex;
+display: inline-table;
 display: inline-flex;
-display: grid;
 display: inline-grid;
-display: flow-root;
+
+
+/* Internal values */
+
+display: table-row-group;
+display: table-header-group;
+display: table-footer-group;
+display: table-row;
+display: table-cell;
+display: table-column-group;
+display: table-column;
+display: table-caption;
+display: ruby-base;
+display: ruby-text;
+display: ruby-base-container;
+display: ruby-text-container;
+   
 
 /* Box suppression */
 display: none;
 display: contents;
-
-/* multi-keyword syntax */
-display: block flex;
-display: block flow;
-display: block flow-root;
-display: block grid;
-display: inline flex;
-display: inline flow;
-display: inline flow-root;
-display: inline grid;
-
-/* other values */
-display: table;
-display: table-row; /* all table elements have an equivalent CSS display value */
-display: list-item;
 
 /* Global values */
 display: inherit;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR reorganizes the 'Values' section for the CSS display property to better align with the modern multi-keyword syntax. The new structure groups values more logically by their function (e.g., two-keyword, internal, list-item) rather than the current mix of precomposed and multi-keyword values.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current syntax section on the display page can be confusing. It mixes legacy single-keyword values with the modern syntax in a way that obscures the underlying structure of the property.

This new organization is more systematic and aligns directly with the concepts in the CSS Display Module specification. By grouping values into clear categories, it provides a much clearer mental model for understanding how the different display values relate to each other. This will help both new and experienced developers grasp the property's full capabilities more easily.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
