### PR TITLE
Mention certain ArrayBuffers have controlled detachment

### DIFF
--- a/files/en-us/web/api/gpubuffer/getmappedrange/index.md
+++ b/files/en-us/web/api/gpubuffer/getmappedrange/index.md
@@ -13,7 +13,7 @@ The **`getMappedRange()`** method of the
 
 This can only happen once the `GPUBuffer` has been successfully mapped with {{domxref("GPUBuffer.mapAsync()")}} (this can be checked via {{domxref("GPUBuffer.mapState")}}). While the `GPUBuffer` is mapped it cannot be used in any GPU commands.
 
-When you have finished working with the `GPUBuffer` values, call {{domxref("GPUBuffer.unmap()")}} to unmap it, making it accessible to the GPU again.
+When you have finished working with the `GPUBuffer` values, call {{domxref("GPUBuffer.unmap()")}} to unmap it, making it accessible to the GPU again. A `TypeError` is thrown if an attempt is made to detach the {{jsxref("ArrayBuffer")}} in any way other than via {{domxref("GPUBuffer.unmap()")}}, such as by calling {{jsxref("ArrayBuffer/transfer", "transfer()")}}.
 
 ## Syntax
 
@@ -41,11 +41,6 @@ The following criteria must be met when calling **`getMappedRange()`**, otherwis
 - `offset` is a multiple of 8.
 - The total range to be mapped (`size` if specified, or mapped range length - `offset` if not) is a multiple of 4.
 - The total range is inside the bounds of the mapped range and does not overlap with the {{jsxref("ArrayBuffer")}} ranges specified by any other active `getMappedRange()` calls.
-
-### Exceptions
-
-- `TypeError` {{domxref("DOMException")}}
-  - : Thrown if an attempt is made to detach the {{jsxref("ArrayBuffer")}} in any way other than via {{domxref("GPUBuffer.unmap()")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
@@ -33,7 +33,7 @@ A new {{jsxref("ArrayBuffer")}} object. Its contents are initialized to the cont
 - {{jsxref("RangeError")}}
   - : Thrown if this `ArrayBuffer` is resizable and `newByteLength` is greater than the {{jsxref("ArrayBuffer/maxByteLength", "maxByteLength")}} of this `ArrayBuffer`.
 - {{jsxref("TypeError")}}
-  - : Thrown if this `ArrayBuffer` is already detached.
+  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such tracked `ArrayBuffer` objects, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
@@ -33,7 +33,7 @@ A new {{jsxref("ArrayBuffer")}} object. Its contents are initialized to the cont
 - {{jsxref("RangeError")}}
   - : Thrown if this `ArrayBuffer` is resizable and `newByteLength` is greater than the {{jsxref("ArrayBuffer/maxByteLength", "maxByteLength")}} of this `ArrayBuffer`.
 - {{jsxref("TypeError")}}
-  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such tracked `ArrayBuffer` objects, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
+  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such `ArrayBuffer` objects with designated detaching methods, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
@@ -33,7 +33,7 @@ A new {{jsxref("ArrayBuffer")}} object. Its contents are initialized to the cont
 - {{jsxref("RangeError")}}
   - : Thrown if this `ArrayBuffer` is resizable and `newByteLength` is greater than the {{jsxref("ArrayBuffer/maxByteLength", "maxByteLength")}} of this `ArrayBuffer`.
 - {{jsxref("TypeError")}}
-  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such `ArrayBuffer` objects with designated detaching methods, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
+  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating `ArrayBuffer` objects with designated detaching methods, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
@@ -30,7 +30,7 @@ A new {{jsxref("ArrayBuffer")}} object. Its contents are initialized to the cont
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such `ArrayBuffer` objects with designated detaching methods, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
+  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating `ArrayBuffer` objects with designated detaching methods, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
@@ -30,7 +30,7 @@ A new {{jsxref("ArrayBuffer")}} object. Its contents are initialized to the cont
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such tracked `ArrayBuffer` objects, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
+  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such `ArrayBuffer` objects with designated detaching methods, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
@@ -30,7 +30,7 @@ A new {{jsxref("ArrayBuffer")}} object. Its contents are initialized to the cont
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if this `ArrayBuffer` is already detached.
+  - : Thrown if this `ArrayBuffer` is already detached, or if it can only be detached by designated operations. Currently, only certain web APIs are capable of creating such tracked `ArrayBuffer` objects, such as {{domxref("GPUBuffer.getMappedRange()")}} and [`WebAssembly.Memory.buffer`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/buffer).
 
 ## Description
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/39021.

The main change is made to the JS docs, but I'm updating `GPUBuffer.getMappedRange` as well, because this is not an exception of this method itself.