### PR TITLE
Remove remaining usage of inline style

### DIFF
--- a/files/en-us/web/css/contain/index.md
+++ b/files/en-us/web/css/contain/index.md
@@ -163,10 +163,14 @@ div {
   margin: 10px;
   font-size: 20px;
 }
+
+.contain-paint {
+  contain: paint;
+}
 ```
 
 ```html
-<div style="contain: paint">
+<div class="contain-paint">
   <p>This text will be clipped to the bounds of the box.</p>
 </div>
 <div>
@@ -181,7 +185,7 @@ div {
 Consider the example below which shows how elements behave with and without layout containment applied:
 
 ```html
-<div class="card" style="contain: layout;">
+<div class="card contain-layout">
   <h2>Card 1</h2>
   <div class="fixed"><p>Fixed box 1</p></div>
   <div class="float"><p>Float box 1</p></div>
@@ -233,6 +237,10 @@ div {
   float: left;
   margin: 10px;
   background: aquamarine;
+}
+
+.contain-layout {
+  contain: layout;
 }
 ```
 
@@ -297,20 +305,20 @@ CSS quotes are similarly affected in that the [`content`](/en-US/docs/Web/CSS/co
 <!-- With style containment -->
 <span class="open-quote">
   outer
-  <span style="contain: style;">
-    <span class="open-quote"> inner </span>
+  <span class="contain-style">
+    <span class="open-quote">inner</span>
   </span>
 </span>
-<span class="close-quote"> close </span>
+<span class="close-quote">close</span>
 <br />
 <!-- Without containment -->
 <span class="open-quote">
   outer
   <span>
-    <span class="open-quote"> inner </span>
+    <span class="open-quote">inner</span>
   </span>
 </span>
-<span class="close-quote"> close </span>
+<span class="close-quote">close</span>
 ```
 
 ```css
@@ -323,6 +331,10 @@ body {
 
 .close-quote::after {
   content: close-quote;
+}
+
+.contain-style {
+  contain: style;
 }
 ```
 

--- a/files/en-us/web/css/css_colors/color_values/index.md
+++ b/files/en-us/web/css/css_colors/color_values/index.md
@@ -193,7 +193,7 @@ th {
 }
 ```
 
-```html
+```html hidden
 <table>
   <thead>
     <tr>
@@ -201,33 +201,31 @@ th {
       <th scope="col">Example</th>
     </tr>
   </thead>
-  <tbody>
-    <tr>
-      <td><code>hsl(90deg 0% 50%)</code></td>
-      <td style="background-color: hsl(90deg 0% 50%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hsl(90 100% 50%)</code></td>
-      <td style="background-color: hsl(90 100% 50%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hsl(0.15turn 50% 75%)</code></td>
-      <td style="background-color: hsl(0.15turn 50% 75%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hsl(0.15turn 90% 75%)</code></td>
-      <td style="background-color: hsl(0.15turn 90% 75%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hsl(0.15turn 90% 50%)</code></td>
-      <td style="background-color: hsl(0.15turn 90% 50%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hsl(270deg 90% 50% / 50%)</code></td>
-      <td style="background-color: hsl(270deg 90% 50% / 50%);">&nbsp;</td>
-    </tr>
-  </tbody>
+  <tbody></tbody>
 </table>
+```
+
+```js hidden
+const colors = [
+  "hsl(90deg 0% 50%)",
+  "hsl(90 100% 50%)",
+  "hsl(0.15turn 50% 75%)",
+  "hsl(0.15turn 90% 75%)",
+  "hsl(0.15turn 90% 50%)",
+  "hsl(270deg 90% 50% / 50%)",
+];
+
+const tbody = document.querySelector("tbody");
+for (const color of colors) {
+  const tr = document.createElement("tr");
+  const td1 = document.createElement("td");
+  td1.appendChild(document.createElement("code")).textContent = color;
+  const td2 = document.createElement("td");
+  td2.style.backgroundColor = color;
+  tr.appendChild(td1);
+  tr.appendChild(td2);
+  tbody.appendChild(tr);
+}
 ```
 
 {{EmbedLiveSample("HSL_functional_notation", 300, 200)}}
@@ -260,8 +258,7 @@ hwb(90 10% 10% / 50%)
 
 In the below examples, we set the same hues as in the `hsl()` examples, but we are adding whiteness and blackness to each hue via `hwb()` instead of saturation and lightness:
 
-```css hidden
-{/*end the bad selector*/}
+```css hidden live-sample___hwb_functional_notation
 table {
   border: 1px solid black;
   font:
@@ -285,7 +282,7 @@ th {
 }
 ```
 
-```html
+```html hidden live-sample___hwb_functional_notation
 <table>
   <thead>
     <tr>
@@ -293,33 +290,31 @@ th {
       <th scope="col">Example</th>
     </tr>
   </thead>
-  <tbody>
-    <tr>
-      <td><code>hwb(90deg 50% 50%)</code></td>
-      <td style="background-color: hwb(90deg 50% 50%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hwb(90 0% 0%)</code></td>
-      <td style="background-color: hwb(90 0% 0%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hwb(0.15turn 25% 0%)</code></td>
-      <td style="background-color: hwb(0.15turn 25% 0%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hwb(0.15turn 10% 25%)</code></td>
-      <td style="background-color: hwb(0.15turn 10% 25%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hwb(1turn 10% 65%)</code></td>
-      <td style="background-color: hwb(1turn 10% 65%);">&nbsp;</td>
-    </tr>
-    <tr>
-      <td><code>hwb(270deg 75% 10%)</code></td>
-      <td style="background-color: hwb(270deg 75% 10%);">&nbsp;</td>
-    </tr>
-  </tbody>
+  <tbody></tbody>
 </table>
+```
+
+```js hidden live-sample___hwb_functional_notation
+const colors = [
+  "hwb(90deg 50% 50%)",
+  "hwb(90 0% 0%)",
+  "hwb(0.15turn 25% 0%)",
+  "hwb(0.15turn 10% 25%)",
+  "hwb(1turn 10% 65%)",
+  "hwb(270deg 75% 10%)",
+];
+
+const tbody = document.querySelector("tbody");
+for (const color of colors) {
+  const tr = document.createElement("tr");
+  const td1 = document.createElement("td");
+  td1.appendChild(document.createElement("code")).textContent = color;
+  const td2 = document.createElement("td");
+  td2.style.backgroundColor = color;
+  tr.appendChild(td1);
+  tr.appendChild(td2);
+  tbody.appendChild(tr);
+}
 ```
 
 {{EmbedLiveSample("HWB_functional_notation", 300, 200)}}
@@ -339,11 +334,11 @@ Similar to the sRGB hue color functions, the hue (`h`) value in `lch()` and `okl
 The following gradients demonstrate the hue colors at every angle form `0deg` to `360deg` in the sRGB, CIE Lab, and OKlab color spaces:
 
 ```html hidden live-sample___hues
-<p>sRGB (`hsl()` and `hwb()`)</p>
+<p>sRGB (<code>hsl()</code> and <code>hwb()</code>)</p>
 <div id="srgb"></div>
-<p>CIE Lab (`lch()`)</p>
+<p>CIE Lab (<code>lch()</code>)</p>
 <div id="lch"></div>
-<p>OKLab (`oklch()`)</p>
+<p>OKLab (<code>oklch()</code>)</p>
 <div id="oklch"></div>
 <p>
   <label><input type="checkbox" /> Toggle greyscale</label>
@@ -417,9 +412,8 @@ The example below shows the effect of changing the lightness value in the `lch()
   grid-template-columns: repeat(6, 1fr);
   gap: 4px;
 }
-[id$="99"],
-[id$="90"],
-[id$="80"] {
+
+.dark-text {
   color: lch(1% 40 0deg);
 }
 
@@ -427,104 +421,32 @@ The example below shows the effect of changing the lightness value in the `lch()
   border-radius: 8px;
   padding: 8px 4px;
 }
-#lch-1 {
-  background-color: lch(1% 40 0deg);
-}
-#lch-10 {
-  background-color: lch(10% 40 0deg);
-}
-#lch-20 {
-  background-color: lch(20% 40 0deg);
-}
-#lch-30 {
-  background-color: lch(30% 40 0deg);
-}
-#lch-40 {
-  background-color: lch(40% 40 0deg);
-}
-#lch-50 {
-  background-color: lch(50% 40 0deg);
-}
-#lch-60 {
-  background-color: lch(60% 40 0deg);
-}
-#lch-70 {
-  background-color: lch(70% 40 0deg);
-}
-#lch-80 {
-  background-color: lch(80% 40 0deg);
-}
-#lch-90 {
-  background-color: lch(90% 40 0deg);
-}
-#lch-99 {
-  background-color: lch(99% 40 0deg);
-}
-
-#oklch-1 {
-  background-color: oklch(1% 0.12 0deg);
-}
-#oklch-10 {
-  background-color: oklch(10% 0.12 0deg);
-}
-#oklch-20 {
-  background-color: oklch(20% 0.12 0deg);
-}
-#oklch-30 {
-  background-color: oklch(30% 0.12 0deg);
-}
-#oklch-40 {
-  background-color: oklch(40% 0.12 0deg);
-}
-#oklch-50 {
-  background-color: oklch(50% 0.12 0deg);
-}
-#oklch-60 {
-  background-color: oklch(60% 0.12 0deg);
-}
-#oklch-70 {
-  background-color: oklch(70% 0.12 0deg);
-}
-#oklch-80 {
-  background-color: oklch(80% 0.12 0deg);
-}
-#oklch-90 {
-  background-color: oklch(90% 0.12 0deg);
-}
-#oklch-99 {
-  background-color: oklch(99% 0.12 0deg);
-}
 ```
 
 ```html hidden live-sample___lch-colors
-<div class="container">
-  <div id="lch-1">lch(1 40 0)</div>
-  <div id="lch-10">lch(10 40 0)</div>
-  <div id="lch-20">lch(20 40 0)</div>
-  <div id="lch-30">lch(30 40 0)</div>
-  <div id="lch-40">lch(40 40 0)</div>
-  <div id="lch-50">lch(50 40 0)</div>
-  <div id="lch-60">lch(60 40 0)</div>
-  <div id="lch-70">lch(70 40 0)</div>
-  <div id="lch-80">lch(80 40 0)</div>
-  <div id="lch-90">lch(90 40 0)</div>
-  <div id="lch-99">lch(99 40 0)</div>
-  <div></div>
-  <div id="oklch-1">oklch(1 .12 0)</div>
-  <div id="oklch-10">oklch(10 .12 0)</div>
-  <div id="oklch-20">oklch(20 .12 0)</div>
-  <div id="oklch-30">oklch(30 .12 0)</div>
-  <div id="oklch-40">oklch(40 .12 0)</div>
-  <div id="oklch-50">oklch(50 .12 0)</div>
-  <div id="oklch-60">oklch(60 .12 0)</div>
-  <div id="oklch-70">oklch(70 .12 0)</div>
-  <div id="oklch-80">oklch(80 .12 0)</div>
-  <div id="oklch-90">oklch(90 .12 0)</div>
-  <div id="oklch-99">oklch(99 .12 0)</div>
-</div>
+<div class="container"></div>
 ```
 
-{{embedlivesample("lch-colors", '100', '150') }}
+```js hidden live-sample___lch-colors
+const container = document.querySelector(".container");
+for (let l = 0; l <= 100; l += 10) {
+  const div = document.createElement("div");
+  const usedL = l === 0 ? 1 : l === 100 ? 99 : l;
+  div.textContent = div.style.backgroundColor = `lch(${usedL}% 40 0)`;
+  if (usedL >= 80) div.classList.add("dark-text");
+  container.appendChild(div);
+}
+container.appendChild(document.createElement("div"));
+for (let l = 0; l <= 100; l += 10) {
+  const div = document.createElement("div");
+  const usedL = l === 0 ? 1 : l === 100 ? 99 : l;
+  div.textContent = div.style.backgroundColor = `oklch(${usedL}% 0.12 0)`;
+  if (usedL >= 80) div.classList.add("dark-text");
+  container.appendChild(div);
+}
+```
+
+{{embedlivesample("lch-colors", '100', '200') }}
 
 ## Lab and OKLab
 
@@ -544,27 +466,7 @@ The `b` value has the same constraints. It specifies the color's distance along 
 The following example demonstrates the effects of varying the `a` axis via a `lab()` function and the `b` axis via an `oklab()` function.
 
 ```html hidden live-sample___lab-colors
-<div class="container">
-  <div id="lab-100">lab(50% -100% 0)</div>
-  <div id="lab-75">lab(50% -75% 0)</div>
-  <div id="lab-50">lab(50% -50% 0)</div>
-  <div id="lab-25">lab(50% -25% 0)</div>
-  <div id="lab-0">lab(50% 0 0)</div>
-  <div id="lab--25">lab(50% 25% 0)</div>
-  <div id="lab--50">lab(50% 50% 0)</div>
-  <div id="lab--75">lab(50% 75% 0)</div>
-  <div id="lab--100">lab(50% 100% 0)</div>
-  <div></div>
-  <div id="oklab-4">oklab(50% 0 -0.4)</div>
-  <div id="oklab-3">oklab(50% 0 -0.3)</div>
-  <div id="oklab-2">oklab(50% 0 -0.2)</div>
-  <div id="oklab-1">oklab(50% 0 -0.1)</div>
-  <div id="oklab-0">oklab(50% 0 0)</div>
-  <div id="oklab--1">oklab(50% 0 0.1)</div>
-  <div id="oklab--2">oklab(50% 0 0.2)</div>
-  <div id="oklab--3">oklab(50% 0 0.3)</div>
-  <div id="oklab--4">oklab(50% 0 0.4)</div>
-</div>
+<div class="container"></div>
 ```
 
 ```css hidden live-sample___lab-colors
@@ -581,60 +483,21 @@ The following example demonstrates the effects of varying the `a` axis via a `la
   border-radius: 8px;
   padding: 8px 4px;
 }
-#lab-100 {
-  background-color: lab(50% -100% 0);
-}
-#lab-75 {
-  background-color: lab(50% -75% 0);
-}
-#lab-50 {
-  background-color: lab(50% -50% 0);
-}
-#lab-25 {
-  background-color: lab(50% -25% 0);
-}
-#lab-0 {
-  background-color: lab(50% 0 0);
-}
-#lab--25 {
-  background-color: lab(50% 25% 0);
-}
-#lab--50 {
-  background-color: lab(50% 50% 0);
-}
-#lab--75 {
-  background-color: lab(50% 75% 0);
-}
-#lab--100 {
-  background-color: lab(50% 100% 0);
-}
+```
 
-#oklab-4 {
-  background-color: oklab(50% 0 -0.4);
+```js hidden live-sample___lab-colors
+const container = document.querySelector(".container");
+
+for (let a = -100; a <= 100; a += 25) {
+  const div = document.createElement("div");
+  div.textContent = div.style.backgroundColor = `lab(50% ${a}% 0)`;
+  container.appendChild(div);
 }
