### PR TITLE
Transfer-Encoding Header: Remove mention of `trailers` value

### DIFF
--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -22,7 +22,7 @@ The header is optional in responses to a {{HTTPMethod("HEAD")}} request as these
 When present it indicates the value that would have applied to the corresponding response to a {{HTTPMethod("GET")}} message, if that `GET` request did not include a preferred `Transfer-Encoding`.
 
 > [!WARNING]
-> HTTP/2 disallows all uses of the `Transfer-Encoding` header other than the HTTP/2 specific value `"trailers"`.
+> HTTP/2 disallows all uses of the `Transfer-Encoding` header.
 > HTTP/2 and later provide more efficient mechanisms for data streaming than chunked transfer.
 > Usage of the header in HTTP/2 may likely result in a specific `protocol error`.
 

--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -105,5 +105,4 @@ Developer Network\r\n
 - {{HTTPHeader("Accept-Encoding")}}
 - {{HTTPHeader("Content-Encoding")}}
 - {{HTTPHeader("Content-Length")}}
-- Header fields that regulate the use of trailers: {{HTTPHeader("TE")}} (requests) and {{HTTPHeader("Trailer")}} (responses).
 - [Chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding)


### PR DESCRIPTION
### Description

The page for `Transfer-Encoding` currently incorrectly mentions a permissible `trailers` value for HTTP/2. But `trailers` is only valid for the `TE` header. `Transfer-Encoding: trailers` is not a thing. There already is a (correct) note on https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/TE.

The PR that introduced this (https://github.com/mdn/content/pull/22032) correctly cites the RFC for `TE`, but then mixes up TE and Transfer-Encoding.

### Additional details

From https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.2 (emphasis mine):

> An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields. This includes the Connection header field and those listed as having connection-specific semantics in [Section 7.6.1](https://www.rfc-editor.org/rfc/rfc9110#section-7.6.1) of [[HTTP](https://datatracker.ietf.org/doc/html/rfc9110)] (that is, Proxy-Connection, Keep-Alive, **Transfer-Encoding**, and Upgrade).

> The only exception to this is the **TE** header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/22032
