### PR TITLE
Add `interactive-widget` to viewport reference

### DIFF
--- a/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
@@ -52,6 +52,12 @@ A `<meta name="viewport">` element has the following additional attributes:
         >
         > - [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
         > - [Understanding Success Criterion 1.4.4 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html)
+    - `interactive-widget`
+      - : Specifies the effect that interactive UI widgets, such as virtual keyboards, have on a page's viewport.
+        It can be the keyword `resizes-visual`, `resizes-content`, or `overlays-content`.
+        - `resizes-visual`: The {{Glossary("visual viewport")}} gets resized by the interactive widget. This is the default.
+        - `resizes-content`: The {{Glossary("viewport")}} gets resized by the interactive widget.
+        - `overlays-content`: Neither the viewport nor the visual viewport gets resized by the interactive widget.
     - `viewport-fit`
       - : Defines the viewable portions of the web page.
         It can be one of the keywords `auto`, `contain`, or `cover`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Adds `interactive-widget` to the `<meta name="viewport">` reference documentation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

`interactive-widget` was documented only in the guide at https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Viewport_meta_element … I was confused when it was missing from the reference materials.

I copied and pasted the core features from the guide into this PR, with updates from @estelle 

### Related issues and pull requests

FYI, BCD data for this page is broken. https://github.com/mdn/browser-compat-data/issues/25311 (That's unrelated to my changes here.) There's an in-progress PR https://github.com/mdn/browser-compat-data/pull/25392 to address it.