### PR TITLE
chore: move sidebar into fm

### DIFF
--- a/files/en-us/web/http/reference/headers/permissions-policy/captured-surface-control/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/captured-surface-control/index.md
@@ -6,9 +6,10 @@ page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.captured-surface-control
+sidebar: http
 ---
 
-{{HTTPSidebar}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `captured-surface-control` directive controls whether or not the document is permitted to use the [Captured Surface Control API](/en-US/docs/Web/API/Screen_Capture_API/Captured_Surface_Control). Specifically, the {{domxref("CaptureController.forwardWheel", "forwardWheel()")}}, {{domxref("CaptureController.increaseZoomLevel", "increaseZoomLevel()")}}, {{domxref("CaptureController.decreaseZoomLevel", "decreaseZoomLevel()")}}, and {{domxref("CaptureController.resetZoomLevel", "resetZoomLevel()")}} methods are controlled by this directive.
 


### PR DESCRIPTION
### Description

Moves the sidebar into front matter

### Motivation

We're using front matter instead of the macro going forward

### Additional details

I think the `captured-surface-control` page landed while the other HTTP section cleanup PR was in-flight: https://github.com/mdn/content/pull/39982