-#oklab-3 {
-  background-color: oklab(50% 0 -0.3);
-}
-#oklab-2 {
-  background-color: oklab(50% 0 -0.2);
-}
-#oklab-1 {
-  background-color: oklab(50% 0 -0.1);
-}
-#oklab-0 {
-  background-color: oklab(50% 0 0);
-}
-#oklab--1 {
-  background-color: oklab(50% 0 0.1);
-}
-#oklab--2 {
-  background-color: oklab(50% 0 0.2);
-}
-#oklab--3 {
-  background-color: oklab(50% 0 0.3);
-}
-#oklab--4 {
-  background-color: oklab(50% 0 0.4);
+container.appendChild(document.createElement("div"));
+for (let b = -4; b <= 4; b++) {
+  const div = document.createElement("div");
+  div.textContent = div.style.backgroundColor = `oklab(50% 0 ${b / 10})`;
+  container.appendChild(div);
 }
 ```
 

--- a/files/en-us/web/css/css_display/block_formatting_context/index.md
+++ b/files/en-us/web/css/css_display/block_formatting_context/index.md
@@ -63,19 +63,19 @@ This is the default rendering for {{htmlelement("button")}} elements and button 
 
 ```html
 <section>
-  <div class="box">
+  <div class="box1">
     <div class="float">I am a floated box!</div>
     <p>I am content inside the container.</p>
   </div>
 </section>
 <section>
