### PR TITLE
FF141 WebGPU API supported on Windows except in serviceworker - relnote/experimental features

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -458,17 +458,22 @@ When this preference is enabled, any WebGL extensions currently in "draft" statu
 
 #### WebGPU API
 
-The [WebGPU API](/en-US/docs/Web/API/WebGPU_API) provides low-level support for performing computation and graphics rendering using the [Graphics Processing Unit](https://en.wikipedia.org/wiki/Graphics_Processing_Unit) (GPU) of the user's device or computer. See [Firefox bug 1602129](https://bugzil.la/1602129) for our progress on this API.
+The [WebGPU API](/en-US/docs/Web/API/WebGPU_API) provides low-level support for performing computation and graphics rendering using the [Graphics Processing Unit](https://en.wikipedia.org/wiki/Graphics_Processing_Unit) (GPU) of the user's device or computer.
+From version 142 this is enabled in on Windows in all contexts except service workers.
+For other platforms it is enabled in nightly.
+See [Firefox bug 1602129](https://bugzil.la/1602129) for our progress on this API.
 
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 113           | Yes                 |
-| Developer Edition | 73            | No                  |
-| Beta              | 73            | No                  |
-| Release           | 73            | No                  |
+| Release channel   | Version added | Enabled by default?                                |
+| ----------------- | ------------- | -------------------------------------------------- |
+| Nightly           | 141           | Yes                                                |
+| Developer Edition | 141           | No (Yes on Windows, not including service workers) |
+| Beta              | 141           | No (Yes on Windows, not including service workers) |
+| Release           | 141           | No (Yes on Windows, not including service workers) |
 
 - `dom.webgpu.enabled`
-  - : Set to `true` to enable.
+  - : Set to `true` to enable (enabled in Nightly and on Windows in all releases)
+- `dom.webgpu.service-workers.enabled`
+  - : Set to `true` to enable (enabled in Nightly)
 
 ### Reporting API support for CSP Violations
 

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -70,6 +70,7 @@ Firefox 141 is the current [Beta version of Firefox](https://www.firefox.com/en-
     In the same way as the equivalent declarative attribute, [`popovertarget`](/en-US/docs/Web/HTML/Reference/Elements/button#popovertarget), this makes the popover more accessible to keyboard users (see [Popover accessibility features](/en-US/docs/Web/API/Popover_API/Using#popover_accessibility_features)). It also creates an implicit anchor reference between the two, which enables more natural positioning of popovers relative to their controls (see [Popover anchor positioning](/en-US/docs/Web/API/Popover_API/Using#popover_anchor_positioning)).
   - The [`force`](/en-US/docs/Web/API/HTMLElement/togglePopover#force) or [`options.force`](/en-US/docs/Web/API/HTMLElement/togglePopover#force_2) arguments to `togglePopover()` can be used to force the popover open or closed, and is ignored if the popover is already in the forced state.
     Unlike `showPopover()` and `hidePopover()`, this does not throw an exception if the popover is already in the target state.
+- The [WebGPU API](/en-US/docs/Web/API/WebGPU_API) is now fully supported on Windows, in all contexts except for service workers. This allows developers to perform computation and graphics rendering using the [Graphics Processing Unit](https://en.wikipedia.org/wiki/Graphics_Processing_Unit) (GPU) of a user's computer. ([Firefox bug 1972486](https://bugzil.la/1972486)).
 
 <!-- #### DOM -->
 


### PR DESCRIPTION
FF142 adds support for WebGPU API on Windows (only) in workers except for service workers.
This adds a release note. It also updates the Experimental features with the caveats and the new preference for enabling service workers.

Related docs work can be tracked in #40473
