### PR TITLE
Glossary idempotent

### DIFF
--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -7,13 +7,17 @@ sidebar: glossarysidebar
 
 An HTTP method is **idempotent** if the intended effect on the server of making a single request is the same as the effect of making several identical requests.
 
-This does not necessarily mean that the request does not have _any_ unique side effects: for example, the server may log every request with the time it was received. Idempotency only applies to effects intended by the client: for example, a POST request intends to send data to the server, or a DELETE request intends to delete a resource on the server.
+The HTTP specification defines several HTTP methods and their semantics, which includes whether they are idempotent or not. All {{glossary("Safe/HTTP", "safe")}} methods are idempotent, as well as {{HTTPMethod("PUT")}} and {{HTTPMethod("DELETE")}}. The {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} methods are not guaranteed to be idempotent.
 
-All {{glossary("Safe/HTTP", "safe")}} methods are idempotent, as well as {{HTTPMethod("PUT")}} and {{HTTPMethod("DELETE")}}. The {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} methods are not idempotent.
+Idempotent methods are distinguished because the client can retry a request if its not sure whether the request reached the server. If both requests happen to reach the server, as long as the method is idempotent, no harm is done.
 
-To be idempotent, only the state of the server is considered. The response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
+Idempotency, as defined by the HTTP specification, only considers the _intented_ effect of the client on the server: for example, a POST request intends to send data to the server, or a DELETE request intends to delete a resource on the server. A request with an idempotent method does not necessarily mean that the request does not have _any_ unique side effects: for example, the server may log every request with the time it was received.
 
-Note that the idempotence of a method is not guaranteed by the server and some applications may incorrectly break the idempotence constraint.
+Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
+
+While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. There is nothing preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method – although clients will be surprised.
+
+A few examples:
 
 `GET /pageX HTTP/1.1` is idempotent, because it is a safe (read-only) method. Successive calls may return different data to the client, if the data on the server was updated in the meantime.
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -17,7 +17,7 @@ Also, the response returned by each request may differ: for example, the first c
 
 While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. Nothing is preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method, although clients may well be surprised.
 
-A few examples:
+## Examples
 
 `GET /pageX HTTP/1.1` is idempotent, because it is a safe (read-only) method. Successive calls may return different data to the client, if the data on the server was updated in the meantime.
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -9,7 +9,7 @@ An HTTP method is **idempotent** if the intended effect on the server of making 
 
 This does not necessarily mean that the request does not have _any_ unique side effects: for example, the server may log every request with the time it was received. Idempotency only applies to effects intended by the client: for example, a POST request intends to send data to the server, or a DELETE request intends to delete a resource on the server.
 
-All {{glossary("Safe/HTTP", "safe")}} methods are idempotent, as well as {{HTTPMethod("PUT")}} and {{HTTPMethod("DELETE")}}. The {{HTTPMethod("POST")}} method is not idempotent.
+All {{glossary("Safe/HTTP", "safe")}} methods are idempotent, as well as {{HTTPMethod("PUT")}} and {{HTTPMethod("DELETE")}}. The {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} methods are not idempotent.
 
 To be idempotent, only the state of the server is considered. The response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -11,7 +11,7 @@ The HTTP specification defines several HTTP methods and their semantics, which i
 
 A client can safely retry a request that uses an idempotent method, for example, in cases where there is doubt as to whether the request reached the server. If multiple identical requests happen to reach the server, as long as the method is idempotent, no harm is done.
 
-Idempotency, as defined by the HTTP specification, only considers the _intented_ effect of the client on the server: for example, a POST request intends to send data to the server, or a DELETE request intends to delete a resource on the server. A request with an idempotent method does not necessarily mean that the request does not have _any_ unique side effects: for example, the server may log every request with the time it was received.
+The HTTP specification only defines idempotency in terms of the _intented_ effect of the client on the server. For example, a `POST` request intends to send data to the server, whereas a `DELETE` request intends to delete a resource on the server. In practice, it falls to the server to make sure the routes it exposes adhere to these semantics. Also, a request with an idempotent method does not necessarily mean that the request has _no_ unique side effects: For example, the server may log the time each request is received.
 
 Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -15,7 +15,7 @@ Idempotency, as defined by the HTTP specification, only considers the _intented_
 
 Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
 
