### PR TITLE
Update "formFactor" to "formFactors" in NavigatorUAData.getHighEntropyValues

### DIFF
--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -30,7 +30,7 @@ getHighEntropyValues(hints)
   - : An array containing the hints to be returned, one or more of:
     - `"architecture"`
     - `"bitness"`
-    - `"formFactor"`
+    - `"formFactors"`
     - `"fullVersionList"`
     - `"model"`
     - `"platformVersion"`
@@ -56,8 +56,8 @@ A {{jsxref("Promise")}} that resolves to an object containing some or all of the
 - `bitness`
   - : A string containing the architecture bitness. For example, `"32"` or `"64"`.
     Note that this information can be sent to a server in the {{HTTPHeader("Sec-CH-UA-Bitness")}} header if the server explicitly requests it in the {{HTTPHeader("Accept-CH")}} header.
-- `formFactor`
-  - : A string containing the form-factor of a device. For example, `"Tablet"` or `"VR"`.
+- `formFactors`
+  - : An array of strings containing the form-factors of a device. For example, `["Tablet", "VR"]`.
     Note that this information can be sent to a server in the {{HTTPHeader("Sec-CH-UA-Form-Factors")}} header if the server explicitly requests it in the {{HTTPHeader("Accept-CH")}} header.
 - `fullVersionList`
   - : An array of objects with properties `"brand"` and `"version"` representing the browser name and full version respectively.

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -57,7 +57,7 @@ A {{jsxref("Promise")}} that resolves to an object containing some or all of the
   - : A string containing the architecture bitness. For example, `"32"` or `"64"`.
     Note that this information can be sent to a server in the {{HTTPHeader("Sec-CH-UA-Bitness")}} header if the server explicitly requests it in the {{HTTPHeader("Accept-CH")}} header.
 - `formFactors`
-  - : An array of strings containing the form-factors of a device. For example, `["Tablet", "VR"]`.
+  - : An array of strings containing the form-factors of a device. For example, `["Tablet", "XR"]`.
     Note that this information can be sent to a server in the {{HTTPHeader("Sec-CH-UA-Form-Factors")}} header if the server explicitly requests it in the {{HTTPHeader("Accept-CH")}} header.
 - `fullVersionList`
   - : An array of objects with properties `"brand"` and `"version"` representing the browser name and full version respectively.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Replaced all occurrences of "formFactor" with "formFactors" in the NavigatorUAData.getHighEntropyValues documentation and examples to ensure consistency with the latest API specification.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The API and related browser implementations now use "formFactors" (plural) instead of "formFactor" (singular). Updating the documentation helps prevent confusion and ensures that readers follow the current specification.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
[MDN Sec-CH-UA-Form-Factors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-CH-UA-Form-Factors) for current usage.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
Fixes #40181