### PR TITLE
Fix syntax comment in box-shadow doc: replace | with && or remove confusing comments)

### DIFF
--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -61,19 +61,19 @@ The `box-shadow` property enables you to cast a drop shadow from the frame of al
 box-shadow: none;
 
 /* A color and two length values */
-/* <color> | <length> | <length> */
+/* <color> && <length> && <length> */
 box-shadow: red 60px -16px;
 
 /* Three length values and a color */
-/* <length> | <length> | <length> | <color> */
+/* <length> && <length> && <length> && <color> */
 box-shadow: 10px 5px 5px black;
 
 /* Four length values and a color */
-/* <length> | <length> | <length> | <length> | <color> */
+/* <length> && <length> && <length> && <length> && <color> */
 box-shadow: 2px 2px 2px 1px rgb(0 0 0 / 20%);
 
 /* inset, length values, and a color */
-/* <inset> | <length> | <length> | <color> */
+/* <inset> && <length> && <length> && <color> */
 box-shadow: inset 5em 1em gold;
 
 /* Any number of shadows, separated by commas */


### PR DESCRIPTION
Description
Fixed the confusing syntax comments in the box-shadow CSS documentation by replacing the | symbol with && to better reflect how the syntax works, or by removing the confusing comments altogether.

Motivation
The previous comments could mislead readers into thinking | means OR, whereas the syntax requires all parts together (AND). This change improves clarity and accuracy for readers learning CSS.