### PR TITLE
Clarify RGB16F_EXT format details and framebuffer support

### DIFF
--- a/files/en-us/web/api/ext_color_buffer_half_float/index.md
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.md
@@ -22,7 +22,7 @@ WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExt
 - `ext.RGBA16F_EXT`
   - : RGBA 16-bit floating-point color-renderable format.
 - `ext.RGB16F_EXT`
-  - : RGB 16-bit floating-point color-renderable format.
+  - : RGB 16-bit floating-point format. In WebGL 1.0, this may be color-renderable (implementation-dependent). In WebGL 2.0, this format is not color-renderable.
 - `ext.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT`
   - : ?
 - `ext.UNSIGNED_NORMALIZED_EXT`
@@ -32,7 +32,8 @@ WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExt
 
 This extension extends {{domxref("WebGLRenderingContext.renderbufferStorage()")}}:
 
-- The `internalformat` parameter now accepts `ext.RGBA16F_EXT` and `ext.RGB16F_EXT`.
+- In WebGL 1.0 contexts, the `internalformat` parameter now accepts `ext.RGBA16F_EXT` and `ext.RGB16F_EXT`. However, `ext.RGB16F_EXT` support is optional and applications must check framebuffer completeness to determine if it's supported.
+- In WebGL 2.0 contexts, the `internalformat` parameter now accepts `ext.RGBA16F_EXT`. The `RGB16F` format is not color-renderable in WebGL 2.0.
 
 ## Examples
 

--- a/files/en-us/web/api/ext_color_buffer_half_float/index.md
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.md
@@ -24,16 +24,20 @@ WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExt
 - `ext.RGB16F_EXT`
   - : RGB 16-bit floating-point format. In WebGL 1.0, this may be color-renderable (implementation-dependent). In WebGL 2.0, this format is not color-renderable.
 - `ext.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT`
-  - : ?
+  - : Passed to {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter()")}} to get the framebuffer type.
 - `ext.UNSIGNED_NORMALIZED_EXT`
-  - : ?
+  - : The framebuffer contains unsigned fixed-point components.
 
 ## Extended methods
 
 This extension extends {{domxref("WebGLRenderingContext.renderbufferStorage()")}}:
 
-- In WebGL 1.0 contexts, the `internalformat` parameter now accepts `ext.RGBA16F_EXT` and `ext.RGB16F_EXT`. However, `ext.RGB16F_EXT` support is optional and applications must check framebuffer completeness to determine if it's supported.
-- In WebGL 2.0 contexts, the `internalformat` parameter now accepts `ext.RGBA16F_EXT`. The `RGB16F` format is not color-renderable in WebGL 2.0.
+- In WebGL 1.0 contexts, the `internalFormat` parameter now accepts `ext.RGBA16F_EXT` and `ext.RGB16F_EXT`. However, `ext.RGB16F_EXT` support is optional and applications must check framebuffer completeness to determine if it's supported.
+- In WebGL 2.0 contexts, the `internalFormat` parameter now accepts `ext.RGBA16F_EXT`. The `RGB16F` format is not color-renderable in WebGL 2.0.
+
+It extends {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter()")}}:
+
+- In WebGL 1.0 contexts, the `pname` parameter now accepts `ext.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT`. An `INVALID_OPERATION` error is generated if `attachment` is `DEPTH_STENCIL_ATTACHMENT` and `pname` is `FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT`. When `pname` is `ext.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT`, `getFramebufferAttachmentParameter()` returns either `gl.FLOAT` or `gl.UNSIGNED_NORMALIZED_EXT` for floating-point or unsigned fixed-point components respectively.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description
Fixed incorrect documentation for the EXT_color_buffer_half_float extension regarding `RGB16F` format support and clarified WebGL version differences.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The original documentation incorrectly stated that `RGB16F_EXT` is always color-renderable, when in fact it has different behavior in WebGL 1.0 vs WebGL 2.0 contexts. This was misleading developers who need to understand the proper usage of this extension across different WebGL versions.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Reference: [WebGL EXT_color_buffer_half_float Extension Specification](https://registry.khronos.org/webgl/extensions/EXT_color_buffer_half_float)
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes #39136 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->