### PR TITLE
Editorial review: Document recent FedCM additions, Chrome 122-136

### DIFF
--- a/files/en-us/glossary/relying_party/index.md
+++ b/files/en-us/glossary/relying_party/index.md
@@ -5,9 +5,9 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-A **relying party** is an entity that needs to control access to a resource and, to do so, needs to {{glossary("authentication", "authenticate")}} other entities that are trying to access that resource. On the web, a relying party is usually a website that allows users to sign in and needs to authenticate users (for example by checking a password) before deciding whether to grant them access.
+A **relying party** (RP) is an entity that needs to control access to a resource and, to do so, needs to {{glossary("authentication", "authenticate")}} other entities that are trying to access that resource. On the web, a relying party is usually a website that allows users to sign in and needs to authenticate users (for example by checking a password) before deciding whether to grant them access.
 
-The website _relies on_ the validity of the credentials the browser presents when it grants access to its resources.
+The RP website _relies on_ the validity of the credentials the browser presents when it grants access to its resources. The authentication and credentials are often provided by a third-party {{glossary("Identity provider", "identity provider")}} (IdP).
 
 ## See also
 

--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -353,7 +353,7 @@ When an [RP attempts federated sign-in](/en-US/docs/Web/API/FedCM_API/RP_sign-in
 - If all IdPs' login statuses are `"logged-out"`, the promise returned by the FedCM `get()` request rejects without making a request to the accounts list endpoint. In such a case, it is up to the developer to handle the flow, for example by prompting the user to go and sign in to a suitable IdP.
 - If an IdP's login status is `"unknown"`, a request is made to the accounts list endpoint and the login status is updated depending on the response:
   - If the endpoint returns a list of available accounts for sign-in, update the status to `"logged-in"` and display the sign-in options to the user in the browser-provided FedCM dialog.
-  - If the endpoint returns no accounts, update the status to `"logged-out"`; the promise returned by the FedCM `get()` request will reject in no other `logged-in` IdPs are available.
+  - If the endpoint returns no accounts, update the status to `"logged-out"`; the promise returned by the FedCM `get()` request will reject if no other `logged-in` IdPs are available.
 
 ### What if the browser and the IdP login status become out of sync?
 

--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -47,6 +47,8 @@ The config file (hosted at `https://accounts.idp.example/config.json` in our exa
 ```json
 {
   "accounts_endpoint": "/accounts.php",
+  "account_label": "developer",
+  "supports_use_other_account": true,
   "client_metadata_endpoint": "/client_metadata.php",
   "disconnect_endpoint": "/disconnect.php",
   "id_assertion_endpoint": "/assertion.php",
@@ -68,6 +70,12 @@ The properties are as follows:
 
 - `accounts_endpoint`
   - : The URL for the accounts list endpoint, which returns a list of accounts that the user is currently signed in to on the IdP. The browser uses these to create a list of sign-in choices to show to the user in the browser-provided FedCM UI.
+- `account_label` {{optional_inline}}
+  - : A string that, if included, specifies an identifier for a subset of accounts that should be returned when this IdP is used for federated authentication. When a `get()` request is made, only accounts matching this string in their `label_hints` parameters will be returned from the [accounts endpoint](#the_accounts_list_endpoint).
+- `supports_use_other_account` {{optional_inline}}
+  - : A boolean that defaults to `false`; if set to `true`, it means that users can sign in with an account different from the one they're currently logged in with (if the IdP supports multiple accounts). This only applies to `get()` calls that specify [active mode](/en-US/docs/Web/API/IdentityCredentialRequestOptions#active).
+    > [!NOTE]
+    > In the browser sign-in UI, this will likely manifest as some kind of "Choose other account" button.
 - `client_metadata_endpoint` {{optional_inline}}
   - : The URL for the client metadata endpoint, which provides URLs pointing to the RP's metadata and terms of service pages, to be used in the FedCM UI.
 - `disconnect_endpoint` {{optional_inline}}
@@ -121,6 +129,8 @@ The response to a successful request returns a list of all the IdP accounts that
       "email": "elaina_maduro@idp.example",
       "picture": "https://idp.example/profile/123",
       "approved_clients": ["123", "456", "789"],
+      "domain_hints": ["rp1.example.com", "rp3.example.com"],
+      "label_hints": ["developer", "admin"],
       "login_hints": ["elaina_maduro", "elaina_maduro@idp.example"]
     },
     {
@@ -130,6 +140,8 @@ The response to a successful request returns a list of all the IdP accounts that
       "email": "Elly@idp.example",
       "picture": "https://idp.example/profile/456",
       "approved_clients": ["abc", "def", "ghi"],
+      "domain_hints": ["rp1.example.com", "rp2.example.com"],
+      "label_hints": ["developer", "test"],
       "login_hints": ["elly", "elly@idp.example"]
     }
   ]
@@ -150,6 +162,10 @@ This includes the following information:
   - : The URL of the user's avatar image.
 - `approved_clients` {{optional_inline}}
   - : An array of RP clients that the user has registered with.
+- `domain_hints` {{optional_inline}}
+  - : An array of domains the account is associated with. The RP can make a `get()` call that includes a [`domainHint`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#domainhint) property to filter the returned accounts by domain.
+- `label_hints` {{optional_inline}}
+  - : An array of strings specifying labels that define account types that the account is identified with. If the config file specifies an [`account_label`](#account_label), only accounts that contain that label in their `label_hints` will be returned from the accounts list endpoint.
 - `login_hints` {{optional_inline}}
   - : An array of strings representing the account. These strings are used to filter the list of account options that the browser offers for the user to sign-in. This occurs when the `loginHint` property is provided within [`identity.providers`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#providers) in a related `get()` call. Any account with a string in its `login_hints` array that matches the provided `loginHint` is included.
 

--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{DefaultAPISidebar("FedCM API")}}
 
-This article details all the steps an identity provider (IdP) needs to take to integrate with the Federated Credential Management (FedCM) API.
+This article details all the steps an {{glossary("Identity provider", "identity provider")}} (IdP) needs to take to integrate with the Federated Credential Management (FedCM) API.
 
 ## IdP integration steps
 
@@ -18,9 +18,9 @@ To integrate with FedCM, an IdP needs to do the following:
 
 ## Provide a well-known file
 
-There is a potential privacy issue whereby an [IdP is able to discern whether a user visited an RP without explicit consent](https://github.com/w3c-fedid/FedCM/issues/230). This has tracking implications, so an IdP is required to provide a well-known file to verify its identity and mitigate this issue.
+There is a potential privacy issue whereby an [IdP is able to discern whether a user visited a relying party (RP) without explicit consent](https://github.com/w3c-fedid/FedCM/issues/230). This has tracking implications, so an IdP is required to provide a well-known file to verify its identity and mitigate this issue.
 
-The well-known file is requested via an uncredentialed [`GET`](/en-US/docs/Web/HTTP/Reference/Methods/GET) request, which doesn't follow redirects. This effectively prevents the IdP from learning who made the request and which RP is attempting to connect.
+The well-known file is requested via an uncredentialed [`GET`](/en-US/docs/Web/HTTP/Reference/Methods/GET) request, which doesn't follow redirects. This effectively prevents the IdP from learning who made the request and which {{glossary("Relying party", "RP")}} is attempting to connect.
 
 The well-known file must be served from the [eTLD+1](https://web.dev/articles/same-site-same-origin#site) of the IdP at `/.well-known/web-identity`. For example, if the IdP endpoints are served under `https://accounts.idp.example/`, they must serve a well-known file at `https://idp.example/.well-known/web-identity`. The well-known file's content should have the following JSON structure:
 
@@ -85,7 +85,7 @@ The properties are as follows:
 - `login_url`
   - : The login page URL for the user to sign into the IdP.
 - `branding` {{optional_inline}}
-  - : Contains branding information that will be used in the browser-supplied FedCM UI to customize its appearance as desired by the IdP.
+  - : Contains branding information that will be used in the browser-supplied FedCM UI to customize its appearance as desired by the IdP. The provided icon size must be greater than or equal to `25` (`25px`) in passive mode and greater than or equal to `40` (`40px`) in active mode (see [Active versus passive mode](/en-US/docs/Web/API/FedCM_API/RP_sign-in#active_versus_passive_mode) for more details).
 
 The following table summarizes the different requests made by the FedCM API:
 

--- a/files/en-us/web/api/fedcm_api/index.md
+++ b/files/en-us/web/api/fedcm_api/index.md
@@ -38,7 +38,8 @@ There are two parts to using the FedCM API, which are covered in the linked guid
 
 ## Permissions Policy integration and `<iframe>` support
 
-The {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) can be used to control permission to use FedCM, more specifically related usage of the following methods:
+The {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) can be used to control permission to use FedCM.
+More specifically, it permits usage of the following methods:
 
 - {{domxref("CredentialsContainer.get()")}}
 - {{domxref("IdentityCredential.disconnect_static", "IdentityCredential.disconnect()")}}

--- a/files/en-us/web/api/fedcm_api/index.md
+++ b/files/en-us/web/api/fedcm_api/index.md
@@ -9,13 +9,13 @@ browser-compat: api.IdentityCredential
 
 {{SeeCompatTable}}{{DefaultAPISidebar("FedCM API")}}
 
-The **Federated Credential Management API** (or _FedCM API_) provides a standard mechanism for identity providers (IdPs) to make identity federation services available on the web in a privacy-preserving way, without the need for [third-party cookies](/en-US/docs/Web/Privacy/Guides/Third-party_cookies) and redirects. This includes a JavaScript API that enables the use of federated authentication for activities such as signing in or signing up on a website.
+The **Federated Credential Management API** (or _FedCM API_) provides a standard mechanism for {{glossary("Identity provider", "identity providers")}} (IdPs) to make identity federation services available on the web in a privacy-preserving way, without the need for [third-party cookies](/en-US/docs/Web/Privacy/Guides/Third-party_cookies) and redirects. This includes a JavaScript API that enables the use of federated authentication for activities such as signing in or signing up on a website.
 
 ## FedCM concepts
 
-Identity federation is the delegation of user authentication from a website requiring user sign-up or sign-in, such as an e-commerce or social networking site (also known as a relying party or RP), to a trusted third-party identity provider (IdP) such as Google, Facebook/Meta, GitHub, etc.
+Identity federation is the delegation of user authentication from a website requiring user sign-up or sign-in, such as an e-commerce or social networking site (also known as a {{glossary("Relying party", "relying party")}} or RP), to a trusted third-party identity provider (IdP) such as Google, Facebook/Meta, GitHub, etc.
 
-Relying parties (RPs) can integrate with IdPs, allowing users to sign-in using the accounts they have registered with the IdP. Identity federation via a small set of dedicated IdPs has improved web authentication in terms of security, consumer confidence, and user experience, as compared to each site managing its own sign-in needs with separate usernames and passwords.
+RPs can integrate with IdPs, allowing users to sign-in using the accounts they have registered with the IdP. Identity federation via a small set of dedicated IdPs has improved web authentication in terms of security, consumer confidence, and user experience, as compared to each site managing its own sign-in needs with separate usernames and passwords.
 
 The problem is that traditional identity federation relies on {{htmlelement("iframe")}}s, redirects, and third-party cookies, which are also used for third-party tracking. Browsers are limiting the usage of these features in an effort to preserve user privacy, but a side effect is that this makes valid, non-tracking uses more difficult to implement, which includes identity federation.
 

--- a/files/en-us/web/api/fedcm_api/index.md
+++ b/files/en-us/web/api/fedcm_api/index.md
@@ -38,7 +38,11 @@ There are two parts to using the FedCM API, which are covered in the linked guid
 
 ## Permissions Policy integration and `<iframe>` support
 
-The {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) can be used to control permission to use FedCM, more specifically usage of the {{domxref("CredentialsContainer.get", "get()")}} method.
+The {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) can be used to control permission to use FedCM, more specifically related usage of the following methods:
+
+- {{domxref("CredentialsContainer.get()")}}
+- {{domxref("IdentityCredential.disconnect_static", "IdentityCredential.disconnect()")}}
+- {{domxref("IdentityProvider.getUserInfo_static", "IdentityProvider.getUserInfo()")}}
 
 Developers can explicitly grant permission for an {{htmlelement("iframe")}} to use FedCM via the `allow` attribute:
 

--- a/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
+++ b/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
@@ -10,7 +10,7 @@ This article describes the process by which a {{glossary("Relying party", "relyi
 
 ## Calling the `get()` method
 
-RPs can call {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with an `identity` option to request that a user be given the option to sign in to the RP with a choice of existing IdP accounts (that they are already signed in to on the browser). The IdPs identify the RP by its `clientId`, which was issued by each IdP to the RP in a separate IdP-specific process. The chosen IdP identifies the specific user using credentials (cookies) provided to the browser during the [sign-in flow](#fedcm_sign-in_flow).
+RPs can call {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with an `identity` option to request that a user be given the option to sign in to the RP with a choice of existing IdP accounts (that they are already signed in with on the browser). The IdPs identify the RP by its `clientId`, which was issued by each IdP to the RP in a separate IdP-specific process. The chosen IdP identifies the specific user who is attempting to sign-in with the credentials (cookies) provided to the browser during the [sign-in flow](#fedcm_sign-in_flow).
 
 The method returns a promise that fulfills with an {{domxref("IdentityCredential")}} object if the user identity is successfully validated by the chosen IdP. This object contains a token that includes user identity information that has been signed with the IdP's {{glossary("digital certificate")}}.
 
@@ -123,7 +123,7 @@ async function signIn() {
 }
 ```
 
-The default value for `mode` is `passive`. If `mode` is not set, or is set explicitly to `passive`, the browser can initiate the sign-in flow via a `get()` call without direct user interaction. In this mode, browsers typically present the user with a sign-in dialog window containing all the different sign-in options specified in the `providers` object, and they can choose whichever one suits them best and then enter the appropriate credentials.
+The default value for `mode` is `passive`. If `mode` is not set, or is set explicitly to `passive`, the browser can initiate the sign-in flow via a `get()` call without direct user interaction. For example, you might want to initiate the sign-in flow as soon as the user navigates to the sign-in page, provided they have IdP accounts to sign in with. In this mode, browsers typically present the user with a sign-in dialog window containing all the different sign-in options specified in the `providers` object, and they can choose whichever one suits them best and then enter the appropriate credentials.
 
 If `mode` is set to `active`, the browser requires the sign-in flow to be initiated via a user action such as clicking a button ({{glossary("transient activation")}} is required), and the `providers` object can only have a length of `1`, otherwise the `get()` promise will reject. This mode is typically used when the RP wishes to provide a separate button for each IdP choice. When the user clicks one of those buttons, a simplified dialog window appears that just requires them to enter the credentials for that account.
 

--- a/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
+++ b/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
@@ -10,7 +10,7 @@ This article describes the process by which a relying party (RP) can use the [Fe
 
 ## Calling the get() method
 
-RPs can call {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with an `identity` option to request that a user is given the option to sign in to the RP with an a choice of existing IdP accounts that they are already signed in to on the browser. The IdPs identify the RP by its `clientId`, which was issued by each IdP to the RP in a separate IdP-specific process. The chosen IdP identifies the specific user using credentials (cookies) provided to the browser on login.
+RPs can call {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with an `identity` option to request that a user be given the option to sign in to the RP with a choice of existing IdP accounts (that they are already signed in to on the browser). The IdPs identify the RP by its `clientId`, which was issued by each IdP to the RP in a separate IdP-specific process. The chosen IdP identifies the specific user using credentials (cookies) provided to the browser on login.
 
 The method returns a promise that fulfills with an {{domxref("IdentityCredential")}} object if the user identity is successfully validated by the chosen IdP. This object contains a token that includes user identity information that has been signed with the IdP's {{glossary("digital certificate")}}.
 

--- a/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
+++ b/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
@@ -10,16 +10,16 @@ This article describes the process by which a relying party (RP) can use the [Fe
 
 ## Calling the get() method
 
-RPs can call {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with an `identity` option to request that a user signs in to the RP with an existing IdP account that they are already signed in to on the browser. The IdP identifies the RP by its `clientId`, which was issued by the IdP to the RP in a separate process that is specific to the IdP. The IdP identifies the specific user using credentials (cookies) provided to the browser on login.
+RPs can call {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with an `identity` option to request that a user is given the option to sign in to the RP with an a choice of existing IdP accounts that they are already signed in to on the browser. The IdPs identify the RP by its `clientId`, which was issued by each IdP to the RP in a separate IdP-specific process. The chosen IdP identifies the specific user using credentials (cookies) provided to the browser on login.
 
-The method returns a promise that fulfills with an {{domxref("IdentityCredential")}} object if the user identity is successfully validated by the IdP. This object contains a token that includes user identity information that has been signed with the IdP's {{glossary("digital certificate")}}.
+The method returns a promise that fulfills with an {{domxref("IdentityCredential")}} object if the user identity is successfully validated by the chosen IdP. This object contains a token that includes user identity information that has been signed with the IdP's {{glossary("digital certificate")}}.
 
 The RP sends the token to its server to validate the certificate, and on success can use the (now trusted) identity information in the token to sign them into their service (starting a new session), sign them up to their service if they are a new user, etc.
 
-If the user has never signed into the IdP or is logged out, the `get()` method rejects with an error and the RP can direct the user to the IdP login page to sign in or create an account.
+If the user has never signed into an IdP or is logged out, the `get()` method rejects with an error and the RP can direct the user to an IdP login page to sign in or create an account.
 
 > [!NOTE]
-> The exact structure and content of the validation token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
+> The exact structure and content of the validation token is opaque to the FedCM API, and to the browser. An IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
 
 A typical request might look like this:
 
@@ -35,24 +35,24 @@ async function signIn() {
           nonce: "******",
           loginHint: "user1@example.com",
         },
+        {
+          //...
+        },
       ],
     },
   });
 }
 ```
 
-The `identity.providers` property takes an array containing a single object specifying the path to an IdP config file (`configURL`) and the RP's client identifier (`clientId`) issued by the IdP.
+The `identity.providers` property takes an array containing one or more objects specifying the path to each IdP's config file (`configURL`) and the RP's client identifier (`clientId`) issued by the IdP.
 
-> [!NOTE]
-> Currently FedCM only allows the API to be invoked with a single IdP, i.e., the `identity.providers` array has to have a length of 1. To offer users a choice of identity provider, the RP will need to call `get()` separately for each. This may change in the future.
-
-The example above also includes a couple of optional features:
+The previous example also includes some optional features:
 
 - `identity.context` specifies the context in which the user is authenticating with FedCM. For example, is it a first-time signup for this account, or a sign-in with an existing account? The browser uses this information to vary the text in its FedCM UI to better suit the context.
 - The `nonce` property provides a random nonce value that ensures the response is issued for this specific request, preventing {{glossary("replay attack", "replay attacks")}}.
-- The `loginHint` property provides a hint about the account option(s) the browser should present for user sign-in. This hint is matched against the `login_hints` values that the IdP provides from the [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint).
+- The `loginHint` property provides a hint about the account option(s) the browser should present for user sign-in. This hint is matched against the `login_hints` values that the IdP provides at the [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint).
 
-The browser requests the IdP config file and carries out the sign-in flow detailed below. For more information on the kind of interaction a user might expect from the browser-supplied UI, see [Sign in to the relying party with the identity provider](https://privacysandbox.google.com/cookies/fedcm#sign-in).
+The browser requests the IdP config files and carries out the sign-in flow detailed below. For more information on the kind of interaction a user might expect from the browser-supplied UI, see [Sign in to the relying party with the identity provider](https://privacysandbox.google.com/cookies/fedcm#sign-in).
 
 ## FedCM sign-in flow
 
@@ -64,39 +64,39 @@ The flow is as follows:
 
 1. The RP invokes {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} to start off the sign-in flow.
 
-2. From the `configURL` provided in the `get()` call, the browser requests two files:
+2. From the `configURL` provided for each IdP, the browser requests two files:
    1. The well-known file (`/.well-known/web-identity`), available from `/.well-known/web-identity` at the [eTLD+1](https://web.dev/articles/same-site-same-origin#site) of the `configURL`.
    2. The [IdP config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) (`/config.json`), available at the `configURL`.
 
-   These are both [`GET`](/en-US/docs/Web/HTTP/Reference/Methods/GET) requests, which don't have cookies and don't follow redirects. This effectively prevents the IdP from learning who made the request and which RP is attempting to connect.
+   These are both [`GET`](/en-US/docs/Web/HTTP/Reference/Methods/GET) requests, which don't have cookies and don't follow redirects. This effectively prevents IdPs from learning who made the request and which RP is attempting to connect.
 
    All requests sent from the browser via FedCM include a `{{httpheader("Sec-Fetch-Dest")}}: webidentity` header to prevent {{glossary("CSRF")}} attacks. All IdP endpoints must confirm this header is included.
 
-3. The IdP responds with the requested well-known file and `config.json` files. The browser validates the config file URL in the `get()` request against the list of valid config URLs inside the well-known file.
+3. The IdPs respond with the requested well-known file and `config.json` files. The browser validates the config file URL in the `get()` request against the list of valid config URLs inside the well-known file.
 
-4. If the browser has the [IdP's login status](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) set to `"logged-in"`, it makes a credentialed request (i.e., with a cookie that identifies the user that is signed in) to the [`accounts_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) inside the IdP config file for the user's account details. This is a `GET` request with cookies, but without a `client_id` parameter or the {{httpheader("Origin")}} header. This effectively prevents the IdP from learning which RP the user is trying to sign in to. As a result, the list of accounts returned is RP-agnostic.
-
-   > [!NOTE]
-   > If the IdP login status is `"logged-out"`, the `get()` call rejects with a `NetworkError` {{domxref("DOMException")}} and does not make a request to the IdP's `accounts_endpoint`. In this case it is up to the developer to handle the flow, for example by prompting the user to go and sign in to a suitable IdP. Note that there may be some delay in the rejection to avoid leaking the IdP login status to the RP.
-
-5. The IdP responds with the account information requested from the `accounts_endpoint`. This is an array of all accounts associated with the user's IdP cookies for any RPs associated with the IdP.
-
-6. {{optional_inline}} If included in the IdP config file, the browser makes an uncredentialed request to the [`client_metadata_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_client_metadata_endpoint) for the location of the RP terms of service and privacy policy pages. This is a `GET` request sent with the `clientId` passed into the `get()` call as a parameter, without cookies.
-
-7. {{optional_inline}} The IdP responds with the URLs requested from the `client_metadata_endpoint`.
-
-8. The browser uses the information obtained by the previous two requests to create the UI asking the user to choose an account to sign in to the RP with (in the case where there is more than one available). The UI also asks the user for permission to sign in to the RP using their chosen federated IdP account.
+4. If the browser has an [IdP's login status](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) set to `"logged-in"`, it makes a credentialed request (i.e., with a cookie that identifies the user that is signed in) to the [`accounts_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) inside the IdP config file for the user's account details. This is a `GET` request with cookies, but without a `client_id` parameter or the {{httpheader("Origin")}} header. This effectively prevents IdPs from learning which RP the user is trying to sign in to. As a result, the list of accounts returned is RP-agnostic.
 
    > [!NOTE]
-   > At this stage, if the user has previously authenticated with a federated RP account in the current browser instance (i.e., created a new account with the RP or signed into the RP's website using an existing account), they may be able to **auto-reauthenticate**, depending on what the [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option is set to in the `get()` call. If so the user will be signed in automatically without entering their credentials, as soon as `get()` is invoked. See the [Auto-reauthentication](#auto-reauthentication) section for more details.
+   > If the IdPs' login statusus are all `"logged-out"`, the `get()` call rejects with a `NetworkError` {{domxref("DOMException")}} and does not make a request to any IdP's `accounts_endpoint`. In this case it is up to the developer to handle the flow, for example by prompting the user to go and sign in to a suitable IdP. Note that there may be some delay in the rejection to avoid leaking IdP login status to the RP.
 
-9. If the user grants permission to do so, the browser makes a credentialed request to the [`id_assertion_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_id_assertion_endpoint) to request a validation token from the IdP for the selected account.
+5. The IdPs respond with the account information requested from their `accounts_endpoint`s. These are arrays of all accounts associated with the user's IdP cookies for any RPs associated with an IdP.
+
+6. {{optional_inline}} If included in an IdP config file, the browser makes an uncredentialed request to the [`client_metadata_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_client_metadata_endpoint) for the location of the RP terms of service and privacy policy pages. This is a `GET` request sent with the `clientId` passed into the `get()` call as a parameter, without cookies.
+
+7. {{optional_inline}} The IdPs respond with the URLs requested from the `client_metadata_endpoint`.
+
+8. The browser uses the information obtained by the previous two sets of requests to create the UI asking the user to choose an IdP (if more than one is signed-in) and an account to sign in to the RP with. The UI also asks the user for permission to sign in to the RP using their chosen federated IdP account.
+
+   > [!NOTE]
+   > At this stage, if the user has previously authenticated with a federated RP account in the current browser instance (that is, created a new account with the RP or signed into the RP's website using an existing account), they may be able to **auto-reauthenticate**, depending on what the [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option is set to in the `get()` call. If so, the user will be signed in automatically without entering their credentials, as soon as `get()` is invoked. See the [Auto-reauthentication](#auto-reauthentication) section for more details.
+
+9. If the user grants permission to do so, the browser makes a credentialed request to the [`id_assertion_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_id_assertion_endpoint) to request a validation token from the chosen IdP for the selected account.
 
    The credentials are sent in an HTTP [`POST`](/en-US/docs/Web/HTTP/Reference/Methods/POST) request with cookies and a content type of `application/x-www-form-urlencoded`.
 
    If the call fails, an error payload is returned as explained in [ID assertion error responses](/en-US/docs/Web/API/FedCM_API/IDP_integration#id_assertion_error_responses) and the promise returned by `get()` will reject with the error.
 
-10. The IdP checks that the account ID sent by the RP matches the ID for the account that is already signed in, and that the `Origin` matches the origin of the RP, which will have been registered in advance with the IdP. If everything looks good, it responds with the requested validation token.
+10. The chosen IdP checks that the account ID sent by the RP matches the ID for the account that is already signed in, and that the `Origin` matches the origin of the RP, which will have been registered in advance with the IdP. If everything looks good, it responds with the requested validation token.
 
     > [!NOTE]
     > The origin of the RP will be registered with the IdP in a completely separate process when the RP first integrates with the IdP. This process will be specific to each IdP.
@@ -135,7 +135,7 @@ Auto-reauthentication can occur if `mediation` is set to `optional` or `silent`.
 With these `mediation` options, auto-reauthentication will occur under the following conditions:
 
 - FedCM is available to use. For example, the user has not disabled FedCM either globally or in the RP's settings.
-- The user has only used one account to sign into the RP website on this browser via FedCM.
+- The user has only used one account to sign into the RP website on this browser via FedCM. If returning accounts exist for multiple IdPs, the user won't be automatically re-authenticated.
 - The user is signed into the IdP with that account.
 - Auto-reauthentication didn't happen within the last 10 minutes. This restriction is put into place to stop users being auto-reauthenticated immediately after they sign out — which would make for a pretty confusing user experience.
 - The RP hasn't called {{domxref("CredentialsContainer.preventSilentAccess", "preventSilentAccess()")}} after the previous sign in. This can be used by an RP to explicitly disable auto-reauthentication if desired.
@@ -149,6 +149,20 @@ If auto-reauthentication fails, the behavior depends on the `mediation` value th
 
 > [!NOTE]
 > The {{domxref("IdentityCredential.isAutoSelected")}} property provides an indication of whether the federated sign-in was carried out using auto-reauthentication. This is helpful to evaluate the API performance and improve UX accordingly. Also, when it's unavailable, the user may be prompted to sign in with explicit user mediation, which is a `get()` call with `mediation: required`.
+
+## Disconnecting a federated sign-in
+
+The RP may disconnect a specified federated sign-in account from the associated IdP by invoking {{domxref("IdentityCredential.disconnect_static", "IdentityCredential.disconnect()")}}. This function can be called from a top-level RP frame.
+
+```js
+IdentityCredential.disconnect({
+  configURL: "https://idp.example.com/config.json",
+  clientId: "rp123",
+  accountHint: "account456",
+});
+```
+
+For a `disconnect()` call to work, the IdP must include a [`disconnect_endpoint`](/docs/Web/API/FedCM_API/IDP_integration#disconnect_endpoint) in its config file. See [The disconnect endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_disconnect_endpoint) for more details of the underlying HTTP communication.
 
 ## See also
 

--- a/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
+++ b/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
@@ -135,7 +135,7 @@ Auto-reauthentication can occur if `mediation` is set to `optional` or `silent`.
 With these `mediation` options, auto-reauthentication will occur under the following conditions:
 
 - FedCM is available to use. For example, the user has not disabled FedCM either globally or in the RP's settings.
-- The user has only used one account to sign into the RP website on this browser via FedCM. If returning accounts exist for multiple IdPs, the user won't be automatically re-authenticated.
+- The user has only used one account to sign into the RP website on this browser via FedCM. If accounts exist for multiple IdPs, the user won't be automatically re-authenticated.
 - The user is signed into the IdP with that account.
 - Auto-reauthentication didn't happen within the last 10 minutes. This restriction is put into place to stop users being auto-reauthenticated immediately after they sign out — which would make for a pretty confusing user experience.
 - The RP hasn't called {{domxref("CredentialsContainer.preventSilentAccess", "preventSilentAccess()")}} after the previous sign in. This can be used by an RP to explicitly disable auto-reauthentication if desired.

--- a/files/en-us/web/api/identitycredential/configurl/index.md
+++ b/files/en-us/web/api/identitycredential/configurl/index.md
@@ -10,7 +10,7 @@ browser-compat: api.IdentityCredential.configURL
 
 {{APIRef("FedCM API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`configURL`** read-only property of the {{domxref("IdentityCredential")}} interface returns a string specifying the config file URL of the IdP used for sign-in.
+The **`configURL`** read-only property of the {{domxref("IdentityCredential")}} interface returns a string specifying the config file URL of the {{glossary("Identity provider", "identity provider")}} (IdP) used for sign-in.
 
 See [Provide a config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) for more information.
 
@@ -20,7 +20,9 @@ A string.
 
 ## Examples
 
-Relying parties (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A request indicating a single provider would look like this:
+### Basic federated sign-in and `configURL` access
+
+{{glossary("Relying party", "Relying parties")}} (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A request indicating a single provider would look like this:
 
 ```js
 async function signIn() {

--- a/files/en-us/web/api/identitycredential/configurl/index.md
+++ b/files/en-us/web/api/identitycredential/configurl/index.md
@@ -20,7 +20,7 @@ A string.
 
 ## Examples
 
-Relying parties (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A typical request would look like this:
+Relying parties (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A request indicating a single provider would look like this:
 
 ```js
 async function signIn() {

--- a/files/en-us/web/api/identitycredential/configurl/index.md
+++ b/files/en-us/web/api/identitycredential/configurl/index.md
@@ -1,0 +1,57 @@
+---
+title: "IdentityCredential: configURL property"
+short-title: configURL
+slug: Web/API/IdentityCredential/configURL
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.IdentityCredential.configURL
+---
+
+{{APIRef("FedCM API")}}{{SeeCompatTable}}{{SecureContext_Header}}
+
+The **`configURL`** read-only property of the {{domxref("IdentityCredential")}} interface returns a string specifying the config file URL of the IdP used for sign-in.
+
+See [Provide a config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+Relying parties (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A typical request would look like this:
+
+```js
+async function signIn() {
+  const identityCredential = await navigator.credentials.get({
+    identity: {
+      providers: [
+        {
+          configURL: "https://accounts.idp.example/config.json",
+          clientId: "********",
+          nonce: "******",
+        },
+      ],
+    },
+  });
+
+  console.log(identityCredential.configURL);
+}
+```
+
+A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call that includes an `identity` option fulfills with an `IdentityCredential` instance, which can be used to access the `configURL` of the IdP used for sign-in.
+
+Check out [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) for more details on how this works. This call will start off the sign-in flow described in [FedCM sign-in flow](/en-US/docs/Web/API/FedCM_API/RP_sign-in#fedcm_sign-in_flow).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Federated Credential Management API](https://privacysandbox.google.com/cookies/fedcm)

--- a/files/en-us/web/api/identitycredential/disconnect_static/index.md
+++ b/files/en-us/web/api/identitycredential/disconnect_static/index.md
@@ -29,7 +29,7 @@ IdentityCredential.disconnect(options)
     - `clientId`
       - : A string specifying the RP's client identifier, as specified in the `providers` [`clientId`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#clientid) property during sign-in.
     - `configURL`
-      - : A string specifying the config file URL of the IdP, as specified during sign-in in the `providers` [`configURL`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#configurl) property.
+      - : A string specifying the config file URL of the IdP, as specified in the `providers` [`configURL`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#configurl) property during sign-in.
 
 ### Return value
 

--- a/files/en-us/web/api/identitycredential/disconnect_static/index.md
+++ b/files/en-us/web/api/identitycredential/disconnect_static/index.md
@@ -47,7 +47,7 @@ A {{jsxref("Promise")}} that fulfills with {{jsxref("undefined")}}.
     - The request is disallowed by a [`connect-src`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/connect-src) {{httpheader("Content-Security-Policy")}}.
     - Another `disconnect()` call was previously made that has not yet resolved.
     - The FedCM API has been disabled globally.
-    - The IdP's `configURL` is not trustworthy
+    - The IdP's `configURL` is neither secure nor [potentially trustworthy](/en-US/docs/Web/Security/Secure_Contexts#potentially_trustworthy_origins).
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if the embedding `<iframe>` does not have a {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) set to allow the use of `disconnect()` or if the FedCM API is disabled globally by a policy set on the top-level document.
 

--- a/files/en-us/web/api/identitycredential/disconnect_static/index.md
+++ b/files/en-us/web/api/identitycredential/disconnect_static/index.md
@@ -1,0 +1,78 @@
+---
+title: "IdentityCredential: disconnect() static method"
+short-title: disconnect()
+slug: Web/API/IdentityCredential/disconnect_static
+page-type: web-api-static-method
+status:
+  - experimental
+browser-compat: api.IdentityCredential.disconnect_static
+---
+
+{{APIRef("FedCM API")}}{{SeeCompatTable}}{{SecureContext_Header}}
+
+The **`disconnect()`** static method of the {{domxref("IdentityCredential")}} interface disconnects a specified federated sign-in account from the IdP used to obtain the credential.
+
+Afterwards, using that account for federated login requires starting the federated sign-in process again.
+
+## Syntax
+
+```js-nolint
+IdentityCredential.disconnect(options)
+```
+
+### Parameters
+
+- `options`
+  - : An options object, which can contain the following properties:
+    - `accountHint`
+      - : A string specifying an account hint that the IdP uses the identify the account to disconnect. The hint can be an arbitrary string as long as the `disconnect_endpoint` can identify the account — for example an email address or user ID. This will not necessarily match the account ID provided by the `accounts_endpoint`.
+    - `clientId`
+      - : A string specifying the RP's client identifier, as specified during sign-in in the `providers` [`clientId`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#clientid) property.
+    - `configURL`
+      - : A string specifying the config file URL of the IdP, as specified during sign-in in the `providers` [`configURL`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#configurl) property.
+
+### Return value
+
+A {{jsxref("Promise")}} that fulfills with {{jsxref("undefined")}}.
+
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if:
+    - The IdP's `configURL` is invalid or missing the `disconnect_enpoint`.
+    - The document's origin does not match the `configURL`.
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown if:
+    - The browser is unable to connect to the IdP.
+    - The request is disallowed by a [`connect-src`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/connect-src) {{httpheader("Content-Security-Policy")}}.
+    - Another `disconnect()` call was previously made that has not yet resolved.
+    - The FedCM API has been disabled globally.
+    - The IdP's `configURL` is not trustworthy
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : Thrown if the embedding `<iframe>` does not have a {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) set to allow the use of `disconnect()` or if the FedCM API is disabled globally by a policy set on the top-level document.
+
+## Examples
+
+The RP may disconnect a specified federated sign-in account from the associated IdP by invoking disconnect(). This function can be called from a top-level RP frame.
+
+```js
+IdentityCredential.disconnect({
+  configURL: "https://idp.example.com/config.json",
+  clientId: "rp123",
+  accountHint: "account456",
+});
+```
+
+For a `disconnect()` call to work, the IdP must include a [`disconnect_endpoint`](/docs/Web/API/FedCM_API/IDP_integration#disconnect_endpoint) in its config file. See [The disconnect endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_disconnect_endpoint) for more details of the underlying HTTP communication.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Federated Credential Management API](https://privacysandbox.google.com/cookies/fedcm) on privacysandbox.google.com (2023)

--- a/files/en-us/web/api/identitycredential/disconnect_static/index.md
+++ b/files/en-us/web/api/identitycredential/disconnect_static/index.md
@@ -27,7 +27,7 @@ IdentityCredential.disconnect(options)
     - `accountHint`
       - : A string specifying an account hint that the IdP uses the identify the account to disconnect. The hint can be an arbitrary string as long as the `disconnect_endpoint` can identify the account — for example an email address or user ID. This will not necessarily match the account ID provided by the `accounts_endpoint`.
     - `clientId`
-      - : A string specifying the RP's client identifier, as specified during sign-in in the `providers` [`clientId`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#clientid) property.
+      - : A string specifying the RP's client identifier, as specified in the `providers` [`clientId`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#clientid) property during sign-in.
     - `configURL`
       - : A string specifying the config file URL of the IdP, as specified during sign-in in the `providers` [`configURL`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#configurl) property.
 

--- a/files/en-us/web/api/identitycredential/disconnect_static/index.md
+++ b/files/en-us/web/api/identitycredential/disconnect_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.IdentityCredential.disconnect_static
 
 {{APIRef("FedCM API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`disconnect()`** static method of the {{domxref("IdentityCredential")}} interface disconnects a specified federated sign-in account from the IdP used to obtain the credential.
+The **`disconnect()`** static method of the {{domxref("IdentityCredential")}} interface disconnects a specified federated sign-in account from the {{glossary("Identity provider", "IdP")}} used to obtain the credential.
 
 Afterwards, using that account for federated login requires starting the federated sign-in process again.
 
@@ -25,9 +25,9 @@ IdentityCredential.disconnect(options)
 - `options`
   - : An options object, which can contain the following properties:
     - `accountHint`
-      - : A string specifying an account hint that the IdP uses the identify the account to disconnect. The hint can be an arbitrary string as long as the `disconnect_endpoint` can identify the account — for example an email address or user ID. This will not necessarily match the account ID provided by the `accounts_endpoint`.
+      - : A string specifying an account hint that the IdP uses to identify the account to disconnect. The hint can be an arbitrary string as long as the [disconnect endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_disconnect_endpoint) can identify the account — for example an email address or user ID. This will not necessarily match the account ID provided by the [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint).
     - `clientId`
-      - : A string specifying the RP's client identifier, as specified in the `providers` [`clientId`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#clientid) property during sign-in.
+      - : A string specifying the {{glossary("Relying party", "RP")}}'s client identifier, as specified in the `providers` [`clientId`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#clientid) property during sign-in.
     - `configURL`
       - : A string specifying the config file URL of the IdP, as specified in the `providers` [`configURL`](/en-US/docs/Web/API/IdentityCredentialRequestOptions#configurl) property during sign-in.
 
@@ -53,7 +53,9 @@ A {{jsxref("Promise")}} that fulfills with {{jsxref("undefined")}}.
 
 ## Examples
 
-The RP may disconnect a specified federated sign-in account from the associated IdP by invoking disconnect(). This function can be called from a top-level RP frame.
+### Basic `disconnect()` usage
+
+The RP may disconnect a specified federated sign-in account from the associated IdP by invoking `disconnect()`. This function can be called from a top-level RP frame.
 
 ```js
 IdentityCredential.disconnect({

--- a/files/en-us/web/api/identitycredential/index.md
+++ b/files/en-us/web/api/identitycredential/index.md
@@ -20,7 +20,7 @@ A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()"
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 - {{domxref("IdentityCredential.configURL")}} {{ReadOnlyInline}} {{experimental_inline}}
-  - : A string specifying the config file URL of the IdP used for sign-in.
+  - : A string specifying the [config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) URL of the IdP used for sign-in.
 - {{domxref("IdentityCredential.isAutoSelected")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : A boolean value that indicates whether the federated sign-in was carried out using [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication) (i.e., without user mediation) or not.
 - {{domxref("IdentityCredential.token")}} {{experimental_inline}}

--- a/files/en-us/web/api/identitycredential/index.md
+++ b/files/en-us/web/api/identitycredential/index.md
@@ -20,7 +20,7 @@ A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()"
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 - {{domxref("IdentityCredential.configURL")}} {{ReadOnlyInline}} {{experimental_inline}}
-  - : A string specifying the [config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) URL of the IdP used for sign-in.
+  - : A string specifying the [config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) URL of the {{glossary("Identity provider", "IdP")}} used for sign-in.
 - {{domxref("IdentityCredential.isAutoSelected")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : A boolean value that indicates whether the federated sign-in was carried out using [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication) (i.e., without user mediation) or not.
 - {{domxref("IdentityCredential.token")}} {{experimental_inline}}
@@ -33,7 +33,9 @@ _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 ## Examples
 
-Relying parties (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A typical request would look like this:
+### Basic federated sign-in
+
+{{glossary("Relying party", "Relying parties")}} (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A typical request would look like this:
 
 ```js
 async function signIn() {

--- a/files/en-us/web/api/identitycredential/index.md
+++ b/files/en-us/web/api/identitycredential/index.md
@@ -19,10 +19,17 @@ A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()"
 
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
+- {{domxref("IdentityCredential.configURL")}} {{ReadOnlyInline}} {{experimental_inline}}
+  - : A string specifying the config file URL of the IdP used for sign-in.
 - {{domxref("IdentityCredential.isAutoSelected")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : A boolean value that indicates whether the federated sign-in was carried out using [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication) (i.e., without user mediation) or not.
 - {{domxref("IdentityCredential.token")}} {{experimental_inline}}
   - : Returns the token used to validate the associated sign-in.
+
+## Static methods
+
+- {{domxref("IdentityCredential.disconnect_static", "IdentityCredential.disconnect()")}}
+  - : Disconnects the federated sign-in account used to obtain the credential.
 
 ## Examples
 

--- a/files/en-us/web/api/identitycredential/isautoselected/index.md
+++ b/files/en-us/web/api/identitycredential/isautoselected/index.md
@@ -12,7 +12,7 @@ browser-compat: api.IdentityCredential.isAutoSelected
 
 The **`isAutoSelected`** read-only property of the {{domxref("IdentityCredential")}} interface indicates whether the federated sign-in flow was carried out using [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication) (i.e., without user mediation) or not.
 
-Automatic reauthentication can occur when a {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call is issued with a [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option value of `"optional"` or `"silent"`. It is useful for a relying party (RP) to know whether auto reauthentication occurred for analytics/performance evaluation and for UX purposes — automatic sign-in may warrant a different UI flow to non-automatic sign-in.
+Automatic reauthentication can occur when a {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call is issued with a [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option value of `"optional"` or `"silent"`. It is useful for a {{glossary("Relying party", "relying party")}} (RP) to know whether auto reauthentication occurred for analytics/performance evaluation and for UX purposes — automatic sign-in may warrant a different UI flow to non-automatic sign-in.
 
 ## Value
 
@@ -20,7 +20,9 @@ A boolean value. `true` indicates that automatic reauthentication was used; `fal
 
 ## Examples
 
-RPs can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. Auto-reauthentication behavior is controlled by the [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option in the `get()` call:
+### Basic federated sign-in and `isAutoSelected` access
+
+RPs can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an {{glossary("Identity provider", "IdP")}}, using identity federation. Auto-reauthentication behavior is controlled by the [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option in the `get()` call:
 
 ```js
 async function signIn() {
@@ -40,6 +42,8 @@ async function signIn() {
   const isAutoSelected = identityCredential.isAutoSelected;
 }
 ```
+
+A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call that includes an `identity` option fulfills with an `IdentityCredential` instance, which can be used to access the `isAutoSelected` property: this will equal `true` if auto-reauthentication occurred.
 
 Check out [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) for more details on how this works. This call will start off the sign-in flow described in [FedCM sign-in flow](/en-US/docs/Web/API/FedCM_API/RP_sign-in#fedcm_sign-in_flow).
 

--- a/files/en-us/web/api/identitycredential/token/index.md
+++ b/files/en-us/web/api/identitycredential/token/index.md
@@ -12,9 +12,9 @@ browser-compat: api.IdentityCredential.token
 
 The **`token`** read-only property of the {{domxref("IdentityCredential")}} interface returns the token used to validate the associated sign-in.
 
-The token includes user identity information that has been signed with the identity provider (IdP)'s {{glossary("digital certificate")}}.
+The token includes user identity information that has been signed with the {{glossary("Identity provider", "IdP")}}'s {{glossary("digital certificate")}}.
 
-The relying party (RP) sends the token to its server to validate the certificate, and on success can use the (now trusted) identity information in the token to sign them into their service (starting a new session), sign them up to their service if they are a new user, etc.
+The {{glossary("Relying party", "relying party")}} (RP) sends the token to its server to validate the certificate, and on success can use the (now trusted) identity information in the token to sign them into their service (starting a new session), sign them up to their service if they are a new user, etc.
 
 If the user has never signed into the IdP or is logged out, the associated {{domxref("CredentialsContainer.get", "get()")}} call rejects with an error and the RP can direct the user to the IdP login page to sign in or create an account.
 
@@ -26,6 +26,8 @@ If the user has never signed into the IdP or is logged out, the associated {{dom
 A string.
 
 ## Examples
+
+### Basic federated sign-in and `token` access
 
 Relying parties (RPs) can call `navigator.credentials.get()` with the `identity` option to make a request for users to sign in to the RP via an identity provider (IdP), using identity federation. A typical request would look like this:
 
@@ -47,7 +49,7 @@ async function signIn() {
 }
 ```
 
-A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call that includes an `identity` option fulfills with an `IdentityCredential` instance, which can be used to access the token used to validate the sign-in.
+A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call that includes an `identity` option fulfills with an `IdentityCredential` instance, which can be used to access the `token` used to validate the sign-in.
 
 Check out [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) for more details on how this works. This call will start off the sign-in flow described in [FedCM sign-in flow](/en-US/docs/Web/API/FedCM_API/RP_sign-in#fedcm_sign-in_flow).
 

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -53,6 +53,8 @@ It is used to request an {{domxref("IdentityCredential")}} provided by a {{gloss
       - : A string specifying the URL of the IdP's config file. See [Provide a config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) for more information.
     - `clientId`
       - : A string specifying the RP's client identifier. This information is issued by the IdP to the RP in a separate process that is specific to the IdP.
+    - `domainHint` {{optional_inline}}
+      - : A string representing a hint corresponding to a domain the RP is interested in. If provided, the user agent will only show accounts that match the domain hint value in their [`domain_hints`](/en-US/docs/Web/API/FedCM_API/IDP_integration#domain_hints) array. If `"any"` is specified, the RP will show any account that is associated with at least one domain hint.
     - `fields` {{optional_inline}}
       - : An array of strings specifying user information that the RP wishes to obtain from the IdP for use in the sign-in process. The exact strings will vary by IdP, but tend to be similar to `"name"`, `"email"`, or `"profile-picture-url"`.
     - `loginHint` {{optional_inline}}

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -40,19 +40,27 @@ It is used to request an {{domxref("IdentityCredential")}} provided by a {{gloss
 
     The default value is `"signin"`.
 
+- `mode` {{optional_inline}}
+  - : A string specifying the UI mode to use for the sign-in flow, which browsers can use to specify different behaviors if wished. Possible values are:
+    - `active`
+      - : The sign-in flow must be initiated via a user action such as clicking a button. If `mode` is set to `active`, `providers` can only have a length of `1`, otherwise the `get()` promise will reject.
+    - `passive`
+      - : The sign-in flow can be initiated without direct user interaction. This is the default value.
+
 - `providers`
-  - : An array containing a single object specifying details of an IdP to be used to sign in. This object can contain the following properties:
+  - : An array of objects specifying details of the IdPs the user should be presented with as options for signing in. These objects can contain the following properties:
     - `configURL`
       - : A string specifying the URL of the IdP's config file. See [Provide a config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) for more information.
     - `clientId`
       - : A string specifying the RP's client identifier. This information is issued by the IdP to the RP in a separate process that is specific to the IdP.
+    - `fields` {{optional_inline}}
+      - : An array of strings specifying user information that the RP wishes to obtain from the IdP for use in the sign-in process. The exact strings will vary by IdP, but tend to be similar to `"name"`, `"email"`, or `"profile-picture-url"`.
     - `loginHint` {{optional_inline}}
       - : A string providing a hint about the account option(s) the browser should provide for the user to sign in with. This is useful in cases where the user has already signed in and the site asks them to reauthenticate. Otherwise, the reauthentication process can be confusing when a user has multiple accounts and can't remember which one they used to sign in previously. The value for the `loginHint` property can be taken from the user's previous sign-in, and is matched against the `login_hints` values provided by the IdP in the array of user information returned from the IdP's [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint).
     - `nonce` {{optional_inline}}
       - : A random string that can be included to ensure the response is issued specifically for this request and prevent {{glossary("replay attack", "replay attacks")}}.
-
-    > [!NOTE]
-    > Currently FedCM only allows the API to be invoked with a single IdP, i.e., the `providers` array has to have a length of 1. Multiple IdPs must be supported via different `get()` calls.
+    - `params` {{optional_inline}}
+      - : A custom object used to specify any additional key-value parameters that RP needs to send to the IdP. This will vary by IdP and could include, for example, additional permission requests such as `admin: true`, or `calendar: "readonly"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -54,7 +54,7 @@ It is used to request an {{domxref("IdentityCredential")}} provided by a {{gloss
     - `clientId`
       - : A string specifying the RP's client identifier. This information is issued by the IdP to the RP in a separate process that is specific to the IdP.
     - `domainHint` {{optional_inline}}
-      - : A string representing a hint corresponding to a domain the RP is interested in. If provided, the user agent will only show accounts that match the domain hint value in their [`domain_hints`](/en-US/docs/Web/API/FedCM_API/IDP_integration#domain_hints) array. If `"any"` is specified, the RP will show any account that is associated with at least one domain hint.
+      - : A string hinting at the domain of accounts that the RP is interested in. If provided, the user agent will only show accounts that match the domain hint value in their [`domain_hints`](/en-US/docs/Web/API/FedCM_API/IDP_integration#domain_hints) array. If `"any"` is specified, the RP will show any account that is associated with at least one domain hint.
     - `fields` {{optional_inline}}
       - : An array of strings specifying user information that the RP wishes to obtain from the IdP for use in the sign-in process. The exact strings will vary by IdP, but tend to be similar to `"name"`, `"email"`, or `"profile-picture-url"`.
     - `loginHint` {{optional_inline}}

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -12,7 +12,7 @@ spec-urls: https://w3c-fedid.github.io/FedCM/#dictdef-identitycredentialrequesto
 
 The **`IdentityCredentialRequestOptions`** dictionary represents the object passed to {{domxref("CredentialsContainer.get()")}} as the value of the `identity` option.
 
-It is used to request an {{domxref("IdentityCredential")}} provided by a {{glossary("identity provider", "federated identity provider")}} that supports the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API).
+When an `identity` option is provided in a `get()` call made on a {{glossary("Relying party", "relying party")}} (RP) website, the user is offered a list of {{glossary("identity provider", "federated identity providers")}} (IdPs) as sign-in options. Once the user signs in successfully using one of these options, the promise returned by the `get()` call returns an {{domxref("IdentityCredential")}} object.
 
 ## Instance properties
 
@@ -41,18 +41,20 @@ It is used to request an {{domxref("IdentityCredential")}} provided by a {{gloss
     The default value is `"signin"`.
 
 - `mode` {{optional_inline}}
-  - : A string specifying the UI mode to use for the sign-in flow, which browsers can use to specify different behaviors if wished. Possible values are:
+  - : A string specifying the UI mode to use for the sign-in flow. Possible values are:
     - `active`
       - : The sign-in flow must be initiated via a user action such as clicking a button. If `mode` is set to `active`, `providers` can only have a length of `1`, otherwise the `get()` promise will reject.
     - `passive`
       - : The sign-in flow can be initiated without direct user interaction. This is the default value.
+
+    See [Active versus passive mode](/en-US/docs/Web/API/FedCM_API/RP_sign-in#active_versus_passive_mode) for more details of the difference between the two modes.
 
 - `providers`
   - : An array of objects specifying details of the IdPs that the user should be presented with as options for signing in. These objects can contain the following properties:
     - `configURL`
       - : A string specifying the URL of the IdP's config file. See [Provide a config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) for more information.
     - `clientId`
-      - : A string specifying the RP's client identifier. This information is issued by the IdP to the RP in a separate process that is specific to the IdP.
+      - : A string specifying the RP client identifier. This information is issued by the IdP to the RP in a separate process that is specific to the IdP.
     - `domainHint` {{optional_inline}}
       - : A string hinting at the domain of accounts that the RP is interested in. If provided, the user agent will only show accounts that match the domain hint value in their [`domain_hints`](/en-US/docs/Web/API/FedCM_API/IDP_integration#domain_hints) array. If `"any"` is specified, the RP will show any account that is associated with at least one domain hint.
     - `fields` {{optional_inline}}

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -48,7 +48,7 @@ It is used to request an {{domxref("IdentityCredential")}} provided by a {{gloss
       - : The sign-in flow can be initiated without direct user interaction. This is the default value.
 
 - `providers`
-  - : An array of objects specifying details of the IdPs the user should be presented with as options for signing in. These objects can contain the following properties:
+  - : An array of objects specifying details of the IdPs that the user should be presented with as options for signing in. These objects can contain the following properties:
     - `configURL`
       - : A string specifying the URL of the IdP's config file. See [Provide a config file](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints) for more information.
     - `clientId`

--- a/files/en-us/web/api/identityprovider/close_static/index.md
+++ b/files/en-us/web/api/identityprovider/close_static/index.md
@@ -10,13 +10,11 @@ browser-compat: api.IdentityProvider.close_static
 
 {{securecontext_header}}{{APIRef("FedCM API")}}{{SeeCompatTable}}
 
-The **`close()`** static method of the {{domxref("IdentityProvider")}} interface provides a manual signal to the browser that an IdP sign-in flow is finished.
-
-## Usage notes
+The **`close()`** static method of the {{domxref("IdentityProvider")}} interface provides a manual signal to the browser that an {{glossary("Identity provider", "IdP")}} sign-in flow is finished.
 
 `close()` needs to be called from the same origin as the specified IdP's sign-in dialog, as defined in the [IdP config](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints).
 
-`close()` is needed to close the IdP sign-in dialog when sign-in is completely finished and the IdP has finished collecting data from the user. A primary use case for `close()` is closing the IdP sign-in dialog in cases where [the browser and the IdP login status become out of sync](/en-US/docs/Web/API/FedCM_API/IDP_integration#what_if_the_browser_and_the_idp_login_status_become_out_of_sync), and the browser initiates a dynamic sign-in flow to correct the issue.
+`close()` is used to close the IdP sign-in dialog when sign-in is completely finished and the IdP has finished collecting data from the user. A primary use case for `close()` is closing the IdP sign-in dialog in cases where [the browser and the IdP login status become out of sync](/en-US/docs/Web/API/FedCM_API/IDP_integration#what_if_the_browser_and_the_idp_login_status_become_out_of_sync), and the browser initiates a dynamic sign-in flow to correct the issue.
 
 ## Syntax
 
@@ -33,6 +31,8 @@ None.
 `undefined`.
 
 ## Examples
+
+### Basic `IdentityProvider.close()` usage
 
 ```js
 IdentityProvider.close();

--- a/files/en-us/web/api/identityprovider/close_static/index.md
+++ b/files/en-us/web/api/identityprovider/close_static/index.md
@@ -14,7 +14,7 @@ The **`close()`** static method of the {{domxref("IdentityProvider")}} interface
 
 ## Usage notes
 
-`close()` needs to be called from the same origin as the IdP sign-in dialog, as defined in the [IdP config](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints).
+`close()` needs to be called from the same origin as the specified IdP's sign-in dialog, as defined in the [IdP config](/en-US/docs/Web/API/FedCM_API/IDP_integration#provide_a_config_file_and_endpoints).
 
 `close()` is needed to close the IdP sign-in dialog when sign-in is completely finished and the IdP has finished collecting data from the user. A primary use case for `close()` is closing the IdP sign-in dialog in cases where [the browser and the IdP login status become out of sync](/en-US/docs/Web/API/FedCM_API/IDP_integration#what_if_the_browser_and_the_idp_login_status_become_out_of_sync), and the browser initiates a dynamic sign-in flow to correct the issue.
 

--- a/files/en-us/web/api/identityprovider/getuserinfo_static/index.md
+++ b/files/en-us/web/api/identityprovider/getuserinfo_static/index.md
@@ -10,24 +10,9 @@ browser-compat: api.IdentityProvider.getUserInfo_static
 
 {{APIRef("FedCM API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`getUserInfo()`** static method of the {{domxref("IdentityProvider")}} interface returns information about a user that has signed in, which can be used to provide a personalized welcome message and sign-in button. This method has to be called from within an identity provider (IdP)-origin {{htmlelement("iframe")}} so that RP scripts cannot access the data. This must occur after a user has been signed in to a relying party (RP) site.
+The **`getUserInfo()`** static method of the {{domxref("IdentityProvider")}} interface returns information about a user that has signed in, which can be used to provide a personalized welcome message and sign-in button. This method has to be called from within an {{glossary("Identity provider", "IdP")}} origin {{htmlelement("iframe")}} so that {{glossary("Relying party", "relying party")}} (RP) scripts cannot access the data. This must occur after a user has been signed in to a RP site.
 
 This pattern is already common on sites that use identity federation for sign-in, but `getUserInfo()` provides a way to achieve it without relying on [third-party cookies](/en-US/docs/Web/Privacy/Guides/Third-party_cookies).
-
-## Usage notes
-
-When `getUserInfo()` is called, the browser will make a request to the specified IdP's [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) for the user information only when both the following conditions below are true:
-
-- The user has previously signed in to the RP with the IdP via FedCM on the same browser instance, and the data hasn't been cleared.
-- The user is signed in to the IdP on the same browser instance.
-
-`getUserInfo()` must be called from within an embedded `<iframe>`, and the embedded site's origin must match the `configURL` of the IdP. In addition, the embedding HTML must explicitly allow its use via the {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy):
-
-```html
-<iframe
-  src="https://idp.example/signin"
-  allow="identity-credentials-get"></iframe>
-```
 
 ## Syntax
 
@@ -66,7 +51,26 @@ A {{jsxref("Promise")}} that fulfills with an array of objects, each containing 
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if the embedding `<iframe>` does not have a {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) set to allow the use of `getUserInfo()` or if the FedCM API is disabled globally by a policy set on the top-level document.
 
+## Description
+
+When `getUserInfo()` is called, the browser will make a request to the specified IdP's [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) for the user information only when both the following conditions below are true:
+
+- The user has previously signed in to the RP with the IdP via FedCM on the same browser instance, and the data hasn't been cleared.
+- The user is signed in to the IdP on the same browser instance.
+
+`getUserInfo()` must be called from within an embedded `<iframe>`, and the embedded site's origin must match the `configURL` of the IdP. In addition, the embedding HTML must explicitly allow its use via the {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy):
+
+```html
+<iframe
+  src="https://idp.example/signin"
+  allow="identity-credentials-get"></iframe>
+```
+
 ## Examples
+
+### Basic `IdentityProvider.getUserInfo()` usage
+
+The following example shows how the {{domxref("IdentityProvider.getUserInfo_static", "getUserInfo()")}} method can be used to return information on a previously-signed in user from a specific IdP.
 
 ```js
 // Iframe displaying a page from the https://idp.example origin

--- a/files/en-us/web/api/identityprovider/getuserinfo_static/index.md
+++ b/files/en-us/web/api/identityprovider/getuserinfo_static/index.md
@@ -16,7 +16,7 @@ This pattern is already common on sites that use identity federation for sign-in
 
 ## Usage notes
 
-When `getUserInfo()` is called, the browser will make a request to the IdP [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) for the user information only when both the conditions below are true:
+When `getUserInfo()` is called, the browser will make a request to the specified IdP's [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) for the user information only when both the following conditions below are true:
 
 - The user has previously signed in to the RP with the IdP via FedCM on the same browser instance, and the data hasn't been cleared.
 - The user is signed in to the IdP on the same browser instance.

--- a/files/en-us/web/api/identityprovider/index.md
+++ b/files/en-us/web/api/identityprovider/index.md
@@ -9,7 +9,7 @@ browser-compat: api.IdentityProvider
 
 {{APIRef("FedCM API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`IdentityProvider`** interface of the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API) represents an identity provider (IdP) and provides access to related information and functionality.
+The **`IdentityProvider`** interface of the [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API) represents an {{glossary("Identity provider", "IdP")}} and provides access to related information and functionality.
 
 {{InheritanceDiagram}}
 
@@ -18,9 +18,13 @@ The **`IdentityProvider`** interface of the [Federated Credential Management (Fe
 - {{domxref("IdentityProvider.close_static", "close()")}} {{experimental_inline}}
   - : Provides a manual signal to the browser that an IdP sign-in flow is finished. This is needed to, for example, close the IdP sign-in dialog when sign-in is completely finished and the IdP has finished collecting data from the user.
 - {{domxref("IdentityProvider.getUserInfo_static", "getUserInfo()")}} {{experimental_inline}}
-  - : Returns information about a previously signed in user on their return to an IdP, which can be used to provide a personalized welcome message and sign-in button.
+  - : Returns information about a previously-signed in user on their return to an IdP, which can be used to provide a personalized welcome message and sign-in button.
 
 ## Examples
+
+### Basic `IdentityProvider.getUserInfo()` usage
+
+The following example shows how the {{domxref("IdentityProvider.getUserInfo_static", "getUserInfo()")}} method can be used to return information on a previously-signed in user from a specific IdP.
 
 ```js
 // Iframe displaying a page from the https://idp.example origin

--- a/files/en-us/web/http/reference/headers/permissions-policy/identity-credentials-get/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/identity-credentials-get/index.md
@@ -11,9 +11,13 @@ sidebar: http
 
 {{SeeCompatTable}}
 
-The HTTP {{HTTPHeader("Permissions-Policy")}} header `identity-credentials-get` directive controls whether the current document is allowed to use the [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API), and more specifically the {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} method with an `identity` option.
+The HTTP {{HTTPHeader("Permissions-Policy")}} header `identity-credentials-get` directive controls whether the current document is allowed to use the [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API), and more specifically usage of the following methods:
 
-Where this policy forbids use of the API, the {{jsxref("Promise")}} returned by the `get()` call will reject with a `NotAllowedError` {{domxref("DOMException")}}.
+- {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} (when used with the `identity` option)
+- {{domxref("IdentityCredential.disconnect_static", "IdentityCredential.disconnect()")}}
+- {{domxref("IdentityProvider.getUserInfo_static", "IdentityProvider.getUserInfo()")}}
+
+Where this policy forbids use of the API, {{jsxref("Promise")}}s returned by these methods will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/index.md
@@ -135,7 +135,7 @@ You can specify
   - : Controls whether the current document is allowed to use the {{domxref("WebHID API", "WebHID API", "", "nocode")}} to connect to uncommon or exotic human interface devices such as alternative keyboards or gamepads.
 
 - {{httpheader('Permissions-Policy/identity-credentials-get','identity-credentials-get')}} {{Experimental_Inline}}
-  - : Controls whether the current document is allowed to use the [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API), and more specifically the {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} method with an `identity` option. Where this policy forbids use of the API, the {{jsxref("Promise")}} returned by the `get()` call will reject with a `NotAllowedError` {{domxref("DOMException")}}.
+  - : Controls whether the current document is allowed to use the [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API).
 
 - {{httpheader('Permissions-Policy/idle-detection','idle-detection')}} {{Experimental_Inline}}
   - : Controls whether the current document is allowed to use the {{domxref("Idle Detection API", "Idle Detection API", "", "nocode")}} to detect when users are interacting with their devices, for example to report "available"/"away" status in chat applications.

--- a/files/en-us/web/security/secure_contexts/index.md
+++ b/files/en-us/web/security/secure_contexts/index.md
@@ -24,15 +24,25 @@ For example, even for a document delivered over TLS within an {{HTMLElement("ifr
 
 However, it's important to note that if a non-secure context causes a new window to be created (with or without specifying [noopener](/en-US/docs/Web/API/Window/open)), then the fact that the opener was insecure has no effect on whether the new window is considered secure. That's because the determination of whether a particular document is in a secure context is based only on considering it within the top-level browsing context with which it is associated — and not whether a non-secure context happened to be used to create it.
 
-Locally-delivered resources such as those with `http://127.0.0.1` URLs, `http://localhost` and `http://*.localhost` URLs (e.g., `http://dev.whatever.localhost/`), and `file://` URLs are also considered to have been delivered securely.
-
-> [!NOTE]
-> Firefox 84 and later support `http://localhost` and `http://*.localhost` URLs as trustworthy origins (earlier versions did not, because `localhost` was not guaranteed to map to a local/loopback address).
-
 Resources that are not local, to be considered secure, must meet the following criteria:
 
 - must be served over `https://` or `wss://` URLs
 - the security properties of the network channel used to deliver the resource must not be considered deprecated
+
+## Potentially trustworthy origins
+
+A **potentially trustworthy origin** is one that the browser can generally trust to deliver data security, even though strictly speaking it does not meet the criteria of a secure context.
+
+Locally-delivered resources such as those with `http://127.0.0.1`, `http://localhost`, and `http://*.localhost` URLs (for example, `http://dev.whatever.localhost/`) are not delivered using HTTPS, but they can be considered to have been delivered securely because they are on the same device as the browser. They are therefore potentially trustworthy. This is convenient for developers testing applications locally.
+
+The same is generally true for `file://` URLs.
+
+Secure [WebSocket](/en-US/docs/Web/API/WebSockets_API) (`"wss://"`) URLs are also considered potentially trustworthy.
+
+> [!NOTE]
+> Firefox 84 and later support `http://localhost` and `http://*.localhost` URLs as trustworthy origins (earlier versions did not, because `localhost` was not guaranteed to map to a local/loopback address).
+
+Vendor-specific URL schemes like `app://` or `chrome-extension://` are not considered potentially trustworthy by all browsers, but they may well be by the browsers whose vendors they originate from.
 
 ## Feature detection
 

--- a/files/en-us/web/security/secure_contexts/index.md
+++ b/files/en-us/web/security/secure_contexts/index.md
@@ -26,8 +26,8 @@ However, it's important to note that if a non-secure context causes a new window
 
 Resources that are not local, to be considered secure, must meet the following criteria:
 
-- must be served over `https://` or `wss://` URLs
-- the security properties of the network channel used to deliver the resource must not be considered deprecated
+- They must be served over `https://` URLs.
+- The security properties of the network channel used to deliver the resource must not be considered deprecated.
 
 ## Potentially trustworthy origins
 
@@ -39,10 +39,10 @@ The same is generally true for `file://` URLs.
 
 Secure [WebSocket](/en-US/docs/Web/API/WebSockets_API) (`"wss://"`) URLs are also considered potentially trustworthy.
 
+Vendor-specific URL schemes like `app://` or `chrome-extension://` are not considered potentially trustworthy by all browsers, but they may well be by the browsers whose vendors they originate from.
+
 > [!NOTE]
 > Firefox 84 and later support `http://localhost` and `http://*.localhost` URLs as trustworthy origins (earlier versions did not, because `localhost` was not guaranteed to map to a local/loopback address).
-
-Vendor-specific URL schemes like `app://` or `chrome-extension://` are not considered potentially trustworthy by all browsers, but they may well be by the browsers whose vendors they originate from.
 
 ## Feature detection
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Chrome has added several [FedCM](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) features that we are missing from MDN. This PR adds docs for them.

The features are:

- Support for multiple IdPs in a single `get()` call, as specified inside the `providers` array, added in Chrome 136: https://chromestatus.com/feature/5067784766095360
- The above ChromeStatus entry also includes the `IdentityCredential.configURL` (if you look at the [associated spec changes](https://github.com/w3c-fedid/FedCM/pull/686/files#diff-40cc3a1ba233cc3ca7b6d5873260da9676f6ae20bb897b62f7871c80d0bda4e9R445))
- `IdentityCredential.disconnect()`, added in Chrome 122: https://chromestatus.com/feature/5202286040580096. 
- `identity.mode` in `get()` calls, added in Chrome 132: https://chromestatus.com/feature/4689551782313984. 
- `identity.fields` and `identity.params` in `get()` calls, added in Chrome 132. I'm not sure what ChromeStatus entry covers these, but [developer.chrome.com](https://privacysandbox.google.com/cookies/fedcm/implement/relying-party#providers_property) says they were added in Chrome 132.
- `account_label` / `label_hints` in the IdP config file / accounts list endpoint. This was added in Chrome 132. Note that this won't have browser compat data - we don't really have a way of recording data for features in endpoints related to an API.
- `supports_use_other_account` in the IdP config file.
- `domain_hints` in the accounts list endpoint and `domainHint` in `get()` calls.

One point I'd especially like the tech review to comment on — the specified [options object for `disconnect()`](https://w3c-fedid.github.io/FedCM/#dictdef-identitycredentialdisconnectoptions) does not match up with the description in the [Chrome docs](https://privacysandbox.google.com/cookies/fedcm/implement/relying-party#disconnect_the_idp_from_the_rp). I think the latter makes more sense, but I'd like to know what is going on here.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
