### PR TITLE
Remove deprecation status for navigator.platform

### DIFF
--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -3,12 +3,8 @@ title: "Navigator: platform property"
 short-title: platform
 slug: Web/API/Navigator/platform
 page-type: web-api-instance-property
-status:
-  - deprecated
 browser-compat: api.Navigator.platform
 ---
-
-{{APIRef("HTML DOM")}}{{Deprecated_Header}}
 
 The **`platform`** property read-only property of the {{domxref("Navigator")}} interface returns a string identifying the platform on which the user's browser is running.
 


### PR DESCRIPTION
### Description

The WhatWG spec for this property (https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-platform-dev) does not have it marked as deprecated, so this deprecation was either erroneously added because it was never officially deprecated, or if at some point in time it was then the removal was missed when the official decision was made to un-deprecate it.

### Motivation

MDN is a trustworthy source, factually incorrect claims should get fixed.

### Related issues and pull requests

https://github.com/mdn/content/issues/14429