### PR TITLE
Better explanation for why `innerHTML` is not a good substitute for `textContent`

### DIFF
--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -58,10 +58,7 @@ important differences:
 
 ### Differences from innerHTML
 
-{{domxref("Element.innerHTML")}} returns HTML, as its name indicates. Sometimes people
-use `innerHTML` to retrieve or write text inside an element, but it is unsuited to
-this purpose, as it deals with raw HTML rather than plain text and can be succeptable
-to {{glossary("Cross-site_scripting", "XSS attacks")}}. Use `textContent` instead.
+{{domxref("Element.innerHTML")}} gets or sets HTML, as its name indicates. Sometimes people use `innerHTML` to get or set text inside an element, but it is unsuited to this purpose, as it deals with raw HTML rather than plain text and can be susceptible to {{glossary("Cross-site_scripting", "XSS attacks")}}. Use `textContent` instead for this purpose.
 
 ## Examples
 

--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -59,11 +59,9 @@ important differences:
 ### Differences from innerHTML
 
 {{domxref("Element.innerHTML")}} returns HTML, as its name indicates. Sometimes people
-use `innerHTML` to retrieve or write text inside an element, but
-`textContent` has better performance because its value is not parsed as
-HTML.
-
-Moreover, using `textContent` can prevent {{glossary("Cross-site_scripting", "XSS attacks")}}.
+use `innerHTML` to retrieve or write text inside an element, but it is unsuited to
+this purpose, as it deals with raw HTML rather than plain text and can be succeptable
+to {{glossary("Cross-site_scripting", "XSS attacks")}}. Use `textContent` instead.
 
 ## Examples
 

--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -58,7 +58,7 @@ important differences:
 
 ### Differences from innerHTML
 
-{{domxref("Element.innerHTML")}} gets or sets HTML, as its name indicates. Sometimes people use `innerHTML` to get or set text inside an element, but it is unsuited to this purpose, as it deals with raw HTML rather than plain text and can be susceptible to {{glossary("Cross-site_scripting", "XSS attacks")}}. Use `textContent` instead for this purpose.
+{{domxref("Element.innerHTML")}} gets or sets HTML, as its name indicates. We advise against using `innerHTML` to get or set text inside an element because it deals with raw HTML rather than plain text and can be susceptible to {{glossary("Cross-site_scripting", "XSS attacks")}}. Even if you are sure that the text never contains HTML syntax, it is still less semantic and slower because it needs to invoke the HTML parser.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Better explanation for why `innerHTML` is not a good substitute for `textContent`.

### Motivation

Current version mentions performance before any other reason, which isn't a primary concern. For any use case where performance had a noticeable impact, correctness and vulnerability to XSS would likely be a much greater concern; and for any use case trivial enough that correctness and vulnerability weren't practically impacted (e.g. setting `button.innerHTML = "Loading..."`), performance impact would be negligible.