### PR TITLE
FF142 Animation.commitStyles() automatically fills values

### DIFF
--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -8,11 +8,9 @@ browser-compat: api.Animation.commitStyles
 
 {{APIRef("Web Animations")}}
 
-The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface writes the [computed values](/en-US/docs/Web/CSS/CSS_cascade/Value_processing#computed_value) of the animation's current styles into its target element's [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute. `commitStyles()` works even if the animation has been [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations).
+The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("Animation")}} interface writes the [computed values](/en-US/docs/Web/CSS/CSS_cascade/Value_processing#computed_value) of the animation's current styles into its target element's [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute.
 
-`commitStyles()` can be used in combination with `fill` to cause the final state of an animation to persist after the animation ends. The same effect could be achieved with `fill` alone, but [using indefinitely filling animations is discouraged](https://drafts.csswg.org/web-animations-1/#fill-behavior). Animations [take precedence over all static styles](/en-US/docs/Web/CSS/CSS_cascade/Cascade#cascading_order), so an indefinite filling animation can prevent the target element from ever being styled normally.
-
-Using `commitStyles()` writes the styling state into the element's [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute, where they can be modified and replaced as normal.
+It is primarily used to write the styles for the final state of an animation into the target element, so that the styling persists after the animation ends.
 
 ## Syntax
 
@@ -28,22 +26,84 @@ None.
 
 None ({{jsxref("undefined")}}).
 
+## Description
+
+The `commitStyles()` method is primarily used to write the [computed values](/en-US/docs/Web/CSS/CSS_cascade/Value_processing#computed_value) for the final state of an animation into the target element's [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute, so that the styling persists after the animation ends.
+This can be done when the animation has {{domxref("Animation.finished","finished")}}.
+
+The code below shows how you can animate an element named `animatedElement`, setting [`fill: "forwards"`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to persist the animation styles after it finishes.
+Once the animation is finished we commit the styles to the element with `commitStyles()`.
+
+```js
+// Start the animation
+const animation = animatedElement.animate(
+  { transform: "translate(100px)" },
+  { duration: 500, fill: "forwards" },
+);
+
+// Wait for the animation to finish
+await animation.finished;
+// Commit animation state to he animatedElement style attribute
+animation.commitStyles();
+// Cancel the animation
+animation.cancel();
+```
+
+As `fill` persists the animation indefinitely, once we've committed the styles, we cancel the animation.
+
+Note that the same effect could be achieved with `fill` alone, but [using indefinitely filling animations is discouraged](https://drafts.csswg.org/web-animations-1/#fill-behavior).
+Animations [take precedence over all static styles](/en-US/docs/Web/CSS/CSS_cascade/Cascade#cascading_order), so an indefinite filling animation can prevent the target element from ever being styled normally.
+
+> [!NOTE]
+> You might also avoid having to explicitly save the final state by setting them as the element initial styles and animating to the final styles.
+
+### commitStyles() without setting fill mode
+
+On older browsers, you must specify the [`fill` mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) in order to be able to commit the styles to the element _after_ the animation has finished.
+In newer browsers you do not need to set the [`fill` mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) (see the [browser compatibility table](#browser_compatibility) for specific versions).
+
+> [!NOTE]
+> There is no way to feature check for this new behaviour.
+> For now most code should continue to set `fill` as shown in the previous section.
+
+The code below shows how you can animate an element named `animatedElement`, wait on the animation to complete using the {{domxref("Animation.finished","finished")}} property, and then commit the styles to the element with `commitStyles()`.
+Because we're not setting `fill` we don't have to cancel the animation afterwards.
+
+```js
+// Start the animation
+const animation = animatedElement.animate(
+  { transform: "translate(100px)" },
+  { duration: 500 },
+);
+
+// Wait for the animation to finish
+await animation.finished;
+
+// Commit animation state to the animatedElement style attribute
+animation.commitStyles();
+```
+
+`commitStyles()` works even if the animation has been [automatically removed](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API#automatically_removing_filling_animations).
+After the element's styles have been committed they can be modified and replaced as normal.
+
 ## Examples
 
-### Committing the final state of an animation
+### Animation with and without using fill
 
-In this example we have two buttons, labeled "Commit styles" and "Fill forwards". Both buttons animate when you click them, and both buttons persist the final state of the animation.
+This example demonstrates how you can use `commitStyles()` to save the computed styles at the end of the animation, both with and without using `fill`.
 
-The difference, though, is that "Fill forwards" only uses `fill: "forwards"` to persist the animation's final state: this means that the browser has to maintain the animation's state indefinitely, or until it can be automatically removed.
+It displays two buttons, labelled "Commit styles only" and "Commit styles with fill".
+Both buttons animate when you click them, and both buttons call `commitStyles()` to persist the final state of the animation.
 
-However, the "Commit styles" button waits for the animation to finish, then calls `commitStyles()`, then cancels the animation, so the finished style is captured as the value of the `style` attribute, rather than as the animation state.
+The difference, is that "Commit styles only" does not specify `fill: "forwards"` to persist the animation's final state.
+On browsers that don't match the current specification the final state may not be captured.
 
 #### HTML
 
 ```html
-<button class="commit-styles">Commit styles</button>
+<button class="commit-styles">Commit styles only</button>
 <br />
-<button class="fill-forwards">Fill forwards</button>
+<button class="commit-with-fill">Commit styles with fill</button>
 ```
 
 ```css hidden
@@ -54,15 +114,45 @@ button {
 
 #### JavaScript
 
+This code defines a click handler for the "Commit styles only" button.
+This animates the button to move right or left when it is clicked.
+Note that `commitStyles()` is called immediately after the animation is finished.
+
 ```js
-const commitStyles = document.querySelector(".commit-styles");
 let offset1 = 0;
+
+const commitStyles = document.querySelector(".commit-styles");
 
 commitStyles.addEventListener("click", async (event) => {
   // Start the animation
   offset1 = 100 - offset1;
   const animation = commitStyles.animate(
     { transform: `translate(${offset1}px)` },
+    { duration: 500 },
+  );
+
+  // Wait for the animation to finish
+  await animation.finished;
+  // Commit animation state to style attribute
+  animation.commitStyles();
+});
+```
+
+This code defines a click handler for the "Commit styles with fill" button.
+This also animates the button to move right or left when it is clicked.
+As it defines a `fill` it needs to cancel the animation afterwards.
+
+Note that `commitStyles()` is called immediately after the animation is finished.
+
+```js
+const commitStylesWithFill = document.querySelector(".commit-with-fill");
+let offset2 = 0;
+
+commitStylesWithFill.addEventListener("click", async (event) => {
+  // Start the animation
+  offset2 = 100 - offset2;
+  const animation = commitStylesWithFill.animate(
+    { transform: `translate(${offset2}px)` },
     { duration: 500, fill: "forwards" },
   );
 
@@ -73,23 +163,14 @@ commitStyles.addEventListener("click", async (event) => {
   // Cancel the animation
   animation.cancel();
 });
-
-const fillForwards = document.querySelector(".fill-forwards");
-let offset2 = 0;
-
-fillForwards.addEventListener("click", async (event) => {
-  // Start the animation
-  offset2 = 100 - offset2;
-  const animation = fillForwards.animate(
-    { transform: `translate(${offset2}px)` },
-    { duration: 500, fill: "forwards" },
-  );
-});
 ```
 
 #### Result
 
-{{EmbedLiveSample("committing_the_final_state_of_an_animation")}}
+Click the buttons to animate them.
+Note that the first button will "jump" at the end of the animation if the current browser still requires `fill` for styles to be committed after the end of the animation.
+
+{{EmbedLiveSample("Animation with and without using fill")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -29,7 +29,7 @@ None ({{jsxref("undefined")}}).
 ## Description
 
 The `commitStyles()` method is primarily used to write the [computed values](/en-US/docs/Web/CSS/CSS_cascade/Value_processing#computed_value) for the final state of an animation into the target element's [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute, so that the styling persists after the animation ends.
-This can be done when the animation has {{domxref("Animation.finished","finished")}}.
+This can be done when the animation has finished (that is, the {{domxref("Animation")}} object's {{domxref("Animation.finished","finished")}} property has resolved).
 
 The code below shows how you can animate an element named `animatedElement`, setting [`fill: "forwards"`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to persist the animation styles after it finishes.
 Once the animation is finished we commit the styles to the element with `commitStyles()`.

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -94,30 +94,45 @@ After the element's styles have been committed they can be modified and replaced
 ### Animation with and without using fill
 
 This example demonstrates how you can use `commitStyles()` to save the computed styles at the end of the animation, both with and without using `fill`.
+It also provides an example of what happens if neither `commitStyles()` or `fill` are used, for comparison.
 
-It displays two buttons, labelled "Commit styles only" and "Commit styles with fill".
+The example first displays two buttons labelled "commitStyles() only" and "commitStyles() with fill".
 Both buttons animate when you click them, and both buttons call `commitStyles()` to persist the final state of the animation.
-
-The difference is that "Commit styles only" does not specify `fill: "forwards"` to persist the animation's final state.
+The difference is that "commitStyles() only" does not specify `fill: "forwards"` to persist the animation's final state.
 On browsers that don't match the current specification the final state may not be captured.
+
+The code then displays a button "No commitStyles() or fill" that can be used for comparison, and a "Reset" button.
 
 #### HTML
 
 ```html
-<button class="commit-styles">Commit styles only</button>
-<br />
-<button class="commit-with-fill">Commit styles with fill</button>
+<button class="commit-styles">commitStyles() only</button>
+<button class="commit-with-fill">commitStyles() with fill</button>
+<button class="no-commit-or-fill">No commitStyles() or fill</button>
+```
+
+```html hidden
+<button id="reset" type="button">Reset</button>
 ```
 
 ```css hidden
 button {
   margin: 0.5rem;
+  display: block;
 }
+```
+
+```js hidden
+const reload = document.querySelector("#reset");
+
+reload.addEventListener("click", () => {
+  window.location.reload(true);
+});
 ```
 
 #### JavaScript
 
-This code defines a click handler for the "Commit styles only" button.
+This code defines a click handler for the "commitStyles() only" button.
 This animates the button to move right or left when it is clicked.
 Note that `commitStyles()` is called immediately after the animation is finished.
 
@@ -141,7 +156,7 @@ commitStyles.addEventListener("click", async (event) => {
 });
 ```
 
-This code defines a click handler for the "Commit styles with fill" button.
+This code defines a click handler for the "commitStyles() with fill" button.
 This also animates the button to move right or left when it is clicked.
 As it defines a `fill` it needs to cancel the animation afterwards.
 
@@ -168,10 +183,29 @@ commitStylesWithFill.addEventListener("click", async (event) => {
 });
 ```
 
+This code defines a click handler for the "No commitStyles() or fill" button.
+This also animates the button to move right or left when it is clicked.
+It doesn't define a fill and we don't cancel the animation.
+
+```js
+const noCommitStylesOrFill = document.querySelector(".no-commit-or-fill");
+let offset3 = 0;
+
+noCommitStylesOrFill.addEventListener("click", async (event) => {
+  // Start the animation
+  offset3 = 100 - offset3;
+  const animation = noCommitStylesOrFill.animate(
+    { transform: `translate(${offset3}px)` },
+    { duration: 500 },
+  );
+});
+```
+
 #### Result
 
 Click the buttons to animate them.
 Note that the first button will "jump" at the end of the animation if the current browser still requires `fill` for styles to be committed after the end of the animation.
+The "No commitStyles() or fill" button always jumps at the end, because the final state is not saved.
 
 {{EmbedLiveSample("Animation with and without using fill")}}
 

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -31,6 +31,10 @@ None ({{jsxref("undefined")}}).
 The `commitStyles()` method is primarily used to write the [computed values](/en-US/docs/Web/CSS/CSS_cascade/Value_processing#computed_value) for the final state of an animation into the target element's [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute, so that the styling persists after the animation ends.
 This can be done when the animation has finished (that is, the {{domxref("Animation")}} object's {{domxref("Animation.finished","finished")}} property has resolved).
 
+### `commitStyles()` alongside fill mode
+
+On older browsers, you must specify the [`fill` mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) in order to be able to commit the styles to the element _after_ the animation has finished.
+
 The code below shows how you can animate an element named `animatedElement`, setting [`fill: "forwards"`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to persist the animation styles after it finishes.
 Once the animation is finished we commit the styles to the element with `commitStyles()`.
 
@@ -59,7 +63,6 @@ Animations [take precedence over all static styles](/en-US/docs/Web/CSS/CSS_casc
 
 ### commitStyles() without setting fill mode
 
-On older browsers, you must specify the [`fill` mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) in order to be able to commit the styles to the element _after_ the animation has finished.
 In newer browsers you do not need to set the [`fill` mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) (see the [browser compatibility table](#browser_compatibility) for specific versions).
 
 > [!NOTE]
@@ -95,7 +98,7 @@ This example demonstrates how you can use `commitStyles()` to save the computed 
 It displays two buttons, labelled "Commit styles only" and "Commit styles with fill".
 Both buttons animate when you click them, and both buttons call `commitStyles()` to persist the final state of the animation.
 
-The difference, is that "Commit styles only" does not specify `fill: "forwards"` to persist the animation's final state.
+The difference is that "Commit styles only" does not specify `fill: "forwards"` to persist the animation's final state.
 On browsers that don't match the current specification the final state may not be captured.
 
 #### HTML

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -61,7 +61,7 @@ Animations [take precedence over all static styles](/en-US/docs/Web/CSS/CSS_casc
 > [!NOTE]
 > You might also avoid having to explicitly save the final state by setting them as the element initial styles and animating to the final styles.
 
-### commitStyles() without setting fill mode
+### `commitStyles()` without setting fill mode
 
 In newer browsers you do not need to set the [`fill` mode](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) (see the [browser compatibility table](#browser_compatibility) for specific versions).
 


### PR DESCRIPTION
FF142 [`Animation/commitStyles()`](https://developer.mozilla.org/en-US/docs/Web/API/Animation/commitStyles) allows animations to capture the final styles without specifying a `fill` in latest spec.

Note that normally I'd have the new behavior front and center and mention the older behavior as a legacy thing. Unfortunately the advice of the developer is that you can't feature check for this, so people will have to stick with the old behaviour until this is in most browsers. 
So this update covers the old case first, and puts the new information second.

Related docs work in #40482