### PR TITLE
Add note on CSP sandbox causing  to iframe sandbox section

### DIFF
--- a/files/en-us/web/http/reference/headers/origin/index.md
+++ b/files/en-us/web/http/reference/headers/origin/index.md
@@ -63,6 +63,7 @@ The `Origin` header value may be `null` in a number of cases, including (non-exh
 - Documents created programmatically using {{domxref("DOMImplementation.createDocument", "createDocument()")}}, generated from a `data:` URL, or that do not have a creator browsing context.
 - Redirects across origins.
 - {{HTMLElement("iframe", "iframes")}} with a sandbox attribute that doesn't contain the value `allow-same-origin`.
+- Documents served with the {{HTTPHeader("Content-Security-Policy")}} `sandbox` directive that doesn't include `allow-same-origin`.
 - Responses that are network errors.
 - {{HTTPHeader("Referrer-Policy")}} set to `no-referrer` for non-`cors` request modes (e.g., basic form posts).
 

--- a/files/en-us/web/http/reference/headers/origin/index.md
+++ b/files/en-us/web/http/reference/headers/origin/index.md
@@ -62,8 +62,8 @@ The `Origin` header value may be `null` in a number of cases, including (non-exh
 - Cross-origin images and media data, including that in {{HTMLElement("img")}}, {{HTMLElement("video")}} and {{HTMLElement("audio")}} elements.
 - Documents created programmatically using {{domxref("DOMImplementation.createDocument", "createDocument()")}}, generated from a `data:` URL, or that do not have a creator browsing context.
 - Redirects across origins.
-- {{HTMLElement("iframe", "iframes")}} with a sandbox attribute that doesn't contain the value `allow-same-origin`.
-- Documents served with the {{HTTPHeader("Content-Security-Policy")}} `sandbox` directive that doesn't include `allow-same-origin`.
+- Documents served with the {{HTTPHeader("Content-Security-Policy")}} `sandbox` directive that don't include `allow-same-origin`.
+- {{HTMLElement("iframe", "iframes")}} with a sandbox attribute that don't contain the value `allow-same-origin`.
 - Responses that are network errors.
 - {{HTTPHeader("Referrer-Policy")}} set to `no-referrer` for non-`cors` request modes (e.g., basic form posts).
 


### PR DESCRIPTION
## Description

Added a new bullet point to the list of cases where the `Origin` header may be `null`.  
It covers the scenario where a page is served with a `Content-Security-Policy: sandbox` header **without** the `allow-same-origin` directive.

Fixes #40093 

