### PR TITLE
fix(glossary): Add cross references between browser glossary pages

### DIFF
--- a/files/en-us/glossary/apple_safari/index.md
+++ b/files/en-us/glossary/apple_safari/index.md
@@ -11,11 +11,13 @@ Safari uses the open source {{glossary("WebKit")}} rendering engine, which was d
 
 ## See also
 
-- [Safari](<https://en.wikipedia.org/wiki/Safari_(web_browser)>) on Wikipedia
+- [Safari (web browser)](<https://en.wikipedia.org/wiki/Safari_(web_browser)>) on Wikipedia
 - [Safari](https://www.apple.com/safari/) on apple.com
-- [The WebKit project](https://webkit.org/)
+- [The WebKit Open Source Project](https://webkit.org/)
 - [WebKit Build Archives](https://webkit.org/build-archives/)
-- [Reporting a bug for Safari](https://bugs.webkit.org/)
+- [Report Safari bugs](https://bugs.webkit.org/)
 - Related glossary terms:
   - {{glossary("Browser")}}
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
   - {{glossary("WebKit")}}
+  - Other browsers: {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}, {{glossary("Opera Browser")}}

--- a/files/en-us/glossary/browser/index.md
+++ b/files/en-us/glossary/browser/index.md
@@ -5,24 +5,25 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-A **Web browser** or **browser** is a program that retrieves and displays pages from the {{Glossary("World Wide Web", "Web")}}, and lets users access further pages through {{Glossary("hyperlink", "hyperlinks")}}. A browser is the most familiar type of {{Glossary("user agent")}}. It uses a {{Glossary("Engine/Rendering", "rendering engine")}} to display web pages.
+A **web browser** or **browser** is a program that retrieves and displays pages from the {{Glossary("World Wide Web", "web")}}, and lets users access additional pages through {{Glossary("hyperlink", "hyperlinks")}}. A browser is the most familiar type of {{Glossary("user agent")}}. It uses a {{Glossary("Engine/Rendering", "rendering engine")}} to display web pages.
 
 Common browsers include:
 
-- {{Glossary("Google Chrome")}}
-- {{Glossary("Mozilla Firefox")}}
 - {{Glossary("Apple Safari")}}
-- {{Glossary("Microsoft Edge")}}
+- {{Glossary("Google Chrome")}}
+- {{Glossary("Microsoft Edge")}} (replaced {{Glossary("Microsoft Internet Explorer", "Internet Explorer")}})
+- {{Glossary("Mozilla Firefox")}}
 - {{Glossary("Opera Browser")}}
 
 ## See also
 
 - [Web browser](https://en.wikipedia.org/wiki/Web_browser) on Wikipedia
-- {{HTTPHeader("User-agent")}} (HTTP Header)
-- Download a browser
-  - [Mozilla Firefox](https://www.firefox.com/en-US/)
+- {{HTTPHeader("User-agent")}} HTTP request header
+- Browser download links:
+  - [Apple Safari](https://support.apple.com/downloads/safari)
   - [Google Chrome](https://www.google.com/chrome/)
   - [Microsoft Edge](https://www.microsoft.com/en-us/edge)
+  - [Mozilla Firefox](https://www.firefox.com/en-US/)
   - [Opera Browser](https://www.opera.com/)
 - Related glossary terms:
   - {{Glossary("Engine/Rendering", "Rendering engine")}}

--- a/files/en-us/glossary/google_chrome/index.md
+++ b/files/en-us/glossary/google_chrome/index.md
@@ -13,7 +13,7 @@ Chrome, like Chromium, uses a rendering engine called {{Glossary("Blink")}}. On 
 
 Chrome is available on multiple platforms and comes in different versions for different user needs.
 
-### For Chrome users
+### Users
 
 If you're an everyday Chrome user, use one of these links based on your platform or device:
 
@@ -21,7 +21,7 @@ If you're an everyday Chrome user, use one of these links based on your platform
 - [iOS](https://apps.apple.com/us/app/google-chrome/id535886823)
 - [Desktop](https://www.google.com/chrome/) (Windows, macOS, Linux)
 
-### For web developers
+### Web developers
 
 If you want to try the latest Chrome features, install one of the pre-stable builds. Google pushes updates frequently and has designed the distributions to run side-by-side with the stable version. Visit the [Chrome Releases Blog](https://chromereleases.googleblog.com/) to learn what's new.
 

--- a/files/en-us/glossary/google_chrome/index.md
+++ b/files/en-us/glossary/google_chrome/index.md
@@ -9,20 +9,9 @@ sidebar: glossarysidebar
 
 Chrome, like Chromium, uses a rendering engine called {{Glossary("Blink")}}. On iOS though, due to platform restrictions, Chrome uses Apple's WebKit-based WebView instead of Blink.
 
-## See also
+## Download Chrome
 
-- [Google Chrome](https://en.wikipedia.org/wiki/Google_Chrome) on Wikipedia
-- [Chrome](https://www.google.com/chrome/) on google.com
-- [The Chromium Projects](https://www.chromium.org/)
-- [Chrome for Developers](https://developer.chrome.com/)
-- [Chrome Platform Status](https://chromestatus.com/)
-- [Report Chromium issues](https://bugs.chromium.org/p/chromium/issues/list)
-- Related glossary terms:
-  - {{glossary("Browser")}}
-  - {{glossary("Blink")}}
-  - {{Glossary("Engine/Rendering", "Rendering engine")}}
-  - {{glossary("WebKit")}}
-  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}, {{glossary("Opera Browser")}}
+Chrome is available on multiple platforms and comes in different versions for different user needs.
 
 ### For Chrome users
 
@@ -38,3 +27,18 @@ If you want to try the latest Chrome features, install one of the pre-stable bui
 
 - [Chrome Dev for Android](https://play.google.com/store/apps/details?id=com.chrome.dev)
 - [Chrome Canary for desktop](https://www.google.com/chrome/canary/)
+
+## See also
+
+- [Google Chrome](https://en.wikipedia.org/wiki/Google_Chrome) on Wikipedia
+- [Chrome](https://www.google.com/chrome/) on google.com
+- [The Chromium Projects](https://www.chromium.org/)
+- [Chrome for Developers](https://developer.chrome.com/)
+- [Chrome Platform Status](https://chromestatus.com/)
+- [Report Chromium issues](https://bugs.chromium.org/p/chromium/issues/list)
+- Related glossary terms:
+  - {{glossary("Browser")}}
+  - {{glossary("Blink")}}
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
+  - {{glossary("WebKit")}}
+  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}, {{glossary("Opera Browser")}}

--- a/files/en-us/glossary/google_chrome/index.md
+++ b/files/en-us/glossary/google_chrome/index.md
@@ -5,25 +5,36 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-Google Chrome is a free Web {{glossary("browser")}} developed by Google, based on the [Chromium](https://www.chromium.org/) open source project. Some key differences are described in BrowserStack's [Chrome vs Chromium: Core Differences](https://www.browserstack.com/guide/difference-between-chrome-and-chromium) guide.
+**Chrome** is a free {{Glossary("Browser","web browser")}} developed by Google, based on the [Chromium](https://www.chromium.org/) open source project. Some key differences are described in BrowserStack's [Chrome vs Chromium: Core Differences](https://www.browserstack.com/guide/difference-between-chrome-and-chromium) guide.
 
-Chromium also has its own layout engine called {{glossary("Blink")}}; note however that the iOS version of Chrome uses that platform's WebView rather than Blink, due to platform restrictions.
+Chrome, like Chromium, uses a rendering engine called {{Glossary("Blink")}}. On iOS though, due to platform restrictions, Chrome uses Apple's WebKit-based WebView instead of Blink.
 
 ## See also
 
 - [Google Chrome](https://en.wikipedia.org/wiki/Google_Chrome) on Wikipedia
+- [Chrome](https://www.google.com/chrome/) on google.com
+- [The Chromium Projects](https://www.chromium.org/)
+- [Chrome for Developers](https://developer.chrome.com/)
+- [Chrome Platform Status](https://chromestatus.com/)
+- [Report Chromium issues](https://bugs.chromium.org/p/chromium/issues/list)
+- Related glossary terms:
+  - {{glossary("Browser")}}
+  - {{glossary("Blink")}}
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
+  - {{glossary("WebKit")}}
+  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}, {{glossary("Opera Browser")}}
 
-### For Chrome Users
+### For Chrome users
 
-Use one of these links if you're an everyday user.
+If you're an everyday Chrome user, use one of these links based on your platform or device:
 
 - [Android](https://play.google.com/store/apps/details?id=com.android.chrome)
 - [iOS](https://apps.apple.com/us/app/google-chrome/id535886823)
-- [Desktop](https://www.google.com/chrome/)
+- [Desktop](https://www.google.com/chrome/) (Windows, macOS, Linux)
 
-### For Web Developers
+### For web developers
 
 If you want to try the latest Chrome features, install one of the pre-stable builds. Google pushes updates frequently and has designed the distributions to run side-by-side with the stable version. Visit the [Chrome Releases Blog](https://chromereleases.googleblog.com/) to learn what's new.
 
 - [Chrome Dev for Android](https://play.google.com/store/apps/details?id=com.chrome.dev)
-- [Chrome Canary for desktop](https://www.google.com/chrome/canary/).
+- [Chrome Canary for desktop](https://www.google.com/chrome/canary/)

--- a/files/en-us/glossary/microsoft_edge/index.md
+++ b/files/en-us/glossary/microsoft_edge/index.md
@@ -5,19 +5,20 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Microsoft Edge** is a proprietary cross-platform {{glossary("World Wide Web", "Web")}} {{Glossary("browser")}} developed by Microsoft since 2014. Initially known as Spartan, Edge replaced the longstanding browser {{glossary("Microsoft Internet Explorer", "Internet Explorer")}}.
+**Edge** is a proprietary, cross-platform {{Glossary("Browser","web browser")}} developed by Microsoft in 2014. Initially known as "Spartan," Edge replaced {{glossary("Microsoft Internet Explorer", "Internet Explorer")}}, which had been Microsoft's primary browser for over 20 years.
 
-Edge is included with Windows 10 and Windows 11, and is also available for macOS, iOS/iPadOS, Android and Linux. Edge used EdgeHTML as its {{Glossary("Engine/Rendering", "rendering engine")}} until 2019, when it was replaced by {{glossary("Blink")}}, the rendering engine used by {{Glossary("Google Chrome")}}. On iOS/iPadOS, Edge instead uses {{glossary("WebKit")}} as its rendering engine. Edge supports 'IE mode' for backwards compatibility that uses the {{glossary("Trident")}} engine to render pages requiring legacy Internet Explorer features.
+Edge is included with Windows 10 and Windows 11, and is also available for macOS, iOS/iPadOS, Android and Linux.
+
+Edge used EdgeHTML as its {{Glossary("Engine/Rendering", "rendering engine")}} until 2019, when it was replaced by {{glossary("Blink")}}, the rendering engine used by {{Glossary("Google Chrome")}}. On iOS/iPadOS, Edge uses {{glossary("WebKit")}} as its rendering engine. Edge supports 'IE mode' for backwards compatibility that uses the {{glossary("Trident")}} engine to render pages requiring legacy Internet Explorer features.
 
 ## See also
 
-- [Official website](https://www.microsoft.com/en-us/edge)
 - [Microsoft Edge](https://en.wikipedia.org/wiki/Microsoft_Edge) on Wikipedia
-- Related glossary terms:
+- [Microsoft Edge](https://www.microsoft.com/en-us/edge) on microsoft.com
 - Related glossary terms:
   - {{Glossary("Browser")}}
   - {{Glossary("Engine/Rendering", "Rendering engine")}}
-  - {{Glossary("Microsoft Internet Explorer", "Internet Explorer")}}
   - {{Glossary("Blink")}}
   - {{Glossary("Trident")}}
   - {{Glossary("WebKit")}}
+  - Other browsers: {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}, {{glossary("Opera Browser")}}

--- a/files/en-us/glossary/microsoft_edge/index.md
+++ b/files/en-us/glossary/microsoft_edge/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Edge** is a proprietary, cross-platform {{Glossary("Browser","web browser")}} developed by Microsoft in 2014. Initially known as "Spartan," Edge replaced {{glossary("Microsoft Internet Explorer", "Internet Explorer")}}, which had been Microsoft's primary browser for over 20 years.
+**Edge** is a proprietary, cross-platform {{Glossary("Browser","web browser")}} developed by Microsoft in 2014. Initially known as "Spartan", Edge replaced {{glossary("Microsoft Internet Explorer", "Internet Explorer")}}, which had been Microsoft's primary browser for over 20 years.
 
 Edge is included with Windows 10 and Windows 11, and is also available for macOS, iOS/iPadOS, Android and Linux.
 

--- a/files/en-us/glossary/microsoft_internet_explorer/index.md
+++ b/files/en-us/glossary/microsoft_internet_explorer/index.md
@@ -5,11 +5,11 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-Internet Explorer (or IE) was a free graphical {{glossary("browser")}} maintained by Microsoft for legacy enterprise uses. {{glossary("Microsoft Edge")}} is currently the default Windows browser.
+**Internet Explorer** (or IE) was a free, graphical {{Glossary("Browser","web browser")}} maintained by Microsoft for legacy enterprise uses. {{glossary("Microsoft Edge")}} is currently the default Windows browser.
 
-Microsoft first bundled IE with Windows in 1995 as part of the package called "Microsoft Plus!". By around 2002, Internet Explorer had become the most used browser in the world, but lost ground to Chrome, Firefox, Edge, and Safari.
+Microsoft first bundled IE with Windows in 1995 as part of the package called "Microsoft Plus!". By around 2002, Internet Explorer had become the most used browser in the world, but lost ground to {{glossary("Google Chrome", "Chrome")}}, {{glossary("Mozilla Firefox", "Firefox")}}, {{glossary("Microsoft Edge", "Edge")}}, and {{glossary("Apple Safari", "Safari")}}.
 
-IE went through many releases and provided version for desktop, mobile, and Xbox Console. It was also available on Mac and UNIX, Microsoft discontinued those versions in 2003 and 2001 respectively. The final Windows release was Windows 11.0.220 on November 10, 2020.
+IE went through many releases and provided versions for desktop, mobile, and Xbox Console. It was also available on Mac and UNIX; Microsoft discontinued those versions in 2003 and 2001, respectively. The final Windows release was version 11.0.220 on November 10, 2020.
 
 Microsoft ended support for IE on June 15, 2022.
 
@@ -17,5 +17,10 @@ Microsoft ended support for IE on June 15, 2022.
 
 - [Internet Explorer](https://en.wikipedia.org/wiki/Internet_Explorer) on Wikipedia
 - [History of Internet Explorer](https://en.wikipedia.org/wiki/History_of_Internet_Explorer) on Wikipedia
-- [Internet Explorer versions](https://en.wikipedia.org/wiki/Internet_Explorer_versions) on Wikipedia
-- [Internet Explorer EOL countdown](https://death-to-ie11.com/)
+- [Internet Explorer version history](https://en.wikipedia.org/wiki/Internet_Explorer_versions) on Wikipedia
+- [IE11 end of support countdown](https://death-to-ie11.com/)
+- Related glossary terms:
+  - {{glossary("Browser")}}
+  - {{glossary("Trident")}} (IE's rendering engine)
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
+  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}, {{glossary("Opera Browser")}}

--- a/files/en-us/glossary/mozilla_firefox/index.md
+++ b/files/en-us/glossary/mozilla_firefox/index.md
@@ -9,22 +9,11 @@ sidebar: glossarysidebar
 
 First released in November 2004, Firefox is customizable with themes, plugins, and [add-ons](/en-US/docs/Mozilla/Add-ons). Firefox uses the {{glossary("Gecko")}} rendering engine to display web pages and implements both current and upcoming {{glossary("world wide web", "web")}} standards.
 
-## See also
+## Download Firefox
 
-- [Firefox](https://en.wikipedia.org/wiki/Firefox) on Wikipedia
-- [Firefox Release Notes](https://www.mozilla.org/en-US/firefox/releases/)
-- [Firefox Source Docs](https://firefox-source-docs.mozilla.org/)
-- [Firefox developer documentation](/en-US/docs/Mozilla/Firefox) on MDN Web Docs
-- [SpiderMonkey](https://spidermonkey.dev/) JavaScript and WebAssembly engine
-- [Mozilla Standards Positions](https://mozilla.github.io/standards-positions/)
-- [Report Firefox bugs](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox)
-- Related glossary terms:
-  - {{glossary("Browser")}}
-  - {{glossary("Gecko")}}
-  - {{Glossary("Engine/Rendering", "Rendering engine")}}
-  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Opera Browser")}}
+Firefox is available on multiple platforms and comes in different versions for different user needs.
 
-### Firefox download options
+### For Firefox users
 
 Use these links to download Firefox for different platforms, devices, or deployment needs:
 
@@ -40,3 +29,18 @@ If you want to try the latest Firefox features, install one of the pre-release b
 - [Firefox Developer Edition](https://www.firefox.com/en-US/channel/desktop/developer/)
 - [Firefox Nightly](https://www.firefox.com/en-US/channel/desktop/#nightly)
 - [Firefox Beta](https://www.firefox.com/en-US/channel/desktop/#beta)
+
+## See also
+
+- [Firefox](https://en.wikipedia.org/wiki/Firefox) on Wikipedia
+- [Firefox Release Notes](https://www.mozilla.org/en-US/firefox/releases/)
+- [Firefox Source Docs](https://firefox-source-docs.mozilla.org/)
+- [Firefox developer documentation](/en-US/docs/Mozilla/Firefox) on MDN Web Docs
+- [SpiderMonkey](https://spidermonkey.dev/) JavaScript and WebAssembly engine
+- [Mozilla Standards Positions](https://mozilla.github.io/standards-positions/)
+- [Report Firefox bugs](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox)
+- Related glossary terms:
+  - {{glossary("Browser")}}
+  - {{glossary("Gecko")}}
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
+  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Opera Browser")}}

--- a/files/en-us/glossary/mozilla_firefox/index.md
+++ b/files/en-us/glossary/mozilla_firefox/index.md
@@ -5,11 +5,38 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Mozilla Firefox** is a free open-source {{Glossary("browser")}} whose development is overseen by the Mozilla Corporation. Firefox runs on Windows, macOS, Linux, and Android.
+**Firefox** is a free, open-source {{Glossary("Browser","web browser")}} developed by the Mozilla Corporation. Firefox is available for Windows, macOS, Linux, Android, and iOS.
 
-First released in November 2004, Firefox is completely customizable with themes, plug-ins, and [add-ons](/en-US/docs/Mozilla/Add-ons). Firefox uses {{glossary("Gecko")}} to render webpages, and implements both current and upcoming {{glossary("world wide web", "Web")}} standards.
+First released in November 2004, Firefox is customizable with themes, plugins, and [add-ons](/en-US/docs/Mozilla/Add-ons). Firefox uses the {{glossary("Gecko")}} rendering engine to display web pages and implements both current and upcoming {{glossary("world wide web", "web")}} standards.
 
 ## See also
 
-- [Mozilla Firefox official website](https://www.firefox.com/en-US/)
-- [Firefox developer documentations](/en-US/docs/Mozilla/Firefox) on MDN
+- [Firefox](https://en.wikipedia.org/wiki/Firefox) on Wikipedia
+- [Firefox Release Notes](https://www.mozilla.org/en-US/firefox/releases/)
+- [Firefox Source Docs](https://firefox-source-docs.mozilla.org/)
+- [Firefox developer documentation](/en-US/docs/Mozilla/Firefox) on MDN Web Docs
+- [SpiderMonkey](https://spidermonkey.dev/) JavaScript and WebAssembly engine
+- [Mozilla Standards Positions](https://mozilla.github.io/standards-positions/)
+- [Report Firefox bugs](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox)
+- Related glossary terms:
+  - {{glossary("Browser")}}
+  - {{glossary("Gecko")}}
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
+  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Opera Browser")}}
+
+### Firefox download options
+
+Use these links to download Firefox for different platforms, devices, or deployment needs:
+
+- [Desktop](https://www.firefox.com/en-US/)
+- [Android](https://www.firefox.com/en-US/browsers/mobile/)
+- [iOS](https://www.firefox.com/en-US/browsers/mobile/)
+- [Firefox for Enterprise](https://www.firefox.com/en-US/browsers/enterprise/)
+
+### For web developers
+
+If you want to try the latest Firefox features, install one of the pre-release builds:
+
+- [Firefox Developer Edition](https://www.firefox.com/en-US/channel/desktop/developer/)
+- [Firefox Nightly](https://www.firefox.com/en-US/channel/desktop/#nightly)
+- [Firefox Beta](https://www.firefox.com/en-US/channel/desktop/#beta)

--- a/files/en-us/glossary/mozilla_firefox/index.md
+++ b/files/en-us/glossary/mozilla_firefox/index.md
@@ -13,7 +13,7 @@ First released in November 2004, Firefox is customizable with themes, plugins, a
 
 Firefox is available on multiple platforms and comes in different versions for different user needs.
 
-### For Firefox users
+### Users
 
 Use these links to download Firefox for different platforms, devices, or deployment needs:
 
@@ -22,7 +22,7 @@ Use these links to download Firefox for different platforms, devices, or deploym
 - [iOS](https://www.firefox.com/en-US/browsers/mobile/)
 - [Firefox for Enterprise](https://www.firefox.com/en-US/browsers/enterprise/)
 
-### For web developers
+### Web developers
 
 If you want to try the latest Firefox features, install one of the pre-release builds:
 

--- a/files/en-us/glossary/opera_browser/index.md
+++ b/files/en-us/glossary/opera_browser/index.md
@@ -7,6 +7,14 @@ sidebar: glossarysidebar
 
 **Opera** is a free {{Glossary("Browser","web browser")}} that was released publicly in 1996 and was initially available only for Windows. Opera has used the {{glossary("Blink")}} rendering engine since 2013 (replacing {{glossary("Presto")}}). Opera is also available on mobiles and tablets.
 
+## Download Opera
+
+Opera is available for multiple platforms:
+
+- [Opera for Windows, macOS, and Linux](https://www.opera.com/download)
+- [Opera for Android](https://play.google.com/store/apps/details?id=com.opera.browser)
+- [Opera for iOS](https://apps.apple.com/app/opera-browser-fast-private/id1411869974)
+
 ## See also
 
 - [Opera (web browser)](https://en.wikipedia.org/wiki/Opera_Browser) on Wikipedia

--- a/files/en-us/glossary/opera_browser/index.md
+++ b/files/en-us/glossary/opera_browser/index.md
@@ -5,9 +5,17 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Opera** is the fifth most used web {{glossary("browser")}}, publicly released in 1996 and initially running on Windows only. Opera uses {{glossary("Blink")}} as its layout engine since 2013 (before that, {{glossary("Presto")}}). Opera also exists in mobile and tablet versions.
+**Opera** is a free {{Glossary("Browser","web browser")}} that was released publicly in 1996 and was initially available only for Windows. Opera has used the {{glossary("Blink")}} rendering engine since 2013 (replacing {{glossary("Presto")}}). Opera is also available on mobiles and tablets.
 
 ## See also
 
-- [Opera Browser](https://en.wikipedia.org/wiki/Opera_Browser) on Wikipedia
-- [Opera browser website](https://www.opera.com/)
+- [Opera (web browser)](https://en.wikipedia.org/wiki/Opera_Browser) on Wikipedia
+- [Opera Web Browser](https://www.opera.com/) on opera.com
+- [Opera help](https://help.opera.com/)
+- Open issues using the [bug report wizard](https://bugs.opera.com/wizard/)
+- Related glossary terms:
+  - {{glossary("Browser")}}
+  - {{glossary("Blink")}}
+  - {{Glossary("Engine/Rendering", "Rendering engine")}}
+  - {{glossary("Presto")}}
+  - Other browsers: {{glossary("Apple Safari")}}, {{glossary("Google Chrome")}}, {{glossary("Microsoft Edge")}}, {{glossary("Mozilla Firefox")}}


### PR DESCRIPTION
### Description

This PR primarily updates the "See also" of web browser glossary pages (Safari, Chrome, Firefox, Edge, Opera, and IE) to add cross-references between all browser entries.

Inspired by the links in Safari's [See also](https://developer.mozilla.org/en-US/docs/Glossary/Apple_Safari#see_also) section, this PR adds similar links to "See also"s on Chrome and Firefox pages.

### Motivation

To make the relevant pages discoverable from any and all browser glossary pages.