### PR TITLE
fix(ci): add GITHUB_TOKEN env for `rari` related commands

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -35,6 +35,10 @@ jobs:
           yarn fix:md
           yarn fix:fm
           node scripts/sort_and_unique_file_lines.js .vscode/dictionaries
+        env:
+          # Used by the `rari` cli to avoid rate limiting issues
+          # when fetching the latest releases info from the GitHub API.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PR with only fixable issues
         if: success()

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -44,3 +44,7 @@ jobs:
       - name: Check redirects file(s)
         if: steps.filter.outputs.required_files == 'true'
         run: yarn content validate-redirects en-US
+        env:
+          # Used by the `rari` cli to avoid rate limiting issues
+          # when fetching the latest releases info from the GitHub API.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Add GITHUB_TOKEN for remaining CIs. As the [fix](https://github.com/mdn/content/pull/39958) seems to resolve the issue with rari related commands failing (I did not observe further errors in `mdn/translated-content`).

### Related issues and pull requests

- #39958
- mdn/translated-content#27745
- mdn/translated-content#28056
