### PR TITLE
Add a browser compat section for Tk header

### DIFF
--- a/files/en-us/web/http/reference/headers/tk/index.md
+++ b/files/en-us/web/http/reference/headers/tk/index.md
@@ -87,6 +87,10 @@ Tk: N
 
 {{specifications}}
 
+## Browser compatibility
+
+This response header doesn't trigger any browser behavior, so browser compatibility is irrelevant.
+
 ## See also
 
 - {{HTTPHeader("DNT")}} header


### PR DESCRIPTION
This is the only case where we have a deprecated/experimental header but not browser compat section. A section would make the anchor in the banner valid, and also explain why there is no compat.