### PR TITLE
Fix incorrect terminology in URL.hostname description

### DIFF
--- a/files/en-us/web/api/url/hostname/index.md
+++ b/files/en-us/web/api/url/hostname/index.md
@@ -12,8 +12,6 @@ The **`hostname`** property of the {{domxref("URL")}} interface is a string cont
 
 This property can be set to change the hostname of the URL. If the URL's scheme is not [hierarchical](https://www.rfc-editor.org/rfc/rfc3986#section-1.2.3) (which the URL standard calls "[special schemes](https://url.spec.whatwg.org/#special-scheme)"), then it has no concept of a host and setting this property has no effect.
 
-The hostname is {{Glossary("Percent-encoding", "percent-encoded")}} when setting but not percent-decoded when reading.
-
 ## Value
 
 A string.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description
Removed the incorrect paragraph in the `URL.hostname` property description that referred to "percent-encoded". The behavior is already covered by the earlier statement about IDN conversion.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The last paragraph of the `URL.hostname` description incorrectly stated that the hostname is "percent-encoded when setting but not percent-decoded when reading."

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
- The earlier sentence in the description, "IPv4 and IPv6 addresses are normalized, such as stripping leading zeros, and domain names are converted to IDN," already covers the correct behavior.

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes #40341