### PR TITLE
Make all Examples sections come before Browser compat in webext

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
@@ -34,6 +34,8 @@ browser.action.setBadgeBackgroundColor(
         - a {{WebExtAPIRef('action.ColorArray')}} object.
         - `null`. If a `tabId` is specified, it removes the tab-specific badge background color so that the tab inherits the global badge background color. Otherwise it reverts the global badge background color to the default value.
 
+        The default color in Firefox is: `[217, 0, 0, 255]`.
+
     - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}
@@ -76,8 +78,6 @@ browser.action.onClicked.addListener((tab) => {
 ## Browser compatibility
 
 {{Compat}}
-
-The default color in Firefox is: `[217, 0, 0, 255]`.
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
@@ -20,11 +20,11 @@ Values of this type are objects. They contain the following properties:
 - `periodInMinutes` {{optional_inline}}
   - : `double`. If this is not `null`, then the alarm is periodic, and this represents its period in minutes.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -36,11 +36,11 @@ An {{jsxref("object")}} with the following properties:
 - `url` {{optional_inline}}
   - : A {{jsxref("string")}} which represents the URL for the bookmark. If the node represents a folder, this property is omitted.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#type-BookmarkTreeNode) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -17,8 +17,8 @@ The **`bookmarks.BookmarkTreeNodeType`** type is used to describe whether a node
 - `"folder"`: the node is a folder.
 - `"separator"`: the node is a separator.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -13,11 +13,11 @@ The **`bookmarks.BookmarkTreeNodeUnmodifiable`** type is used to indicate the re
 
 `bookmarks.BookmarkTreeNodeUnmodifiable` is a {{jsxref("string")}} which can currently have only one value: `"managed"`. This indicates that the bookmark node was configured by an administrator or by the custodian of a supervised user (such as a parent, in the case of parental controls).
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#type-BookmarkTreeNodeUnmodifiable) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -24,11 +24,11 @@ An {{jsxref("object")}} containing some combination of the following fields:
 - `url` {{optional_inline}}
   - : `string`. A {{jsxref("string")}} which specifies the URL of the page to bookmark. If this is omitted or is `null`, a folder is created instead of a bookmark.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#type-CreateDetails) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.md
@@ -66,11 +66,11 @@ Extensions cannot create, modify, or delete bookmarks in the root node of the bo
 - {{WebExtAPIRef("bookmarks.onImportEnded")}}
   - : Fired when a bookmark import session has finished.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -44,10 +44,6 @@ Events have three functions:
 - `childIds`
   - : `array` of `string`. Array containing the IDs of all the bookmark items in this folder, in the order they now appear in the UI.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -64,6 +60,10 @@ browser.browserAction.onClicked.addListener(handleClick);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onChildrenReordered) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -35,10 +35,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs. It's passed no parameters.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -59,6 +55,10 @@ browser.browserAction.onClicked.addListener(handleClick);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onImportBegan) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -35,10 +35,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs. It's passed no parameters.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -59,6 +55,10 @@ browser.browserAction.onClicked.addListener(handleClick);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onImportEnded) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -53,10 +53,6 @@ Events have three functions:
 - `oldIndex`
   - : `integer`. The old index of the item in its parent.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -76,6 +72,10 @@ browser.browserAction.onClicked.addListener(handleClick);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onMoved) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -18,11 +18,11 @@ An `array` of four integers in the range 0-255, defining an RGBA color. The four
 
 For example, opaque red is `[255, 0, 0, 255]`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#type-ColorArray) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -22,10 +22,6 @@ browser.browserAction.disable(
 - `tabId` {{optional_inline}}
   - : `integer`. The id of the tab for which you want to disable the browser action.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Disable the browser action when clicked, and re-enable it every time a new tab is opened:
