### PR TITLE
Make all page status backed by some BCD

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8027,6 +8027,7 @@
 /en-US/docs/Web/API/AudioWorkletNode/AudioWorkletNode.parameters	/en-US/docs/Web/API/AudioWorkletNode/parameters
 /en-US/docs/Web/API/AudioWorkletNode/onprocessorerror	/en-US/docs/Web/API/AudioWorkletNode/processorerror_event
 /en-US/docs/Web/API/AudioWorkletNodeOptions	/en-US/docs/Web/API/AudioWorkletNode/AudioWorkletNode
+/en-US/docs/Web/API/AudioWorkletProcessor/parameterDescriptors	/en-US/docs/Web/API/AudioWorkletProcessor/parameterDescriptors_static
 /en-US/docs/Web/API/BackgroundFetchRegistration/onprogress	/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event
 /en-US/docs/Web/API/BarcodeDetector/getSupportedFormats	/en-US/docs/Web/API/BarcodeDetector/getSupportedFormats_static
 /en-US/docs/Web/API/Barcode_Detector_API	/en-US/docs/Web/API/Barcode_Detection_API

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -20329,7 +20329,7 @@
     "modified": "2020-10-15T22:21:03.220Z",
     "contributors": ["1valdis"]
   },
-  "Web/API/AudioWorkletProcessor/parameterDescriptors": {
+  "Web/API/AudioWorkletProcessor/parameterDescriptors_static": {
     "modified": "2020-10-15T22:21:04.116Z",
     "contributors": ["Sheppy", "chrisdavidmills", "1valdis"]
   },
@@ -121985,20 +121985,6 @@
       "sebmozilla"
     ]
   },
