### PR TITLE
Internalize ConvolverNode codepen example

### DIFF
--- a/files/en-us/web/api/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/index.md
@@ -59,7 +59,7 @@ _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_
 
 ## ConvolverNode Example
 
-The following example shows basic usage of an AudioContext to create a convolver node. You will need to find an impulse response to complete the example below. See our [HolySpaceCow](https://mdn.github.io/webaudio-examples/holy-space-cow) example for an applied example.
+The following example shows basic usage of an AudioContext to create a convolver node. You will need to find an impulse response to complete the example below. See our [HolySpaceCow](https://mdn.github.io/webaudio-examples/holy-space-cow) example for a complete, applied example.
 
 ```js
 let audioCtx = new window.AudioContext();

--- a/files/en-us/web/api/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/index.md
@@ -59,10 +59,7 @@ _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_
 
 ## ConvolverNode Example
 
-The following example shows basic usage of an AudioContext to create a convolver node.
-
-> [!NOTE]
-> You will need to find an impulse response to complete the example below. See this [CodePen](https://codepen.io/DonKarlssonSan/pen/doVKRE) for an applied example.
+The following example shows basic usage of an AudioContext to create a convolver node. You will need to find an impulse response to complete the example below. See our [HolySpaceCow](https://mdn.github.io/webaudio-examples/holy-space-cow) example for an applied example.
 
 ```js
 let audioCtx = new window.AudioContext();

--- a/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
@@ -249,7 +249,7 @@ source.connect(convolver);
 convolver.connect(context.destination);
 ```
 
-See this [CodePen](https://codepen.io/a2sheppy/pen/JjPgVYL) for an applied (but very, very silly; like, little kids will giggle kind of silly) example.
+See our [HolySpaceCow](https://mdn.github.io/webaudio-examples/holy-space-cow) example for an applied (but very, very silly) example.
 
 ### Spatial audio
 


### PR DESCRIPTION
I'm going to say that it fixes #16120. The last three (groups) of examples are tracked by https://github.com/mdn/content/issues/35578, https://github.com/mdn/content/issues/25379, and https://github.com/mdn/content/issues/10318.

Needs to merge https://github.com/mdn/webaudio-examples/pull/131 first.