### PR TITLE
Remove unnecessary LiveSampleLink macros

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/flexbox/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/flexbox/index.md
@@ -53,7 +53,7 @@ Flexbox features may be the perfect solution for your one dimensional layout nee
 
 ## Introducing a simple example
 
-In this article, you'll work through a series of exercises to help you understand how flexbox works. To get started, you should make a local copy of the HTML and CSS. Load it in a modern browser (like Firefox or Chrome) and have a look at the code in your code editor. Alternatively open the example in {{LiveSampleLink("flexbox_0", "open the playground")}}.
+In this article, you'll work through a series of exercises to help you understand how flexbox works. To get started, you should make a local copy of the HTML and CSS. Load it in a modern browser (like Firefox or Chrome) and have a look at the code in your code editor. Alternatively click the "Play" button to open it in the playground.
 
 ```html live-sample___flexbox_0
 <header>

--- a/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
@@ -534,8 +534,9 @@ email.addEventListener("input", (event) => {
 });
 ```
 
-You can try this example in the page at the {{LiveSampleLink('Extending_built-in_form_validation', 'Live sample demo link')}}.
 Try submitting an invalid email address, a valid email address that doesn't end in `@example.com`, and one that does end in `@example.com`.
+
+{{EmbedLiveSample("extending built-in form validation", "", 200, , , , , "allow-forms")}}
 
 #### A more detailed example
 

--- a/files/en-us/web/api/datatransferitemlist/add/index.md
+++ b/files/en-us/web/api/datatransferitemlist/add/index.md
@@ -139,8 +139,6 @@ target.addEventListener("dragover", (ev) => {
 
 {{EmbedLiveSample('Examples', 400, 300)}}
 
-{{LiveSampleLink('Examples', 'Result link')}}
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
@@ -211,7 +211,7 @@ This function uses `getSettings()` to obtain the track's currently in-use values
 
 In this example, we create an exerciser which lets you experiment with media constraints by editing the source code describing the constraint sets for audio and video tracks. You can then apply those changes and see the result, including both what the stream looks like and what the actual media settings are set to after applying the new constraints.
 
-The HTML and CSS for this example are pretty simple, and aren't shown here. You can look at the complete example by {{LiveSampleLink("Example_Constraint_exerciser", "clicking here")}}.
+The HTML and CSS for this example are pretty simple, and aren't shown here. You can look at the complete code by clicking "Play" to view it in the playground.
 
 ```html hidden
 <p>

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -272,7 +272,7 @@ When put all together with the rest of the HTML and the CSS not shown above, it 
 
 {{EmbedLiveSample('Example_of_recording_a_media_element', '600', '440', , , , 'camera;microphone')}}
 
-You can {{LiveSampleLink("Example_of_recording_a_media_element", "view the full demo here")}}, and use your browsers developer tools to inspect the page and look at all the code, including the parts hidden above because they aren't critical to the explanation of how the APIs are being used.
+You can also open this example in the playground using the "Play" button, which allows you to look at the combined code, including the parts hidden above because they aren't critical to the explanation of how the APIs are being used.
 
 ## See also
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/37366. The live sample links are unnecessary if:

- They are to let the reader check the full source code. You can just click "Play" instead.
- They are to work around sandbox settings. We can add the necessary `allow` and `sandbox` instead.

The remaining live sample links are because the example needs a resizable window.