### PR TITLE
chore: small improvements to SVG examples

### DIFF
--- a/files/en-us/web/svg/reference/attribute/font-family/index.md
+++ b/files/en-us/web/svg/reference/attribute/font-family/index.md
@@ -17,15 +17,9 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 
-## Example
+## Examples
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
+### Controlling SVG font family
 
 ```html
 <svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg">
@@ -34,7 +28,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "200", "30")}}
+{{EmbedLiveSample}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/reference/attribute/font-size/index.md
+++ b/files/en-us/web/svg/reference/attribute/font-size/index.md
@@ -17,24 +17,18 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 
-## Example
+## Examples
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
+### Controlling SVG font size
 
 ```html
 <svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg">
-  <text y="20" font-size="smaller">smaller</text>
-  <text x="100" y="20" font-size="2em">2em</text>
+  <text y="25" font-size="smaller">smaller</text>
+  <text x="100" y="25" font-size="2em">2em</text>
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "200", "30")}}
+{{EmbedLiveSample}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/reference/attribute/font-style/index.md
+++ b/files/en-us/web/svg/reference/attribute/font-style/index.md
@@ -17,15 +17,9 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 
-## Example
+## Examples
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
+### Controlling SVG font style
 
 ```html
 <svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg">
@@ -34,7 +28,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "250", "30")}}
+{{EmbedLiveSample}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/reference/attribute/font-variant/index.md
+++ b/files/en-us/web/svg/reference/attribute/font-variant/index.md
@@ -17,15 +17,9 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 
-## Example
+## Examples
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
+### Controlling SVG font variations
 
 ```html
 <svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg">
@@ -34,7 +28,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "250", "30")}}
+{{EmbedLiveSample}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/reference/attribute/font-weight/index.md
+++ b/files/en-us/web/svg/reference/attribute/font-weight/index.md
@@ -17,15 +17,9 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 
-## Example
+## Examples
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
+### Controlling SVG font weight
 
 ```html
 <svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg">
@@ -34,7 +28,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "200", "30")}}
+{{EmbedLiveSample}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/reference/attribute/letter-spacing/index.md
+++ b/files/en-us/web/svg/reference/attribute/letter-spacing/index.md
@@ -10,7 +10,7 @@ The **`letter-spacing`** attribute controls spacing between text characters.
 
 If the attribute value is a unitless number (like `128`), the browser processes it as a {{cssxref("length")}} in the current user coordinate system.
 
-If the attribute value has a unit identifier, such as `.25em` or `1%`, then the browser converts the \<length> into its corresponding value in the current user coordinate system.
+If the attribute value has a unit identifier, such as `.25em` or `1%`, then the browser converts the `<length>` into its corresponding value in the current user coordinate system.
 
 > [!NOTE]
 > As a presentation attribute, `letter-spacing` also has a CSS property counterpart: {{cssxref("letter-spacing")}}. When both are specified, the CSS property takes priority.
@@ -21,15 +21,9 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 
-## Example
+## Examples
 
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
+### Controlling SVG letter spacing
 
 ```html
 <svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg">
@@ -38,7 +32,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "200", "30")}}
+{{EmbedLiveSample}}
 
 ## Usage notes
 


### PR DESCRIPTION
### Description

Looking at examples with a small defined height, these show a few with redundant styles.

* `## Example` -> `## Examples`
* Add example h3
* Removed redundant styles

### Motivation

Making page structures uniform.
