### PR TITLE
Add scrollIntoView() container option

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -37,36 +37,36 @@ scrollIntoView(options)
   - : An object with the following properties:
     - `behavior` {{optional_inline}}
       - : Determines whether scrolling is instant or animates smoothly. Its value can be one of the following:
-        - `"smooth"`: scrolling should animate smoothly
-        - `"instant"`: scrolling should happen instantly in a single jump
-        - `"auto"`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
-        The default is `"auto"`.
+        The default is `auto`.
 
     - `block` {{optional_inline}}
       - : Defines the vertical alignment of the element within the scrollable ancestor container. Its value can be one of the following:
-        - `"start"`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
-        - `"center"`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
-        - `"end"`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
-        - `"nearest"`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. This minimizes the scrolling distance.
+        - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
+        - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
+        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. This minimizes the scrolling distance.
 
-        The default is `"start"`.
+        The default is `start`.
 
     - `container` {{optional_inline}}
       - : Defines the scrollable ancestor container. Its value can be one of the following:
-        - `"all"`: All scrollable containers are impacted (including the viewport).
-        - `"nearest"`: Only the nearest scrollable container is impacted by the scroll.
+        - `all`: All scrollable containers are impacted (including the viewport).
+        - `nearest`: Only the nearest scrollable container is impacted by the scroll.
 
-        The default is `"all"`.
+        The default is `all`.
 
     - `inline` {{optional_inline}}
       - : Defines the horizontal alignment of the element within the scrollable ancestor container. Its value can be one of the following:
-        - `"start"`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
-        - `"center"`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
-        - `"end"`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
-        - `"nearest"`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
+        - `start`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
+        - `center`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
+        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
 
-        The default is `"nearest"`.
+        The default is `nearest`.
 
 ### Return value
 

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -56,6 +56,11 @@ scrollIntoView(scrollIntoViewOptions)
         - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
         - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
         - Defaults to `nearest`.
+    - `container` {{optional_inline}}
+      - : Defines the scrollable ancestor container. This option is a string and accepts one of the following values:
+        - `all`: All scrollable containers will be impacted (including the viewport).
+        - `nearest`: Only the nearest scrollable container will be impacted by the scroll.
+        - Defaults to `all`.
 
 ### Return value
 

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -56,7 +56,7 @@ scrollIntoView(scrollIntoViewOptions)
         - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
         - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
         - Defaults to `nearest`.
-    - `container` {{optional_inline}}
+    - `container` {{optional_inline}} {{experimental_inline}}
       - : Defines the scrollable ancestor container. This option is a string and accepts one of the following values:
         - `all`: All scrollable containers will be impacted (including the viewport).
         - `nearest`: Only the nearest scrollable container will be impacted by the scroll.

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -37,7 +37,6 @@ scrollIntoView(options)
   - : An object with the following properties:
     - `behavior` {{optional_inline}}
       - : Determines whether scrolling is instant or animates smoothly. Its value can be one of the following:
-
         - `"smooth"`: scrolling should animate smoothly
         - `"instant"`: scrolling should happen instantly in a single jump
         - `"auto"`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
@@ -46,7 +45,6 @@ scrollIntoView(options)
 
     - `block` {{optional_inline}}
       - : Defines the vertical alignment of the element within the scrollable ancestor container. Its value can be one of the following:
-
         - `"start"`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
         - `"center"`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
         - `"end"`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
@@ -56,7 +54,6 @@ scrollIntoView(options)
 
     - `container` {{optional_inline}}
       - : Defines the scrollable ancestor container. Its value can be one of the following:
-
         - `"all"`: All scrollable containers are impacted (including the viewport).
         - `"nearest"`: Only the nearest scrollable container is impacted by the scroll.
 
@@ -64,7 +61,6 @@ scrollIntoView(options)
 
     - `inline` {{optional_inline}}
       - : Defines the horizontal alignment of the element within the scrollable ancestor container. Its value can be one of the following:
-
         - `"start"`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
         - `"center"`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
         - `"end"`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -18,7 +18,7 @@ visible to the user.
 ```js-nolint
 scrollIntoView()
 scrollIntoView(alignToTop)
-scrollIntoView(scrollIntoViewOptions)
+scrollIntoView(options)
 ```
 
 ### Parameters
@@ -33,34 +33,44 @@ scrollIntoView(scrollIntoViewOptions)
       of the visible area of the scrollable ancestor. Corresponds to
       `scrollIntoViewOptions: {block: "end", inline: "nearest"}`.
 
-- `scrollIntoViewOptions` {{optional_inline}}
-  {{experimental_inline}}
-  - : An Object with the following properties:
+- `options` {{optional_inline}}
+  - : An object with the following properties:
     - `behavior` {{optional_inline}}
-      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
-        - `smooth`: scrolling should animate smoothly
-        - `instant`: scrolling should happen instantly in a single jump
-        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+      - : Determines whether scrolling is instant or animates smoothly. Its value can be one of the following:
+
+        - `"smooth"`: scrolling should animate smoothly
+        - `"instant"`: scrolling should happen instantly in a single jump
+        - `"auto"`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+
+        The default is `"auto"`.
+
     - `block` {{optional_inline}}
-      - : Defines the vertical alignment of the element within the scrollable ancestor container. This option is a string and accepts one of the following values:
-        - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
-        - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
-        - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
-        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom
-          edge, it will align to the bottom. This minimizes the scrolling distance.
-        - Defaults to `start`.
+      - : Defines the vertical alignment of the element within the scrollable ancestor container. Its value can be one of the following:
+
+        - `"start"`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
+        - `"center"`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `"end"`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
+        - `"nearest"`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. This minimizes the scrolling distance.
+
+        The default is `"start"`.
+
+    - `container` {{optional_inline}}
+      - : Defines the scrollable ancestor container. Its value can be one of the following:
+
+        - `"all"`: All scrollable containers are impacted (including the viewport).
+        - `"nearest"`: Only the nearest scrollable container is impacted by the scroll.
+
+        The default is `"all"`.
+
     - `inline` {{optional_inline}}
-      - : Defines the horizontal alignment of the element within the scrollable ancestor container. This option is a string and accepts one of the following values:
-        - `start`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
-        - `center`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
-        - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
-        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
-        - Defaults to `nearest`.
-    - `container` {{optional_inline}} {{experimental_inline}}
-      - : Defines the scrollable ancestor container. This option is a string and accepts one of the following values:
-        - `all`: All scrollable containers will be impacted (including the viewport).
-        - `nearest`: Only the nearest scrollable container will be impacted by the scroll.
-        - Defaults to `all`.
+      - : Defines the horizontal alignment of the element within the scrollable ancestor container. Its value can be one of the following:
+
+        - `"start"`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
+        - `"center"`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `"end"`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
+        - `"nearest"`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
+
+        The default is `"nearest"`.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Documentation of the new `Element.scrollintoView()` `container` option.
 
### Motivation

The `container` option has been specified & scheduled to ship in Chrome 140.

### Additional details

https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-container
https://cr-status.appspot.com/feature/5100036528275456?gate=5140738792488960

### Related issues
https://github.com/mdn/browser-compat-data/pull/27463