### PR TITLE
Replace misleading `json`/`json1`/`json2` with `result`

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -25,8 +25,8 @@ async function getData() {
       throw new Error(`Response status: ${response.status}`);
     }
 
-    const json = await response.json();
-    console.log(json);
+    const result = await response.json();
+    console.log(result);
   } catch (error) {
     console.error(error.message);
   }
@@ -549,8 +549,8 @@ async function getData() {
       throw new Error(`Response status: ${response.status}`);
     }
 
-    const json1 = await response.json();
-    const json2 = await response.json(); // will throw
+    const result1 = await response.json();
+    const result2 = await response.json(); // will throw
   } catch (error) {
     console.error(error.message);
   }
@@ -570,8 +570,8 @@ async function getData() {
 
     const response2 = response1.clone();
 
-    const json1 = await response1.json();
-    const json2 = await response2.json();
+    const result1 = await response1.json();
+    const result2 = await response2.json();
   } catch (error) {
     console.error(error.message);
   }

--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.md
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.md
@@ -51,9 +51,9 @@ document.addEventListener("click", async (event) => {
     try {
       // Fetch new content
       const response = await fetch(`creatures/${creature}.json`);
-      const json = await response.json();
+      const result = await response.json();
       // Update the page with the new content
-      displayContent(json);
+      displayContent(result);
     } catch (err) {
       console.error(err);
     }
@@ -111,8 +111,8 @@ document.addEventListener("click", async (event) => {
     event.preventDefault();
     try {
       const response = await fetch(`creatures/${creature}.json`);
-      const json = await response.json();
-      displayContent(json);
+      const result = await response.json();
+      displayContent(result);
       // Add a new entry to the history.
       // This simulates loading a new page.
       history.pushState(json, "", creature);
@@ -125,7 +125,7 @@ document.addEventListener("click", async (event) => {
 
 Here, we're calling `pushState()` with three arguments:
 
-- `json`: This is the content we just fetched. It will be stored with the history entry, and later included as the {{domxref("PopStateEvent.state", "state")}} property of the argument passed to the `popstate` event handler.
+- `result`: This is the content we just fetched. It will be stored with the history entry, and later included as the {{domxref("PopStateEvent.state", "state")}} property of the argument passed to the `popstate` event handler.
 - `""`: This is needed for backward compatibility with legacy sites, and should always be an empty string.
 - `creature`: This will be used as the URL for the entry. It will be shown in the browser's URL bar, and will be used as the value of the {{httpheader("Referer")}} header in any HTTP requests that the page makes. Note that this must be {{Glossary("Same-origin policy", "same-origin")}} with the page.
 

--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.md
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.md
@@ -115,7 +115,7 @@ document.addEventListener("click", async (event) => {
       displayContent(result);
       // Add a new entry to the history.
       // This simulates loading a new page.
-      history.pushState(json, "", creature);
+      history.pushState(result, "", creature);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Renamed `json`/`json1`/`json2` to `result` to clarify parsed data.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fix misleading variable names (`Response: json() method` returns a Promise that resolves to a JavaScript object, not a JSON string).

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
[MDN Response.json() docs](https://developer.mozilla.org/en-US/docs/Web/API/Response/json#:~:text=Note%20that%20despite%20the%20method%20being%20named%20json()%2C%20the%20result%20is%20not%20JSON%20but%20is%20instead%20the%20result%20of%20taking%20JSON%20as%20input%20and%20parsing%20it%20to%20produce%20a%20JavaScript%20object.)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
