### PR TITLE
Add a "Guides" section to the API landing page template

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -109,7 +109,7 @@ For a practical usage guide with code examples, you should include a "Usage…" 
 
 ## Guides
 
-Include a list of guide pages under this landing page. Each DT should link to the guide page.
+Include a list of guide pages under this landing page. Each DT should link to the guide page. This section is optional; if there's only a single "Using" guide, along with a few other conceptual guides, you may find it more convenient to link to it at the end of the "Concepts and usage" section instead. This section may be more helpful if there are so many guides that prose becomes hard to scan.
 
 - Using the ... API
   - : Intro paragraph of this guide page

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -107,7 +107,14 @@ Don't go into a lot of detail in this section, and don't include code examples.
 If there are a lot of concepts to explain around this API, you should explain them in a separate "Fundamentals" or "Concepts" article (e.g., [Fundamentals of WebXR](/en-US/docs/Web/API/WebXR_Device_API/Fundamentals)).
 For a practical usage guide with code examples, you should include a "Usage…" article in your API docs (e.g., [Using the WebVR API](/en-US/docs/Web/API/WebVR_API/Using_the_WebVR_API)).
 
-To help improve content discoverability and {{Glossary("SEO")}}, keep the following tips in mind:
+## Guides
+
+Include a list of guide pages under this landing page. Each DT should link to the guide page.
+
+- Using the ... API
+  - : Intro paragraph of this guide page
+- Guide 2
+  - : Intro paragraph of this guide page
 
 ## Interfaces
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -109,7 +109,7 @@ For a practical usage guide with code examples, you should include a "Usage…" 
 
 ## Guides
 
-Include a list of guide pages under this landing page. Each DT should link to the guide page. This section is optional; if there's only a single "Using" guide, along with a few other conceptual guides, you may find it more convenient to link to it at the end of the "Concepts and usage" section instead. This section may be more helpful if there are so many guides that prose becomes hard to scan.
+Include a list of guide pages under this landing page. Each DT should link to the guide page. This section is optional; if there's only a single "Using" guide, along with a few other conceptual guides, you may find it more convenient to link to them as a paragraph at the end of the "Concepts and usage" section instead. This section may be more helpful if there are so many guides that prose becomes hard to scan.
 
 - Using the ... API
   - : Intro paragraph of this guide page


### PR DESCRIPTION
Many guide pages are not reachable from their parent page, which is a minus for discoverability and for consistent IA. This adds a "Guides" section to enforce consistent structure; afterwards I can send another PR to apply this structure to API pages.