### PR TITLE
Correct `navigate` addeventlistener

### DIFF
--- a/files/en-us/web/api/navigation/navigate_event/index.md
+++ b/files/en-us/web/api/navigation/navigate_event/index.md
@@ -17,7 +17,7 @@ The **`navigate`** event of the {{domxref("Navigation")}} interface is fired whe
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js-nolint
-addEventListener("navigate", (event) => { })
+navigation.addEventListener("navigate", (event) => { })
 
 onnavigate = (event) => { }
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Missing a `navigation` from the `addEventListener` example, without which it doesn't work. You can see the rest of the examples in the doc use the correct syntax.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It's wrong :-)

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

You can test it with this SQL in the console of any page in Chrome:

```js
// This will log
navigation.addEventListener("navigate", (event) => {console.log('navigation event:',event)});
// This won't log
addEventListener("navigate", (event) => {console.log('window event',event)});
// Neither will this
window.addEventListener("navigate", (event) => {console.log('explicit window event',event)})
// Nor this
document.addEventListener("navigate", (event) => {console.log('document event',event)})

// Push a history to trigger above
history.pushState({}, "", "/barrry");
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

FYI: @mattzeunert
