### PR TITLE
Replace archive link with actual link to the blog post

### DIFF
--- a/files/en-us/glossary/iife/index.md
+++ b/files/en-us/glossary/iife/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-An **IIFE** (Immediately Invoked Function Expression) is an idiom in which a {{glossary("JavaScript")}} {{glossary("function")}} runs as soon as it is defined. It is also known as a _self-executing anonymous function_. The name IIFE is promoted by Ben Alman in [his blog](https://web.archive.org/web/20171201033208/http://benalman.com/news/2010/11/immediately-invoked-function-expression/#iife).
+An **IIFE** (Immediately Invoked Function Expression) is an idiom in which a {{glossary("JavaScript")}} {{glossary("function")}} runs as soon as it is defined. It is also known as a _self-executing anonymous function_. The name IIFE is promoted by Ben Alman in [his blog](http://benalman.com/news/2010/11/immediately-invoked-function-expression/#iife).
 
 ```js
 // standard IIFE


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Ideally, archive links should be used only if the original URL/domain does not
work anymore, or has changed content that no longer matches the intent here.
That is not the case for this blog post, hence replacing the archive link with
actual URL feels like the right thing to do.

### Motivation

Doing the right thing on the internet :-)
