### PR TITLE
Remove URL hash from import()

### DIFF
--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -15,7 +15,7 @@ A service worker is an event-driven [worker](/en-US/docs/Web/API/Worker) registe
 
 Service workers run in a worker context: they therefore have no DOM access and run on a different thread to the main JavaScript that powers your app. They are non-blocking and designed to be fully asynchronous. As a consequence, APIs such as synchronous [XHR](/en-US/docs/Web/API/XMLHttpRequest) and [Web Storage](/en-US/docs/Web/API/Web_Storage_API) can't be used inside a service worker.
 
-Service workers can't import JavaScript modules dynamically, and [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility) will throw an error if it is called in a service worker global scope. Static imports using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) statement are allowed.
+Service workers can't import JavaScript modules dynamically, and [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import) will throw an error if it is called in a service worker global scope. Static imports using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) statement are allowed.
 
 Service workers are only available in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts): this means that their document is served over HTTPS, although browsers also treat `http://localhost` as a secure context, to facilitate local development. HTTP connections are susceptible to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs.
 


### PR DESCRIPTION
### Description

Remove unnecessary URL hash from the `import()`-link

### Motivation

The linked section is unnecessary for the reader, who expects to read about the `import()` function, not specifically what the browser support is.

### Additional details

Link before:
[`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility)
Link after:
[`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import)
