### PR TITLE
Correct typo in brightness example

### DIFF
--- a/files/en-us/web/css/filter-function/brightness/index.md
+++ b/files/en-us/web/css/filter-function/brightness/index.md
@@ -56,7 +56,7 @@ brightness(0%)
 brightness(0.4) /* Brightness of input is reduced to 40%, so input is 60% darker */
 brightness(40%)
 
-brightens()     /* Brightness of input is not changed */
+brightness()     /* Brightness of input is not changed */
 brightness(1)
 brightness(100%)
 


### PR DESCRIPTION
One of the examples uses `brightens()` instead of `brightness()`