### PR TITLE
[CSS] Docs: Clarify the dual role of the font-size property

### DIFF
--- a/files/en-us/web/css/font-size/index.md
+++ b/files/en-us/web/css/font-size/index.md
@@ -6,7 +6,9 @@ browser-compat: css.properties.font-size
 sidebar: cssref
 ---
 
-The **`font-size`** [CSS](/en-US/docs/Web/CSS) property sets the size of the font. Changing the font size also updates the sizes of the font size-relative {{cssxref("&lt;length&gt;")}} units, such as `em`, `ex`, and so forth.
+The **`font-size`** [CSS](/en-US/docs/Web/CSS) property has two primary functions:
+1. **It sets the size of the font.** Its most direct job is to specify the size of the glyphs for the text within an element. 
+2. **It acts as a reference for other properties.** It is the foundational unit used to compute font-relative {{cssxref("&lt;length&gt;")}} units like em, rem, ch etc. These units are then often used to set the value of other properties, such as width, margin, and padding.
 
 {{InteractiveExample("CSS Demo: font-size")}}
 

--- a/files/en-us/web/css/font-size/index.md
+++ b/files/en-us/web/css/font-size/index.md
@@ -7,7 +7,8 @@ sidebar: cssref
 ---
 
 The **`font-size`** [CSS](/en-US/docs/Web/CSS) property has two primary functions:
-1. **It sets the size of the font.** Its most direct job is to specify the size of the glyphs for the text within an element. 
+
+1. **It sets the size of the font.** Its most direct job is to specify the size of the glyphs for the text within an element.
 2. **It acts as a reference for other properties.** It is the foundational unit used to compute font-relative {{cssxref("&lt;length&gt;")}} units like em, rem, ch etc. These units are then often used to set the value of other properties, such as width, margin, and padding.
 
 {{InteractiveExample("CSS Demo: font-size")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR reframes the introduction to the font-size page to more clearly and explicitly state the two primary roles the property serves in CSS.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current introduction is correct, but it presents the property's role as a reference for other units (like em) as a secondary effect. For learners, it can be clearer to understand that font-size has two equally important, distinct jobs. This change helps build a more accurate mental model from the start.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
