### PR TITLE
Improve wording of then() return value

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -49,7 +49,7 @@ then(onFulfilled, onRejected)
 
 Returns a new {{jsxref("Promise")}} immediately. This returned promise is always pending when returned, regardless of the current promise's status.
 
-One of the `onFulfilled` and `onRejected` handlers will be executed to handle the current promise's fulfillment or rejection. The call always happens asynchronously, even when the current promise is already settled. The behavior of the promise returned by `then()` (call it `p`) depends on the handler's execution result, following a specific set of rules. If the handler function:
+One of the `onFulfilled` and `onRejected` handlers will be executed to handle the current promise's fulfillment or rejection. The call always happens asynchronously, even when the current promise is already settled. The behavior of the promise returned by `then()` (referred to as `p` in the following list) depends on the handler's execution result, following a specific set of rules. If the handler function:
 
 - returns a value: `p` gets fulfilled with the returned value as its value.
 - doesn't return anything: `p` gets fulfilled with `undefined` as its value.

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.md
@@ -47,9 +47,9 @@ then(onFulfilled, onRejected)
 
 ### Return value
 
-Returns a new {{jsxref("Promise")}} immediately. This new promise is always pending when returned, regardless of the current promise's status.
+Returns a new {{jsxref("Promise")}} immediately. This returned promise is always pending when returned, regardless of the current promise's status.
 
-One of the `onFulfilled` and `onRejected` handlers will be executed to handle the current promise's fulfillment or rejection. The call always happens asynchronously, even when the current promise is already settled. The behavior of the returned promise (call it `p`) depends on the handler's execution result, following a specific set of rules. If the handler function:
+One of the `onFulfilled` and `onRejected` handlers will be executed to handle the current promise's fulfillment or rejection. The call always happens asynchronously, even when the current promise is already settled. The behavior of the promise returned by `then()` (call it `p`) depends on the handler's execution result, following a specific set of rules. If the handler function:
 
 - returns a value: `p` gets fulfilled with the returned value as its value.
 - doesn't return anything: `p` gets fulfilled with `undefined` as its value.


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/40352.

@OP-TechTrekker How does this look to you?