### PR TITLE
Uint8Array.prototype.toHex: correct output

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/uint8array/tohex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/tohex/index.md
@@ -41,7 +41,7 @@ for (let i = 0; i < data.length; i += 3) {
 }
 // "ff0000"
 // "00ff00"
-// "00ff00"
+// "0000ff"
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

The output displayed for the second part of the example is incorrect. This is easily verified in a web browser.

### Motivation

Developers may be confused by incorrect output in the example.
