### PR TITLE
chore: move EmbedGH live samples into the page

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -83,9 +83,12 @@ This method returns an `ImageData` object representing the pixel data for the ar
 
 This method is also demonstrated in the article [Manipulating video using canvas](/en-US/docs/Web/API/Canvas_API/Manipulating_video_using_canvas).
 
-### A color picker
+## Creating a color picker
 
-In this example, we are using the [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method to display the color under the mouse cursor. For this, we need the current position of the mouse, then we look up the pixel data at that position in the pixel array that [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) provides. Finally, we use the array data to set a background color and a text in the `<div>` to display the color. Clicking on the image will do the same operation but uses the selected color.
+In this example, we are using the [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method to display the color under the mouse cursor.
+For this, we need the current position of the mouse, then we look up the pixel data at that position in the pixel array that [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) provides.
+Finally, we use the array data to set a background color and a text in the `<div>` to display the color.
+Clicking on the image will do the same operation but uses the selected color.
 
 ```html
 <table>
@@ -156,9 +159,10 @@ td {
 }
 ```
 
-Hover your cursor anywhere over the image to see the result in the "Hovered color" column. Click anywhere in the image to see the result in the "Selected color" column. 
+Hover your cursor anywhere over the image to see the result in the "Hovered color" column.
+Click anywhere in the image to see the result in the "Selected color" column.
 
-{{embedlivesample("", , 300)}}
+{{embedlivesample("creating_a_color_picker", , 300)}}
 
 ## Painting pixel data into a context
 
@@ -176,9 +180,12 @@ For example, to paint the entire image represented by `myImageData` to the top l
 ctx.putImageData(myImageData, 0, 0);
 ```
 
-### Grayscaling and inverting colors
+## Grayscaling and inverting colors
 
-In this example, we iterate over all pixels to change their values, then we put the modified pixel array back onto the canvas using [putImageData()](/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData). The `invert` function subtracts each color from the max value, `255`. The `grayscale` function uses the average of red, green and blue. You can also use a weighted average, given by the formula `x = 0.299r + 0.587g + 0.114b`, for example. See [Grayscale](https://en.wikipedia.org/wiki/Grayscale) on Wikipedia for more information.
+In this example, we iterate over all pixels to change their values, then we put the modified pixel array back onto the canvas using [putImageData()](/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData).
+The `invert` function subtracts each color from the max value, `255`.
+The `grayscale` function uses the average of red, green and blue. You can also use a weighted average, given by the formula `x = 0.299r + 0.587g + 0.114b`, for example.
+See [Grayscale](https://en.wikipedia.org/wiki/Grayscale) on Wikipedia for more information.
 
 ```html
 <canvas id="canvas" width="300" height="227"></canvas>
@@ -273,7 +280,7 @@ for (const input of inputs) {
 
 Click different options to view the result in action.
 
-{{embedlivesample("", , 300)}}
+{{embedlivesample("grayscaling_and_inverting_colors", , 300)}}
 
 ## Zooming and anti-aliasing
 
@@ -357,7 +364,7 @@ function draw(img) {
 }
 ```
 
-{{embedlivesample("", , 300)}}
+{{embedlivesample("zooming_and_anti-aliasing", , 300)}}
 
 ## Saving images
 

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -124,7 +124,7 @@ img.addEventListener("load", () => {
 const hoveredColor = document.getElementById("hovered-color");
 const selectedColor = document.getElementById("selected-color");
 
-function pick(event, destination) {
+const pick = (event, destination) => {
   const bounding = canvas.getBoundingClientRect();
   const x = event.clientX - bounding.left;
   const y = event.clientY - bounding.top;
@@ -136,7 +136,7 @@ function pick(event, destination) {
   destination.textContent = rgbColor;
 
   return rgbColor;
-}
+};
 
 canvas.addEventListener("mousemove", (event) => pick(event, hoveredColor));
 canvas.addEventListener("click", (event) => pick(event, selectedColor));
@@ -205,13 +205,12 @@ See [Grayscale](https://en.wikipedia.org/wiki/Grayscale) on Wikipedia for more i
 ```
 
 ```js
-const img = new Image();
-img.crossOrigin = "anonymous";
-img.src = "/shared-assets/images/examples/rhino.jpg";
-
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
+const img = new Image();
+img.crossOrigin = "anonymous";
+img.src = "/shared-assets/images/examples/rhino.jpg";
 img.onload = () => {
   ctx.drawImage(img, 0, 0);
 };
@@ -328,10 +327,10 @@ img.onload = () => {
   draw(img);
 };
 
-function draw(img) {
+const draw = (image) => {
   const canvas = document.getElementById("canvas");
   const ctx = canvas.getContext("2d");
-  ctx.drawImage(img, 0, 0);
+  ctx.drawImage(image, 0, 0);
 
   const smoothCtx = document.getElementById("smoothed").getContext("2d");
   smoothCtx.imageSmoothingEnabled = true;
@@ -340,19 +339,10 @@ function draw(img) {
   pixelatedCtx.imageSmoothingEnabled = false;
 
   const zoom = (ctx, x, y) => {
-    const imageData = ctx.getImageData(
-      Math.min(Math.max(0, x - 5), img.width - 10),
-      Math.min(Math.max(0, y - 5), img.height - 10),
-      10,
-      10,
-    );
-
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-
     ctx.drawImage(
       canvas,
-      Math.min(Math.max(0, x - 5), img.width - 10),
-      Math.min(Math.max(0, y - 5), img.height - 10),
+      Math.min(Math.max(0, x - 5), image.width - 10),
+      Math.min(Math.max(0, y - 5), image.height - 10),
       10,
       10,
       0,
@@ -368,7 +358,7 @@ function draw(img) {
     zoom(smoothCtx, x, y);
     zoom(pixelatedCtx, x, y);
   });
-}
+};
 ```
 
 {{embedlivesample("zooming_and_anti-aliasing", , 300)}}

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -87,10 +87,31 @@ This method is also demonstrated in the article [Manipulating video using canvas
 
 In this example we are using the [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method to display the color under the mouse cursor. For this, we need the current position of the mouse, then we look up the pixel data on that position in the pixel array that [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) provides us. Finally, we use the array data to set a background color and a text in the `<div>` to display the color. Clicking on the image will do the same operation but remember what the selected color was.
 
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Source</th>
+      <th>Hovered color</th>
+      <th>Selected color</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <canvas id="canvas" width="300" height="227"></canvas>
+      </td>
+      <td class="color-cell" id="hovered-color"></td>
+      <td class="color-cell" id="selected-color"></td>
+    </tr>
+  </tbody>
+</table>
+```
+
 ```js
 const img = new Image();
 img.crossOrigin = "anonymous";
-img.src = "./assets/rhino.jpg";
+img.src = "/shared-assets/images/examples/rhino.jpg";
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 img.addEventListener("load", () => {
@@ -118,11 +139,24 @@ canvas.addEventListener("mousemove", (event) => pick(event, hoveredColor));
 canvas.addEventListener("click", (event) => pick(event, selectedColor));
 ```
 
-The code's usage is demonstrated in the following live example:
+```css hidden
+body {
+  font-family: sans-serif;
+}
+.color-cell {
+  color: white;
+}
+th {
+  width: 30%;
+}
+td {
+  font-family: monospace;
+  font-weight: bold;
+  padding-left: 1rem;
+}
+```
 
-{{EmbedGHLiveSample("dom-examples/canvas/pixel-manipulation/color-picker.html", '100%', 300)}}
-
-Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/main/canvas/pixel-manipulation/color-picker.html), [JavaScript](https://github.com/mdn/dom-examples/blob/main/canvas/pixel-manipulation/color-picker.js).
+{{embedlivesample("", , 300)}}
 
 ## Painting pixel data into a context
 
@@ -144,10 +178,27 @@ ctx.putImageData(myImageData, 0, 0);
 
 In this example we iterate over all pixels to change their values, then we put the modified pixel array back to the canvas using [putImageData()](/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData). The invert function subtracts each color from the max value 255. The grayscale function uses the average of red, green and blue. You can also use a weighted average, given by the formula `x = 0.299r + 0.587g + 0.114b`, for example. See [Grayscale](https://en.wikipedia.org/wiki/Grayscale) on Wikipedia for more information.
 
+```html
+<canvas id="canvas" width="300" height="227"></canvas>
+<form>
+  <input type="radio" id="original" name="color" value="original" checked />
+  <label for="original">Original</label>
+
+  <input type="radio" id="grayscale" name="color" value="grayscale" />
+  <label for="grayscale">Grayscale</label>
+
+  <input type="radio" id="inverted" name="color" value="inverted" />
+  <label for="inverted">Inverted</label>
+
+  <input type="radio" id="sepia" name="color" value="sepia" />
+  <label for="sepia">Sepia</label>
+</form>
+```
+
 ```js
 const img = new Image();
 img.crossOrigin = "anonymous";
-img.src = "./assets/rhino.jpg";
+img.src = "/shared-assets/images/examples/rhino.jpg";
 
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
@@ -185,6 +236,22 @@ const grayscale = () => {
   ctx.putImageData(imageData, 0, 0);
 };
 
+const sepia = () => {
+  ctx.drawImage(img, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    let r = data[i], // red
+      g = data[i + 1], // green
+      b = data[i + 2]; // blue
+
+    data[i] = Math.min(Math.round(0.393 * r + 0.769 * g + 0.189 * b), 255);
+    data[i + 1] = Math.min(Math.round(0.349 * r + 0.686 * g + 0.168 * b), 255);
+    data[i + 2] = Math.min(Math.round(0.272 * r + 0.534 * g + 0.131 * b), 255);
+  }
+  ctx.putImageData(imageData, 0, 0);
+};
+
 const inputs = document.querySelectorAll("[name=color]");
 for (const input of inputs) {
   input.addEventListener("change", (evt) => {
@@ -193,6 +260,8 @@ for (const input of inputs) {
         return invert();
       case "grayscale":
         return grayscale();
+      case "sepia":
+        return sepia();
       default:
         return original();
     }
@@ -200,38 +269,50 @@ for (const input of inputs) {
 }
 ```
 
-The code's usage is demonstrated in the following live example:
-
-{{EmbedGHLiveSample("dom-examples/canvas/pixel-manipulation/color-manipulation.html", '100%', 300)}}
-
-Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/main/canvas/pixel-manipulation/color-manipulation.html), [JavaScript](https://github.com/mdn/dom-examples/blob/main/canvas/pixel-manipulation/color-manipulation.js).
+{{embedlivesample("", , 300)}}
 
 ## Zooming and anti-aliasing
 
-With the help of the {{domxref("CanvasRenderingContext2D.drawImage", "drawImage()")}} method, a second canvas and the {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} property, we are able to zoom into our picture and see the details. A third canvas without {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} is also drawn onto to be able to have a side by side comparison
+With the help of the {{domxref("CanvasRenderingContext2D.drawImage", "drawImage()")}} method, a second canvas and the {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} property, we are able to zoom into our picture and see the details. A third canvas without {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} is also drawn onto to be able to have a side by side comparison.
 
-We get the position of the mouse and crop an image of 5 pixels left and above to 5 pixels right and below. Then we copy that one over to another canvas and resize the image to the size we want it to. In the zoom canvas we resize a 10×10 pixel crop of the original canvas to 200×200.
-
-```js
-zoomCtx.drawImage(
-  canvas,
-  Math.min(Math.max(0, x - 5), img.width - 10),
-  Math.min(Math.max(0, y - 5), img.height - 10),
-  10,
-  10,
-  0,
-  0,
-  200,
-  200,
-);
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Source</th>
+      <th>Smoothing enabled = true</th>
+      <th>Smoothing enabled = false</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <canvas id="canvas" width="300" height="227"></canvas>
+      </td>
+      <td>
+        <canvas id="smoothed-zoom" width="200" height="200"></canvas>
+      </td>
+      <td>
+        <canvas id="pixelated-zoom" width="200" height="200"></canvas>
+      </td>
+    </tr>
+  </tbody>
+</table>
 ```
 
-Zoom example:
+```css hidden
+body {
+  font-family: monospace;
+}
+```
+
+We get the position of the mouse and crop an image of 5 pixels left and above to 5 pixels right and below.
+Then we copy that one over to another canvas and resize the image to the size we want it to. In the zoom canvas we resize a 10×10 pixel crop of the original canvas to 200×200:
 
 ```js
 const img = new Image();
 img.crossOrigin = "anonymous";
-img.src = "./assets/rhino.jpg";
+img.src = "/shared-assets/images/examples/rhino.jpg";
 img.onload = () => {
   draw(this);
 };
@@ -241,15 +322,13 @@ function draw(img) {
   const ctx = canvas.getContext("2d");
   ctx.drawImage(img, 0, 0);
 
-  const smoothedZoomCtx = document
-    .getElementById("smoothed-zoom")
-    .getContext("2d");
-  smoothedZoomCtx.imageSmoothingEnabled = true;
+  const smoothCtx = document.getElementById("smoothed-zoom").getContext("2d");
+  smoothCtx.imageSmoothingEnabled = true;
 
-  const pixelatedZoomCtx = document
+  const pixelatedCtx = document
     .getElementById("pixelated-zoom")
     .getContext("2d");
-  pixelatedZoomCtx.imageSmoothingEnabled = false;
+  pixelatedCtx.imageSmoothingEnabled = false;
 
   const zoom = (ctx, x, y) => {
     ctx.drawImage(
@@ -268,17 +347,13 @@ function draw(img) {
   canvas.addEventListener("mousemove", (event) => {
     const x = event.layerX;
     const y = event.layerY;
-    zoom(smoothedZoomCtx, x, y);
-    zoom(pixelatedZoomCtx, x, y);
+    zoom(smoothCtx, x, y);
+    zoom(pixelatedCtx, x, y);
   });
 }
 ```
 
-The code's usage is demonstrated in the following live example:
-
-{{EmbedGHLiveSample("dom-examples/canvas/pixel-manipulation/image-smoothing.html", '100%', 300)}}
-
-Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/main/canvas/pixel-manipulation/image-smoothing.html), [JavaScript](https://github.com/mdn/dom-examples/blob/main/canvas/pixel-manipulation/image-smoothing.js).
+{{embedlivesample("", , 300)}}
 
 ## Saving images
 

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -85,7 +85,7 @@ This method is also demonstrated in the article [Manipulating video using canvas
 
 ### A color picker
 
-In this example we are using the [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method to display the color under the mouse cursor. For this, we need the current position of the mouse, then we look up the pixel data on that position in the pixel array that [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) provides us. Finally, we use the array data to set a background color and a text in the `<div>` to display the color. Clicking on the image will do the same operation but remember what the selected color was.
+In this example, we are using the [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) method to display the color under the mouse cursor. For this, we need the current position of the mouse, then we look up the pixel data at that position in the pixel array that [`getImageData()`](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData) provides. Finally, we use the array data to set a background color and a text in the `<div>` to display the color. Clicking on the image will do the same operation but uses the selected color.
 
 ```html
 <table>
@@ -156,6 +156,8 @@ td {
 }
 ```
 
+Hover your cursor anywhere over the image to see the result in the "Hovered color" column. Click anywhere in the image to see the result in the "Selected color" column. 
+
 {{embedlivesample("", , 300)}}
 
 ## Painting pixel data into a context
@@ -176,7 +178,7 @@ ctx.putImageData(myImageData, 0, 0);
 
 ### Grayscaling and inverting colors
 
-In this example we iterate over all pixels to change their values, then we put the modified pixel array back to the canvas using [putImageData()](/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData). The invert function subtracts each color from the max value 255. The grayscale function uses the average of red, green and blue. You can also use a weighted average, given by the formula `x = 0.299r + 0.587g + 0.114b`, for example. See [Grayscale](https://en.wikipedia.org/wiki/Grayscale) on Wikipedia for more information.
+In this example, we iterate over all pixels to change their values, then we put the modified pixel array back onto the canvas using [putImageData()](/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData). The `invert` function subtracts each color from the max value, `255`. The `grayscale` function uses the average of red, green and blue. You can also use a weighted average, given by the formula `x = 0.299r + 0.587g + 0.114b`, for example. See [Grayscale](https://en.wikipedia.org/wiki/Grayscale) on Wikipedia for more information.
 
 ```html
 <canvas id="canvas" width="300" height="227"></canvas>
@@ -269,11 +271,13 @@ for (const input of inputs) {
 }
 ```
 
+Click different options to view the result in action.
+
 {{embedlivesample("", , 300)}}
 
 ## Zooming and anti-aliasing
 
-With the help of the {{domxref("CanvasRenderingContext2D.drawImage", "drawImage()")}} method, a second canvas and the {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} property, we are able to zoom into our picture and see the details. A third canvas without {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} is also drawn onto to be able to have a side by side comparison.
+With the help of the {{domxref("CanvasRenderingContext2D.drawImage", "drawImage()")}} method, a second canvas, and the {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} property, we are able to zoom in on our picture and see the details. A third canvas without {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}} is also drawn to allow a side by side comparison.
 
 ```html
 <table>

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -301,10 +301,10 @@ With the help of the {{domxref("CanvasRenderingContext2D.drawImage", "drawImage(
         <canvas id="canvas" width="300" height="227"></canvas>
       </td>
       <td>
-        <canvas id="smoothed-zoom" width="200" height="200"></canvas>
+        <canvas id="smoothed" width="200" height="200"></canvas>
       </td>
       <td>
-        <canvas id="pixelated-zoom" width="200" height="200"></canvas>
+        <canvas id="pixelated" width="200" height="200"></canvas>
       </td>
     </tr>
   </tbody>
@@ -325,7 +325,7 @@ const img = new Image();
 img.crossOrigin = "anonymous";
 img.src = "/shared-assets/images/examples/rhino.jpg";
 img.onload = () => {
-  draw(this);
+  draw(img);
 };
 
 function draw(img) {
@@ -333,15 +333,22 @@ function draw(img) {
   const ctx = canvas.getContext("2d");
   ctx.drawImage(img, 0, 0);
 
-  const smoothCtx = document.getElementById("smoothed-zoom").getContext("2d");
+  const smoothCtx = document.getElementById("smoothed").getContext("2d");
   smoothCtx.imageSmoothingEnabled = true;
 
-  const pixelatedCtx = document
-    .getElementById("pixelated-zoom")
-    .getContext("2d");
+  const pixelatedCtx = document.getElementById("pixelated").getContext("2d");
   pixelatedCtx.imageSmoothingEnabled = false;
 
   const zoom = (ctx, x, y) => {
+    const imageData = ctx.getImageData(
+      Math.min(Math.max(0, x - 5), img.width - 10),
+      Math.min(Math.max(0, y - 5), img.height - 10),
+      10,
+      10,
+    );
+
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
     ctx.drawImage(
       canvas,
       Math.min(Math.max(0, x - 5), img.width - 10),


### PR DESCRIPTION
### Description

Move three related gh live samples into the page.

### Motivation

These are easier to maintain, and the complete code can be directly explored / broken out into the playground. Most of the code is already there, this adds the necessary bits to make it work as a live sample.

