### PR TITLE
Replace all broken links in FF relnote with wayback machine

### DIFF
--- a/files/en-us/mozilla/firefox/releases/1.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/index.md
@@ -15,7 +15,7 @@ Several tools and browser extensions are available to help developers support Fi
 - [DOM Inspector](https://firefox-source-docs.mozilla.org/devtools-user/dom_property_viewer/index.html), a tool that allows developers to inspect and modify documents without having to edit the document directly. DOM Inspector is available as part of the Custom install option in Firefox 1.5 under Developer Tools.
 - JavaScript console, a tool to write and test JavaScript code as well as view JavaScript and CSS errors on a page.
 - View page source, with syntax highlighting and find features.
-- [Browser extensions](https://addons.mozilla.org/en-US/firefox/search/?q=Developer%20Tools) including the [FireBug](https://web.archive.org/web/20061205073236/http://www.joehewitt.com/software/firebug/), [Web Developer toolbar](</en-US/docs/Web_Developer_Extension_(external)>), [Live HTTP Headers](</en-US/docs/Live_HTTP_Headers_(external)>), [HTML Validator](</en-US/docs/HTML_Validator_(external)>) and many more.
+- [Browser extensions](https://addons.mozilla.org/en-US/firefox/search/?q=Developer%20Tools) including the [FireBug](https://web.archive.org/web/20061205073236/http://www.joehewitt.com/software/firebug/), [Web Developer toolbar](https://addons.mozilla.org/en-US/firefox/addon/web-developer/), [Live HTTP Headers](https://web.archive.org/web/20200628024648/http://livehttpheaders.mozdev.org/), [HTML Validator](https://validator.w3.org/) and many more.
 
 > [!NOTE]
 > Some extensions do not currently support Firefox 1.5, and will be automatically disabled.
@@ -27,7 +27,7 @@ Some of the new features in Firefox 1.5:
 ### Website and application developers
 
 - SVG is supported in XHTML
-  - : SVG can be used in XHTML pages. JavaScript and CSS can be used to manipulate the picture in the same way you would script regular XHTML. See [SVG in Firefox](/en-US/docs/Web/SVG/SVG_1.1_Support_in_Firefox) to learn about the status and known problems of SVG implementation in Firefox.
+  - : SVG can be used in XHTML pages. JavaScript and CSS can be used to manipulate the picture in the same way you would script regular XHTML. See [SVG in Firefox](https://web.archive.org/web/20210413180914/https://developer.mozilla.org/en-US/docs/Web/SVG/SVG_1.1_Support_in_Firefox) to learn about the status and known problems of SVG implementation in Firefox.
 - [Drawing Graphics with Canvas](/en-US/docs/Web/API/Canvas_API/Tutorial)
   - : Learn about the new `<canvas>` tag and how to draw graphs and other objects in Firefox.
 - [CSS3 Columns](/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts)
@@ -39,15 +39,15 @@ Some of the new features in Firefox 1.5:
 
 - [Building an Extension](/en-US/docs/Mozilla/Add-ons)
   - : This tutorial will take you through the steps required to build a very basic extension for Firefox. Also see [another tutorial on MozillaZine knowledge base](https://kb.mozillazine.org/Getting_started_with_extension_development), which demonstrates the new features of the Extension Manager in 1.5 that make creating a new extension even easier.
-- [XPCNativeWrapper](/en-US/docs/XPCNativeWrapper)
-  - : `XPCNativeWrapper` is a way to wrap up an object so that it's [safe to access from privileged code](/en-US/docs/Safely_accessing_content_DOM_from_chrome). It can be used in all Firefox versions, though the behavior changed somewhat starting with Firefox 1.5 (Gecko 1.8).
-- [Preferences System](/en-US/docs/Preferences_System)
+- [XPCNativeWrapper](https://web.archive.org/web/20140604075216/https://developer.mozilla.org/en-US/docs/XPCNativeWrapper)
+  - : `XPCNativeWrapper` is a way to wrap up an object so that it's [safe to access from privileged code](https://web.archive.org/web/20130905110328/https://developer.mozilla.org/en-US/docs/Safely_accessing_content_DOM_from_chrome). It can be used in all Firefox versions, though the behavior changed somewhat starting with Firefox 1.5 (Gecko 1.8).
+- [Preferences System](https://web.archive.org/web/20210620034317/https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preferences_system)
   - : Learn about the new widgets that allow you to create Options windows easier using less JavaScript code.
-- [International characters in XUL JavaScript](/en-US/docs/International_characters_in_XUL_JavaScript)
+- [International characters in XUL JavaScript](https://web.archive.org/web/20210126100844/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/International_characters_in_XUL_JavaScript)
   - : XUL JavaScript files can now contain non-{{Glossary("ASCII")}} characters.
-- [Tree API changes](/en-US/docs/Tree_Widget_Changes)
+- [Tree API changes](https://web.archive.org/web/20210414021241/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/Tree_Widget_Changes)
   - : The interfaces for accessing XUL `<tree>` elements have changed.
-- [XUL Changes for Firefox 1.5](/en-US/docs/XUL_Changes_for_Firefox_1.5)
+- [XUL Changes for Firefox 1.5](https://web.archive.org/web/20200812075014/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/XUL_Changes_for_Firefox_1.5)
   - : Summary of XUL changes.
 
 #### Networking-related changes
@@ -89,7 +89,7 @@ Firefox support for Web standards continues to lead the industry with consistent
 - Simple Object Access Protocol (SOAP): [SOAP 1.1](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/)
 - [JavaScript](/en-US/docs/Web/JavaScript) 1.6, based on [ECMA-262, revision 3](https://ecma-international.org/publications-and-standards/standards/ecma-262/)
 
-Firefox 1.5 supports the following data transport protocols (HTTP, FTP, SSL, TLS, and others), multilingual character data (Unicode), graphics (GIF, JPEG, PNG, SVG, and others) and the latest version of the world's most popular scripting language, [JavaScript 1.6](/en-US/docs/New_in_JavaScript_1.6).
+Firefox 1.5 supports the following data transport protocols (HTTP, FTP, SSL, TLS, and others), multilingual character data (Unicode), graphics (GIF, JPEG, PNG, SVG, and others) and the latest version of the world's most popular scripting language, [JavaScript 1.6](https://web.archive.org/web/20210623231028/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/1.6).
 
 ## Changes since Firefox 1.0
 

--- a/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
@@ -80,7 +80,7 @@ This page is based largely on [https://www.squarefree.com/burningedg...eases/](h
   - : The Mozilla networking library now supports the prioritization of connections to a specific server using `nsISupportsPriority`. [Firefox bug 278531](https://bugzil.la/278531)
 
 - API for managing user and UA stylesheets
-  - : Extensions can now register stylesheet URIs as additional user and UA stylesheets. This means extensions no longer have to try to edit `userContent.css` to add styling (say for XBL binding attachment) to web pages. See [Using the Stylesheet Service](/en-US/docs/Archive/Add-ons/Using_the_Stylesheet_Service).
+  - : Extensions can now register stylesheet URIs as additional user and UA stylesheets. This means extensions no longer have to try to edit `userContent.css` to add styling (say for XBL binding attachment) to web pages. See [Using the Stylesheet Service](https://web.archive.org/web/20210413211020/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Using_the_Stylesheet_Service).
 
 - API for configuring proxies
   - : It is now possible for extensions to easily override the proxy configuration without affecting user-visible preferences. See `nsIProtocolProxyService`, `nsIProtocolProxyFilter`, and `nsIProtocolProxyCallback`. [Firefox bug 282442](https://bugzil.la/282442)
@@ -100,7 +100,7 @@ This page is based largely on [https://www.squarefree.com/burningedg...eases/](h
 
 - Toolkit chrome registry
   - : Chrome registration has been significantly improved to use simple plaintext chrome registration manifests, and no longer keeps the chrome.rdf/overlayinfo cache.
-    See [Chrome Registration](/en-US/docs/Mozilla/Chrome_Registration).
+    See [Chrome Registration](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration).
 
 - Extension Manager
   - : Following are the new features:

--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -119,16 +119,16 @@ Great progress has been made to update IndexedDB to the latest draft specificati
 For an overview of likely issues that may arise when updating your add-ons to support Firefox 10, see [Updating add-ons for Firefox 10](/en-US/docs/Mozilla/Firefox/Releases/10/Updating_add-ons).
 
 > [!NOTE]
-> The old [`PRBool`](/en-US/docs/PRBool) data type has been retired! Anywhere in the documentation that refers to it now uses the standard C++ `bool` type instead. Documentation will be updated in the future, but for now, just keep this in mind.
+> The old [`PRBool`](https://web.archive.org/web/20210224213411/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR/Reference/PRBool) data type has been retired! Anywhere in the documentation that refers to it now uses the standard C++ `bool` type instead. Documentation will be updated in the future, but for now, just keep this in mind.
 
 ### Manifests
 
-- Support for [`<em:strictCompatibility>`](/en-US/docs/Install_Manifests#strictcompatibility) has been added to the install manifest. It allows add-ons authors to opt in to checking the maximum version of their extension. If set to `true` the add-on will be disabled if the application version is greater than `<em:maxVersion>`. Firefox 10 defaults to add-ons being compatible, regardless of their specified maximum version. This flag overrides that preference. You should set this if your add-on does things that are likely to be broken by Firefox updates, **but not** if your add-on has a binary component, since such add-ons always get strictly checked (remember that binary components must always be recompiled for each major Firefox release).
+- Support for [`<em:strictCompatibility>`](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#strictcompatibility) has been added to the install manifest. It allows add-ons authors to opt in to checking the maximum version of their extension. If set to `true` the add-on will be disabled if the application version is greater than `<em:maxVersion>`. Firefox 10 defaults to add-ons being compatible, regardless of their specified maximum version. This flag overrides that preference. You should set this if your add-on does things that are likely to be broken by Firefox updates, **but not** if your add-on has a binary component, since such add-ons always get strictly checked (remember that binary components must always be recompiled for each major Firefox release).
 - If you wish to revert to the old behavior — that is, to strict compatibility checking for all add-ons, regardless of the value of the `strictCompatibility` flag in their manifests, you can set the `extensions.strictCompatibility` preference to `true`.
 
 ### XUL
 
-- Bootstrapped add-ons using a `chrome.manifest` file now have the manifest file registered automatically. See the section [Adding user interface with a chrome.manifest](/en-US/docs/Extensions/Bootstrapped_extensions#Adding_user_interface_with_a_chrome.manifest) for details.
+- Bootstrapped add-ons using a `chrome.manifest` file now have the manifest file registered automatically. See the section [Adding user interface with a chrome.manifest](https://web.archive.org/web/20210519000929/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Bootstrapped_extensions#Adding_user_interface_with_a_chrome.manifest) for details.
 
 ### XPConnect
 

--- a/files/en-us/mozilla/firefox/releases/10/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/updating_add-ons/index.md
@@ -9,7 +9,7 @@ Although a lot of things have changed in Firefox 10 that, in theory, can cause a
 
 ## Compatible by default
 
-The first and most important thing to note is that starting in Firefox 10, add-ons are assumed to be compatible by default. Unless you use the [`<em:strictCompatibility>`](/en-US/docs/Install_Manifests#strictcompatibility) flag in your manifest, Firefox will no longer mark your add-on as incompatible after an upgrade to Firefox 10 or later. You can use that flag to ensure that an add-on that is likely to break will not try to run in updated copies of Firefox. It's worth noting that add-ons that have binary components will always be strictly checked for compatibility, since binary components always need to be recompiled for each major Firefox release.
+The first and most important thing to note is that starting in Firefox 10, add-ons are assumed to be compatible by default. Unless you use the [`<em:strictCompatibility>`](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#strictcompatibility) flag in your manifest, Firefox will no longer mark your add-on as incompatible after an upgrade to Firefox 10 or later. You can use that flag to ensure that an add-on that is likely to break will not try to run in updated copies of Firefox. It's worth noting that add-ons that have binary components will always be strictly checked for compatibility, since binary components always need to be recompiled for each major Firefox release.
 
 > [!NOTE]
 > You should still test your add-on on Firefox 10, even in the world of compatibility by default. Read over the rest of this article to see if there's anything you need to change.
@@ -28,7 +28,7 @@ Some obsolete APIs have been removed from the DOM:
 
 ## XPCOM and interface changes
 
-The most significant change is that everywhere that previously used the [`PRBool`](/en-US/docs/PRBool) data type now uses the standard C++ `bool` type instead.
+The most significant change is that everywhere that previously used the [`PRBool`](https://web.archive.org/web/20210224213411/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR/Reference/PRBool) data type now uses the standard C++ `bool` type instead.
 
 ### Removed interfaces
 
@@ -44,7 +44,7 @@ The following interfaces have been removed:
 ### Other interface changes
 
 - `nsNavHistory` no longer implements the `nsICharsetResolver` interface. **Note that `nsICharsetResolver` is no longer used and is being removed in Firefox 11.0**.
-- The `mozISpellCheckingEngine` and `nsIEditorSpellCheck` interfaces have been updated to let restartless add-ons add dictionaries to the spell checker. See [Using an external spell checker](/en-US/Using_an_External_Spell-checker) for details (note this article has not yet been updated, but will be soon).
+- The `mozISpellCheckingEngine` and `nsIEditorSpellCheck` interfaces have been updated to let restartless add-ons add dictionaries to the spell checker. See [Using an external spell checker](/en-US/docs/Mozilla/Firefox/Releases/3/Using_an_external_spell_checker) for details (note this article has not yet been updated, but will be soon).
 - The `nsIBrowserHistory.lastPageVisited` attribute has been removed, as it hasn't been supported for some time.
 - Several [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) internal interfaces have changed to support revised APIs. This shouldn't affect you but is worth noting on the off chance you were doing something unusual.
 
@@ -52,5 +52,5 @@ The following interfaces have been removed:
 
 - All binary components on Windows should be built with ASLR (address space layout randomization) support enabled. While this is not **yet** required, it may be in the future, and not enabling it results in a performance penalty.
 - A bug in regular expression handling that was introduced in Firefox 7 has been fixed. This can change the result of some regular expressions, so be aware of it.
-- You can now [dynamically load and unload chrome.manifest files in bootstrapped add-ons](/en-US/docs/Extensions/Bootstrapped_extensions#Adding_user_interface_with_a_chrome.manifest).
+- You can now [dynamically load and unload chrome.manifest files in bootstrapped add-ons](https://web.archive.org/web/20210519000929/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Bootstrapped_extensions#Adding_user_interface_with_a_chrome.manifest).
 - The `mouseenter` and `mouseleave` events are now supported.

--- a/files/en-us/mozilla/firefox/releases/11/index.md
+++ b/files/en-us/mozilla/firefox/releases/11/index.md
@@ -97,7 +97,7 @@ _No change._
 
 #### New JavaScript code modules
 
-- [`source-editor.jsm`](/en-US/docs/JavaScript_code_modules/source-editor.jsm)
+- [`source-editor.jsm`](https://web.archive.org/web/20210620193439/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.jsm)
   - : Provides a convenient, easy-to-use source code editor that you can use in your add-ons. This is the same editor used by _Scratchpad_ and other developer tools integrated into Firefox.
 
 ### Interface changes
@@ -116,7 +116,7 @@ The following interfaces were implementation details that are no longer needed:
 
 ### Theme-related changes
 
-- The `omni.jar` file is now called [`omni.ja`](</en-US/docs/Mozilla/About_omni.ja_(formerly_omni.jar)>).
+- The `omni.jar` file is now called [`omni.ja`](https://web.archive.org/web/20210620190432/https://developer.mozilla.org/en-US/docs/Mozilla/About_omni.ja_%28formerly_omni.jar%29).
 
 ### Preference changes
 

--- a/files/en-us/mozilla/firefox/releases/13/index.md
+++ b/files/en-us/mozilla/firefox/releases/13/index.md
@@ -60,7 +60,7 @@ Firefox 13 was shipped on June 5, 2012. This page summarizes the changes in Fire
 ### MathML
 
 - Support for the `width` attribute on {{MathMLElement("mtable")}} elements has been added ([Firefox bug 722880](https://bugzil.la/722880)).
-- [MathJax fonts](https://docs.mathjax.org/en/latest/output/fonts.html) are now used as the default fonts for mathematical text. See [Fonts for Mozilla's MathML engine](/en-US/docs/Mozilla_MathML_Project/Fonts) for more information.
+- [MathJax fonts](https://docs.mathjax.org/en/latest/output/fonts.html) are now used as the default fonts for mathematical text. See [Fonts for Mozilla's MathML engine](/en-US/docs/Web/MathML/Guides/Fonts) for more information.
 
 ### Network
 
@@ -95,13 +95,13 @@ Starting in Firefox 13, Firefox for Windows requires at least Windows XP Service
 - Support for a dirty flag has been added to the Source Editor API.
 - The Source Editor no longer supports falling back to a {{HTMLElement("textarea")}} instead of using Orion.
 - The editor now exposes focus and blur events.
-- The [`getIndentationString()`](/en-US/docs/JavaScript_code_modules/source-editor.jsm#getIndentationString%28%29) method has been added; this returns the string to use for indenting text in the editor.
+- The [`getIndentationString()`](https://web.archive.org/web/20210620193439/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.jsm#getIndentationString%28%29) method has been added; this returns the string to use for indenting text in the editor.
 - The Source Editor now supports managing a list of breakpoints and displaying user interface for toggling them on and off; it does not actually implement breakpoints, however. That's up to you to write debugger code for.
 - Support has been added for highlighting the current line, using the `highlightCurrentLine` configuration option.
 
 ### ARIA
 
-- The CSS properties {{cssxref("margin-left")}}, {{cssxref("margin-right")}}, {{cssxref("margin-top")}}, {{cssxref("margin-bottom")}} are now all reflected into ARIA object attributes with the same name. See [Gecko object attributes](/en-US/docs/Accessibility/AT-APIs/Gecko/Attrs) for more information.
+- The CSS properties {{cssxref("margin-left")}}, {{cssxref("margin-right")}}, {{cssxref("margin-top")}}, {{cssxref("margin-bottom")}} are now all reflected into ARIA object attributes with the same name. See [Gecko object attributes](https://web.archive.org/web/20210120101715/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Accessibility/AT-APIs/Gecko/Attrs) for more information.
 
 ### Interfaces
 

--- a/files/en-us/mozilla/firefox/releases/14/index.md
+++ b/files/en-us/mozilla/firefox/releases/14/index.md
@@ -57,7 +57,7 @@ _No change._
 
 - Added a keyboard shortcut to toggle commenting for the current selection (Ctrl-/ or Cmd-/ on Mac OS X).
 - Added the Ctrl-\[ and Ctrl-] keyboard shortcuts for moving the text input position to the beginning and end of the current block.
-- Added the new [`getLineStart()`](/en-US/docs/JavaScript_code_modules/source-editor.jsm#getLineStart%28%29) and [`getLineEnd()`](/en-US/docs/JavaScript_code_modules/source-editor.jsm#getLineEnd%28%29) methods.
+- Added the new [`getLineStart()`](https://web.archive.org/web/20210620193439/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.jsm#getLineStart%28%29) and [`getLineEnd()`](https://web.archive.org/web/20210620193439/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/source-editor.jsm#getLineEnd%28%29) methods.
 
 ### XUL
 
@@ -66,7 +66,7 @@ _No change._
 ### Interfaces
 
 - The `nsILocalFile` interface has been merged into `nsIFile` ([bug 682360](https://bugzil.la/682360)).
-- The methods in `nsIPlacesImportExportService` for importing bookmarks have all been removed in favor of the [`BookmarkHTMLUtils.jsm`](/en-US/docs/JavaScript_code_modules/BookmarkHTMLUtils.jsm) JavaScript code module.
+- The methods in `nsIPlacesImportExportService` for importing bookmarks have all been removed in favor of the `BookmarkHTMLUtils.jsm` JavaScript code module.
 - The `nsIDOMGeoPositionAddress` interface has been removed.
 - The `getItemGUID`, `setItemGUID` and `getItemIdForGUID` methods have been removed from `nsINavBookmarksService` ([Firefox bug 715355](https://bugzil.la/715355)).
 

--- a/files/en-us/mozilla/firefox/releases/16/index.md
+++ b/files/en-us/mozilla/firefox/releases/16/index.md
@@ -41,7 +41,7 @@ Firefox 16 shipped on October 9, 2012. This article lists key changes that are u
 - The [Battery API](/en-US/docs/Web/API/Navigator/getBattery) is now unprefixed.
 - The Vibration API has been unprefixed.
 - The non-standard `Keyboard` interface, prefixed as `mozKeyboard`, now has the `Keyboard.setSelectedOption()` and `Keyboard.setValue()` methods, as well as the `Keyboard.onfocuschange`. _This interface, only available for Firefox OS, has been removed in Firefox 31._
-- The [`java`](/en-US/docs/LiveConnect_Reference/java) and [`Packages`](/en-US/docs/LiveConnect_Reference/Packages) global objects have been removed. See [LiveConnect](/en-US/docs/LiveConnect).
+- The [`java`](https://web.archive.org/web/20201004062409/https://developer.mozilla.org/en-US/docs/Archive/Web/LiveConnect_Reference/java) and [`Packages`](https://web.archive.org/web/20201031083247/https://developer.mozilla.org/en-US/docs/Archive/Web/LiveConnect_Reference/Packages) global objects have been removed. See [LiveConnect](https://web.archive.org/web/20210516230302/https://developer.mozilla.org/en-US/docs/Archive/Web/LiveConnect).
 - The `CSSRule.type` associated with {{domxref("CSSNamespaceRule")}} has been updated from `UNKNOWN_RULE` (`0`) to `NAMESPACE_RULE` (`10`) ([bug 765590](https://bugzil.la/765590)).
 - WebSMS API: `SmsRequest` has been superseded by the more general `DOMRequest`.
 - The non-standard {{domxref("Element.scrollTopMax")}} and {{domxref("Element.scrollLeftMax")}} read-only properties have been added ([Firefox bug 766937](https://bugzil.la/766937)).
@@ -75,7 +75,7 @@ _No change._
 
 ## Changes for Open Web App developers
 
-- Initial [Open Web App support](/en-US/docs/Web/Apps/Getting_Started) has been implemented in the desktop versions of Firefox (that is, on Windows, Mac OS X, and Linux).
+- Initial [Open Web App support](https://web.archive.org/web/20190117093115/https://developer.mozilla.org/en-US/docs/Web/Apps/Getting_Started) has been implemented in the desktop versions of Firefox (that is, on Windows, Mac OS X, and Linux).
 
 ## Changes for add-on and Mozilla developers
 

--- a/files/en-us/mozilla/firefox/releases/2/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/index.md
@@ -14,21 +14,21 @@ Firefox 2 introduces a vast array of new features and capabilities. This article
 
 - [Microsummaries](https://wiki.mozilla.org/Microsummaries)
   - : Microsummaries are regularly-updated succinct compilations of the most important information on web pages. Site and third-party developers can both provide them, and users can choose to display microsummaries instead of static titles when they bookmark pages with microsummaries.
-- [Creating a Microsummary](/en-US/docs/Creating_a_Microsummary)
+- [Creating a Microsummary](https://web.archive.org/web/20210214003325/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Creating_a_microsummary)
   - : A tutorial on creating a microsummary generator.
-- [Microsummary XML grammar reference](/en-US/docs/Microsummary_XML_grammar_reference)
+- [Microsummary XML grammar reference](https://web.archive.org/web/20191011001930/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Microsummary_topics/XML_grammar_reference)
   - : A reference guide to the XML grammar used for creating microsummary generators.
 - [Creating OpenSearch plugins for Firefox](/en-US/docs/Web/XML/Guides/OpenSearch)
   - : Firefox 2 supports the OpenSearch search engine format.
-- [Creating MozSearch plugins](/en-US/docs/Creating_MozSearch_plugins)
+- [Creating MozSearch plugins](https://web.archive.org/web/20210411070858/https://developer.mozilla.org/en-US/docs/Mozilla/Creating_MozSearch_plugins)
   - : Firefox 2 supports MozSearch, a search plugin format based on OpenSearch, but intended only for internal use.
-- [Supporting search suggestions in search plugins](/en-US/docs/Supporting_search_suggestions_in_search_plugins)
+- [Supporting search suggestions in search plugins](https://web.archive.org/web/20191015161436/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins)
   - : How to make your MozSearch plugin support search suggestions, which appear in a drop-down list while typing in the search bar.
-- [New in JavaScript 1.7](/en-US/docs/New_in_JavaScript_1.7)
+- [New in JavaScript 1.7](https://web.archive.org/web/20210704072534/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/1.7)
   - : Firefox 2 supports JavaScript 1.7, which includes new features including `let`, destructuring assignment, generators and iterators, and array comprehensions.
 - [WHATWG Client-side session and persistent storage (aka DOM Storage)](/en-US/docs/Web/API/Web_Storage_API)
   - : Client-side session and persistent storage allows web applications to store structured data on the client side.
-- [SVG in Firefox](/en-US/docs/Web/SVG/SVG_1.1_Support_in_Firefox)
+- [SVG in Firefox](https://web.archive.org/web/20210413180914/https://developer.mozilla.org/en-US/docs/Web/SVG/SVG_1.1_Support_in_Firefox)
   - : Firefox 2 improves Scalable Vector Graphics (SVG) support, implementing the `<textPath>` element and adding support for some attributes not previously supported.
 - [Controlling spell checking in HTML forms](/en-US/docs/Web/HTML/Reference/Global_attributes/spellcheck)
   - : Firefox 2 includes support for inline spell checking in text areas and text fields. This article describes how to write your HTML to enable and disable spell checking on individual form elements.
@@ -39,23 +39,23 @@ Firefox 2 introduces a vast array of new features and capabilities. This article
 
 - [Updating extensions for Firefox 2](/en-US/docs/Mozilla/Firefox/Releases/2/Updating_extensions)
   - : Covers how to get your existing extensions to work with Firefox 2.
-- [Session store API](/en-US/docs/Session_store_API)
+- [Session store API](https://web.archive.org/web/20210401045237/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Session_store_API)
   - : Contributing items to be saved and restored across sessions in Firefox.
-- [Feed content access API](/en-US/docs/Feed_content_access_API)
+- [Feed content access API](https://web.archive.org/web/20191010031908/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Feed_content_access_API)
   - : API that lets developers access and parse RSS and Atom feeds.
-- [SAX support](/en-US/docs/SAX)
+- [SAX support](https://web.archive.org/web/20210315122336/http://developer.mozilla.org/en-US/docs/Archive/SAX)
   - : Event-based XML parser API.
 - [Adding search engines from web pages](/en-US/docs/Web/XML/Guides/OpenSearch)
   - : JavaScript code can instruct Firefox to install a new search engine plugin, which can be written using either OpenSearch or Sherlock format.
-- [Using spell checking in XUL](/en-US/docs/Using_spell_checking_in_XUL)
+- [Using spell checking in XUL](https://web.archive.org/web/20191009211612/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Using_spell_checking_in_XUL)
   - : How to check the spelling of words or get a list of suggested spellings from code.
-- [Adding phishing protection data providers](/en-US/docs/Adding_phishing_protection_data_providers)
+- [Adding phishing protection data providers](https://web.archive.org/web/20210219151809/https://developer.mozilla.org/en-US/docs/Mozilla/Adding_phishing_protection_data_providers)
   - : It's possible to enhance Firefox's phishing protection by adding additional data providers for the safe browsing system.
 - [Adding feed readers to Firefox](/en-US/docs/Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox)
   - : You can add new feed readers to Firefox, whether web-based or application-based.
-- [Storage](/en-US/docs/Storage)
+- [Storage](https://web.archive.org/web/20210401045303/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Storage)
   - : Firefox 2 introduces mozStorage, an sqlite based database architecture.
-- [Theme changes in Firefox 2](/en-US/docs/Theme_changes_in_Firefox_2)
+- [Theme changes in Firefox 2](https://web.archive.org/web/20191005020825/https://developer.mozilla.org/en-US/Add-ons/Themes/Obsolete/Theme_changes_in_Firefox_2)
   - : Discusses the changes needed to update existing themes to work in Firefox 2.
 - Textbox Improvements (Firefox 2.0.0.1 and higher only)
   - : The `<textbox>` now has a `reset()` method to reset the value of the textbox to the default value. The `defaultValue` property may be used to retrieve and modify the default value of the textbox ([Firefox bug 312867](https://bugzil.la/312867)). Supports an `editor` property to get the internal `nsIEditor` for the text field ([WebKit bug 312867](https://bugzil.la/312867)).

--- a/files/en-us/mozilla/firefox/releases/2/security_changes/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/security_changes/index.md
@@ -27,4 +27,4 @@ As always, you can find out what ciphers are supported — and which are enabled
 
 ## Security improved for the jar: protocol
 
-In order to correct a potential security problem when using the `jar:` protocol, it's now necessary to serve JAR files with the MIME type `application/java-archive`. See [Security and the jar protocol](/en-US/docs/Security_and_the_jar_protocol) for further details.
+In order to correct a potential security problem when using the `jar:` protocol, it's now necessary to serve JAR files with the MIME type `application/java-archive`. See [Security and the jar protocol](https://web.archive.org/web/20180706040540/https://developer.mozilla.org/en-US/docs/Mozilla/Security/Security_and_the_jar_protocol) for further details.

--- a/files/en-us/mozilla/firefox/releases/2/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/updating_extensions/index.md
@@ -9,18 +9,18 @@ This article provides information that will be useful to developers that wish to
 
 ## Step 1: Update the install manifest
 
-The first step — and, for most extensions, the only one that will be needed — is to update the [install manifest](/en-US/Install_Manifests) file, install.rdf, to indicate compatibility with Firefox 2.
+The first step — and, for most extensions, the only one that will be needed — is to update the [install manifest](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests) file, install.rdf, to indicate compatibility with Firefox 2.
 
 Find the line indicating the maximum compatible version of Firefox (which, for Firefox 1.5, might look like this):
 
-```bash
- <em:maxVersion>1.5.0.*</em:maxVersion>
+```xml
+<em:maxVersion>1.5.0.*</em:maxVersion>
 ```
 
 Change it to indicate compatibility with Firefox 2:
 
-```bash
- <em:maxVersion>2.0.0.*</em:maxVersion>
+```xml
+<em:maxVersion>2.0.0.*</em:maxVersion>
 ```
 
 Then reinstall your extension.
@@ -29,7 +29,7 @@ Then reinstall your extension.
 
 Firefox 2 incorporates changes to the default skin. Additionally, some user interface elements have been changed or moved, and it's possible your extension may be affected by these, depending on what your XUL overlays do.
 
-Look over the article [Theme changes in Firefox 2](/en-US/Theme_changes_in_Firefox_2) to learn what changes were made that may affect your extension's XUL overlays.
+Look over the article [Theme changes in Firefox 2](https://web.archive.org/web/20191005020825/https://developer.mozilla.org/en-US/Add-ons/Themes/Obsolete/Theme_changes_in_Firefox_2) to learn what changes were made that may affect your extension's XUL overlays.
 
 ## Step 3: Test
 
@@ -39,4 +39,4 @@ Be sure to test your extension carefully on Firefox 2 before you release it to t
 
 Update your extension's entry on [https://addons.mozilla.org](https://addons.mozilla.org/). This will ensure that users can find it.
 
-In addition, if your extension provides an [`updateURL`](/en-US/Install_Manifests#updateurl) in the install manifest, be sure to update the update manifest so that the new version of your extension can be found automatically by Firefox. By doing this, the first time the user runs your extension after upgrading to Firefox 2, Firefox can offer to automatically install it for them.
+In addition, if your extension provides an [`updateURL`](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#updateurl) in the install manifest, be sure to update the update manifest so that the new version of your extension can be found automatically by Firefox. By doing this, the first time the user runs your extension after upgrading to Firefox 2, Firefox can offer to automatically install it for them.

--- a/files/en-us/mozilla/firefox/releases/27/index.md
+++ b/files/en-us/mozilla/firefox/releases/27/index.md
@@ -43,7 +43,7 @@ More details in [this post](https://hacks.mozilla.org/2013/11/firefox-developer-
 
 ### JavaScript
 
-[ECMAScript 2015](/en-US/docs/Web/JavaScript/ECMAScript_6_support_in_Mozilla) implementation continues!
+[ECMAScript 2015](https://web.archive.org/web/20210612110055/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/ECMAScript_2015_support_in_Mozilla) implementation continues!
 
 - The [spread operator](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) is now supported in Function calls ([Firefox bug 762363](https://bugzil.la/762363)).
 - The mathematical function {{jsxref("Global_Objects/Math/hypot", "Math.hypot()")}} has been implemented ([Firefox bug 896264](https://bugzil.la/896264)).

--- a/files/en-us/mozilla/firefox/releases/3.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/index.md
@@ -141,7 +141,7 @@ If you're an extension developer, you should start by reading [Updating extensio
 
 #### New components and functionality
 
-- [Supporting private browsing mode](https://web.archive.org/web/20191029190431/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Supporting_private_browsing_mode)
+- [Supporting private browsing mode](https://web.archive.org/web/20210620014429/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Supporting_private_browsing_mode)
   - : Firefox 3.5 offers Private Browsing mode, which doesn't record the user's activities. Extensions may support private browsing following the guidelines offered by this article.
 - [Security changes in Firefox 3.5](/en-US/docs/Mozilla/Firefox/Releases/3.5/Security_changes)
   - : This article covers security-related changes in Firefox 3.5.

--- a/files/en-us/mozilla/firefox/releases/3.5/security_changes/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/security_changes/index.md
@@ -15,9 +15,9 @@ Fixing this bug was accomplished by adding a new `URI_IS_LOCAL_RESOURCE` flag to
 
 ## Private browsing
 
-Firefox 3.5 implements private browsing, a mode in which cookies, history, and other potentially private information isn't saved permanently on the user's computer. Extensions and other add-ons may support the private browsing feature, detecting when it's in use so they can avoid saving private information while private browsing mode is enabled. See [Supporting private browsing mode](/en-US/Supporting_private_browsing_mode) for details.
+Firefox 3.5 implements private browsing, a mode in which cookies, history, and other potentially private information isn't saved permanently on the user's computer. Extensions and other add-ons may support the private browsing feature, detecting when it's in use so they can avoid saving private information while private browsing mode is enabled. See [Supporting private browsing mode](https://web.archive.org/web/20210620014429/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Supporting_private_browsing_mode) for details.
 
-Plug-ins can detect whether or not private browsing mode is in effect by using the [`NPN_GetValue()`](/en-US/docs/NPN_GetValue) function to check the current value of the `NPNVprivateModeBool` variable.
+Plug-ins can detect whether or not private browsing mode is in effect by using the [`NPN_GetValue()`](https://web.archive.org/web/20210308202622/https://developer.mozilla.org/en-US/docs/Archive/Plugins/Reference/NPN_GetValue) function to check the current value of the `NPNVprivateModeBool` variable.
 
 ## New certificate error handling
 
@@ -29,4 +29,4 @@ Embedders needing to provide custom certificate error pages can now do so by sup
 
 ## See also
 
-- [Firefox 3.5 for developers](/en-US/Firefox%203.5%20for%20developers)
+- [Firefox 3.5 for developers](/en-US/docs/Mozilla/Firefox/Releases/3.5)

--- a/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
@@ -49,11 +49,11 @@ Once you've done that, try using your extension again, this time with your regul
 
 Finally, it's time to release your updated extension. If your extension didn't need any code changes you can log into the AMO dashboard and update the compatibility version there. Otherwise, you'll need to upload a new version to AMO.
 
-See [Submitting an add-on to AMO](/en-US/docs/Submitting_an_add-on_to_AMO) for additional information.
+See [Submitting an add-on to AMO](https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/#distributing-your-addon) for additional information.
 
 ## Accessing the Places database
 
-Prior to Firefox 3.5, accessing the Places database directly using the [Storage API](/en-US/docs/Storage) required a little bit of trickery:
+Prior to Firefox 3.5, accessing the Places database directly using the [Storage API](https://web.archive.org/web/20210401045303/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Storage) required a little bit of trickery:
 
 ```js
 var places = Components.classes["@mozilla.org/file/directory_service;1"]
@@ -77,7 +77,7 @@ var db = Components.classes[
 
 ## Search textboxes
 
-The [`textbox`](/en-US/docs/XUL/textbox) type `timed` is deprecated; instead, you should use `search`.
+The [`textbox`](https://web.archive.org/web/20201205234810/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/textbox) type `timed` is deprecated; instead, you should use `search`.
 
 In Firefox 3, you might have used:
 
@@ -93,7 +93,7 @@ In Firefox 3.5, you should change this to:
 
 ## JSON
 
-The JSON.jsm JavaScript module was dropped in Firefox 3.5 in favor of native JSON object support. For details, see [Using JSON in Firefox](/en-US/Using_native_JSON) and the article on [JSON](/en-US/docs/Glossary/JSON) for a more general overview of JSON and how to use it in various versions of Firefox.
+The JSON.jsm JavaScript module was dropped in Firefox 3.5 in favor of native JSON object support. For details, see the article on [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) for a more general overview of JSON and how to use it in various versions of Firefox.
 
 To ensure compatibility with both Firefox 3 and Firefox 3.5, you can do the following:
 
@@ -115,7 +115,7 @@ In order to support the new audio and video features added in Gecko 1.9.1, the `
 
 ## Changes to chrome registration
 
-Firefox 3.5 closes a security hole that made it possible to use remote chrome. This will affect any add-on that includes a resource in their `chrome.manifest` file that references a website, data or resource URLs. See [Security changes in Firefox 3.5](/en-US/Security_changes_in_Firefox_3.5) for details.
+Firefox 3.5 closes a security hole that made it possible to use remote chrome. This will affect any add-on that includes a resource in their `chrome.manifest` file that references a website, data or resource URLs. See [Security changes in Firefox 3.5](/en-US/docs/Mozilla/Firefox/Releases/3.5/Security_changes) for details.
 
 ## Getting a load context from a request
 
@@ -193,9 +193,9 @@ If your extension is using `xpcnativewrappers=no` (which it shouldn't be doing i
 
 ### Listening to events on all tabs
 
-Firefox 3.5 introduces support for adding and removing progress listeners that listen on all tabs. See [Listening to events on all tabs](/en-US/Listening_to_events_on_all_tabs) for details.
+Firefox 3.5 introduces support for adding and removing progress listeners that listen on all tabs. See [Listening to events on all tabs](https://web.archive.org/web/20210412023656/https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Listening_to_events_on_all_tabs) for details.
 
 ## For Theme developers
 
-- Check [Theme changes in Firefox 3.1](/en-US/Theme_changes_in_Firefox_3.1).
+- Check [Theme changes in Firefox 3.5](https://web.archive.org/web/20191004004454/https://developer.mozilla.org/en-US/docs/Archive/Themes/Theme_changes_in_Firefox_3.5).
 - Go to the MozillaZine forum [Theme changes for FF3.1](https://forums.mozillazine.org/viewtopic.php?f=18&t=665138) to get an overview / listing of all changes between 3.0 and 3.1 that impact theme developers. This concerns new CSS features (like nth-child, -moz-box-shadow, etc.), changes to existing widgets, overall UI improvements, and new FF3.1 features (audio/video support, private browsing, extended session restore, box/window/text shadows).

--- a/files/en-us/mozilla/firefox/releases/3.6/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/index.md
@@ -50,7 +50,7 @@ sidebar: firefox
 
 ### JavaScript
 
-Gecko 1.9.2 introduces JavaScript 1.8.2, which adds a number of language features from the [ECMAScript 5 standard](/en-US/docs/JavaScript/ECMAScript_5_support_in_Mozilla):
+Gecko 1.9.2 introduces JavaScript 1.8.2, which adds a number of language features from the [ECMAScript 5 standard](https://web.archive.org/web/20210619182836/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/ECMAScript_5_support_in_Mozilla):
 
 - [`Date.parse()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) can now parse ISO 8601 dates like YYYY-MM-DD.
 - The [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) property of function instances is no longer enumerable.
@@ -94,9 +94,9 @@ If you're an extension developer, you should start by reading [Updating extensio
 
 - [Detecting device orientation](/en-US/docs/Web/API/Device_orientation_events/Detecting_device_orientation)
   - : Content can now detect the orientation of the device if it has a supported accelerometer, using the [`MozOrientation`](/en-US/docs/Web/API/Screen/change_event) event. Firefox 3.6 supports the accelerometer in Mac laptops.
-- [Monitoring HTTP activity](/en-US/docs/Monitoring_HTTP_activity)
+- [Monitoring HTTP activity](https://web.archive.org/web/20210421090042/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Monitoring_HTTP_activity)
   - : You can now monitor HTTP transactions to observe requests and responses in real time.
-- [Working with the Windows taskbar](/en-US/docs/Working_with_the_Windows_taskbar)
+- Working with the Windows taskbar
   - : It's now possible to customize the appearance of windows in the taskbar in Windows 7 or later. _This has been disabled by default in Firefox 3.6._
 
 ### Places
@@ -106,9 +106,9 @@ If you're an extension developer, you should start by reading [Updating extensio
 
 ### Storage
 
-- [Locale-aware collation of data is now supported by the Storage API](</en-US/docs/Storage#Collation_(sorting)>)
+- [Locale-aware collation of data is now supported by the Storage API](https://web.archive.org/web/20210401045303/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Storage#collation_sorting)
   - : Gecko 1.9.2 added several new collation methods to provide optimized collation (sorting) of results using locale-aware techniques.
-- [Properties on a statement can now be enumerated](/en-US/docs/mozIStorageStatementParams#enumeration_of_properties)
+- [Properties on a statement can now be enumerated](https://web.archive.org/web/20210513165422/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/mozIStorageStatementParams#enumeration_of_properties)
   - : You can now use a [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) enumeration to enumerate all the properties on a statement.
 - mozIStorageStatement's getParameterIndex changed behavior between 3.5 and 3.6.
   - : See [Firefox bug 528166](https://bugzil.la/528166) for details.
@@ -123,13 +123,13 @@ If you're an extension developer, you should start by reading [Updating extensio
 
 See [Updating themes for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6/Updating_themes) for a list of changes related to themes.
 
-- [Lightweight themes](/en-US/docs/Themes/Lightweight_themes)
+- [Lightweight themes](https://web.archive.org/web/20180617103446/https://developer.mozilla.org/en-US/Add-ons/Themes/Lightweight_themes)
   - : Firefox 3.6 supports lightweight themes; these are easy-to-create themes that apply a background to the top (URL bar and button bar) and bottom (status bar) of browser windows. This is an integration of the existing [Personas](https://addons.mozilla.org/en-US/firefox/themes/) theme architecture into Firefox.
 
 ### Miscellaneous
 
-- Firefox will no longer load third-party components installed in its internal components directory. This helps to ensure stability by preventing buggy third-party components from being executed. Developers that install components this way must [repackage their components as XPI packages](/en-US/docs/Migrating_raw_components_to_add-ons) so they can be installed as standard add-ons.
-- `contents.rdf` is no longer supported for registering chrome in extensions. You must now use the [`chrome.manifest`](/en-US/docs/Install_Manifests) file instead. See [Firefox bug 492008](https://bugzil.la/492008).
+- Firefox will no longer load third-party components installed in its internal components directory. This helps to ensure stability by preventing buggy third-party components from being executed. Developers that install components this way must [repackage their components as XPI packages](https://web.archive.org/web/20170622232046/https://developer.mozilla.org/en-US/docs/Migrating_raw_components_to_add-ons) so they can be installed as standard add-ons.
+- `contents.rdf` is no longer supported for registering chrome in extensions. You must now use the [`chrome.manifest`](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests) file instead. See [Firefox bug 492008](https://bugzil.la/492008).
 - Added support for hiding the menu bar automatically. See [Firefox bug 477256](https://bugzil.la/477256).
 - Added support for the `container-live-role` attribute to objects. See [Firefox bug 391829](https://bugzil.la/391829).
 - The `tabs-closebutton` binding has been removed. See [Firefox bug 500971](https://bugzil.la/500971).
@@ -137,16 +137,16 @@ See [Updating themes for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6/U
 - The syntax for the `nsITreeView` methods `nsITreeView.canDrop()` and `nsITreeView.drop()` has changed to support the new drag & drop API introduced in Gecko 1.9. See [Firefox bug 455590](https://bugzil.la/455590).
 - Added support to snap the mouse cursor to the default button of dialog or wizard on Windows, see [Firefox bug 76053](https://bugzil.la/76053). This is processed automatically by dialog and wizard element. But if a XUL application creates a window using the `window` element and it has a default button, it needs to call `nsIDOMChromeWindow.notifyDefaultButtonLoaded` during the window's `onload` event handler.
 - The `nsILocalFileMac` interface has had two methods removed: `setFileTypeAndCreatorFromMIMEType()` and `setFileTypeAndCreatorFromExtension()`.
-- The new [`NetUtils.jsm`](/en-US/docs/JavaScript_code_modules/NetUtil.jsm) code module provides an easy-to-use method for asynchronously copying data from an input stream to an output stream.
-- The new [`openLocationLastURL.jsm`](/en-US/docs/JavaScript_code_modules/openLocationLastURL.jsm) code module makes it easy to read and change the value of the "Open Location" dialog box's remembered URL while properly taking private browsing mode into account.
+- The new [`NetUtils.jsm`](https://web.archive.org/web/20210620035742/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/NetUtil.jsm) code module provides an easy-to-use method for asynchronously copying data from an input stream to an output stream.
+- The new [`openLocationLastURL.jsm`](https://web.archive.org/web/20210417025317/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/openLocationLastURL.jsm) code module makes it easy to read and change the value of the "Open Location" dialog box's remembered URL while properly taking private browsing mode into account.
 - On Windows, the `nsIScreen` interface now reports 24-bit per pixel color depths when the graphics driver claims 32 bits, since 24 more accurately represents the actual number of color pixels in use.
-- Menu bars can now be hidden on Windows, using the new [`autohide`](/en-US/docs/Mozilla/Tech/XUL/Attribute/autohide) attribute on the [`<xul:toolbar>`](/en-US/docs/Mozilla/Tech/XUL/toolbar) XUL element.
-- The [`loadOneTab`](/en-US/docs/Mozilla/Tech/XUL/Method/loadOneTab) and [`addTab`](/en-US/docs/Mozilla/Tech/XUL/Method/addTab) methods now accept a new `relatedToCurrent` parameter and, in addition, allow the parameters to be specified by name, since nearly all of the parameters are optional.
-- The "[hidden](/en-US/docs/Install_Manifests#hidden)" property is no longer supported in install manifests; it's no longer possible to prevent the user from seeing add-ons in the add-on manager window.
+- Menu bars can now be hidden on Windows, using the new [`autohide`](https://web.archive.org/web/20201124231843/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/toolbar#autohide) attribute on the [`<xul:toolbar>`](https://web.archive.org/web/20201124231843/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/toolbar) XUL element.
+- The [`loadOneTab`](https://web.archive.org/web/20201210182023/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/Method/loadOneTab) and [`addTab`](https://web.archive.org/web/20201208182934/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/Method/addTab) methods now accept a new `relatedToCurrent` parameter and, in addition, allow the parameters to be specified by name, since nearly all of the parameters are optional.
+- The "[hidden](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#hidden)" property is no longer supported in install manifests; it's no longer possible to prevent the user from seeing add-ons in the add-on manager window.
 - The `@mozilla.org/webshell;1` component no longer exists; you need to use `@mozilla.org/docshell;1` instead.
 - You can now register with the update-timer category to schedule timer events without having to instantiate the object that the timer will eventually call into; it will instead be instantiated when it's needed. See `nsIUpdateTimerManager.registerTimer()` for details.
-- The [`NPN_GetValue()`](/en-US/docs/NPN_GetValue) function no longer provides access to XPCOM through the variable values `NPNVserviceManager`, `NPNVDOMelement`, and `NPNVDOMWindow`. This is part of the work toward making plugins run in separate processes in a future version of Gecko.
-- Plugins are no longer scriptable through XPCOM (IDL) interfaces, [NPRuntime](/en-US/docs/Gecko_Plugin_API_Reference/Scripting_plugins) is the API to use for making plugins scriptable, and [`NPP_GetValue()`](/en-US/docs/NPP_GetValue) is no longer called to with the value `NPPVpluginScriptableInstance` or `NPPVpluginScriptableIID`. This is part of the work toward making plugins run in separate processes in a future version of Gecko.
+- The [`NPN_GetValue()`](https://web.archive.org/web/20210308202622/https://developer.mozilla.org/en-US/docs/Archive/Plugins/Reference/NPN_GetValue) function no longer provides access to XPCOM through the variable values `NPNVserviceManager`, `NPNVDOMelement`, and `NPNVDOMWindow`. This is part of the work toward making plugins run in separate processes in a future version of Gecko.
+- Plugins are no longer scriptable through XPCOM (IDL) interfaces, [NPRuntime](https://web.archive.org/web/20211028124814/https://developer.mozilla.org/en-US/docs/Plugins/Guide/Scripting_plugins) is the API to use for making plugins scriptable, and [`NPP_GetValue()`](https://web.archive.org/web/20201023225330/https://developer.mozilla.org/en-US/docs/Archive/Plugins/Reference/NPP_GetValue) is no longer called to with the value `NPPVpluginScriptableInstance` or `NPPVpluginScriptableIID`. This is part of the work toward making plugins run in separate processes in a future version of Gecko.
 
 ## For Firefox/Gecko developers
 
@@ -198,5 +198,5 @@ The following assorted changes have been made:
 
 ### Changes in accessibility code
 
-- The `EVENT_REORDER` [accessibility event](/en-US/docs/XPCOM_Interface_Reference/nsIAccessibleEvent) is now sent when the children of frames and iframes change, as well as when the main document's children change. See [Firefox bug 420845](https://bugzil.la/420845).
+- The `EVENT_REORDER` [accessibility event](https://web.archive.org/web/20210516055347/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIAccessibleEvent) is now sent when the children of frames and iframes change, as well as when the main document's children change. See [Firefox bug 420845](https://bugzil.la/420845).
 - The `nsIAccessibleTable.selectRow()` now correctly removes any current selection before selecting the specified row.

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.md
@@ -46,7 +46,7 @@ The most probable upgrade problem is the pattern `if (elt.localName === "FOO")`.
 
 Support for the obsolete `contents.rdf` method for registering chrome has been removed in Gecko 1.9.2, and is no longer supported by Firefox 3.6. This means that add-ons that use contents.rdf can no longer be installed.
 
-Make sure you include a [chrome.manifest](/en-US/docs/Chrome_Registration) in your XPI.
+Make sure you include a [chrome.manifest](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration) in your XPI.
 
 > [!NOTE]
 > Add-ons that are already installed using the old contents.rdf method for registering chrome will continue to function if already installed. Make sure that you test your add-on by actually removing and reinstalling it to ensure that the install works after updating it to use an install manifest.

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_themes/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_themes/index.md
@@ -17,7 +17,7 @@ XUL textboxes don't have the `empty` attribute anymore, but `isempty` instead. S
 
 ## Right-to-left UI support
 
-The `[chromedir="rtl"]` and `[chromedir="ltr"]` selectors have been obsoleted and won't work anymore on most elements. Instead, you need to use the new {{ cssxref(":-moz-locale-dir_rtl", ":-moz-locale-dir(rtl)") }} and {{ cssxref(":-moz-locale-dir_ltr", ":-moz-locale-dir(ltr)") }} selectors. See also: [Making sure your theme works with RTL locales](/en-US/docs/Making_Sure_Your_Theme_Works_with_RTL_Locales).
+The `[chromedir="rtl"]` and `[chromedir="ltr"]` selectors have been obsoleted and won't work anymore on most elements. Instead, you need to use the new {{ cssxref(":-moz-locale-dir_rtl", ":-moz-locale-dir(rtl)") }} and {{ cssxref(":-moz-locale-dir_ltr", ":-moz-locale-dir(ltr)") }} selectors. See also: [Making sure your theme works with RTL locales](https://web.archive.org/web/20210509011412/https://developer.mozilla.org/en-US/docs/Archive/Themes/Making_sure_your_theme_works_with_RTL_locales).
 
 ## Cross-platform tabbed browser styling
 
@@ -30,5 +30,5 @@ There's a new [Full Screen toolbar button](https://bugzil.la/206544) available f
 ## See also
 
 - [MozillaZine forum: Mozilla 1.9.2 / Firefox 3.6 theme changes](https://forums.mozillazine.org/viewtopic.php?f=18&t=975065)
-- [Themes](/en-US/docs/Themes)
-- [Building a theme](/en-US/docs/Building_a_Theme)
+- [Themes](https://web.archive.org/web/20210422190409/https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Themes)
+- [Building a theme](https://web.archive.org/web/20210506064733/https://developer.mozilla.org/en-US/docs/Archive/Themes/Building_a_Theme)

--- a/files/en-us/mozilla/firefox/releases/3/dom_improvements/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/dom_improvements/index.md
@@ -12,7 +12,7 @@ Firefox 3 offers a number of improvements to the [Document Object Model](/en-US/
 - The [`getClientRects`](/en-US/docs/Web/API/Element/getClientRects) and [`getBoundingClientRect`](/en-US/docs/Web/API/Element/getBoundingClientRect) DOM extensions are now supported (see [Firefox bug 174397](https://bugzil.la/174397)).
 - The Internet Explorer [`elementFromPoint`](/en-US/docs/Web/API/Document/elementFromPoint) DOM extension is now supported ([Firefox bug 199692](https://bugzil.la/199692)).
 - The Internet Explorer [`oncut`](/en-US/docs/Web/API/Element/cut_event), [`oncopy`](/en-US/docs/Web/API/Element/copy_event), and [`onpaste`](/en-US/docs/Web/API/Element/paste_event) DOM extensions are now supported ([Firefox bug 280959](https://bugzil.la/280959)).
-- Added privileged-code-only getters for `Node.nodePrincipal`, `Node.baseURIObject`, and `document.documentURIObject`. Chrome code must not touch (get or set) these properties on an unwrapped content object (e.g., on a `wrappedJSObject` of an [`XPCNativeWrapper`](/en-US/XPCNativeWrapper)), see [Firefox bug 324464](https://bugzil.la/324464) for details.
+- Added privileged-code-only getters for `Node.nodePrincipal`, `Node.baseURIObject`, and `document.documentURIObject`. Chrome code must not touch (get or set) these properties on an unwrapped content object (e.g., on a `wrappedJSObject` of an [`XPCNativeWrapper`](https://web.archive.org/web/20140604075216/https://developer.mozilla.org/en-US/docs/XPCNativeWrapper)), see [Firefox bug 324464](https://bugzil.la/324464) for details.
 - The Web Applications 1.0 (HTML5) [`getElementsByClassName()`](/en-US/docs/Web/API/Document/getElementsByClassName) DOM method is now supported.
 - The Web Applications 1.0 (HTML5) [`window.postMessage`](/en-US/docs/Web/API/Window/postMessage) DOM method is now supported. This method allows a limited, opt-in form of client-side communication between windows not necessarily on the same domain.
 - The `charCode` value of the `keypress` event is changed to an ASCII character if the accelerator key is pressed. Otherwise the `charCode` is the unmodified character (excepting `Shift` state).
@@ -20,5 +20,5 @@ Firefox 3 offers a number of improvements to the [Document Object Model](/en-US/
 ### See also
 
 - [Firefox 3 for developers](/en-US/docs/Mozilla/Firefox/Releases/3)
-- [CSS improvements in Firefox 3](/en-US/docs/CSS_improvements_in_Firefox_3)
+- [CSS improvements in Firefox 3](https://web.archive.org/web/20210224062716/https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/releases/3/CSS_improvements)
 - [DOM](/en-US/docs/Web/API/Document_Object_Model)

--- a/files/en-us/mozilla/firefox/releases/3/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/index.md
@@ -30,11 +30,11 @@ If you're a developer trying to get a handle on all the new features in Firefox 
   - : The new HTML 5 `activeElement` and `hasFocus` attributes are supported.
 - Offline resources in Firefox
   - : Firefox now lets web applications request that resources be cached to allow the application to be used while offline.
-- [CSS improvements in Firefox 3](/en-US/docs/CSS_improvements_in_Firefox_3)
+- [CSS improvements in Firefox 3](https://web.archive.org/web/20210224062716/https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/releases/3/CSS_improvements)
   - : Firefox 3 features a number of improvements in its CSS support.
 - [DOM improvements in Firefox 3](/en-US/docs/Mozilla/Firefox/Releases/3/DOM_improvements)
   - : Firefox 3 offers a number of new features in Firefox 3's DOM implementation, including support for several Internet Explorer extensions to the DOM.
-- [JavaScript 1.8 support](/en-US/docs/New_in_JavaScript_1.8)
+- [JavaScript 1.8 support](https://web.archive.org/web/20210224081539/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/1.8)
   - : Firefox 3 offers JavaScript 1.8.
 - [EXSLT support](/en-US/docs/Web/XML/EXSLT)
   - : Firefox 3 provides support for a substantial subset of the [EXSLT](/en-US/docs/Web/XML/EXSLT) extensions to [XSLT](/en-US/docs/Web/XML/XSLT).
@@ -49,52 +49,52 @@ If you're a developer trying to get a handle on all the new features in Firefox 
 
 - [Updating extensions for Firefox 3](/en-US/docs/Mozilla/Firefox/Releases/3/Updating_extensions)
   - : Provides a guide to the things you'll need to do to update your extension to work with Firefox 3.
-- [XUL improvements in Firefox 3](/en-US/docs/XUL_improvements_in_Firefox_3)
+- [XUL improvements in Firefox 3](/en-US/docs/Mozilla/Firefox/Releases/3/XUL_improvements_in_Firefox_3)
   - : Firefox 3 offers a number of new XUL elements, including new sliding scales, the date and time pickers, and spin buttons.
-- [Templates in Firefox 3](/en-US/docs/Templates_in_Firefox_3)
+- [Templates in Firefox 3](/en-US/docs/Mozilla/Firefox/Releases/3/Templates)
   - : Templates have been significantly improved in Firefox 3. The key improvement allows the use of custom query processors to allow data sources other than RDF to be used.
-- [Securing updates](/en-US/docs/Extension_Versioning,_Update_and_Compatibility#securing_updates)
+- [Securing updates](https://web.archive.org/web/20201031093738/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Extension_Versioning,_Update_and_Compatibility#securing_updates)
   - : In order to provide a more secure add-on upgrade path for users, add-ons are now required to provide a secure method for obtaining updates before they can be installed. Add-ons hosted at [AMO](https://addons.mozilla.org/) automatically provide this. Any add-ons installed that do not provide a secure update method when the user upgrades to Firefox 3 will be automatically disabled. Firefox will however continue to check for updates to the extension over the insecure path and attempt to install any update offered (installation will fail if the update also fails to provide a secure update method).
-- [Places migration guide](/en-US/docs/Places_Developer_Guide)
+- [Places migration guide](https://web.archive.org/web/20200621121524/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Places_Developer_Guide)
   - : An article about how to update an existing extension to use the Places API.
-- [Download Manager improvements in Firefox 3](/en-US/docs/Download_Manager_improvements_in_Firefox_3)
+- [Download Manager improvements in Firefox 3](https://web.archive.org/web/20191009203342/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Download_Manager_improvements_in_Firefox_3)
   - : The Firefox 3 Download Manager features new and improved APIs, including support for multiple progress listeners.
 - Using nsILoginManager
   - : The Password Manager has been replaced by the new Login Manager.
-- [Embedding XBL bindings](/en-US/docs/XBL/XBL_1.0_Reference/Elements#binding)
+- [Embedding XBL bindings](https://web.archive.org/web/20190710111835/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XBL/XBL_1.0_Reference/Elements#binding)
   - : You can now use the `data:` URL scheme from chrome code to embed XBL bindings directly instead of having them in separate XML files.
-- [Localizing extension descriptions](/en-US/docs/Localizing_extension_descriptions)
+- [Localizing extension descriptions](https://web.archive.org/web/20210126131244/https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localizing_extension_descriptions)
   - : Firefox 3 offers a new method for localizing add-on metadata. This lets the localized details be available as soon as the add-on has been downloaded, as well as when the add-on is disabled.
-- [Localization and Plurals](/en-US/docs/Localization_and_Plurals)
+- [Localization and Plurals](https://web.archive.org/web/20210619213040/https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_and_Plurals)
   - : Firefox 3 adds the new PluralForm module, which provides tools to aid in correctly pluralizing words in multiple localizations.
-- [Theme changes in Firefox 3](/en-US/docs/Theme_changes_in_Firefox_3)
+- [Theme changes in Firefox 3](https://web.archive.org/web/20210518052656/https://developer.mozilla.org/en-US/docs/Archive/Themes/Theme_changes_in_Firefox_3)
   - : Notes and information of use to people who want to create themes for Firefox 3.
 
 #### New components and functionality
 
-- [FUEL Library](/en-US/docs/Toolkit_API/FUEL)
+- [FUEL Library](https://web.archive.org/web/20210516092241/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Toolkit_API/FUEL)
   - : FUEL is about making it easier for extension developers to be productive, by minimizing some of the XPCOM formality and adding some "modern" JavaScript ideas.
-- [Places](/en-US/docs/Places)
-  - : The history and bookmarks APIs have been completely replaced by the new [Places](/en-US/docs/Places) API.
-- [Idle service](/en-US/docs/nsIIdleService)
+- [Places](https://web.archive.org/web/20210620103113/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places)
+  - : The history and bookmarks APIs have been completely replaced by the new Places API.
+- [Idle service](https://web.archive.org/web/20210511041145/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIIdleService)
   - : Firefox 3 offers the new `nsIIdleService` interface, which lets extensions determine how long it's been since the user last pressed a key or moved their mouse.
-- [ZIP writer](/en-US/docs/nsIZipWriter)
+- [ZIP writer](https://web.archive.org/web/20210619003034/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIZipWriter)
   - : The new `nsIZipWriter` interface lets extensions create ZIP archives.
 - [Full page zoom](/en-US/docs/Mozilla/Firefox/Releases/3/Full_page_zoom)
   - : Firefox 3 improves the user experience by offering full page zoom in addition to text-only zoom.
-- [Interfacing with the XPCOM cycle collector](/en-US/docs/Interfacing_with_the_XPCOM_cycle_collector)
+- [Interfacing with the XPCOM cycle collector](https://web.archive.org/web/20210620195127/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Interfacing_with_the_XPCOM_cycle_collector)
   - : XPCOM code can now take advantage of the cycle collector, which helps ensure that unused memory gets released instead of leaking.
-- [The Thread Manager](/en-US/docs/The_Thread_Manager)
+- [The Thread Manager](https://web.archive.org/web/20210419232321/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/The_Thread_Manager)
   - : Firefox 3 provides the new `nsIThreadManager` interface, along with new interfaces for threads and thread events, which provides a convenient way to create and manage threads in your code.
-- [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules)
+- [JavaScript modules](https://web.archive.org/web/20210531090101/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules)
   - : Firefox 3 now offers a new shared code module mechanism that lets you easily create modules in JavaScript that can be loaded by extensions and applications for use, much like shared libraries.
-- [The `nsIJSON` interface](/en-US/docs/nsIJSON)
+- [The `nsIJSON` interface](https://web.archive.org/web/20210514110540/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIJSON)
   - : Firefox 3 offers the new `nsIJSON` interface, which offers high-performance encoding and decoding of [JSON](/en-US/docs/Glossary/JSON) strings.
 - The `nsIParentalControlsService` interface
   - : Firefox 3 now supports the Microsoft Windows Vista parental controls feature, and allows code to interact with it.
-- [Using content preferences](/en-US/docs/Using_content_preferences)
+- [Using content preferences](https://web.archive.org/web/20210314182749/https://developer.mozilla.org/en-US/docs/Archive/Misc_top_level/Using_content_preferences)
   - : Firefox 3 includes a new service for getting and setting arbitrary site-specific preferences that extensions as well as core code can use to keep track of their users' preferences for individual sites.
-- [Plug-in Monitoring](/en-US/docs/Monitoring_plugins)
+- [Plug-in Monitoring](https://web.archive.org/web/20160617124200/https://developer.mozilla.org/en-US/Add-ons/Plugins/Monitoring_plugins)
   - : A new component of the plugin system is now available to measure how long it takes plugins (e.g., Macromedia Flash) to execute their calls.
 
 #### Fixed bugs

--- a/files/en-us/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
@@ -13,7 +13,7 @@ This article offers a list of important bug fixes offered by Firefox 3 that are 
 - the `canBubble` argument to {{ Domxref("event.initEvent") }} now works properly so that events can be fired which don't bubble. ([Firefox bug 330190](https://bugzil.la/330190))
 - the `DOMAttrModified` event now handles namespaced attributes properly. ([Firefox bug 362391](https://bugzil.la/362391))
 - XML processing instructions, such as `<?xml-stylesheet ?>`, are now added to a XUL document's DOM. This means {{ Domxref("Node.firstChild", "document.firstChild") }} isn't guaranteed to be the root element, use {{ Domxref("document.documentElement") }} instead. Also, `<?xml-stylesheet ?>` and `<?xul-overlay ?>` processing instructions now have no effect outside the document prolog. ([Firefox bug 319654](https://bugzil.la/319654))
-- [`getElementsByAttributeNS()`](/en-US/docs/Mozilla/Tech/XUL/Method/getElementsByAttributeNS) functions have been added to XUL elements and documents. ([Firefox bug 239976](https://bugzil.la/239976))
+- [`getElementsByAttributeNS()`](https://web.archive.org/web/20201210015651/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/Method/getElementsByAttributeNS) functions have been added to XUL elements and documents. ([Firefox bug 239976](https://bugzil.la/239976))
 - event listeners are maintained when moving or removing an element from a XUL document. ([Firefox bug 286619](https://bugzil.la/286619))
 - mutation events are now fired for non-displayed documents. ([Firefox bug 201236](https://bugzil.la/201236))
 - various issues with elements drawing in the wrong order are fixed. ([Firefox bug 317375](https://bugzil.la/317375))
@@ -21,7 +21,7 @@ This article offers a list of important bug fixes offered by Firefox 3 that are 
 - The `DOMNodeInserted` and `DOMNodeRemoved` events now properly apply to the correct nodes ([Firefox bug 367164](https://bugzil.la/367164)).
 - `\d`, one of special characters in regular expressions, has been fixed to match only Basic Latin alphabet digits (equivalent to `[0-9]`). ([Firefox bug 378738](https://bugzil.la/378738))
 - The image-sniffing-services category allows for image decoders implemented as extensions to correctly decode images sent with incorrect mime-types. ([Firefox bug 391667](https://bugzil.la/391667))
-- Right-clicks on form controls no longer brings up a context menu by default ([Firefox bug 404536](https://bugzil.la/404536). See [Offering a context menu for form controls](/en-US/docs/Offering%20a%20context%20menu%20for%20form%20controls) to learn how to enable this on a case-by-case basis.
+- Right-clicks on form controls no longer brings up a context menu by default ([Firefox bug 404536](https://bugzil.la/404536). See [Offering a context menu for form controls](https://web.archive.org/web/20210612231358/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Offering_a_context_menu_for_form_controls) to learn how to enable this on a case-by-case basis.
 
 ### See also
 

--- a/files/en-us/mozilla/firefox/releases/3/site_compatibility/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/site_compatibility/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: firefox
 ---
 
-This page tries to give an overview of the changes between [Gecko](/en-US/Gecko) 1.8 and Gecko 1.9, that could possibly affect websites in their behavior or rendering.
+This page tries to give an overview of the changes between Gecko 1.8 and Gecko 1.9, that could possibly affect websites in their behavior or rendering.
 
 See also [Firefox 3 for developers](/en-US/docs/Mozilla/Firefox/Releases/3).
 

--- a/files/en-us/mozilla/firefox/releases/3/templates/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/templates/index.md
@@ -5,14 +5,14 @@ page-type: guide
 sidebar: firefox
 ---
 
-Templates have been significantly improved in Firefox 3. The key improvement allows the use of [custom query processors](/en-US/docs/How_to_implement_a_custom_XUL_query_processor_component) to handle other types of datasources besides RDF. A new query syntax makes this possible. Built-in support for SQL ([mozStorage](/en-US/docs/Storage)) and XML datasources is also provided. A full description of the new features available for templates [is available](https://wiki.mozilla.org/XUL:Template_Features_in_1.9). ([Firefox bug 285631](https://bugzil.la/285631))
+Templates have been significantly improved in Firefox 3. The key improvement allows the use of [custom query processors](https://web.archive.org/web/20180309091530/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/How_to_implement_a_custom_XUL_query_processor_component) to handle other types of datasources besides RDF. A new query syntax makes this possible. Built-in support for SQL ([mozStorage](https://web.archive.org/web/20210401045303/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Storage)) and XML datasources is also provided. A full description of the new features available for templates [is available](https://wiki.mozilla.org/XUL:Template_Features_in_1.9). ([Firefox bug 285631](https://bugzil.la/285631))
 
 ### Other template improvements
 
 - Relational conditions have been added to allow for more precise control over what results match a rule. This allows, for example, matching of results that start or end with certain strings, or that are before or after other values.
 - A flag, `dont-recurse`, has been added to prevent recursion from happening such that only one level of results are generated
 - APIs have been added to the template builder to retrieve a result object representing an output item.
-- The XUL sort service is more robust and [sorts](/en-US/docs/XUL/Template_Guide/Sorting_Results) both content and non-content trees better. It also allows sorting of non-template built content. ([Firefox bug 335122](https://bugzil.la/335122))
+- The XUL sort service is more robust and [sorts](https://web.archive.org/web/20201028214819/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/Template_Guide/Sorting_Results) both content and non-content trees better. It also allows sorting of non-template built content. ([Firefox bug 335122](https://bugzil.la/335122))
 
 ### See also
 

--- a/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -11,7 +11,7 @@ Before going further, there's one helpful hint we can offer: if the only change 
 
 ## Step 1: Update the install manifest
 
-The first step — and, for most extensions, the only one that will be needed — is to update the [install manifest](/en-US/docs/Install_Manifests) file, [`install.rdf`](/en-US/docs/Creating_a_Skin_for_Firefox/install.rdf), to indicate compatibility with Firefox 3.
+The first step — and, for most extensions, the only one that will be needed — is to update the [install manifest](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests) file, [`install.rdf`](https://web.archive.org/web/20160809001138/https://developer.mozilla.org/en-US/Add-ons/Themes/Obsolete/Creating_a_Skin_for_Firefox/install.rdf), to indicate compatibility with Firefox 3.
 
 Find the line indicating the maximum compatible version of Firefox (which, for Firefox 2, might look like this):
 
@@ -32,15 +32,15 @@ Note that Firefox 3 does away with the extra ".0" in the version number, so inst
 There have been (and will continue to be) a number of API changes that will likely break some extensions. We're still working on compiling a complete list of these changes.
 
 > [!NOTE]
-> If your extension still uses an [`Install.js`](/en-US/docs/Install.js) script instead of an [install manifest](/en-US/docs/Install_Manifests), you need to make the transition to an install manifest now. Firefox 3 no longer supports `install.js` scripts in XPI files.
+> If your extension still uses an [`Install.js`](https://web.archive.org/web/20210604075726/https://developer.mozilla.org/en-US/docs/Archive/Install.js) script instead of an [install manifest](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests), you need to make the transition to an install manifest now. Firefox 3 no longer supports `install.js` scripts in XPI files.
 
 ### Add localizations to the install manifest
 
-Firefox 3 supports new properties in the install manifest to specify localized descriptions. The old methods still work however the new allow Firefox to pick up the localizations even when the add-on is disabled and pending install. See [Localizing extension descriptions](/en-US/docs/Localizing_extension_descriptions) for more details.
+Firefox 3 supports new properties in the install manifest to specify localized descriptions. The old methods still work however the new allow Firefox to pick up the localizations even when the add-on is disabled and pending install. See [Localizing extension descriptions](https://web.archive.org/web/20210126131244/https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localizing_extension_descriptions) for more details.
 
 ## Step 2: Ensure you are providing secure updates
 
-If you are hosting addons yourself and not on a secure add-on hosting provider like [addons.mozilla.org](https://addons.mozilla.org/) then you must provide a secure method of updating your add-on. This will either involve hosting your updates on an SSL website, or using cryptographic keys to sign the update information. Read [Securing Updates](/en-US/docs/Extension_Versioning,_Update_and_Compatibility#securing_updates) for more information.
+If you are hosting addons yourself and not on a secure add-on hosting provider like [addons.mozilla.org](https://addons.mozilla.org/) then you must provide a secure method of updating your add-on. This will either involve hosting your updates on an SSL website, or using cryptographic keys to sign the update information. Read [Securing Updates](https://web.archive.org/web/20201031093738/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Extension_Versioning,_Update_and_Compatibility#securing_updates) for more information.
 
 ## Step 3: Deal with changed APIs
 
@@ -54,25 +54,25 @@ Firefox doesn't currently enforce this rule (it did for a while during the devel
 
 ### Bookmarks & History
 
-If your extension accesses bookmark or history data in any way, it will need substantial work to be compatible with Firefox 3. The old APIs for accessing this information have been replaced by the new [Places](/en-US/docs/Places) architecture. See the [Places migration guide](/en-US/docs/Places_Developer_Guide) for details on updating your existing extension to use the Places API.
+If your extension accesses bookmark or history data in any way, it will need substantial work to be compatible with Firefox 3. The old APIs for accessing this information have been replaced by the new [Places](https://web.archive.org/web/20210620103113/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places) architecture. See the [Places migration guide](https://web.archive.org/web/20200621121524/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Places/Places_Developer_Guide) for details on updating your existing extension to use the Places API.
 
 ### Download Manager
 
-The Download Manager API has changed slightly due to the transition from an RDF data store to using the [Storage](/en-US/docs/Storage) API. This should be a pretty easy transition to make. In addition, the API for monitoring download progress has changed to support multiple download manager listeners. See `nsIDownloadManager`, `nsIDownloadProgressListener`, and [Monitoring downloads](/en-US/docs/Monitoring_downloads) for more information.
+The Download Manager API has changed slightly due to the transition from an RDF data store to using the [Storage](https://web.archive.org/web/20210401045303/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Storage) API. This should be a pretty easy transition to make. In addition, the API for monitoring download progress has changed to support multiple download manager listeners. See `nsIDownloadManager`, `nsIDownloadProgressListener`, and [Monitoring downloads](https://web.archive.org/web/20210516125311/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Monitoring_downloads) for more information.
 
 ### Password Manager
 
 If your extension accesses user login information using the Password Manager, it will need to be updated to use the new Login Manager API.
 
-- The article [Using nsILoginManager](/en-US/docs/XPCOM_Interface_Reference/Using_nsILoginManager) includes examples, including a demonstration of how to write your extension to work with both the Password Manager and the Login Manager, so it will work with both Firefox 3 and earlier versions.
+- The article [Using nsILoginManager](https://web.archive.org/web/20210530180123/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsILoginManager/Using_nsILoginManager) includes examples, including a demonstration of how to write your extension to work with both the Password Manager and the Login Manager, so it will work with both Firefox 3 and earlier versions.
 - `nsILoginInfo`
 - `nsILoginManager`
 
-You can also override the built-in password manager storage if you want to provide your own password storage implementation in your extensions. See [Creating a Login Manager storage module](/en-US/docs/Creating_a_Login_Manager_storage_module) for details.
+You can also override the built-in password manager storage if you want to provide your own password storage implementation in your extensions. See [Creating a Login Manager storage module](https://web.archive.org/web/20210515154057/https://developer.mozilla.org/en-US/docs/Mozilla/Creating_a_login_manager_storage_module) for details.
 
 ### Popups (Menus, Context Menus, Tooltips and Panels)
 
-The XUL Popup system was heavily modified in Firefox 3. The Popup system includes main menus, context menus and popup panels. A guide to [using Popups](/en-US/docs/XUL/PopupGuide) has been created, detailing how the system works. One thing to note is that `popup.showPopup` has been deprecated in favor of new `popup.openPopup` and `popup.openPopupAtScreen`.
+The XUL Popup system was heavily modified in Firefox 3. The Popup system includes main menus, context menus and popup panels. A guide to [using Popups](https://web.archive.org/web/20210418010207/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/PopupGuide) has been created, detailing how the system works. One thing to note is that `popup.showPopup` has been deprecated in favor of new `popup.openPopup` and `popup.openPopupAtScreen`.
 
 ### Autocomplete
 
@@ -92,9 +92,9 @@ The `nsIAutoCompleteController` interface's `handleEnter()` method has been chan
 
 The internal string API is no longer exported; you must migrate to the external string API. See these articles for helpful information:
 
-- [Mozilla external string guide](/en-US/docs/Mozilla_external_string_guide)
-- [XPCOM Glue](/en-US/docs/XPCOM_Glue)
-- [Migrating from Internal Linkage to Frozen Linkage](/en-US/docs/Migrating_from_Internal_Linkage_to_Frozen_Linkage)
+- [Mozilla external string guide](https://web.archive.org/web/20160423162648/https://developer.mozilla.org/en-US/docs/Mozilla/Mozilla_external_string_guide)
+- [XPCOM Glue](https://web.archive.org/web/20210625030032/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Glue)
+- [Migrating from Internal Linkage to Frozen Linkage](https://web.archive.org/web/20210620000937/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Migrating_from_Internal_Linkage_to_Frozen_Linkage)
 
 ### Removed interfaces
 
@@ -142,7 +142,7 @@ Or use the following technique to make your overlay work on both Firefox 2 and F
 
 ### Changed boxes
 
-Extensions that attempt to overlay onto the "appcontent" box try to float chrome over document content will no longer display that material. You should update your extension to use the new [`<xul:panel>`](/en-US/docs/Mozilla/Tech/XUL/panel) XUL element. If you wish to keep the panel from automatically disappearing after a delay, you can set the `noautohide` attribute to `true`.
+Extensions that attempt to overlay onto the "appcontent" box try to float chrome over document content will no longer display that material. You should update your extension to use the new [`<xul:panel>`](https://web.archive.org/web/20210301150646/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/panel) XUL element. If you wish to keep the panel from automatically disappearing after a delay, you can set the `noautohide` attribute to `true`.
 
 ## Other changes
 
@@ -150,7 +150,7 @@ _Add simple changes you had to make while updating your extension to work with F
 
 - `chrome://browser/base/utilityOverlay.js` is no longer supported for security reasons. If you were previously using this, you should switch to `chrome://browser/content/utilityOverlay.js`.
 - `nsIAboutModule` implementations are now required to support the `getURIFlags` method. See [nsIAboutModule.idl](https://searchfox.org/mozilla-central/source/netwerk/protocol/about/nsIAboutModule.idl) for documentation. This affects extensions that provide new `about:` URIs. ([Firefox bug 337746](https://bugzil.la/337746))
-- The [`<xul:tabbrowser>`](/en-US/docs/Mozilla/Tech/XUL/tabbrowser) element is no longer part of "toolkit" ([Firefox bug 339964](https://bugzil.la/339964)). This means this element is no longer available to XUL applications and extensions. It continues to be used in the main Firefox window (browser.xul).
+- The [`<xul:tabbrowser>`](https://web.archive.org/web/20210221234616/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/tabbrowser) element is no longer part of "toolkit" ([Firefox bug 339964](https://bugzil.la/339964)). This means this element is no longer available to XUL applications and extensions. It continues to be used in the main Firefox window (browser.xul).
 - Changes to `nsISupports_proxies` and possibly to threading-related interfaces need to be documented.
 - If you use XML processing instructions, such as `<?xml-stylesheet ?>` in your XUL files, be aware of the changes made in [Firefox bug 319654](https://bugzil.la/319654):
   1. XML PIs are now added to a XUL document's DOM. This means {{ Domxref("Node.firstChild", "document.firstChild") }} is no longer guaranteed to be the root element. If you need to get the root document in your script, use {{ Domxref("document.documentElement") }} instead.
@@ -160,4 +160,4 @@ _Add simple changes you had to make while updating your extension to work with F
 - `content.window.getSelection()` gives an object (which can be converted to a string by `toString()`), unlike the now deprecated `content.document.getSelection()` which returns a string
 - `event.preventBubble()` was deprecated in Firefox 2 and has been removed in Firefox 3. Use [`event.stopPropagation()`](/en-US/docs/Web/API/Event/stopPropagation), which works in Firefox 2 as well.
 - Timers that are initiated using {{domxref("Window.setTimeout", "setTimeout()")}} and {{domxref("WorkerGlobalScope.setTimeout", "setTimeout()")}} are now blocked by modal windows due to the fix made for [Firefox bug 52209](https://bugzil.la/52209). You may use `nsITimer` instead.
-- If your extension needs to allow an untrusted source (e.g., a website) to access the extension's chrome, then you must use the new [`contentaccessible` flag](/en-US/docs/Chrome_Registration#contentaccessible).
+- If your extension needs to allow an untrusted source (e.g., a website) to access the extension's chrome, then you must use the new [`contentaccessible` flag](https://web.archive.org/web/20210623201644/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration#contentaccessible).

--- a/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -85,10 +85,10 @@ The same-origin policy for file: URIs has changed in Firefox 3. This may affect 
 
 ## JavaScript changes
 
-Firefox 3 supports [JavaScript 1.8](/en-US/docs/New_in_JavaScript_1.8). One important change that may require updates to your website or application is that the obsolete and non-standard `Script` object is no longer supported. This is not the `<script>` tag, but a JavaScript object that was never standardized. It is unlikely this is something you ever used anyway, so you're probably fine.
+Firefox 3 supports [JavaScript 1.8](https://web.archive.org/web/20210224081539/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/1.8). One important change that may require updates to your website or application is that the obsolete and non-standard `Script` object is no longer supported. This is not the `<script>` tag, but a JavaScript object that was never standardized. It is unlikely this is something you ever used anyway, so you're probably fine.
 
 ## See also
 
 - [Firefox 3 for developers](/en-US/docs/Mozilla/Firefox/Releases/3)
-- [New in JavaScript 1.8](/en-US/docs/New_in_JavaScript_1.8)
+- [New in JavaScript 1.8](https://web.archive.org/web/20210224081539/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/1.8)
 - [Updating extensions for Firefox 3](/en-US/docs/Mozilla/Firefox/Releases/3/Updating_extensions)

--- a/files/en-us/mozilla/firefox/releases/31/index.md
+++ b/files/en-us/mozilla/firefox/releases/31/index.md
@@ -66,7 +66,7 @@ New ECMAScript 2015 features implemented:
 
 ### MathML
 
-- Partial implementation of the [OpenType MATH table](https://learn.microsoft.com/en-us/typography/opentype/spec/math), section 6.3.6 ([Firefox bug 407059](https://bugzil.la/407059)). For details, try the [MathML torture test](/en-US/docs/Mozilla/MathML_Project/MathML_Torture_Test).
+- Partial implementation of the [OpenType MATH table](https://learn.microsoft.com/en-us/typography/opentype/spec/math), section 6.3.6 ([Firefox bug 407059](https://bugzil.la/407059)). For details, try the [MathML torture test](https://web.archive.org/web/20210605072117/https://developer.mozilla.org/en-US/docs/Mozilla/MathML_Project/MathML_Torture_Test).
 - The `::-moz-math-stretchy` pseudo-element has been removed ([Firefox bug 1000879](https://bugzil.la/1000879)).
 - When available, the Unicode Mathematical alphanumeric characters are used for bold, italic and bold-italic math variants ([Firefox bug 930504](https://bugzil.la/930504)).
 
@@ -92,16 +92,16 @@ _No change._
   }
   ```
 
-- `nsIDOMWindowUtils.sendQueryContentEvent()` and `nsIDOMWindowUtils.sendSelectionSetEvent()` have `aAdditionalFlags` as optional argument. If you called `nsIDOMWindowUtils.sendSelectionSetEvent()` with `true` for `aReverse`, the behavior would be broken by this change. See [explanation of each flag](/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIDOMWindowUtils#constants) (`QUERY_CONTENT_FLAG_*` and `SELECTION_SET_FLAG_*`) for the detail of `aAdditionalFlags`.
+- `nsIDOMWindowUtils.sendQueryContentEvent()` and `nsIDOMWindowUtils.sendSelectionSetEvent()` have `aAdditionalFlags` as optional argument. If you called `nsIDOMWindowUtils.sendSelectionSetEvent()` with `true` for `aReverse`, the behavior would be broken by this change. See [explanation of each flag](https://web.archive.org/web/20210518041413/https://developer.mozilla.org/en-US/docs/mozilla/tech/xpcom/reference/interface/nsidomwindowutils#constants) (`QUERY_CONTENT_FLAG_*` and `SELECTION_SET_FLAG_*`) for the detail of `aAdditionalFlags`.
 
 ### Add-on SDK
 
 Highlights:
 
 - [Add-on Debugger](https://extensionworkshop.com/documentation/develop/debugging/)
-- Added the ability to convert [between high-level BrowserWindow objects and DOM windows](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/windows#converting_to_dom_windows), and [between high-level Tab objects and XUL tabs](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/tabs#converting_to_xul_tabs).
+- Added the ability to convert [between high-level BrowserWindow objects and DOM windows](https://web.archive.org/web/20201201230444/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/windows#converting_to_dom_windows), and [between high-level Tab objects and XUL tabs](https://web.archive.org/web/20210117200824/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/tabs#converting_to_xul_tabs).
 - Updated the default theme used for panels on Mac OS X.
-- Added [contentStyle and contentStyleFile](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/panel#styling_panel_content) options to panel.
+- Added [contentStyle and contentStyleFile](https://web.archive.org/web/20201201022417/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/panel#styling_panel_content) options to panel.
 
 [GitHub commits made between Firefox 30 and Firefox 31](https://github.com/mozilla/addon-sdk/compare/firefox30...firefox31). This will not include any uplifts made after this release entered Aurora.
 

--- a/files/en-us/mozilla/firefox/releases/32/index.md
+++ b/files/en-us/mozilla/firefox/releases/32/index.md
@@ -52,9 +52,9 @@ Highlights:
 - The {{domxref("KeyboardEvent.code")}} property have been experimentally implemented: it is disabled on release build ([Firefox bug 865649](https://bugzil.la/865649)).
 - Scoped selectors for {{domxref("Document.querySelector()")}} and {{domxref("Document.querySelectorAll()")}}, for example `querySelector(":scope > li")` have been implemented ([Firefox bug 528456](https://bugzil.la/528456)).
 - The experimental implementation of the {{domxref("Document.timeline")}} interface, related to the [Web Animation API](https://drafts.fxtf.org/web-animations/), has been added ([Firefox bug 998246](https://bugzil.la/998246)). It is controlled by `layout.web-animations.api.enabled` preference, enabled only on Nightly and Aurora for the moment.
-- The [Data Store API](/en-US/docs/Web/API/Data_Store_API) has been made available to [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) ([Firefox bug 949325](https://bugzil.la/949325)). It still is only activated for certified applications.
-- The [ServiceWorker](/en-US/docs/Web/API/Service_Worker_API) {{domxref("InstallPhaseEvent")}} and {{domxref("InstallEvent")}} interfaces have been implemented ([Firefox bug 967264](https://bugzil.la/967264)).
-- The [MSISDN Verification API](/en-US/docs/Web/API/MSISDN_Verification_API), only activated for privileged apps, has been added ([Firefox bug 988469](https://bugzil.la/988469)).
+- The [Data Store API](https://web.archive.org/web/20210613234447/https://developer.mozilla.org/en-US/docs/Archive/B2G_OS/API/Data_Store_API) has been made available to [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) ([Firefox bug 949325](https://bugzil.la/949325)). It still is only activated for certified applications.
+- The [ServiceWorker](/en-US/docs/Web/API/Service_Worker_API) `InstallPhaseEvent` and {{domxref("InstallEvent")}} interfaces have been implemented ([Firefox bug 967264](https://bugzil.la/967264)).
+- The MSISDN Verification API, only activated for privileged apps, has been added ([Firefox bug 988469](https://bugzil.la/988469)).
 - The [Gamepad API](/en-US/docs/Web/API/Gamepad_API) is now supported on Firefox for Android ([Firefox bug 852935](https://bugzil.la/852935)).
 - To match the spec and the evolution of the CSS syntax, minor changes have been done to {{domxref("CSS.escape_static", "CSS.escape()")}}. The identifier now can begins with `'--'` and the second dash must not be escaped. Also vendor identifier are no more escaped. ([Firefox bug 1008719](https://bugzil.la/1008719))
 - To complete our Hit Regions implementation, `MouseEvent.region` has been implemented ([Firefox bug 979692](https://bugzil.la/979692)).
@@ -109,8 +109,8 @@ A `getDataDirectory()` method has been added to `Addon` instances. This method r
 
 #### Highlights
 
-- Added [`exclude`](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/page-mod#pagemod%28options%29) option to `PageMod`.
-- Added [`anonymous`](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/request#request%28options%29) option to `Request`.
+- Added [`exclude`](https://web.archive.org/web/20210216122834/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/page-mod#pagemod%28options%29) option to `PageMod`.
+- Added [`anonymous`](https://web.archive.org/web/20201201022954/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/request#request%28options%29) option to `Request`.
 - [Add-on Debugger](https://extensionworkshop.com/documentation/develop/debugging/) now includes a Console and a Scratchpad.
 
 #### Details

--- a/files/en-us/mozilla/firefox/releases/34/index.md
+++ b/files/en-us/mozilla/firefox/releases/34/index.md
@@ -106,8 +106,8 @@ _No change._
 
 #### Highlights
 
-- New API: [dev/panel](/en-US/docs/Mozilla/Add-ons/SDK/Low-Level_APIs/dev_panel) enables you to extend the Firefox Developer Tools.
-- [jpm](/en-US/docs/Mozilla/Add-ons/SDK/Tools/jpm) beta released.
+- New API: [dev/panel](https://web.archive.org/web/20210517043357/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Low-Level_APIs/dev_panel) enables you to extend the Firefox Developer Tools.
+- [jpm](https://web.archive.org/web/20210221222338/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Tools/jpm) beta released.
 - `"./my-file"` introduced everywhere as an alias for `require("sdk/self").data.url("my-file")`
 - Added the ability to [attach stylesheets to individual tabs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API#manipulating_a_tabs_css).
 

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -32,7 +32,7 @@ Highlights:
 - The {{cssxref("text-decoration")}} property is turned into shorthand property ([Firefox bug 1039488](https://bugzil.la/1039488)).
 - The properties {{cssxref("object-fit")}} and {{cssxref("object-position")}} are now supported ([Firefox bug 624647](https://bugzil.la/624647))
 - The `contents` value of the {{cssxref("display")}} property has been experimentally implemented. It is preffed off by default ([Firefox bug 907396](https://bugzil.la/907396)).
-- In [Quirks mode](/en-US/docs/Web/HTML/Guides/Quirks_mode_and_standards_mode), the [`:active` and `:hover` quiver quirk](/en-US/docs/Mozilla_Quirks_Mode_Behavior#Miscellaneous_.26_Style) has been altered to be applied less often: it is now used only on links, only if there are no pseudo-element or other pseudo-class in the element and if it isn't part of a pseudo-class element ([Firefox bug 783213](https://bugzil.la/783213)).
+- In [Quirks mode](/en-US/docs/Web/HTML/Guides/Quirks_mode_and_standards_mode), the [`:active` and `:hover` quiver quirk](https://web.archive.org/web/20210414153205/https://developer.mozilla.org/en-US/docs/Mozilla/Mozilla_quirks_mode_behavior#Miscellaneous_.26_Style) has been altered to be applied less often: it is now used only on links, only if there are no pseudo-element or other pseudo-class in the element and if it isn't part of a pseudo-class element ([Firefox bug 783213](https://bugzil.la/783213)).
 - The {{cssxref("isolation")}} property has been implemented ([Firefox bug 1077872](https://bugzil.la/1077872)).
 - CSS {{cssxref("&lt;gradient&gt;")}} now applies on the premultiplied colors, matching the spec and other browsers, and getting rid of unexpected gray colors appearing in them ([Firefox bug 591600](https://bugzil.la/591600)).
 - Interpolation hint syntax has been added to {{cssxref("&lt;gradient&gt;")}} ([Firefox bug 1074056](https://bugzil.la/1074056)).
@@ -45,7 +45,7 @@ Highlights:
 
 ### JavaScript
 
-- The [ECMAScript 2015](/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla) Symbol data type has been enabled by default (was available in the Nightly channel since version 33) ([Firefox bug 1066322](https://bugzil.la/1066322)):
+- The [ECMAScript 2015](https://web.archive.org/web/20210612110055/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/ECMAScript_2015_support_in_Mozilla) Symbol data type has been enabled by default (was available in the Nightly channel since version 33) ([Firefox bug 1066322](https://bugzil.la/1066322)):
   - {{jsxref("Symbol")}}
   - {{jsxref("Symbol.for()")}}
   - {{jsxref("Symbol.keyFor()")}}
@@ -116,8 +116,8 @@ _No change._
 
 #### Highlights
 
-- The [`sdk/test/httpd`](/en-US/docs/Mozilla/Add-ons/SDK/Low-Level_APIs/test_httpd) module was removed, use the [addon-httpd](https://www.npmjs.com/package/addon-httpd) npm module instead.
-- Add badges to [`sdk/ui`](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/ui) buttons ([Firefox bug 994280](https://bugzil.la/994280)).
+- The [`sdk/test/httpd`](https://web.archive.org/web/20160422002127/https://developer.mozilla.org/en-US/Add-ons/SDK/Low-Level_APIs/test_httpd) module was removed, use the [addon-httpd](https://www.npmjs.com/package/addon-httpd) npm module instead.
+- Add badges to [`sdk/ui`](https://web.archive.org/web/20210216154222/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/ui) buttons ([Firefox bug 994280](https://bugzil.la/994280)).
 - Implemented global `require` function to access sdk modules anywhere ([Firefox bug 1070927](https://bugzil.la/1070927)), using:
 
   ```js

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -139,7 +139,7 @@ _No change._
 
 #### Downloads.jsm
 
-- [`DownloadTarget`](/en-US/docs/Mozilla/JavaScript_code_modules/Downloads.jsm/DownloadTarget) objects now have `exists` and `size` properties, allowing you to determine the existence of and the size of the download's target file on disk, as well as a new `refresh()` method, which asks that these values be updated.
+- [`DownloadTarget`](https://web.archive.org/web/20210623121639/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Downloads.jsm/DownloadTarget) objects now have `exists` and `size` properties, allowing you to determine the existence of and the size of the download's target file on disk, as well as a new `refresh()` method, which asks that these values be updated.
 
 ### XPCOM
 

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -251,7 +251,7 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
   - : Support for the Internet Explorer-originated `setCapture()` and `releaseCapture()` APIs has been added. See [Firefox bug 503943](https://bugzil.la/503943).
 - [Manipulating the browser history](/en-US/docs/Web/API/History_API)
   - : The existing document history object, available through the {{domxref("window.history")}} object, now supports the new HTML5 `pushState()` and `replaceState()` methods.
-- Animations using MozBeforePaint
+- Animations using `MozBeforePaint`
   - : A new event has been added which, in concert with the `window.mozRequestAnimationFrame()` method and `window.mozAnimationStartTime` property, provides a way to create animations that are synchronized with one another.
 - Touch and multi-touch events
   - : Support has been added for touch and multi-touch events.

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -228,8 +228,6 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
 
 - [WebGL](/en-US/docs/Web/API/WebGL_API)
   - : The developing WebGL standard is now supported by Firefox.
-- [Optimizing graphics performance](/en-US/docs/Optimizing_graphics_performance)
-  - : Tips and tricks for getting the most out of graphics and video performance in Firefox 4.
 - [Support for WebM video](/en-US/docs/Web/Media/Guides/Formats/Containers#webm)
   - : The new open [WebM](https://www.webmproject.org/) video format is supported by Gecko 2.0.
 - [SVG animation with SMIL](/en-US/docs/Web/SVG/Guides/SVG_animation_with_SMIL)
@@ -253,7 +251,7 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
   - : Support for the Internet Explorer-originated `setCapture()` and `releaseCapture()` APIs has been added. See [Firefox bug 503943](https://bugzil.la/503943).
 - [Manipulating the browser history](/en-US/docs/Web/API/History_API)
   - : The existing document history object, available through the {{domxref("window.history")}} object, now supports the new HTML5 `pushState()` and `replaceState()` methods.
-- [Animations using MozBeforePaint](/en-US/docs/DOM/Animations_using_MozBeforePaint)
+- Animations using MozBeforePaint
   - : A new event has been added which, in concert with the `window.mozRequestAnimationFrame()` method and `window.mozAnimationStartTime` property, provides a way to create animations that are synchronized with one another.
 - Touch and multi-touch events
   - : Support has been added for touch and multi-touch events.
@@ -291,11 +289,11 @@ Several HTML elements have had their DOM interfaces changed to the ones required
 - The {{domxref("DOMImplementation.createHTMLDocument()")}} method lets you create a new HTML document.
 - `Node.mozMatchesSelector()` now throws a `SYNTAX_ERR` exception if the specified selector string is invalid, instead of incorrectly returning `false`.
 - You can now set an element's SVG properties' values using the same shorthand syntax as with CSS. For example: `element.style.fill = 'lime'`. See {{domxref("HTMLElement/style", "style")}} for details.
-- The document root now has [a `privatebrowsingmode` attribute](/en-US/docs/Supporting_private_browsing_mode#detecting_whether_private_browsing_mode_is_permanent) that describes the state of private browsing mode, including an indication of whether private browsing is temporary or permanent for the session.
+- The document root now has [a `privatebrowsingmode` attribute](https://web.archive.org/web/20210620014429/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Supporting_private_browsing_mode#detecting_whether_private_browsing_mode_is_permanent) that describes the state of private browsing mode, including an indication of whether private browsing is temporary or permanent for the session.
 - The second parameter of the {{domxref("window.getComputedStyle()")}} method is now optional, as it is in every other major browser.
 - The DOM {{domxref("StorageEvent")}} object now matches the latest version of the specification.
 - The minimum allowed delay for the {{domxref("Window.setTimeout", "setTimeout()")}} and {{domxref("WorkerGlobalScope.setTimeout", "setTimeout()")}} method is now a preference, `dom.min_timeout_value`.
-- The [`MozAfterPaint`](/en-US/docs/Gecko-Specific_DOM_Events#mozafterpaint) event is no longer sent by default, due to a potential security issue. It can be re-enabled by setting a preference.
+- The [`MozAfterPaint`](https://web.archive.org/web/20191010014917/https://developer.mozilla.org/en-US/docs/Web/Events#Add-on-specific_events) event is no longer sent by default, due to a potential security issue. It can be re-enabled by setting a preference.
 
 ### Security
 
@@ -310,7 +308,7 @@ Several HTML elements have had their DOM interfaces changed to the ones required
 
 ### JavaScript
 
-For an overview of the changes implemented in JavaScript 1.8.5, see [New in JavaScript 1.8.5](/en-US/docs/JavaScript/New_in_JavaScript/1.8.5). JavaScript in Firefox 4 will have additional adherence to the ECMAScript 5 standard.
+For an overview of the changes implemented in JavaScript 1.8.5, see [New in JavaScript 1.8.5](https://web.archive.org/web/20210516173330/https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/1.8.5). JavaScript in Firefox 4 will have additional adherence to the ECMAScript 5 standard.
 
 ### Developer tools
 
@@ -324,41 +322,41 @@ For an overview of the changes implemented in JavaScript 1.8.5, see [New in Java
 
 For helpful tips on updating existing extensions for Firefox 4, see [Updating extensions for Firefox 4](/en-US/docs/Mozilla/Firefox/Releases/4/Updating_extensions_for_Firefox_4). There are several key changes that break compatibility with existing add-ons, so be sure to read that article.
 
-If you're a theme developer, you should read [Theme changes in Firefox 4](/en-US/docs/Theme_changes_in_Firefox_4) to understand some critical changes you'll need to be aware of.
+If you're a theme developer, you should read [Theme changes in Firefox 4](https://web.archive.org/web/20210515184532/https://developer.mozilla.org/en-US/docs/Archive/Themes/Theme_changes_in_Firefox_4) to understand some critical changes you'll need to be aware of.
 
 ### JavaScript code modules
 
-- [Services.jsm](/en-US/docs/JavaScript_code_modules/Services.jsm)
+- [Services.jsm](https://web.archive.org/web/20210417185248/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Services.jsm)
   - : The `Services.jsm` code module provides getters that make it easy to obtain references to commonly-used services, such as the preferences service or the window mediator, among others.
-- [JS-ctypes API](/en-US/docs/JavaScript_code_modules/ctypes.jsm)
+- [JS-ctypes API](https://web.archive.org/web/20210528115949/https://developer.mozilla.org/en-US/docs/Mozilla/js-ctypes)
   - : The JS-ctypes API makes it possible to call C-compatible foreign library functions without using XPCOM.
 - [Add-ons Manager](https://firefox-source-docs.mozilla.org/toolkit/mozapps/extensions/addon-manager/index.html)
   - : The new Add-ons Manager provides information about installed add-ons, support for managing them, and provides ways to install and remove add-ons.
-- [PopupNotifications.jsm](/en-US/docs/JavaScript_code_modules/PopupNotifications.jsm)
-  - : The new popup notifications module makes it easy to present attractive, non-modal notifications to the user. You can see how to use this API in [Using popup notifications](/en-US/docs/Using_popup_notifications).
-- [Loading code modules from chrome: URLs](/en-US/docs/JavaScript_code_modules/Using#locating_the_code_module)
+- [PopupNotifications.jsm](https://web.archive.org/web/20210414083224/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/PopupNotifications.jsm)
+  - : The new popup notifications module makes it easy to present attractive, non-modal notifications to the user. You can see how to use this API in [Using popup notifications](https://web.archive.org/web/20210411021529/https://developer.mozilla.org/en-US/docs/Mozilla/Using_popup_notifications).
+- [Loading code modules from chrome: URLs](https://web.archive.org/web/20210529003507/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Using#locating_the_code_module)
   - : You can now load JavaScript code modules using **chrome:** URLs, even inside JAR files.
 - DownloadLastDir.jsm
-  - : The [`DownloadLastDir.jsm`](/en-US/docs/JavaScript_code_modules/DownloadLastDir.jsm) code module provides the `gDownloadLastDir` global variable, which contains a string you can use to learn the path of the directory into which the last download occurred. This module handles issues related to private browsing for you.
-- [Measuring performance using the PerfMeasurement.jsm code module](/en-US/docs/Performance/Measuring_performance_using_the_PerfMeasurement.jsm_code_module)
-  - : The [`PerfMeasurement.jsm`](/en-US/docs/JavaScript_code_modules/PerfMeasurement.jsm) code module provides an API to measure CPU-level performance data in JavaScript code.
+  - : The [`DownloadLastDir.jsm`](https://web.archive.org/web/20210615230651/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/DownloadLastDir.jsm) code module provides the `gDownloadLastDir` global variable, which contains a string you can use to learn the path of the directory into which the last download occurred. This module handles issues related to private browsing for you.
+- [Measuring performance using the PerfMeasurement.jsm code module](https://web.archive.org/web/20210420142952/https://developer.mozilla.org/en-US/docs/Mozilla/Performance/Measuring_performance_using_the_PerfMeasurement.jsm_code_module)
+  - : The [`PerfMeasurement.jsm`](https://web.archive.org/web/20210620175828/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/PerfMeasurement.jsm) code module provides an API to measure CPU-level performance data in JavaScript code.
 
 #### Miscellaneous changes to code modules
 
 - The `NetUtil.jsm` code module now offers the `readInputStreamToString()` method, which lets you read arbitrary bytes from a stream into a string, even if the stream includes zeroes.
 - The XPCOMUtils.jsm code module now offers IterSimpleEnumerator() and IterStringEnumerator() helpers to iterate over XPCOM enumerators.
-- You can now [use workers in JavaScript code modules](/en-US/docs/JavaScript_code_modules/Using_workers_in_JavaScript_code_modules).
+- You can now [use workers in JavaScript code modules](https://web.archive.org/web/20210620192749/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Using_workers_in_JavaScript_code_modules).
 
 ### DOM changes
 
 - `ChromeWorker`
-  - : A new type of worker for privileged code; this lets you use things like [js-ctypes](/en-US/docs/js-ctypes) from workers in extensions and application code.
+  - : A new type of worker for privileged code; this lets you use things like [js-ctypes](https://web.archive.org/web/20210528115949/https://developer.mozilla.org/en-US/docs/Mozilla/js-ctypes) from workers in extensions and application code.
 - [Touch events](/en-US/docs/Web/API/Touch_events)
   - : Support for (non-standard) touch events has been added; these let you track multiple fingers moving on a touch screen at the same time.
 
 #### Other DOM changes
 
-- The [new "document-element-inserted" notification](/en-US/docs/Observer_Notifications#documents) is sent when a document's root element is created, but before any scripts are executed on it.
+- The [new "document-element-inserted" notification](https://web.archive.org/web/20210703204149/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Observer_Notifications#documents) is sent when a document's root element is created, but before any scripts are executed on it.
 
 ### XUL
 
@@ -431,28 +429,28 @@ Remote XUL is no longer supported; this affects XUL documents being served throu
 
 In addition to the specific changes referenced below, it's important to note that there are no longer any frozen interfaces. All interfaces are now unfrozen, regardless of what the documentation may say. We'll update the documentation over time.
 
-- [XPCOM changes in Gecko 2.0](/en-US/docs/XPCOM/XPCOM_changes_in_Gecko_2.0)
+- [XPCOM changes in Gecko 2.0](https://web.archive.org/web/20210514105748/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Changes_in_Gecko_2.0)
   - : Details about changes to XPCOM that impact compatibility in Firefox 4.
-- [Components.utils.getGlobalForObject()](/en-US/docs/Components.utils.getGlobalForObject)
+- [Components.utils.getGlobalForObject()](https://web.archive.org/web/20210625071536/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.getGlobalForObject)
   - : This new method returns the global object with which an object is associated; this replaces a common use case of the now-removed `__parent__`.
 
 ### Places
 
 - Places query results may now be observed by multiple observers, and queries may be executed asynchronously. This means there have been some changes to the `nsINavHistoryResult`, `nsINavHistoryQueryOptions`, and `nsINavHistoryContainerResultNode` interfaces. More significantly, the `nsINavHistoryResultViewer` interface has been renamed to `nsINavHistoryResultObserver`.
-- Some [new notifications](/en-US/docs/Observer_Notifications#places) have been added to enable the browser to track the shutdown process of the Places service more reliably. Of these, most are for internal use only, but the `places-connection-closed` notification is available to know when the Places service has completed its shutdown process.
+- Some [new notifications](https://web.archive.org/web/20210703204149/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Observer_Notifications) have been added to enable the browser to track the shutdown process of the Places service more reliably. Of these, most are for internal use only, but the `places-connection-closed` notification is available to know when the Places service has completed its shutdown process.
 - The array size output parameter on several Places methods is now optional.
-- Support for `<menupopup type="places">` has been removed. Instead, you need to create and populate a menu with Places information manually, instead of having it done for you. See [Displaying Places information using views: Menu view](/en-US/docs/Displaying_Places_information_using_views#menu_view) for details.
+- Support for `<menupopup type="places">` has been removed. Instead, you need to create and populate a menu with Places information manually, instead of having it done for you. See [Displaying Places information using views: Menu view](https://web.archive.org/web/20201028190050/https://developer.mozilla.org/en-US/docs/Mozilla/Displaying_Place_information_using_views#menu_view) for details.
 
 ### Interface changes
 
 - The `nsIDocShell` and `nsIWebBrowser` interfaces now have a new `isActive` attribute, which is used to allow optimization of code paths for documents that aren't currently visible.
-- The `nsIMemory` method `nsIMemory.isLowMemory()` has been deprecated. You should use ["memory-pressure" notifications](/en-US/docs/XPCOM_Interface_Reference/nsIMemory#low_memory_notifications) to watch for low memory situations instead.
+- The `nsIMemory` method `nsIMemory.isLowMemory()` has been deprecated. You should use ["memory-pressure" notifications](https://web.archive.org/web/20210516060454/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIMemory#low_memory_notifications) to watch for low memory situations instead.
 - The API for handling redirects on HTTP channels has changed to let them be processed asynchronously. Any code that implements redirect handling using `nsIChannelEventSink.onChannelRedirect()` needs to be updated to use `nsIChannelEventSink.asyncOnChannelRedirect()` instead. This accepts a callback handler that must be called when a redirect is successfully completed.
 - The `nsINavHistoryResultObserver.batching()` method has been added, providing a way to group Places operations into batches, reducing the number of update notifications delivered, which can improve performance when observers are performing relatively involved tasks (such as refreshing views).
 - The long-obsolete `nsIPref` interface has finally been removed. If you haven't already switched to `nsIPrefService`, now is the time.
 - The `nsISessionStore` and `nsISessionStartup` interfaces received changes to support on-demand session restore. See the `nsISessionStore.restoreLastSession()` method.
 - The `nsIPrincipal` methods `nsIPrincipal.subsumes()` and `nsIPrincipal.checkMayLoad()`, as well as its `origin`, `csp`, and `URI` attributes, are now available from script; previously they were only available from native code.
-- The `nsIPrompt` interface now supports tab-modal alerts; see [Using tab-modal prompts](/en-US/docs/Using_tab-modal_prompts) for details.
+- The `nsIPrompt` interface now supports tab-modal alerts; see [Using tab-modal prompts](https://web.archive.org/web/20210513121539/https://developer.mozilla.org/en-US/docs/Mozilla/Using_tab-modal_prompts) for details.
 - The `nsIEffectiveTLDService.getPublicSuffixFromHost()` method now correctly rejects host name starting with a period (".").
 - The `mozIJSSubScriptLoader.loadSubScript()` method now has an optional argument allowing you to specify the character set of the script; if one is not provided, ASCII is assumed (as was always assumed previously).
 - The `nsIAccessProxy` interface has been removed. It was an implementation detail that has outlived its usefulness.
@@ -464,33 +462,33 @@ In addition to the specific changes referenced below, it's important to note tha
 
 ### Memory management
 
-- [Infallible memory allocation](/en-US/docs/Infallible_memory_allocation)
+- [Infallible memory allocation](https://web.archive.org/web/20201026230445/https://developer.mozilla.org/en-US/docs/Mozilla/Infallible_memory_allocation)
   - : Mozilla now provides infallible memory allocators that are guaranteed not to return null. You should read this article to learn how they work and how to explicitly request fallible versus infallible memory allocation.
 
 ### Other changes
 
-- Most of the resources contained within Firefox have been combined into a single JAR archive, `omni.jar`, which improves startup performance by reducing I/O. For details, read [About omni.jar](/en-US/docs/About_omni.jar).
+- Most of the resources contained within Firefox have been combined into a single JAR archive, `omni.jar`, which improves startup performance by reducing I/O. For details, read [About omni.jar](https://web.archive.org/web/20210620190432/https://developer.mozilla.org/en-US/docs/Mozilla/About_omni.ja_%28formerly_omni.jar%29).
 - The `accessibility.disablecache` preference is no longer supported; it was only exposed for debugging purposes and is no longer used.
 - Addons whose GUID changes from one version to another can now be updated properly.
 - As a side effect of the removal of platform-specific directories in add-on bundles, you can no longer provide different default preferences for each platform.
-- By default, [extensions are no longer unpacked when they are installed](https://web.archive.org/web/20130707104214/https://blog.mozilla.org/mwu/2010/09/10/extensions-now-installed-packed/), but are instead run directly from the XPI file. Extensions can use the [unpack](/en-US/docs/Install_Manifests#unpack) property in the [install manifest](/en-US/docs/Install_Manifests) to choose the old behavior. Extensions that use binary components, DLLs loaded using [js-ctypes](/en-US/docs/js-ctypes), [search plugins](/en-US/docs/Web/XML/Guides/OpenSearch), dictionaries, and window icons must specify that they need to be unpacked. Extensions that [create SQLite database](/en-US/docs/XUL_School/Local_Storage#sqlite), or do copy things from the filesystem relatively to the extension's directory, may also need to change their code.
-- You may now include extensions that [automatically get installed at application startup](/en-US/docs/Mozilla/Developer_guide/Customizing_Firefox#including_extensions_with_your_distribution_of_firefox) within a customized Firefox.
+- By default, [extensions are no longer unpacked when they are installed](https://web.archive.org/web/20130707104214/https://blog.mozilla.org/mwu/2010/09/10/extensions-now-installed-packed/), but are instead run directly from the XPI file. Extensions can use the [unpack](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#unpack) property in the [install manifest](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests) to choose the old behavior. Extensions that use binary components, DLLs loaded using [js-ctypes](https://web.archive.org/web/20210528115949/https://developer.mozilla.org/en-US/docs/Mozilla/js-ctypes), [search plugins](/en-US/docs/Web/XML/Guides/OpenSearch), dictionaries, and window icons must specify that they need to be unpacked. Extensions that [create SQLite database](https://web.archive.org/web/20201109001036/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Overlay_Extensions/XUL_School/Local_Storage#sqlite), or do copy things from the filesystem relatively to the extension's directory, may also need to change their code.
+- You may now include extensions that [automatically get installed at application startup](https://web.archive.org/web/20180604010849/https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Customizing_Firefox#including_extensions_with_your_distribution_of_firefox) within a customized Firefox.
 
 ## Other changes
 
 - Only the root chrome.manifest file is loaded
-  - : Only the root `chrome.manifest` file is loaded now; if you need secondary manifest files to be loaded, you can use the [`manifest`](/en-US/docs/Chrome_Registration#manifest) command in your root `chrome.manifest` to load them.
+  - : Only the root `chrome.manifest` file is loaded now; if you need secondary manifest files to be loaded, you can use the [`manifest`](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration#manifest) command in your root `chrome.manifest` to load them.
 - Gopher support removed
   - : The Gopher protocol is no longer supported natively. Continued support is available via the [OverbiteFF](https://addons.mozilla.org/en-US/firefox/addon/overbitenx/) extension.
-- [Content process event handling](/en-US/docs/The_message_manager)
+- [Content process event handling](https://web.archive.org/web/20210531151101/https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox/Message_Manager)
   - : In order to support out-of-process plugins and other multiple-process features, a new API has been introduced to support sending messages across processes.
-- [Bootstrapped extensions](/en-US/docs/Extensions/Bootstrapped_extensions)
+- [Bootstrapped extensions](https://web.archive.org/web/20210519000929/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Bootstrapped_extensions)
   - : You can now create extensions that can be installed, uninstalled, and upgraded (or downgraded) without requiring a browser restart.
 - Default plugin removed
   - : The default plugin has been removed. The application plugins folder has also been removed by default, however support for installing plugins via this folder still exists. See [Firefox bug 533891](https://bugzil.la/533891).
 - Extension Manager replaced by Addon Manager
   - : `nsIExtensionManager` has been replaced by [AddonManager](https://firefox-source-docs.mozilla.org/toolkit/mozapps/extensions/addon-manager/AddonManager.html).
 - Child HWNDs no longer used
-  - : Firefox no longer creates child HWNDs for its internal use on Windows. If you've written an extension that uses native code to manipulate these HWNDs, your extension will not work on Firefox 4. You'll need to either stop using HWNDs or wrap your code that relies on HWNDs in an [NPAPI](/en-US/docs/NPAPI) plugin. That's a lot of work, so if you can avoid using HWNDs directly, you should.
+  - : Firefox no longer creates child HWNDs for its internal use on Windows. If you've written an extension that uses native code to manipulate these HWNDs, your extension will not work on Firefox 4. You'll need to either stop using HWNDs or wrap your code that relies on HWNDs in an NPAPI plugin. That's a lot of work, so if you can avoid using HWNDs directly, you should.
 - Gesture changes
   - : The three finger up and down swipe gestures on trackpads have been changed to, by default, open and close Firefox Panorama view (neé TabCandy). To change these back to the previous scroll-to-top and scroll-to-bottom commands, open about:config and set `browser.gesture.swipe.down` to `cmd_scrollBottom` and `browser.gesture.swipe.up` to `cmd_scrollTop`.

--- a/files/en-us/mozilla/firefox/releases/4/updating_extensions_for_firefox_4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/updating_extensions_for_firefox_4/index.md
@@ -30,23 +30,23 @@ If your add-on is discoverable only through the menu bar, you'll want to overlay
 A number of changes were made to the `<tabbrowser>` element to help support app tabs and Panoramas, as well as to make the tab bar into a standard toolbar. Other changes that may break existing extensions include:
 
 - The `TabClose`, `TabSelect`, and `TabOpen` events no longer bubble up to the `<tabbrowser>` element (`gBrowser`). Event listeners for those events should be added to `gBrowser.tabContainer` rather than to `gBrowser` directly.
-- The tab context menu is no longer an anonymous child of the `<tabbrowser>`. It can therefore be overlaid directly with [XUL overlays](/en-US/docs/XUL_Overlays). It can also be accessed more directly in JavaScript via `gBrowser.tabContextMenu`. See [this blog post](https://gavinsharp.com/blog/2010/03/31/accessingmodifying-the-firefox-tab-context-menu-from-extensions/) for more details.
+- The tab context menu is no longer an anonymous child of the `<tabbrowser>`. It can therefore be overlaid directly with [XUL overlays](https://web.archive.org/web/20160927025909/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Overlays). It can also be accessed more directly in JavaScript via `gBrowser.tabContextMenu`. See [this blog post](https://gavinsharp.com/blog/2010/03/31/accessingmodifying-the-firefox-tab-context-menu-from-extensions/) for more details.
 
 ## XPCOM changes
 
-Several changes have been made that affect add-ons and applications that include XPCOM components. See [XPCOM changes in Gecko 2](/en-US/docs/XPCOM/XPCOM_changes_in_Gecko_2.0) for details.
+Several changes have been made that affect add-ons and applications that include XPCOM components. See [XPCOM changes in Gecko 2](https://web.archive.org/web/20210514105748/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Changes_in_Gecko_2.0) for details.
 
 ## The Add-on Manager
 
 The overhauled Add-on Manager is implemented as a tab instead of in a separate window. Among the changes that affect your browser from a user experience perspective is that your add-on's icon can be 64x64 pixels now instead of 32x32. While 32x32 pixel icons still work, obviously your add-on will look better if it provides a 64x64 pixel icon instead. Fortunately, 64x64 icons are backward compatible and scale down well, so you can just switch instead of needing both sizes.
 
-In addition, the back-end of the Add-on Manager was redesigned. The `nsIExtensionManager` interface is gone, as is the old RDF-based storage it used. Add-on metadata is now stored in an SQLite database, and the Add-on Manager is now a [JavaScript code module](/en-US/docs/JavaScript_code_modules) called [AddonManager](https://firefox-source-docs.mozilla.org/toolkit/mozapps/extensions/addon-manager/AddonManager.html).
+In addition, the back-end of the Add-on Manager was redesigned. The `nsIExtensionManager` interface is gone, as is the old RDF-based storage it used. Add-on metadata is now stored in an SQLite database, and the Add-on Manager is now a [JavaScript code module](https://web.archive.org/web/20210531090101/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules) called [AddonManager](https://firefox-source-docs.mozilla.org/toolkit/mozapps/extensions/addon-manager/AddonManager.html).
 
 A key difference with the new API is that requesting add-on metadata is now asynchronous instead of synchronous; this applies to add-ons using FUEL as well, so all add-ons that request metadata about add-ons will need to be updated.
 
 ## Threading
 
-You can no longer pass JavaScript objects between threads. This renders the Thread Manager mostly useless for add-on developers, unfortunately, and there aren't at this time many alternatives. It's possible that in the future the [`ChromeWorker`](/en-US/docs/DOM/ChromeWorker) will be improved to fill the void.
+You can no longer pass JavaScript objects between threads. This renders the Thread Manager mostly useless for add-on developers, unfortunately, and there aren't at this time many alternatives. It's possible that in the future the [`ChromeWorker`](https://web.archive.org/web/20210512121129/https://developer.mozilla.org/en-US/docs/Mozilla/Gecko/Chrome/API/ChromeWorker) will be improved to fill the void.
 
 ## Network redirects
 
@@ -54,7 +54,7 @@ The API for handling network redirects has been changed to be asynchronous; any 
 
 ## XPI unpacking
 
-Firefox 4 [no longer extracts XPIs](https://bugzil.la/533038) when installing extensions. It just places the XPI file in the user profile, and then reads the chrome files and others directly out of the XPI. A jar inside the XPI still works, but is no longer necessary, so that can make your development or build easier. This was done mainly for performance reasons on slow OSes, and allows better cache invalidation, which also helps developers. However, not all kinds of files can be read from within the XPI yet, so if your extension uses one of those, you need to specify [`<em:unpack>`](/en-US/Install_Manifests#unpack) in your install.rdf to cause Firefox to still extract your XPI and use single files, otherwise your extension will fail when trying to access these files.
+Firefox 4 [no longer extracts XPIs](https://bugzil.la/533038) when installing extensions. It just places the XPI file in the user profile, and then reads the chrome files and others directly out of the XPI. A jar inside the XPI still works, but is no longer necessary, so that can make your development or build easier. This was done mainly for performance reasons on slow OSes, and allows better cache invalidation, which also helps developers. However, not all kinds of files can be read from within the XPI yet, so if your extension uses one of those, you need to specify [`<em:unpack>`](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#unpack) in your install.rdf to cause Firefox to still extract your XPI and use single files, otherwise your extension will fail when trying to access these files.
 
 If your extension only contains these types of files then you do not need to make any changes:
 
@@ -84,7 +84,7 @@ If you maintain an extension that uses native components that rely on `HWND`s th
 
 The first, and better, solution is to stop accessing `HWND`s and instead use Web features or XUL to implement your extension. There are a lot of new features in Firefox 4 that make possible a lot of things that used to require native code, so you may no longer need to do this.
 
-If you find that this doesn't work, and you still need to directly access `HWND`s, you may find that your only solution is to write an [NPAPI](/en-US/docs/NPAPI) plugin that does the work. This may be a lot of work, but it should work. Of course, this may not help you if the specific `HWND`s you were using no longer exist.
+If you find that this doesn't work, and you still need to directly access `HWND`s, you may find that your only solution is to write an NPAPI plugin that does the work. This may be a lot of work, but it should work. Of course, this may not help you if the specific `HWND`s you were using no longer exist.
 
 ## Development and testing tips
 

--- a/files/en-us/mozilla/firefox/releases/44/index.md
+++ b/files/en-us/mozilla/firefox/releases/44/index.md
@@ -203,7 +203,7 @@ _No change._
 ### JavaScript code modules
 
 - Added `LIKE` support to Sqlite.jsm ([Firefox bug 1188760](https://bugzil.la/1188760)).
-- Added [Snackbars.jsm](/en-US/docs/Mozilla/Add-ons/Firefox_for_Android/API/Snackbars.jsm) module to [Firefox for Android](/en-US/docs/Mozilla/Firefox_for_Android) ([Firefox bug 1215026](https://bugzil.la/1215026))
+- Added [Snackbars.jsm](https://web.archive.org/web/20160423072423/https://developer.mozilla.org/en-US/Add-ons/Firefox_for_Android/API/Snackbars.jsm) module to [Firefox for Android](https://web.archive.org/web/20210518020027/https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_for_Android) ([Firefox bug 1215026](https://bugzil.la/1215026))
 
 ### XPCOM
 
@@ -211,4 +211,4 @@ _No change._
 
 ### Other
 
-- Due to breaking changes in Firefox 44 ([bug 1202902](https://bugzil.la/1202902)), add-ons packed with [cfx](/en-US/docs/Mozilla/Add-ons/SDK/Tools/cfx) will not work any longer. To make your add-on compatible again, please use [jpm](/en-US/docs/Mozilla/Add-ons/SDK/Tools/jpm). See the [_cfx_ to _jpm_ migration guide](/en-US/docs/Mozilla/Add-ons/SDK/Tools/cfx_to_jpm).
+- Due to breaking changes in Firefox 44 ([bug 1202902](https://bugzil.la/1202902)), add-ons packed with [cfx](https://web.archive.org/web/20201201072958/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Tools/cfx) will not work any longer. To make your add-on compatible again, please use [jpm](https://web.archive.org/web/20210221222338/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Tools/jpm). See the [_cfx_ to _jpm_ migration guide](https://web.archive.org/web/20181116093809/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/Tools/cfx_to_jpm).

--- a/files/en-us/mozilla/firefox/releases/5/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/index.md
@@ -13,10 +13,10 @@ Firefox 5, based on Gecko 5.0, was released on June 21, 2011. This article provi
 ### HTML
 
 - All HTML elements now have the {{ domxref("HTMLElement.accessKey", "accessKey") }} attribute, as well as the {{ domxref("HTMLElement.blur()", "blur()") }}, {{ domxref("HTMLElement.click()", "click()") }}, and {{ domxref("HTMLElement.focus()", "focus()") }} methods. These are specified in the {{ domxref("HTMLElement") }} interface.
-- In order to comply with the HTML5 specification, support for the UTF-7 and UTF-32 [character sets](/en-US/docs/Character_Sets_Supported_by_Gecko) has been removed.
+- In order to comply with the HTML5 specification, support for the UTF-7 and UTF-32 [character sets](https://web.archive.org/web/20210612224236/https://developer.mozilla.org/en-US/docs/Gecko/Character_sets_supported_by_Gecko) has been removed.
 - When in quirks mode, empty {{ HTMLElement("map") }}s are no longer skipped over in favor of non-empty ones when matching.
 - Firefox mobile on Android now supports WOFF fonts for {{ cssxref("@font-face") }}.
-- WebGL [no longer loads textures from domains other than the originating domain](/en-US/docs/Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL#cross-domain_textures), as a security measure. [HTTP access control](/en-US/docs/Web/HTTP_access_control) support should be coming sometime in the future to make this possible more securely.
+- WebGL [no longer loads textures from domains other than the originating domain](/en-US/docs/Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL#cross-domain_textures), as a security measure. [HTTP access control](/en-US/docs/Web/HTTP/Guides/CORS) support should be coming sometime in the future to make this possible more securely.
 
 #### Canvas improvements
 
@@ -82,13 +82,13 @@ Firefox 5, based on Gecko 5.0, was released on June 21, 2011. This article provi
 For a guide to updating your add-on for Firefox 5, please see [Updating add-ons for Firefox 5](/en-US/docs/Mozilla/Firefox/Releases/5/Updating_add-ons).
 
 > [!NOTE]
-> Firefox 5 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
+> Firefox 5 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](https://web.archive.org/web/20210119071646/https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
 
 ### Changes to JavaScript code modules
 
 #### New JavaScript code modules
 
-- The [`Dict.jsm`](/en-US/docs/JavaScript_code_modules/Dict.jsm) code module was added; it provides an API for dictionaries of key/value pairs.
+- The [`Dict.jsm`](https://web.archive.org/web/20210517202711/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Dict.jsm) code module was added; it provides an API for dictionaries of key/value pairs.
 
 #### NetUtil.jsm
 
@@ -118,11 +118,11 @@ The following interfaces were implementation details that are no longer needed:
 
 ### Debugging aids
 
-- The new [`DebugOnly<T>`](/en-US/Namespace/Mozilla/DebugOnly%3CT%3E) helper makes it possible to declare variables only for `DEBUG` builds.
+- The new [`DebugOnly<T>`](https://web.archive.org/web/20160805223656/https://developer.mozilla.org/en-US/docs/Archive/Mozilla/Namespace/Mozilla) helper makes it possible to declare variables only for `DEBUG` builds.
 
 ### JavaScript API (SpiderMonkey)
 
-- [`JS_DoubleToInt32()`](/en-US/docs/SpiderMonkey/JSAPI_Reference/JS_DoubleToInt32) and [`JS_DoubleToUint32()`](/en-US/docs/SpiderMonkey/JSAPI_Reference/JS_DoubleToUint32) have been added, for converting [`jsdouble`](/en-US/docs/SpiderMonkey/JSAPI_Reference/jsdouble) values into C integers and unsigned integers.
+- [`JS_DoubleToInt32()`](https://web.archive.org/web/20210124042726/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_Reference/JS_DoubleToInt32) and [`JS_DoubleToUint32()`](https://web.archive.org/web/20210124042726/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_Reference/JS_DoubleToInt32) have been added, for converting [`jsdouble`](https://web.archive.org/web/20210512110527/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_reference/jsdouble) values into C integers and unsigned integers.
 
 ### Build system changes
 

--- a/files/en-us/mozilla/firefox/releases/51/index.md
+++ b/files/en-us/mozilla/firefox/releases/51/index.md
@@ -148,7 +148,7 @@ Firefox 51 was released on January 24, 2017. This article lists key changes that
   - {{WebExtAPIRef("runtime.getBrowserInfo()")}} ([Firefox bug 1268399](https://bugzil.la/1268399))
   - {{WebExtAPIRef("runtime.reload()")}} and {{WebExtAPIRef("runtime.onUpdateAvailable()")}} ([Firefox bug 1279012](https://bugzil.la/1279012))
 
-- You can now [embed a WebExtension in a legacy add-on type](/en-US/docs/Mozilla/Add-ons/WebExtensions/Embedded_WebExtensions) ([Firefox bug 1252215](https://bugzil.la/1252215)).
+- You can now [embed a WebExtension in a legacy add-on type](https://web.archive.org/web/20210528055219/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Embedded_WebExtensions) ([Firefox bug 1252215](https://bugzil.la/1252215)).
 - [Clipboard access](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard) is now supported ([Firefox bug 1197451](https://bugzil.la/1197451))
 - The arguments passed to the callback of {{WebExtAPIRef("tabs.executeScript()")}} have been fixed ([Firefox bug 1290157](https://bugzil.la/1290157))
 - [localStorage](/en-US/docs/Web/API/Window/localStorage) is now cleared when a WebExtension is uninstalled ([Firefox bug 1213990](https://bugzil.la/1213990))
@@ -156,7 +156,7 @@ Firefox 51 was released on January 24, 2017. This article lists key changes that
 
 ### Other
 
-- The [`multiprocessCompatible` property of `install.rdf`](/en-US/docs/Mozilla/Add-ons/Install_Manifests#multiprocesscompatible) must now be explicitly set to `false` to prevent multiprocess from being enabled in Firefox when the add-on is installed.
+- The [`multiprocessCompatible` property of `install.rdf`](https://web.archive.org/web/20210421140209/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Install_Manifests#multiprocesscompatible) must now be explicitly set to `false` to prevent multiprocess from being enabled in Firefox when the add-on is installed.
 - The Mozilla-specific Social API has been substantially changed (largely to remove APIs no longer used), as follows:
   - The `MozSocial` interface and the `Navigator.mozSocial` property which supports it have been removed.
   - The Social Bookmarks API has been removed.
@@ -167,4 +167,4 @@ Firefox 51 was released on January 24, 2017. This article lists key changes that
   - Social service provider manifest properties supporting the removed functionality are no longer supported.
 
 - If an add-on uses `mimeTypes.rdf` to provide a file extension to MIME type mapping, it must now register an entry in the `"ext-to-type-mapping"` category ([Firefox bug 306471](https://bugzil.la/306471)).
-- The [Browser API](/en-US/docs/Mozilla/Gecko/Chrome/API/Browser_API) now includes a `detail` object on the event object of the `mozbrowserlocationchange` event that contains `canGoForward`/`canGoBack` properties, allowing retrieval of the mozBrowser's back/forward status synchronously ([Firefox bug 1279635](https://bugzil.la/1279635)).
+- The [Browser API](https://web.archive.org/web/20210124171655/https://developer.mozilla.org/en-US/docs/Mozilla/Gecko/Chrome/API/Browser_API) now includes a `detail` object on the event object of the `mozbrowserlocationchange` event that contains `canGoForward`/`canGoBack` properties, allowing retrieval of the mozBrowser's back/forward status synchronously ([Firefox bug 1279635](https://bugzil.la/1279635)).

--- a/files/en-us/mozilla/firefox/releases/57/index.md
+++ b/files/en-us/mozilla/firefox/releases/57/index.md
@@ -109,7 +109,7 @@ _No changes._
 
 ### Other
 
-- Firefox [headless mode](/en-US/docs/Mozilla/Firefox/Headless_mode) now includes a `-screenshot` flag that allows you to take website screenshots directly from the command line ([Firefox bug 1378010](https://bugzil.la/1378010)).
+- Firefox [headless mode](https://web.archive.org/web/20210604151145/https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode) now includes a `-screenshot` flag that allows you to take website screenshots directly from the command line ([Firefox bug 1378010](https://bugzil.la/1378010)).
 
 ## Removals from the web platform
 
@@ -119,7 +119,7 @@ _No changes._
 
 ### APIs
 
-- Mozilla's proprietary [Social API](/en-US/docs/Archive/Social_API) has been completely removed ([Firefox bug 1388902](https://bugzil.la/1388902)).
+- Mozilla's proprietary [Social API](https://web.archive.org/web/20210509145412/https://developer.mozilla.org/en-US/docs/Archive/Social_API) has been completely removed ([Firefox bug 1388902](https://bugzil.la/1388902)).
 
 ### SVG
 

--- a/files/en-us/mozilla/firefox/releases/59/index.md
+++ b/files/en-us/mozilla/firefox/releases/59/index.md
@@ -153,7 +153,7 @@ Support for the non-standard `pcast:` and `feed:` protocols has been removed fro
   - [`tabs.hide()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/hide)
   - [`tabs.show()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/show)
 
-- The [`contextMenus`](/en-US/docs/Archive/Add-ons/Legacy_Firefox_for_Android/API/NativeWindow/contextmenus) API now supports a ["bookmark" context](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType).
+- The `contextMenus` API now supports a ["bookmark" context](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType).
 - New [`contentScripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts) API enables runtime registration of content scripts.
 - New [`pageAction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction), [`browserAction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction), [`SidebarAction`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction) APIs:
   - `browserAction/pageAction/sidebarAction.set*` functions now accept `null` to undo changes.

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -15,7 +15,7 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 - The HTML5 {{ HTMLElement("progress") }} element, which lets you create a progress bar, is now supported.
 - The parsing of the HTML5 {{ HTMLElement("track") }} element, which specifies text tracks for media elements, is now supported. This element should appear in the DOM now, though its behavior is still not implemented.
 - The {{ HTMLElement("iframe") }} element is now clipped correctly by its container when the container's corners have been rounded using the {{ cssxref("border-radius") }} property.
-- {{ HTMLElement("form") }} elements' text {{ HTMLElement("input") }} fields no longer support the XUL [`maxwidth`](/en-US/docs/XUL/Property/maxwidth) property; this was never intentional, and is in violation of the HTML specification. You should instead use the [`size`](/en-US/docs/Web/HTML/Reference/Elements/input#size) attribute to set the maximum width of input fields.
+- {{ HTMLElement("form") }} elements' text {{ HTMLElement("input") }} fields no longer support the XUL [`maxwidth`](https://web.archive.org/web/20190117013205/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Property/maxWidth) property; this was never intentional, and is in violation of the HTML specification. You should instead use the [`size`](/en-US/docs/Web/HTML/Reference/Elements/input#size) attribute to set the maximum width of input fields.
 - The {{ HTMLElement("canvas") }} {{ domxref("CanvasRenderingContext2d") }} properties `fillStyle` and `strokeStyle` used to ignore garbage included after a valid color definition; now this is correctly treated as an error. For example, "red blue" as a color used to be treated as "red", when it should have been ignored.
 - The width and height of {{ HTMLElement("canvas") }} elements can now properly be set to 0px; previously, these were getting arbitrarily set to 300px when you tried to do that.
 - Support for the HTML [custom data attributes](/en-US/docs/Web/HTML/Reference/Global_attributes/data-*) (`data-*`) has been added. The DOM {{ domxref("HTMLElement/dataset", "dataset") }} property allows to access them.
@@ -70,7 +70,7 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 - The standard {{ domxref("event.defaultPrevented") }} property is now supported; you should use this instead of the non-standard `getPreventDefault()` method to detect whether or not {{ domxref("event.preventDefault()") }} was called on the event.
 - The {{ domxref("window.top") }} property is now properly read only.
 - DOM views, which we never documented, have been removed. This was a bit of implementation detail that was unnecessarily complicating things, so we got rid of it. If you notice this change, you're probably doing something wrong.
-- The `EventTarget` function [`addEventListener()`](/en-US/docs/XPCOM_Interface_Reference/nsIDOMEventTarget)'s `useCapture` parameter is now optional, as it is in WebKit (and as per the latest version of the specification).
+- The `EventTarget` function [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener)'s `useCapture` parameter is now optional, as it is in WebKit (and as per the latest version of the specification).
 - The `mozResponseArrayBuffer` property of the [`XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) object has been replaced with the `responseType` and `response` properties.
 - The {{ domxref("HTMLElement/dataset", "dataset") }} property has been added to the [`HTMLElement`](/en-US/docs/Web/API/HTMLElement) interface allowing access to the [`data-*` global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes/data-*) of an element.
 - The {{ domxref("CustomEvent") }} interface has been implemented. (see [Firefox bug 427537](https://bugzil.la/427537))
@@ -118,13 +118,13 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 For an overview of the changes you may need to make in order to make your add-on compatible with Firefox 6, see [Updating add-ons for Firefox 6](/en-US/docs/Mozilla/Firefox/Releases/6/Updating_add-ons).
 
 > [!NOTE]
-> Firefox 6 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
+> Firefox 6 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](https://web.archive.org/web/20210119071646/https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
 
 ### JavaScript code modules
 
 #### FileUtils.jsm
 
-- The `openSafeFileOutputStream()` method now opens files with the `DEFER_OPEN` [behavior flag](/en-US/docs/XPCOM_Interface_Reference/nsIFileOutputStream#behavior_flag_constants) instead of attempting to open them immediately.
+- The `openSafeFileOutputStream()` method now opens files with the `DEFER_OPEN` [behavior flag](https://web.archive.org/web/20210506072901/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIFileOutputStream#behavior_flag_constants) instead of attempting to open them immediately.
 
 #### XPCOMUtils.jsm
 
@@ -132,11 +132,11 @@ For an overview of the changes you may need to make in order to make your add-on
 
 ### XPCOM
 
-- [`nsCOMArray<T>`](/en-US/docs/XPCOM_array_guide#nsCOMArray.3cT.3e) now has a [`RemoveObjectsAt()`](/en-US/docs/XPCOM_array_guide#deleting_objects) method for removing multiple objects at once from the array.
+- [`nsCOMArray<T>`](https://web.archive.org/web/20210413085248/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Arrays#nsCOMArray.3cT.3e) now has a [`RemoveObjectsAt()`](https://web.archive.org/web/20210413085248/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Arrays#deleting_objects) method for removing multiple objects at once from the array.
 
 ### Using the DOM from chrome
 
-- [Using the DOM File API in chrome code](/en-US/docs/Extensions/Using_the_DOM_File_API_in_chrome_code)
+- [Using the DOM File API in chrome code](https://web.archive.org/web/20210618235235/https://developer.mozilla.org/en-US/docs/Extensions/Using_the_DOM_File_API_in_chrome_code)
   - : Although you've always been able to use the DOM File API from chrome code, the {{ domxref("File") }} constructor now supports specifying a local pathname string when used from chrome. In addition, you can also specify the file to access using the DOM File API using an `nsIFile` object.
 
 ### Interface changes
@@ -190,5 +190,5 @@ The following interfaces were implementation details that are no longer needed:
 
 ### Other changes
 
-- [Using preferences from application code](/en-US/docs/Mozilla/Preferences/Using_preferences_from_application_code)
+- [Using preferences from application code](https://web.archive.org/web/20210419233418/https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Using_preferences_from_application_code)
   - : A new static API is available for easily accessing preferences; this is only available to application code and can't be used by add-ons.

--- a/files/en-us/mozilla/firefox/releases/7/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/updating_extensions/index.md
@@ -10,7 +10,7 @@ This article offers advice for add-on developers that want to update their exten
 > [!NOTE]
 > For a complete list of developer-related changes in Firefox 7, see [Firefox 7 for developers](/en-US/docs/Mozilla/Firefox/Releases/7).
 
-As always, you will need to [recompile any binary components](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) to make them compatible with Firefox 7.
+As always, you will need to [recompile any binary components](https://web.archive.org/web/20210119071646/https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) to make them compatible with Firefox 7.
 
 ## XPCOM changes affecting compatibility
 
@@ -47,10 +47,10 @@ The new `Components.utils.unload()` method lets you unload JavaScript code modul
 
 ### Inline preferences
 
-You can now have [preference options inline](/en-US/docs/Extensions/Inline_Options) in the Add-on Manager window, which lets users configure your add-on without having to open a separate preference dialog box. There are limits to what types of configuration controls can be provided, but this is still very helpful — plus it works for [restartless (bootstrapped) extensions](/en-US/docs/Extensions/Bootstrapped_extensions).
+You can now have [preference options inline](https://web.archive.org/web/20210417084958/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Inline_Options) in the Add-on Manager window, which lets users configure your add-on without having to open a separate preference dialog box. There are limits to what types of configuration controls can be provided, but this is still very helpful — plus it works for [restartless (bootstrapped) extensions](https://web.archive.org/web/20210519000929/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Bootstrapped_extensions).
 
 ## See also
 
 - [Firefox 7 for developers](/en-US/docs/Mozilla/Firefox/Releases/7)
 - [Add-ons Blog: Firefox 7 add-on compatibility](https://blog.mozilla.org/addons/2011/07/19/firefox-7-compat-looking-to-8/)
-- [XPCOM changes in Gecko 2.0](/en-US/docs/XPCOM/XPCOM_changes_in_Gecko_2.0)
+- [XPCOM changes in Gecko 2.0](https://web.archive.org/web/20210514105748/https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Changes_in_Gecko_2.0)

--- a/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.md
@@ -9,7 +9,7 @@ This article provides information on steps you need to take in order to update y
 
 ## Do you need to do anything at all?
 
-If your add-on is distributed on [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/) (AMO), it's been checked by an automated compatibility verification tool. Add-ons that don't use APIs that changed in Firefox 8, and have no binary components (which [need to be recompiled for every major Firefox release](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces)), have automatically been updated on AMO to indicate that they work in Firefox 8.
+If your add-on is distributed on [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/) (AMO), it's been checked by an automated compatibility verification tool. Add-ons that don't use APIs that changed in Firefox 8, and have no binary components (which [need to be recompiled for every major Firefox release](https://web.archive.org/web/20210119071646/https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces)), have automatically been updated on AMO to indicate that they work in Firefox 8.
 
 So you should start by visiting AMO and looking to see if your add-on needs any work done at all.
 
@@ -33,7 +33,7 @@ As part of our ongoing effort to streamline Gecko's internals, a few interfaces 
 
 ## Date handling improved
 
-Now that the JavaScript [`Date`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object can parse ISO 8601 dates, the [`ISO8601DateUtils.jsm`](/en-US/docs/JavaScript_code_modules/ISO8601DateUtils.jsm) code module has been removed. If you were using this code module, you should update your code to use the methods on `Date` instead.
+Now that the JavaScript [`Date`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object can parse ISO 8601 dates, the [`ISO8601DateUtils.jsm`](https://web.archive.org/web/20210613204753/https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/ISO8601DateUtils.jsm) code module has been removed. If you were using this code module, you should update your code to use the methods on `Date` instead.
 
 ## DOM changes
 


### PR DESCRIPTION
Fix broken links. I've received general feedback that using wayback machine is the right way to go.

Generally, I use the latest version that's available, including redirects. In a few cases, there's no such page on wayback machine either, and I have to remove the link. In a few other places there are better places to link to.