### PR TITLE
FF142 RTCIceCandidatePairStats mandatory properties - relnote

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -60,6 +60,8 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
+- The {{domxref("RTCIceCandidatePairStats/currentRoundTripTime", "currentRoundTripTime")}}, {{domxref("RTCIceCandidatePairStats/totalRoundTripTime", "totalRoundTripTime")}}, and {{domxref("RTCIceCandidatePairStats/responsesReceived", "responsesReceived")}} properties of the {{domxref("RTCIceCandidatePairStats")}} dictionary are now supported. These return the current round trip time (RTT) and the information needed to calculate the average RTT for the connection.
+  ([Firefox bug 1371391](https://bugzil.la/1371391)).
 - The {{domxref("RTCRtpSender.setParameters()","setParameters()")}} and {{domxref("RTCRtpSender.getParameters()","getParameters()")}} methods of the {{domxref("RTCRtpSender")}} interface now support setting and getting the specific [`codec`](/en-US/docs/Web/API/RTCRtpSender/setParameters#codecs) used for each `encoding`.
   You can also set a `codec` for each encoding in the [`init.sendEncodings`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings) array that's passed to the {{domxref("RTCPeerConnection/addTransceiver","addTransceiver()")}} method of the {{domxref("RTCPeerConnection")}} interface.
   ([Firefox bug 1894137](https://bugzil.la/1894137)).

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCStatsReport.type_candidate-pair.responsesReceived
 
 {{APIRef("WebRTC")}}
 
-The **`responsesReceived`** property in the {{domxref("RTCIceCandidatePairStats")}} dictionary indicates the total number of {{Glossary("STUN")}} connectivity check responses that have been received on the connection described by this pair of candidates.
+The **`responsesReceived`** property of the {{domxref("RTCIceCandidatePairStats")}} dictionary indicates the total number of {{Glossary("STUN")}} connectivity check responses that have been received on the connection described by this pair of candidates.
 
 ## Value
 


### PR DESCRIPTION
FF142 adds support for the remaining mandatory properties of  `RTCIceCandidatePairStats`: [`RTCIceCandidatePairStats.totalRoundTripTime`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/totalRoundTripTime), [`RTCIceCandidatePairStats.currentRoundTripTime`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/currentRoundTripTime), [`RTCIceCandidatePairStats.responsesReceived`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/responsesReceived) in https://bugzilla.mozilla.org/show_bug.cgi?id=1371391

This adds a release note and a docs typo fix.

Related docs work can be tracked in #40476