### PR TITLE
Internalize DataTransfer codepen example

### DIFF
--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -58,4 +58,3 @@ This method is not defined in any Web standard.
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -183,4 +183,3 @@ window.addEventListener("DOMContentLoaded", () => {
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/dropeffect/index.md
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.md
@@ -138,4 +138,3 @@ target.addEventListener("dragover", (ev) => {
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -155,4 +155,3 @@ reset.addEventListener("click", () => document.location.reload());
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -107,4 +107,3 @@ function drop(dropEvent) {
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -64,7 +64,7 @@ In the following example, we have a {{htmlelement("form")}} containing three dif
       </tr>
       <tr>
         <th scope="row">Content type</th>
-        <td><ol></ol></td>
+        <td></td>
       </tr>
     </table>
   </fieldset>
@@ -78,7 +78,7 @@ In the following example, we have a {{htmlelement("form")}} containing three dif
       </tr>
       <tr>
         <th scope="row">Content type</th>
-        <td><ol></ol></td>
+        <td></td>
       </tr>
     </table>
   </fieldset>
@@ -92,7 +92,7 @@ In the following example, we have a {{htmlelement("form")}} containing three dif
       </tr>
       <tr>
         <th scope="row">Content type</th>
-        <td><ol></ol></td>
+        <td></td>
       </tr>
     </table>
   </fieldset>
@@ -144,11 +144,13 @@ function displayData(event) {
   const cells = event.target.nextElementSibling.querySelectorAll("td");
   cells[0].textContent = event.type;
   const transfer = event.clipboardData || event.dataTransfer;
-
-  cells[1].firstChild.innerHTML = Array.from(
-    transfer.items,
-    (item) => `<li>${item.kind} ${item.type}</li>`,
-  ).join("\n");
+  const ol = document.createElement("ol");
+  cells[1].appendChild(ol);
+  for (const item of transfer.items) {
+    const li = document.createElement("li");
+    li.textContent = `${item.kind} ${item.type}`;
+    ol.appendChild(li);
+  }
 }
 
 form.addEventListener("paste", displayData);

--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -145,6 +145,7 @@ function displayData(event) {
   cells[0].textContent = event.type;
   const transfer = event.clipboardData || event.dataTransfer;
   const ol = document.createElement("ol");
+  cells[1].textContent = "";
   cells[1].appendChild(ol);
   for (const item of transfer.items) {
     const li = document.createElement("li");

--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -46,6 +46,124 @@ The **`DataTransfer`** object is used to hold any data transferred between conte
 
 Every method and property listed in this document has its own reference page and each reference page either directly includes an example of the interface or has a link to an example.
 
+### Reading the data in a paste or drop event
+
+In the following example, we have a {{htmlelement("form")}} containing three different types of text inputs: a text {{htmlelement("input")}} element, a {{htmlelement("textarea")}} element, and a {{htmlelement("div")}} element with [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) set to `true`. The user can paste or drop text into any of these elements, and the data in the {{domxref("ClipboardEvent.clipboardData")}} or {{domxref("DragEvent.dataTransfer")}} object will be displayed.
+
+#### HTML
+
+```html
+<form>
+  <fieldset>
+    <legend>&lt;input /></legend>
+    <input type="text" />
+    <table class="center">
+      <tr>
+        <th scope="row">Operation type</th>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row">Content type</th>
+        <td><ol></ol></td>
+      </tr>
+    </table>
+  </fieldset>
+  <fieldset>
+    <legend>&lt;textarea /></legend>
+    <textarea></textarea>
+    <table class="center">
+      <tr>
+        <th scope="row">Operation type</th>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row">Content type</th>
+        <td><ol></ol></td>
+      </tr>
+    </table>
+  </fieldset>
+  <fieldset>
+    <legend>&lt;div contenteditable /></legend>
+    <div contenteditable></div>
+    <table class="center">
+      <tr>
+        <th scope="row">Operation type</th>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row">Content type</th>
+        <td><ol></ol></td>
+      </tr>
+    </table>
+  </fieldset>
+  <p class="center">
+    <input type="reset" />
+  </p>
+</form>
+```
+
+#### CSS
+
+```css
+.center {
+  text-align: center;
+}
+
+form > fieldset > * {
+  vertical-align: top;
+}
+form input,
+form textarea,
+form [contenteditable] {
+  min-width: 15rem;
+  padding: 0.25rem;
+}
+[contenteditable] {
+  appearance: textfield;
+  display: inline-block;
+  min-height: 1rem;
+  border: 1px solid;
+}
+
+form table {
+  display: inline-table;
+}
+table ol {
+  text-align: left;
+}
+```
+
+#### JavaScript
+
+```js
+const form = document.querySelector("form");
+
+function displayData(event) {
+  if (event.type === "drop") event.preventDefault();
+
+  const cells = event.target.nextElementSibling.querySelectorAll("td");
+  cells[0].textContent = event.type;
+  const transfer = event.clipboardData || event.dataTransfer;
+
+  cells[1].firstChild.innerHTML = Array.from(
+    transfer.items,
+    (item) => `<li>${item.kind} ${item.type}</li>`,
+  ).join("\n");
+}
+
+form.addEventListener("paste", displayData);
+form.addEventListener("drop", displayData);
+form.addEventListener("reset", () => {
+  for (const cell of form.querySelectorAll("[contenteditable], td")) {
+    cell.textContent = "";
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample("Reading the data in a paste or drop event", "", 400, , , , , "allow-forms")}}
+
 ## Specifications
 
 {{Specifications}}
@@ -59,4 +177,3 @@ Every method and property listed in this document has its own reference page and
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/items/index.md
+++ b/files/en-us/web/api/datatransfer/items/index.md
@@ -108,4 +108,3 @@ reset.addEventListener("click", () => document.location.reload());
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -133,4 +133,3 @@ reset.addEventListener("click", () => document.location.reload());
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -126,4 +126,3 @@ target.addEventListener("drop", (ev) => {
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -104,4 +104,3 @@ target.addEventListener("dragover", (ev) => {
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -59,4 +59,3 @@ function dropHandler(ev) {
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)

--- a/files/en-us/web/api/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/index.md
@@ -59,4 +59,3 @@ An Example of each property, constructor, event type and global event handlers i
 - [Drag and drop](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - [Drag Operations](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations)
 - [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types)
-- [DataTransfer test - Paste or Drag](https://codepen.io/tech_query/pen/MqGgap)


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/16120. This example is linked on all DataTransfer pages, which seems a bit too much. I've removed all links and put it on the main interface page.