### PR TITLE
Update Firefox storage access heuristic definitions to match Firefox 141

### DIFF
--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -129,19 +129,13 @@ These heuristics are intended to allow some third-party integrations that are co
 > Storage access heuristics are a transitional feature meant to prevent website breakage.
 > They should not be relied upon for current and future web development.
 
-#### Opener Heuristics
+#### Opener Heuristic
 
-- When a partitioned third-party opens a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document, the third-party is granted storage access to its embedder for 30 days.
-- When a first-party `a.example` opens a third-party pop-up `b.example`, `b.example` is granted third-party storage access to `a.example` for 30 days.
+When a partitioned third-party opens a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document and the user interacts with that popup, the third-party is granted storage access to its embedder for 30 days.
 
-> [!NOTE]
-> For third-parties which abuse these heuristic for tracking purposes, we may require user interaction with the popup before storage access is granted.
+#### Navigation Heuristic
 
-#### Redirect Heuristics
-
-- If a site `b.example` redirects to `a.example`, then `b.example` receives storage access to its embedder `a.example` if both `a.example` and `b.example` have been visited and interacted with within the last 10 minutes.
-  This storage access will be granted for 15 minutes.
-- If a tracker `tracker.example` (as classified by the Enhanced Tracking Protection) redirects to a non-tracker `a.example` and `tracker.example` received user interaction as a first-party within the last 45 days, `tracker.example` is granted storage access to `a.example` for 15 minutes.
+When a site `a.example` navigates a user to `b.example` in the same window, the user interacts with `b.example`, then the user is quickly navigated back to `a.example`, then `b.example` is granted storage access as a third party on `a.example` for 30 days.
 
 ## Storage Access API
 

--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -135,7 +135,7 @@ When a partitioned third-party opens a pop-up window that has [opener access](/e
 
 #### Navigation Heuristic
 
-When a site `a.example` navigates a user to `b.example` in the same window, the user interacts with `b.example`, then the user is quickly navigated back to `a.example`, then `b.example` is granted storage access as a third party on `a.example` for 30 days.
+Let's say a site hosted at `a.example` navigates a user to `b.example` in the same window, the user interacts with `b.example`, then the user is quickly navigated back to `a.example`. In such a case, `b.example` is granted storage access as a third-party on `a.example` for 30 days.
 
 ## Storage Access API
 

--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -189,8 +189,8 @@ Features disabled by the pref include:
 
 The following preferences can be used to disable individual storage access heuristics via the [config editor](https://support.mozilla.org/en-US/kb/about-config-editor-firefox):
 
-- Enable / disable the [redirect heuristics](#redirect_heuristics): `privacy.restrict3rdpartystorage.heuristic.recently_visited`, `privacy.restrict3rdpartystorage.heuristic.redirect`
-- Enable / disable the [window open heuristics](#opener_heuristics): `privacy.restrict3rdpartystorage.heuristic.window_open`, `privacy.restrict3rdpartystorage.heuristic.opened_window_after_interaction`
+- Enable / disable the [navigation heuristic](#navigation_heuristic): `privacy.restrict3rdpartystorage.heuristic.navigation`
+- Enable / disable the [opener heuristic](#opener_heuristic): `privacy.restrict3rdpartystorage.heuristic.opened_window_after_interaction`
 
 #### Disable Network Partitioning
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/index.md
@@ -93,7 +93,7 @@ In order to improve web compatibility and permit third-party integrations that r
 
 In order to improve web compatibility, Firefox currently includes some heuristics to grant storage access automatically to third parties that receive user interaction. These heuristics are intended to allow some third-party integrations that are common on the web to continue to function. They are intended to be temporary and will be removed in a future version of Firefox. They should not be relied upon for current and future web development.
 
-Third-party storage access may be granted when a user gesture triggers a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document. When that occurs, and then the user interacts with the pop-up, the origin of the resource that is initially loaded in the pop-up window is granted storage access on the opener document if that origin has received user interaction as a first party within the past 30 days.
+Third-party storage access may be granted when a user gesture triggers a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document. If the user interacts with the pop-up, the origin of the resource that is initially loaded in the pop-up window is granted storage access to the opener document if that origin has received user interaction as a first-party within the past 30 days.
 
 Third-party storage access may also be granted when a user navigates to another origin within the same window, interacts with that other origin, then quickly navigates back to the initial origin. This gives the origin in the intermediate page storage access on the final document.
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/index.md
@@ -95,7 +95,7 @@ In order to improve web compatibility, Firefox currently includes some heuristic
 
 Third-party storage access may be granted when a user gesture triggers a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document. If the user interacts with the pop-up, the origin of the resource that is initially loaded in the pop-up window is granted storage access to the opener document if that origin has received user interaction as a first-party within the past 30 days.
 
-Third-party storage access may also be granted when a user navigates to another origin within the same window, interacts with that other origin, then quickly navigates back to the initial origin. This gives the origin in the intermediate page storage access on the final document.
+Third-party storage access may also be granted when a user navigates to another origin within the same window. If the user interacts with that origin, then quickly navigates to a document in the initial origin, the intermediate page is granted storage access to that final document.
 
 ### Scope of storage access
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/index.md
@@ -93,11 +93,9 @@ In order to improve web compatibility and permit third-party integrations that r
 
 In order to improve web compatibility, Firefox currently includes some heuristics to grant storage access automatically to third parties that receive user interaction. These heuristics are intended to allow some third-party integrations that are common on the web to continue to function. They are intended to be temporary and will be removed in a future version of Firefox. They should not be relied upon for current and future web development.
 
-Third-party storage access may be granted to resources that have been classified as tracking resources when a user gesture triggers a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document. When that occurs, there are three possible ways a third-party origin can be granted access:
+Third-party storage access may be granted when a user gesture triggers a pop-up window that has [opener access](/en-US/docs/Web/API/Window/opener) to the originating document. When that occurs, and then the user interacts with the pop-up, the origin of the resource that is initially loaded in the pop-up window is granted storage access on the opener document if that origin has received user interaction as a first party within the past 30 days.
 
-- The origin of the resource that is initially loaded in the pop-up window is granted storage access on the opener document if that origin has received user interaction as a first party within the past 30 days.
-- After the initial resource is loaded in the pop-up window, the window may go through a series of redirects to other hosts. If a user interacts with the pop-up window following a redirect, the origin of the content loaded in the pop-up window is given storage access on the opener document.
-- When there is a top-level redirect from a tracking origin to a non-tracking origin, the tracking origin receives short-lived storage access on the non-tracking origin and any other non-tracking origins that appear further down the redirect chain (i.e., if the load continues to redirect). The tracking origin must have received user interaction as a first party within the past 30 days, and the storage access permission expires after 15 minutes.
+Third-party storage access may also be granted when a user navigates to another origin within the same window, interacts with that other origin, then quickly navigates back to the initial origin. This gives the origin in the intermediate page storage access on the final document.
 
 ### Scope of storage access
 


### PR DESCRIPTION
### Description

I'm updating Firefox-specific documentation to reflect how we are restricting the storage access heuristics. This work will be landing in Firefox 141. 

### Motivation

I want developers to have up-to-date information on how we are granting third-party storage exceptions. I did the engineering, and could quickly summarize the new state of the world to the same level of accuracy as the previous entries, so I did!

### Additional details

- https://bugzilla.mozilla.org/show_bug.cgi?id=1918125
- https://bugzilla.mozilla.org/show_bug.cgi?id=1918122

### Related issues and pull requests
n/a
