### PR TITLE
Fix getAsFileSystemHandle() example

### DIFF
--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -40,7 +40,7 @@ This example uses the `getAsFileSystemHandle()` method to return
 {{domxref('FileSystemHandle', 'file handles', '', 'nocode')}} for dropped items.
 
 > [!NOTE]
-> Because `getAsFileSystemHandle()` can only retrieve the entry handle the same tick as the `drop` event handler, there must be no `await` before it. This is why we synchronously invoke `getAsFileSystemHandle()` for all items first, and then wait for their results concurrently.
+> Because `getAsFileSystemHandle()` can only retrieve the entry handle in the same tick as the `drop` event handler, there must be no `await` before it. This is why we synchronously invoke `getAsFileSystemHandle()` for all items first, and then wait for their results concurrently.
 
 ```js
 elem.addEventListener("dragover", (e) => {


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/36496.

This makes this example consistent with https://wicg.github.io/file-system-access/#dom-datatransferitem-getasfilesystemhandle