-While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. There is nothing preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method – although clients will be surprised.
+While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. There is nothing preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method – although clients will be surprised.
 
 A few examples:
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -9,7 +9,7 @@ An HTTP method is **idempotent** if the intended effect on the server of making 
 
 The HTTP specification defines several HTTP methods and their semantics, which includes whether they are idempotent or not. All {{glossary("Safe/HTTP", "safe")}} methods are idempotent, as well as {{HTTPMethod("PUT")}} and {{HTTPMethod("DELETE")}}. The {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} methods are not guaranteed to be idempotent.
 
-Idempotent methods are distinguished because the client can retry a request if its not sure whether the request reached the server. If both requests happen to reach the server, as long as the method is idempotent, no harm is done.
+A client can safely retry a request that uses an idempotent method, for example, in cases where there is doubt as to whether the request reached the server. If multiple identical requests happen to reach the server, as long as the method is idempotent, no harm is done.
 
 Idempotency, as defined by the HTTP specification, only considers the _intented_ effect of the client on the server: for example, a POST request intends to send data to the server, or a DELETE request intends to delete a resource on the server. A request with an idempotent method does not necessarily mean that the request does not have _any_ unique side effects: for example, the server may log every request with the time it was received.
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -11,11 +11,15 @@ The HTTP specification defines several HTTP methods and their semantics, which i
 
 A client can safely retry a request that uses an idempotent method, for example, in cases where there is doubt as to whether the request reached the server. If multiple identical requests happen to reach the server, as long as the method is idempotent, no harm is done.
 
-The HTTP specification only defines idempotency in terms of the _intented_ effect of the client on the server. For example, a `POST` request intends to send data to the server, whereas a `DELETE` request intends to delete a resource on the server. In practice, it falls to the server to make sure the routes it exposes adhere to these semantics. Also, a request with an idempotent method does not necessarily mean that the request has _no_ unique side effects: For example, the server may log the time each request is received.
+The HTTP specification only defines idempotency in terms of the _intented_ effect of the client on the server. For example, a `POST` request intends to send data to the server, whereas a `DELETE` request intends to delete a resource on the server. In practice, it falls to the server to make sure the routes it exposes adhere to these semantics.
 
-Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}.
+> [!NOTE]
+> While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. Nothing is preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method, although clients may be surprised.
 
-While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. Nothing is preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method, although clients may well be surprised.
+Also, bear in mind:
+
+- A request with an idempotent method does not necessarily mean that the request has _no_ unique side effects: For example, the server may log the time each request is received.
+- The response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}.
 
 ## Examples
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -18,7 +18,7 @@ The HTTP specification only defines idempotency in terms of the _intented_ effec
 
 Also, bear in mind:
 
-- A request with an idempotent method does not necessarily mean that the request has _no_ unique side effects: For example, the server may log the time each request is received.
+- A request with an idempotent method does not necessarily mean that the request has _no_ side effects on the server, only that the client intended none: For example, the server may log the time each request is received.
 - The response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}.
 
 ## Examples

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -13,7 +13,7 @@ A client can safely retry a request that uses an idempotent method, for example,
 
 The HTTP specification only defines idempotency in terms of the _intented_ effect of the client on the server. For example, a `POST` request intends to send data to the server, whereas a `DELETE` request intends to delete a resource on the server. In practice, it falls to the server to make sure the routes it exposes adhere to these semantics. Also, a request with an idempotent method does not necessarily mean that the request has _no_ unique side effects: For example, the server may log the time each request is received.
 
-Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
+Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}.
 
 While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. Nothing is preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method, although clients may well be surprised.
 

--- a/files/en-us/glossary/idempotent/index.md
+++ b/files/en-us/glossary/idempotent/index.md
@@ -15,7 +15,7 @@ Idempotency, as defined by the HTTP specification, only considers the _intented_
 
 Also, the response returned by each request may differ: for example, the first call of a {{HTTPMethod("DELETE")}} will likely return a {{HTTPStatus("200")}}, while successive ones will likely return a {{HTTPStatus("404")}}. Another implication of {{HTTPMethod("DELETE")}} being idempotent is that developers should not implement RESTful APIs with a _delete last entry_ functionality using the `DELETE` method.
 
-While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. There is nothing preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method – although clients will be surprised.
+While servers are very much encouraged to adhere to the semantics laid out by the HTTP specification, the spec does not mandate it. Nothing is preventing a server in the wild from exposing a non-idempotent endpoint under an idempotent HTTP method, although clients may well be surprised.
 
 A few examples:
 


### PR DESCRIPTION

### Description
Clarify PATCH idempotency in body text

### Motivation

Previously the paragraph mentioned PUT, DELETE and POST but curiously left out PATCH, which on a cursory reading could be interpreted as PATCH being idempotent (yes, the cursory reader was me).