### PR TITLE
Fix variable redeclaration in url.origin code example

### DIFF
--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -28,6 +28,7 @@ A string.
 const url = new URL("blob:https://mozilla.org:443/");
 console.log(url.origin); // 'https://mozilla.org'
 ```
+
 ```js
 const url = new URL("http://localhost:80/");
 console.log(url.origin); // 'http://localhost'

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -24,6 +24,8 @@ A string.
 
 ## Examples
 
+The following examples show how the `origin` property is computed for a `blob:` URL, an `http:` URL, and one using a non-default port:
+
 ```js
 const url = new URL("blob:https://mozilla.org:443/");
 console.log(url.origin); // 'https://mozilla.org'

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -25,14 +25,14 @@ A string.
 ## Examples
 
 ```js
-const url = new URL("blob:https://mozilla.org:443/");
-console.log(url.origin); // 'https://mozilla.org'
+const url1 = new URL("blob:https://mozilla.org:443/");
+console.log(url1.origin); // 'https://mozilla.org'
 
-const url = new URL("http://localhost:80/");
-console.log(url.origin); // 'http://localhost'
+const url2 = new URL("http://localhost:80/");
+console.log(url2.origin); // 'http://localhost'
 
-const url = new URL("https://mozilla.org:8080/");
-console.log(url.origin); // 'https://mozilla.org:8080'
+const url3 = new URL("https://mozilla.org:8080/");
+console.log(url3.origin); // 'https://mozilla.org:8080'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -25,14 +25,16 @@ A string.
 ## Examples
 
 ```js
-const url1 = new URL("blob:https://mozilla.org:443/");
-console.log(url1.origin); // 'https://mozilla.org'
-
-const url2 = new URL("http://localhost:80/");
-console.log(url2.origin); // 'http://localhost'
-
-const url3 = new URL("https://mozilla.org:8080/");
-console.log(url3.origin); // 'https://mozilla.org:8080'
+const url = new URL("blob:https://mozilla.org:443/");
+console.log(url.origin); // 'https://mozilla.org'
+```
+```js
+const url = new URL("http://localhost:80/");
+console.log(url.origin); // 'http://localhost'
+```
+```js
+const url = new URL("https://mozilla.org:8080/");
+console.log(url.origin); // 'https://mozilla.org:8080'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -32,6 +32,7 @@ console.log(url.origin); // 'https://mozilla.org'
 const url = new URL("http://localhost:80/");
 console.log(url.origin); // 'http://localhost'
 ```
+
 ```js
 const url = new URL("https://mozilla.org:8080/");
 console.log(url.origin); // 'https://mozilla.org:8080'


### PR DESCRIPTION
```
const url = new URL("blob:https://mozilla.org:443/");
console.log(url.origin); // 'https://mozilla.org'

const url = new URL("http://localhost:80/");
console.log(url.origin); // 'http://localhost'

const url = new URL("https://mozilla.org:8080/");
console.log(url.origin); // 'https://mozilla.org:8080'
```
Error:
`Uncaught SyntaxError: Identifier 'url' has already been declared`
