### PR TITLE
FF142 Relnote/Expr: Prioritized task scheduling API

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -689,22 +689,6 @@ See [Firefox bug 1697647](https://bugzil.la/1697647) for more details.
 - `dom.screenorientation.allow-lock`
   - : Set to `true` to enable.
 
-### Prioritized Task Scheduling API
-
-The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third-party libraries and frameworks.
-From Firefox version 140 the API is both feature complete and enabled in the Nightly release.
-([Firefox bug 1734997](https://bugzil.la/1734997) and [Firefox bug 1920115](https://bugzil.la/1920115)).
-
-| Release channel   | Version changed | Enabled by default? |
-| ----------------- | --------------- | ------------------- |
-| Nightly           | 139             | Yes                 |
-| Developer Edition | 101             | No                  |
-| Beta              | 101             | No                  |
-| Release           | 101             | No                  |
-
-- `dom.enable_web_task_scheduling`
-  - : Set to `true` to enable.
-
 ### Notifications API
 
 Notifications have the [`requireInteraction`](/en-US/docs/Web/API/Notification/requireInteraction) property set to true by default on Windows systems and in the Nightly release ([Firefox bug 1794475](https://bugzil.la/1794475)).

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -59,7 +59,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("Animation.commitStyles()")}} method no longer requires [`fill`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to be set on an animation to commit the computed styles after the animation has finished. Note that until more browsers support this change, you should continue to set `fill`. ([Firefox bug 1973203](https://bugzil.la/1973203)).
 - The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) is now supported, providing a standardized mechanism to assign and manage task priorities for an application.
   The supported interfaces include: {{domxref("Scheduler")}}, {{domxref("TaskController")}}, {{domxref("TaskSignal")}}, {{domxref("TaskPriorityChangeEvent")}} (and the {{domxref("TaskSignal/prioritychange_event","prioritychange")}} event), and the properties {{domxref("Window.scheduler")}} and {{domxref("WorkerGlobalScope.scheduler")}}.
-  The {{domxref("Scheduling")}} interface and {{domxref("Navigator.scheduling")}} property are not supported.
+  The {{domxref("Scheduling")}} interface and the {{domxref("Navigator.scheduling")}} property are not supported.
   ([Firefox bug 1966997](https://bugzil.la/1966997)).
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -57,6 +57,10 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("Selection.getComposedRanges()")}} method is now supported, allowing developers to accurately get selected text ranges across shadow DOM boundaries. In addition, the methods {{domxref("Selection.setBaseAndExtent()","setBaseAndExtent()")}}, {{domxref("Selection.collapse()","collapse()")}}, and {{domxref("Selection.extend()","extend()")}} of the {{domxref("Selection")}} interface have been modified to accept nodes inside a shadow root. ([Firefox bug 1903870](https://bugzil.la/1903870)).
 - The {{domxref("Animation.overallProgress")}} property is now supported, allowing developers to track and display progress through an animation. ([Firefox bug 1834878](https://bugzil.la/1834878)).
 - The {{domxref("Animation.commitStyles()")}} method no longer requires [`fill`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to be set on an animation to commit the computed styles after the animation has finished. Note that until more browsers support this change, you should continue to set `fill`. ([Firefox bug 1973203](https://bugzil.la/1973203)).
+- The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) is now supported, providing a standardized mechanism to assign and manage task priorities for an application.
+  The supported interfaces include: {{domxref("Scheduler")}}, {{domxref("TaskController")}}, {{domxref("TaskSignal")}}, {{domxref("TaskPriorityChangeEvent")}} (and the {{domxref("TaskSignal/prioritychange_event","prioritychange")}} event), and the properties {{domxref("Window.scheduler")}} and {{domxref("WorkerGlobalScope.scheduler")}}.
+  The {{domxref("Scheduling")}} interface and {{domxref("Navigator.scheduling")}} property are not supported.
+  ([Firefox bug 1966997](https://bugzil.la/1966997)).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
FF142 supports the [Prioritized Task Scheduling AP](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) in https://bugzilla.mozilla.org/show_bug.cgi?id=1966997

This adds a release note and removes the experimental features entry.

Related docs work can be tracked in  #40484
