### PR TITLE
fix: compile Wasm to bundler-friendly (and native) module format edits

### DIFF
--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -111,7 +111,7 @@ import "./hello.js";
 Alternatively, you can produce a factory module, which allows you to produce multiple instances of the module (by default the glue code loads the module globally, causing multiple instances to collide).
 
 ```bash
-emcc hello.c -o hello.mjs -sMODULARIZE
+emcc -o hello.mjs hello.c -O3 -sMODULARIZE
 ```
 
 > [!NOTE]

--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -62,6 +62,43 @@ Now all that remains is for you to load the resulting `hello.html` in a browser 
 > [!NOTE]
 > If you try to open generated HTML file (`hello.html`) directly from your local hard drive (e.g., `file://your_path/hello.html`), you will end up with an error message along the lines of _`both async and sync fetching of the wasm failed`._ You need to run your HTML file through an HTTP server (`http://`) — see [How do you set up a local testing server?](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server) for more information.
 
+### Using your Wasm in an ES 6 bundler (webpack / Vite / Rollup)
+
+If your project uses ES 6 imports and a bundler, you can import the generated JavaScript glue file so it runs as a side effect:
+
+```bash
+emcc hello.c -o hello.js
+```
+
+In your app's entry module, add:
+
+```js
+import "./hello.js"; // this fetches, compiles, and instantiates the Wasm module automatically
+```
+
+In Vite, the same behavior can be achieved. Simply import './hello.js', and the module will run as soon as the bundle loads.
+
+To produce an ES 6 factory module that you can instantiate on demand, add two flags:
+
+```bash
+emcc hello.c \
+  -o hello.mjs \
+  -s MODULARIZE=1 \
+  -s EXPORT_ES6=1
+```
+
+Then in your code import the factory and call it:
+
+```js
+import createModule from "./hello.mjs";
+
+createModule().then((Module) => {
+  console.log("Wasm ready", Module);
+});
+```
+
+Note: TypeScript projects may need a simple `declare module './hello.js';` in a `.d.ts` file. Full TypeScript integration is beyond the scope of this guide.
+
 If everything has worked as planned, you should see "Hello world" output in the Emscripten console appearing on the web page, and your browser's JavaScript console. Congratulations, you've just compiled C to WebAssembly and run it in your browser!
 ![image](helloworld.png)
 

--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -99,28 +99,28 @@ Sometimes you will want to use a custom HTML template. Let's look at how we can 
 You could specify outputting just the JavaScript "glue" file (Emscripten requires a large variety of JavaScript "glue" code to handle memory allocation, memory leaks, and a host of other problems) rather than the full HTML by specifying a .js file instead of an HTML file in the `-o` flag, like this:
 
 ```bash
-emcc -o hello2.js hello2.c -O3
+emcc -o hello.js hello.c -O3
 ```
 
 You could then incorporate this JavaScript file into your program, which is especially useful if you are using a bundler and are not working with the HTML directly. For example, you can import the generated JavaScript glue file so it runs as a side effect. In your app's entry module, add:
 
 ```js
-import "./hello2.js";
+import "./hello.js";
 ```
 
-To produce an ES 6 factory module that you can instantiate on demand, add two flags:
+Alternatively, you can produce a factory module, which allows you to produce multiple instances of the module (by default the glue code loads the module globally, causing multiple instances to collide).
 
 ```bash
-emcc hello.c \
-  -o hello.mjs \
-  -s MODULARIZE=1 \
-  -s EXPORT_ES6=1
+emcc hello.c -o hello.mjs -sMODULARIZE
 ```
+
+> [!NOTE]
+> If your output file extension is .js and not .mjs, then you have to add the `-sEXPORT_ES6` setting to output a JavaScript module.
 
 Then in your code import the factory and call it:
 
 ```js
-import createModule from "./hello.mjs";
+import createModule from "./hello.js";
 
 createModule().then((Module) => {
   console.log("Wasm ready", Module);

--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -62,43 +62,6 @@ Now all that remains is for you to load the resulting `hello.html` in a browser 
 > [!NOTE]
 > If you try to open generated HTML file (`hello.html`) directly from your local hard drive (e.g., `file://your_path/hello.html`), you will end up with an error message along the lines of _`both async and sync fetching of the wasm failed`._ You need to run your HTML file through an HTTP server (`http://`) — see [How do you set up a local testing server?](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server) for more information.
 
