### PR TITLE
[CSS] Docs: Clarify margin collapse rule for parent/child scenarios

### DIFF
--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -17,7 +17,7 @@ Margin collapsing occurs in three basic cases:
   - : Specifically, this occurs in two main cases:
   - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has \_[clearance](/en-US/docs/Web/CSS/clear) applied.
   - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
-  - : In both cases, creating a new  [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
+  - : In both cases, creating a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
 - Empty blocks
   - : If there is no border, padding, inline content, {{cssxref("height")}}, or {{cssxref("min-height")}} to separate a block's {{cssxref("margin-top")}} from its {{cssxref("margin-bottom")}}, then its top and bottom margins collapse.
 

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -13,11 +13,12 @@ Margin collapsing occurs in three basic cases:
 - Adjacent siblings
   - : The margins of adjacent siblings are collapsed (except when the latter sibling needs to be [cleared](/en-US/docs/Web/CSS/clear) past floats).
 - No content separating parent and descendants
-  - : The vertical margins between a parent block and its descendants can collapse. This happens when there is no separating content between them.
-  - : Specifically, this occurs in two main cases:
-  - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has \_[clearance](/en-US/docs/Web/CSS/clear) applied.
-  - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
-  - : In both cases, creating a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
+  - : The vertical margins between a parent block and its descendants can collapse. This happens when there is no separating content between them. Specifically, this occurs in two main cases:
+
+    - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has _[clearance](/en-US/docs/Web/CSS/clear)_ applied.
+    - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
+
+    In both cases, creating a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
 - Empty blocks
   - : If there is no border, padding, inline content, {{cssxref("height")}}, or {{cssxref("min-height")}} to separate a block's {{cssxref("margin-top")}} from its {{cssxref("margin-bottom")}}, then its top and bottom margins collapse.
 

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -14,7 +14,7 @@ Margin collapsing occurs in three basic cases:
   - : The margins of adjacent siblings are collapsed (except when the latter sibling needs to be [cleared](/en-US/docs/Web/CSS/clear) past floats).
 - No content separating parent and descendants
   - : The vertical margins between a parent block and its descendants can collapse. This happens when there is no separating content between them. Specifically, this occurs in two main cases:
-    - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has _[clearance](/en-US/docs/Web/CSS/clear)_ applied.
+    - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a {{cssxref("border-top")}} , {{cssxref("padding-top")}} , contains any inline content (such as text), or has _[clearance](/en-US/docs/Web/CSS/clear)_ applied.
     - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
 
     In both cases, creating a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -15,7 +15,7 @@ Margin collapsing occurs in three basic cases:
 - No content separating parent and descendants
   - : The vertical margins between a parent block and its descendants can collapse. This happens when there is no separating content between them.
   - : Specifically, this occurs in two main cases:
-  - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has  _[clearance](/en-US/docs/Web/CSS/clear) applied.
+  - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has \_[clearance](/en-US/docs/Web/CSS/clear) applied.
   - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
   - : In both cases, creating a new  [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
 - Empty blocks

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -14,11 +14,11 @@ Margin collapsing occurs in three basic cases:
   - : The margins of adjacent siblings are collapsed (except when the latter sibling needs to be [cleared](/en-US/docs/Web/CSS/clear) past floats).
 - No content separating parent and descendants
   - : The vertical margins between a parent block and its descendants can collapse. This happens when there is no separating content between them. Specifically, this occurs in two main cases:
-
     - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has _[clearance](/en-US/docs/Web/CSS/clear)_ applied.
     - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
 
     In both cases, creating a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
+
 - Empty blocks
   - : If there is no border, padding, inline content, {{cssxref("height")}}, or {{cssxref("min-height")}} to separate a block's {{cssxref("margin-top")}} from its {{cssxref("margin-bottom")}}, then its top and bottom margins collapse.
 

--- a/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/en-us/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -13,7 +13,11 @@ Margin collapsing occurs in three basic cases:
 - Adjacent siblings
   - : The margins of adjacent siblings are collapsed (except when the latter sibling needs to be [cleared](/en-US/docs/Web/CSS/clear) past floats).
 - No content separating parent and descendants
-  - : If there is no border, padding, inline part, [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) created, or _[clearance](/en-US/docs/Web/CSS/clear)_ to separate the {{cssxref("margin-top")}} of a block from the {{cssxref("margin-top")}} of one or more of its descendant blocks; or no border, padding, inline content, {{cssxref("height")}}, or {{cssxref("min-height")}} to separate the {{cssxref("margin-bottom")}} of a block from the {{cssxref("margin-bottom")}} of one or more of its descendant blocks, then those margins collapse. The collapsed margin ends up outside the parent.
+  - : The vertical margins between a parent block and its descendants can collapse. This happens when there is no separating content between them.
+  - : Specifically, this occurs in two main cases:
+  - The {{cssxref("margin-top")}} of a parent collapses with the {{cssxref("margin-top")}} of its first in-flow descendant unless the parent has a border-top, padding-top, contains any inline content (like text), or has  _[clearance](/en-US/docs/Web/CSS/clear) applied.
+  - The {{cssxref("margin-bottom")}} of a parent collapses with the {{cssxref("margin-bottom")}} of its last in-flow descendant unless the parent has a defined {{cssxref("height")}} or {{cssxref("min-height")}}, a {{cssxref("border-bottom")}}, or {{cssxref("padding-bottom")}}.
+  - : In both cases, creating a new  [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) on the parent will also prevent its margins from collapsing with its children.
 - Empty blocks
   - : If there is no border, padding, inline content, {{cssxref("height")}}, or {{cssxref("min-height")}} to separate a block's {{cssxref("margin-top")}} from its {{cssxref("margin-bottom")}}, then its top and bottom margins collapse.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->


### Description

This PR proposes a small wording change to the section on parent/child margin collapsing to be more precise and easier to understand.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current text states that a parent's margin collapses with "one or more of its descendant blocks". While technically true in some complex edge cases, this can be misleading for the most common parent-child scenario. It might imply that a parent's margin could collapse with a grandchild, which is not the case.

Changing the wording to specify the "first descendant block" for margin-top and the "last descendant block" for margin-bottom is more precise and provides a clearer mental model for developers trying to understand this tricky concept.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

**Suggested Change**

I suggest changing the wording from:

    "...to separate the margin-top of a block from the margin-top of one or more of its descendant blocks..."

To the more precise:

    "...to separate the margin-top of a block from the margin-top of its first in-flow descendant block..."

(And a similar change for the margin-bottom rule).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
