### PR TITLE
Suggest Web Workers as an alternative to Service Workers

### DIFF
--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -9,6 +9,9 @@ spec-urls: https://w3c.github.io/ServiceWorker/
 
 Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests, and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 
+> [!NOTE]
+> If you're looking for a way to move heavy computation away from the UI thread, [Web workers](/en-US/docs/Web/API/Web_Workers_API) may be a more appropriate solution: their lifecycle is simpler and they have better browser support for features such as ES modules 
+
 ## Service worker concepts and usage
 
 A service worker is an event-driven [worker](/en-US/docs/Web/API/Worker) registered against an origin and a path. It takes the form of a JavaScript file that can control the web page/site that it is associated with, intercepting and modifying navigation and resource requests, and caching resources in a very granular fashion to give you complete control over how your app behaves in certain situations (the most obvious one being when the network is not available).

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -10,7 +10,7 @@ spec-urls: https://w3c.github.io/ServiceWorker/
 Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests, and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 
 > [!NOTE]
-> If you're looking for a way to move heavy computation away from the UI thread, [Web workers](/en-US/docs/Web/API/Web_Workers_API) may be a more appropriate solution: their lifecycle is simpler and they have better browser support for features such as ES modules 
+> If you're looking for a way to move heavy computation away from the UI thread, [Web workers](/en-US/docs/Web/API/Web_Workers_API) may be a more appropriate solution: their lifecycle is simpler and they have better browser support for features such as ES modules
 
 ## Service worker concepts and usage
 

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -10,7 +10,7 @@ spec-urls: https://w3c.github.io/ServiceWorker/
 Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests, and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 
 > [!NOTE]
-> If you're looking for a way to move heavy computation away from the UI thread, [Web workers](/en-US/docs/Web/API/Web_Workers_API) may be a more appropriate solution: their lifecycle is simpler and they have better browser support for features such as ES modules
+> Service workers are a type of web worker. See [Web workers](/en-US/docs/Web/API/Web_Workers_API) for general information about worker types and use cases.
 
 ## Service worker concepts and usage
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Add a note at the beginning of the page calling out Web Workers as a better technology for parallel computing

### Motivation

I'm going to be honest, I only knew about service workers up until today and did _not_ know at all about other "types" of workers.

I always thought that Firefox didn't support ES modules in SWs for _localhost origins only_, but realized today that it just does not work, regardless of the origin.

Thus, I looked for sources on how work on implementation was going for firefox... only to stumble upon a similar implementation bug... for _web_ workers. I searched for "service worker vs web workers"... and turns out I was trying to move heavy computation (notably local neural network inference) off of the UI thread by putting them in a _service worker_, where a web worker is much more appropriate (notably, ONNX Runtime Web uses `import.meta` in its code, which means that any service worker importing ONNX will not work on Firefox...)

I think that putting a note here about the differences about the two may steer people towards the right direction. Even if web workers seem older than SWs (judging by initial browser support dates), I only knew about SWs, thru the PWA movement. (I even ended up making a RPC library for SWs, swarpc... i need to rename it now 💀)

im not sure about the exact phrasing used here but I think that some kind of note/warning that highlights how Web Workers are more appropriate for moving things off the UI thread is beneficial to devs dabbling into that field


### Additional details

- caniuse for ES Modules in Web Workers https://caniuse.com/mdn-api_worker_worker_ecmascript_modules
- web.dev article for ES Modules in SWs https://web.dev/articles/es-modules-in-sw
- caniuse for ES Modules in SWs https://caniuse.com/mdn-api_serviceworker_ecmascript_modules
- the library i made https://github.com/gwennlbh/swarpc
- project where i'm doing this https://github.com/cigaleapp/cigale/pull/370

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
