### PR TITLE
added experimental release notes for CSS anchor-size() function

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -323,6 +323,20 @@ The CSS {{CSSXRef(":active-view-transition")}} pseudo-class enables you to style
 - `dom.viewTransitions.enabled`
   - : Set to `true` to enable.
 
+### `anchor-size()` function
+
+The CSS {{CSSXRef("anchor-size")}} function enables setting anchor-positioned element's size, position, and margins relative to the dimensions of anchor elements. ([Firefox bug 1972610](https://bugzil.la/1972610)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 142           | No                  |
+| Developer Edition | 142           | No                  |
+| Beta              | 142           | No                  |
+| Release           | 142           | No                  |
+
+- `layout.css.anchor-positioning.enabled`
+  - : Set to `true` to enable.
+
 ## SVG
 
 **No experimental features in this release cycle.**

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -80,6 +80,10 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Experimental web features
 
+- **`anchor-size()`** (Nightly): `layout.css.anchor-positioning.enabled`
+
+  The CSS {{CSSXRef("anchor-size")}} function enables setting anchor-positioned element's size, position, and margins relative to the dimensions of anchor elements. ([Firefox bug 1972610](https://bugzil.la/1972610)).
+
 These features are shipping in Firefox 142 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
### Description

- For the CSS `anchor-size()` function:
  - Added experimental release note to Firefox 142 release page
  - Added experimental release with table of support

### Motivation

- Working on [issue #40480](https://github.com/mdn/content/issues/40480)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/27440)