### PR TITLE
Remove securecontext_header from guide pages, add compat to API pages

### DIFF
--- a/files/en-us/web/api/device_orientation_events/orientation_and_motion_data_explained/index.md
+++ b/files/en-us/web/api/device_orientation_events/orientation_and_motion_data_explained/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Device_orientation_events/Orientation_and_motion_data_explained
 page-type: guide
 ---
 
-{{DefaultAPISidebar("Device Orientation Events")}}{{securecontext_header}}
+{{DefaultAPISidebar("Device Orientation Events")}}
 
 When using orientation and motion events, it's important to understand what the values you're given by the browser mean. This article provides details about the coordinate systems at play and how you use them.
 

--- a/files/en-us/web/api/device_orientation_events/using_device_orientation_with_3d_transforms/index.md
+++ b/files/en-us/web/api/device_orientation_events/using_device_orientation_with_3d_transforms/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Device_orientation_events/Using_device_orientation_with_3D_transfo
 page-type: guide
 ---
 
-{{DefaultAPISidebar("Device Orientation Events")}}{{securecontext_header}}
+{{DefaultAPISidebar("Device Orientation Events")}}
 
 This article provides tips on how to use device orientation information in tandem with CSS 3D transforms.
 

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Document_Picture-in-Picture_API/Using
 page-type: guide
 ---
 
-{{DefaultAPISidebar("Document Picture-in-Picture API")}}{{securecontext_header}}
+{{DefaultAPISidebar("Document Picture-in-Picture API")}}
 
 This guide provides a walkthrough of typical usage of the {{domxref("Document Picture-in-Picture API", "Document Picture-in-Picture API", "", "nocode")}}.
 

--- a/files/en-us/web/api/file_system_api/origin_private_file_system/index.md
+++ b/files/en-us/web/api/file_system_api/origin_private_file_system/index.md
@@ -2,6 +2,7 @@
 title: Origin private file system
 slug: Web/API/File_System_API/Origin_private_file_system
 page-type: guide
+browser-compat: api.StorageManager.getDirectory
 ---
 
 {{securecontext_header}}{{DefaultAPISidebar("File System API")}}{{AvailableInWorkers}}
