### PR TITLE
Add `'write'` value to `FileSystemHandle` permission `descriptor.mode`

### DIFF
--- a/files/en-us/web/api/filesystemhandle/querypermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.md
@@ -25,7 +25,7 @@ queryPermission(descriptor)
 - `descriptor` {{optional_inline}}
   - : An object which specifies the permission mode to query for. Options are as follows:
     - `'mode'` {{optional_inline}}
-      - : Can be either `'read'` or `'readwrite'`.
+      - : Can be either `'read'`, `'write'`, or `'readwrite'`.
 
 ### Return value
 
@@ -42,7 +42,7 @@ the user revoking permission, a handle retrieved from IndexedDB is also likely t
 
 - {{jsxref("TypeError")}}
   - : Thrown if `mode` is specified with a value other than
-    `'read'` or `'readwrite'`
+    `'read'`, `'write'`, or `'readwrite'`
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -25,7 +25,7 @@ requestPermission(descriptor)
 - `descriptor` {{optional_inline}}
   - : An object which specifies the permission mode to query for. Options are as follows:
     - `'mode'` {{optional_inline}}
-      - : Can be either `'read'`, `write`, or `'readwrite'`.
+      - : Can be either `'read'`, `'write'`, or `'readwrite'`.
 
 ### Return value
 

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -25,7 +25,7 @@ requestPermission(descriptor)
 - `descriptor` {{optional_inline}}
   - : An object which specifies the permission mode to query for. Options are as follows:
     - `'mode'` {{optional_inline}}
-      - : Can be either `'read'` or `'readwrite'`.
+      - : Can be either `'read'`, `write`, or `'readwrite'`.
 
 ### Return value
 
@@ -35,7 +35,7 @@ A {{jsxref("Promise")}} that resolves with {{domxref('PermissionStatus.state')}}
 
 - {{jsxref("TypeError")}}
   - : Thrown if no parameter is specified or the `mode` is not that of
-    `'read'` or `'readwrite'`
+    `'read'`, `'write'`, or `'readwrite'`
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown in one of the following cases:
     - The method was called in a context that's not [same-origin](/en-US/docs/Web/Security/Same-origin_policy) as the top-level context (i.e., a cross-origin iframe).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

The File System Access API defines two access modes for file system entries: "read" and "readwrite". These modes are used when querying or requesting permission to an entry.

An issue with the current model is that operations requiring only file system modification, such as FileSystemHandle.remove(), are forced to request broad "readwrite" permission. This behavior poses some unnecessary security risks. Add a new "write"-only access mode and adjust the existing APIs would solve the issue.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Add `'write'` value to `FileSystemHandle` permission `descriptor.mode` so developers are aware. 

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

See https://chromestatus.com/feature/5324970347200512 and https://wicg.github.io/file-system-access/#enumdef-filesystempermissionmode. 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
