### PR TITLE
Clarify the meaning of absolute units length

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -145,6 +145,10 @@ The following are all **absolute** length units — they are not relative to any
 
 Most of these units are more useful when used for print, rather than screen output. For example, we don't typically use `cm` (centimeters) on screen. The only value that you will commonly use is `px` (pixels).
 
+Note that `1px` doesn't necessarily equal one physical device pixel. On HD displays, it may span multiple physical pixels.
+Similarly, `1cm` in CSS often doesn't correspond to one tenth of [SI](https://en.wikipedia.org/wiki/International_System_of_Units) meter. On a large TV screen, it typically be longer than that.
+The lengths are perceptual: `16px` looks roughly the same on a phone, laptop, or TV screen.
+
 #### Relative length units
 
 Relative length units are relative to something else. For example:

--- a/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -146,7 +146,7 @@ The following are all **absolute** length units — they are not relative to any
 Most of these units are more useful when used for print, rather than screen output. For example, we don't typically use `cm` (centimeters) on screen. The only value that you will commonly use is `px` (pixels).
 
 Note that `1px` doesn't necessarily equal one physical device pixel. On HD displays, it may span multiple physical pixels.
-Similarly, `1cm` in CSS often doesn't correspond to one tenth of [SI](https://en.wikipedia.org/wiki/International_System_of_Units) meter. On a large TV screen, it typically be longer than that.
+Similarly, `1cm` in CSS often doesn't correspond to one hundredth of [SI](https://en.wikipedia.org/wiki/International_System_of_Units) meter. On a large TV screen, it typically is longer than that.
 The lengths are perceptual: `16px` looks roughly the same on a phone, laptop, or TV screen at typical viewing distance.
 
 #### Relative length units

--- a/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -147,7 +147,7 @@ Most of these units are more useful when used for print, rather than screen outp
 
 Note that `1px` doesn't necessarily equal one physical device pixel. On HD displays, it may span multiple physical pixels.
 Similarly, `1cm` in CSS often doesn't correspond to one tenth of [SI](https://en.wikipedia.org/wiki/International_System_of_Units) meter. On a large TV screen, it typically be longer than that.
-The lengths are perceptual: `16px` looks roughly the same on a phone, laptop, or TV screen.
+The lengths are perceptual: `16px` looks roughly the same on a phone, laptop, or TV screen at typical viewing distance.
 
 #### Relative length units
 


### PR DESCRIPTION
These units are named `pixels` and `centimeters`, but it is important to call out that those are "CSS" pixels and centimeters,  and  that they _don't_ match usual definitions of things. 

Call out explicitly that `1px` != pixel and that `1cm` != centimeter. 

I explicitly decided _not_ to mention angular measures, as my goal here is to give correct intuition (or rather, avoid incorrect one), rather than being fully pedantic (for which we have a spec).

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
