### PR TITLE
Element.innerHTML - add info trusted types

### DIFF
--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -23,11 +23,8 @@ To insert the HTML into the document rather than replace the contents of an elem
 
 Getting the property returns a string containing the HTML serialization of the element's descendants.
 
-Setting the value of `innerHTML` removes all of the element's descendants and replaces them with nodes constructed by parsing the HTML given in the assigned {{domxref("TrustedHTML")}} or string.
+Setting the property accepts either a {{domxref("TrustedHTML")}} object or a string. It parses this value as HTML and replaces all the element's descendants with the result.
 When set to the `null` value, that `null` value is converted to the empty string (`""`), so `elt.innerHTML = null` is equivalent to `elt.innerHTML = ""`.
-Note that {{htmlelement("script")}} elements in the assigned value are injected but not executed.
-
-Shadow roots are dropped from the serialized and injected HTML.
 
 ### Exceptions
 
@@ -102,7 +99,7 @@ if (typeof trustedTypes === "undefined")
   trustedTypes = { createPolicy: (n, rules) => rules };
 ```
 
-Next create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createHTML", "createHTML()")}} for transforming an input string into {{domxref("TrustedHTML")}} instances.
+Next we create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createHTML", "createHTML()")}} for transforming an input string into {{domxref("TrustedHTML")}} instances.
 Commonly implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the input as shown below:
 
 ```js
@@ -111,7 +108,7 @@ const policy = trustedTypes.createPolicy("my-policy", {
 });
 ```
 
-Then use this `policy` object to create a `TrustedHTML` object from the potentially unsafe input string, and assign the result to the element:
+Then we use this `policy` object to create a `TrustedHTML` object from the potentially unsafe input string, and assign the result to the element:
 
 ```js
 // The potentially malicious string
@@ -138,9 +135,6 @@ For example, the code below clears the entire contents of a document by setting 
 // Create a TrustedHTML instance using the policy
 document.body.textContent = policy.createHTML(policy.createHTML(""));
 ```
-
-Note that in this case we're setting the element to an empty string, which we know is safe.
-If we weren't [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) we could instead directly assign the empty string:
 
 ```js
 document.body.textContent = "";

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -92,8 +92,8 @@ console.log(contents); // "\n  <p>My name is Joe</p>\n"
 
 ### Replacing the contents of an element
 
-Setting the value of `innerHTML` lets you replace the existing contents of an element with a new DOM tree parsed from an input.
-This completely removes the original content, including any event handlers associated with the removed elements.
+In this example we'll replace an element's DOM by assigning HTML to the element's `innerHTML` property.
+To mitigate the risk of XSS, we'll first create a `TrustedHTML` object from the string containing the HTML, and then assign that object to `innerHTML`.
 
 Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
 This acts as a transparent replacement for the trusted types JavaScript API:

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -271,3 +271,4 @@ You can see output into the log by moving the mouse in and out of the box, click
 - {{domxref("ShadowRoot.getHTML()")}}
 - {{domxref("Element.setHTMLUnsafe()")}}
 - {{domxref("ShadowRoot.setHTMLUnsafe()")}}
+- [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API)

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -8,36 +8,69 @@ browser-compat: api.Element.innerHTML
 
 {{APIRef("DOM")}}
 
-The **`innerHTML`** property of the {{domxref("Element")}} interface gets or sets the HTML or XML markup contained within the element.
+> [!WARNING]
+> This property parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> You can reduce the risk by assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+> This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup, such as {{htmlelement("script")}} elements and event handler attributes.
 
-More precisely, `innerHTML` gets a serialization of the nested child DOM elements within the element, or sets HTML or XML that should be parsed to replace the DOM tree within the element.
+The **`innerHTML`** property of the {{domxref("Element")}} interface gets or sets the HTML or XML markup contained within the element, omitting any {{glossary("shadow tree", "shadow roots")}} in both cases.
 
 To insert the HTML into the document rather than replace the contents of an element, use the method {{domxref("Element.insertAdjacentHTML", "insertAdjacentHTML()")}}.
 
