### PR TITLE
chore: improvements to l10n page

### DIFF
--- a/files/en-us/mdn/community/translated_content/index.md
+++ b/files/en-us/mdn/community/translated_content/index.md
@@ -6,16 +6,14 @@ page-type: mdn-community-guide
 sidebar: mdnsidebar
 ---
 
-Since December 14th 2020, MDN runs on a platform that's [maintained on GitHub](/en-US/docs/MDN/Community/Our_repositories).
-This has a lot of advantages for MDN, but we've needed to make radical changes to the way in which we handle localization.
-A lot of unmaintained and out-of-date content ended up in non-English locales, and we want to manage it better in the future.
-
-We have archived all locales, **except** for the ones listed below, meaning that they are read-only on GitHub and cannot be viewed on MDN.
-The active locales have dedicated teams taking responsibility for maintaining them.
+MDN Web Docs contains close to 14000 pages of documentation in the `en-US` locale.
+The English documentation is available in eight locales maintained by a dedicated and diverse community of contributors.
 
 ## How to contribute
 
-If you want to contribute to one of the existing active locales, check out the [mdn/translated-content GitHub repository](https://github.com/mdn/translated-content). This repository contains all of the localized documents for all active locales, as well as issue tracking. We recommend reading the [translation guide](https://github.com/mdn/translated-content/tree/main/docs) first.
+If you want to contribute to one of the existing active locales, check out the [mdn/translated-content GitHub repository](https://github.com/mdn/translated-content).
+This repository contains all of the localized documents for all active locales, as well as issue tracking projects.
+We recommend reading the [translation guide](https://github.com/mdn/translated-content/tree/main/docs) first.
 
 If you need help or have any questions, feel free to get in touch with one of the active members or communities listed below, or [contact us](/en-US/docs/MDN/Community/Communication_channels).
 
@@ -72,9 +70,18 @@ The following experimental locales are machine-translated from the English local
 - Discussions: [Discord (`#italian`)](/discord)
 - Current maintainers: [caugner](https://github.com/caugner)
 
+## Retired locales
+
+Since December 14th 2020, MDN runs on a platform that's [maintained on GitHub](/en-US/docs/MDN/Community/Our_repositories).
+This has a lot of advantages, but we needed to make radical changes to the way in which we handled localization before this migration.
+A lot of unmaintained and out-of-date content ended up in non-English locales, and we want to manage it better going forward.
+
+For this reason, we have archived all locales, **except** for the ones listed on this page, meaning that they are read-only on GitHub and cannot be viewed on developer.mozilla.org.
+The active locales have dedicated teams taking responsibility for maintaining them.
+
 ## See also
 
-- [MDN localization update, February 2021](https://hacks.mozilla.org/2021/02/mdn-localization-update-february-2021/) — the latest state of localization on MDN
-- [An update on MDN Web Docs' localization strategy](https://hacks.mozilla.org/2020/12/an-update-on-mdn-web-docs-localization-strategy/) — updated strategy based on community feedback
-- [MDN Web Docs evolves! Lowdown on the upcoming new platform](https://hacks.mozilla.org/2020/10/mdn-web-docs-evolves-lowdown-on-the-upcoming-new-platform/) — more on the advantages of the new platform, and the rationale behind the localization changes
+- [MDN localization update, February 2021](https://hacks.mozilla.org/2021/02/mdn-localization-update-february-2021/) — the latest state of localization on MDN (2021)
+- [An update on MDN Web Docs' localization strategy](https://hacks.mozilla.org/2020/12/an-update-on-mdn-web-docs-localization-strategy/) — updated strategy based on community feedback (2020)
+- [MDN Web Docs evolves! Lowdown on the upcoming new platform](https://hacks.mozilla.org/2020/10/mdn-web-docs-evolves-lowdown-on-the-upcoming-new-platform/) — more on the advantages of the new platform, and the rationale behind the localization changes (2020)
 - [MDN communication channels](/en-US/docs/MDN/Community/Communication_channels)

--- a/files/en-us/mdn/community/translated_content/index.md
+++ b/files/en-us/mdn/community/translated_content/index.md
@@ -7,7 +7,7 @@ sidebar: mdnsidebar
 ---
 
 MDN Web Docs contains close to 14000 pages of documentation in the `en-US` locale.
-The English documentation is available in eight locales maintained by a dedicated and diverse community of contributors.
+MDN content is translated into eight locales maintained by a dedicated and diverse community of contributors.
 
 ## How to contribute
 

--- a/files/en-us/mdn/community/translated_content/index.md
+++ b/files/en-us/mdn/community/translated_content/index.md
@@ -56,7 +56,7 @@ If you need help or have any questions, feel free to get in touch with one of th
 
 ## Machine-translated locales
 
-The following experimental locales are machine-translated from the English locale.
+The following experimental locales are machine-translated from English, and are managed in separate repositories from other locales.
 
 ### German (`de`)
 


### PR DESCRIPTION
### Description

* Start off the page with information about l10n efforts
* Move retired locales section to the end of the page
* Add dates to blog posts

### Motivation

Relevance of this information is less so now, we can highlight active locales over notices of retired ones.
