### PR TITLE
PasswordCredential cannot be passed an object from fetch()

### DIFF
--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.md
@@ -10,8 +10,7 @@ browser-compat: api.PasswordCredential.PasswordCredential
 
 {{APIRef("Credential Management API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`PasswordCredential()`**
-constructor creates a new {{domxref("PasswordCredential")}} object.
+The **`PasswordCredential()`** constructor creates a new {{domxref("PasswordCredential")}} object.
 
 ## Syntax
 
@@ -38,9 +37,9 @@ Either of the following:
       - : A string representing the credential password.
 
 - `form`
-  - : A reference to an {{domxref("HTMLFormElement")}} with appropriate input fields. The
-    form should, at the very least, contain an id and password. It could also require a
-    CSRF token.
+  - : A reference to an {{domxref("HTMLFormElement")}} with appropriate input fields.
+    The form should, at the very least, contain an id and password.
+    It could also require a CSRF token.
 
 ### Exceptions
 
@@ -49,8 +48,7 @@ Either of the following:
 
 ## Examples
 
-This example shows how to set up an {{domxref("HTMLFormElement")}} to capture data
-which we'll use to create a {{domxref("PasswordCredential")}} object.
+This example shows how to set up an {{domxref("HTMLFormElement")}} to capture data which we'll use to create a {{domxref("PasswordCredential")}} object.
 
 Starting with the form element.
 
@@ -64,9 +62,7 @@ Starting with the form element.
 </form>
 ```
 
-Then, a reference to this form element, using it to create
-a {{domxref("PasswordCredential")}} object, and storing it in the browser's password
-system.
+Then, a reference to this form element, using it to create a {{domxref("PasswordCredential")}} object, and storing it in the browser's password system.
 
 ```js
 const form = document.querySelector("#form");

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.md
@@ -11,9 +11,7 @@ browser-compat: api.PasswordCredential.PasswordCredential
 {{APIRef("Credential Management API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`PasswordCredential()`**
-constructor creates a new {{domxref("PasswordCredential")}} object. In
-supporting browsers, an instance of this class may be passed the `credential`
-from the `init` object for global {{domxref("Window/fetch", "fetch()")}}.
+constructor creates a new {{domxref("PasswordCredential")}} object.
 
 ## Syntax
 


### PR DESCRIPTION
The bit in https://developer.mozilla.org/en-US/docs/Web/API/PasswordCredential/PasswordCredential:

> In supporting browsers, an instance of this class may be passed the credential from the init object for global [fetch()](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch).

...as far as we can tell makes no sense.