### PR TITLE
response.bodyUsed: Fix bad URL, update syntax

### DIFF
--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -30,7 +30,7 @@ When the user clicks "Use response", we check whether the response has been used
 
 ```html
 <p><button id="use">Use response</button> <button id="reset">Reset</button></p>
-<p><img id="my-image" src="" width="200" /></p>
+<p><img id="my-image" src="" width="150" /></p>
 <p id="log"></p>
 ```
 

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -29,11 +29,10 @@ When the user clicks "Use response", we check whether the response has been used
 #### HTML
 
 ```html
-<button id="use">Use response</button>
-<button id="reset">Reset</button>
-<br />
-<img id="my-image" src="" />
-<pre id="log"></pre>
+<p><button id="use">Use response</button>
+<button id="reset">Reset</button></p>
+<p><img id="my-image" src="" width="200"></p>
+<p id="log"></p>
 ```
 
 #### JavaScript
@@ -45,7 +44,7 @@ const myImage = document.querySelector("#my-image");
 const log = document.querySelector("#log");
 
 const responsePromise = fetch(
-  "https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg",
+  "/shared-assets/images/examples/firefox-logo.svg",
 );
 
 useResponse.addEventListener("click", async () => {

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -31,7 +31,7 @@ When the user clicks "Use response", we check whether the response has been used
 ```html
 <p><button id="use">Use response</button> <button id="reset">Reset</button></p>
 <p><img id="my-image" src="" width="150" /></p>
-<p id="log"></p>
+<pre id="log"></pre>
 ```
 
 #### JavaScript

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -29,9 +29,8 @@ When the user clicks "Use response", we check whether the response has been used
 #### HTML
 
 ```html
-<p><button id="use">Use response</button>
-<button id="reset">Reset</button></p>
-<p><img id="my-image" src="" width="200"></p>
+<p><button id="use">Use response</button> <button id="reset">Reset</button></p>
+<p><img id="my-image" src="" width="200" /></p>
 <p id="log"></p>
 ```
 


### PR DESCRIPTION
Replace bad image URL:
- The URL used in the example (an image on a Mediawiki server) was no longer valid. For future-proofing, seems better to use a local image URL.
- Add `width=150` to `<img>` tag, because the new image is an SVG that will otherwise render overpoweringly large. Update code:
- <s>Remove the trailing / in the `<img>` tag, because we're writing HTML not XML.</s> (Linter decided it likes `<img ... />`.)
- Replace the non-conforming use of `<br />` to separate thematic elements with enclosing `<p>` tags around each thematic element.
- <s>Replace arbitrary, gratuitous use of `<pre>` with `<p>` tags.</s>

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The URL used in the example (an image on a Mediawiki server) was no longer valid. Also, the code was... quite outdated, by current web standards.

### Motivation

Examples are more effective when they successfully demonstrate the features being documented, which a broken image placeholder doesn't really accomplish. Ditto, code that demonstrates recent web standards and practices, rather than flaunting them.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
