### PR TITLE
📝 Clarify that align-items: stretch also shrinks oversized items

### DIFF
--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -120,7 +120,7 @@ align-items: unset;
   - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
 
 - `stretch`
-  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
+  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container. Likewise, if items are larger than the container, they will be shrunk to fit the container, respecting the items' width and height limits.
 
 - `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the items to the center of the associated anchor element in the block direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).


### PR DESCRIPTION
### Description

Clarified the documentation for `align-items: stretch` to explain that it not only stretches smaller items to fill the container, but also shrinks items that are larger than the container.

### Motivation

The existing description only mentioned enlarging smaller items. This update makes it clearer for readers that overflow items are also shrunk to fit the container, matching the actual behavior of `stretch`.

### Additional details

Tested visually with a simple Flexbox container to verify that oversized items shrink as expected. This mirrors the suggestion in the issue and aligns with Flexbox behavior.

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/39491    [](https://codepen.io/dweinz/pen/GdMbPz)