### PR TITLE
Bug-1910669 add `StorageArea.getKeys()` doc and release note

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -27,6 +27,8 @@ The `local` object implements the methods defined on the {{WebExtAPIRef("storage
   - : Retrieves one or more items from the storage area.
 - {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.local.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used for one or more items in the storage area.
+- {{WebExtAPIRef("storage.StorageArea.getKeys()", "storage.local.getKeys()")}}
+  - : Retrieves the keys of all items in the storage area.
 - {{WebExtAPIRef("storage.StorageArea.set()", "storage.local.set()")}}
   - : Stores one or more items in the storage area. If the item exists, its value is updated.
 - {{WebExtAPIRef("storage.StorageArea.remove()", "storage.local.remove()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -50,7 +50,6 @@ The `managed` object implements the methods defined on the {{WebExtAPIRef("stora
 - {{WebExtAPIRef("storage.StorageArea.getKeys()", "storage.managed.getKeys()")}}
   - : Retrieves the keys of all items in the storage area.
 
-
 ## Events
 
 The `managed` object implements the events defined on the {{WebExtAPIRef("storage.StorageArea")}} type:

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -47,6 +47,9 @@ The `managed` object implements the methods defined on the {{WebExtAPIRef("stora
   - : Retrieves one or more items from the storage area.
 - {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.managed.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used for one or more items in the storage area.
+- {{WebExtAPIRef("storage.StorageArea.getKeys()", "storage.managed.getKeys()")}}
+  - : Retrieves the keys of all items in the storage area.
+
 
 ## Events
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
@@ -26,6 +26,8 @@ The `session` object implements the methods defined on the {{WebExtAPIRef("stora
   - : Retrieves one or more items from the storage area.
 - {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.session.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used for one or more items in the storage area.
+- {{WebExtAPIRef("storage.StorageArea.getKeys()", "storage.session.getKeys()")}}
+  - : Retrieves the keys of all items in the storage area.
 - {{WebExtAPIRef("storage.StorageArea.set()", "storage.session.set()")}}
   - : Stores one or more items in the storage area. If the item exists, its value is updated.
 - {{WebExtAPIRef("storage.StorageArea.setAccessLevel", "storage.session.setAccessLevel()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
@@ -1,0 +1,73 @@
+---
+title: StorageArea.getKeys()
+slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getKeys
+page-type: webextension-api-function
+browser-compat: webextensions.api.storage.StorageArea.getKeys
+sidebar: addonsidebar
+---
+
+Retrieves the keys of all items in a storage area.
+
+
+## Syntax
+
+```js-nolint
+let results = browser.storage.<storageType>.getKeys();
+```
+
+Where `<storageType>` is one of the storage types — {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, or {{WebExtAPIRef("storage.managed", "managed")}}.
+
+### Parameters
+
+This method takes no parameters.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an array containing storage item keys.
+
+If the operation fails, the promise is rejected with an error message.
+
+If managed storage is not set, `undefined` is returned.
+
+> [!WARNING]
+> In Firefox, if an extension's managed storage has not been configured with a [native manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or using the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)).
+
+## Examples
+
+Suppose storage contains two items:
+
+```js
+// storage contains two items,
+// "kitten" and "monster"
+browser.storage.local.set({
+  kitten: { name: "Mog", eats: "mice" },
+  monster: { name: "Kraken", eats: "people" },
+});
+```
+
+With these success and failure handlers for the promise:
+
+```js
+function onGot(item) {
+  console.log(item);
+}
+
+function onError(error) {
+  console.log(`Error: ${error}`);
+}
+```
+
+Retrieve the storage item keys:
+
+```js
+let gettingKeys = browser.storage.local.getKeys();
+gettingKeys.then(onGot, onError);
+
+// -> array [ kitten, monster ]
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
@@ -36,33 +36,19 @@ If managed storage is not set, `undefined` is returned.
 Suppose storage contains two items:
 
 ```js
-// storage contains two items,
-// "kitten" and "monster"
+// storage contains two items, "kitten" and "monster"
 browser.storage.local.set({
   kitten: { name: "Mog", eats: "mice" },
   monster: { name: "Kraken", eats: "people" },
 });
 ```
 
-With these success and failure handlers for the promise:
+Retrieve keys of all items in storage.local and log the result.
 
 ```js
-function onGot(item) {
-  console.log(item);
-}
-
-function onError(error) {
-  console.log(`Error: ${error}`);
-}
-```
-
-Retrieve the storage item keys:
-
-```js
-let gettingKeys = browser.storage.local.getKeys();
-gettingKeys.then(onGot, onError);
-
-// -> array [ kitten, monster ]
+browser.storage.local.getKeys()
+  .then((keys) => console.log(keys)) // [ "kitten", "monster" ]
+  .catch((err) => console.error(`Error: ${error}`));
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
@@ -8,7 +8,6 @@ sidebar: addonsidebar
 
 Retrieves the keys of all items in a storage area.
 
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
@@ -46,7 +46,8 @@ browser.storage.local.set({
 Retrieve keys of all items in storage.local and log the result.
 
 ```js
-browser.storage.local.getKeys()
+browser.storage.local
+  .getKeys()
   .then((keys) => console.log(keys)) // [ "kitten", "monster" ]
   .catch((err) => console.error(`Error: ${error}`));
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -18,6 +18,8 @@ Values of this type are objects.
   - : Retrieves one or more items from the storage area.
 - {{WebExtAPIRef("storage.StorageArea.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used one or more items being stored in the storage area.
+- {{WebExtAPIRef("storage.StorageArea.getKeys()")}}
+  - : Retrieves the keys of all items in the storage area.
 - {{WebExtAPIRef("storage.StorageArea.set()")}}
   - : Stores one or more items in the storage area. If an item already exists, its value will be updated.
 - {{WebExtAPIRef("storage.StorageArea.setAccessLevel()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -79,6 +79,8 @@ The `sync` object implements the methods defined on the {{WebExtAPIRef("storage.
   - : Retrieves one or more items from the storage area.
 - {{WebExtAPIRef("storage.StorageArea.getBytesInUse()", "storage.sync.getBytesInUse()")}}
   - : Gets the amount of storage space (in bytes) used for one or more items in the storage area.
+- {{WebExtAPIRef("storage.StorageArea.getKeys()", "storage.sync.getKeys()")}}
+  - : Retrieves the keys of all items in the storage area.
 - {{WebExtAPIRef("storage.StorageArea.set()", "storage.sync.set()")}}
   - : Stores one or more items in the storage area. If the item exists, its value is updated.
 - {{WebExtAPIRef("storage.StorageArea.remove()", "storage.sync.remove()")}}

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -68,7 +68,9 @@ Firefox 143 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 <!-- #### Marionette -->
 
-<!-- ## Changes for add-on developers -->
+## Changes for add-on developers
+
+- Addition of {{WebExtAPIRef("storage.StorageArea.getKeys()")}}. This method returns an array containing all of the keys in a storage area. It's available for all storage areas, that is {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, and {{WebExtAPIRef("storage.managed", "managed")}}. ([Firefox bug 1910669](https://bugzil.la/1910669))
 
 <!-- ### Removals -->
 


### PR DESCRIPTION
### Description

Add details of the `StorageArea.getKeys()` method, including a page for the method and details on the storagearea type and each of the storagearea types.

This address is the dev-docs-needed requirements of [Bug 1910669](https://bugzilla.mozilla.org/show_bug.cgi?id=1910669) Implement StorageArea.getKeys() in extension storage API

### Related issues and pull requests

Related BCD changes included in PR https://github.com/mdn/browser-compat-data/pull/27442.
