### PR TITLE
fix(ci/spelling-check-bot): Argument list too long

### DIFF
--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -46,7 +46,7 @@ jobs:
             maxLength=64000
             if [ ${#output} -gt ${maxLength} ]; then
               output=$(echo "$output" | head -c $maxLength)
-              output+=$'\n...\n\n> [!WARNING]\n> The long report is has been truncated. Check the complete report in the [workflow logs](https://github.com/mdn/content/actions/runs/'"${GITHUB_RUN_ID}"$').'
+              output+=$'\n...\n\n> [!WARNING]\n> The report is too long to be posted in full. Check the complete report in the [workflow logs](https://github.com/mdn/content/actions/runs/'"${GITHUB_RUN_ID}"$').'
             fi
 
             echo "OUTPUT<<EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -39,7 +39,16 @@ jobs:
           if [ -n "${output}" ]; then
             output=$(node scripts/linkify-logs.js "${output}")
             output=$(echo "$output" | sed 's/^/- /')
+            echo "Log size is ${#output} characters"
             echo "$output"
+
+            # Trim output to avoid GraphQL 'Body is too long (maximum is 65536 characters)' error
+            maxLength=64000
+            if [ ${#output} -gt ${maxLength} ]; then
+              output=$(echo "$output" | head -c $maxLength)
+              output+=$'\n...\n\n> [!WARNING]\n> The long report is has been truncated. Check the complete report in the [workflow logs](https://github.com/mdn/content/actions/runs/'"${GITHUB_RUN_ID}"$').'
+            fi
+
             echo "OUTPUT<<EOF" >> "$GITHUB_OUTPUT"
             echo "$output" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- related to https://github.com/mdn/content/actions/runs/16405622975/job/46351087903#step:6:789

The workflow run threw the following error:
> `Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/content/content'. Argument list too long`

But the underlying GraphQL error, getting shadowed in this case, is the following:
> Body is too long (maximum is 65536 characters)

The workflow script created `186,709` characters long logs. This is a rare occurrence that happened due to a platform-content `addonsidebar` update. To avoid workflow failures in such rare cases, let us truncate the logs to fit in the GitHub issue body and add a warning at the bottom.

The fix sets max length for the logs to 64,000. Let us keep rest of the 1,536 characters for other stuff in the issue body. Also, if someone appends more info to the issue body in the future, then I think 1,536 will prevent resurgence of this issue. 

## Testing

The fix has been tested here https://github.com/OnkarRuikar/content/issues/51, and the corresponding workflow run https://github.com/OnkarRuikar/content/actions/runs/16435324052/job/46444171057#step:5:27 