### PR TITLE
WebXR Input: Switch on source handedness

### DIFF
--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -147,7 +147,7 @@ xrSession.addEventListener("inputsourceschange", (event) => {
   inputSourceList = event.session.inputSources;
 
   inputSourceList.forEach((source) => {
-    switch (source) {
+    switch (source.handedness) {
       case "left":
         leftHandSource = source;
         break;


### PR DESCRIPTION
### Description

Adds a missing `.handedness` in the switch statement example:
<pre>
  inputSourceList.forEach((source) => {
    switch (source<b>.handedness</b>) {
      case "left":
        leftHandSource = source;
        break;
      case "right":
        rightHandSource = source;
        break;
    }
  });
</pre>

### Motivation

Fix a typo in the example.

### Additional details

https://www.w3.org/TR/webxr/#dom-xrinputsource-handedness

### Related issues and pull requests

N/A
