### PR TITLE
Use consistent capitalisation for "ETag"

### DIFF
--- a/files/en-us/glossary/response_header/index.md
+++ b/files/en-us/glossary/response_header/index.md
@@ -18,7 +18,7 @@ Connection: Keep-Alive
 Content-Encoding: gzip
 Content-Type: text/html; charset=utf-8
 Date: Mon, 18 Jul 2016 16:06:00 GMT
-Etag: "c561c68d0ba92bbeb8b0f612a9199f722e3a621a"
+ETag: "c561c68d0ba92bbeb8b0f612a9199f722e3a621a"
 Keep-Alive: timeout=5, max=997
 Last-Modified: Mon, 18 Jul 2016 02:36:04 GMT
 Server: Apache

--- a/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
+++ b/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
@@ -119,7 +119,7 @@ date: Tue, 11 Feb 2025 11:13:30 GMT
 expires: Tue, 11 Feb 2025 11:40:01 GMT
 server: Google frontend
 last-modified: Tue, 11 Feb 2025 00:49:32 GMT
-etag: "65f26b7f6463e2347f4e5a7a2adcee54"
+ETag: "65f26b7f6463e2347f4e5a7a2adcee54"
 content-length: 45227
 content-type: text/html
 

--- a/files/en-us/web/http/reference/headers/etag/index.md
+++ b/files/en-us/web/http/reference/headers/etag/index.md
@@ -11,7 +11,7 @@ The HTTP **`ETag`** (entity tag) {{Glossary("response header")}} is an identifie
 It lets [caches](/en-US/docs/Web/HTTP/Guides/Caching) be more efficient and save bandwidth, as a web server does not need to resend a full response if the content has not changed.
 Additionally, ETags help to prevent simultaneous updates of a resource from overwriting each other (["mid-air collisions"](#avoiding_mid-air_collisions)).
 
-If the resource at a given URL changes, a new `Etag` value _must_ be generated.
+If the resource at a given URL changes, a new `ETag` value _must_ be generated.
 A comparison of them can determine whether two representations of a resource are the same.
 
 <table class="properties">
@@ -59,7 +59,7 @@ ETag: W/"0815"
 
 With the help of the `ETag` and the {{HTTPHeader("If-Match")}} headers, you can detect mid-air edit collisions (conflicts).
 
-For example, when editing a wiki, the current wiki content may be hashed and put into an `Etag` header in the response:
+For example, when editing a wiki, the current wiki content may be hashed and put into an `ETag` header in the response:
 
 ```http
 ETag: "33a64df551425fcc55e4d42a148795d9f25f89d4"


### PR DESCRIPTION
### Description

Use consistent capitalisation for `ETag` in the _ETag header_ article.