-  <div class="box" style="overflow:auto">
+  <div class="box2">
     <div class="float">I am a floated box!</div>
     <p>I am content inside the <code>overflow:auto</code> container.</p>
   </div>
 </section>
 <section>
-  <div class="box" style="display:flow-root">
+  <div class="box3">
     <div class="float">I am a floated box!</div>
     <p>I am content inside the <code>display:flow-root</code> container.</p>
   </div>
@@ -88,13 +88,20 @@ This is the default rendering for {{htmlelement("button")}} elements and button 
 section {
   height: 150px;
 }
-.box {
+.box1 {
   background-color: rgb(224 206 247);
   border: 5px solid rebeccapurple;
 }
-.box[style] {
+.box2,
+.box3 {
   background-color: aliceblue;
   border: 5px solid steelblue;
+}
+.box2 {
+  overflow: auto;
+}
+.box3 {
+  display: flow-root;
 }
 .float {
   float: left;
@@ -110,7 +117,7 @@ section {
 
 ### Exclude external floats
 
-In the following example, we are using `display:flow-root` and floats, creating two side-by-side boxes demonstrating that an element in the normal flow establishes a new BFC and does not overlap the margin box of any floats in the same block formatting context as the element itself.
+In the following example, we are using `display: flow-root` and floats, creating two side-by-side boxes demonstrating that an element in the normal flow establishes a new BFC and does not overlap the margin box of any floats in the same block formatting context as the element itself.
 
 #### HTML
 
@@ -121,7 +128,7 @@ In the following example, we are using `display:flow-root` and floats, creating 
 </section>
 <section>
   <div class="float">Try to resize this outer float</div>
-  <div class="box" style="display:flow-root">
+  <div class="box2">
     <p><code>display:flow-root</code></p>
   </div>
 </section>
@@ -137,9 +144,10 @@ section {
   background-color: rgb(224 206 247);
   border: 5px solid rebeccapurple;
 }
-.box[style] {
+.box2 {
   background-color: aliceblue;
   border: 5px solid steelblue;
+  display: flow-root;
 }
 .float {
   float: left;

--- a/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
@@ -115,13 +115,20 @@ As an example, we have two paragraphs below. The first uses the default `horizon
 
 ```html
 <div class="wrapper">
-  <p style="writing-mode: horizontal-tb">
+  <p class="horizontal-tb">
     I have writing mode set to the default <code>horizontal-tb</code>
   </p>
-  <p style="writing-mode: vertical-rl">
-    I have writing mode set to <code>vertical-rl</code>
-  </p>
+  <p class="vertical-rl">I have writing mode set to <code>vertical-rl</code></p>
 </div>
+```
+
+```css
+.horizontal-tb {
+  writing-mode: horizontal-tb;
+}
+.vertical-rl {
+  writing-mode: vertical-rl;
+}
 ```
 
 {{ EmbedLiveSample('writing-mode', '500', '420') }}

--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
@@ -22,9 +22,13 @@ The child elements of this container will now lay out item by item along the row
 
 As the items move onto new rows, they will display according to the masonry algorithm. Items will load into the column with the most room, causing a tightly packed layout without strict row tracks.
 
-```css hidden live-sample___block-axis
+```css hidden live-sample___block-axis live-sample___inline-axis live-sample___spanners live-sample___positioned
 * {
   box-sizing: border-box;
+}
+
+body {
+  font: 1.2em sans-serif;
 }
 
 .grid {
@@ -51,57 +55,46 @@ As the items move onto new rows, they will display according to the masonry algo
 }
 ```
 
-```html live-sample___block-axis
+```html live-sample___block-axis live-sample___inline-axis
 <div class="grid">
-  <div class="item" style="block-size: 2em;"></div>
-  <div class="item" style="block-size: 3em;"></div>
-  <div class="item" style="block-size: 1.6em;"></div>
-  <div class="item" style="block-size: 4em;"></div>
-  <div class="item" style="block-size: 2.2em;"></div>
-  <div class="item" style="block-size: 3em;"></div>
-  <div class="item" style="block-size: 4.5em;"></div>
-  <div class="item" style="block-size: 1em;"></div>
-  <div class="item" style="block-size: 3.5em;"></div>
-  <div class="item" style="block-size: 2.8em;"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
 </div>
+```
+
+```js live-sample___block-axis live-sample___spanners live-sample___positioned
+// prettier-ignore
+const itemSizes = [
+  "2em", "3em", "1.6em", "4em", "3.2em",
+  "3em", "4.5em", "1em", "3.5em", "2.8em",
+];
+const items = document.querySelectorAll(".item");
+for (let i = 0; i < items.length; i++) {
+  items[i].style.blockSize = itemSizes[i];
+}
 ```
 
 {{EmbedLiveSample("block-axis", "", "250px")}}
 
 It is also possible to create a masonry layout with items loading into rows.
 
-```html hidden live-sample___inline-axis
-<div class="grid">
-  <div class="item" style="inline-size: 2em;"></div>
-  <div class="item" style="inline-size: 3em;"></div>
-  <div class="item" style="inline-size: 1.6em;"></div>
-  <div class="item" style="inline-size: 4em;"></div>
-  <div class="item" style="inline-size: 2.2em;"></div>
-  <div class="item" style="inline-size: 3em;"></div>
-  <div class="item" style="inline-size: 4.5em;"></div>
-  <div class="item" style="inline-size: 1em;"></div>
-  <div class="item" style="inline-size: 3.5em;"></div>
-  <div class="item" style="inline-size: 2.8em;"></div>
-</div>
-```
-
-```css hidden live-sample___inline-axis
-* {
-  box-sizing: border-box;
-}
-
-.grid {
-  padding: 10px;
-  border: 2px solid #f76707;
-  border-radius: 5px;
-  background-color: #fff4e6;
-}
-
-.item {
-  border: 2px solid #ffa94d;
-  border-radius: 5px;
-  background-color: #ffd8a8;
-  color: #d9480f;
+```js live-sample___inline-axis
+// prettier-ignore
+const itemSizes = [
+  "2em", "3em", "1.6em", "4em", "2.2em",
+  "3em", "4.5em", "1em", "3.5em", "2.8em",
+];
+const items = document.querySelectorAll(".item");
+for (let i = 0; i < items.length; i++) {
+  items[i].style.inlineSize = itemSizes[i];
 }
 ```
 
@@ -126,37 +119,17 @@ In this example two of the items span two tracks, and the masonry items work aro
 
 ```html live-sample___spanners
 <div class="grid">
-  <div class="item" style="block-size: 2em;"></div>
-  <div class="item" style="block-size: 3em; grid-column-end: span 2;"></div>
-  <div class="item" style="block-size: 1.6em;"></div>
-  <div class="item" style="block-size: 4em;"></div>
-  <div class="item" style="block-size: 2.2em; grid-column-end: span 2"></div>
-  <div class="item" style="block-size: 3em;"></div>
-  <div class="item" style="block-size: 4.5em;"></div>
-  <div class="item" style="block-size: 1em;"></div>
-  <div class="item" style="block-size: 3.5em;"></div>
-  <div class="item" style="block-size: 2.8em;"></div>
+  <div class="item"></div>
+  <div class="item span-2"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item span-2"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
 </div>
-```
-
-```css hidden live-sample___spanners
-* {
-  box-sizing: border-box;
-}
-
-.grid {
-  padding: 10px;
-  border: 2px solid #f76707;
-  border-radius: 5px;
-  background-color: #fff4e6;
-}
-
-.item {
-  border: 2px solid #ffa94d;
-  border-radius: 5px;
-  background-color: #ffd8a8;
-  color: #d9480f;
-}
 ```
 
 ```css live-sample___spanners
@@ -166,6 +139,10 @@ In this example two of the items span two tracks, and the masonry items work aro
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   grid-template-rows: masonry;
 }
+
+.span-2 {
+  grid-column-end: span 2;
+}
 ```
 
 {{EmbedLiveSample("spanners", "", "270px")}}
@@ -174,41 +151,17 @@ This example includes an item which has positioning for columns. Items with defi
 
 ```html live-sample___positioned
 <div class="grid">
-  <div class="item" style="block-size: 2em;"></div>
-  <div class="item" style="block-size: 3em;"></div>
-  <div class="item" style="block-size: 1.6em;"></div>
-  <div class="item" style="block-size: 4em;"></div>
-  <div class="item positioned" style="block-size: 3.2em;">positioned.</div>
-  <div class="item" style="block-size: 3em;"></div>
-  <div class="item" style="block-size: 4.5em;"></div>
-  <div class="item" style="block-size: 1em;"></div>
-  <div class="item" style="block-size: 3.5em;"></div>
-  <div class="item" style="block-size: 2.8em;"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item positioned">positioned.</div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
+  <div class="item"></div>
 </div>
-```
-
-```css hidden live-sample___positioned
-* {
-  box-sizing: border-box;
-}
-
-body {
-  font: 1.2em sans-serif;
-}
-
-.grid {
-  padding: 10px;
-  border: 2px solid #f76707;
-  border-radius: 5px;
-  background-color: #fff4e6;
-}
-
-.item {
-  border: 2px solid #ffa94d;
-  border-radius: 5px;
-  background-color: #ffd8a8;
-  color: #d9480f;
-}
 ```
 
 ```css live-sample___positioned

--- a/files/en-us/web/css/filter-function/brightness/index.md
+++ b/files/en-us/web/css/filter-function/brightness/index.md
@@ -159,15 +159,6 @@ In this example, to create a filter that darkens the content on which it is appl
 
 Given the following:
 
-```css hidden live-sample___svg_filter
-.filter {
-  filter: brightness(0.75);
-}
-svg {
-  position: absolute;
-}
-```
-
 ```html live-sample___svg_filter
 <svg role="none">
   <filter id="darken25" color-interpolation-filters="sRGB">
@@ -184,8 +175,8 @@ The following declarations produce similar effects:
 
 ```css
 filter: brightness(75%);
-filter: url(#darken25); /* with embedded SVG */
-filter: url(folder/fileName.svg#darken25); /* external svg filter definition */
+filter: url("#darken25"); /* with embedded SVG */
+filter: url("folder/fileName.svg#darken25"); /* external svg filter definition */
 ```
 
 In the images below, the first one has a `brightness()` filter function applied, the second one has a similar SVG brightness function applied, and the third is the original image for comparison.
@@ -203,13 +194,13 @@ In the images below, the first one has a `brightness()` filter function applied,
     <tr>
       <td>
         <img
-          class="filter"
+          class="css-filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="darkened pride flag" />
       </td>
       <td>
         <img
-          style="filter: url(#darken25)"
+          class="svg-filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="darkened pride flag" />
       </td>
@@ -221,6 +212,18 @@ In the images below, the first one has a `brightness()` filter function applied,
     </tr>
   </tbody>
 </table>
+```
+
+```css hidden live-sample___svg_filter
+.css-filter {
+  filter: brightness(0.75);
+}
+.svg-filter {
+  filter: url("#darken25");
+}
+svg {
+  position: absolute;
+}
 ```
 
 {{EmbedLiveSample('svg_filter','100%','280')}}

--- a/files/en-us/web/css/filter-function/brightness/index.md
+++ b/files/en-us/web/css/filter-function/brightness/index.md
@@ -221,8 +221,8 @@ In the images below, the first one has a `brightness()` filter function applied,
 .svg-filter {
   filter: url("#darken25");
 }
-svg {
-  position: absolute;
+svg:not(:root) {
+  display: none;
 }
 ```
 

--- a/files/en-us/web/css/filter-function/contrast/index.md
+++ b/files/en-us/web/css/filter-function/contrast/index.md
@@ -223,6 +223,9 @@ This example shows three images: the image with a `contrast()` filter function a
 .svg-filter {
   filter: url("#contrast");
 }
+svg:not(:root) {
+  display: none;
+}
 ```
 
 {{EmbedLiveSample('svg_filter','100%','280')}}

--- a/files/en-us/web/css/filter-function/contrast/index.md
+++ b/files/en-us/web/css/filter-function/contrast/index.md
@@ -177,8 +177,8 @@ These values produce the same results:
 
 ```css
 filter: contrast(200%);
-filter: url(#contrast); /* with embedded SVG */
-filter: url(folder/fileName.svg#contrast); /* external svg filter definition */
+filter: url("#contrast"); /* with embedded SVG */
+filter: url("folder/fileName.svg#contrast"); /* external svg filter definition */
 ```
 
 This example shows three images: the image with a `contrast()` filter function applied, the image with an equivalent `url()` filter applied, and the original images for comparison:
@@ -196,13 +196,13 @@ This example shows three images: the image with a `contrast()` filter function a
     <tr>
       <td>
         <img
-          style="filter: contrast(200%)"
+          class="css-filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="Pride flag" />
       </td>
       <td>
         <img
-          style="filter: url(#contrast)"
+          class="svg-filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="Pride flag" />
       </td>
@@ -214,6 +214,15 @@ This example shows three images: the image with a `contrast()` filter function a
     </tr>
   </tbody>
 </table>
+```
+
+```css hidden live-sample___svg_filter
+.css-filter {
+  filter: contrast(200%);
+}
+.svg-filter {
+  filter: url("#contrast");
+}
 ```
 
 {{EmbedLiveSample('svg_filter','100%','280')}}

--- a/files/en-us/web/css/filter-function/hue-rotate/index.md
+++ b/files/en-us/web/css/filter-function/hue-rotate/index.md
@@ -158,8 +158,8 @@ These values produce the same results:
 
 ```css
 filter: hue-rotate(90deg); /* 90deg rotation */
-filter: url(#hue-rotate); /* with embedded SVG */
-filter: url(folder/fileName.svg#hue-rotate); /* external svg filter definition */
+filter: url("#hue-rotate)"; /* with embedded SVG */
+filter: url("folder/fileName.svg#hue-rotate"); /* external svg filter definition */
 ```
 
 This example shows three images: the image with a `hue-rotate()` filter function applied, the image with an equivalent `url()` filter applied, and the original images for comparison:
@@ -177,13 +177,13 @@ This example shows three images: the image with a `hue-rotate()` filter function
     <tr>
       <td>
         <img
-          style="filter: hue-rotate(90deg)"
+          class="css-filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="Pride flag with rotated colors" />
       </td>
       <td>
         <img
-          style="filter: url(#hue-rotate)"
+          class="svg-filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="Pride flag with rotated colors" />
       </td>
@@ -195,6 +195,15 @@ This example shows three images: the image with a `hue-rotate()` filter function
     </tr>
   </tbody>
 </table>
+```
+
+```css hidden live-sample___svg_filter
+.css-filter {
+  filter: hue-rotate(90deg);
+}
+.svg-filter {
+  filter: url("#hue-rotate");
+}
 ```
 
 {{EmbedLiveSample('svg_filter','100%','280')}}

--- a/files/en-us/web/css/filter-function/hue-rotate/index.md
+++ b/files/en-us/web/css/filter-function/hue-rotate/index.md
@@ -204,6 +204,9 @@ This example shows three images: the image with a `hue-rotate()` filter function
 .svg-filter {
   filter: url("#hue-rotate");
 }
+svg:not(:root) {
+  display: none;
+}
 ```
 
 {{EmbedLiveSample('svg_filter','100%','280')}}

--- a/files/en-us/web/css/flex-grow/index.md
+++ b/files/en-us/web/css/flex-grow/index.md
@@ -113,12 +113,12 @@ In this example, the sum of six flex-grow factors is equal to eight, meaning eac
   <code>flex-grow: 2</code> set.
 </p>
 <div id="content">
-  <div class="small" style="background-color:red;">A</div>
-  <div class="small" style="background-color:lightblue;">B</div>
-  <div class="small" style="background-color:yellow;">C</div>
-  <div class="double" style="background-color:brown;">D</div>
-  <div class="double" style="background-color:lightgreen;">E</div>
-  <div class="small" style="background-color:brown;">F</div>
+  <div class="box1">A</div>
+  <div class="box2">B</div>
+  <div class="box3">C</div>
+  <div class="box4">D</div>
+  <div class="box5">E</div>
+  <div class="box6">F</div>
 </div>
 ```
 
@@ -133,13 +133,36 @@ div > div {
   border: 3px solid rgb(0 0 0 / 20%);
 }
 
-.small {
+.box1,
+.box2,
+.box3,
+.box6 {
   flex-grow: 1;
 }
 
-.double {
+.box4,
+.box5 {
   flex-grow: 2;
   border: 3px solid rgb(0 0 0 / 20%);
+}
+
+.box1 {
+  background-color: red;
+}
+.box2 {
+  background-color: lightblue;
+}
+.box3 {
+  background-color: yellow;
+}
+.box4 {
+  background-color: brown;
+}
+.box5 {
+  background-color: lightgreen;
+}
+.box6 {
+  background-color: brown;
 }
 ```
 

--- a/files/en-us/web/css/flex-shrink/index.md
+++ b/files/en-us/web/css/flex-shrink/index.md
@@ -102,11 +102,11 @@ This example demonstrates how negative free space is distributed based on the it
 
 ```html
 <div id="content">
-  <div class="box" style="background-color:red;">A</div>
-  <div class="box" style="background-color:lightblue;">B</div>
-  <div class="box" style="background-color:yellow;">C</div>
-  <div class="box4" style="background-color:lightsalmon;">D</div>
-  <div class="box5" style="background-color:lightgreen;">E</div>
+  <div class="box1">A</div>
+  <div class="box2">B</div>
+  <div class="box3">C</div>
+  <div class="box4">D</div>
+  <div class="box5">E</div>
 </div>
 ```
 
@@ -124,7 +124,9 @@ We give each flex item a {{cssxref("width")}} of `200px`. As the {{cssxref("flex
   width: 200px;
 }
 
-.box {
+.box1,
+.box2,
+.box3 {
   flex-shrink: 1;
 }
 
@@ -146,6 +148,21 @@ div {
   outline: 1px solid;
   line-height: 4em;
   text-align: center;
+}
+.box1 {
+  background-color: red;
+}
+.box2 {
+  background-color: lightblue;
+}
+.box3 {
+  background-color: yellow;
+}
+.box4 {
+  background-color: lightsalmon;
+}
+.box5 {
+  background-color: lightgreen;
 }
 ```
 

--- a/files/en-us/web/css/if/index.md
+++ b/files/en-us/web/css/if/index.md
@@ -240,7 +240,7 @@ For example, the following returns an {{cssxref("color_value/lch()")}} color if 
 ```css-nolint
 color: if(
   supports(color: lch(77.7% 0 0)): lch(77.7% 0 0);
-  else: rgb(192, 192, 192);
+  else: rgb(192 192 192);
 )
 ```
 
@@ -390,7 +390,7 @@ section {
   display: flex;
   gap: 16px;
   flex-direction: if(
-    media(orientation:landscape): row;
+    media(orientation: landscape): row;
     else: column;
   )
 }
@@ -401,7 +401,7 @@ Next, we target the `<h2>` element's {{cssxref("::before")}} pseudo-element, set
 ```css-nolint live-sample___basic
 h2::before {
   content: if(
-    style(--show-apple:true): "🍎 ";
+    style(--show-apple: true): "🍎 ";
   );
 }
 ```
@@ -410,7 +410,7 @@ Finally, we target the `<h2>` element itself. We use a feature query `<if-test>`
 
 ```css-nolint live-sample___basic
 h2 {
-    color: if(
+  color: if(
     supports(color: lch(29.57% 43.25 344.44)): lch(29.57% 43.25 344.44);
     else: #792359;
   )

--- a/files/en-us/web/css/line-style/index.md
+++ b/files/en-us/web/css/line-style/index.md
@@ -208,48 +208,12 @@ Notice that the black border is not always black.
 
 This example demonstrates line-style and color choice. With some `<line-style>` keyword values, the color of the line may not be what you expect. To create the required "3D" effect of `groove`, `ridge`, `inset`, and `outset` styles when displaying these values in black or white, user agents use different color calculations than any other color-line combinations.
 
-#### HTML
-
-This example uses multiple {{HTMLElement( "div" )}} elements, each with a different `border-color` set as an inline [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style).
-
-```html
-<div style="border-color: #000000"></div>
-```
-
-```html hidden live-sample___line_style_colors
-<section>
-  <div style="border-color: #000000"></div>
-  <div style="border-color: #000001"></div>
-  <div style="border-color: #ffffff"></div>
-
-  <div style="border-color: #ff00ff"></div>
-  <div style="border-color: #ffff00"></div>
-  <div style="border-color: #00ffff"></div>
-
-  <div style="border-color: #cc33cc"></div>
-  <div style="border-color: #cccc33"></div>
-  <div style="border-color: #33cccc"></div>
-
-  <div style="border-color: #ff0000"></div>
-  <div style="border-color: #00ff00"></div>
-  <div style="border-color: #0000ff"></div>
-
-  <div style="border-color: #cc3333"></div>
-  <div style="border-color: #33cc33"></div>
-  <div style="border-color: #3333cc"></div>
-
-  <div style="border-color: #993333"></div>
-  <div style="border-color: #339933"></div>
-  <div style="border-color: #333399"></div>
-</section>
-```
-
 #### CSS
 
 The four sides of each `<div>` have a different `<line-style>` value, and each list item has a different {{cssxref("color_value", "&lt;color>")}} value. We use [generated content](/en-US/docs/Web/CSS/content) to display the CSS declared inline.
 
 ```css hidden live-sample___line_style_colors
-section {
+body {
   display: flex;
   flex-wrap: wrap;
   gap: 1em;
@@ -264,14 +228,34 @@ div {
   border-style: inset groove ridge outset;
   padding: 5px;
 }
-div::before {
-  content: attr(style);
+```
+
+#### JavaScript
+
+The JavaScript dynamically creates {{HTMLElement( "div" )}} elements, each with a different `border-color` set.
+
+```js live-sample___line_style_colors
+// prettier-ignore
+const colors = [
+  "#000000", "#000001", "#ffffff",
+  "#ff00ff", "#ffff00", "#00ffff",
+  "#cc33cc", "#cccc33", "#33cccc",
+  "#ff0000", "#00ff00", "#0000ff",
+  "#cc3333", "#33cc33", "#3333cc",
+  "#993333", "#339933", "#333399",
+];
+
+for (const c of colors) {
+  const div = document.createElement("div");
+  div.style.borderColor = c;
+  div.textContent = c;
+  document.body.appendChild(div);
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("line_style_colors", "500", "400")}}
+{{EmbedLiveSample("line_style_colors", "500", "200")}}
 
 Notice that the almost-black color of `#000001` may be different from the actual black, and the contrast between the dark and light edges is more noticeable when using lighter colors.
 

--- a/files/en-us/web/css/math-shift/index.md
+++ b/files/en-us/web/css/math-shift/index.md
@@ -50,6 +50,13 @@ math {
   math-shift: compact;
   font-size: 64pt;
 }
+
+.normal-shift {
+  math-shift: normal;
+}
+.compact-shift {
+  math-shift: compact;
+}
 ```
 
 ### MathML
@@ -58,11 +65,11 @@ The following MathML displays two versions of "x squared" using a font with an O
 
 ```html
 <math>
-  <msup style="math-shift: normal">
+  <msup class="normal-shift">
     <mi>x</mi>
     <mn>2</mn>
   </msup>
-  <msup style="math-shift: compact">
+  <msup class="compact-shift">
     <mi>x</mi>
     <mn>2</mn>
   </msup>


### PR DESCRIPTION
Continuation of https://github.com/mdn/content/pull/40121. After this PR, we have almost no use of `style` and `on*` HTML attributes.

In a lot of cases, we are adding ad-hoc styles to each element in a list. In this case I'm using JavaScript instead, which better parallels how this kind of code likely works IRL (it will come from some external data).