### PR TITLE
fix(css): Improve description of `:hover` pseudo-class

### DIFF
--- a/files/en-us/web/css/_colon_hover/index.md
+++ b/files/en-us/web/css/_colon_hover/index.md
@@ -6,7 +6,7 @@ browser-compat: css.selectors.hover
 sidebar: cssref
 ---
 
-The **`:hover`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches when the user interacts with an element with a pointing device, but does not necessarily activate it. It is generally triggered when the user hovers over an element with the cursor (mouse pointer).
+The **`:hover`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches an element when a user interacts with it using a pointing device. The pseudo-class is generally triggered when the user moves the cursor (mouse pointer) over an element without pressing the mouse button.
 
 {{InteractiveExample("CSS Demo: :hover", "tabbed-shorter")}}
 


### PR DESCRIPTION
### Description

This PR:
- Changes the phrasing to follow this approach: "matches {what} when a user {action}".
- Removes "but does not necessarily activate it" because it's not very clear and can cause confusion. This idea is also being explained in the next sentence.
- spells out "activate" as "pressing the mouse button" in the second sentence.

### Motivation

I came across this page randomly and noticed a scope to improve for clarity.

