### PR TITLE
CSP sandbox allow-same-origin - clarify

### DIFF
--- a/files/en-us/glossary/origin/index.md
+++ b/files/en-us/glossary/origin/index.md
@@ -9,6 +9,20 @@ Web content's **origin** is defined by the _scheme_ (protocol), _hostname_ (doma
 
 Some operations are restricted to same-origin content, and this restriction can be lifted using {{Glossary("CORS")}}.
 
+## Opaque origin
+
+An opaque origin is a special type of "internal" origin that obscures the true origin of a resource (opaque origins are always serialized as `null`), and ensures that it never matches as same-origin with other resources — including those from other opaque origins.
+
+Opaque origins are applied in cases where the true origin of a resource is sensitive, cannot be safely used for security checks, or does not exist.
+A resource with an opaque origin will have its {{httpheader("Origin")}} HTTP header in requests set to [`null`](/en-US/docs/Web/HTTP/Reference/Headers/Origin#null).
+It will also fail same-origin checks with any other resource, and hence be restricted to only those operations available to cross-origin resources.
+
+Common cases where opaque origins are used include:
+
+- A document within an iframe that has the [sandbox](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/sandbox) attribute set, and does not include the `allow-same-origin` flag.
+- `file:` URLs are usually treated as opaque origins so that files on they file system cannot read each other.
+- Documents created programatically using APIs like https://developer.mozilla.org/en-US/docs/Web/API/ {{domxref("DOMImplementation.createDocument()")}}.
+
 ## Examples
 
 These are same origin because they have the same scheme (`http`) and hostname (`example.com`), and the different file path does not matter:

--- a/files/en-us/glossary/origin/index.md
+++ b/files/en-us/glossary/origin/index.md
@@ -11,7 +11,7 @@ Some operations are restricted to same-origin content, and this restriction can 
 
 ## Opaque origin
 
-An opaque origin is a special type of "internal" origin that obscures the true origin of a resource (opaque origins are always serialized as `null`), and ensures that it never matches as same-origin with other resources — including those from other opaque origins.
+An opaque origin is a special type of browser-internal value that obscures the true origin of a resource (opaque origins are always serialized as `null`). They are used by the browser to ensure resource isolation as they are never considered equal to any other origin — including other opaque origins.
 
 Opaque origins are applied in cases where the true origin of a resource is sensitive, cannot be safely used for security checks, or does not exist.
 A resource with an opaque origin will have its {{httpheader("Origin")}} HTTP header in requests set to [`null`](/en-US/docs/Web/HTTP/Reference/Headers/Origin#null).

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -59,7 +59,6 @@ where `<value>` can optionally be one of the following values:
   - : Allows a sandboxed resource to retain its {{Glossary("origin")}}.
     A sandboxed resource is otherwise treated as being from an opaque origin, which ensures that it will always fail {{Glossary("same-origin policy")}} checks, and hence cannot access [`localstorage` and `document.cookie`](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs.
     The {{httpheader("Origin")}} of sandboxed resources without the `allow-same-origin` keyword is `null`.
-
 - `allow-scripts`
   - : Allows the page to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed.
 - `allow-storage-access-by-user-activation` {{experimental_inline}}

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -56,9 +56,8 @@ where `<value>` can optionally be one of the following values:
 - `allow-presentation`
   - : Allows embedders to have control over whether an iframe can start a [presentation session](/en-US/docs/Web/API/PresentationRequest).
 - `allow-same-origin`
-  - : Allows a same-origin sandboxed resource to be treated as same-origin, reducing the restrictions normally applied to a sandbox.
-
-    If this token is not used, the resource is treated as being from a special origin that always fails the {{Glossary("same-origin policy")}} (potentially preventing access to [data storage/cookies](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).
+  - : Allows a sandboxed resource to retain its {{Glossary("origin")}}.
+    A sandboxed resource is otherwise treated as being from an opaque origin, which ensures that it will always fail {{Glossary("same-origin policy")}} checks, and hence cannot access [`localstorage` and `document.cookie`](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs.
     The {{httpheader("Origin")}} of sandboxed resources without the `allow-same-origin` keyword is `null`.
 
 - `allow-scripts`

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -59,7 +59,7 @@ where `<value>` can optionally be one of the following values:
   - : Allows a same-origin sandboxed resource to be treated as same-origin, reducing the restrictions normally applied to a sandbox.
 
     If this token is not used, the resource is treated as being from a special origin that always fails the {{Glossary("same-origin policy")}} (potentially preventing access to [data storage/cookies](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).
-    The {{httpheader("Origin")}} of such a request would be `null`.
+    The {{httpheader("Origin")}} of sandboxed resources without the `allow-same-origin` keyword is `null`.
 
 - `allow-scripts`
   - : Allows the page to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed.

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -56,7 +56,11 @@ where `<value>` can optionally be one of the following values:
 - `allow-presentation`
   - : Allows embedders to have control over whether an iframe can start a [presentation session](/en-US/docs/Web/API/PresentationRequest).
 - `allow-same-origin`
-  - : If this token is not used, the resource is treated as being from a special origin that always fails the {{Glossary("same-origin policy")}} (potentially preventing access to [data storage/cookies](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).
+  - : Allows a same-origin sandboxed resource to be treated as same-origin, reducing the restrictions normally applied to a sandbox.
+
+    If this token is not used, the resource is treated as being from a special origin that always fails the {{Glossary("same-origin policy")}} (potentially preventing access to [data storage/cookies](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).
+    The {{httpheader("Origin")}} of such a request would be `null`.
+
 - `allow-scripts`
   - : Allows the page to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed.
 - `allow-storage-access-by-user-activation` {{experimental_inline}}

--- a/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/sandbox/index.md
@@ -57,7 +57,7 @@ where `<value>` can optionally be one of the following values:
   - : Allows embedders to have control over whether an iframe can start a [presentation session](/en-US/docs/Web/API/PresentationRequest).
 - `allow-same-origin`
   - : Allows a sandboxed resource to retain its {{Glossary("origin")}}.
-    A sandboxed resource is otherwise treated as being from an opaque origin, which ensures that it will always fail {{Glossary("same-origin policy")}} checks, and hence cannot access [`localstorage` and `document.cookie`](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs.
+    A sandboxed resource is otherwise treated as being from an [opaque origin](/en-US/docs/Glossary/Origin#opaque_origin), which ensures that it will always fail {{Glossary("same-origin policy")}} checks, and hence cannot access [`localstorage` and `document.cookie`](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs.
     The {{httpheader("Origin")}} of sandboxed resources without the `allow-same-origin` keyword is `null`.
 - `allow-scripts`
   - : Allows the page to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed.

--- a/files/en-us/web/http/reference/headers/origin/index.md
+++ b/files/en-us/web/http/reference/headers/origin/index.md
@@ -34,7 +34,7 @@ Origin: <scheme>://<hostname>:<port>
 ## Directives
 
 - `null`
-  - : The origin is "privacy sensitive", or is an _opaque origin_ as defined by the HTML specification (specific cases are listed in the [description](#description) section).
+  - : The origin is "privacy sensitive", or is an [opaque origin](/en-US/docs/Glossary/Origin#opaque_origin) (specific cases are listed in the [description](#description) section).
 - `<scheme>`
   - : The protocol that is used.
     Usually, it is the HTTP protocol or its secured version, HTTPS.


### PR DESCRIPTION
If found the description of the CSP sandbox value `allow-same-origin` to be a little confusing. This rewords to match the pattern of the other values, and adds the note that the `Origin` header will be null if this is not set.

This fell out of reviewing https://github.com/mdn/content/issues/40093

Fixes #40094