### PR TITLE
Editorial review: Document the BaseAudioContext.state interrupted value

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -30,7 +30,7 @@ A string. Possible values are:
 
 The `state` property of an audio context is used to expose its current operational state. This is normally done by querying the `state` inside a {{domxref("BaseAudioContext.statechange_event", "statechange")}} event handler so that changes in state can be responded to appropriately.
 
-The `running` and `closed` values are self-explanatory — they indicate that the audio context is either running normally (created and connected to an output destination), or closed (via the {{domxref("AudioContext.close()")}} method).
+The `running` and `closed` values are self-explanatory — they indicate that the audio context is either running normally, or closed (via the {{domxref("AudioContext.close()")}} method).
 
 The `interrupted` and `suspended` states both represent a "paused" state that can later be resumed, but they differ in terms of what they signify:
 
@@ -41,11 +41,16 @@ Interruptions that may trigger the `interrupted` state can include:
 
 - A conferencing or phone app on the same system requiring exclusive access to the device's audio hardware.
 - The user closing their laptop.
+- API features designed to initiate or respond to audio interruptions.
+
+> [!NOTE]
+> There are currently no browser implementations that make use of the `interrupted` state.
 
 Note also the potential for transitions between the `interrupted` and `suspended` states:
 
 - If `suspend()` is called on an audio context during an interruption (`state = "interrupted"`), the state will transition to `suspended` immediately.
 - If `resume()` is called on a suspended audio context (`state = "suspended"`) during an interruption, the state will transition to `interrupted` immediately.
+- If an interruption happens while the audio context is suspended (`state = "suspended"`), the context will not transition to `interrupted`. This transition won't happen unless `resume()` is called on the context (as outlined by the previous point). This choice was made to avoid exposing too much device information to web pages - for example, logging every time the laptop is closed could be a privacy issue.
 
 ## Examples
 

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -48,7 +48,7 @@ Interruptions that may trigger the `interrupted` state can include:
 
 Note also the potential for transitions between the `interrupted` and `suspended` states:
 
-- If `suspend()` is called on an audio context during an interruption (`state === "interrupted"`), the state will transition to `suspended` immediately.
+- If `suspend()` is called on an audio context during an interruption (`state` is `interrupted`), the state will transition to `suspended` immediately.
 - If `resume()` is called on a `suspended` audio context during an interruption, the state will transition to `interrupted` immediately.
 - If an interruption happens while the audio context is `suspended`, the context will not transition to `interrupted`. This transition won't happen unless `resume()` is called on the context (as outlined by the previous point). This choice was made to avoid exposing too much device information to web pages - for example, logging every time the laptop is closed could be a privacy issue.
 

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -44,7 +44,7 @@ Interruptions that may trigger the `interrupted` state can include:
 - API features designed to initiate or respond to audio interruptions.
 
 > [!NOTE]
-> There are currently no browser implementations that make use of the `interrupted` state.
+> How the `interrupted` state is triggered may vary between browsers.
 
 Note also the potential for transitions between the `interrupted` and `suspended` states:
 

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -48,9 +48,9 @@ Interruptions that may trigger the `interrupted` state can include:
 
 Note also the potential for transitions between the `interrupted` and `suspended` states:
 
-- If `suspend()` is called on an audio context during an interruption (`state = "interrupted"`), the state will transition to `suspended` immediately.
-- If `resume()` is called on a suspended audio context (`state = "suspended"`) during an interruption, the state will transition to `interrupted` immediately.
-- If an interruption happens while the audio context is suspended (`state = "suspended"`), the context will not transition to `interrupted`. This transition won't happen unless `resume()` is called on the context (as outlined by the previous point). This choice was made to avoid exposing too much device information to web pages - for example, logging every time the laptop is closed could be a privacy issue.
+- If `suspend()` is called on an audio context during an interruption (`state === "interrupted"`), the state will transition to `suspended` immediately.
+- If `resume()` is called on a `suspended` audio context during an interruption, the state will transition to `interrupted` immediately.
+- If an interruption happens while the audio context is `suspended`, the context will not transition to `interrupted`. This transition won't happen unless `resume()` is called on the context (as outlined by the previous point). This choice was made to avoid exposing too much device information to web pages - for example, logging every time the laptop is closed could be a privacy issue.
 
 ## Examples
 

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -44,7 +44,7 @@ Interruptions that may trigger the `interrupted` state can include:
 
 Note also the potential for transitions between the `interrupted` and `suspended` states:
 
-- If `suspend()` is called on an audio context during an interruption (`state = "interrupted"`), the state will transition to `suspended` once the interruption ends.
+- If `suspend()` is called on an audio context during an interruption (`state = "interrupted"`), the state will transition to `suspended` immediately.
 - If `resume()` is called on a suspended audio context (`state = "suspended"`) during an interruption, the state will transition to `interrupted` immediately.
 
 ## Examples

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -15,14 +15,37 @@ interface returns the current state of the `AudioContext`.
 
 A string. Possible values are:
 
-- `suspended`
-  - : The audio context has been suspended (with the
-    {{domxref("AudioContext.suspend()")}} method.)
-- `running`
-  - : The audio context is running normally.
 - `closed`
   - : The audio context has been closed (with the
     {{domxref("AudioContext.close()")}} method.)
+- `interrupted` {{experimental_inline}}
+  - : The audio context has been interrupted by an occurence outside the control of the web app.
+- `running`
+  - : The audio context is running normally.
+- `suspended`
+  - : The audio context has been suspended (with the
+    {{domxref("AudioContext.suspend()")}} method.)
+
+## Description
+
+The `state` property of an audio context is used to expose its current operational state. This is normally done by querying the `state` inside a {{domxref("BaseAudioContext.statechange_event", "statechange")}} event handler so that changes in state can be responded to appropriately.
+
+The `running` and `closed` values are self-explanatory — they indicate that the audio context is either running normally (created and connected to an output destination), or closed (via the {{domxref("AudioContext.close()")}} method).
+
+The `interrupted` and `suspended` states both represent a "paused" state that can later be resumed, but they differ in terms of what they signify:
+
+- The `suspended` state indicates that the audio context was paused in response to a user action inside the web app, by running the {{domxref("AudioContext.suspend()")}} method inside a `click` (or similar) event handler. In this case, the context would be unpaused by running the {{domxref("AudioContext.resume()")}} method.
+- The `interrupted` state indicates that the audio context was paused in response to an interruption outside the control of the web app. In this case, the browser decides when to pause and unpause the app. The web app can then handle the `interrupted` state appropriately, for example by pausing an audio stream to avoid wasting resources while an app is not being used.
+
+Interruptions that may trigger the `interrupted` state can include:
+
+- A conferencing or phone app on the same system requiring exclusive access to the device's audio hardware.
+- The user closing their laptop.
+
+Note also the potential for transitions between the `interrupted` and `suspended` states:
+
+- If `suspend()` is called on an audio context during an interruption (`state = "interrupted"`), the state will transition to `suspended` once the interruption ends.
+- If `resume()` is called on a suspended audio context (`state = "suspended"`) during an interruption, the state will transition to `interrupted` immediately.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Chrome 136 adds support for the [`BaseAudioContext.state`](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/state) property's `interrupted` value: see https://chromestatus.com/feature/5172068166139904.

See also the explainer at https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/AudioContextInterruptedState/explainer.md 

This PR documents the new value.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

fixes https://github.com/mdn/content/issues/26129

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