@@ -49,6 +45,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-disable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -22,10 +22,6 @@ browser.browserAction.enable(
 - `tabId` {{optional_inline}}
   - : `integer`. The id of the tab for which you want to enable the browser action.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Disable the browser action when clicked, and re-enable it every time a new tab is opened:
@@ -41,6 +37,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-enable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -37,10 +37,6 @@ browser.browserAction.getBadgeBackgroundColor(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with the retrieved color as a {{WebExtAPIRef('browserAction.ColorArray')}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the badge's background color:
@@ -58,6 +54,10 @@ browser.browserAction.getBadgeBackgroundColor({}).then(onGot, onFailure);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -37,10 +37,6 @@ let gettingText = browser.browserAction.getBadgeText(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the badge text.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the badge text:
@@ -55,6 +51,10 @@ gettingBadgeText.then(gotBadgeText);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -41,10 +41,6 @@ browser.browserAction.getBadgeTextColor(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with the retrieved color as a {{WebExtAPIRef('browserAction.ColorArray')}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the badge's text color:
@@ -62,6 +58,10 @@ browser.browserAction.getBadgeTextColor({}).then(onGot, onFailure);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -37,10 +37,6 @@ let gettingPopup = browser.browserAction.getPopup(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the URL for the popup's document. This will be a fully qualified URL, such as `moz-extension://d1d8a2eb-fe60-f646-af30-a866c5b39942/popups/popup2.html`.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the popup's URL:
@@ -55,6 +51,10 @@ gettingPopup.then(gotPopup);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -39,10 +39,6 @@ let gettingTitle = browser.browserAction.getTitle(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the browser action's title.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code switches the title between "this" and "that" each time the user clicks the browser action:
@@ -63,6 +59,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
@@ -13,11 +13,11 @@ Pixel data for an image. Must be an [`ImageData`](/en-US/docs/Web/API/ImageData)
 
 An [`ImageData`](/en-US/docs/Web/API/ImageData) object.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#type-ImageDataType) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -69,11 +69,11 @@ With the `browserAction` API, you can:
 - {{WebExtAPIRef("browserAction.onClicked")}}
   - : Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
@@ -37,10 +37,6 @@ let gettingIsEnabled = browser.browserAction.isEnabled(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with `true` if the extension's browser action is enabled, and `false` otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Check the global state:
@@ -67,3 +63,7 @@ async function enabledInActiveTab() {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -43,10 +43,6 @@ Events have three functions:
         - `button`
           - : An `integer`. Indicates the button used to click the page action icon: `0` for a left-click or a click not associated with a mouse, such as one from the keyboard and `1` for a middle button or wheel click. Note that the right-click is not supported because Firefox consumes that click to display the context menu before this event is triggered.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 When the user clicks the browser action icon this code turns it off for the active tab and logs the tab's URL:
@@ -61,6 +57,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#event-onClicked) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
@@ -30,10 +30,6 @@ browser.browserAction.openPopup(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Open the popup when the user selects a context menu item:
@@ -51,3 +47,7 @@ browser.menus.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -31,6 +31,8 @@ browser.browserAction.setBadgeBackgroundColor(
         - a {{WebExtAPIRef('browserAction.ColorArray')}} object.
         - `null`. If a `tabId` is specified, it removes the tab-specific badge background color so that the tab inherits the global badge background color. Otherwise it reverts the global badge background color to the default value.
 
+        The default color in Firefox is: `[217, 0, 0, 255]`.
+
     - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}
@@ -40,12 +42,6 @@ browser.browserAction.setBadgeBackgroundColor(
 
 - If `windowId` and `tabId` are both supplied, the function fails and the color is not set.
 - If `windowId` and `tabId` are both omitted, the global badge background color is set instead.
-
-## Browser compatibility
-
-{{Compat}}
-
-The default color in Firefox is: `[217, 0, 0, 255]`.
 
 ## Examples
 
@@ -75,6 +71,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -44,10 +44,6 @@ This API is also available as `chrome.browserAction.setBadgeText()`.
 - If `windowId` and `tabId` are both supplied, the function fails.
 - If `windowId` and `tabId` are both omitted, the global badge is set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Add a badge indicating how many times the user clicked the button:
@@ -63,6 +59,10 @@ browser.browserAction.onClicked.addListener(increment);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -37,10 +37,6 @@ browser.browserAction.setBadgeTextColor(
 - If `windowId` and `tabId` are both supplied, the function fails and the color is not set.
 - If `windowId` and `tabId` are both omitted, the global badge text color is set instead.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 A badge text color that starts off as red, and turns green when the browser action is clicked:
@@ -69,6 +65,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -81,10 +81,6 @@ If each one of `imageData` and `path` is one of `undefined`, `null` or empty obj
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments once the icon has been set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 The code below uses a browser action to toggle a listener for {{WebExtAPIRef("webRequest.onHeadersReceived")}}, and uses `setIcon()` to indicate whether listening is on or off:
@@ -149,6 +145,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setIcon) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -42,10 +42,6 @@ browser.browserAction.setPopup(
 - If `windowId` and `tabId` are both supplied, the function fails and the popup is not set.
 - If `windowId` and `tabId` are both omitted, the global popup is set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code adds a pair of context menu items that you can use to switch between two popups. Note that you'll need the "contextMenus" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) set in the extension's manifest to create context menu items.
@@ -91,6 +87,10 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -41,10 +41,6 @@ browser.browserAction.setTitle(
 - If `windowId` and `tabId` are both supplied, the function fails and the title is not set.
 - If `windowId` and `tabId` are both omitted, the global title is set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code switches the title between "this" and "that" each time the user clicks the browser action:
@@ -65,6 +61,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
@@ -23,10 +23,6 @@ window.addEventListener("click", (e) => {
 
 By default, this will open a popup window. If your extension sets `allowPopupsForUserEvents` to `false`, then it will not open a popup, and the user will be informed that the popup was blocked.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Toggle the setting:
@@ -49,3 +45,7 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
@@ -11,10 +11,6 @@ A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that can be 
 
 The underlying value is a boolean.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Getting the current value of this setting:
@@ -39,3 +35,7 @@ browser.browserSettings.cacheEnabled.set({ value: false }).then(logResult);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/colormanagement/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/colormanagement/index.md
@@ -20,10 +20,6 @@ The object has these properties:
 - `useWebRenderCompositor`
   - : A boolean representing whether or not the WebRender compositor is used.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set color mode to "full":
@@ -49,3 +45,7 @@ browser.browserSettings.colorManagement.useNativeSRGB.get({}).then(logResult);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
@@ -13,10 +13,6 @@ Its underlying value is a string that may be either "mouseup" or "mousedown".
 
 The default value is "mouseup" on Windows, and "mousedown" on macOS and Linux. Assigning to it on Windows has no effect - the setting is only designed to allow the context menu to be opened on mouseup instead of mousedown, not the inverse.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to "mouseup":
@@ -32,3 +28,7 @@ browser.browserSettings.contextMenuShowEvent
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
@@ -14,10 +14,6 @@ The underlying value is a boolean.
 > [!NOTE]
 > From Firefox version 88 this setting is read-only.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Toggle the setting:
@@ -38,3 +34,7 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
@@ -11,10 +11,6 @@ A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that can be 
 
 Note that this is a read-only setting. To change the homepage, see [chrome_settings_overrides](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the current value of the homepage URL:
@@ -26,3 +22,7 @@ browser.browserSettings.homepageOverride.get({}).then((result) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
@@ -15,10 +15,6 @@ The underlying value is a string that can take one of three values:
 - "none": don't animate images at all.
 - "once": play the animation once.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Disable animated images:
@@ -28,3 +24,7 @@ browser.browserSettings.imageAnimationBehavior.set({ value: "none" });
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -56,8 +56,8 @@ To use this API you need to have the "browserSettings" [permission](/en-US/docs/
 - {{WebExtAPIRef("browserSettings.zoomSiteSpecific")}}
   - : Controls whether page zoom is applied on a per-site or per-tab basis. If [`privacy.websites.resistFingerprinting`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy/websites#resistfingerprinting) is true, this setting has no effect and zoom is applied on a per-tab basis.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
@@ -11,10 +11,6 @@ A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that can be 
 
 Note that this is a read-only setting.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the current value of the new tab URL:
@@ -26,3 +22,7 @@ browser.browserSettings.newTabPageOverride.get({}).then((result) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
@@ -15,10 +15,6 @@ The underlying value is a string that can take one of three values:
 - "relatedAfterCurrent": The default. Open new tabs next to the current tab if they are related to the current tab (for example, if they were opened via a link in the current tab). Otherwise, open new tabs at the end of the tabstrip.
 - "atEnd": Open all tabs at the end of the tabstrip.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code sets the value to "afterCurrent" and then logs the new value:
@@ -35,3 +31,7 @@ async function setAfterCurrent() {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
@@ -11,10 +11,6 @@ A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object whose underl
 
 If set to `true`, then when the user selects a bookmark, it will be opened in a new tab. If set to `false` (the default) bookmarks are opened in the current tab.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to `true`:
@@ -30,3 +26,7 @@ browser.browserSettings.openBookmarksInNewTabs
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
@@ -13,10 +13,6 @@ If set to `true`, then when the user selects a term in the browser's search box,
 
 Note that this does not affect the behavior when selecting items from the omnibox/awesomebar,only the dedicated search box.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to `true`:
@@ -32,3 +28,7 @@ browser.browserSettings.openSearchResultsInNewTabs
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
@@ -13,10 +13,6 @@ When the user focuses the address bar and starts typing, the browser offers auto
 
 If set to `true`, then when the user selects one of these items, the item is opened in a new tab. If set to `false` (the default) the item is opened in the current tab.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to `true`:
@@ -32,3 +28,7 @@ browser.browserSettings.openUrlbarResultsInNewTabs
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridecontentcolorscheme/index.md
@@ -17,10 +17,6 @@ This object takes these values:
 - "dark": Applies a dark theme to webpages.
 - "auto": Automatically applies a light or dark theme to webpages based on the browser's theme.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example overrides the setting to use the dark theme for webpages:
@@ -36,3 +32,7 @@ browser.browserSettings.overrideContentColorScheme
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
@@ -17,10 +17,6 @@ Its underlying value is a string that may take any one of the following values:
 - "never": Never apply the user's choices.
 - "always": Always apply the user's choices.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to "always":
@@ -36,3 +32,7 @@ browser.browserSettings.overrideDocumentColors
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/tlsversionrestrictionconfig/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/tlsversionrestrictionconfig/index.md
@@ -18,10 +18,6 @@ The object has these properties:
 
 This is a read-only setting.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the highest TLS version supported by the browser:
@@ -35,3 +31,7 @@ browser.browserSettings.tlsVersionRestrictionConfig.maximum
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
@@ -16,10 +16,6 @@ Its underlying value is a boolean:
 - `true`: use the fonts specified by the web page. This is the default.
 - `false`: use the system fonts.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to `false`:
@@ -33,3 +29,7 @@ browser.browserSettings.useDocumentFonts.set({ value: false }).then(logResult);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
@@ -19,10 +19,6 @@ Setting `browserSettings.webNotificationsDisabled` to `false` switches the globa
 
 Note that this setting has no effect on notifications created by extensions using the [`notifications`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications) API.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Toggle the setting:
@@ -42,3 +38,7 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
@@ -16,10 +16,6 @@ The settings are:
 - `true`: zoom applies to all the content of a web page (default).
 - `false`: zoom applies to web page text only.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to `false`:
@@ -33,3 +29,7 @@ browser.browserSettings.zoomFullPage.set({ value: false }).then(logResult);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
@@ -25,10 +25,6 @@ When Firefox is installed, `browser.zoom.siteSpecific` is true.
 
 If [`privacy.websites.resistFingerprinting`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy/websites#resistfingerprinting) is true, this setting has no effect and zoom is set on a per-tab basis.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the setting to `false`:
@@ -42,3 +38,7 @@ browser.browserSettings.zoomSiteSpecific.set({ value: false }).then(logResult);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -61,11 +61,11 @@ To use this API you must have the "browsingData" [API permission](/en-US/docs/Mo
 - {{WebExtAPIRef("browsingData.settings()")}}
   - : Gets the current value of settings in the browser's "Clear History" feature.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -46,11 +46,11 @@ function onError(error) {
 browser.browsingData.removeCache({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -76,11 +76,11 @@ function onError(error) {
 browser.browsingData.removeCookies({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -71,11 +71,11 @@ function onError(error) {
 browser.browsingData.removeDownloads({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -71,11 +71,11 @@ function onError(error) {
 browser.browsingData.removeFormData({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -71,11 +71,11 @@ function onError(error) {
 browser.browsingData.removeHistory({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -49,11 +49,11 @@ function onError(error) {
 browser.browsingData.removeLocalStorage({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -71,11 +71,11 @@ function onError(error) {
 browser.browsingData.removePasswords({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -71,11 +71,11 @@ function onError(error) {
 browser.browsingData.removePluginData({}).then(onRemoved, onError);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -38,10 +38,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log current settings:
@@ -61,6 +57,10 @@ browser.browsingData.settings().then(onGotSettings, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
@@ -9,11 +9,11 @@ browser-compat: webextensions.api.captivePortal.canonicalURL
 
 Return the canonical URL of the captive-portal detection page. Read-only.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#property-TAB_ID_NONE) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.md
@@ -30,11 +30,11 @@ To use this API you need to have the "captivePortal" [permission](/en-US/docs/Mo
 - {{WebExtAPIRef("captivePortal.onStateChanged")}}
   - : Fires when the captive portal state changes.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -22,9 +22,9 @@ To use this API you need the `"clipboardWrite"` extension [permission](/en-US/do
 - {{WebExtAPIRef("clipboard.setImageData()")}}
   - : Copy an image to the clipboard.
 
-## Browser compatibility
-
 {{WebExtExamples("h2")}}
+
+## Browser compatibility
 
 {{Compat}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -37,10 +37,6 @@ browser.clipboard.setImageData(imageData, imageType)
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved with no arguments if the operation succeeded, or rejected if there was an error (for example, because the data did not represent a valid image).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Copy a remote image:
@@ -66,6 +62,10 @@ fetch(browser.runtime.getURL("image.png"))
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.clipboard`](https://developer.chrome.com/docs/apps/reference/clipboard) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -24,11 +24,11 @@ A value of this type is an object containing these properties for the commands:
 
 `description` and `shortcut` reflect the values given in the `commands` manifest.json key unless they have been updated with {{WebExtAPIRef('commands.update()')}} or, in the case of the shortcut, customized by the user.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -40,9 +40,9 @@ getCommands.then(logCommands);
 
 {{WebExtExamples}}
 
-> [!NOTE]
-> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.
-
 ## Browser compatibility
 
 {{Compat}}
+
+> [!NOTE]
+> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/onchanged/index.md
@@ -43,10 +43,6 @@ Events have three functions:
         - `oldShortcut`
           - : `string`. The shortcut that was active for this command, or blank if no shortcut was active.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 You could log changes to command shortcuts like this:
@@ -62,3 +58,7 @@ browser.commands.onChanged.addListener(handleChanged);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.md
@@ -28,10 +28,6 @@ browser.commands.reset(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the shortcut has been reset.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Resets the command named "my-command" when the user clicks the "reset" button:
@@ -47,3 +43,7 @@ document.querySelector("#reset").addEventListener("click", resetShortcut);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
@@ -36,10 +36,6 @@ browser.commands.update(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the shortcut has been updated. The promise will be rejected with an error if the command could not be found.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Updates the command named "my-command" with the given shortcut value, when the user clicks "update":
@@ -58,3 +54,7 @@ document.querySelector("#update").addEventListener("click", updateShortcut);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.md
@@ -30,8 +30,8 @@ There is no `contentScripts` API permission, but an extension must have the appr
 - {{WebExtAPIRef("contentScripts.register()")}}
   - : Registers the given content scripts.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -60,10 +60,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 Currently, content scripts are unregistered when the related extension page (from which the content scripts were registered) is unloaded, so you should register a content script from an extension page that persists at least as long as you want the content scripts to stay registered.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example registers the `defaultCode` content script for all `.org` URLs:
@@ -96,3 +92,7 @@ const scriptObj = await browser.contentScripts.register({
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -19,10 +19,6 @@ It defines a single function {{WebExtAPIRef("contentScripts.RegisteredContentScr
 - {{WebExtAPIRef("contentScripts.RegisteredContentScript.unregister","unregister()")}}
   - : Unregisters the content scripts represented by this object.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code toggles a registered content script on a browser action click:
@@ -55,3 +51,7 @@ browser.browserAction.onClicked.addListener(toggle);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -23,10 +23,6 @@ None.
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code toggles a registered content script on a browser action click:
@@ -59,3 +55,7 @@ browser.browserAction.onClicked.addListener(toggle);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
@@ -57,10 +57,6 @@ let createContext = browser.contextualIdentities.create(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} that describes the new identity. If the contextual identities feature is not enabled, the promise is rejected.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example creates a new contextual identity and logs its cookie store ID:
@@ -84,3 +80,7 @@ browser.contextualIdentities
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
@@ -28,10 +28,6 @@ let getContext = browser.contextualIdentities.get(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} that describes the identity. If the identity could not be found or the contextual identities feature is not enabled, the promise is rejected.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example tries to retrieve the contextual identity whose ID is "firefox-container-1":
@@ -53,3 +49,7 @@ browser.contextualIdentities.get("firefox-container-1").then(onGot, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.md
@@ -56,8 +56,8 @@ To use this API you need to include the "contextualIdentities" and "cookies" [pe
 - {{WebExtAPIRef("contextualIdentities.onUpdated")}}
   - : Fired when one or more properties of a contextual identity is updated.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `changeInfo`
       - : `object`. An object that contains a single property, `contextualIdentity`, which is a {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} object, representing the identity that was created.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -50,6 +46,10 @@ browser.contextualIdentities.onCreated.addListener(handleCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `changeInfo`
       - : `object`. An object that contains a single property, `contextualIdentity`, which is a {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} object representing the identity that was removed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -50,6 +46,10 @@ browser.contextualIdentities.onRemoved.addListener(handleRemoved);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `changeInfo`
       - : `object`. An object that contains a single property, `contextualIdentity`, which is a {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} object representing the identity whose properties were updated.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -50,6 +46,10 @@ browser.contextualIdentities.onUpdated.addListener(handleUpdated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
@@ -30,10 +30,6 @@ let getContext = browser.contextualIdentities.query(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an array of {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} objects, each describing a single identity. If the contextual identities feature is not enabled, the promise is rejected.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Retrieve all contextual identities, and log their names:
@@ -73,3 +69,7 @@ browser.contextualIdentities
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
@@ -28,10 +28,6 @@ let removeContext = browser.contextualIdentities.remove(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} that describes the identity that was removed. If the identity could not be found or the contextual identities feature is not enabled, the promise is rejected.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example tries to remove the contextual identity whose ID is "firefox-container-1":
@@ -55,3 +51,7 @@ browser.contextualIdentities
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
@@ -60,10 +60,6 @@ let createContext = browser.contextualIdentities.update(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} that describes the updated identity. If the identity could not be found or the contextual identities feature is not enabled, the promise is rejected.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example updates the contextual identity whose ID is "firefox-container-1" to have a new name, color, and icon:
@@ -87,3 +83,7 @@ browser.contextualIdentities
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -24,10 +24,6 @@ Values of this type are strings. Possible values are:
 - `overwrite`
   - : A call to {{WebExtAPIRef("cookies.set()")}} overwrote this cookie with a different one.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 You can listen to the {{WebExtAPIRef("cookies.onChanged")}} event to be notified when cookies change. The listener is passed a `changeInfo` object that contains a `cause` property, whose value is the `OnChangeCaused` string:
@@ -44,6 +40,10 @@ browser.cookies.onChanged.addListener((changeInfo) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#type-OnChangedCause) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -72,10 +72,6 @@ If an error occurred, element 0 will be `undefined`, and element 1 will contain 
   - a boolean property `isError`, set to `true`
   - a string property `code` containing an error code.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This tests whether jQuery is defined in the inspected window, and logs the result. Note that this wouldn't work in a content script, because even if jQuery were defined, the content script would not see it.
@@ -158,6 +154,10 @@ inspectButton.addEventListener("click", () => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -28,10 +28,6 @@ browser.devtools.inspectedWindow.reload(
     - `injectedScript` {{optional_inline}}
       - : `string`. Inject the given JavaScript expression into all frames in the page, before any other scripts.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Reload the inspected window, setting the user agent and injecting a script:
@@ -48,6 +44,10 @@ reloadButton.addEventListener("click", () => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -36,11 +36,11 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -25,10 +25,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an object containing the HAR log for the current tab. For details of what the log object contains, refer to the [HAR specification](http://www.softwareishard.com/blog/har-12-spec/#log).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the URLs of requests contained in the HAR log:
@@ -46,6 +42,10 @@ logRequestsButton.addEventListener("click", logRequests);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.network`](https://developer.chrome.com/docs/extensions/reference/api/devtools/network) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -23,11 +23,11 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 - [`devtools.network.onRequestFinished`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/network/onRequestFinished)
   - : Fired when the network request has finished and its details are available to the extension.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.network`](https://developer.chrome.com/docs/extensions/reference/api/devtools/network) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `url`
       - : `string`. The new URL for the window.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -50,6 +46,10 @@ browser.devtools.network.onNavigated.addListener(handleNavigated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
@@ -39,10 +39,6 @@ Events have three functions:
     - `request`
       - : `object`. An object representing the request. This object is a single [HAR entry](http://www.softwareishard.com/blog/har-12-spec/#entries) object. It also defines an asynchronous `getContent()` method, which returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves with an array of two elements. The first element is the HTTP response body as a string, while the second element is the [MIME type](/en-US/docs/Glossary/MIME_type) of the HTTP response also as a string.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Add a listener that logs the server IP address and response body for every network request.
@@ -60,6 +56,10 @@ browser.devtools.network.onRequestFinished.addListener(handleRequestFinished);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -34,10 +34,6 @@ let creating = browser.devtools.panels.create(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an [`ExtensionPanel`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionPanel) object representing the new panel.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Create a new panel, and add listeners to its onShown and onHidden events:
@@ -64,6 +60,10 @@ browser.devtools.panels
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
@@ -9,11 +9,11 @@ browser-compat: webextensions.api.devtools.panels.elements
 
 An [`ElementsPanel`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel) object, which represents the browser's HTML/CSS inspector.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -34,10 +34,6 @@ let creating = browser.devtools.panels.elements.createSidebarPane(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an [`ExtensionSidebarPane`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane) object representing the new pane.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Create a new pane, and populate it with a JSON object. You could run this code in a script loaded by your extension's [devtools page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page).
@@ -58,6 +54,10 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
@@ -19,11 +19,11 @@ An `ElementsPanel` represents the HTML/CSS inspector in the browser's devtools. 
 - [`devtools.panels.ElementsPanel.onSelectionChanged`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ElementsPanel/onSelectionChanged)
   - : Fired when the user selects a different element in the page, for example using the "Inspect element" context menu item.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -33,10 +33,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs. The function is passed no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for selection changed events, and log the text content of the newly selected element:
@@ -54,6 +50,10 @@ browser.devtools.panels.elements.onSelectionChanged.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -16,10 +16,6 @@ Values of this type are objects. The define two events, `onShown` and `onHidden`
 - `onShown` is emitted when the panel is shown in the devtools (for example, because the user clicked on the panel's tab in the devtools window).
 - `onHidden` is emitted when the panel is hidden (for example, because the user switched to a different tab in the devtools window).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code creates a new panel, then adds handlers for its `onShown` and `onHidden` events.
@@ -48,6 +44,10 @@ browser.devtools.panels
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
@@ -29,11 +29,11 @@ To create an `ExtensionSidebarPane`, call the [`browser.devtools.panels.elements
 - [`devtools.panels.ExtensionSidebarPane.onHidden`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/onHidden)
   - : Fired when the sidebar pane is hidden.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -33,10 +33,6 @@ Events have three functions:
 - `listener`
   - : Function called when this event occurs. This function will be passed no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Create a sidebar pane, and log show and hide events.
@@ -56,6 +52,10 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `window`
       - : `object`. The {{DOMxRef("window")}} object of the sidebar page, if a page was set with {{WebExtAPIRef("devtools.panels.ExtensionSidebarPane.setPage()","setPage()")}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Create a sidebar pane, and log show and hide events.
@@ -58,6 +54,10 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -35,10 +35,6 @@ let evaluating = browser.devtools.panels.setExpression(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments, once the expression has been evaluated.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code creates a sidebar pane that displays the [`tagName`](/en-US/docs/Web/API/Element/tagName) of the currently selected element:
@@ -56,6 +52,10 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -33,10 +33,6 @@ let setting = browser.devtools.panels.setObject(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments, once the object has been set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Create a new pane, and populate it with a JSON object. You could run this code in a script loaded by your extension's [devtools page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page).
@@ -57,6 +53,10 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `themeName`
       - : `string`. Name of the new theme: this will be one of the permitted values for [`devtools.panels.themeName`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/themeName).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -48,6 +44,10 @@ browser.devtools.panels.onThemeChanged.addListener((newThemeName) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
@@ -15,11 +15,11 @@ This is a string whose possible values are:
 - "dark"
 - "firebug"
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/index.md
@@ -19,8 +19,8 @@ To use this API, an extension must request the "dns" [permission](/en-US/docs/Mo
 - {{WebExtAPIRef("dns.resolve()")}}
   - : Resolves the given hostname to a DNS record.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.md
@@ -48,10 +48,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 - `isTRR`
   - : `boolean`: `true` if the record was retrieved using a Trusted Recursive Resolver (TRR).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -84,3 +80,7 @@ resolving.then(resolved);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -30,11 +30,11 @@ let prompting = browser.downloads.acceptDanger(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). When the dialog closes, the promise will be fulfilled with no arguments.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-acceptDanger) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -18,11 +18,11 @@ Values of this type are objects. They contain the following properties:
 - `previous` {{optional_inline}}
   - : A `boolean` representing the previous boolean value.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-BooleanDelta) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -28,10 +28,6 @@ let canceling = browser.downloads.cancel(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the request was successful, the promise will be fulfilled with no arguments. If the request failed, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -50,6 +46,10 @@ canceling.then(onCanceled, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-cancel) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
@@ -35,11 +35,11 @@ Values of this type are strings. Possible values are:
 - `accepted`
   - : The user has accepted the dangerous download.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DangerType) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -18,11 +18,11 @@ Values of this type are objects. They contain the following properties:
 - `previous` {{optional_inline}}
   - : A `number` representing the previous double value.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DoubleDelta) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -66,10 +66,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If t
 
 If you use [URL.createObjectURL()](/en-US/docs/Web/API/URL/createObjectURL_static) to download data created in JavaScript and you want to revoke the object URL (with [revokeObjectURL](/en-US/docs/Web/API/URL/revokeObjectURL_static)) later (as it is strongly recommended), you need to do that after the download has been completed. To do so, listen to the [downloads.onChanged](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/downloads/onChanged) event.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 The following snippet attempts to download an example file, also specifying a filename and location to save it in, and `uniquify` as the value of the `conflictAction` option.
@@ -95,6 +91,10 @@ downloading.then(onStartedDownload, onFailed);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-download) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -56,11 +56,11 @@ Values of this type are objects. They contain the following properties:
 - `url`
   - : A `string` representing the absolute URL from which the file was downloaded.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DownloadItem) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -68,11 +68,11 @@ Values of this type are objects. They contain the following properties:
 - `exists` {{optional_inline}}
   - : A `boolean` indicating whether a downloaded file still exists (`true`) or not (`false`). Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `exists` value.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DownloadQuery) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
@@ -20,11 +20,11 @@ A `DownloadTime` can be one of three different types:
 
 - a number: this is interpreted as the number of milliseconds since the UNIX epoch.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DownloadTime) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -33,10 +33,6 @@ let erasing = browser.downloads.erase(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the call was successful, the promise will be fulfilled with an array of integers representing the ids of the erased {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}}. If no items matching the query parameter could be found, the array will be empty. If the call failed, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Erase the most recent download:
@@ -74,6 +70,10 @@ erasing.then(onErased, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-erase) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
@@ -22,11 +22,11 @@ Values of this type are strings. Possible values are:
 - `"prompt"`
   - : The browser will prompt the user, asking them to choose whether to uniquify or overwrite.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-FilenameConflictAction) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -37,10 +37,6 @@ let gettingIcon = browser.downloads.getFileIcon(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the request succeeds, the promise will be fulfilled with a string representing the absolute URL of the icon. If the request fails, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example logs the icon URL for the most recent download:
@@ -71,6 +67,10 @@ searching.then(getIcon, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-getFileIcon) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.md
@@ -72,11 +72,11 @@ To use this API you need to have the "downloads" [API permission](/en-US/docs/Mo
 - {{WebExtAPIRef("downloads.onChanged")}}
   - : When any of a {{WebExtAPIRef("downloads.DownloadItem", "DownloadItem")}}'s properties except `bytesReceived` changes, this event fires with the `downloadId` and an object containing the properties that changed.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
@@ -54,11 +54,11 @@ Miscellaneous:
 
 - `"CRASH"`
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-InterruptReason) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -72,10 +72,6 @@ The `downloadDelta` object has the following properties available:
 - `exists` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.BooleanDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `exists` status.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log a message when downloads complete:
@@ -91,6 +87,10 @@ browser.downloads.onChanged.addListener(handleChanged);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#event-onChanged) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `downloadItem`
       - : The {{WebExtAPIRef('downloads.DownloadItem')}} object in question.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the URL of items as they are downloaded:
@@ -54,6 +50,10 @@ browser.downloads.onCreated.addListener(handleCreated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#event-onCreated) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `downloadId`
       - : An `integer` representing the `id` of the {{WebExtAPIRef('downloads.DownloadItem')}} that was erased.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Add a listener for `onErased` events, then erase the most recent download:
@@ -59,6 +55,10 @@ let erasing = browser.downloads.erase({
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#event-onErased) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -30,10 +30,6 @@ let opening = browser.downloads.open(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the request is successful, the promise is fulfilled with no arguments. If the request failed, the promise is rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example opens the most recently downloaded item:
@@ -63,6 +59,10 @@ searching.then(openDownload, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-open) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -28,10 +28,6 @@ let pausing = browser.downloads.pause(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the call was successful, the download will be put in a paused state, and the promise will be fulfilled with no arguments. If the call fails, the promise will be rejected with an error message. The call will fail if the download is not active: for example, because it has finished downloading.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -48,6 +44,10 @@ pausing.then(onPaused, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-pause) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -35,10 +35,6 @@ let removing = browser.downloads.removeFile(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the request was successful, the promise will be fulfilled with no arguments. If the request failed, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Remove the most recently downloaded file:
@@ -68,6 +64,10 @@ searching.then(remove, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-removeFile) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -28,10 +28,6 @@ let resuming = browser.downloads.resume(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the request was successful, the promise will be fulfilled with no arguments. If the request failed, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -50,6 +46,10 @@ resuming.then(onResumed, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-resume) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -26,10 +26,6 @@ let searching = browser.downloads.search(query);
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). The promise is fulfilled with an `array` of {{WebExtAPIRef('downloads.DownloadItem')}} objects that match the given criteria.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 In general, you restrict the items retrieved using the `query` parameter.
@@ -122,6 +118,10 @@ browser.downloads
 You can see this code in action in our [latest-download](https://github.com/mdn/webextensions-examples/blob/main/latest-download/popup/latest_download.js) example.
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-search) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
@@ -27,11 +27,11 @@ This API is also available as `browser.downloads.setShelfEnabled()`.
 - `enabled`
   - : A `boolean` representing the state that you want to set `setShelfEnabled()` to — `true` for enable, and `false` for disable.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-setShelfEnabled) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -28,10 +28,6 @@ let showing = browser.downloads.show(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the request succeeds, the promise will be fulfilled with a boolean about whether the request was successful. If the request fails, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example shows the most recently downloaded item:
@@ -62,6 +58,10 @@ searching.then(openDownload, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-show) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -19,10 +19,6 @@ browser.downloads.showDefaultFolder();
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 The following snippet contains a show button, which when clicked invokes `showDefaultFolder()` to open the default downloads folder in the platform's file manager:
@@ -36,6 +32,10 @@ showBtn.onclick = () => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-showDefaultFolder) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.md
@@ -25,11 +25,11 @@ Values of this type are strings. Possible values are:
 > [!NOTE]
 > These string constants will never change, but new constants may be added.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-State) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -18,11 +18,11 @@ Values of this type are objects. They contain the following properties:
 - `previous` {{optional_inline}}
   - : A `string` representing the previous string value.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-StringDelta) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.md
@@ -30,11 +30,11 @@ Values of this type are objects.
 - {{WebExtAPIRef("events.Event.removeRules","events.Event.removeRules()")}}
   - : Unregisters currently registered rules.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events#type-Event) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/index.md
@@ -18,11 +18,11 @@ Common types used by APIs that dispatch events.
 - {{WebExtAPIRef("events.UrlFilter")}}
   - : Filters URLs for various criteria. If any of the given criteria match, then the whole filter matches.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -24,11 +24,11 @@ Values of this type are objects. They contain the following properties:
 - `priority` {{optional_inline}}
   - : `integer`. Optional priority of this rule. Defaults to 100.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events#type-Rule) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -74,11 +74,11 @@ However, note that these last two patterns will not match the last component of 
   - : `array` of (`integer` or (`array` of `integer`)). An array which may contain integers and arrays of integers. Integers are interpreted as port numbers, while arrays of integers are interpreted as port ranges. Matches if the port of the URL matches any port number or is contained in any ranges.
     - For example: `[80, 443, [1000, 1200]]` matches all requests on ports 80, 443, and in the range 1000-1200.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events#type-UrlFilter) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -31,11 +31,11 @@ This API is also available as `browser.extension.getExtensionTabs()`.
 
 `array` of `object`. Array of global window objects
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getExtensionTabs) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
@@ -31,10 +31,6 @@ browser.extension.getURL(
 
 `string`. The fully-qualified URL to the resource.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Given a file packaged with the add-on at "beasts/frog.html", get the full URL like this:
@@ -47,6 +43,10 @@ let fullURL = browser.extension.getURL("beasts/frog.html");
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getURL) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -37,10 +37,6 @@ let windows = browser.extension.getViews(
 
 `array` of `object`. Array of [Window](/en-US/docs/Web/API/Window) objects.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get all windows belonging to this extension, and log their URLs:
@@ -66,6 +62,10 @@ const windows = browser.extension.getViews({ type: "popup" });
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getViews) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
@@ -50,11 +50,11 @@ Utilities related to your extension. Get URLs to resources packages with your ex
 - {{WebExtAPIRef("extension.onRequestExternal")}} {{deprecated_inline}}
   - : Fired when a request is sent from another extension.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
@@ -19,11 +19,11 @@ let isPrivate = browser.extension.inIncognitoContext;  // true or false
 
 A _boolean_ value indicate if the current script is running in a private tab or process.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#property-inIncognitoContext) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -27,10 +27,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 Firefox will always return `false`.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -43,6 +39,10 @@ isAllowed.then(logIsAllowed);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-isAllowedFileSchemeAccess) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
@@ -12,11 +12,11 @@ browser-compat: webextensions.api.extension.lastError
 
 An alias for {{WebExtAPIRef("runtime.lastError")}}.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#property-lastError) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
@@ -46,11 +46,11 @@ Events have three functions:
     - `sendResponse`
       - : `function`. Function to call (at most once) when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response. If you have more than one `onRequest` listener in the same document, then only one may send a response.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#event-onRequest) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -46,11 +46,11 @@ Events have three functions:
     - `sendResponse`
       - : `function`. Function to call when you have a response. The argument should be any JSON-ifiable object, or undefined if there is no response.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#event-onRequestExternal) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -37,11 +37,11 @@ This API is also available as `browser.extension.sendRequest()` in a version tha
     - `response`
       - : `any`. The JSON response object sent by the handler of the request. If an error occurs while connecting to the extension, the callback will be called with no arguments and {{WebExtAPIRef('runtime.lastError')}} will be set to the error message.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-sendRequest) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
@@ -22,13 +22,13 @@ browser.extension.setUpdateUrlData(
 - `data`
   - : `string`.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-setUpdateUrlData) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
@@ -13,11 +13,11 @@ The type of extension view.
 
 Values of this type are strings. Possible values are: `"tab"`, `"popup"`, `"sidebar"`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#type-ViewType) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -29,11 +29,11 @@ Values of this type are objects. They contain the following properties:
 - `scale` {{optional_inline}}
   - : `number`. The scale to render at, defaults to [`devicePixelRatio`](/en-US/docs/Web/API/Window/devicePixelRatio). This option was introduced in Firefox 82.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-ImageDetails) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
@@ -13,11 +13,11 @@ The format of an image.
 
 Values of this type are strings. Possible values are: `"jpeg"`, `"png"`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-ImageFormat) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.md
@@ -22,11 +22,11 @@ Some common types used in other WebExtension APIs.
 - `extensionTypes.CSSOrigin`
   - : Indicates whether a CSS stylesheet injected by [`tabs.insertCSS`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS) should be treated as an "author" or "user" stylesheet.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -19,11 +19,11 @@ Values of this type are strings. Possible values are: `"document_start"`, `"docu
 
 The default value is `"document_idle"`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-RunAt) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -95,10 +95,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
     - `text`
       - : The complete text of the match, "You may" in the example above.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ### Basic examples
@@ -280,3 +276,7 @@ browser.runtime.onMessage.addListener((message) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
@@ -36,10 +36,6 @@ browser.find.highlightResults(
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Search the active tab for "banana", log the number of matches, and highlight them:
@@ -54,3 +50,7 @@ function found(results) {
 
 browser.find.find("banana").then(found);
 ```
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
@@ -20,8 +20,8 @@ To use this API you need to have the "find" [permission](/en-US/docs/Mozilla/Add
 - {{WebExtAPIRef("find.removeHighlighting()")}}
   - : Remove any highlighting.
 
-## Browser compatibility
-
 {{WebExtExamples("h2")}}
+
+## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
@@ -23,12 +23,12 @@ None.
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
 browser.find.removeHighlighting();
 ```
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -36,10 +36,6 @@ let addingUrl = browser.history.addUrl(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) will be fulfilled with no parameters when the item has been added.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Add a record of a visit to "https\://example.org/", then check that the new visit was recorded by searching history for the most recent item and logging it:
@@ -95,6 +91,10 @@ browser.history
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-addUrl) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) will be fulfilled with no parameters when all history has been deleted.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Delete all history when the user clicks a browser action:
@@ -49,6 +45,10 @@ deleteAllHistory();
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-deleteAll) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -32,10 +32,6 @@ let deletingRange = browser.history.deleteRange(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) will be fulfilled with no parameters when the range has been deleted.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Delete all visits made in the last minute:
@@ -54,6 +50,10 @@ browser.history.deleteRange({
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-deleteRange) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -30,10 +30,6 @@ let deletingUrl = browser.history.deleteUrl(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) will be fulfilled with no parameters when the visits have been removed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Remove all visits to "https\://example.org/" from history, then check that this URL no longer returned from {{WebExtAPIRef("history.search()")}}:
@@ -91,6 +87,10 @@ searching.then(onGot);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-deleteUrl) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -30,10 +30,6 @@ let getting = browser.history.getVisits(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) will be fulfilled with an array of {{WebExtAPIRef('history.VisitItem')}} objects each representing a visit to the given URL. Visits are sorted in reverse chronological order.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 List all visits to the most recently-visited page:
@@ -66,6 +62,10 @@ searching.then(listVisits);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-getVisits) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -26,11 +26,11 @@ This is an object with the following properties:
 - `typedCount` {{optional_inline}}
   - : `number`. The number of times the user has navigated to this page by typing in the address.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#type-HistoryItem) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.md
@@ -61,11 +61,11 @@ To use this API, an extension must request the "history" [permission](/en-US/doc
 - {{WebExtAPIRef("history.onVisitRemoved")}}
   - : Fired when a URL is removed completely from the browser history.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -39,10 +39,6 @@ Events have three functions:
     - `title`
       - : `String`. Title of the page visited.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for title change events, and log the ID, URL, and title of the visited pages.
@@ -58,6 +54,10 @@ browser.history.onTitleChanged.addListener(handleTitleChanged);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#event-onVisited) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.md
@@ -37,10 +37,6 @@ Events have three functions:
 
         At the time that this event is sent, the browser doesn't yet know the title of the page. If the browser has visited this page before and has remembered its old title, then the `HistoryItem.title` object will contain the old title of the page. If the browser doesn't have a record of the page's old title, then `HistoryItem.title` will be empty. To get the titles of pages as soon as they are known, listen for {{WebExtAPIRef("history.onTitleChanged")}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for visits, and log the URL and visit time.
@@ -55,6 +51,10 @@ browser.history.onVisited.addListener(onVisited);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#event-onVisited) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
@@ -41,10 +41,6 @@ Events have three functions:
         - If this event is firing because all history was cleared, `allHistory` will be `true` and `urls` will be an empty array.
         - Otherwise, `allHistory` will be `false` and `urls` will contain one item, which is the URL of the removed page.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -60,6 +56,10 @@ browser.history.onVisitRemoved.addListener(onRemoved);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#event-onVisitRemoved) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
@@ -36,11 +36,11 @@ Values of this type are strings. Possible values are:
 - "keyword_generated"
   - : Corresponds to a visit generated for a keyword.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#type-TransitionType) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -24,11 +24,11 @@ Values of this type are objects. They contain the following properties:
 - `transition`
   - : {{WebExtAPIRef('history.TransitionType')}}. Describes how the browser navigated to the page on this occasion.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#type-VisitItem) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -39,10 +39,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
     - `percentage`
       - : `integer`. The percentage of the input string that was in the detected language.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -60,6 +56,10 @@ detecting.then(onLanguageDetected);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-detectLanguage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an `array` of {{WebExtAPIRef('i18n.LanguageCode')}} objects.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -44,6 +40,10 @@ gettingAcceptLanguages.then(onGot);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-getAcceptLanguages) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -36,10 +36,6 @@ browser.i18n.getMessage(
 
 `string`. Message localized for current locale.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the localized string for `"messageContent"`, with `target.url` substituted:
@@ -73,6 +69,10 @@ If `target.url` is "https\://developer.mozilla.org", then the value of message, 
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-getMessage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -25,10 +25,6 @@ None.
 
 `string`. The browser UI language code as an {{WebExtAPIRef("i18n.LanguageCode")}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -39,6 +35,10 @@ console.log(uiLanguage);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-getUILanguage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -31,11 +31,11 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 - {{WebExtAPIRef("i18n.getSystemUILanguage()")}}
   - : Returns the current UI locale of the operating system.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -13,11 +13,11 @@ A [language tag](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10)
 
 Values of this type are strings.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#type-LanguageCode) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -27,10 +27,6 @@ None.
 
 A string containing a redirect URL value.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the redirect URL:
@@ -40,6 +36,10 @@ let redirectURL = browser.identity.getRedirectURL();
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`identity`](https://developer.chrome.com/docs/extensions/reference/api/identity) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
@@ -57,11 +57,11 @@ This will tend to be specific to the service provider, but in general it means c
 - {{WebExtAPIRef("identity.launchWebAuthFlow()")}}
   - : Launches WAF.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.identity`](https://developer.chrome.com/docs/extensions/reference/api/identity) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -58,10 +58,6 @@ let authorizing = browser.identity.launchWebAuthFlow(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the extension is authorized successfully, this will be fulfilled with a string containing the redirect URL. The URL will include a parameter that either is an access token or can be exchanged for an access token, using the documented flow for the particular service provider.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This function authorizes an extension to access a user's Google data, according to the documentation at <https://developers.google.com/identity/protocols/oauth2/javascript-implicit-flow>. Validation of the returned access token isn't shown here:
@@ -94,6 +90,10 @@ function getAccessToken() {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`identity`](https://developer.chrome.com/docs/extensions/reference/api/identity) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
@@ -13,11 +13,11 @@ String describing the device's idle state.
 
 Values of this type are strings. Possible values are: `"active"`, `"idle"`, `"locked"`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#type-IdleState) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/index.md
@@ -28,11 +28,11 @@ To use this API you need to have the "idle" [permission](/en-US/docs/Mozilla/Add
 - {{WebExtAPIRef("idle.onStateChanged")}}
   - : Fired when the system changes state.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
@@ -39,10 +39,6 @@ Events have three functions:
     - `newState`
       - : {{WebExtAPIRef('idle.IdleState')}}. The new idle state.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -54,6 +50,10 @@ browser.idle.onStateChanged.addListener(newState);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#event-onStateChanged) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -28,10 +28,6 @@ let querying = browser.idle.queryState(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an {{WebExtAPIRef('idle.IdleState')}} string, indicating the current state.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 In this simple snippet, we call `queryState()` and then check if the returned `newState` is `idle` or `active`, logging a message as appropriate. Because we have specified a `detectionIntervalInSeconds` of 15, an `idle` state will only be reported if there has been no user activity for at least 15 seconds
@@ -50,6 +46,10 @@ querying.then(onGot);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#method-queryState) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
@@ -24,10 +24,6 @@ browser.idle.setDetectionInterval(
 - `intervalInSeconds`
   - : `integer`. Threshold, in seconds, used to determine when the system is in an idle state. The minimum value you can supply here is 15.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -35,6 +31,10 @@ browser.idle.setDetectionInterval(15);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#method-setDetectionInterval) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
@@ -65,11 +65,11 @@ It is an object with the following properties:
 - `versionName`
   - : `string`. Descriptive name for this add-on's version, taken from the manifest.json [version_name](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name) key.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#type-ExtensionInfo) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -30,10 +30,6 @@ let gettingInfo = browser.management.get(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}} object, containing information about the add-on. The promise will be rejected if no extension with the given ID is installed or the extension is not allowed to be accessed by the caller.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the name of the add-on whose ID is "my-add-on":
@@ -50,6 +46,10 @@ getting.then(got);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-get) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -29,10 +29,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an array of {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}} objects, one for each installed add-on.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the name of all installed add-ons:
@@ -51,6 +47,10 @@ gettingAll.then(gotAll);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getAll) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -32,10 +32,6 @@ let gettingWarnings = browser.management.getPermissionWarningsById(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an array of strings, each of which contains the text of a permission warning.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the permission warnings for the add-on whose ID is "my-add-on":
@@ -53,6 +49,10 @@ browser.management.getPermissionWarningsById(id).then(gotWarnings);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getPermissionWarningsById) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -32,10 +32,6 @@ let gettingWarnings = browser.management.getPermissionWarningsByManifest(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an array of strings, each of which contains the text of a permission warning.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the permission warnings for the given manifest file:
@@ -64,6 +60,10 @@ gettingWarnings.then(gotWarnings, gotError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getPermissionWarningsByManifest) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}} object, containing information about the add-on.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the add-on's name:
@@ -45,6 +41,10 @@ gettingSelf.then(gotSelf);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getSelf) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/index.md
@@ -56,11 +56,11 @@ Most of these operations require the "management" [API permission](/en-US/docs/M
 - {{WebExtAPIRef("management.onDisabled")}}
   - : Fired when an add-on is disabled.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.md
@@ -28,10 +28,6 @@ browser.management.install(options)
 
 A [Promise](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an object, containing the `ExtensionID` defined for the theme in manifest.json.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Cycle through a list of themes:
@@ -73,3 +69,7 @@ for (const url of themes) {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `info`
       - : [`ExtensionInfo`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo): info about the add-on that was disabled.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the names of add-ons when they are disabled:
@@ -52,6 +48,10 @@ browser.management.onDisabled.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onDisabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `info`
       - : [`ExtensionInfo`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo): info about the add-on that was enabled.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the names of add-ons when they are enabled:
@@ -52,6 +48,10 @@ browser.management.onEnabled.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onEnabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `info`
       - : [`ExtensionInfo`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo): info about the add-on that was installed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the names of add-ons when they are installed:
@@ -52,6 +48,10 @@ browser.management.onInstalled.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onInstalled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `info`
       - : [`ExtensionInfo`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo): info about the add-on that was uninstalled.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the names of add-ons when they are uninstalled:
@@ -52,6 +48,10 @@ browser.management.onUninstalled.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onUninstalled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -37,10 +37,6 @@ let settingEnabled = browser.management.setEnabled(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the add-on has been disabled or enabled.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Toggle enable/disable for the add-on whose ID is "my-add-on":
@@ -59,6 +55,10 @@ toggleEnabled(id);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-setEnabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -38,10 +38,6 @@ let uninstalling = browser.management.uninstall(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be rejected with an error message if the user canceled the uninstallation.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Uninstall the add-on whose ID is "addon-id" and ask the user to confirm. In the callback, we check whether the user canceled the uninstallation or if the operation succeeded.
@@ -62,6 +58,10 @@ uninstalling.then(onUninstalled, onCanceled);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-uninstall) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -34,10 +34,6 @@ let uninstallingSelf = browser.management.uninstallSelf(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be rejected with an error message if the user canceled uninstall.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Uninstall the add-on, asking the user to confirm. In the callback, check whether the user canceled uninstallation.
@@ -72,6 +68,10 @@ uninstalling.then(null, onCanceled);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-uninstallSelf) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
@@ -13,11 +13,11 @@ Its value is `6` on Firefox and Chrome.
 
 For compatibility with other browsers, Firefox makes this property available via the `contextMenus` namespace as well as the `menus` namespace.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#property-ACTION_MENU_TOP_LEVEL_LIMIT) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -52,11 +52,11 @@ Values of this type are strings. The item is displayed when the given context ap
 
 Note that "launcher" is not supported.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#type-ContextType) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -166,9 +166,9 @@ browser.menus.create(
 - {{WebExtAPIRef("menus.onShown")}}
   - : Fired when the browser shows a menu.
 
-## Browser compatibility
-
 {{WebExtExamples("h2")}}
+
+## Browser compatibility
 
 {{Compat}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
@@ -22,11 +22,11 @@ Values of this type are strings. Possible values are:
 - separator
   - : A line separating a group of items.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#type-ItemType) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -50,11 +50,11 @@ Values of this type are objects. They contain the following properties:
 - `wasChecked` {{optional_inline}}
   - : `boolean`. A flag indicating whether a checkbox or radio item was checked before it was clicked.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#type-OnClickData) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -39,10 +39,6 @@ Events have three functions:
     - `tab`
       - : {{WebExtAPIRef('tabs.Tab')}}. The details of the tab where the click took place. If the click did not take place in or on a tab, this parameter will be missing.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example listens for clicks on a menu item, then log the item's ID and the tab ID:
@@ -60,6 +56,10 @@ browser.menus.onClicked.addListener((info, tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#event-onClicked) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
@@ -39,10 +39,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs. The function is passed no parameters.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example just logs a message whenever a menu is hidden:
@@ -56,3 +52,7 @@ browser.menus.onHidden.addListener(hidden);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.md
@@ -31,10 +31,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example listens for the context menu to be shown over a link, then updates the `openLabelledId` menu item with the link's hostname:
@@ -58,3 +54,7 @@ browser.menus.onShown.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when all items have been removed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example adds two menu items. When the user clicks the item labeled "Remove all!", the extension removes both items using `removeAll()`.
@@ -61,6 +57,10 @@ browser.menus.onClicked.addListener((info, tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#method-removeAll) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -28,10 +28,6 @@ let clearing = browser.notifications.clear(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a boolean: `true` if the notification was cleared, or `false` if it was not (for example, because the notification referenced by `id` did not exist).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example shows a notification when the user clicks a browser action, unless the notification was already being shown, in which case it clears the notification:
@@ -61,6 +57,10 @@ browser.browserAction.onClicked.addListener(handleClick);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -27,10 +27,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 Note that you can define an ID for a notification explicitly by passing it into {{WebExtAPIRef("notifications.create()")}}. If you don't do this, the browser will generate one. Explicitly-specified IDs are strings, but generated IDs are numbers.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example shows a notification when the user clicks a browser action, unless the notification was already being shown, in which case it clears the notification. It uses getAll() to figure out whether the notification is being shown:
@@ -74,6 +70,10 @@ browser.notifications.getAll().then(logNotifications);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.md
@@ -48,11 +48,11 @@ To use this API, you need to have the "notifications" [permission](/en-US/docs/M
 - {{WebExtAPIRef("notifications.onShown")}}
   - : Fired immediately after a notification has been shown.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -60,11 +60,11 @@ The first three properties - `type`, `title`, `message` - are mandatory in {{Web
 
 Note that `appIconMaskUrl` and `isClickable` are not supported.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
@@ -37,11 +37,11 @@ Events have three functions:
     - `buttonIndex`
       - : `integer`. The [zero-based](https://en.wikipedia.org/wiki/Zero-based_numbering) index of the button that was clicked.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `notificationId`
       - : `string`. ID of the notification that the user clicked.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 In this simple example we add a listener to the `notifications.onClicked` event to listen for system notifications being clicked. When this occurs, we log an appropriate message to the console.
@@ -50,6 +46,10 @@ browser.notifications.onClicked.addListener((notificationId) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
@@ -37,10 +37,6 @@ Events have three functions:
     - `byUser`
       - : `boolean`. `true` if the notification was closed by the user, or `false` if it was closed by the system. This argument is not supported in Firefox.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 In this simple example we add a listener to the `notifications.onClosed` event to listen for system notifications being closed. When this occurs, we log an appropriate message to the console.
@@ -52,6 +48,10 @@ browser.notifications.onClosed.addListener((notificationId) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `notificationId`
       - : `string`. ID of the notification that has been shown.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Add a listener to the `notifications.onShown` event and log its details:
@@ -55,6 +51,10 @@ browser.notifications.onShown.addListener(logShown);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -33,11 +33,11 @@ Values of this type are strings. Possible values are:
 
 Currently Firefox only supports "basic" here.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -31,10 +31,6 @@ let updating = browser.notifications.update(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a boolean: `true` if the notification was updated, or `false` if it was not (for example, because the notification referenced by `id` did not exist).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example uses `update()` to update a progress notification. Clicking the browser action shows the notification and starts an {{WebExtAPIRef("alarms", "alarm")}}, which we use to update the notification's progress indicator.
@@ -89,6 +85,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
@@ -30,10 +30,6 @@ Events have three functions:
 
 The listener function is passed no parameters.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -43,6 +39,10 @@ browser.omnibox.onInputCancelled.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -42,10 +42,6 @@ The listener function is passed two parameters: a string `text`, and the functio
 - `suggest`
   - : `Function`. A function that the event listener can call to supply suggestions for the address bar's drop-down list. The function expects to receive an array of {{WebExtAPIRef("omnibox.SuggestResult")}} objects, one for each suggestion. Only the first six suggestions will be displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example interprets the user's input as a CSS property name and populates the drop-down list with one {{WebExtAPIRef("omnibox.SuggestResult")}} object for each CSS property matching the input. The `description` property of `SuggestResult` is the full name of the property, and the `content` is the MDN page for that property.
@@ -124,6 +120,10 @@ browser.omnibox.onInputEntered.addListener((url, disposition) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -42,10 +42,6 @@ The listener function will be passed two parameters: a string `text`, and an {{W
 - `disposition`
   - : {{WebExtAPIRef("omnibox.OnInputEnteredDisposition", "OnInputEnteredDisposition")}}. A {{WebExtAPIRef("omnibox.OnInputEnteredDisposition")}} enumeration, indicating whether the extension should open the page in the current tab, in a new foreground tab, or in a new background tab.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example interprets the user's input as a CSS property name and populates the drop-down list with one {{WebExtAPIRef("omnibox.SuggestResult")}} object for each CSS property matching the input. The `description` property of `SuggestResult` is the full name of the property, and the `content` is the MDN page for that property.
@@ -124,6 +120,10 @@ browser.omnibox.onInputEntered.addListener((url, disposition) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -35,10 +35,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs. The function is passed no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -48,6 +44,10 @@ browser.omnibox.onInputStarted.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -28,10 +28,6 @@ browser.omnibox.setDefaultSuggestion(
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -41,6 +37,10 @@ browser.omnibox.setDefaultSuggestion({
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [chrome.omnibox](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -30,10 +30,6 @@ let gettingPopup = browser.pageAction.getPopup(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the popup's URL.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Add a context menu item that logs the popup URL for the current tab. Note that you'll need the `contextMenus` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in your [manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) to create context menu items.
@@ -57,6 +53,10 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-getPopup) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -30,10 +30,6 @@ let gettingTitle = browser.pageAction.getTitle(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the page action's title.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example logs the page action's title when the user clicks its icon:
@@ -52,6 +48,10 @@ browser.pageAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-getTitle) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
@@ -24,10 +24,6 @@ browser.pageAction.hide(
 - `tabId`
   - : `integer`. The ID of the tab for which you want to hide the page action.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Hide the page action for the current tab when the user clicks it:
@@ -39,6 +35,10 @@ browser.pageAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-hide) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
@@ -13,11 +13,11 @@ Pixel data for an image.
 
 An [`ImageData`](/en-US/docs/Web/API/ImageData) object, e.g., from a {{htmlelement("canvas")}} element.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#type-ImageDataType) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -52,11 +52,11 @@ Page actions are for actions that are only relevant to particular pages (such as
 - {{WebExtAPIRef("pageAction.onClicked")}}
   - : Fired when a page action icon is clicked. This event will not fire if the page action has a popup.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
@@ -30,10 +30,6 @@ let gettingIsShown = browser.pageAction.isShown(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with `true` if the extension's page action is being shown for the given tab, and `false` otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Check the state of the currently active tab:
@@ -52,3 +48,7 @@ async function shownInActiveTab() {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -43,10 +43,6 @@ Events have three functions:
         - `button`
           - : An `integer`. Indicates the button used to click the page action icon: `0` for a left-click or a click not associated with a mouse, such as one from the keyboard and `1` for a middle button or wheel click. Note that the right-click is not supported because Firefox consumes that click to display the context menu before this event is triggered.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 When the user clicks the page action, hide it, and navigate the active tab to "<https://giphy.com/explore/cat>":
@@ -63,6 +59,10 @@ browser.pageAction.onClicked.addListener(() => {});
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#event-onClicked) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
@@ -25,10 +25,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Open the popup when the user selects a context menu item:
@@ -46,3 +42,7 @@ browser.menus.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -72,10 +72,6 @@ let settingIcon = browser.pageAction.setIcon(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments once the icon has been set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the icon for the page action when the user clicks it:
@@ -90,6 +86,10 @@ browser.pageAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-setIcon) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -30,10 +30,6 @@ browser.pageAction.setPopup(
 
         If `null` is passed here, the popup is reset to the popup that was specified in the [`page_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) manifest key.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for {{WebExtAPIRef("tabs.onUpdated")}} events, and switch the popup if the loading status changes:
@@ -58,6 +54,10 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-setPopup) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
@@ -28,10 +28,6 @@ browser.pageAction.setTitle(
 
         If `null` is passed here, the title is reset to the title that was specified in the [`page_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) manifest key.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Whenever a tab is updated, show the page action for that tab, and set its title to show the tab's ID:
@@ -47,6 +43,10 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-setTitle) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -30,10 +30,6 @@ browser.pageAction.show(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with `undefined`.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example shows the {{WebExtAPIRef("pageAction")}} for the active tab when the user selects a context menu item.
@@ -55,6 +51,10 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-show) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -30,10 +30,6 @@ let getContains = browser.permissions.contains(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with `true` if the extension already has all the permissions listed in the `permissions` argument, or `false` otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -73,6 +69,10 @@ console.log(testResult4); // false: "https://example.org/", `origins` doesn't ma
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -25,10 +25,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef("permissions.Permissions")}} object containing all the permissions currently granted to the extension. This includes all permissions the extension has listed in the [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) key, and any permissions listed in [`optional_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) that the extension has been granted by calling {{WebExtAPIRef("permissions.request()")}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -42,6 +38,10 @@ console.log(currentPermissions.origins); // [ "*://*.mozilla.org/*" ]
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -51,6 +51,8 @@ For advice on designing your request for runtime permissions, to maximize the li
 - {{WebExtAPIRef("permissions.onRemoved")}}
   - : Fired when a permission is removed.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
@@ -59,8 +61,6 @@ For advice on designing your request for runtime permissions, to maximize the li
 
 - `manifest.json` [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) property
 - `manifest.json` [`optional_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) property
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `permissions`
       - : {{WebExtAPIRef("permissions.Permissions")}} object containing the permissions that were granted.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -51,6 +47,10 @@ browser.permissions.onAdded.addListener(handleAdded);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `permissions`
       - : {{WebExtAPIRef("permissions.Permissions")}} object containing the permissions that were removed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -51,6 +47,10 @@ browser.permissions.onRemoved.addListener(handleRemoved);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -18,11 +18,11 @@ An {{jsxref("object")}} with the following properties:
 - `permissions` {{optional_inline}}
   - : An array of named permissions, including [API permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions) and [clipboard permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#clipboard_access).
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -30,10 +30,6 @@ let removing = browser.permissions.remove(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with `true` if the permissions listed in the `permissions` argument are now not granted to the extension, or `false` otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code adds a click handler that removes a given permission.
@@ -53,6 +49,10 @@ document.querySelector("#remove").addEventListener("click", remove);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -38,10 +38,6 @@ let requesting = browser.permissions.request(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with `true` if the extension is granted the permissions listed in the `permissions` argument, or `false` otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code adds a click handler that asks for various permissions, then logs the result of the request and the extension's permissions after the request completes.
@@ -74,6 +70,10 @@ document
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
@@ -50,10 +50,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the module could not be found or some other error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Installs a module, then lists its slots and list the tokens they contain:
@@ -78,3 +74,7 @@ browser.pkcs11.installModule("my_module").then(onInstalled).then(onGotSlots);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -56,8 +56,8 @@ For details about the manifest file's contents and location, see [Native manifes
 - {{WebExtAPIRef("pkcs11.uninstallModule()")}}
   - : Uninstalls the named PKCS #11 module.
 
-## Browser compatibility
-
 {{WebExtExamples("h2")}}
+
+## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
@@ -33,10 +33,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the module could not be found or some other error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Installs a module, then lists its slots and list the tokens they contain:
@@ -61,3 +57,7 @@ browser.pkcs11.installModule("my_module").then(onInstalled).then(onGotSlots);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
@@ -30,10 +30,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the module an error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Checks whether the module named "pkcs11_module" is installed:
@@ -47,3 +43,7 @@ browser.pkcs11.isModuleInstalled("pkcs11_module").then(logIsInstalled);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
@@ -30,10 +30,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the module could not be found or some other error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Uninstalls the module named "pkcs11_module":
@@ -43,3 +39,7 @@ browser.pkcs11.uninstallModule("pkcs11_module");
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.md
@@ -20,11 +20,11 @@ To use the privacy API, you must have the "privacy" [API permission](/en-US/docs
 - {{WebExtAPIRef("privacy.websites")}}
   - : Access and modify privacy settings relating to the behavior of websites.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -36,10 +36,6 @@ Default values for these properties tend to vary across browsers.
   - : this setting allows your extension to determine if a user has enabled
     [Global Privacy Control](/en-US/docs/Web/API/Navigator/globalPrivacyControl). This property is read-only on all platforms. Its underlying value is a boolean where `true` indicates that the browser sends Global Privacy Control signals and `false` indicates the browser does not send the signals.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the `webRTCIPHandlingPolicy` property:
@@ -73,6 +69,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API. This documentation is derived from [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -14,10 +14,6 @@ The `privacy.services` property contains privacy-related settings controlling se
 - `passwordSavingEnabled`
   - : A {{WebExtAPIRef("types.BrowserSetting")}} object whose underlying value is a boolean. If `true`, the browser's password manager will offer to store passwords when the user enters them. Defaults to `true`.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Disable the password manager if possible.
@@ -49,6 +45,10 @@ getting.then((got) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -57,10 +57,6 @@ Default values for these properties tend to vary across browsers.
     - `"never"`: tracking protection is off.
     - `"private_browsing"`: tracking protection is on in private browsing windows only.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set the `hyperlinkAuditingEnabled` property.
@@ -94,6 +90,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API. This documentation is derived from [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -41,8 +41,8 @@ Values of this type are objects. They contain the following properties:
 - `connectionIsolationKey` {{optional_inline}}
   - : `string`. An optional key used for additional isolation of this proxy connection.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -44,8 +44,8 @@ Values of this type are objects. They contain the following properties:
 - `url`
   - : `string`. Target of the request.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -42,10 +42,6 @@ let port = browser.runtime.connect(
 
 {{WebExtAPIRef('runtime.Port')}}. Port through which messages can be sent and received. The port's `onDisconnect` event is fired if the extension does not exist.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This content script:
@@ -102,6 +98,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-connect) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -28,10 +28,6 @@ let port = browser.runtime.connectNative(
 
 A {{WebExtAPIRef('runtime.Port')}} object. The port which the caller can use to exchange messages with the native application.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example connects to the native application "ping_pong" and starts listening for messages from it. It also sends the native application a message when the user clicks a browser action icon:
@@ -59,6 +55,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-connectNative) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -40,10 +40,6 @@ None.
 
 A {{JSxRef("Promise")}} that will be fulfilled with the {{DOMxRef("Window")}} object for the background page, if there is one. If the extension does not include a background page, the promise is rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Suppose a [background script](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) defines a function `foo()`:
@@ -74,6 +70,10 @@ getting.then(onGot, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getBackgroundPage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -23,10 +23,6 @@ None.
 
 An `object` representing the manifest.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the manifest and log the "name" property:
@@ -37,6 +33,10 @@ console.log(manifest.name);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getManifest) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -31,10 +31,6 @@ browser.runtime.getPackageDirectoryEntry(
 
 None (`undefined`) if a `callback` is provided. Otherwise, returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a `DirectoryEntry` object representing the package directory.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -44,6 +40,10 @@ browser.runtime.getPackageDirectoryEntry((directoryEntry) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getPackageDirectoryEntry) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -24,10 +24,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('runtime.PlatformInfo')}} value representing the current platform.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get and log the platform OS:
@@ -42,6 +38,10 @@ gettingInfo.then(gotPlatformInfo);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getPlatformInfo) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -28,10 +28,6 @@ browser.runtime.getURL(
 
 `string`. The fully-qualified URL to the resource within the extension.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Given a file packaged with the extension at "beasts/frog.html", get the full URL like this:
@@ -44,6 +40,10 @@ console.log(fullURL);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getURL) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -19,11 +19,11 @@ let myAddonId = browser.runtime.id;
 
 A `string` representing the add-on ID. If the extension specifies an ID in its [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) manifest.json key, `runtime.id` contains that value. Otherwise, `runtime.id` contains the ID that was generated for the extension.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#property-id) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -113,11 +113,11 @@ It also provides messaging APIs enabling you to:
 - {{WebExtAPIRef("runtime.onRestartRequired")}}
   - : Fired when the device needs to be restarted.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -67,11 +67,11 @@ setCookie.then(logCookie, logError);
 > [!NOTE]
 > `runtime.lastError` is an alias for {{WebExtAPIRef("extension.lastError")}}. They are set together, and checking either one will work.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#property-lastError) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -35,10 +35,6 @@ Events have three functions:
 - `function`
   - : The function called when this event occurs.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for this event:
@@ -54,6 +50,10 @@ browser.runtime.onBrowserUpdateAvailable.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onBrowserUpdateAvailable) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `port`
       - : A {{WebExtAPIRef('runtime.Port')}} object connecting the current script to the other context it is connecting to.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This content script:
@@ -95,6 +91,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onConnect) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -39,10 +39,6 @@ Events have three functions:
     - `port`
       - : A {{WebExtAPIRef('runtime.Port')}} object connecting the current script to the other extension it is connecting to.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 In this example the extension Hansel connects to the extension Gretel:
@@ -82,6 +78,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onConnectExternal) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -45,10 +45,6 @@ Events have three functions:
         - `temporary`
           - : `boolean`. True if the add-on was installed temporarily. For example, using the "about:debugging" page in Firefox or using [web-ext run](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/). False otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 When the extension is installed, log the install reason and open <https://example.com>:
@@ -65,6 +61,10 @@ browser.runtime.onInstalled.addListener(handleInstalled);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onInstalled) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
@@ -22,11 +22,11 @@ Values of this type are strings. Possible values are:
 - `"shared_module_update"`
   - : Another extension, which contains a module used by this extension, was updated.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-OnInstalledReason) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
@@ -35,13 +35,13 @@ Events have three functions:
     - `reason`
       - : A {{WebExtAPIRef('runtime.OnRestartRequiredReason')}} value — the reason that the event is being dispatched.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onRestartRequired) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
@@ -17,11 +17,11 @@ Values of this type are strings. Possible values are:
 - `"os_update"`: The browser/OS is updated to a newer version.
 - `"periodic"`: The system has run for more than the permitted uptime set in the enterprise policy.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-OnRestartRequiredReason) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
@@ -36,10 +36,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for suspend events:
@@ -54,6 +50,10 @@ browser.runtime.onSuspend.addListener(handleSuspend);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onSuspend) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
@@ -33,10 +33,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for `SuspendCanceled` events:
@@ -50,6 +46,10 @@ browser.runtime.onSuspendCanceled.addListener(handleSuspendCanceled);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onSuspendCanceled) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
@@ -41,10 +41,6 @@ Events have three functions:
     - `details`
       - : `object`. Contains a single property, a string named `version`, which represents the version number of the update.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Listen for `UpdateAvailable` events:
@@ -60,6 +56,10 @@ browser.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onUpdateAvailable) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -25,10 +25,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the options page has been created successfully, or rejected with an error message if the operation failed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Open the options page when the user clicks a browser action's icon:
@@ -47,6 +43,10 @@ opening.then(onOpened, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-openOptionsPage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -20,11 +20,11 @@ Values of this type are strings. Possible values are:
 - `"x86-64"`
   - : The platform is based on x86 64-bit architecture.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformArch) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -20,11 +20,11 @@ Values of this type are objects, which contain the following properties:
 - `nacl_arch`
   - : {{WebExtAPIRef('runtime.PlatformNaclArch')}}. The native client architecture. This may be different from `arch` on some platforms.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformInfo) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -13,11 +13,11 @@ The native client architecture. This may be different from arch on some platform
 
 Values of this type are strings. Possible values are: `"arm"`, `"x86-32"`, `"x86-64"`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformNaclArch) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -30,11 +30,11 @@ Values of this type are strings. Possible values are:
 - `"fuchsia"`
   - : The underlying operating system is Fuchsia.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformOs) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -104,10 +104,6 @@ which holds in Chrome, is replaced by
 
 in Firefox (see [bug 1465514](https://bugzil.la/1465514)).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ### Connecting from content scripts
@@ -215,6 +211,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-Port) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.md
@@ -21,10 +21,6 @@ browser.runtime.reload()
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Reload the extension when the user clicks a browser action's icon:
@@ -36,6 +32,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-reload) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
@@ -20,11 +20,11 @@ Values of this type are strings. Possible values are:
 - `"update_available"`
   - : An update of the extension is available.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-RequestUpdateCheckStatus) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -65,10 +65,6 @@ Note that before Firefox 55, the rules were different in the 2-argument case. Un
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the receiver sent a response, this will be fulfilled with the response. Otherwise it will be fulfilled with no arguments. If an error occurs while connecting to the extension, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Here's a content script that sends a message to the background script when the user clicks the content window. The message payload is `{greeting: "Greeting from the content script"}`, and the sender also expects to get a response, which is handled in the `handleResponse` function:
@@ -111,6 +107,10 @@ browser.runtime.onMessage.addListener(handleMessage);
 > Examples using a Promise are available in the [examples section](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#examples) of the {{WebExtAPIRef('runtime.onMessage')}} listener.
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-sendMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -37,10 +37,6 @@ let sending = browser.runtime.sendNativeMessage(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If the sender sent a response, this will be fulfilled with the response as a JSON object. Otherwise it will be fulfilled with no arguments. If an error occurs while connecting to the native application, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Here's a background script that sends a "ping" message to the "ping_pong" app and logs the response, whenever the user clicks the browser action:
@@ -65,6 +61,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-sendNativeMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -28,10 +28,6 @@ let settingUrl = browser.runtime.setUninstallURL(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with no arguments when the URL is set or rejected with an error message if the operation fails.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -48,6 +44,10 @@ settingUrl.then(onSetURL, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-setUninstallURL) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/contentscriptfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/contentscriptfilter/index.md
@@ -16,11 +16,11 @@ Values of this type are objects. They contain these properties:
 - `ids`
   - : `array` of `string`. Array of scripts IDs.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-ContentScriptFilter) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
@@ -47,11 +47,11 @@ Alternatively, you can get permission temporarily in the active tab and only in 
 - {{WebExtAPIRef("scripting.unregisterContentScripts()")}}
   - : Unregisters one or more content scripts.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
@@ -22,11 +22,11 @@ Values of this type are objects. They contain these properties:
 - `tabId`
   - : `number`. The ID of the tab to inject into.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-InjectionTarget) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -36,11 +36,11 @@ Values of this type are objects. They contain these properties:
 - `world` {{optional_inline}}
   - : {{WebExtAPIRef("scripting.ExecutionWorld")}}. The execution environment for a script to execute in. The default value is `ISOLATED`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-RegisteredContentScript) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -36,10 +36,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 - `favIconUrl` {{optional_inline}}
   - : `string`. The search engine's icon, as a data: URL.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get all installed search engines:
@@ -58,3 +54,7 @@ browser.search.get().then(retrieved);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -16,13 +16,13 @@ Values of this type are objects. They contain the following properties:
 - `maxResults` {{optional_inline}}
   - : `number`. The maximum number of results to return.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -33,10 +33,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This
 
 If an error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code forgets the single most recently-closed session, whether it's a tab or a window:
@@ -68,3 +64,7 @@ browser.sessions
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -30,10 +30,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This
 
 If an error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code forgets the single most recently-closed session, whether it's a tab or a window:
@@ -65,3 +61,7 @@ browser.sessions
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -30,10 +30,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This
 
 If an error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code restores the single most recently-closed session, whether it's a tab or a window:
@@ -65,6 +61,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
@@ -33,10 +33,6 @@ let retrieving = browser.sessions.getTabValue(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved with the value if it exists, or `undefined` if it does not exist. If the call failed (for example, because the tab ID could not be found) then the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the value of "my-key" for all newly created tabs (this will include any tabs that have been restored):
@@ -58,3 +54,7 @@ browser.tabs.onCreated.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
@@ -33,10 +33,6 @@ let retrieving = browser.sessions.getWindowValue(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved with the value if it exists, or `undefined` if it does not exist. If the call failed (for example, because the window ID could not be found) then the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the value of "my-key" for all newly created windows (this will include any windows that have been restored):
@@ -58,3 +54,7 @@ browser.windows.onCreated.addListener((window) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.md
@@ -57,11 +57,11 @@ To use the sessions API you must have the "sessions" [API permission](/en-US/doc
 - {{WebExtAPIRef("sessions.onChanged")}}
   - : Fired when a tab or window is closed.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -33,10 +33,6 @@ Events have three functions:
 - `listener`
   - : The function called when this event occurs. It's passed no parameters.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This very annoying extension listens for `onChanged`, then immediately restores the most recently closed session, thus making it impossible to close windows or tabs:
@@ -70,6 +66,10 @@ browser.sessions.onChanged.addListener(restoreMostRecent);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
@@ -31,10 +31,6 @@ let removing = browser.sessions.removeTabValue(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved no arguments if the item was successfully removed. If the call failed (for example, because the tab ID could not be found) then the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code adds two context menu items: one stores a value associated with the current tab, the other one removes it:
@@ -80,3 +76,7 @@ browser.menus.onClicked.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
@@ -31,10 +31,6 @@ let removing = browser.sessions.removeWindowValue(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved no arguments if the item was successfully removed. If the call failed (for example, because the window ID could not be found) then the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code adds two context menu items: one stores a value associated with the current window, the other one removes it:
@@ -72,3 +68,7 @@ browser.menus.onClicked.addListener((info) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -28,10 +28,6 @@ let restoringSession = browser.sessions.restore(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This will be fulfilled with a {{WebExtAPIRef("sessions.Session", "Session")}} object representing the session that was restored.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This restores the single most recently-closed session, whether it's a window or tab:
@@ -63,6 +59,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
@@ -36,10 +36,6 @@ let storing = browser.sessions.setTabValue(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved with no arguments if the call succeeded. If the call failed (for example, because the tab ID could not be found) then the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set a value on the active tab when the user selects a menu item. Note that you'll need the "menus" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) to run this example:
@@ -64,3 +60,7 @@ browser.menus.onClicked.addListener(setOnActiveTab);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
@@ -36,10 +36,6 @@ let storing = browser.sessions.setWindowValue(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be resolved with no arguments if the call succeeded. If the call failed (for example, because the window ID could not be found) then the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Set a value on the active window when the user selects a menu item. Note that you'll need the "menus" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) to run this example:
@@ -60,3 +56,7 @@ browser.menus.onClicked.addListener(setOnActiveWindow);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Close the sidebar when the user selects a context menu item:
@@ -48,3 +44,7 @@ browser.menus.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -41,10 +41,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 moz-extension://d1d8a2eb-fe60-f646-af30-a866c5b39942/sidebar.html
 ```
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the panel's URL:
@@ -59,6 +55,10 @@ gettingPanel.then(onGot);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -39,10 +39,6 @@ let gettingTitle = browser.sidebarAction.getTitle(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the sidebar's title.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code switches the title between "this" and "that" each time the user clicks the browser action
@@ -63,6 +59,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
@@ -13,11 +13,11 @@ Pixel data for an image. Must be an [`ImageData`](/en-US/docs/Web/API/ImageData)
 
 An [`ImageData`](/en-US/docs/Web/API/ImageData) object.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
@@ -35,10 +35,6 @@ let gettingIsOpen = browser.sidebarAction.isOpen(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with `true` if the extension's sidebar is open in the given window, or `false` otherwise.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Check the topmost window:
@@ -65,3 +61,7 @@ browser.windows.getAll().then((all) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Open the sidebar when the user selects a context menu item:
@@ -48,3 +44,7 @@ browser.menus.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -93,10 +93,6 @@ let settingIcon = browser.sidebarAction.setIcon(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments once the icon has been set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 The code below toggles the sidebar icon for the active tab when the user clicks a browser action:
@@ -124,6 +120,10 @@ browser.browserAction.onClicked.addListener(toggle);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -51,10 +51,6 @@ browser.sidebarAction.setTitle(
 - If `windowId` and `tabId` are both supplied, the function fails and the title is not set.
 - If `windowId` and `tabId` are both omitted, the global title is set.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code changes the title for the sidebar when the user clicks a browser action, but only for the current tab:
@@ -70,6 +66,10 @@ browser.browserAction.onClicked.addListener(setTitleForTab);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Toggles the sidebar when the user selects an item from the context menu:
@@ -48,3 +44,7 @@ browser.menus.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/index.md
@@ -52,11 +52,11 @@ You can examine the stored data under the Extension Storage item in the [Storage
 - {{WebExtAPIRef("storage.onChanged")}}
   - : Fired when one or more items change in any of the storage areas.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -40,10 +40,6 @@ Events have three functions:
     - `areaName`
       - : `string`. The name of the storage area (`"sync"`, `"local"`, or `"managed"`) to which the changes were made.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -68,6 +64,10 @@ browser.storage.onChanged.addListener(logStorageChange);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#event-onChanged) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -27,10 +27,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments if the operation succeeded. If the operation failed, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -47,6 +43,10 @@ clearStorage.then(onCleared, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -40,11 +40,11 @@ In Firefox, `<storageType>` can't be {{WebExtAPIRef("storage.local")}}, because 
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an integer, `bytesUsed`, representing the storage space used by the objects specified in `keys`. If the operation fails, the promise is rejected with an error message.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -33,11 +33,11 @@ Values of this type are objects.
 - {{WebExtAPIRef("storage.StorageArea.onChanged")}}
   - : Fires when one or more items in the storage area change.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#type-StorageArea) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -30,10 +30,6 @@ Where `<storageType>` is one of the writable storage types — {{WebExtAPIRef("s
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments if the operation succeeded. If the operation failed, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Remove a single item:
@@ -52,6 +48,10 @@ removeKitten.then(onRemoved, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -18,11 +18,11 @@ browser-compat: webextensions.api.storage.StorageChange
 - `newValue` {{optional_inline}}
   - : The new value of the item, if there is a new value. This can be any data type.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#type-StorageChange) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -33,11 +33,11 @@ let getting = browser.tabs.getAllInWindow(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an `array` of {{WebExtAPIRef('tabs.Tab')}} objects, containing information about all the tabs in the window. If the window could not be found or some other error occurs, the promise will be rejected with an error message.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getAllInWindow) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -33,11 +33,11 @@ let gettingSelected = browser.tabs.getSelected(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a [`tabs.Tab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab) object containing information about the selected tab. If the tab could not be found or some other error occurs, the promise will be rejected with an error message.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getSelected) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -31,10 +31,6 @@ let withGoingBack = browser.tabs.goBack(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled when the page navigation finishes.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Go back to the previous page in the current tab:
@@ -53,6 +49,10 @@ goingBack.then(onGoBack, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -31,10 +31,6 @@ let goingForward = browser.tabs.goForward(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled when the page navigation finishes.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Go forward to the next page in the current tab:
@@ -53,6 +49,10 @@ goingForward.then(onGoForward, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -38,11 +38,11 @@ let highlighting = browser.tabs.highlight(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('windows.Window')}} object containing details about the window whose tabs were highlighted. If the window could not be found or some other error occurs, the promise will be rejected with an error message.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-highlight) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -159,11 +159,11 @@ Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a s
 - {{WebExtAPIRef("tabs.onZoomChange")}}
   - : Fired when a tab is zoomed.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -20,11 +20,11 @@ Values of this type are objects. They contain the following properties:
 - `reason` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.MutedInfoReason')}}. The reason the tab was muted or unmuted. Not set if the tab's muted state has never been changed.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-MutedInfo) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -20,11 +20,11 @@ Values of this type are strings. Possible values are:
 - "user"
   - : The user set the muted state.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-MutedInfoReason) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
@@ -49,11 +49,11 @@ Events have three functions:
 - `windowId`
   - : `integer`. The ID of the window the selected tab changed in.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onSelectionChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
@@ -70,8 +70,8 @@ Values of this type are objects. They contain the following properties:
 - `toFileName` {{optional_inline}}
   - : `string`. The name of the file the PDF is saved in, with or without the `.pdf` extension.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -78,11 +78,11 @@ Values of this type are objects. They contain the following properties:
 - `windowId`
   - : `integer`. The ID of the window that hosts this tab.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-Tab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
@@ -11,11 +11,11 @@ A special ID value given to tabs that are not browser tabs (for example, tabs in
 
 Its value is `-1`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#property-TAB_ID_NONE) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
@@ -13,11 +13,11 @@ Indicates whether the tab has finished loading.
 
 Values of this type are strings. Possible values are: `"loading"` and `"complete"`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-TabStatus) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
@@ -18,11 +18,11 @@ Values of this type are strings. Possible values are:
 - **"panel"**
 - **"devtools"**
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-WindowType) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -20,11 +20,11 @@ Values of this type are objects. They contain the following properties:
 - `scope` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.ZoomSettingsScope')}}. Defines whether zoom changes will persist for the page's origin, or only take effect in this tab.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-ZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
@@ -20,11 +20,11 @@ Values of this type are strings. Possible values are:
 - "manual"
   - : The extension will handle zoom changes itself, by listening for the {{WebExtAPIRef("tabs.onZoomChange")}} event and scaling the page accordingly. This mode does not support `per-origin` zooming: it will ignore the `scope` [zoom setting](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettings) and always use `per-tab`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-ZoomSettingsMode) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
@@ -20,11 +20,11 @@ Values of this type are strings. Possible values are:
     - in Firefox the zoom level persists across page loads and navigation within the tab.
     - in Chrome-based browsers zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-ZoomSettingsScope) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -54,10 +54,6 @@ let gettingTopSites = browser.topSites.get(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This will be fulfilled with an array of {{WebExtAPIRef("topSites.MostVisitedURL", "MostVisitedURL")}} objects, one for each page listed in the browser's "New Tab" page. If an error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code logs the title and URL for all pages in the "New Tab" page:
@@ -98,6 +94,10 @@ browser.topSites
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/api/topSites) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.md
@@ -23,11 +23,11 @@ To use the topSites API you must have the "topSites" [API permission](/en-US/doc
 - {{WebExtAPIRef("topSites.get()")}}
   - : Gets an array containing all the sites listed in the browser's "New Tab" page. Note that the number of sites returned here is browser-specific, and the particular sites returned will probably be specific to the user, based on their browsing history.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/api/topSites) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
@@ -20,13 +20,13 @@ Values of this type are objects. They contain the following properties:
 - `url`
   - : `String`. The page's URL.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/api/topSites) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -29,10 +29,6 @@ let clearing = setting.clear(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a `boolean`: `true` if the setting was cleared, `false` otherwise.
 
-## Browser compatibility
-
-See {{WebExtAPIRef("types.BrowserSetting")}}.
-
 ## Example
 
 Clear the `webRTCIPHandlingPolicy` setting:
@@ -51,6 +47,10 @@ clearing.then(onCleared);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+See {{WebExtAPIRef("types.BrowserSetting")}}.
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -54,10 +54,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
       </tbody>
     </table>
 
-## Browser compatibility
-
-See {{WebExtAPIRef("types.BrowserSetting")}}.
-
 ## Example
 
 Log the value and level of control for the `networkPredictionEnabled` property of the {{WebExtAPIRef("privacy.network")}} object, for private browsing windows. Note that this requires the "privacy" browser permission.
@@ -72,6 +68,10 @@ getting.then((got) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+See {{WebExtAPIRef("types.BrowserSetting")}}.
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
@@ -27,11 +27,11 @@ Note that while this object is based on the [ChromeSetting](https://developer.ch
 - {{WebExtAPIRef("types.BrowserSetting.onChange")}}
   - : Fired when the setting's value changes.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
@@ -63,13 +63,13 @@ Events have three functions:
               </tbody>
             </table>
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -43,10 +43,6 @@ let setting = setting.set(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a `boolean`: `true` if the setting was modified, `false` otherwise (for example, because the extension did not control the setting).
 
-## Browser compatibility
-
-See {{WebExtAPIRef("types.BrowserSetting")}}.
-
 ## Example
 
 Modify the `hyperlinkAuditingEnabled` setting (this requires the "privacy" permission):
@@ -69,6 +65,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+See {{WebExtAPIRef("types.BrowserSetting")}}.
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/index.md
@@ -14,11 +14,11 @@ Defines the `BrowserSetting` type, which is used to represent a browser setting.
 - {{WebExtAPIRef("types.BrowserSetting")}}
   - : Represents a browser setting.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -43,10 +43,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the tab is discarded, the promise will instead resolve with a `null` value. If the specified tab could not be found, or some other error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code logs the URLs of all frames in the active tab, when the user clicks a browser action:
@@ -81,6 +77,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#method-getAllFrames) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -43,10 +43,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the tab is discarded, the promise will instead resolve with a `null` value. If the specified tab or frame ID could not be found, or some other error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -70,6 +66,10 @@ gettingFrame.then(onGot, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#method-getFrame) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -70,11 +70,11 @@ To use this API you need to have the "webNavigation" [permission](/en-US/docs/Mo
 - {{WebExtAPIRef("webNavigation.onHistoryStateUpdated")}}
   - : Fired when the page used the [history API](/en-US/docs/Web/API/History_API) to update the URL displayed in the browser's location bar.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -58,10 +58,6 @@ Events have three functions:
 - `timeStamp`
   - : `number`. The time when the browser is about to start the navigation, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs for `onBeforeNavigate`, if the target's hostname contains "example.com" or starts with "developer".
@@ -79,6 +75,10 @@ browser.webNavigation.onBeforeNavigate.addListener(logOnBefore, filter);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -62,10 +62,6 @@ Events have three functions:
 - `transitionQualifiers`
   - : `Array` of {{WebExtAPIRef("webNavigation.transitionQualifier", "transitionQualifier")}}. Extra information about the navigation: for example, whether there was a server or client redirect.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs and extra transition information for `onCommitted`, if the target URL's hostname contains "example.com" or starts with "developer".
@@ -85,6 +81,10 @@ browser.webNavigation.onCommitted.addListener(logOnCommitted, filter);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -56,10 +56,6 @@ Events have three functions:
 - `timeStamp`
   - : `number`. The time at which the page finished loading, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs for `onCompleted`, if the target URL's hostname contains "example.com" or starts with "developer".
@@ -77,6 +73,10 @@ browser.webNavigation.onCompleted.addListener(logOnCompleted, filter);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -67,10 +67,6 @@ Events have three functions:
 - `windowId`
   - : `number`. The ID of the window in which the new tab is created.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URL, source Tab ID, and source frame ID for `onCreatedNavigationTarget`, if the target's hostname contains "example.com" or starts with "developer".
@@ -93,6 +89,10 @@ browser.webNavigation.onCreatedNavigationTarget.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -56,10 +56,6 @@ Events have three functions:
 - `timeStamp`
   - : `number`. The time at which `DOMContentLoaded` was fired, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs for `onDOMContentLoaded`, if the target URL's hostname contains "example.com" or starts with "developer".
@@ -80,6 +76,10 @@ browser.webNavigation.onDOMContentLoaded.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -66,10 +66,6 @@ Events have three functions:
 
     If you omit this parameter, the event fires for all transitions.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs for `onErrorOccurred`, if the target URL's `hostname` contains `"example.com"` or starts with `"developer"`.
@@ -88,6 +84,10 @@ browser.webNavigation.onErrorOccurred.addListener(logOnErrorOccurred, filter);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -60,10 +60,6 @@ Events have three functions:
 - `transitionQualifiers`
   - : `Array` of {{WebExtAPIRef("webNavigation.transitionQualifier", "transitionQualifier")}}. Extra information about the navigation: for example, whether there was a server or client redirect.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs and extra transition information for `onHistoryStateUpdated`, if the target URL's hostname contains "example.com" or starts with "developer".
@@ -86,6 +82,10 @@ browser.webNavigation.onHistoryStateUpdated.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -60,10 +60,6 @@ Events have three functions:
 - `transitionQualifiers`
   - : `Array` of {{WebExtAPIRef("webNavigation.transitionQualifier", "transitionQualifier")}}. Extra information about the navigation: for example, whether there was a server or client redirect.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Logs the target URLs and extra transition information for `onReferenceFragmentUpdated`, if the target URL's hostname contains "example.com" or starts with "developer".
@@ -86,6 +82,10 @@ browser.webNavigation.onReferenceFragmentUpdated.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -49,10 +49,6 @@ Events have three functions:
 - `timeStamp`
   - : `number`. The time when the replacement happened, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -64,6 +60,10 @@ browser.webNavigation.onTabReplaced.addListener(logOnTabReplaced);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onTabReplaced) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -22,11 +22,11 @@ Values of this type are strings. Possible values are:
 - "from_address_bar"
   - : The user triggered the navigation from the address bar.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#type-TransitionQualifier) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
@@ -38,11 +38,11 @@ Values of this type are strings. Possible values are:
 - "keyword_generated"
   - : Corresponds to a visit generated for a keyword.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#type-TransitionType) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -40,11 +40,11 @@ Values of this type are objects. They contain the following properties:
 - `upgradeToSecure` {{optional_inline}}
   - : `boolean`. If set to `true` and the original request is an HTTP request, this will prevent the original request from being sent and instead make a secure (HTTPS) request. If any extension returns `redirectUrl` in `onBeforeRequest`, then `upgradeToSecure` will be ignored for that request. You can only set this property in {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}}.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-BlockingResponse) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
@@ -50,8 +50,8 @@ Values of this type are objects. They contain the following properties:
     - `end`
       - : `Number`. The end of the certificate's validity period, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -39,10 +39,6 @@ let gettingInfo = browser.webRequest.getSecurityInfo(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which resolves to a {{WebExtAPIRef("webRequest.SecurityInfo", "SecurityInfo")}} object.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example listens for all HTTPS requests to "mozilla.org" or its subdomains, and logs the subject name in the server certificate:
@@ -98,3 +94,7 @@ browser.webRequest.onHeadersReceived.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -40,10 +40,6 @@ None.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments, when the operation has completed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 In the following snippet, we flush the in-memory cache via a call to `handlerBehaviorChanged()`, and report this action by logging an appropriate message to the console.
@@ -62,6 +58,10 @@ flushingCache.then(onFlushed, onError);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#method-handlerBehaviorChanged) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -20,11 +20,11 @@ An `array` of `object`s. Each object has the following properties:
 - `binaryValue` {{optional_inline}}
   - : `array` of `integer`. Value of the HTTP header if it cannot be represented by UTF-8, represented as bytes (0..255). Either this property or `value` must be present.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-HttpHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -129,13 +129,13 @@ To do this, you must have the `"webRequestBlocking"` API permission as well as t
 - {{WebExtAPIRef("webRequest.onErrorOccurred")}}
   - : Fired when an error occurs.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
 
 [Additional notes on Chrome incompatibilities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#webrequest_api).
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
@@ -11,11 +11,11 @@ The maximum number of times that {{WebExtAPIRef("webRequest.handlerBehaviorChang
 
 This property is read-only and has a value of `20`.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#property-MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -134,10 +134,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -159,6 +155,10 @@ browser.webRequest.onBeforeRedirect.addListener(logResponse, {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRedirect) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -155,10 +155,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ### DNS resolution ordering when BlockingResponse is used
 
 Regarding DNS resolution when BlockingResponse is used with OnBeforeRequest: In HTTP Channel, onBeforeRequest with blocking response does happen prior to DNS resolution and also prior to speculative connect. For other channels, speculative connect may cause DNS requests to happen before onBeforeRequest. This ordering is not something an extension developer ought to rely on as it may vary across browsers, and from one browser version to another, let alone one request channel to another. Refer [BugZilla issue clarification provided by Mozilla developers on DNS resolution ordering](https://bugzil.la/1466099)
@@ -307,6 +303,10 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRequest) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -155,10 +155,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code changes the "User-Agent" header so the browser identifies itself as Opera 12.16, but only when visiting pages under `https://httpbin.org/`.
@@ -250,6 +246,10 @@ browser.webRequest.onBeforeSendHeaders.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeSendHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -132,10 +132,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -160,6 +156,10 @@ browser.webRequest.onCompleted.addListener(logResponse, { urls: [target] });
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onCompleted) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -139,10 +139,6 @@ Events have three functions:
     - `NS_ERROR_CRYPTOMINING_URI` indicating a cryptomining URI.
     - `NS_ERROR_SOCIALTRACKING_URI` indicating a social tracking URI.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -163,6 +159,10 @@ browser.webRequest.onErrorOccurred.addListener(logError, { urls: [target] });
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onErrorOccurred) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -150,10 +150,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code sets an extra cookie when requesting a resource from the target URL:
@@ -216,6 +212,10 @@ browser.webRequest.onHeadersReceived.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onHeadersReceived) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -132,10 +132,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -159,6 +155,10 @@ browser.webRequest.onResponseStarted.addListener(logResponse, {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onResponseStarted) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -124,10 +124,6 @@ Events have three functions:
 
     You can find more information on tracker types on the [disconnect.me](https://disconnect.me/trackerprotection#categories_of_trackers) website. The `content` suffix indicates trackers that track and serve content. Blocking them protects users but can lead to sites breaking or elements not being displayed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code logs all cookies that will be sent in making requests to the target [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns):
@@ -155,6 +151,10 @@ browser.webRequest.onSendHeaders.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onSendHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -24,11 +24,11 @@ Values of this type are objects. They contain the following properties:
 - `incognito` {{optional_inline}}
   - : `boolean`. If provided, requests that do not match the incognito state (`true` or `false`) will be filtered out.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-RequestFilter) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -64,11 +64,11 @@ Values of this type are strings. Possible values are:
 - `other`
   - : Resources that aren't covered by any other available type.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-ResourceType) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
@@ -83,8 +83,8 @@ Values of this type are objects. They contain the following properties:
 - `weaknessReasons` {{optional_inline}}
   - : `String`. If `state` is "weak", this indicates the reason. Currently this may contain only a single value "cipher", indicating that the negotiated cipher suite is considered weak.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
@@ -29,10 +29,6 @@ None.
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example will replace the page content with "replacement text":
@@ -57,3 +53,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -27,10 +27,6 @@ None.
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example will prepend "preface text" to the response body. It then disconnects, so the original response body will load normally:
@@ -55,3 +51,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
@@ -9,10 +9,6 @@ browser-compat: webextensions.api.webRequest.StreamFilter.error
 
 A string that will contain an error message after the {{WebExtAPIRef("webRequest.StreamFilter.onerror", "onerror")}} event has fired.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example adds an {{WebExtAPIRef("webRequest.StreamFilter.onerror", "onerror")}} listener which logs the value of `error`.
@@ -36,3 +32,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -69,10 +69,6 @@ The filter also provides functions to {{WebEXTAPIRef("webRequest.StreamFilter.su
 - {{WebExtAPIRef("webRequest.StreamFilter.status")}}
   - : Describes the current status of the stream.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This code listens for `onstart`, `ondata`, and `onstop`. It logs those events, and the response data as an {{jsxref("ArrayBuffer")}} itself:
@@ -106,3 +102,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -13,10 +13,6 @@ After this event is fired, the {{WebExtAPIRef("webRequest.StreamFilter.error")}}
 
 Note that this event is **not** triggered for network errors.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example adds an `onerror` listener which logs the value of {{WebExtAPIRef("webRequest.StreamFilter.error")}}.
@@ -57,3 +53,7 @@ browser.webRequest.onBeforeRequest.addListener(listener, {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
@@ -9,10 +9,6 @@ browser-compat: webextensions.api.webRequest.StreamFilter.onstart
 
 An event handler that will be called when the stream is opened and is about to begin delivering data. From this point on, the extension may use filter functions like {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, or {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example will replace the page content with "replacement text":
@@ -37,3 +33,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
@@ -9,10 +9,6 @@ browser-compat: webextensions.api.webRequest.StreamFilter.onstop
 
 An event handler that will be called when the stream has no more data to deliver. In the event handler you can still call filter functions such as {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, or {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example will append "extra stuff" to the response:
@@ -69,3 +65,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
@@ -25,10 +25,6 @@ None.
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example uses suspend/resume to delay a web request.
@@ -55,3 +51,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
@@ -24,10 +24,6 @@ A string that describes the current status of the request. It will be one of the
 - `"failed"`
   - : An error has occurred and the filter has been disconnected from the request. The extension can find an error message in {{WebExtAPIRef("webRequest.StreamFilter.error", "error")}}, and may not call any filter functions.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 ```js
@@ -60,3 +56,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
@@ -25,10 +25,6 @@ None.
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example uses suspend/resume to delay a web request.
@@ -55,3 +51,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -28,10 +28,6 @@ filter.write(
 
 None.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example uses `write()`, to replace "Example" in the first chunk of the response with "WebExtension Example".
@@ -62,3 +58,7 @@ browser.webRequest.onBeforeRequest.addListener(
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -18,11 +18,11 @@ Values of this type are objects. They contain the following properties:
 - `file` {{optional_inline}}
   - : `string`. A string with the file's path and name.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-UploadData) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.md
@@ -18,11 +18,11 @@ Values of this type are `strings`. Possible values are:
 - `"panel"`
 - `"detached_panel"`
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-CreateType) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -38,10 +38,6 @@ let getting = browser.windows.get(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('windows.Window')}} object containing the details of the window. If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example gets the current window and logs the URLs of the tabs it contains. Note that you'll need the "tabs" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or matching [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) to access tab URLs.
@@ -66,6 +62,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-get) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -32,10 +32,6 @@ let gettingAll = browser.windows.getAll(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an array of {{WebExtAPIRef('windows.Window')}} objects, representing all windows that match the given criteria. If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the URLs for the tabs across all "normal" browser windows. Note that you'll need the "tabs" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or matching [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) to access tab URLs.
@@ -63,6 +59,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-getAll) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -37,10 +37,6 @@ let gettingCurrent = browser.windows.getCurrent(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a [`windows.Window`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window) object containing the details of the window. If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 When the user clicks a browser action's icon, this example gets the current window and logs the URLs of the tabs it contains. Note that you'll need the "tabs" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or matching [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) to access tab URLs.
@@ -62,6 +58,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-getCurrent) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -35,10 +35,6 @@ let gettingWindow = browser.windows.getLastFocused(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('windows.Window')}} object containing the details of the last focused window. If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Get the last focused window, and log the tabs it contains. Note that you'll need the "tabs" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or matching [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) to access tab URLs.
@@ -60,6 +56,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-getLastFocused) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/index.md
@@ -55,11 +55,11 @@ Interact with browser windows. You can use this API to get information about ope
 - {{WebExtAPIRef("windows.onFocusChanged")}}
   - : Fired when the currently focused window changes.
 
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `window`
       - : A {{WebExtAPIRef('windows.Window')}} object containing details of the window that was created.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the IDs of new windows as they are created:
@@ -50,6 +46,10 @@ browser.windows.onCreated.addListener((window) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onCreated) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -38,10 +38,6 @@ Events have three functions:
     - `windowId`
       - : `integer`. ID of the newly focused window.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log focus changes:
@@ -53,6 +49,10 @@ browser.windows.onFocusChanged.addListener((windowId) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onFocusChanged) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -35,10 +35,6 @@ Events have three functions:
     - `windowId`
       - : `integer`. ID of the window that was closed.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 Log the IDs of windows as they are removed.
@@ -50,6 +46,10 @@ browser.windows.onRemoved.addListener((windowId) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onRemoved) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -28,10 +28,6 @@ let removing = browser.windows.remove(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the window has been closed. If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 When the user clicks a browser action's icon, close the window in which the icon was clicked:
@@ -70,6 +66,10 @@ document.querySelector("#close").addEventListener(async ({ button }) => {
 In Firefox, the same could be achieved with the `.allowScriptsToClose` window creation property and `window.close()`.
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-remove) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -47,10 +47,6 @@ let updating = browser.windows.update(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('windows.Window')}} object containing the details of the updated window. If any error occurs, the promise will be rejected with an error message.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 When the user clicks a browser action's icon, move the window to the top left corner:
@@ -74,6 +70,10 @@ browser.browserAction.onClicked.addListener((tab) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-update) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -40,11 +40,11 @@ Values of this type are `objects`. They contain the following properties:
 - `width` {{optional_inline}}
   - : `integer`. The width of the window, including the frame, in pixels.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-Window) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
@@ -9,11 +9,11 @@ browser-compat: webextensions.api.windows.WINDOW_ID_CURRENT
 
 `browser.windows.WINDOW_ID_CURRENT` is a value that can be used as a `windowId` parameter in some APIs to represent the current window.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#property-WINDOW_ID_CURRENT) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
@@ -9,11 +9,11 @@ browser-compat: webextensions.api.windows.WINDOW_ID_NONE
 
 The `windowId` value that represents the absence of a browser window.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#property-WINDOW_ID_NONE) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -26,11 +26,11 @@ Values of this type are `strings`. Possible values are:
 
 macOS compatibility: Beginning in macOS 10.10, the default maximizing behavior for windows changed to run applications as full screen applications instead of "zoomed" windows. `fullscreen` refers to both the browser running as a full screen application and when content in a tab uses the Fullscreen API.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-WindowState) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -18,11 +18,11 @@ Values of this type are `strings`. Possible values are:
 - `"panel"`
 - `"devtools"`
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-WindowType) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/22631. I only made a few ad-hoc changes, which I've remarked below.