### PR TITLE
fix: move an svgref macro to front matter

### DIFF
--- a/files/en-us/web/svg/reference/attribute/transform-origin/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform-origin/index.md
@@ -3,9 +3,8 @@ title: transform-origin
 slug: Web/SVG/Reference/Attribute/transform-origin
 page-type: svg-attribute
 browser-compat: svg.global_attributes.transform-origin
+sidebar: svgref
 ---
-
-{{SVGRef()}}
 
 The **`transform-origin`** SVG attribute sets the origin for an item's transformations.
 


### PR DESCRIPTION
### Description

Move the svgref macro into front matter.

### Motivation

Spot-checking sections we've moved macros so far.

### Additional details

Caught using:

```bash
grep -L "sidebar: " ./files/en-us/**/*.md
```

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/38589
