### PR TITLE
Internalize codepen examples on offset-path

### DIFF
--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -406,7 +406,8 @@ This example involves different {{cssxref("&lt;basic-shape&gt;")}} values: {{css
     no-repeat;
   background-size: cover;
   color: white;
-  animation: move 3s linear infinite;
+  animation: move 10s linear infinite;
+  font-family: monospace;
   position: absolute;
   left: 50%;
   transform: translateX(-50%);

--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -246,41 +246,72 @@ In this example, the {{svgelement("svg")}} element creates a house with a chimne
     stroke-linejoin="round"
     stroke-linecap="round" />
   <path
-    id="firstScissorHalf"
-    class="scissorHalf"
-    d="M30,0 H-10 A10,10 0 0,0 -20,10 A20,20 0 1,1 -40,-10 H20 A10,10 0 0,1 30,0 M-40,20 A10,10 1 0,0 -40,0 A10,10 1 0,0 -40,20 M0,0"
-    transform="translate(0,0)"
-    fill="green"
-    stroke="black"
-    stroke-width="5"
-    stroke-linejoin="round"
-    stroke-linecap="round"
-    fill-rule="evenodd" />
+    id="first-scissor-half"
+    class="scissor-half"
+    d="M30,0 H-10 A10,10 0 0,0 -20,10 A20,20 0 1,1 -40,-10 H20 A10,10 0 0,1 30,0 M-40,20 A10,10 1 0,0 -40,0 A10,10 1 0,0 -40,20 M0,0" />
   <path
-    id="secondScissorHalf"
-    class="scissorHalf"
-    d="M30,0 H-10 A10,10 0 0,1 -20,-10 A20,20 0 1,0 -40,10 H20 A10,10 0 0,0 30,0 M-40,-20 A10,10 1 0,0 -40,0 A10,10 1 0,0 -40,-20 M0,0"
-    transform="translate(0,0)"
-    fill="forestgreen"
-    stroke="black"
-    stroke-width="5"
-    stroke-linejoin="round"
-    stroke-linecap="round"
-    fill-rule="evenodd" />
+    id="second-scissor-half"
+    class="scissor-half"
+    d="M30,0 H-10 A10,10 0 0,1 -20,-10 A20,20 0 1,0 -40,10 H20 A10,10 0 0,0 30,0 M-40,-20 A10,10 1 0,0 -40,0 A10,10 1 0,0 -40,-20 M0,0" />
 </svg>
 ```
 
 ```css live-sample___offset_path_path
-.scissorHalf {
+.scissor-half {
   offset-path: path(
-    "M900,190  L993,245 V201  A11,11 0 0,1 1004,190  H1075  A11,11 0 0,1 1086,201  V300  L1294,423 H1216  A11,11 0 0,0 1205,434  V789  A11,11 0 0,1 1194,800  H606  A11,11 0 0,1 595,789  V434  A11,11 0 0,0 584,423  H506 L900,190"
+    "M900,190 L993,245 V201 A11,11 0 0,1 1004,190 H1075 A11,11 0 0,1 1086,201 V300 L1294,423 H1216 A11,11 0 0,0 1205,434 V789 A11,11 0 0,1 1194,800 H606 A11,11 0 0,1 595,789 V434 A11,11 0 0,0 584,423 H506 L900,190"
   );
-  animation: follow-path 4s linear infinite;
+  transform: translate(0px, 0px);
+  fill: green;
+  stroke: black;
+  stroke-width: 5px;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  fill-rule: evenodd;
+  offset-anchor: 0 0;
 }
 
-@keyframes follow-path {
+#first-scissor-half {
+  animation:
+    move 12s linear infinite,
+    rotate-left 1s infinite;
+}
+#second-scissor-half {
+  animation:
+    move 12s linear infinite,
+    rotate-right 1s infinite;
+}
+
+@keyframes move {
+  from {
+    offset-distance: 0%;
+  }
   to {
     offset-distance: 100%;
+  }
+}
+
+@keyframes rotate-left {
+  0% {
+    offset-rotate: auto 0deg;
+  }
+  50% {
+    offset-rotate: auto -45deg;
+  }
+  100% {
+    offset-rotate: auto 0deg;
+  }
+}
+
+@keyframes rotate-right {
+  0% {
+    offset-rotate: auto 0deg;
+  }
+  50% {
+    offset-rotate: auto 45deg;
+  }
+  100% {
+    offset-rotate: auto 0deg;
   }
 }
 ```
@@ -341,6 +372,105 @@ The SVG rectangle that defines the path shape is shown here only to visually dem
 
 {{EmbedLiveSample('live-sample___offset_path_url', '100%', '250')}}
 
+### Different shapes
+
+This example involves different {{cssxref("&lt;basic-shape&gt;")}} values: {{cssxref("basic-shape/circle", "circle()")}}, {{cssxref("basic-shape/ellipse", "ellipse()")}}, {{cssxref("basic-shape/inset", "inset()")}}, {{cssxref("basic-shape/polygon", "polygon()")}}.
+
+```html
+<div class="container">
+  <div class="mover mover-path">path()</div>
+  <div class="mover mover-circle">circle()</div>
+  <div class="mover mover-ellipse">ellipse()</div>
+  <div class="mover mover-inset">inset()</div>
+  <div class="mover mover-polygon">polygon()</div>
+</div>
+```
+
+```css
+.container {
+  border: 1px solid black;
+  width: 80vw;
+  height: 80vh;
+  position: relative;
+  left: 10vw;
+  top: 10vh;
+}
+
+.mover {
+  width: 100px;
+  height: 80px;
+  border-radius: 50%;
+  line-height: 80px;
+  text-indent: 10px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='e644da42-a34e-4ceb-a89a-89a4eb6dcc51' data-name='Layer 1' viewBox='0 0 71.08 54.62'%3E%3Ctitle%3Epointer-hand%3C/title%3E%3Cpath d='M43.56,49.35a5.24,5.24,0,0,0-1.27-3.43,5.26,5.26,0,0,0,1.86-9,5.26,5.26,0,0,0-.5-9.53L66.12,27c2.28-.07,5-1.57,5-4.58a5.06,5.06,0,0,0-4.58-4.83L34.08,17c3.48-2.89,6.26-6.55,6.73-11.08C41.45-.14,36.07-1.15,35,1.09,32,7.11,23,12.75,17.42,15.52,8.64,19.08,0,19.77,0,34.56,0,42.7,2.7,47.94,9.42,51c5.51,2.52,13.71,3.59,25.36,3.59H38.3A5.27,5.27,0,0,0,43.56,49.35Z'/%3E%3C/svg%3E")
+    no-repeat;
+  background-size: cover;
+  color: white;
+  animation: move 3s linear infinite;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  transform-origin: center center;
+  geometry-box: 50px 0 100px;
+}
+.mover-path {
+  top: 50px;
+  motion-path: path(
+    "M18.45,58.46s52.87-70.07,101.25-.75,101.75-6.23,101.75-6.23S246.38,5.59,165.33,9.08s-15,71.57-94.51,74.56S18.45,58.46,18.45,58.46Z"
+  );
+  offset-path: path(
+    "M18.45,58.46s52.87-70.07,101.25-.75,101.75-6.23,101.75-6.23S246.38,5.59,165.33,9.08s-15,71.57-94.51,74.56S18.45,58.46,18.45,58.46Z"
+  );
+}
+.mover-circle {
+  top: 150px;
+  offset-path: circle(100px at 50px 50px);
+  motion-path: circle(100px at 50px 50px);
+}
+.mover-ellipse {
+  top: 250px;
+  offset-path: ellipse(25% 40% at 50% 50%);
+  motion-path: ellipse(25% 40% at 50% 50%);
+}
+.mover-inset {
+  top: 350px;
+  offset-path: inset(5% 20% 15% 10%);
+  motion-path: inset(5% 20% 15% 10%);
+}
+.mover-polygon {
+  top: 450px;
+  offset-path: polygon(
+    30% 0%,
+    70% 0%,
+    100% 30%,
+    100% 70%,
+    70% 100%,
+    30% 100%,
+    0% 70%,
+    0% 30%
+  );
+  motion-path: polygon(
+    30% 0%,
+    70% 0%,
+    100% 30%,
+    100% 70%,
+    70% 100%,
+    30% 100%,
+    0% 70%,
+    0% 30%
+  );
+}
+
+@keyframes move {
+  100% {
+    motion-offset: 100%;
+    offset-distance: 100%;
+  }
+}
+```
+
+{{EmbedLiveSample("different shapes", "", "500")}}
+
 ## Specifications
 
 {{Specifications}}
@@ -354,10 +484,5 @@ The SVG rectangle that defines the path shape is shown here only to visually dem
 - {{cssxref("offset")}}
 - {{cssxref("offset-distance")}}
 - {{cssxref("offset-rotate")}}
-- [SVG \<path>](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths)
+- SVG [paths](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths) tutorial
 - {{cssxref("basic-shape/path","path()")}}
-- Other demos:
-  - [Examples using various shapes values](https://codepen.io/team/css-tricks/pen/WZdKMq) on CodePen by CSS-Tricks
-  - [Moving a triangle along a curved path](https://codepen.io/ericwilligers/pen/jMbJPp) on CodePen by Eric Willigers
-  - [Moving a pair of scissors along the shape of a house](https://codepen.io/ericwilligers/pen/bwVZNa) on CodePen by Eric Willigers
-  - [Moving multiple pairs of eyes](https://jsfiddle.net/ericwilligers/r1snqdan/) on JSFiddle by Eric Willigers


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/16120. The scissors example is already on this page and just needs some additional polishing for moving the scissor halves. The "different shapes" example looks useful enough to be on this page. The other two examples are too trivial compared to what's already shown here.