### PR TITLE
[CSS] Clarify that float has no effect when display: contents is applied

### DIFF
--- a/files/en-us/web/css/float/index.md
+++ b/files/en-us/web/css/float/index.md
@@ -120,6 +120,8 @@ The `float` property is specified as a single keyword, chosen from the list of v
 
 {{cssinfo}}
 
+**Note:** The `float` property has no effect when applied to elements with `display: none` or `display: contents`
+
 ## Formal syntax
 
 {{csssyntax}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

This PR adds a clarification note explaining that the float property also has no effect on elements with display: contents, to help readers better understand the limitations mentioned in the formal definition.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