-The serialization of the DOM tree read from the property does not include {{glossary("shadow tree", "shadow roots")}} — if you want to get a HTML string that includes shadow roots, you must instead use the {{domxref("Element.getHTML()")}} or {{domxref("ShadowRoot.getHTML()")}} methods.
-Similarly, when setting element content using `innerHTML`, the HTML string is parsed into DOM elements that do not contain shadow roots.
-
-So for example [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) is parsed into as {{domxref("HTMLTemplateElement")}}, whether or not the [`shadowrootmode`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode) attribute is specified
-In order to set an element's contents from an HTML string that includes declarative shadow roots, you must use either {{domxref("Element.setHTMLUnsafe()")}} or {{domxref("ShadowRoot.setHTMLUnsafe()")}}.
-
-Note that some browsers serialize the `<` and `>` characters as `&lt;` and `&gt;` when they appear in attribute values (see [Browser compatibility](#browser_compatibility)).
-This is to prevent a potential security vulnerability ([mutation XSS](https://www.securitum.com/mutation-xss-via-mathml-mutation-dompurify-2-0-17-bypass.html)) in which an attacker can craft input that bypasses a [sanitization function](/en-US/docs/Web/Security/Attacks/XSS#sanitization), enabling a cross-site scripting (XSS) attack.
-
 ## Value
 
-A string containing the HTML serialization of the element's descendants.
-Setting the value of `innerHTML` removes all of the element's descendants and replaces them with nodes constructed by parsing the HTML given in the string _htmlString_.
+Getting the property returns a string containing the HTML serialization of the element's descendants.
 
+Setting the value of `innerHTML` removes all of the element's descendants and replaces them with nodes constructed by parsing the HTML given in the assigned {{domxref("TrustedHTML")}} or string.
 When set to the `null` value, that `null` value is converted to the empty string (`""`), so `elt.innerHTML = null` is equivalent to `elt.innerHTML = ""`.
+Note that {{htmlelement("script")}} elements in the assigned value are injected but not executed.
+
+Shadow roots are dropped from the serialized and injected HTML.
 
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if an attempt was made to set the value of `innerHTML` using a string which is not properly-formed HTML.
+- `TypeError`
+  - : Thrown if the property is set to a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
 - `NoModificationAllowedError` {{domxref("DOMException")}}
   - : Thrown if an attempt was made to insert the HTML into a node whose parent is a {{domxref("Document")}}.
 
-## Usage notes
+## Description
+
+`innerHTML` gets a serialization of the nested child DOM elements within the element, or sets HTML or XML that should be parsed to replace the DOM tree within the element.
+
+The serialization of the DOM tree read from the property does not include {{glossary("shadow tree", "shadow roots")}} — if you want to get a HTML string that includes shadow roots, you must instead use the {{domxref("Element.getHTML()")}} or {{domxref("ShadowRoot.getHTML()")}} methods.
+
+Similarly, when setting element content using `innerHTML`, the HTML string is parsed into DOM elements that do not contain shadow roots.
+So for example [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) is parsed into as {{domxref("HTMLTemplateElement")}}, whether or not the [`shadowrootmode`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode) attribute is specified.
+In order to set an element's contents from an HTML string that includes declarative shadow roots, you must instead use {{domxref("Element.setHTMLUnsafe()")}} or {{domxref("ShadowRoot.setHTMLUnsafe()")}}.
+
+Note that some browsers serialize the `<` and `>` characters as `&lt;` and `&gt;` when they appear in attribute values (see [Browser compatibility](#browser_compatibility)).
+This is to prevent a potential security vulnerability ([mutation XSS](https://research.securitum.com/dompurify-bypass-using-mxss/)) in which an attacker can craft input that bypasses a [sanitization function](/en-US/docs/Web/Security/Attacks/XSS#sanitization), enabling a cross-site scripting (XSS) attack.
+
+### Security considerations
+
+The `innerHTML` property is probably the most common vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are injected into the DOM without first being sanitized.
+While the property does prevent {{HTMLElement("script")}} elements from executing when they are injected, it is susceptible to many other ways that attackers can craft HTML to run malicious JavaScript.
+For example, the following example would execute the code in the `error` event handler, because the {{htmlelement("img")}} `src` value is not a valid image URL:
+
+```js
+const name = "<img src='x' onerror='alert(1)'>";
+el.innerHTML = name; // shows the alert
+```
+
+You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup before it is injected.
+This is demonstrated in the following sections.
+
+> [!NOTE]
+> {{domxref("Node.textContent")}} should be used when you know that the user provided content should be plain text.
+> This prevents it being parsed as HTML.
+
+## Examples
 
 ### Reading the HTML contents of an element
 
@@ -51,126 +84,145 @@ const contents = myElement.innerHTML;
 This lets you look at the HTML markup of the element's content nodes.
 
 > [!NOTE]
-> The returned HTML or XML fragment is generated based on the current contents of the element, so the markup and formatting of the returned fragment is likely not to match the original page markup.
+> The returned HTML or XML fragment is generated based on the current contents of the element, so the markup and formatting of the returned fragment may not match the original page markup.
+> It will also omit any shadow roots.
 
 ### Replacing the contents of an element
 
-Setting the value of `innerHTML` lets you easily replace the existing contents of an element with new content.
+Setting the value of `innerHTML` lets you replace the existing contents of an element with a new DOM tree parsed from an input.
+This completely removes the original content, including any event handlers associated with the removed elements.
+
+Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
+This provides an implementation of `trustedTypes.createPolicy()` which just returns the `policyOptions` object it was passed.
+The object defines sanitization functions for data, and these functions are expected to return strings.
+Effectively it is a transparent replacement for the trusted types JavaScript API:
+
+```js
+if (typeof trustedTypes === "undefined")
+  trustedTypes = { createPolicy: (n, rules) => rules };
+```
+
+Next create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createHTML", "createHTML()")}} for transforming an input string into {{domxref("TrustedHTML")}} instances.
+Commonly implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the input as shown below:
+
+```js
+const policy = trustedTypes.createPolicy("my-policy", {
+  createHTML: (input) => DOMPurify.sanitize(input),
+});
+```
+
+Then use this `policy` object to create a `TrustedHTML` object from the potentially unsafe input string, and assign the result to the element:
+
+```js
+// The potentially malicious string
+const untrustedString = "<p>I might be XSS</p><img src='x' onerror='alert(1)'>";
+
+// Create a TrustedHTML instance using the policy
+const trustedHTML = policy.createHTML(untrustedString);
+
+// Inject the TrustedHTML (which contains a trusted string)
+const element = document.querySelector("#container");
+element.innerHTML = trustedHTML;
+```
 
 > [!WARNING]
-> This is a [security risk](#security_considerations) if the string to be inserted might contain potentially malicious content.
-> When inserting user-supplied data you should always consider using a sanitizer library, in order to sanitize the content before it is inserted.
+> While you can directly assign a string to `innerHTML` this is a [security risk](#security_considerations) if the string to be inserted might contain potentially malicious content.
+> You should use `TrustedHTML` to ensure that the content is sanitized before it is inserted, and you should set a CSP header to [enforce trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 
-For example, you can erase the entire contents of a document by clearing the contents of the document's {{domxref("Document.body", "body")}} attribute:
+### Clearing the contents of an element
+
+You can clear the content of an element by setting its content to the empty string.
+For example, the code below clears the entire contents of a document by setting the {{domxref("Document.body", "body")}} element to a `TrustedHTML` object for the empty string:
+
+```js
+// Create a TrustedHTML instance using the policy
+document.body.textContent = policy.createHTML(policy.createHTML(""));
+```
+
+Note that in this case we're setting the element to an empty string, which we know is safe.
+If we weren't [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) we could instead directly assign the empty string:
 
 ```js
 document.body.textContent = "";
 ```
 
-This example fetches the document's current HTML markup and replaces the `"<"` characters with the {{glossary("character reference")}} `"&lt;"`, thereby essentially converting the HTML into raw text.
-This is then wrapped in a {{HTMLElement("pre")}} element.
-Then the value of `innerHTML` is changed to this new string.
-As a result, the document contents are replaced with a display of the page's entire source code.
+### Logging messages using innerHTML
 
-```js
-document.documentElement.innerHTML = `<pre>${document.documentElement.innerHTML.replace(
-  /</g,
-  "&lt;",
-)}</pre>`;
-```
-
-#### Operational details
-
-What exactly happens when you set value of `innerHTML`?
-Doing so causes the user agent to follow these steps:
-
-1. The specified value is parsed as HTML or XML (based on the document type), resulting in a {{domxref("DocumentFragment")}} object representing the new set of DOM nodes for the new elements.
-2. If the element whose contents are being replaced is a {{HTMLElement("template")}} element, then the `<template>` element's {{domxref("HTMLTemplateElement.content", "content")}} attribute is replaced with the new `DocumentFragment` created in step 1.
-3. For all other elements, the element's contents are replaced with the nodes in the new `DocumentFragment`.
-
-### Appending HTML to an element
-
-Setting the value of `innerHTML` lets you append new contents to the existing one of an element.
-
-For example, we can append a new list item (`<li>`) to the existing list (`<ul>`):
+This example uses `innerHTML` to create a mechanism for logging messages into a box on a web page.
 
 #### HTML
 
+The HTML is quite simple for our example.
+
 ```html
-<ul id="list">
-  <li><a href="#">Item 1</a></li>
-  <li><a href="#">Item 2</a></li>
-  <li><a href="#">Item 3</a></li>
-</ul>
+<div class="box">
+  <div><strong>Log:</strong></div>
+  <div class="log"></div>
+</div>
+```
+
+The {{HTMLElement("div")}} with the class `"box"` is just a container for layout purposes, presenting the contents with a box around it.
+The `<div>` whose class is `"log"` is the container for the log text itself.
+
+#### CSS
+
+The following CSS styles our example content.
+
+```css
+.box {
+  width: 600px;
+  height: 300px;
+  border: 1px solid black;
+  padding: 2px 4px;
+  overflow-y: scroll;
+  overflow-x: auto;
+}
+
+.log {
+  margin-top: 8px;
+  font-family: monospace;
+}
 ```
 
 #### JavaScript
 
-```js
-const list = document.getElementById("list");
+The example doesn't actually require sanitization/trusted types because we know that the strings will only contain {{htmlelement("strong")}} and {{htmlelement("em")}} elements.
+However we'll use them anyway, because in a real application you should enforce and use trusted types everywhere.
 
-list.innerHTML += `<li><a href="#">Item ${list.children.length + 1}</a></li>`;
+First we define the tinyfill:
+
+```js
+if (typeof trustedTypes === "undefined")
+  trustedTypes = { createPolicy: (n, rules) => rules };
 ```
 
-Please note that using `innerHTML` to append HTML elements (e.g., `el.innerHTML += "<a href='…'>link</a>"`) will result in the removal of any previously set event listeners.
-That is, after you append any HTML element that way you won't be able to listen to the previously set event listeners.
-
-### Security considerations
-
-It is not uncommon to see `innerHTML` used to insert text into a web page.
-There is potential for this to become an attack vector on a site, creating a potential security risk.
+Then we create our policy `"safe-string-policy"` for using with inputs that we _know_ to be safe.
+This just passes the input through to the output without performing sanitization:
 
 ```js
-let name = "John";
-// assuming 'el' is an HTML DOM element
-el.innerHTML = name; // harmless in this case
-
-// …
-
-name = "<script>alert('I am John in an annoying alert!')</script>";
-el.innerHTML = name; // harmless in this case
+const safeStringPolicy = trustedTypes.createPolicy("safe-string-policy", {
+  createHTML: (input) => input,
+});
 ```
 
-Although this may look like a [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attack, the result is harmless. A {{HTMLElement("script")}} tag inserted with `innerHTML` will not execute.
-
-However, there are ways to execute JavaScript without using {{HTMLElement("script")}} elements, so there is still a security risk whenever you use `innerHTML` to set strings over which you have no control.
-For example:
+Next we define a `log()` function that uses this policy.
 
 ```js
-const name = "<img src='x' onerror='alert(1)'>";
-el.innerHTML = name; // shows the alert
-```
+const logElem = document.querySelector(".log");
 
-For that reason, it is recommended that instead of `innerHTML` you use:
-
-- {{domxref("Node.textContent")}} when inserting plain text, as this inserts it as raw text rather than parsing it as HTML.
-
-> [!WARNING]
-> If your project is one that will undergo any form of security review, using `innerHTML` most likely will result in your code being rejected.
-> For example, [if you use `innerHTML`](https://wiki.mozilla.org/Add-ons/Reviewers/Guide/Reviewing#Step_2:_Automatic_validation) in a [browser extension](/en-US/docs/Mozilla/Add-ons/WebExtensions) and submit
-> the extension to [addons.mozilla.org](https://addons.mozilla.org/), it may be rejected in the review process.
-> Please see [Safely inserting external content into a page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page) for alternative methods.
-
-## Examples
-
-This example uses `innerHTML` to create a mechanism for logging messages into a box on a web page.
-
-### JavaScript
-
-```js
 function log(msg) {
-  const logElem = document.querySelector(".log");
-
   const time = new Date();
-  const timeStr = time.toLocaleTimeString();
-  logElem.innerHTML += `${timeStr}: ${msg}<br/>`;
+  const timeStr = `${logElem.innerHTML}${time.toLocaleTimeString()}: ${msg}<br/>`;
+  const trustedHTML = safeStringPolicy.createHTML(timeStr);
+  logElem.innerHTML = trustedHTML;
 }
 
 log("Logging mouse events inside this container…");
 ```
 
 The `log()` function creates the log output by getting the current time from a {{jsxref("Date")}} object using {{jsxref("Date.toLocaleTimeString", "toLocaleTimeString()")}}, and building a string with the timestamp and the message text.
-Then the message is appended to the box with the class `"log"`.
+This string is appended to the original content of the log and then the policy is used to pass the string through our `createHTML()` "transformation" function.
+Then the message is assigned to the element with the class `"log"`.
 
 We add a second method that logs information about {{domxref("MouseEvent")}} based events (such as {{domxref("Element/mousedown_event", "mousedown")}}, {{domxref("Element/click_event", "click")}}, and {{domxref("Element/mouseenter_event", "mouseenter")}}):
 
@@ -193,46 +245,12 @@ boxElem.addEventListener("mouseenter", logEvent);
 boxElem.addEventListener("mouseleave", logEvent);
 ```
 
-### HTML
-
-The HTML is quite simple for our example.
-
-```html
-<div class="box">
-  <div><strong>Log:</strong></div>
-  <div class="log"></div>
-</div>
-```
-
-The {{HTMLElement("div")}} with the class `"box"` is just a container for layout purposes, presenting the contents with a box around it.
-The `<div>` whose class is `"log"` is the container for the log text itself.
-
-### CSS
-
-The following CSS styles our example content.
-
-```css
-.box {
-  width: 600px;
-  height: 300px;
-  border: 1px solid black;
-  padding: 2px 4px;
-  overflow-y: scroll;
-  overflow-x: auto;
-}
-
-.log {
-  margin-top: 8px;
-  font-family: monospace;
-}
-```
-
-### Result
+#### Result
 
 The resulting content looks like this.
 You can see output into the log by moving the mouse in and out of the box, clicking in it, and so forth.
 
-{{EmbedLiveSample("Examples", 640, 350)}}
+{{EmbedLiveSample("Logging messages using innerHTML", 640, 350)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/insertadjacenthtml/index.md
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.md
@@ -119,20 +119,24 @@ code {
 
 #### JavaScript
 
-```js hidden
+Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
+This acts as a transparent replacement for the trusted types JavaScript API:
+
+```js
 if (typeof trustedTypes === "undefined")
   trustedTypes = { createPolicy: (n, rules) => rules };
 ```
 
-While not required for this example, below we follow the recommendation of defining a policy to create {{domxref("TrustedHTML")}} objects from the input (we should also enforce the policy `safe-content-policy` using CSP).
-In this case we know the input is safe so this policy passes it through without modification.
-The commented code shows how you might instead use the "DOMPurify" library to sanitize content that wasn't trusted.
+Next we define a policy named `some-content-policy` to create {{domxref("TrustedHTML")}} objects from the input (we should also enforce the `some-content-policy` using CSP).
+The code implements no-op policy in order to allow this example to work without a third-party dependency.
+Your own application code should use a third party library such as the "DOMPurify" library to return sanitized content from the untrusted input.
 
 ```js
-const policy = trustedTypes.createPolicy("safe-content-policy", {
+const policy = trustedTypes.createPolicy("some-content-policy", {
   createHTML: (input) => {
-    // DOMPurify.sanitize(input);
-    return input;
+    return input; // Do not do this in your own code!
+    // Instead do something like:
+    // return DOMPurify.sanitize(input);
   },
 });
 
@@ -174,4 +178,3 @@ reset.addEventListener("click", () => {
 - {{domxref("Element.insertAdjacentText()")}}
 - {{domxref("XMLSerializer")}}: Serialize a DOM tree into an XML string
 - [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API)
-- [hacks.mozilla.org guest post](https://hacks.mozilla.org/2011/11/insertadjacenthtml-enables-faster-html-snippet-injection/) by Henri Sivonen including benchmark showing that `insertAdjacentHTML()` can be way faster in some cases.


### PR DESCRIPTION
This updates the following properties to explain how they are used with TrustedTypes:

- [x] [`Element.innerHTML` ](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML)
- [x] [`Element.insertAdjacentHTML()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)

This is in progress:
- Add boilerplate
- Add TT information, including the new exception and tinyfill
- Restructured - this isn't to current templates. Need to move the guid-ish stuff either down as examples or up into description

This does not mention the sanitizer methods as alternatives since the `setHTML()` is not implemented anywhere, and the sanitizer in `setHTMLUnsafe()` is not yet implemented. We're in separate discussion on those and when they are in a release we can revisit.

Part of #37518 (tracking issue)