### PR TITLE
Specify getFloatTimeDomainData() encoding range

### DIFF
--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AnalyserNode.getFloatTimeDomainData
 
 The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it. Each array value is a _sample_, the magnitude of the signal at a particular time.
 
-The waveform is encoded as PCM data, which has a nominal range of -1.0 to 1.0, but values can exceed the range such as when down-mixing stereo to mono.
+The waveform is represented as PCM data, which has a nominal range of -1.0 to 1.0, but values can exceed the range such as when down-mixing stereo to mono.
 
 ## Syntax
 

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -10,6 +10,8 @@ browser-compat: api.AnalyserNode.getFloatTimeDomainData
 
 The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} Interface copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it. Each array value is a _sample_, the magnitude of the signal at a particular time.
 
+The waveform is encoded as PCM data, which has a nominal range of -1.0 to 1.0, but values can exceed the range such as when down-mixing stereo to mono.
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/25571. Wondering if you could advise @padenot—thanks!