### PR TITLE
Improve description of "broadcastchannel-message" bfcache blocking reason

### DIFF
--- a/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
+++ b/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
@@ -171,7 +171,7 @@ Additional blocking reasons that may be used by some browsers are also specified
 - `"background-work"`
   - : The Document requested background work by calling [`SyncManager`](/en-US/docs/Web/API/SyncManager)'s [`register()`](/en-US/docs/Web/API/SyncManager/register) method, [`PeriodicSyncManager`](/en-US/docs/Web/API/PeriodicSyncManager)'s [`register()`](/en-US/docs/Web/API/PeriodicSyncManager/register) method, or [`BackgroundFetchManager`](/en-US/docs/Web/API/BackgroundFetchManager)'s [`fetch()`](/en-US/docs/Web/API/BackgroundFetchManager/fetch) method.
 - `"broadcastchannel-message"`
-  - : While the page was stored in back/forward cache, a [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel) connection on the page received a message to trigger a `message` event.
+  - : While the page was stored in back/forward cache, a [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel) connection on the page received a message to trigger a [`message`](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) event.
 - `"idbversionchangeevent"`
   - : The Document had a pending [`IDBVersionChangeEvent`](/en-US/docs/Web/API/IDBVersionChangeEvent) while unloading.
 - `"idledetector"`

--- a/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
+++ b/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
@@ -171,7 +171,7 @@ Additional blocking reasons that may be used by some browsers are also specified
 - `"background-work"`
   - : The Document requested background work by calling [`SyncManager`](/en-US/docs/Web/API/SyncManager)'s [`register()`](/en-US/docs/Web/API/SyncManager/register) method, [`PeriodicSyncManager`](/en-US/docs/Web/API/PeriodicSyncManager)'s [`register()`](/en-US/docs/Web/API/PeriodicSyncManager/register) method, or [`BackgroundFetchManager`](/en-US/docs/Web/API/BackgroundFetchManager)'s [`fetch()`](/en-US/docs/Web/API/BackgroundFetchManager/fetch) method.
 - `"broadcastchannel-message"`
-  - : While the page was stored in back/forward cache, a [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel) connection on the page received a message and message event was fired.
+  - : While the page was stored in back/forward cache, a [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel) connection on the page received a message to trigger a `message` event.
 - `"idbversionchangeevent"`
   - : The Document had a pending [`IDBVersionChangeEvent`](/en-US/docs/Web/API/IDBVersionChangeEvent) while unloading.
 - `"idledetector"`

--- a/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
+++ b/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
@@ -171,7 +171,7 @@ Additional blocking reasons that may be used by some browsers are also specified
 - `"background-work"`
   - : The Document requested background work by calling [`SyncManager`](/en-US/docs/Web/API/SyncManager)'s [`register()`](/en-US/docs/Web/API/SyncManager/register) method, [`PeriodicSyncManager`](/en-US/docs/Web/API/PeriodicSyncManager)'s [`register()`](/en-US/docs/Web/API/PeriodicSyncManager/register) method, or [`BackgroundFetchManager`](/en-US/docs/Web/API/BackgroundFetchManager)'s [`fetch()`](/en-US/docs/Web/API/BackgroundFetchManager/fetch) method.
 - `"broadcastchannel-message"`
-  - : While the page was stored in back/forward cache, a [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel) connection on the page received a message to trigger a [`message`](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) event.
+  - : While the page was stored in back/forward cache, a [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel) connection on the page received a message to trigger a [`message`](/en-US/docs/Web/API/MessageEvent) event.
 - `"idbversionchangeevent"`
   - : The Document had a pending [`IDBVersionChangeEvent`](/en-US/docs/Web/API/IDBVersionChangeEvent) while unloading.
 - `"idledetector"`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The `message` event being referenced is not using code formatting and it isn't linking to the `MessageEvent` docs. This PR adds the formatting and add the link.

### Motivation

Formatting the `message` event and adding a link to improve readability and discoverability.
