### PR TITLE
Add example to force import re-evaluation

### DIFF
--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -200,6 +200,23 @@ Promise.all(
 ).then((modules) => modules.forEach((module) => module.load()));
 ```
 
+### Importing a module with forced re-evaluation
+
+Another way to re-import and re-evaluate a module without restarting the entire JavaScript environment is to use a [`Blob`](/en-US/docs/Web/API/Blob) with [`URL.createObjectUrl`](/en-US/docs/Web/API/URL/createObjectURL_static):
+
+```js
+fetch("/my-module.js")
+  .then((r) => r.text())
+  .then((code) => {
+    const url = URL.createObjectURL(
+      new Blob([code], { type: "text/javascript" }),
+    );
+    return import(url).finally(() => {
+      URL.revokeObjectURL(url);
+    });
+  });
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Added another import example to show how to bypass the module cache and force re-evaluation without using a unique 'cache-busting' query parameter

### Motivation

The existing example:

```import(`/my-module.js?t=${Date.now()}`);```

felt a bit hacky to me, and it took a while to find a (subjectively) 'cleaner' alternative online. So I thought it would be helpful to add an alternative example.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
None

### Related issues and pull requests

None
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
