### PR TITLE
Fix bug in example code

### DIFF
--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -112,7 +112,7 @@ The error can be due to the `type` not being one of the two possible values, the
 ```js
 navigator.mediaCapabilities
   .decodingInfo(videoConfiguration)
-  .then(console.log("It worked"))
+  .then(() => console.log("It worked"))
   .catch((error) => console.error(`It failed: ${error}`));
 ```
 

--- a/files/en-us/web/api/sharedstorage/append/index.md
+++ b/files/en-us/web/api/sharedstorage/append/index.md
@@ -48,7 +48,7 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
 ```js
 window.sharedStorage
   .append("integer-list", ",9")
-  .then(console.log("Value appended to integer list"));
+  .then(() => console.log("Value appended to integer list"));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/sharedstorage/clear/index.md
+++ b/files/en-us/web/api/sharedstorage/clear/index.md
@@ -39,7 +39,7 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
 ## Examples
 
 ```js
-window.sharedStorage.clear().then(console.log("Shared storage cleared"));
+window.sharedStorage.clear().then(() => console.log("Shared storage cleared"));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/sharedstorage/delete/index.md
+++ b/files/en-us/web/api/sharedstorage/delete/index.md
@@ -47,7 +47,7 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
 ```js
 window.sharedStorage
   .delete("ab-testing-group")
-  .then(console.log("Value deleted"));
+  .then(() => console.log("Value deleted"));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/sharedstorage/index.md
+++ b/files/en-us/web/api/sharedstorage/index.md
@@ -34,7 +34,7 @@ The **`SharedStorage`** interface of the {{domxref("Shared Storage API", "Shared
 ```js
 window.sharedStorage
   .set("ab-testing-group", "0")
-  .then(console.log("Value saved to shared storage"));
+  .then(() => console.log("Value saved to shared storage"));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/sharedstorage/set/index.md
+++ b/files/en-us/web/api/sharedstorage/set/index.md
@@ -52,7 +52,7 @@ window.sharedStorage
   .set("ab-testing-group", "0", {
     ignoreIfPresent: true,
   })
-  .then(console.log("Set operation completed"));
+  .then(() => console.log("Set operation completed"));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/window/sharedstorage/index.md
+++ b/files/en-us/web/api/window/sharedstorage/index.md
@@ -24,7 +24,7 @@ A {{domxref("WindowSharedStorage")}} object instance.
 ```js
 window.sharedStorage
   .set("ab-testing-group", "0")
-  .then(console.log("Value saved to shared storage"));
+  .then(() => console.log("Value saved to shared storage"));
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

An error was found in the example code in the first positional argument for Promise#then ([1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)). Instead of providing a function, a function call was provided which would run before the promise is resolved.

### Motivation

I believe this would help developers who are new to this feature and are trying to learn and test using the example code, as was I. An error would be thrown after attempting to use the example code provided here.

### References

1. [Promise#then](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)