### PR TITLE
Remove a codepen link about testing support

### DIFF
--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -171,4 +171,3 @@ function getElementByIdWrapper(xmlDoc, id) {
 
 - {{domxref("Document.createExpression()")}}
 - {{domxref("XPathResult")}}
-- [Check for browser support](https://codepen.io/johan/full/DJoqaX)


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/16120. This codepen only demonstrates support, which is already shown in BCD. It's also written in CoffeeScript.