### PR TITLE
TrustedTypes: Add boilerplate for the xxxHtmlUnsafe() methods

### DIFF
--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -15,7 +15,7 @@ browser-compat: api.Document.parseHTMLUnsafe_static
 > For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 > This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
-The **`parseHTMLUnsafe()`** static method of the {{domxref("Document")}} object is used to parse an HTML input, optionally filtering unwanted HTML elements and attributes, in order to create a new {{domxref("Document")}} instance.
+The **`parseHTMLUnsafe()`** static method of the {{domxref("Document")}} object is used to parse HTML input, optionally filtering unwanted HTML elements and attributes, in order to create a new {{domxref("Document")}} instance.
 
 Unlike with {{domxref("Document.parseHTML_static", "Document.parseHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
 

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -35,6 +35,7 @@ Document.parseHTMLUnsafe(input, options)
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed.
+        This can also be a string with the value `"default"`, which applies a `Sanitizer` with the default (XSS-safe) configuration.
         Note that generally a `"Sanitizer` is expected than the to be more efficient than a `SanitizerConfig` if the configuration is to reused.
         If not specified, no sanitizer is used.
 

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Document.parseHTMLUnsafe_static
 {{APIRef("DOM")}}
 
 > [!WARNING]
-> This API parses its input as HTML, writing the result into the DOM.
+> This method parses its input as HTML, writing the result into the DOM.
 > APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
 >
 > For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -36,8 +36,9 @@ Document.parseHTMLUnsafe(input, options)
     - `sanitizer` {{optional_inline}}
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed.
         This can also be a string with the value `"default"`, which applies a `Sanitizer` with the default (XSS-safe) configuration.
-        Note that generally a `"Sanitizer` is expected than the to be more efficient than a `SanitizerConfig` if the configuration is to reused.
         If not specified, no sanitizer is used.
+        
+        Note that generally a `Sanitizer` is expected than the to be more efficient than a `SanitizerConfig` if the configuration is to reused.
 
 ### Return value
 
@@ -74,7 +75,7 @@ You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objec
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.
-It should be unnecessary to additionally pass a sanitizer to the method when using `TrustedHTML`.
+You should not need to pass a sanitizer to the method when using `TrustedHTML`.
 
 If for any reason you can't use `TrustedHTML` (or even better, `setHTML()`) then the next safest option is to use `setHTMLUnsafe()` with the XSS-safe default {{domxref("Sanitizer")}}.
 

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -8,6 +8,13 @@ browser-compat: api.Document.parseHTMLUnsafe_static
 
 {{APIRef("DOM")}}
 
+> [!WARNING]
+> This API parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+> This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
+
 The **`parseHTMLUnsafe()`** static method of the {{domxref("Document")}} object is used to parse an HTML input, optionally filtering unwanted HTML elements and attributes, in order to create a new {{domxref("Document")}} instance.
 
 Unlike with {{domxref("Document.parseHTML_static", "Document.parseHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
@@ -22,7 +29,7 @@ Document.parseHTMLUnsafe(input, options)
 ### Parameters
 
 - `input`
-  - : A string or {{domxref("TrustedHTML")}} instance defining HTML to be parsed.
+  - : A {{domxref("TrustedHTML")}} or string instance defining HTML to be parsed.
 - `options` {{optional_inline}}
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -15,9 +15,10 @@ browser-compat: api.Document.parseHTMLUnsafe_static
 > You can mitigate this risk by always passing `TrustedHTML` objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 > See [Security considerations](#security_considerations) for more information.
 
-The **`parseHTMLUnsafe()`** static method of the {{domxref("Document")}} object is used to parse HTML input, optionally filtering unwanted HTML elements and attributes, in order to create a new {{domxref("Document")}} instance.
+> [!NOTE]
+> {{domxref("Document/parseHTML_static", "Document.parseHTML()")}} should almost always be used instead of this method — on browsers where it is supported — as it always removes XSS-unsafe HTML entities.
 
-Unlike with {{domxref("Document.parseHTML_static", "Document.parseHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
+The **`parseHTMLUnsafe()`** static method of the {{domxref("Document")}} object is used to parse HTML input, optionally filtering unwanted HTML elements and attributes, in order to create a new {{domxref("Document")}} instance.
 
 ## Syntax
 
@@ -59,22 +60,22 @@ The resulting `Document` will have a [content type](/en-US/docs/Web/API/Document
 The input HTML may include [declarative shadow roots](/en-US/docs/Web/HTML/Reference/Elements/template#declarative_shadow_dom).
 If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Reference/Elements/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as {{htmlelement("template")}} elements within that shadow root.
 
-{{domxref("Document/parseHTML_static", "Document.parseHTML()")}} should almost always be used instead of this method — on browsers where it is supported — as it always removes XSS-unsafe HTML entities.
-`parseHTMLUnsafe()` may be useful in the rare cases where you _need_ to allow for at least some XSS-unsafe elements or attributes in the input.
-In this case the unsafe elements that aren't needed can still be filtered, which may reduce the overall risk.
+`parseHTMLUnsafe()` doesn't perform any sanitization by default.
+If no sanitizer is passed as a parameter, all HTML entities in the input will be injected.
 
 ### Security considerations
 
-The suffix "Unsafe" in the method name indicates that while the method allows the input string to be filtered of unwanted and XSS-unsafe HTML entities, unlike {{domxref("Document/parseHTML_static", "Document.parseHTML()")}} it does not enforce this sanitization.
-In fact, by default no sanitizer is used!
+The suffix "Unsafe" in the method name indicates that it does not enforce removal of all XSS-unsafe HTML entities (unlike {{domxref("Document/parseHTML_static", "Document.parseHTML()")}}).
+While it can do so if used with an appropriate sanitizer, it doesn't have to use an effective sanitizer, or any sanitizer at all!
 The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are injected into the DOM without first being sanitized.
 
 You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
-Note that this may lead to "double-sanitization" of the input — once in the transformation function, and again in the `parseHTMLUnsafe()` method.
-The recommendation is to use trusted types to sanitize according to your website policies, because trusted types allow auditing of potential injection sinks.
-If you wish to sanitize the input again by passing a sanitizer to this method, that's up to you!
+Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.
+It should be unnecessary to additionally pass a sanitizer to the method when using `TrustedHTML`.
+
+If for any reason you can't use `TrustedHTML` (or even better, `setHTML()`) then the next safest option is to use `setHTMLUnsafe()` with the XSS-safe default {{domxref("Sanitizer")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -34,7 +34,8 @@ setHTMLUnsafe(input, options)
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed.
-        Note that generally a `"Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
+         This can also be a string with the value `"default"`, which applies a `Sanitizer` with the default (XSS-safe) configuration.
+        Note that generally a `Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
         If not specified, no sanitizer is used.
 
 ### Return value
@@ -115,7 +116,7 @@ const trustedHTML = policy.createHTML(untrustedString);
 Now that we have `trustedHTML`, the code below shows how you can use it with `setHTMLUnsafe()`, both with and without a sanitizer.
 
 > [!NOTE]
-> The input may already sanitized by the trusted type policy at this point.
+> The input may already have been sanitized by the trusted type policy at this point.
 
 ```js
 // Get the target Element with id "target"
@@ -141,7 +142,7 @@ target.setHTMLUnsafe(trustedHTML, {
 ### `setHTMLUnsafe()` live example
 
 This example provides a "live" demonstration of the method when called with different sanitizers.
-The code defines buttons that you can click to inject a string of HTML that is not sanitized, and that uses and a custom sanitizer, respectively.
+The code defines buttons that you can click to inject a string of HTML. One button injects the HTML without sanitizing it at all, and the second uses a custom sanitizer than allows `<script>` elements but not other unsafe items.
 The original string and injected HTML are logged so you can inspect the results in each case.
 
 > [!NOTE]

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -99,7 +99,7 @@ Using `setHTMLUnsafe()` might be appropriate if:
   While this is still unsafe, it is safer than allowing all of them.
 
 For the last point, consider a situation where your code relies on being able to use unsafe `onclick` handlers.
-The following code shows the effect of different the different methods and sanitizers for this case.
+The following code shows the effect of the different methods and sanitizers for this case.
 
 ```js
 const target = document.querySelector("#target");
@@ -117,9 +117,9 @@ target.innerHTML = input;
 const configSafe = new Sanitizer();
 target.setHTMLUnsafe(input, { sanitizer: configSafe });
 
-// Removes all XSS-unsafe entities except `onerror`
+// Removes all XSS-unsafe entities except `onclick`
 const configLessSafe = new Sanitizer();
-config.allowAttribute("onerror");
+config.allowAttribute("onclick");
 target.setHTMLUnsafe(input, { sanitizer: configLessSafe });
 ```
 
@@ -196,7 +196,7 @@ target.setHTMLUnsafe(untrustedString, {
 
 This example provides a "live" demonstration of the method when called with different sanitizers.
 The code defines buttons that you can click to inject a string of HTML.
-One button injects the HTML without sanitizing it at all, and the second uses a custom sanitizer than allows `<script>` elements but not other unsafe items.
+One button injects the HTML without sanitizing it at all, and the second uses a custom sanitizer that allows `<script>` elements but not other unsafe items.
 The original string and injected HTML are logged so you can inspect the results in each case.
 
 > [!NOTE]

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -81,6 +81,8 @@ If you wish to sanitize the input again by passing a sanitizer to this method, t
 
 This example shows some of the ways you can use `setHTMLUnsafe()` to inject HTML markup into the DOM.
 
+#### Set up trusted types
+
 To mitigate the risk of XSS, we'll first create a `TrustedHTML` object from the string containing the HTML, and then pass that object to `setHTMLUnsafe()`.
 Since trusted types are not yet supported on all browsers, we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
 This acts as a transparent replacement for the trusted types JavaScript API:
@@ -107,6 +109,8 @@ const untrustedString = "abc <script>alert(1)<" + "/script> def";
 // Create a TrustedHTML instance using the policy
 const trustedHTML = policy.createHTML(untrustedString);
 ```
+
+#### Using setHTMLUnsafe() with and without a sanitizer
 
 Now that we have `trustedHTML`, the code below shows how you can use it with `setHTMLUnsafe()`, both with and without a sanitizer.
 

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -8,6 +8,13 @@ browser-compat: api.Element.setHTMLUnsafe
 
 {{APIRef("DOM")}}
 
+> [!WARNING]
+> This API parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+> This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
+
 The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
 
 Unlike with {{domxref("Element.setHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
@@ -27,7 +34,7 @@ setHTMLUnsafe(input, options)
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed.
-        Note that generally a `"Sanitizer` is expected than the to be more efficient than a `SanitizerConfig` if the configuration is to reused.
+        Note that generally a `"Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
         If not specified, no sanitizer is used.
 
 ### Return value
@@ -54,9 +61,10 @@ If no sanitizer configuration is specified in the `options.sanitizer` parameter,
 The input HTML may include [declarative shadow roots](/en-US/docs/Web/HTML/Reference/Elements/template#declarative_shadow_dom).
 If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Reference/Elements/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
 
-Like `setHTML()`, `setHTMLUnsafe()` may be used instead of {{domxref("Element.innerHTML")}} in order to parse strings of HTML that may contain declarative shadow roots.
-`setHTMLUnsafe()` should be instead of {{domxref("Element.setHTML()")}} when parsing potentially unsafe strings of HTML that for whatever reason need to contain XSS-unsafe elements or attributes.
-If strings to be injected don't need to contain unsafe HTML entities, then you should always use {{domxref("Element.setHTML()")}}.
+`setHTMLUnsafe()` may be used instead of {{domxref("Element.innerHTML")}} in order to parse strings of HTML that may contain declarative shadow roots.
+
+`setHTMLUnsafe()` should be instead of {{domxref("Element.innerHTML")}} when parsing potentially unsafe strings of HTML that for whatever reason need to allow for at least some XSS-unsafe elements or attributes (unsafe elements that aren't needed can still be filtered).
+If strings to be injected don't need to contain any unsafe HTML entities, then you should instead use {{domxref("Element.setHTML()")}}.
 
 Note that since this method does not necessarily sanitize input strings of XSS-unsafe entities, input strings should also be validated using the [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API).
 If the method is used with both a trusted types and a sanitizer, the input string will be passed through the trusted transformation function before it is sanitized.

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -76,7 +76,7 @@ You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objec
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.
-It should be unnecessary to additionally pass a sanitizer to the method when using `TrustedHTML`.
+You should not have to pass a sanitizer to the method when using `TrustedHTML`.
 
 If for any reason you can't use `TrustedHTML` (or even better, `setHTML()`) then the next safest option is to use `setHTMLUnsafe()` with the XSS-safe default {{domxref("Sanitizer")}}.
 

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -9,13 +9,13 @@ browser-compat: api.Element.setHTMLUnsafe
 {{APIRef("DOM")}}
 
 > [!WARNING]
-> This API parses its input as HTML, writing the result into the DOM.
+> This method parses its input as HTML, writing the result into the DOM.
 > APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
 >
 > For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 > This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
-The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
+The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse HTML input into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
 
 Unlike with {{domxref("Element.setHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
 
@@ -29,7 +29,7 @@ setHTMLUnsafe(input, options)
 ### Parameters
 
 - `input`
-  - : A string or {{domxref("TrustedHTML")}} instance defining HTML to be parsed.
+  - : A {{domxref("TrustedHTML")}} instance or string defining HTML to be parsed.
 - `options` {{optional_inline}}
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -8,6 +8,13 @@ browser-compat: api.ShadowRoot.setHTMLUnsafe
 
 {{APIRef("Shadow DOM")}}
 
+> [!WARNING]
+> This API parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+> This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
+
 The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface can be used to parse a string of HTML into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and then use it to replace the existing tree in the Shadow DOM.
 
 Unlike with {{domxref("ShadowRoot.setHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
@@ -22,12 +29,12 @@ setHTMLUnsafe(input, options)
 ### Parameters
 
 - `input`
-  - : A string or {{domxref("TrustedHTML")}} instance defining HTML to be parsed.
+  - : A {{domxref("TrustedHTML")}} or string instance defining HTML to be parsed.
 - `options` {{optional_inline}}
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed.
-        Note that generally a `"Sanitizer` is expected than the to be more efficient than a `SanitizerConfig` if the configuration is to reused.
+        Note that generally a `"Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
         If not specified, no sanitizer is used.
 
 ### Return value
@@ -38,7 +45,7 @@ None (`undefined`).
 
 - `TypeError`
   - : This is thrown if:
-    - `html` is passed a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
+    - `input` is passed a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
     - `options.sanitizer` is passed a:
       - value that is not a {{domxref("Sanitizer")}}, {{domxref("SanitizerConfig")}}, or string.
       - non-normalized {{domxref("SanitizerConfig")}} (one that includes both "allowed" and "removed" configuration settings).

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -70,7 +70,7 @@ The suffix "Unsafe" in the method name indicates that it does not enforce remova
 While it can do so if used with an appropriate sanitizer, it doesn't have to use an effective sanitizer, or any sanitizer at all!
 The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are injected into the DOM without first being sanitized.
 
-You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -9,14 +9,14 @@ browser-compat: api.ShadowRoot.setHTMLUnsafe
 {{APIRef("Shadow DOM")}}
 
 > [!WARNING]
-> This API parses its input as HTML, writing the result into the DOM.
+> This method parses its input as HTML, writing the result into the DOM.
 > APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
 > It is better to use XSS-safe methods where possible, such as {{domxref("ShadowRoot.setHTML()")}}.
 >
 > On sites that [enforce Trusted Type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive you will need to pass {{domxref("TrustedHTML")}} objects into this method.
 > This allows you to pass through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
-The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface can be used to parse a string of HTML into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and then use it to replace the existing tree in the Shadow DOM.
+The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface can be used to parse HTML input into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and then use it to replace the existing tree in the Shadow DOM.
 
 Unlike with {{domxref("ShadowRoot.setHTML()")}}, XSS-unsafe HTML entities are not guaranteed to be removed.
 

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -11,9 +11,10 @@ browser-compat: api.ShadowRoot.setHTMLUnsafe
 > [!WARNING]
 > This API parses its input as HTML, writing the result into the DOM.
 > APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+> It is better to use XSS-safe methods where possible, such as {{domxref("ShadowRoot.setHTML()")}}.
 >
-> For this reason it's much safer to pass only {{domxref("TrustedHTML")}} objects into this method, and to [enforce](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) this using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
-> This means you can be sure that the input has been passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
+> On sites that [enforce Trusted Type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive you will need to pass {{domxref("TrustedHTML")}} objects into this method.
+> This allows you to pass through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
 The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface can be used to parse a string of HTML into a {{domxref("DocumentFragment")}}, optionally filtering out unwanted elements and attributes, and then use it to replace the existing tree in the Shadow DOM.
 
@@ -233,6 +234,31 @@ When you click the "allowScript" button the `<script>` element is still present,
 With this approach you can create safe HTML, but you aren't forced to.
 
 {{EmbedLiveSample("setHTMLUnsafe() live example","100","350px")}}
+
+<!--
+
+### `setHTMLUnsafe()` with trusted types
+
+If trusted types are enforced using Xxxx you will need to define a policy.
+
+```js
+const parsePolicy = trustedTypes.createPolicy('parseHTMLPolicy', {
+  createHTML(input) {
+    // Developer must pass input through here manually
+    return input;
+  }
+});
+
+const unsanitizedString = "abc <script>alert(1)<" + "/script> def";
+const trusted = parsePolicy.createHTML(rawInput);
+
+// Define custom Sanitizer and use in setHTMLUnsafe()
+// This allows only elements: <div>, <p>, <span>, <script> (<script> is unsafe)
+const sanitizer1 = new Sanitizer({ elements: ["div", "p", "span", "script"] });
+shadow.setHTMLUnsafe(trusted, { sanitizer: sanitizer });
+```
+
+-->
 
 ## Specifications
 

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -34,7 +34,8 @@ setHTMLUnsafe(input, options)
   - : An options object with the following optional parameters:
     - `sanitizer` {{optional_inline}}
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed.
-        Note that generally a `"Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
+        This can also be a string with the value `"default"`, which applies a `Sanitizer` with the default (XSS-safe) configuration.
+        Note that generally a `Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
         If not specified, no sanitizer is used.
 
 ### Return value
@@ -111,7 +112,7 @@ const trustedHTML = policy.createHTML(untrustedString);
 Now that we have `trustedHTML`, the code below shows how you can use it with `setHTMLUnsafe()`, both with and without a sanitizer.
 
 > [!NOTE]
-> The input may already sanitized by the trusted type policy at this point.
+> The input may already have been sanitized by the trusted type policy at this point.
 
 First we create the {{domxref("ShadowRoot")}} we want to target.
 This could be created programmatically using {{domxref("Element.attachShadow()")}} but for this example we'll create the root declaratively.
@@ -151,7 +152,7 @@ shadow.setHTMLUnsafe(trustedHTML, {
 ### `setHTMLUnsafe()` live example
 
 This example provides a "live" demonstration of the method when called with different sanitizers.
-The code defines buttons that you can click to sanitize and inject a string of HTML using a default and a custom sanitizer, respectively.
+The code defines buttons that you can click to inject a string of HTML. One button injects the HTML without sanitizing it at all, and the second uses a custom sanitizer than allows `<script>` elements but not other unsafe items.
 The original string and sanitized HTML are logged so you can inspect the results in each case.
 
 > [!NOTE]

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -74,7 +74,7 @@ You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objec
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.
-It should be unnecessary to additionally pass a sanitizer to the method when using `TrustedHTML`.
+You should not have to pass a sanitizer to the method when using `TrustedHTML`.
 
 If for any reason you can't use `TrustedHTML` (or even better, `setHTML()`) then the next safest option is to use `setHTMLUnsafe()` with the XSS-safe default {{domxref("Sanitizer")}}.
 
@@ -97,7 +97,7 @@ Using `setHTMLUnsafe()` might be appropriate if:
   While this is still unsafe, it is safer than allowing all of them.
 
 For the last point, consider a situation where your code relies on being able to use unsafe `onclick` handlers.
-The following code shows the effect of different the different methods and sanitizers on this case.
+The following code shows the effect of the different methods and sanitizers on this case.
 
 ```js
 const shadow = document.querySelector("#host").shadowRoot;
@@ -115,9 +115,9 @@ shadow.innerHTML = input;
 const configSafe = new Sanitizer();
 shadow.setHTMLUnsafe(input, { sanitizer: configSafe });
 
-// Removes all XSS-unsafe entities except `onerror`
+// Removes all XSS-unsafe entities except `onclick`
 const configLessSafe = new Sanitizer();
-config.allowAttribute("onerror");
+config.allowAttribute("onclick");
 shadow.setHTMLUnsafe(input, { sanitizer: configLessSafe });
 ```
 
@@ -204,7 +204,7 @@ shadow.setHTMLUnsafe(untrustedString, {
 
 This example provides a "live" demonstration of the method when called with different sanitizers.
 The code defines buttons that you can click to inject a string of HTML.
-One button injects the HTML without sanitizing it at all, and the second uses a custom sanitizer than allows `<script>` elements but not other unsafe items.
+One button injects the HTML without sanitizing it at all, and the second uses a custom sanitizer that allows `<script>` elements but not other unsafe items.
 The original string and injected HTML are logged so you can inspect the results in each case.
 
 > [!NOTE]


### PR DESCRIPTION
This updates the following methods to explain how they are used with TrustedTypes:

- [x] [`Document.parseHTMLUnsafe()` ](https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static)
- [x] [`Element.setHTMLUnsafe()` ](https://developer.mozilla.org/en-US/docs/Web/API/Element/setHTMLUnsafe)
- [x] [`ShadowRoot.setHTMLUnsafe()` ](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/setHTMLUnsafe)

Part of #37518 (tracking issue)

The advice from https://github.com/WICG/sanitizer-api/issues/303 was that the recommendation is to the safe methods where possible, once it is defined. The setUnsafeHTML should be treated the same way as innerHTML w.r.t. trusted types. I believe this is because the point of TT is to provide easily auditable policy files that can then be enforced.

There was no specific comment on whether you should use a noop policy to avoid double sanitization: but the inference was that if that is allowed by your website policies then you can. However it isn't particularly safe. 

I have updated all three to have the new header and a security considerations section that says "use the safe versions, if supported. If you need to use this you can, but use trusted types "first" - up to you if you then use the sanitizer.

The two `setHTMLUnsafe()` methods have examples that show basic usage that includes TT in line with the guidance. I have explicitly omitted the use of TT in the live examples to keep them simple, but added a note disclaimer.
There was no example for the parseHTMLUnsafe() and I have not added on.