@@ -191,6 +192,10 @@ console.log(textDecoder.decode(dataView));
 // Truncate the file after 4 bytes.
 accessHandle.truncate(4);
 ```
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Geolocation_API/Using_the_Geolocation_API
 page-type: guide
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Geolocation API")}}
+{{DefaultAPISidebar("Geolocation API")}}
 
 The Geolocation API is used to retrieve the user's location, so that it can for example be used to display their position using a mapping API. This article explains the basics of how to use it.
 

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 spec-urls: https://w3c-fedid.github.io/FedCM/#dictdef-identitycredentialrequestoptions
 ---
 
-{{APIRef("FedCM API")}}{{SecureContext_Header}}
+{{APIRef("FedCM API")}}
 
 The **`IdentityCredentialRequestOptions`** dictionary represents the object passed to {{domxref("CredentialsContainer.get()")}} as the value of the `identity` option.
 

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -2,10 +2,13 @@
 title: IdentityCredentialRequestOptions
 slug: Web/API/IdentityCredentialRequestOptions
 page-type: web-api-interface
+status:
+  - experimental
+browser-compat: api.CredentialsContainer.get.identity_option
 spec-urls: https://w3c-fedid.github.io/FedCM/#dictdef-identitycredentialrequestoptions
 ---
 
-{{APIRef("FedCM API")}}
+{{APIRef("FedCM API")}}{{SecureContext_Header}}
 
 The **`IdentityCredentialRequestOptions`** dictionary represents the object passed to {{domxref("CredentialsContainer.get()")}} as the value of the `identity` option.
 
@@ -54,3 +57,7 @@ It is used to request an {{domxref("IdentityCredential")}} provided by a {{gloss
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/insertable_streams_for_mediastreamtrack_api/index.md
+++ b/files/en-us/web/api/insertable_streams_for_mediastreamtrack_api/index.md
@@ -2,6 +2,10 @@
 title: Insertable Streams for MediaStreamTrack API
 slug: Web/API/Insertable_Streams_for_MediaStreamTrack_API
 page-type: web-api-overview
+status:
+  - experimental
+browser-compat: api.MediaStreamTrackProcessor
+spec-urls: https://w3c.github.io/mediacapture-transform/
 ---
 
 {{DefaultAPISidebar("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}{{AvailableInWorkers("dedicated")}}
@@ -48,3 +52,11 @@ onmessage = async ({ data: { track } }) => {
     .pipeTo(vtg.writable);
 };
 ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/insertable_streams_for_mediastreamtrack_api/index.md
+++ b/files/en-us/web/api/insertable_streams_for_mediastreamtrack_api/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Insertable_Streams_for_MediaStreamTrack_API
 page-type: web-api-overview
 status:
   - experimental
-browser-compat: api.MediaStreamTrackProcessor
+browser-compat: api.VideoTrackGenerator
 spec-urls: https://w3c.github.io/mediacapture-transform/
 ---
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Notifications_API/Using_the_Notifications_API
 page-type: guide
 ---
 
-{{DefaultAPISidebar("Web Notifications")}}{{securecontext_header}} {{AvailableInWorkers}}
+{{DefaultAPISidebar("Web Notifications")}}
 
 The [Notifications API](/en-US/docs/Web/API/Notifications_API) lets a web page or app send notifications that are displayed outside the page at the system level; this lets web apps send information to a user even if the application is idle or in the background. This article looks at the basics of using this API in your own apps.
 

--- a/files/en-us/web/api/payment_request_api/concepts/index.md
+++ b/files/en-us/web/api/payment_request_api/concepts/index.md
@@ -7,7 +7,7 @@ spec-urls:
   - https://w3c.github.io/payment-method-id/
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Payment Request API")}}
+{{DefaultAPISidebar("Payment Request API")}}
 
 The [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) makes it easy to handle payments in a website or app. In this article, we'll take a look at how the API operates and what each of its components does.
 

--- a/files/en-us/web/api/payment_request_api/using_secure_payment_confirmation/index.md
+++ b/files/en-us/web/api/payment_request_api/using_secure_payment_confirmation/index.md
@@ -8,7 +8,7 @@ spec-urls:
   - https://w3c.github.io/webauthn/
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Payment Request API")}}
+{{DefaultAPISidebar("Payment Request API")}}
 
 Secure Payment Confirmation (SPC), available through the Payment Request API, provides a mechanism for strong customer authentication during checkout, thereby protecting against online payment fraud.
 

--- a/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Payment_Request_API/Using_the_Payment_Request_API
 page-type: guide
 ---
 
-{{DefaultAPISidebar("Payment Request API")}}{{securecontext_header}}
+{{DefaultAPISidebar("Payment Request API")}}
 
 The [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) provides a browser-based method of connecting users and their preferred payment systems and platforms to merchants that they want to pay for goods and services. This article is a guide to making use of the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API), with examples and suggested best practices.
 

--- a/files/en-us/web/api/storage_access_api/related_website_sets/index.md
+++ b/files/en-us/web/api/storage_access_api/related_website_sets/index.md
@@ -4,6 +4,7 @@ slug: Web/API/Storage_Access_API/Related_website_sets
 page-type: guide
 status:
   - non-standard
+browser-compat: api.Document.requestStorageAccessFor
 spec-urls: https://wicg.github.io/first-party-sets/
 ---
 
@@ -155,6 +156,10 @@ Two browser vendors [oppose](/en-US/docs/Glossary/Web_standards#opposing_standar
 
 - Mozilla (Firefox): [Negative](https://mozilla.github.io/standards-positions/#first-party-sets)
 - Apple (Safari): [Negative](https://webkit.org/standards-positions/#position-93)
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/webotp_api/index.md
+++ b/files/en-us/web/api/webotp_api/index.md
@@ -2,10 +2,13 @@
 title: WebOTP API
 slug: Web/API/WebOTP_API
 page-type: web-api-overview
+status:
+  - experimental
+browser-compat: api.OTPCredential
 spec-urls: https://wicg.github.io/web-otp/
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}
+{{DefaultAPISidebar("WebOTP API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **WebOTP API** provides a streamlined user experience for web apps to verify that a phone number belongs to a user when using it as a sign-in factor. WebOTP is an extension of the [Credential Management API](/en-US/docs/Web/API/Credential_Management_API).
 
@@ -172,6 +175,10 @@ If the user becomes distracted or navigates somewhere else, it is good to cancel
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
- "Secure context" is about a particular API, not about a concept. Guides are not references and shouldn't go into technical details about one interface or method.
- API landing pages that say something is experimental should have BCD