-### Using your Wasm in an ES 6 bundler (webpack / Vite / Rollup)
-
-If your project uses ES 6 imports and a bundler, you can import the generated JavaScript glue file so it runs as a side effect:
-
-```bash
-emcc hello.c -o hello.js
-```
-
-In your app's entry module, add:
-
-```js
-import "./hello.js"; // this fetches, compiles, and instantiates the Wasm module automatically
-```
-
-In Vite, the same behavior can be achieved. Simply import './hello.js', and the module will run as soon as the bundle loads.
-
-To produce an ES 6 factory module that you can instantiate on demand, add two flags:
-
-```bash
-emcc hello.c \
-  -o hello.mjs \
-  -s MODULARIZE=1 \
-  -s EXPORT_ES6=1
-```
-
-Then in your code import the factory and call it:
-
-```js
-import createModule from "./hello.mjs";
-
-createModule().then((Module) => {
-  console.log("Wasm ready", Module);
-});
-```
-
-Note: TypeScript projects may need a simple `declare module './hello.js';` in a `.d.ts` file. Full TypeScript integration is beyond the scope of this guide.
-
 If everything has worked as planned, you should see "Hello world" output in the Emscripten console appearing on the web page, and your browser's JavaScript console. Congratulations, you've just compiled C to WebAssembly and run it in your browser!
 ![image](helloworld.png)
 
@@ -131,12 +94,40 @@ Sometimes you will want to use a custom HTML template. Let's look at how we can 
 
 4. Now let's run this example. The above command will have generated `hello2.html`, which will have much the same content as the template with some glue code added into load the generated Wasm, run it, etc. Open it in your browser and you'll see much the same output as the last example.
 
-> [!NOTE]
-> You could specify outputting just the JavaScript "glue" file\* rather than the full HTML by specifying a .js file instead of an HTML file in the `-o` flag, e.g., `emcc -o hello2.js hello2.c -O3`. You could then build your custom HTML completely from scratch, although this is an advanced approach; it is usually easier to use the provided HTML template.
->
-> - Emscripten requires a large variety of JavaScript "glue" code to handle memory allocation, memory leaks, and a host of other problems
+### Compiling to a JavaScript module
 
-### Calling a custom function defined in C
+You could specify outputting just the JavaScript "glue" file (Emscripten requires a large variety of JavaScript "glue" code to handle memory allocation, memory leaks, and a host of other problems) rather than the full HTML by specifying a .js file instead of an HTML file in the `-o` flag, like this:
+
+```bash
+emcc -o hello2.js hello2.c -O3
+```
+
+You could then incorporate this JavaScript file into your program, which is especially useful if you are using a bundler and are not working with the HTML directly. For example, you can import the generated JavaScript glue file so it runs as a side effect. In your app's entry module, add:
+
+```js
+import "./hello2.js";
+```
+
+To produce an ES 6 factory module that you can instantiate on demand, add two flags:
+
+```bash
+emcc hello.c \
+  -o hello.mjs \
+  -s MODULARIZE=1 \
+  -s EXPORT_ES6=1
+```
+
+Then in your code import the factory and call it:
+
+```js
+import createModule from "./hello.mjs";
+
+createModule().then((Module) => {
+  console.log("Wasm ready", Module);
+});
+```
+
+## Calling a custom function defined in C
 
 If you want to call a function defined in your C code from JavaScript, you can use the Emscripten `ccall()` function and the `EMSCRIPTEN_KEEPALIVE` declaration, which adds your functions to the exported functions list (see [Why do functions in my C/C++ source code vanish when I compile to JavaScript, and/or I get No functions to process?](https://emscripten.org/docs/getting_started/FAQ.html#why-do-functions-in-my-c-c-source-code-vanish-when-i-compile-to-webassembly)). Let's look at how this works.
 

--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -120,7 +120,7 @@ emcc hello.c -o hello.mjs -sMODULARIZE
 Then in your code import the factory and call it:
 
 ```js
-import createModule from "./hello.js";
+import createModule from "./hello.mjs";
 
 createModule().then((Module) => {
   console.log("Wasm ready", Module);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Add a “Using your Wasm in an ES 6 bundler” section that shows how to import the generated JavaScript glue file as a side effect and how to emit a factory‐style ES 6 module with Emscripten flags `MODULARIZE` and `EXPORT_ES6`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The following changes were made because, just as the issue stated, Most modern web projects use ES 6 modules and a bundler (webpack, Vite, Rollup, etc.). Readers need a simple recipe for integrating Emscripten’s output into their build system without extra loader configuration.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Sources I have used for the edits, along with the issue description in github:

- Emscripten `MODULARIZE` option (produces a factory function):  
  https://emscripten.org/docs/tools_reference/emcc.html#modularize  
- Emscripten `EXPORT_ES6` option (emits an ES 6 module):  
  https://emscripten.org/docs/tools_reference/emcc.html#export_es6  
- Example of using Emscripten output with npm and bundlers:  
  https://web.dev/wasm-npm/

### Related issues and pull requests

Fixes #40526 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