-  "Web/SVG/Reference/Attribute/from": {
-    "modified": "2020-10-15T21:13:01.508Z",
-    "contributors": ["Sebastianz", "SueSmith", "Jeremie", "sebmozilla"]
-  },
-  "Web/SVG/Reference/Attribute/to": {
-    "modified": "2019-07-04T18:01:27.376Z",
-    "contributors": [
-      "Sebastianz",
-      "HTMLValidator",
-      "SueSmith",
-      "Jeremie",
-      "sebmozilla"
-    ]
-  },
   "Web/SVG/Reference/Attribute/accumulate": {
     "modified": "2019-04-20T11:26:46.650Z",
     "contributors": ["Sebastianz", "Jeremie"]
@@ -122437,6 +122423,10 @@
   "Web/SVG/Reference/Attribute/fr": {
     "modified": "2020-10-15T21:54:40.575Z",
     "contributors": ["Sebastianz", "chrisdavidmills"]
+  },
+  "Web/SVG/Reference/Attribute/from": {
+    "modified": "2020-10-15T21:13:01.508Z",
+    "contributors": ["Sebastianz", "SueSmith", "Jeremie", "sebmozilla"]
   },
   "Web/SVG/Reference/Attribute/fx": {
     "modified": "2020-10-15T21:32:47.074Z",
@@ -123113,6 +123103,16 @@
       "Sheppy",
       "rolfedh",
       "Tigt"
+    ]
+  },
+  "Web/SVG/Reference/Attribute/to": {
+    "modified": "2019-07-04T18:01:27.376Z",
+    "contributors": [
+      "Sebastianz",
+      "HTMLValidator",
+      "SueSmith",
+      "Jeremie",
+      "sebmozilla"
     ]
   },
   "Web/SVG/Reference/Attribute/transform": {

--- a/files/en-us/web/api/attribution_reporting_api/generating_reports/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/generating_reports/index.md
@@ -2,8 +2,6 @@
 title: Generating attribution reports
 slug: Web/API/Attribution_Reporting_API/Generating_reports
 page-type: guide
-status:
-  - experimental
 ---
 
 {{SeeCompatTable}}{{DefaultAPISidebar("Attribution Reporting API")}}

--- a/files/en-us/web/api/attribution_reporting_api/registering_sources/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/registering_sources/index.md
@@ -2,8 +2,6 @@
 title: Registering attribution sources
 slug: Web/API/Attribution_Reporting_API/Registering_sources
 page-type: guide
-status:
-  - experimental
 ---
 
 {{SeeCompatTable}}{{DefaultAPISidebar("Attribution Reporting API")}}

--- a/files/en-us/web/api/attribution_reporting_api/registering_triggers/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/registering_triggers/index.md
@@ -2,8 +2,6 @@
 title: Registering attribution triggers
 slug: Web/API/Attribution_Reporting_API/Registering_triggers
 page-type: guide
-status:
-  - experimental
 ---
 
 {{SeeCompatTable}}{{DefaultAPISidebar("Attribution Reporting API")}}

--- a/files/en-us/web/api/audioworkletprocessor/parameterdescriptors_static/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/parameterdescriptors_static/index.md
@@ -1,14 +1,12 @@
 ---
-title: "AudioWorkletProcessor: parameterDescriptors property"
+title: "AudioWorkletProcessor: parameterDescriptors static property"
 short-title: parameterDescriptors
-slug: Web/API/AudioWorkletProcessor/parameterDescriptors
-page-type: web-api-instance-property
-status:
-  - experimental
+slug: Web/API/AudioWorkletProcessor/parameterDescriptors_static
+page-type: web-api-static-property
 spec-urls: https://webaudio.github.io/web-audio-api/#audioworkletprocess-callback-parameters
 ---
 
-{{APIRef("Web Audio API")}}{{SeeCompatTable}}
+{{APIRef("Web Audio API")}}
 
 The read-only **`parameterDescriptors`** property of an {{domxref("AudioWorkletProcessor")}}-derived class is a _static getter_,
 which returns an iterable of {{domxref("AudioParamDescriptor")}}-based objects.

--- a/files/en-us/web/api/audioworkletprocessor/process/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.md
@@ -3,8 +3,6 @@ title: "AudioWorkletProcessor: process() method"
 short-title: process()
 slug: Web/API/AudioWorkletProcessor/process
 page-type: web-api-instance-method
-status:
-  - experimental
 spec-urls: https://webaudio.github.io/web-audio-api/#process
 ---
 

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -2,8 +2,6 @@
 title: Media Source API
 slug: Web/API/Media_Source_Extensions_API
 page-type: web-api-overview
-status:
-  - experimental
 spec-urls:
   - https://w3c.github.io/media-source/
   - https://w3c.github.io/media-playback-quality/

--- a/files/en-us/web/api/popover_api/using/index.md
+++ b/files/en-us/web/api/popover_api/using/index.md
@@ -2,8 +2,6 @@
 title: Using the Popover API
 slug: Web/API/Popover_API/Using
 page-type: guide
-status:
-  - experimental
 ---
 
 {{DefaultAPISidebar("Popover API")}}

--- a/files/en-us/web/api/topics_api/using/index.md
+++ b/files/en-us/web/api/topics_api/using/index.md
@@ -2,14 +2,9 @@
 title: Using the Topics API
 slug: Web/API/Topics_API/Using
 page-type: web-api-overview
-status:
-  - non-standard
 ---
 
 {{DefaultAPISidebar("Topics API")}}
-
-> [!WARNING]
-> This feature is currently opposed by two browser vendors. See the [Standards positions](/en-US/docs/Web/API/Topics_API#standards_positions) section below for details of opposition.
 
 > [!NOTE]
 > An [Enrollment process](/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Enrollment) is required to use the Topics API in your applications. See the [Enrollment](/en-US/docs/Web/API/Topics_API#enrollment) section for details of what sub-features are gated by enrollment.

--- a/files/en-us/web/api/topics_api/using/index.md
+++ b/files/en-us/web/api/topics_api/using/index.md
@@ -6,6 +6,9 @@ page-type: web-api-overview
 
 {{DefaultAPISidebar("Topics API")}}
 
+> [!WARNING]
+> This feature is currently opposed by two browser vendors. See the [Standards positions](/en-US/docs/Web/API/Topics_API#standards_positions) section for details of opposition.
+
 > [!NOTE]
 > An [Enrollment process](/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Enrollment) is required to use the Topics API in your applications. See the [Enrollment](/en-US/docs/Web/API/Topics_API#enrollment) section for details of what sub-features are gated by enrollment.
 

--- a/files/en-us/web/api/vrlayerinit/index.md
+++ b/files/en-us/web/api/vrlayerinit/index.md
@@ -4,6 +4,7 @@ slug: Web/API/VRLayerInit
 page-type: web-api-interface
 status:
   - deprecated
+browser-compat: api.VRDisplay.getLayers
 ---
 
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
@@ -76,6 +77,10 @@ const init = {
 This dictionary was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers. Read [Meta's Porting from WebVR to WebXR](https://developers.meta.com/horizon/documentation/web/port-vr-xr/) guide for more information.
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.md
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.md
@@ -5,6 +5,7 @@ slug: Web/API/VRLayerInit/leftBounds
 page-type: web-api-instance-property
 status:
   - deprecated
+browser-compat: api.VRDisplay.getLayers
 ---
 
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
@@ -34,6 +35,10 @@ See [`VRLayerInit`](/en-US/docs/Web/API/VRLayerInit#examples) for example code.
 This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers. Read [Meta's Porting from WebVR to WebXR](https://developers.meta.com/horizon/documentation/web/port-vr-xr/) guide for more information.
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.md
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.md
@@ -5,6 +5,7 @@ slug: Web/API/VRLayerInit/rightBounds
 page-type: web-api-instance-property
 status:
   - deprecated
+browser-compat: api.VRDisplay.getLayers
 ---
 
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
@@ -34,6 +35,10 @@ See [`VRLayerInit`](/en-US/docs/Web/API/VRLayerInit#examples) for example code.
 This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers. Read [Meta's Porting from WebVR to WebXR](https://developers.meta.com/horizon/documentation/web/port-vr-xr/) guide for more information.
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vrlayerinit/source/index.md
+++ b/files/en-us/web/api/vrlayerinit/source/index.md
@@ -5,6 +5,7 @@ slug: Web/API/VRLayerInit/source
 page-type: web-api-instance-property
 status:
   - deprecated
+browser-compat: api.VRDisplay.getLayers
 ---
 
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
@@ -27,6 +28,10 @@ See [`VRLayerInit`](/en-US/docs/Web/API/VRLayerInit#examples) for example code.
 This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/) that has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/). It is no longer on track to becoming a standard.
 
 Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals), it is recommended to rely on frameworks, like [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), or [Three.js](https://threejs.org/), or a [polyfill](https://github.com/immersive-web/webxr-polyfill), to develop WebXR applications that will work across all browsers. Read [Meta's Porting from WebVR to WebXR](https://developers.meta.com/horizon/documentation/web/port-vr-xr/) guide for more information.
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/websockets_api/using_websocketstream/index.md
+++ b/files/en-us/web/api/websockets_api/using_websocketstream/index.md
@@ -2,12 +2,9 @@
 title: Using WebSocketStream to write a client
 slug: Web/API/WebSockets_API/Using_WebSocketStream
 page-type: guide
-status:
-  - experimental
-  - non-standard
 ---
 
-{{DefaultAPISidebar("WebSockets API")}}{{non-standard_header}}
+{{DefaultAPISidebar("WebSockets API")}}
 
 The {{domxref("WebSocketStream")}} API is a {{jsxref("Promise")}}-based alternative to {{domxref("WebSocket")}} for creating and using client-side WebSocket connections. `WebSocketStream` uses the [Streams API](/en-US/docs/Web/API/Streams_API) to handle receiving and sending messages, meaning that socket connections can take advantage of stream [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) automatically (no additional action required by the developer), regulating the speed of reading or writing to avoid bottlenecks in the application.
 

--- a/files/en-us/web/api/webusb_api/index.md
+++ b/files/en-us/web/api/webusb_api/index.md
@@ -4,6 +4,7 @@ slug: Web/API/WebUSB_API
 page-type: web-api-overview
 status:
   - experimental
+browser-compat: api.USB
 spec-urls: https://wicg.github.io/webusb/
 ---
 
@@ -84,6 +85,10 @@ navigator.usb.getDevices().then((devices) => {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -2,11 +2,9 @@
 title: Using VR controllers with WebVR
 slug: Web/API/WebVR_API/Using_VR_controllers_with_WebVR
 page-type: guide
-status:
-  - experimental
 ---
 
-{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}
+{{DefaultAPISidebar("WebVR API")}}
 
 Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the [Gamepad API](/en-US/docs/Web/API/Gamepad_API), and specifically the [Gamepad Extensions API](/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions) that adds API features for accessing [controller pose](/en-US/docs/Web/API/GamepadPose), [haptic actuators](/en-US/docs/Web/API/GamepadHapticActuator), and more. This article explains the basics.
 

--- a/files/en-us/web/css/css_properties_and_values_api/houdini/index.md
+++ b/files/en-us/web/css/css_properties_and_values_api/houdini/index.md
@@ -2,8 +2,6 @@
 title: CSS Houdini
 slug: Web/CSS/CSS_properties_and_values_API/Houdini
 page-type: guide
-status:
-  - experimental
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/svg/reference/attribute/attributetype/index.md
+++ b/files/en-us/web/svg/reference/attribute/attributetype/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Reference/Attribute/attributeType
 page-type: svg-attribute
 status:
   - deprecated
-spec-urls: https://www.w3.org/TR/SVG11/animate.html#AttributeTypeAttribute
+browser-compat: svg.elements.animate.attributeType
 sidebar: svgref
 ---
 
@@ -73,6 +73,10 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/attributetype/index.md
+++ b/files/en-us/web/svg/reference/attribute/attributetype/index.md
@@ -2,8 +2,6 @@
 title: attributeType
 slug: Web/SVG/Reference/Attribute/attributeType
 page-type: svg-attribute
-status:
-  - deprecated
 browser-compat: svg.elements.animate.attributeType
 sidebar: svgref
 ---

--- a/files/en-us/web/svg/reference/attribute/baseprofile/index.md
+++ b/files/en-us/web/svg/reference/attribute/baseprofile/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Reference/Attribute/baseProfile
 page-type: svg-attribute
 status:
   - deprecated
-spec-urls: https://www.w3.org/TR/SVG11/struct.html#SVGElementBaseProfileAttribute
+browser-compat: svg.elements.svg.baseProfile
 sidebar: svgref
 ---
 
@@ -53,3 +53,7 @@ You can use this attribute with the following SVG elements:
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/rotate/index.md
+++ b/files/en-us/web/svg/reference/attribute/rotate/index.md
@@ -2,9 +2,7 @@
 title: rotate
 slug: Web/SVG/Reference/Attribute/rotate
 page-type: svg-attribute
-status:
-  - experimental
-spec-urls: https://svgwg.org/specs/animations/#RotateAttribute
+browser-compat: svg.elements.animateMotion.rotate
 sidebar: svgref
 ---
 
@@ -108,3 +106,7 @@ Setting `rotate`'s value to a number specifies a constant rotation, in degrees, 
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
Whereever we use `status`, I'm adding a `browser-compat` so they can be cross-checked. In this process I'm noticing some pages that shouldn't get a status, and one page with an incorrect page-type, even, so I'm fixing them alongside.