### PR TITLE
feat: move Quick_Links into front matter

### DIFF
--- a/files/en-us/related/imsc/basics/index.md
+++ b/files/en-us/related/imsc/basics/index.md
@@ -2,6 +2,7 @@
 title: IMSC basics
 slug: Related/IMSC/Basics
 page-type: guide
+sidebar: related
 ---
 
 IMSC allows you to add subtitles or captions to your online video. In this article we'll take you through what you need to get started, including basic document structure, and the basics of how to style, time, and position subtitles.
@@ -236,25 +237,3 @@ The more expanded example below gives you an idea what you can do with IMSC afte
 ## Summary
 
 That's it for your crash course in IMSC code basics! We've only really scratched the surface here, and you'll go much deeper into the above topics in subsequent articles.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/imsc_and_other_standards/index.md
+++ b/files/en-us/related/imsc/imsc_and_other_standards/index.md
@@ -2,6 +2,7 @@
 title: IMSC and other standards
 slug: Related/IMSC/IMSC_and_other_standards
 page-type: guide
+sidebar: related
 ---
 
 IMSC is the result of an international effort to bring together popular profiles of [TTML](https://www.w3.org/TR/ttml/), like [EBU-TT-D](https://tech.ebu.ch/publications/tech3380) and [SMPTE-TT](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7291854). This article provides an overview how IMSC is related to these other subtitle standards, and explains the differences between the versions of IMSC.
@@ -39,25 +40,3 @@ In summary, authors are encouraged to create IMSC 1.0.1 documents if possible an
 ## Summary
 
 This document gives you all you need to know about IMSC and its relationship with other specifications.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/index.md
+++ b/files/en-us/related/imsc/index.md
@@ -1,7 +1,9 @@
 ---
 title: "IMSC: subtitles and captioning for the Web"
+short-title: IMSC
 slug: Related/IMSC
 page-type: guide
+sidebar: related
 ---
 
 IMSC (TTML Profiles for Internet Media Subtitles and Captions) is a file format for representing subtitles and captions. It uses XML to describe content, timing, layout, and styling. IMSC is very similar to HTML and CSS in concept — in fact, most IMSC styles have a direct equivalent in CSS.
@@ -149,25 +151,3 @@ Team:
 - Andreas Tai
 
 If you want to get involved with documenting IMSC, please contact [Andreas Tai](mailto:tai@irt.de).
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
+++ b/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
@@ -2,6 +2,7 @@
 title: Mapping video time codes to IMSC
 slug: Related/IMSC/Mapping_video_time_codes_to_IMSC
 page-type: guide
+sidebar: related
 ---
 
 Mapping the time or time code value that is seen within a video track or video editor timeline to an IMSC document can be a little tricky. There are a few different issues that you'll need to be aware of, which we'll cover in this article.
@@ -53,25 +54,3 @@ The two attributes that must be included to use the frames method are `frameRate
 This is saying that there are 24 frames in a second, and those are playing back at a speed of 23.976 frames per real time second (24 \* (1000 / 1001)).
 
 By describing this actual frame rate, you are now able to describe time expressions in frames, or f. This is the actual frame number that the event begins and ends. Here is the same example as above, where the event begins at 01:00:00:00, and ends one second later.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/namespaces/index.md
+++ b/files/en-us/related/imsc/namespaces/index.md
@@ -2,6 +2,7 @@
 title: Namespaces in IMSC
 slug: Related/IMSC/Namespaces
 page-type: guide
+sidebar: related
 ---
 
 This article covers the subject of XML namespaces, giving you enough information to recognize their usage in IMSC, and be able to use it effectively.
@@ -131,25 +132,3 @@ Much more readable, isn't it?
 
 > [!NOTE]
 > The namespace/prefix match is only a document-wide agreement. Theoretically you can use another prefix than `tts` to bind the styling namespace. It is completely legal to define `xmlns:foo="http://www.w3.org/ns/ttml#styling"` and then write `<p foo:color="yellow">`. But it makes your IMSC document much more readable if you use the official prefixes listed in [namespace section](https://w3c.github.io/imsc/imsc1/spec/ttml-ww-profiles.html#namespaces) of the IMSC standard.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/styling/index.md
+++ b/files/en-us/related/imsc/styling/index.md
@@ -2,6 +2,7 @@
 title: Styling IMSC documents
 slug: Related/IMSC/Styling
 page-type: guide
+sidebar: related
 ---
 
 IMSC offers many options for styling documents, and most of the IMSC styling properties have direct CSS equivalents, making them familiar to web developers. In this guide you'll learn a bit more about IMSC styling including the difference between inline and referential styling, and efficient styling using inheritance and region styling.
@@ -155,25 +156,3 @@ Multiple styles can be also applied simultaneously on an element. For example, i
 ```xml
 <p style="s1 s2">Hello, I am Mork from Ork</p>
 ```
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/subtitle_placement/index.md
+++ b/files/en-us/related/imsc/subtitle_placement/index.md
@@ -2,6 +2,7 @@
 title: Subtitle placement in IMSC
 slug: Related/IMSC/Subtitle_placement
 page-type: guide
+sidebar: related
 ---
 
 IMSC allows for very explicit positioning of the text over the video content you are displaying it against. There are a few tricks and best practices that can be used in order to simplify the placement of the on-screen text.
@@ -26,25 +27,3 @@ The important items to consider here are:
 - `tts:showBackground` — should be set to `whenActive`. The other allowable value is `always`, which tells the IMSC decoder to display all region boxes with the value of `always` at the same time. This is very unlikely to be something you want to do.
 - `tts:textAlign` — the horizontal text justification. Like a word processor, this can be set to `left`, `center`, or `right`. `center` is the most common text justification for subtitles.
 - `tts:displayAlign` — the vertical alignment of the text. This can be set to `before`, `center`, or `after`. `before` means that the text will start from the very top of the region box, and flow downwards. `center` means the text will be vertically centered within the region box. After means that the text will start from the very bottom of the region box, and flow upwards.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/timing_in_imsc/index.md
+++ b/files/en-us/related/imsc/timing_in_imsc/index.md
@@ -2,6 +2,7 @@
 title: Timing in IMSC
 slug: Related/IMSC/Timing_in_IMSC
 page-type: guide
+sidebar: related
 ---
 
 When building an IMSC document, each defined piece of text must include timing information to specify when it should appear. There are multiple ways to describe when a subtitle should start and stop displaying, with pros and cons to each method. This article explains those different methods.
@@ -78,25 +79,3 @@ The advantage of using this method is that the time expression frame number is t
 
 > [!NOTE]
 > You can find an additional explanation of these values in [Mapping video time codes to IMSC](/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC).
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
@@ -2,6 +2,7 @@
 title: Using the imscJS polyfill
 slug: Related/IMSC/Using_the_imscJS_polyfill
 page-type: guide
+sidebar: related
 ---
 
 You currently need a polyfill to render IMSC on the web. imscJS is a good choice as it is actively maintained and has almost complete coverage of the IMSC features. This article shows you how to make use of imscJS and how to integrate it on your own website.
@@ -273,25 +274,3 @@ This has the effect that pointer events are going "through" the overlay (see [re
 The caption user interface problem is a bit harder to solve. Although we can listen to events, activating a track using the caption user interface will also activate the rendering of corresponding WebVTT. As we are using VTTCues for IMSC rendering, this can course undesired presentation behavior. The text property of the VTTCue has always the empty string as value but in some browser this may lead nonetheless to the rendering of artifacts.
 
 the best solution is to building your own custom controls. Find out how in our [Creating a cross-browser video player](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player) tutorial.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
-    <li class="toggle">
-      <details open>
-        <summary>IMSC guides</summary>
-        <ol>
-          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
-          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
-          </li>
-          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
-        </ol>
-      </details>
-    </li>
-  </ol>
-</section>

--- a/files/en-us/related/index.md
+++ b/files/en-us/related/index.md
@@ -2,14 +2,14 @@
 title: Web-related technologies
 slug: Related
 page-type: landing-page
+sidebar: related
 ---
 
 This section of the site is a home for documentation on web-related technologies that aren't central to the MDN's remit (i.e., they aren't web standards technologies), but are nonetheless related to the web and of interest to web developers.
 
-> [!NOTE]
-> These documentation resources generally aren't maintained by the MDN writer's team — if you have suggestions or queries related to these resources, check out the landing pages for those technologies for contact details of the relevant maintenance team.
-
 ## Technology list
 
 - [IMSC: subtitles and captioning for the Web](/en-US/docs/Related/IMSC)
-  - : IMSC (TTML Profiles for Internet Media Subtitles and Captions) is a file format for representing subtitles and captions. It uses XML to describe content, timing, layout, and styling. IMSC is very similar to HTML and CSS in concept — in fact, most IMSC styles have a direct equivalent in CSS.
+  - : IMSC (TTML Profiles for Internet Media Subtitles and Captions) is a file format for representing subtitles and captions.
+    It uses XML to describe content, timing, layout, and styling.
+    IMSC is very similar to HTML and CSS in concept — in fact, most IMSC styles have a direct equivalent in CSS.

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -2,6 +2,7 @@
 title: Creating and triggering events
 slug: Web/Events/Creating_and_triggering_events
 page-type: guide
+sidebar: events
 ---
 
 This article demonstrates how to create and dispatch DOM events. Such events are commonly called **synthetic events**, as opposed to the events fired by the browser itself.
@@ -166,12 +167,3 @@ function simulateClick() {
 - {{domxref("Event.initEvent()")}}
 - {{domxref("EventTarget.dispatchEvent()")}}
 - {{domxref("EventTarget.addEventListener()")}}
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
-    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
-    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a></li>
-    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
-  </ol>
-</section>

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -1,7 +1,8 @@
 ---
-title: Event handling (overview)
+title: Working with events and event handlers
 slug: Web/Events/Event_handlers
 page-type: guide
+sidebar: events
 ---
 
 Events are signals fired inside the browser window that notify of changes in the browser or operating system environment. Programmers can create _event handler_ code that will run when an event fires, allowing web pages to respond appropriately to change.
@@ -85,12 +86,3 @@ Then the event handler created by the code above can be removed like this:
 ```js
 controller.abort(); // removes any/all event handlers associated with this controller
 ```
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
-    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
-    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a></li>
-    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
-  </ol>
-</section>

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -1,8 +1,10 @@
 ---
 title: Event reference
+short-title: Events
 slug: Web/Events
 page-type: landing-page
 spec-urls: https://html.spec.whatwg.org/multipage/indices.html#events-2
+sidebar: events
 ---
 
 [Events](/en-US/docs/Learn_web_development/Core/Scripting/Events) are fired to notify code of "interesting changes" that may affect code execution. These can arise from user interactions such as using a mouse or resizing a window, changes in the state of the underlying environment (e.g., low battery or media events from the operating system), and other causes.
@@ -828,12 +830,3 @@ This topic provides an index to the main _sorts_ of events you might be interest
 
 - [Creating and triggering events](/en-US/docs/Web/Events/Creating_and_triggering_events)
 - [Event handlers overview](/en-US/docs/Web/Events/Event_handlers)
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Learn_web_development/Core/Scripting/Events">Introduction to events</a></li>
-    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
-    <li><a href="/en-US/docs/Web/Events/Creating_and_triggering_events">Creating and triggering events</a></li>
-    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
-  </ol>
-</section>

--- a/files/sidebars/events.yaml
+++ b/files/sidebars/events.yaml
@@ -1,0 +1,11 @@
+# Do not add comments to this file. They will be lost.
+
+sidebar:
+  - type: section
+    link: /Web/Events
+  - /Web/Events/Creating_and_triggering_events
+  - /Web/Events/Event_handlers
+  - type: section
+    title: Learn
+  - link: /Learn_web_development/Core/Scripting/Events
+    title: Introduction to events

--- a/files/sidebars/related.yaml
+++ b/files/sidebars/related.yaml
@@ -1,0 +1,15 @@
+# Do not add comments to this file. They will be lost.
+
+sidebar:
+  - type: section
+    link: /Related
+  - type: section
+    link: /Related/IMSC
+  - /Related/IMSC/Basics
+  - /Related/IMSC/Using_the_imscJS_polyfill
+  - /Related/IMSC/Styling
+  - /Related/IMSC/Subtitle_placement
+  - /Related/IMSC/Namespaces
+  - /Related/IMSC/Timing_in_IMSC
+  - /Related/IMSC/Mapping_video_time_codes_to_IMSC
+  - /Related/IMSC/IMSC_and_other_standards


### PR DESCRIPTION
### Description

For the "Related" and "IMSC" sections:

* Add yaml sidebars
* Use front matter sidebars
* Remove `Quick_links`

### Motivation

We're setting sidebars in front matter.
