### PR TITLE
docs (content-length) : Add HTTP version comparison

### DIFF
--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -47,11 +47,11 @@ Content-Length: <length>
 
 The handling of `Content-Length` differs between HTTP versions:
 
-| Feature               | HTTP/1.1                         | HTTP/2                    |
-|-----------------------|----------------------------------|---------------------------|
-| Required              | Yes (for persistent connections) | Optional                  |
-| Primary purpose       | Frame body size                  | Backward compatibility    |
-| Alternatives          | `Transfer-Encoding`              | Inferred from DATA frames |
+| Feature         | HTTP/1.1                         | HTTP/2                    |
+| --------------- | -------------------------------- | ------------------------- |
+| Required        | Yes (for persistent connections) | Optional                  |
+| Primary purpose | Frame body size                  | Backward compatibility    |
+| Alternatives    | `Transfer-Encoding`              | Inferred from DATA frames |
 
 ## Specifications
 

--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -45,14 +45,15 @@ Content-Length: <length>
 
 ## HTTP version comparison
 
-The handling of `Content-Length` differs between HTTP versions:
+`Content-Length` is required in HTTP/1.0.
+`Content-Length` is limited in that the message size must be known up front, before sending the headers, which is a problem when content is dynamically generated or streamed.
 
-| Feature         | HTTP/1.1                         | HTTP/2                    |
-| --------------- | -------------------------------- | ------------------------- |
-| Required        | Yes (for persistent connections) | Optional                  |
-| Primary purpose | Frame body size                  | Backward compatibility    |
-| Alternatives    | `Transfer-Encoding`              | Inferred from DATA frames |
-
+In HTTP/1.1 either `Content-Length` or {{httpheader("Transfer-Encoding","Transfer-Encoding: chunked")}} can be used to indicate message size (`Content-Length` is ignored if `Transfer-Encoding: chunked` is set).
+At least one of these is required for persistent connections.
+Note that `Transfer-Encoding: chunked` allows the content to be sent out in parts as its size is calculated, which is recommended better when the message size is not known up front.
+    
+In HTTP/2 `Content-Length` is optional and redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
+Note that `Transfer-Encoding` should not be used in HTTP/2.
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -9,6 +9,12 @@ sidebar: http
 
 The HTTP **`Content-Length`** header indicates the size, in bytes, of the message body sent to the recipient.
 
+`Content-Length` is limited in that the message size must be known up front, before sending the headers, which is a problem when content is dynamically generated or streamed.
+
+- In HTTP/1.0, it is required.
+- In HTTP/1.1, it could be replaced with {{httpheader("Transfer-Encoding", "Transfer-Encoding: chunked")}} for responses sent out in parts as its size is calculated.
+- In HTTP/2, `Content-Length` is redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
+
 <table class="properties">
   <tbody>
     <tr>
@@ -42,14 +48,6 @@ Content-Length: <length>
 
 - `<length>`
   - : The length in octets.
-
-## HTTP version comparison
-
-`Content-Length` is limited in that the message size must be known up front, before sending the headers, which is a problem when content is dynamically generated or streamed.
-
-- In HTTP/1.0, it is required.
-- In HTTP/1.1, it could be replaced with {{httpheader("Transfer-Encoding", "Transfer-Encoding: chunked")}} for responses sent out in parts as its size is calculated.
-- In HTTP/2, `Content-Length` is redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
 
 ## Specifications
 

--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -51,9 +51,9 @@ Content-Length: <length>
 In HTTP/1.1 either `Content-Length` or {{httpheader("Transfer-Encoding","Transfer-Encoding: chunked")}} can be used to indicate message size (`Content-Length` is ignored if `Transfer-Encoding: chunked` is set).
 At least one of these is required for persistent connections.
 Note that `Transfer-Encoding: chunked` allows the content to be sent out in parts as its size is calculated, which is recommended better when the message size is not known up front.
-    
 In HTTP/2 `Content-Length` is optional and redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
 Note that `Transfer-Encoding` should not be used in HTTP/2.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -51,6 +51,7 @@ Content-Length: <length>
 In HTTP/1.1 either `Content-Length` or {{httpheader("Transfer-Encoding","Transfer-Encoding: chunked")}} can be used to indicate message size (`Content-Length` is ignored if `Transfer-Encoding: chunked` is set).
 At least one of these is required for persistent connections.
 Note that `Transfer-Encoding: chunked` allows the content to be sent out in parts as its size is calculated, which is recommended better when the message size is not known up front.
+
 In HTTP/2 `Content-Length` is optional and redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
 Note that `Transfer-Encoding` should not be used in HTTP/2.
 

--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -45,15 +45,11 @@ Content-Length: <length>
 
 ## HTTP version comparison
 
-`Content-Length` is required in HTTP/1.0.
 `Content-Length` is limited in that the message size must be known up front, before sending the headers, which is a problem when content is dynamically generated or streamed.
 
-In HTTP/1.1 either `Content-Length` or {{httpheader("Transfer-Encoding","Transfer-Encoding: chunked")}} can be used to indicate message size (`Content-Length` is ignored if `Transfer-Encoding: chunked` is set).
-At least one of these is required for persistent connections.
-Note that `Transfer-Encoding: chunked` allows the content to be sent out in parts as its size is calculated, which is recommended better when the message size is not known up front.
-
-In HTTP/2 `Content-Length` is optional and redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
-Note that `Transfer-Encoding` should not be used in HTTP/2.
+- In HTTP/1.0, it is required.
+- In HTTP/1.1, it could be replaced with {{httpheader("Transfer-Encoding", "Transfer-Encoding: chunked")}} for responses sent out in parts as its size is calculated.
+- In HTTP/2, `Content-Length` is redundant, because the content length may be inferred from DATA frames. It may still be included for backwards compatibility.
 
 ## Specifications
 

--- a/files/en-us/web/http/reference/headers/content-length/index.md
+++ b/files/en-us/web/http/reference/headers/content-length/index.md
@@ -43,6 +43,16 @@ Content-Length: <length>
 - `<length>`
   - : The length in octets.
 
+## HTTP version comparison
+
+The handling of `Content-Length` differs between HTTP versions:
+
+| Feature               | HTTP/1.1                         | HTTP/2                    |
+|-----------------------|----------------------------------|---------------------------|
+| Required              | Yes (for persistent connections) | Optional                  |
+| Primary purpose       | Frame body size                  | Backward compatibility    |
+| Alternatives          | `Transfer-Encoding`              | Inferred from DATA frames |
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Added a comparison table clarifying 'Content-Length' header behavior differences between HTTP/1.1 and HTTP/2.

### Motivation

I made this simple change because it helps resolve confusion in a simple way. Developers may use this information to avoid unecessary header usage.

### Additional details

https://httpwg.org/specs/rfc9113.html#rfc.section.8.1

### Related issues and pull requests

Fixes #36681 