### PR TITLE
Lint: add quotes for all url() arguments

### DIFF
--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
@@ -319,7 +319,7 @@ It would be arguably better to implement the background header image using CSS b
 
 ```css
 h1 {
-  background: url(https://mdn.github.io/shared-assets/images/examples/star-pink_32x32.png)
+  background: url("https://mdn.github.io/shared-assets/images/examples/star-pink_32x32.png")
     no-repeat left;
   padding-left: 50px;
 }

--- a/files/en-us/learn_web_development/core/challenges/index.md
+++ b/files/en-us/learn_web_development/core/challenges/index.md
@@ -250,7 +250,7 @@ The challenges on page [Media](/en-US/docs/Web/CSS/CSS_media_queries/Using_media
   - : Cut and paste the lines between `/* print only */` and `/* end print only */` into a file named `style4_print.css`. In style4.css, add the following line at the beginning of the file:
 
     ```css
-    @import url("style4_print.css") print;
+    @import "style4_print.css" print;
     ```
 
 ### Heading hover color

--- a/files/en-us/learn_web_development/core/scripting/build_your_own_function/index.md
+++ b/files/en-us/learn_web_development/core/scripting/build_your_own_function/index.md
@@ -261,10 +261,10 @@ On to the next parameter. This one is going to involve slightly more work — we
 
    ```js
    if (msgType === "warning") {
-     msg.style.backgroundImage = "url(icons/warning.png)";
+     msg.style.backgroundImage = 'url("icons/warning.png")';
      panel.style.backgroundColor = "red";
    } else if (msgType === "chat") {
-     msg.style.backgroundImage = "url(icons/chat.png)";
+     msg.style.backgroundImage = 'url("icons/chat.png")';
      panel.style.backgroundColor = "aqua";
    } else {
      msg.style.paddingLeft = "20px";

--- a/files/en-us/learn_web_development/core/styling_basics/advanced_styling_effects/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/advanced_styling_effects/index.md
@@ -301,7 +301,7 @@ div {
   padding: 10px;
   margin: 10px;
   display: inline-block;
-  background: url(colorful-heart.png) no-repeat center 20px;
+  background: url("colorful-heart.png") no-repeat center 20px;
   background-color: green;
 }
 
@@ -354,7 +354,7 @@ article div:first-child {
   position: absolute;
   top: 10px;
   left: 0;
-  background: url(colorful-heart.png) no-repeat center 20px;
+  background: url("colorful-heart.png") no-repeat center 20px;
   background-color: green;
 }
 
@@ -454,7 +454,7 @@ h2 {
 h2 {
   color: white;
   display: inline-block;
-  background: url(colorful-heart.png) no-repeat center;
+  background: url("colorful-heart.png") no-repeat center;
 }
 
 .text-clip {

--- a/files/en-us/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
@@ -94,11 +94,11 @@ This example demonstrates two things about background images. By default, the la
 }
 
 .a {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/balloons.jpg");
 }
 
 .b {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/star.png");
 }
 ```
 
@@ -136,7 +136,7 @@ Try these values out in the example below. We have set the value to `no-repeat` 
 
 ```css live-sample___repeat
 .box {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/star.png");
   background-repeat: no-repeat;
 }
 ```
@@ -178,7 +178,7 @@ Try the following:
 
 ```css live-sample___size
 .box {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/balloons.jpg");
   background-repeat: no-repeat;
   background-size: 80px 10em;
 }
@@ -197,7 +197,7 @@ The most common `background-position` values take two individual values — a ho
 
 ```css
 .box {
-  background-image: url(image.png);
+  background-image: url("image.png");
   background-repeat: no-repeat;
   background-position: top center;
 }
@@ -207,7 +207,7 @@ You can also use {{cssxref("length", "lengths")}} and {{cssxref("percentage", "p
 
 ```css
 .box {
-  background-image: url(image.png);
+  background-image: url("image.png");
   background-repeat: no-repeat;
   background-position: 20px 10%;
 }
@@ -217,7 +217,7 @@ You can also mix keyword values with lengths or percentages, in which case the f
 
 ```css
 .box {
-  background-image: url(image.png);
+  background-image: url("image.png");
   background-repeat: no-repeat;
   background-position: 20px top;
 }
@@ -227,7 +227,7 @@ Finally, you can also use a 4-value syntax to indicate a distance from certain e
 
 ```css
 .box {
-  background-image: url(image.png);
+  background-image: url("image.png");
   background-repeat: no-repeat;
   background-position: top 20px right 10px;
 }
@@ -253,7 +253,7 @@ Use the example below to play around with these values and move the star around 
 
 ```css live-sample___position
 .box {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/star.png");
   background-repeat: no-repeat;
   background-position: 120px 1em;
 }
@@ -328,7 +328,7 @@ The other `background-*` properties can also have comma-separated values in the 
 
 ```css
 background-image:
-  url(image1.png), url(image2.png), url(image3.png), url(image4.png);
+  url("image1.png"), url("image2.png"), url("image3.png"), url("image4.png");
 background-repeat: no-repeat, repeat-x, repeat;
 background-position:
   10px 20px,
@@ -366,8 +366,8 @@ Let's play. The example below includes two background images. Try editing the ex
 
 .box {
   background-image:
-    url(https://mdn.github.io/shared-assets/images/examples/star.png),
-    url(https://mdn.github.io/shared-assets/images/examples/big-star.png);
+    url("https://mdn.github.io/shared-assets/images/examples/star.png"),
+    url("https://mdn.github.io/shared-assets/images/examples/big-star.png");
 }
 ```
 
@@ -412,8 +412,8 @@ Take a look at the MDN page for {{cssxref("background")}} to learn more about th
         rgb(51 56 57 / 100%) 96%
       )
       center center / 400px 200px no-repeat,
-    url(https://mdn.github.io/shared-assets/images/examples/big-star.png) center
-      no-repeat,
+    url("https://mdn.github.io/shared-assets/images/examples/big-star.png")
+      center no-repeat,
     rebeccapurple;
 }
 ```

--- a/files/en-us/learn_web_development/core/styling_basics/cascade_layers/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/cascade_layers/index.md
@@ -301,24 +301,24 @@ When importing stylesheets, the `@import` statement must be defined before any C
 You can import a stylesheet into a named layer, a nested named layer, or an anonymous layer. The following layer imports the style sheets into a `components` layer, a nested `dialog` layer within the `components` layer, and an un-named layer, respectively:
 
 ```css
-@import url("components-lib.css") layer(components);
-@import url("dialog.css") layer(components.dialog);
-@import url("marketing.css") layer();
+@import "components-lib.css" layer(components);
+@import "dialog.css" layer(components.dialog);
+@import "marketing.css" layer();
 ```
 
 You can import more than one CSS file into a single layer. The following declaration imports two separate files into a single `social` layer:
 
 ```css
-@import url(comments.css) layer(social);
-@import url(sm-icons.css) layer(social);
+@import "comments.css" layer(social);
+@import "sm-icons.css" layer(social);
 ```
 
 You can import styles and create layers based on specific conditions using [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) and [feature queries](/en-US/docs/Web/CSS/CSS_conditional_rules/Using_feature_queries). The following imports a style sheet into an `international` layer only if the browser supports `display: ruby`, and the file being imported is dependent on the width of the screen.
 
 ```css
-@import url("ruby-narrow.css") layer(international) supports(display: ruby)
+@import "ruby-narrow.css" layer(international) supports(display: ruby)
   (width < 32rem);
-@import url("ruby-wide.css") layer(international) supports(display: ruby)
+@import "ruby-wide.css" layer(international) supports(display: ruby)
   (width >= 32rem);
 ```
 
@@ -342,8 +342,8 @@ If you nest a block `@layer` at-rule inside another block `@layer` at-rule, with
 Let's look at the following example:
 
 ```css
-@import url("components-lib.css") layer(components);
-@import url("narrow-theme.css") layer(components.narrow);
+@import "components-lib.css" layer(components);
+@import "narrow-theme.css" layer(components.narrow);
 ```
 
 In the first line, we import `components-lib.css` into the `components` layer. If that file contains any layers, named or not, those layers become nested layers within the `components` layer.
@@ -353,7 +353,7 @@ The second line imports `narrow-theme.css` into the `narrow` layer, which is a s
 Let's look at another example, where we [import `layers1.css` into a named layer](#the_layer_block_at-rule_for_named_and_anonymous_layers) using the following statement:
 
 ```css
-@import url(layers1.css) layer(example);
+@import "layers1.css" layer(example);
 ```
 
 This will create a single layer named `example` containing some declarations and five nested layers - `example.layout`, `example.<anonymous(01)>`, `example.theme`, `example.utilities`, and `example.<anonymous(02)>`.
@@ -375,9 +375,9 @@ The order of layers determines their order of precedence. Therefore, the order o
 ### Precedence order of regular cascade layers
 
 ```css
-@import url(A.css) layer(firstLayer);
-@import url(B.css) layer(secondLayer);
-@import url(C.css);
+@import "A.css" layer(firstLayer);
+@import "B.css" layer(secondLayer);
+@import "C.css";
 ```
 
 The above code creates two named layers (C.css styles get appended to the implicit layer of unlayered styles). Let us assume that the three files (`A.css`, `B.css`, and `C.css`) do not contain any additional layers within them. The following list shows where styles declared inside and outside of these files will be sorted from least (1) precedence to highest (10).

--- a/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
@@ -497,14 +497,14 @@ padding-left: 5px;
 This one line:
 
 ```css
-background: red url(bg-graphic.png) 10px 10px repeat-x fixed;
+background: red url("bg-graphic.png") 10px 10px repeat-x fixed;
 ```
 
 is equivalent to these five lines:
 
 ```css
 background-color: red;
-background-image: url(bg-graphic.png);
+background-image: url("bg-graphic.png");
 background-position: 10px 10px;
 background-repeat: repeat-x;
 background-attachment: fixed;

--- a/files/en-us/learn_web_development/core/styling_basics/tables/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/tables/index.md
@@ -118,7 +118,7 @@ We need to use some CSS to fix this up. You can style a table in any way you wan
 
 ```css hidden live-sample___styled
 /* font import */
-@import url("https://fonts.googleapis.com/css2?family=Rock+Salt&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Rock+Salt&display=swap";
 
 /* spacing */
 table {
@@ -182,7 +182,7 @@ tfoot th {
 /* graphics */
 thead,
 tfoot {
-  background: url(https://mdn.github.io/learning-area/css/styling-boxes/styling-tables/leopardskin.jpg);
+  background: url("https://mdn.github.io/learning-area/css/styling-boxes/styling-tables/leopardskin.jpg");
   color: white;
 }
 
@@ -203,7 +203,7 @@ tbody tr:nth-child(even) {
 }
 
 tbody tr {
-  background-image: url(https://mdn.github.io/learning-area/css/styling-boxes/styling-tables/noise.png);
+  background-image: url("https://mdn.github.io/learning-area/css/styling-boxes/styling-tables/noise.png");
 }
 
 table {

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/backgrounds_and_borders/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/backgrounds_and_borders/index.md
@@ -69,7 +69,7 @@ You should use `border`, `border-radius`, `background-image`, and `background-si
 .box {
   border: 5px solid #000;
   border-radius: 10px;
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/balloons.jpg");
   background-size: cover;
 }
 
@@ -148,9 +148,9 @@ h2 {
   padding: 0 40px;
   text-align: center;
   background:
-    url(https://mdn.github.io/shared-assets/images/examples/star.png) no-repeat
-      left center,
-    url(https://mdn.github.io/shared-assets/images/examples/star.png) repeat-y
+    url("https://mdn.github.io/shared-assets/images/examples/star.png")
+      no-repeat left center,
+    url("https://mdn.github.io/shared-assets/images/examples/star.png") repeat-y
       right center;
 }
 ```

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/values/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/values/index.md
@@ -176,7 +176,7 @@ Your final result should look like the image below:
 }
 
 .box {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/purple-star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/purple-star.png");
   background-repeat: no-repeat;
 }
 ```
@@ -190,7 +190,7 @@ Use `background-position` with the `center` keyword and a percentage:
 
 ```css
 .box {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/purple-star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/purple-star.png");
   background-repeat: no-repeat;
   background-position: center 20%;
 }

--- a/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -358,7 +358,7 @@ In the below example, try changing the value of `opacity` to various decimal val
 
 ```css live-sample___opacity
 .wrapper {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/balloons.jpg");
   background-repeat: no-repeat;
   background-position: bottom left;
   padding: 20px;
@@ -521,7 +521,7 @@ Try changing the alpha channel values to see how it affects the color output.
 
 ```css live-sample___color-rgba
 .wrapper {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/balloons.jpg");
   padding: 40px 20px;
 }
 
@@ -623,7 +623,7 @@ Just like with `rgb()` you can pass an alpha parameter to `hsl()` to specify opa
 
 ```css live-sample___color-hsla
 .wrapper {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/balloons.jpg);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/balloons.jpg");
   padding: 40px 20px;
 }
 
@@ -670,7 +670,7 @@ In the example below, we are using an image and a gradient as values for the CSS
 }
 
 .image {
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/big-star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/big-star.png");
 }
 
 .gradient {
@@ -707,7 +707,7 @@ Try playing around with these values to see how you can push the image around.
 .box {
   height: 200px;
   width: 400px;
-  background-image: url(https://mdn.github.io/shared-assets/images/examples/big-star.png);
+  background-image: url("https://mdn.github.io/shared-assets/images/examples/big-star.png");
   background-repeat: no-repeat;
   background-position: right 60px;
   margin: 20px auto;

--- a/files/en-us/learn_web_development/core/text_styling/styling_lists/index.md
+++ b/files/en-us/learn_web_development/core/text_styling/styling_lists/index.md
@@ -194,7 +194,7 @@ The {{cssxref("list-style-image")}} property allows you to use a custom image fo
 
 ```css
 ul {
-  list-style-image: url(star.svg);
+  list-style-image: url("star.svg");
 }
 ```
 
@@ -210,7 +210,7 @@ ul {
 
 ul li {
   padding-left: 2rem;
-  background-image: url(star.svg);
+  background-image: url("star.svg");
   background-position: 0 0;
   background-size: 1.6rem 1.6rem;
   background-repeat: no-repeat;
@@ -238,7 +238,7 @@ The three properties mentioned above can all be set using a single shorthand pro
 ```css
 ul {
   list-style-type: square;
-  list-style-image: url(example.png);
+  list-style-image: url("example.png");
   list-style-position: inside;
 }
 ```
@@ -247,7 +247,7 @@ Could be replaced by this:
 
 ```css
 ul {
-  list-style: square url(example.png) inside;
+  list-style: square url("example.png") inside;
 }
 ```
 

--- a/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -250,7 +250,7 @@ form {
   margin: 0 auto;
   padding: 1em;
   box-sizing: border-box;
-  background: #fff url(background.jpg);
+  background: #fff url("background.jpg");
 
   /* we create our grid */
   display: grid;

--- a/files/en-us/learn_web_development/extensions/performance/css/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/css/index.md
@@ -253,7 +253,7 @@ Applied to the `@font-face` at-rule, the [`font-display`](/en-US/docs/Web/CSS/@f
 ```css
 @font-face {
   font-family: someFont;
-  src: url(/path/to/fonts/someFont.woff) format("woff");
+  src: url("/path/to/fonts/someFont.woff") format("woff");
   font-weight: 400;
   font-style: normal;
   font-display: fallback;

--- a/files/en-us/learn_web_development/extensions/testing/html_and_css/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/html_and_css/index.md
@@ -230,8 +230,8 @@ If using a prefix, make sure it is needed; that the property is one of the few r
 
 ```css
 .masked {
-  -webkit-mask-image: url(MDN.svg);
-  mask-image: url(MDN.svg);
+  -webkit-mask-image: url("MDN.svg");
+  mask-image: url("MDN.svg");
   -webkit-mask-size: 50%;
   mask-size: 50%;
 }

--- a/files/en-us/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/internationalization/index.md
@@ -130,7 +130,7 @@ Note that you can also retrieve localized strings from CSS files in the extensio
 
 ```css
 header {
-  background-image: url(../images/__MSG_extensionName__/header.png);
+  background-image: url("../images/__MSG_extensionName__/header.png");
 }
 ```
 
@@ -337,7 +337,7 @@ Going back to our earlier example, it would make more sense to write it like thi
 
 ```css
 header {
-  background-image: url(../images/__MSG_@@ui_locale__/header.png);
+  background-image: url("../images/__MSG_@@ui_locale__/header.png");
 }
 ```
 

--- a/files/en-us/web/accessibility/guides/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/guides/seizure_disorders/index.md
@@ -430,8 +430,8 @@ Use the {{HTMLElement('link')}} element, alongside with and together with the at
 **{{CSSxref('@import')}}** is also a way to incorporate style sheets, but it is not quite as well supported as the {{HTMLElement('link')}} element.
 
 ```css
-@import url(alternate1.css);
-@import url(alternate2.css);
+@import "alternate1.css";
+@import "alternate2.css";
 ```
 
 By using alternate style sheets (remember to add the titles) you are setting it up for users to be able to use their browsers to choose alternate styles.

--- a/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -26,7 +26,7 @@ The HTML document used to render this content is shown below.
         color: #cccccc;
       }
       #c2 {
-        background-image: url(media/foo.png);
+        background-image: url("media/foo.png");
         background-repeat: no-repeat;
       }
       div {

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -324,7 +324,7 @@ And here's some CSS to make things look nice:
 
 ```css
 body {
-  background: 0 -100px repeat-x url(bg_gallery.png) #4f191a;
+  background: 0 -100px repeat-x url("bg_gallery.png") #4f191a;
   margin: 10px;
 }
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
@@ -48,7 +48,7 @@ We then add this to the document's [`FontFaceSet`](/en-US/docs/Web/API/FontFaceS
 ```js
 const fontFile = new FontFace(
   "Inconsolata",
-  'url(https://fonts.gstatic.com/s/inconsolata/v31/QlddNThLqRwH-OJ1UHjlKENVzlm-WkL3GZQmAwPyya15.woff2) format("woff2")',
+  'url("https://fonts.gstatic.com/s/inconsolata/v31/QlddNThLqRwH-OJ1UHjlKENVzlm-WkL3GZQmAwPyya15.woff2") format("woff2")',
   { stretch: "50% 200%" },
 );
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -201,7 +201,7 @@ And this code, `runComposite()`, handles the bulk of the work, relying on a numb
 ```js
 function createCanvas() {
   const canvas = document.createElement("canvas");
-  canvas.style.background = `url(${op_8x8.data})`;
+  canvas.style.background = `url(${JSON.stringify(op_8x8.data)})`;
   canvas.style.border = "1px solid #000";
   canvas.style.margin = "5px";
   canvas.width = width / 2;

--- a/files/en-us/web/api/canvasrenderingcontext2d/lang/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lang/index.md
@@ -91,7 +91,7 @@ const selectElem = document.querySelector("select");
 const latoMediumFontFace = new FontFace(
   // Lato-Medium is a font with language specific ligatures
   "Lato-Medium",
-  "url(https://mdn.github.io/shared-assets/fonts/Lato-Medium.ttf)",
+  'url("https://mdn.github.io/shared-assets/fonts/Lato-Medium.ttf")',
 );
 
 latoMediumFontFace.load().then((font) => {
@@ -168,7 +168,7 @@ const selectElem = document.querySelector("select");
 const latoMediumFontFace = new FontFace(
   // Lato-Medium is a font with language specific ligatures.
   "Lato-Medium",
-  "url(https://mdn.github.io/shared-assets/fonts/Lato-Medium.ttf)",
+  'url("https://mdn.github.io/shared-assets/fonts/Lato-Medium.ttf")',
 );
 
 latoMediumFontFace.load().then((font) => {

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -39,7 +39,7 @@ A typical font face definition using a URL source might be as shown below.
 Note that the `url()` function is required for URL font sources.
 
 ```js
-const font = new FontFace("my-font", "url(my-font.woff)", {
+const font = new FontFace("my-font", 'url("my-font.woff")', {
   style: "italic",
   weight: "400",
   stretch: "condensed",
@@ -61,7 +61,7 @@ The code below shows a font face being added to the document.
 
 ```js
 // Define a FontFace
-const font = new FontFace("my-font", "url(my-font.woff)", {
+const font = new FontFace("my-font", 'url("my-font.woff")', {
   style: "italic",
   weight: "400",
   stretch: "condensed",
@@ -80,7 +80,7 @@ The code below shows how to define a font face, add it to the document fonts, an
 
 ```js
 // Define a FontFace
-const font = new FontFace("my-font", "url(my-font.woff)");
+const font = new FontFace("my-font", 'url("my-font.woff")');
 
 // Add to the document.fonts (FontFaceSet)
 document.fonts.add(font);
@@ -140,7 +140,7 @@ We then log the font status, which should be `unloaded`.
 ```js
 const bitterFontFace = new FontFace(
   "FontFamily Bitter",
-  "url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)",
+  'url("https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2")',
 );
 document.fonts.add(bitterFontFace);
 log.textContent += `Bitter font: ${bitterFontFace.status}\n`; // > Bitter font: unloaded
@@ -199,7 +199,7 @@ const ctx = canvas.getContext("2d");
 
 const oxygenFontFace = new FontFace(
   "FontFamily Oxygen",
-  "url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)",
+  'url("https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2")',
 );
 document.fonts.add(oxygenFontFace);
 log.textContent += `Oxygen status: ${oxygenFontFace.status}\n`;

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -264,7 +264,7 @@ button {
   display: inline-block;
   padding: var(--unit) calc(var(--unit) * 2);
   width: calc(30% + 20px);
-  background: no-repeat 5% center url(magic-wand.png) var(--mainColor);
+  background: no-repeat 5% center url("magic-wand.png") var(--mainColor);
   border: 4px solid var(--mainColor);
   border-radius: 2px;
   font-size: calc(var(--unit) * 2);

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -31,7 +31,7 @@ This example uses the CSS found as an example on the {{cssxref("@font-face")}} p
   font-family: MyHelvetica;
   src:
     local("Helvetica Neue Bold"), local("HelveticaNeue-Bold"),
-    url(MgOpenModernaBold.ttf);
+    url("MgOpenModernaBold.ttf");
   font-weight: bold;
 }
 ```

--- a/files/en-us/web/api/cssfontfacerule/style/index.md
+++ b/files/en-us/web/api/cssfontfacerule/style/index.md
@@ -23,7 +23,7 @@ This example uses the CSS found as an example on the {{cssxref("@font-face")}} p
   font-family: MyHelvetica;
   src:
     local("Helvetica Neue Bold"), local("HelveticaNeue-Bold"),
-    url(MgOpenModernaBold.ttf);
+    url("MgOpenModernaBold.ttf");
   font-weight: bold;
 }
 ```

--- a/files/en-us/web/api/cssfontpalettevaluesrule/basepalette/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/basepalette/index.md
@@ -39,7 +39,7 @@ This example adds rules in an extra stylesheet added to the document, returned a
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Nabla&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Nabla&display=swap";
 
 h2 {
   font-family: "Nabla", fantasy;

--- a/files/en-us/web/api/cssfontpalettevaluesrule/fontfamily/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/fontfamily/index.md
@@ -31,7 +31,7 @@ The @font-palette-values at-rule's applies to the font families:</pre
 #### CSS
 
 ```css
-@import url(https://fonts.googleapis.com/css2?family=Bungee+Spice);
+@import "https://fonts.googleapis.com/css2?family=Bungee+Spice";
 
 @font-palette-values --Alternate {
   font-family: "Bungee Spice";

--- a/files/en-us/web/api/cssfontpalettevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/index.md
@@ -43,7 +43,7 @@ This example first defines an {{cssxref("@import")}} and an {{cssxref("@font-pal
 #### CSS
 
 ```css
-@import url(https://fonts.googleapis.com/css2?family=Bungee+Spice);
+@import "https://fonts.googleapis.com/css2?family=Bungee+Spice";
 
 @font-palette-values --Alternate {
   font-family: "Bungee Spice";

--- a/files/en-us/web/api/cssfontpalettevaluesrule/name/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/name/index.md
@@ -29,7 +29,7 @@ This example first defines an {{cssxref("@import")}} and an {{cssxref("@font-pal
 #### CSS
 
 ```css
-@import url(https://fonts.googleapis.com/css2?family=Bungee+Spice);
+@import "https://fonts.googleapis.com/css2?family=Bungee+Spice";
 
 @font-palette-values --Alternate {
   font-family: "Bungee Spice";

--- a/files/en-us/web/api/cssfontpalettevaluesrule/overridecolors/index.md
+++ b/files/en-us/web/api/cssfontpalettevaluesrule/overridecolors/index.md
@@ -37,7 +37,7 @@ This example first defines a few at-rules, among them two {{cssxref("@font-palet
   font-family: "Noto Color Emoji";
   font-style: normal;
   font-weight: 400;
-  src: url(https://fonts.gstatic.com/l/font?kit=Yq6P-KqIXTD0t4D9z1ESnKM3-HpFabts6diywYkdG3gjD0U&skey=a373f7129eaba270&v=v24)
+  src: url("https://fonts.gstatic.com/l/font?kit=Yq6P-KqIXTD0t4D9z1ESnKM3-HpFabts6diywYkdG3gjD0U&skey=a373f7129eaba270&v=v24")
     format("woff2");
 }
 

--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -36,7 +36,7 @@ button {
   display: inline-block;
   min-height: 100px;
   min-width: 100px;
-  background: no-repeat 5% center url(magic-wand.png) aqua;
+  background: no-repeat 5% center url("magic-wand.png") aqua;
 }
 ```
 

--- a/files/en-us/web/api/cssimportrule/href/index.md
+++ b/files/en-us/web/api/cssimportrule/href/index.md
@@ -26,7 +26,7 @@ first item in the list of CSS rules will be a `CSSImportRule`. The
 `href` property returns the URL of the imported stylesheet.
 
 ```css
-@import url("style.css") screen;
+@import "style.css" screen;
 ```
 
 ```js

--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -35,7 +35,7 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 The document includes a single stylesheet which contains a single {{cssxref("@import")}} rule. Therefore the first item in the list of CSS rules will be a `CSSImportRule`.
 
 ```css
-@import url("style.css") screen;
+@import "style.css" screen;
 ```
 
 ```js

--- a/files/en-us/web/api/cssimportrule/layername/index.md
+++ b/files/en-us/web/api/cssimportrule/layername/index.md
@@ -25,9 +25,9 @@ The `layerName` property returns the name of the layer associated with the impor
 stylesheet.
 
 ```css
-@import url("style1.css") layer(layer-1);
-@import url("style2.css") layer;
-@import url("style3.css");
+@import "style1.css" layer(layer-1);
+@import "style2.css" layer;
+@import "style3.css";
 ```
 
 ```js

--- a/files/en-us/web/api/cssimportrule/media/index.md
+++ b/files/en-us/web/api/cssimportrule/media/index.md
@@ -28,7 +28,7 @@ first item in the list of CSS rules will be a `CSSImportRule`. The
 the `mediaText` property with a value of `screen`.
 
 ```css
-@import url("style.css") screen;
+@import "style.css" screen;
 ```
 
 ```js

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.md
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.md
@@ -27,7 +27,7 @@ first item in the list of CSS rules will be a `CSSImportRule`. The
 `styleSheet` property returns the imported stylesheet.
 
 ```css
-@import url("style.css") screen;
+@import "style.css" screen;
 ```
 
 ```js

--- a/files/en-us/web/api/cssimportrule/supportstext/index.md
+++ b/files/en-us/web/api/cssimportrule/supportstext/index.md
@@ -21,9 +21,9 @@ The document's single stylesheet contains three {{cssxref("@import")}} rules. Th
 The `supportsText` property returns the import conditions associated with the at-rule.
 
 ```css
-@import url("style1.css") supports(display: flex);
-@import url("style2.css") supports(selector(p:has(a)));
-@import url("style3.css");
+@import "style1.css" supports(display: flex);
+@import "style2.css" supports(selector(p:has(a)));
+@import "style3.css";
 ```
 
 ```js

--- a/files/en-us/web/api/cssnamespacerule/index.md
+++ b/files/en-us/web/api/cssnamespacerule/index.md
@@ -29,7 +29,7 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 The stylesheet includes a namespace as the only rule. Therefore the first {{domxref("CSSRule")}} returned will be a `CSSNamespaceRule`.
 
 ```css
-@namespace url(http://www.w3.org/1999/xhtml);
+@namespace url("http://www.w3.org/1999/xhtml");
 ```
 
 ```js

--- a/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
+++ b/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
@@ -19,7 +19,7 @@ A string containing a URI.
 The stylesheet includes a namespace as the only rule. Therefore the first {{domxref("CSSRule")}} returned will be a `CSSNamespaceRule`. The value of the `namespaceURI` property will be `http://www.w3.org/1999/xhtml`.
 
 ```css
-@namespace url(http://www.w3.org/1999/xhtml);
+@namespace url("http://www.w3.org/1999/xhtml");
 ```
 
 ```js

--- a/files/en-us/web/api/cssnamespacerule/prefix/index.md
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.md
@@ -19,8 +19,8 @@ A string containing the prefix associated to this namespace. If there is no pref
 The stylesheet includes two namespace rules. The first has no prefix the second the prefix `svg`. Two `CSSNamespaceRule` objects will be returned. The value of the `prefix` property for the first will be an empty string, for the second `svg`.
 
 ```css
-@namespace url(http://www.w3.org/1999/xhtml);
-@namespace svg url(http://www.w3.org/2000/svg);
+@namespace url("http://www.w3.org/1999/xhtml");
+@namespace svg url("http://www.w3.org/2000/svg");
 ```
 
 ```js

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -23,7 +23,7 @@ This property accepts the same values as the {{cssxref("@font-face/ascent-overri
 ```js
 let fontFace = new FontFace(
   "Roboto",
-  "url(https://fonts.example.com/roboto.woff2)",
+  'url("https://fonts.example.com/roboto.woff2")',
   { ascentOverride: "90%" },
 );
 console.log(fontFace.ascentOverride); // 90%

--- a/files/en-us/web/api/fontface/descentoverride/index.md
+++ b/files/en-us/web/api/fontface/descentoverride/index.md
@@ -20,7 +20,7 @@ A string.
 ```js
 let fontFace = new FontFace(
   "Roboto",
-  "url(https://fonts.example.com/roboto.woff2)",
+  'url("https://fonts.example.com/roboto.woff2")',
   { descentOverride: "90%" },
 );
 console.log(fontFace.descentOverride); // 90%

--- a/files/en-us/web/api/fontface/family/index.md
+++ b/files/en-us/web/api/fontface/family/index.md
@@ -24,7 +24,7 @@ A string.
 ```js
 let fontFace = new FontFace(
   "Roboto",
-  "url(https://fonts.example.com/roboto.woff2)",
+  'url("https://fonts.example.com/roboto.woff2")',
 );
 console.log(fontFace.family); // 'Roboto'
 

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -65,7 +65,7 @@ new FontFace(family, source, descriptors)
 
 ```js
 async function loadFonts() {
-  const font = new FontFace("my-font", "url(my-font.woff)", {
+  const font = new FontFace("my-font", 'url("my-font.woff")', {
     style: "normal",
     weight: "400",
     stretch: "condensed",

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -57,7 +57,7 @@ Just to show how it works, we then define the `stretch` descriptor using a prope
 
 ```js
 // Define a FontFace
-const font = new FontFace("my-font", "url(my-font.woff)", {
+const font = new FontFace("my-font", 'url("my-font.woff")', {
   style: "italic",
   weight: "400",
 });

--- a/files/en-us/web/api/fontface/linegapoverride/index.md
+++ b/files/en-us/web/api/fontface/linegapoverride/index.md
@@ -20,7 +20,7 @@ A string.
 ```js
 let fontFace = new FontFace(
   "Roboto",
-  "url(https://fonts.example.com/roboto.woff2)",
+  'url("https://fonts.example.com/roboto.woff2")',
   { lineGapOverride: "90%" },
 );
 console.log(fontFace.lineGapOverride); // 90%

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -45,7 +45,7 @@ const canvas = document.getElementById("js-canvas");
 // load the "Bitter" font from Google Fonts
 const fontFile = new FontFace(
   "FontFamily Style Bitter",
-  "url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)",
+  'url("https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2")',
 );
 document.fonts.add(fontFile);
 

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -35,7 +35,7 @@ A new {{domxref("FontFaceSet")}}.
 In the following example a new {{domxref("FontFace")}} object is created and then added to the {{domxref("FontFaceSet")}}.
 
 ```js
-const font = new FontFace("MyFont", "url(myFont.woff2)");
+const font = new FontFace("MyFont", 'url("myFont.woff2")');
 document.fonts.add(font);
 ```
 

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -40,7 +40,7 @@ Otherwise, this function returns `false`.
 In the following example, we create a new `FontFace` and add it to the `FontFaceSet`:
 
 ```js
-const font = new FontFace("molot", "url(/shared-assets/fonts/molot.woff2)", {
+const font = new FontFace("molot", 'url("/shared-assets/fonts/molot.woff2")', {
   style: "normal",
   weight: "400",
   stretch: "condensed",

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -32,7 +32,7 @@ A boolean value which is `true` if the deletion was successful, and `false` othe
 In the following example a new {{domxref("FontFace")}} object is created and then deleted from the {{domxref("FontFaceSet")}}.
 
 ```js
-const font = new FontFace("MyFont", "url(myFont.woff2)");
+const font = new FontFace("MyFont", 'url("myFont.woff2")');
 document.fonts.delete(font);
 ```
 

--- a/files/en-us/web/api/paintworkletglobalscope/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/index.md
@@ -83,7 +83,7 @@ This example shows how to use a paint `Worklet` in a stylesheet, including the s
 
 ```css
 textarea {
-  background-image: url(checkerboard);
+  background-image: url("checkerboard.png"); /* Fallback */
   background-image: paint(checkerboard);
 }
 ```

--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -65,7 +65,7 @@ Then the four boxes defining the segments of the image are defined. Let's look a
 
 ```css
 #box1 {
-  background-image: -moz-image-rect(url(firefox.png), 0%, 50%, 50%, 0%);
+  background-image: -moz-image-rect(url("firefox.png"), 0%, 50%, 50%, 0%);
   width: 133px;
   height: 136px;
   left: 0px;
@@ -78,7 +78,7 @@ This is the top-left corner of the image. It defines a rectangle containing the 
 
 ```css
 #box2 {
-  background-image: -moz-image-rect(url(firefox.png), 0%, 100%, 50%, 50%);
+  background-image: -moz-image-rect(url("firefox.png"), 0%, 100%, 50%, 50%);
   width: 133px;
   height: 136px;
   left: 133px;
@@ -93,7 +93,7 @@ The other corners follow a similar pattern:
 
 ```css
 #box3 {
-  background-image: -moz-image-rect(url(firefox.png), 50%, 50%, 100%, 0%);
+  background-image: -moz-image-rect(url("firefox.png"), 50%, 50%, 100%, 0%);
   width: 133px;
   height: 136px;
   left: 0px;
@@ -101,7 +101,7 @@ The other corners follow a similar pattern:
   position: absolute;
 }
 #box4 {
-  background-image: -moz-image-rect(url(firefox.png), 50%, 100%, 100%, 50%);
+  background-image: -moz-image-rect(url("firefox.png"), 50%, 100%, 100%, 50%);
   width: 133px;
   height: 136px;
   left: 133px;

--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -32,17 +32,17 @@ The values includes the `<image>` to be used as the mask border, and optionally 
 -webkit-mask-box-image: none;
 
 /* image */
--webkit-mask-box-image: url(image.png);
+-webkit-mask-box-image: url("image.png");
 
 /* image edge-offset */
--webkit-mask-box-image: url(image.png) 10 20 20 10;
--webkit-mask-box-image: url(image.png) 10px 20px 20px 10px;
+-webkit-mask-box-image: url("image.png") 10 20 20 10;
+-webkit-mask-box-image: url("image.png") 10px 20px 20px 10px;
 
 /* image repeat-style */
--webkit-mask-box-image: url(image.png) space repeat;
+-webkit-mask-box-image: url("image.png") space repeat;
 
 /* image edge-offset repeat-style */
--webkit-mask-box-image: url(image.png) 10px 20px 20px 10px space repeat;
+-webkit-mask-box-image: url("image.png") 10px 20px 20px 10px space repeat;
 
 /* Global values */
 -webkit-mask-box-image: inherit;

--- a/files/en-us/web/css/-webkit-mask-composite/index.md
+++ b/files/en-us/web/css/-webkit-mask-composite/index.md
@@ -78,7 +78,7 @@ The **`-webkit-mask-composite`** property specifies the manner in which multiple
 
 ```css
 .example {
-  -webkit-mask-image: url(mask1.png), url("mask2.png");
+  -webkit-mask-image: url("mask1.png"), url("mask2.png");
   -webkit-mask-composite: xor, source-over;
 }
 ```

--- a/files/en-us/web/css/-webkit-mask-position-x/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-x/index.md
@@ -67,12 +67,12 @@ The `-webkit-mask-position-x` CSS property sets the initial horizontal position 
 
 ```css
 .exampleOne {
-  -webkit-mask-image: url(mask.png);
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-position-x: right;
 }
 
 .exampleTwo {
-  -webkit-mask-image: url(mask.png);
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-position-x: 25%;
 }
 ```

--- a/files/en-us/web/css/-webkit-mask-position-y/index.md
+++ b/files/en-us/web/css/-webkit-mask-position-y/index.md
@@ -67,12 +67,12 @@ The `-webkit-mask-position-y` CSS property sets the initial vertical position of
 
 ```css
 .exampleOne {
-  -webkit-mask-image: url(mask.png);
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-position-y: bottom;
 }
 
 .exampleTwo {
-  -webkit-mask-image: url(mask.png);
+  -webkit-mask-image: url("mask.png");
   -webkit-mask-position-y: 25%;
 }
 ```

--- a/files/en-us/web/css/@counter-style/additive-symbols/index.md
+++ b/files/en-us/web/css/@counter-style/additive-symbols/index.md
@@ -18,7 +18,7 @@ additive-symbols: 3 "*";
 additive-symbols:
   3 "0",
   2 "\2E\20",
-  1 url(symbol.png);
+  1 url("symbol.png");
 
 /* Binary counter */
 additive-symbols:

--- a/files/en-us/web/css/@counter-style/prefix/index.md
+++ b/files/en-us/web/css/@counter-style/prefix/index.md
@@ -16,7 +16,7 @@ When the counter value is negative, the `prefix` comes before the negative sign 
 /* <symbol> value: string, image, or identifier */
 prefix: "»";
 prefix: "Page ";
-prefix: url(bullet.png);
+prefix: url("bullet.png");
 ```
 
 ### Values

--- a/files/en-us/web/css/@counter-style/suffix/index.md
+++ b/files/en-us/web/css/@counter-style/suffix/index.md
@@ -14,7 +14,7 @@ The **`suffix`** descriptor of the {{cssxref("@counter-style")}} rule specifies 
 /* <symbol> value: string, image, or identifier  */
 suffix: "";
 suffix: ") ";
-suffix: url(bullet.png);
+suffix: url("bullet.png");
 ```
 
 ### Values

--- a/files/en-us/web/css/@font-face/font-display/index.md
+++ b/files/en-us/web/css/@font-face/font-display/index.md
@@ -61,8 +61,8 @@ The font display timeline is based on a timer that begins the moment the user ag
 @font-face {
   font-family: ExampleFont;
   src:
-    url(/path/to/fonts/example-font.woff) format("woff"),
-    url(/path/to/fonts/example-font.eot) format("eot");
+    url("/path/to/fonts/example-font.woff") format("woff"),
+    url("/path/to/fonts/example-font.eot") format("eot");
   font-weight: 400;
   font-style: normal;
   font-display: fallback;

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -12,10 +12,9 @@ The **`src`** CSS descriptor for the {{cssxref("@font-face")}} at-rule specifies
 
 ```css
 /* <url> values */
-src: url(https://somewebsite.com/path/to/font.woff); /* Absolute URL */
-src: url(path/to/font.woff); /* Relative URL */
-src: url("path/to/font.woff"); /* Quoted URL */
-src: url(path/to/svgFont.svg#example); /* Fragment identifying font */
+src: url("https://example.com/path/to/font.woff"); /* Absolute URL */
+src: url("path/to/font.woff"); /* Relative URL */
+src: url("path/to/svgFont.svg#example"); /* Fragment identifying font */
 
 /* <font-face-name> values */
 src: local(font); /* Unquoted name */
@@ -24,17 +23,17 @@ src: local("font"); /* Quoted name */
 src: local("some font"); /* Quoted name containing a space */
 
 /* <tech(<font-tech>)> values */
-src: url(path/to/fontCOLRv1.otf) tech(color-COLRv1);
-src: url(path/to/fontCOLR-svg.otf) tech(color-SVG);
+src: url("path/to/fontCOLRv1.otf") tech(color-COLRv1);
+src: url("path/to/fontCOLR-svg.otf") tech(color-SVG);
 
 /* <format(<font-format>)> values */
-src: url(path/to/font.woff) format("woff");
-src: url(path/to/font.otf) format("opentype");
+src: url("path/to/font.woff") format("woff");
+src: url("path/to/font.otf") format("opentype");
 
 /* Multiple resources */
 src:
-  url(path/to/font.woff) format("woff"),
-  url(path/to/font.otf) format("opentype");
+  url("path/to/font.woff") format("woff"),
+  url("path/to/font.otf") format("opentype");
 
 /* Multiple resources with font format and technologies */
 src:
@@ -98,9 +97,9 @@ If the font file is a container for multiple fonts, a fragment identifier is inc
 
 ```css
 /* WhichFont is the PostScript name of a font in the font file */
-src: url(collection.otc#WhichFont);
+src: url("collection.otc#WhichFont");
 /* WhichFont is the element id of a font in the SVG Font file */
-src: url(fonts.svg#WhichFont);
+src: url("fonts.svg#WhichFont");
 ```
 
 ### Font formats

--- a/files/en-us/web/css/@font-palette-values/font-family/index.md
+++ b/files/en-us/web/css/@font-palette-values/font-family/index.md
@@ -48,7 +48,7 @@ In this example, when the `font-family` descriptor is used in the [@font-palette
 #### CSS
 
 ```css
-@import url(https://fonts.googleapis.com/css2?family=Bungee+Spice);
+@import "https://fonts.googleapis.com/css2?family=Bungee+Spice";
 @font-palette-values --bungee-extra-spicy {
   font-family: "Bungee Spice";
   override-colors:

--- a/files/en-us/web/css/@font-palette-values/index.md
+++ b/files/en-us/web/css/@font-palette-values/index.md
@@ -50,7 +50,7 @@ This example shows how you can change some or all of the colors in a color font.
 #### CSS
 
 ```css
-@import url(https://fonts.googleapis.com/css2?family=Bungee+Spice);
+@import "https://fonts.googleapis.com/css2?family=Bungee+Spice";
 p {
   font-family: "Bungee Spice", fantasy;
   font-size: 2rem;

--- a/files/en-us/web/css/@font-palette-values/override-colors/index.md
+++ b/files/en-us/web/css/@font-palette-values/override-colors/index.md
@@ -91,7 +91,7 @@ This example shows how to override colors in the [Noto Color Emoji](https://font
   font-family: "Noto Color Emoji";
   font-style: normal;
   font-weight: 400;
-  src: url(https://fonts.gstatic.com/l/font?kit=Yq6P-KqIXTD0t4D9z1ESnKM3-HpFabts6diywYkdG3gjD0U&skey=a373f7129eaba270&v=v24)
+  src: url("https://fonts.gstatic.com/l/font?kit=Yq6P-KqIXTD0t4D9z1ESnKM3-HpFabts6diywYkdG3gjD0U&skey=a373f7129eaba270&v=v24")
     format("woff2");
 }
 

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -48,13 +48,13 @@ Imported rules must come before all other types of rules, except {{CSSxRef("@cha
   padding: 0;
 }
 /* more styles */
-@import url("my-imported-styles.css");
+@import "my-imported-styles.css";
 ```
 
 As the `@import` at-rule is declared after the styles it is invalid and hence ignored.
 
 ```css example-good
-@import url("my-imported-styles.css");
+@import "my-imported-styles.css";
 * {
   margin: 0;
   padding: 0;
@@ -90,10 +90,10 @@ The two examples above show how to specify the _url_ as a `<string>` and as a `u
 ### Importing CSS rules conditional on media queries
 
 ```css
-@import url("fine-print.css") print;
-@import url("bluish.css") print, screen;
+@import "fine-print.css" print;
+@import "bluish.css" print, screen;
 @import "common.css" screen;
-@import url("landscape.css") screen and (orientation: landscape);
+@import "landscape.css" screen and (orientation: landscape);
 ```
 
 The `@import` rules in the above examples show media-dependent conditions that will need to be true before the linked CSS rules are applied. So for instance, the last `@import` rule will load the `landscape.css` stylesheet only on a screen device in landscape orientation.
@@ -101,9 +101,9 @@ The `@import` rules in the above examples show media-dependent conditions that w
 ### Importing CSS rules conditional on feature support
 
 ```css
-@import url("grid.css") supports(display: grid) screen and (width <= 400px);
-@import url("flex.css") supports((not (display: grid)) and (display: flex))
-  screen and (width <= 400px);
+@import "grid.css" supports(display: grid) screen and (width <= 400px);
+@import "flex.css" supports((not (display: grid)) and (display: flex)) screen
+  and (width <= 400px);
 ```
 
 The `@import` rules above illustrate how you might import a layout that uses a grid if `display: grid` is supported, and otherwise imports CSS that uses `display: flex`.
@@ -115,8 +115,8 @@ You can also specify CSS functions in `supports()`, and it will evaluate to `tru
 For example, the code below shows an `@import` that is conditional on both [child combinators](/en-US/docs/Web/CSS/Child_combinator) (`selector()`) and the `font-tech()` function:
 
 ```css
-@import url("whatever.css")
-supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
+@import "whatever.css"
+  supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
 ```
 
 ### Importing CSS rules into a cascade layer
@@ -128,8 +128,8 @@ supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
 In the above example, a cascade layer named `utilities` is created and it will include rules from the imported stylesheet `theme`.
 
 ```css
-@import url(headings.css) layer(default);
-@import url(links.css) layer(default);
+@import "headings.css" layer(default);
+@import "links.css" layer(default);
 
 @layer default {
   audio[controls] {

--- a/files/en-us/web/css/@namespace/index.md
+++ b/files/en-us/web/css/@namespace/index.md
@@ -42,11 +42,11 @@ svg|a {
 
 ```css
 /* Default namespace */
-@namespace url(XML-namespace-URL);
+@namespace url("XML-namespace-URL");
 @namespace "XML-namespace-URL";
 
 /* Prefixed namespace */
-@namespace prefix url(XML-namespace-URL);
+@namespace prefix url("XML-namespace-URL");
 @namespace prefix "XML-namespace-URL";
 ```
 
@@ -74,8 +74,8 @@ In HTML, known [foreign elements](https://html.spec.whatwg.org/multipage/syntax.
 ### Specifying default and prefixed namespaces
 
 ```css
-@namespace url(http://www.w3.org/1999/xhtml);
-@namespace svg url(http://www.w3.org/2000/svg);
+@namespace url("http://www.w3.org/1999/xhtml");
+@namespace svg url("http://www.w3.org/2000/svg");
 
 /* This matches all XHTML <a> elements, as XHTML is the default unprefixed namespace */
 a {

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -278,7 +278,7 @@ ul:has(> li li) {
 The following example applies the CSS style if the browser supports the `COLRv1` font technology:
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Bungee+Spice");
+@import "https://fonts.googleapis.com/css2?family=Bungee+Spice";
 
 @supports font-tech(color-COLRv1) {
   p {

--- a/files/en-us/web/css/_colon_-moz-loading/index.md
+++ b/files/en-us/web/css/_colon_-moz-loading/index.md
@@ -28,7 +28,7 @@ The **`:-moz-loading`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/We
 
 ```css
 :-moz-loading {
-  background: url(loading-animation.gif) center no-repeat;
+  background: url("loading-animation.gif") center no-repeat;
 }
 ```
 

--- a/files/en-us/web/css/backdrop-filter/index.md
+++ b/files/en-us/web/css/backdrop-filter/index.md
@@ -58,7 +58,7 @@ backdrop-filter: sepia(90%);
 backdrop-filter: none;
 
 /* URL to SVG filter */
-backdrop-filter: url(common-filters.svg#filter);
+backdrop-filter: url("common-filters.svg#filter");
 
 /* <filter-function> values */
 backdrop-filter: blur(2px);
@@ -73,7 +73,7 @@ backdrop-filter: sepia(90%);
 backdrop-filter: saturate(80%);
 
 /* Multiple filters */
-backdrop-filter: url(filters.svg#filter) blur(4px) saturate(150%);
+backdrop-filter: url("filters.svg#filter") blur(4px) saturate(150%);
 
 /* Global values */
 backdrop-filter: inherit;

--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -122,7 +122,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: skyblue;
-  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url("https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png");
   background-repeat: no-repeat;
   background-position-x: center;
   background-position-y: bottom;
@@ -150,7 +150,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: seagreen;
-  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url("https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png");
   background-repeat: no-repeat;
   background-position-x: right 20px;
   background-position-y: bottom 10px;

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -122,7 +122,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: skyblue;
-  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url("https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png");
   background-repeat: no-repeat;
   background-position-x: center;
   background-position-y: bottom;
@@ -150,7 +150,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: seagreen;
-  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url("https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png");
   background-repeat: no-repeat;
   background-position-x: right 20px;
   background-position-y: bottom 10px;

--- a/files/en-us/web/css/background-repeat/index.md
+++ b/files/en-us/web/css/background-repeat/index.md
@@ -177,7 +177,7 @@ li {
   margin-bottom: 12px;
 }
 div {
-  background-image: url(star-solid.gif);
+  background-image: url("star-solid.gif");
   width: 160px;
   height: 70px;
 }
@@ -205,7 +205,7 @@ div {
 /* Multiple images */
 .seven {
   background-image:
-    url(star-solid.gif), url(/shared-assets/images/examples/favicon32.png);
+    url("star-solid.gif"), url("/shared-assets/images/examples/favicon32.png");
   background-repeat: repeat-x, repeat-y;
   height: 144px;
 }

--- a/files/en-us/web/css/background-size/index.md
+++ b/files/en-us/web/css/background-size/index.md
@@ -176,7 +176,7 @@ To do this, we can use a fixed `background-size` value of 150 pixels.
 
 ```css
 .tiledBackground {
-  background-image: url(https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png);
+  background-image: url("https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png");
   background-size: 150px;
   width: 300px;
   height: 300px;

--- a/files/en-us/web/css/blend-mode/index.md
+++ b/files/en-us/web/css/blend-mode/index.md
@@ -386,7 +386,7 @@ div {
   width: 300px;
   height: 300px;
   background:
-    url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
+    url("https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png")
       no-repeat center,
     linear-gradient(to bottom, blue, orange);
 }

--- a/files/en-us/web/css/border-image-slice/index.md
+++ b/files/en-us/web/css/border-image-slice/index.md
@@ -171,7 +171,7 @@ div > div {
   height: 200px;
   border-width: 30px;
   border-style: solid;
-  border-image: url(/shared-assets/images/examples/border-diamonds.png);
+  border-image: url("/shared-assets/images/examples/border-diamonds.png");
   border-image-slice: 30;
   border-image-repeat: round;
 }

--- a/files/en-us/web/css/border-image-source/index.md
+++ b/files/en-us/web/css/border-image-source/index.md
@@ -62,7 +62,7 @@ The {{cssxref("border-image-slice")}} property is used to divide the source imag
 border-image-source: none;
 
 /* <image> values */
-border-image-source: url(image.jpg);
+border-image-source: url("image.jpg");
 border-image-source: linear-gradient(to top, red, yellow);
 
 /* Global values */

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -78,7 +78,7 @@ section {
 clip-path: none;
 
 /* <clip-source> values */
-clip-path: url(resources.svg#c1);
+clip-path: url("resources.svg#c1");
 
 /* <geometry-box> values */
 clip-path: margin-box;
@@ -308,11 +308,11 @@ We then set the `id` of the `<clipPath>` as the `<clip-source>`. We center the t
 
 ```css
 .window {
-  clip-path: url(#window);
+  clip-path: url("#window");
 }
 
 .cross {
-  clip-path: url(#cross);
+  clip-path: url("#cross");
   align-content: center;
 }
 ```
@@ -368,7 +368,7 @@ The initial rendering includes the star as the `clip-path` source.
 ```css
 #clipped {
   margin-bottom: 20px;
-  clip-path: url(#star);
+  clip-path: url("#star");
 }
 ```
 

--- a/files/en-us/web/css/clip-rule/index.md
+++ b/files/en-us/web/css/clip-rule/index.md
@@ -155,10 +155,10 @@ We use the {{cssxref("clip-path")}} property to set the different `<clipPath>` e
 
 ```css
 div:first-of-type {
-  clip-path: url(#star1);
+  clip-path: url("#star1");
 }
 div:last-of-type {
-  clip-path: url(#star2);
+  clip-path: url("#star2");
 }
 ```
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -72,7 +72,7 @@ content: no-close-quote;
 
 /* <content-list>: a list of content values. 
 Several values can be used simultaneously */
-content: "prefix" url(http://www.example.com/test.png);
+content: "prefix" url("http://www.example.com/test.png");
 content: "prefix" url("/img/test.png") "suffix" / "Alt text";
 content: open-quote counter(chapter_counter);
 

--- a/files/en-us/web/css/cross-fade/index.md
+++ b/files/en-us/web/css/cross-fade/index.md
@@ -26,12 +26,12 @@ The function can be used in CSS anywhere an ordinary image reference can be used
 Think of the percentage as an opacity value for each image. This means a value of 0% means the image is fully transparent while a value of 100% makes the image fully opaque.
 
 ```css
-cross-fade(url(white.png) 0%, url(black.png) 100%); /* fully black */
-cross-fade(url(white.png) 25%, url(black.png) 75%); /* 25% white, 75% black */
-cross-fade(url(white.png) 50%, url(black.png) 50%); /* 50% white, 50% black */
-cross-fade(url(white.png) 75%, url(black.png) 25%); /* 75% white, 25% black */
-cross-fade(url(white.png) 100%, url(black.png) 0%); /* fully white */
-cross-fade(url(green.png) 75%, url(red.png) 75%); /* both green and red at 75% */
+cross-fade(url("white.png") 0%, url("black.png") 100%); /* fully black */
+cross-fade(url("white.png") 25%, url("black.png") 75%); /* 25% white, 75% black */
+cross-fade(url("white.png") 50%, url("black.png") 50%); /* 50% white, 50% black */
+cross-fade(url("white.png") 75%, url("black.png") 25%); /* 75% white, 25% black */
+cross-fade(url("white.png") 100%, url("black.png") 0%); /* fully white */
+cross-fade(url("green.png") 75%, url("red.png") 75%); /* both green and red at 75% */
 ```
 
 If any percentages are omitted, all the specified percentages are summed together and subtracted from `100%`.
@@ -44,12 +44,12 @@ A 25% value renders the first image at 25% and the second at 75%. The 75% value 
 The above could also have been written as:
 
 ```css
-cross-fade(url(white.png) 0%, url(black.png)); /* fully black */
-cross-fade(url(white.png) 25%, url(black.png)); /* 25% white, 75% black */
-cross-fade(url(white.png), url(black.png)); /* 50% white, 50% black */
-cross-fade(url(white.png) 75%, url(black.png)); /* 75% white, 25% black */
-cross-fade(url(white.png) 100%, url(black.png)); /* fully white */
-cross-fade(url(green.png) 75%, url(red.png) 75%); /* both green and red at 75% */
+cross-fade(url("white.png") 0%, url("black.png")); /* fully black */
+cross-fade(url("white.png") 25%, url("black.png")); /* 25% white, 75% black */
+cross-fade(url("white.png"), url("black.png")); /* 50% white, 50% black */
+cross-fade(url("white.png") 75%, url("black.png")); /* 75% white, 25% black */
+cross-fade(url("white.png") 100%, url("black.png")); /* fully white */
+cross-fade(url("green.png") 75%, url("red.png") 75%); /* both green and red at 75% */
 ```
 
 If no percentages are declared, both the images will be 50% opaque, with a cross-fade rendering as an even merge of both images.
@@ -61,8 +61,8 @@ In the last example, the sum of both percentages is not 100%, and therefore both
 If no percentages are declared and three images are included, each image will be 33.33% opaque. The two following are lines (almost) identical:
 
 ```css
-cross-fade(url(red.png), url(yellow.png), url(blue.png)); /* all three will be 33.3333% opaque */
-cross-fade(url(red.png) 33.33%, url(yellow.png) 33.33%, url(blue.png) 33.33%);
+cross-fade(url("red.png"), url("yellow.png"), url("blue.png")); /* all three will be 33.3333% opaque */
+cross-fade(url("red.png") 33.33%, url("yellow.png") 33.33%, url("blue.png") 33.33%);
 ```
 
 ### Older, implemented syntax
@@ -77,11 +77,11 @@ The original syntax, which has been implemented in some browsers, only allowed f
 The original syntax is supported in Safari and supported with the `-webkit-` prefix in Chrome, Opera, and other blink-based browsers.
 
 ```css
-cross-fade(url(white.png), url(black.png), 0%);   /* fully black */
-cross-fade(url(white.png), url(black.png), 25%);  /* 25% white, 75% black */
-cross-fade(url(white.png), url(black.png), 50%);  /* 50% white, 50% black */
-cross-fade(url(white.png), url(black.png), 75%);  /* 75% white, 25% black */
-cross-fade(url(white.png), url(black.png), 100%); /* fully white */
+cross-fade(url("white.png"), url("black.png"), 0%);   /* fully black */
+cross-fade(url("white.png"), url("black.png"), 25%);  /* 25% white, 75% black */
+cross-fade(url("white.png"), url("black.png"), 50%);  /* 50% white, 50% black */
+cross-fade(url("white.png"), url("black.png"), 75%);  /* 75% white, 25% black */
+cross-fade(url("white.png"), url("black.png"), 100%); /* fully white */
 ```
 
 In the implemented syntax, the two comma-separated images are declared first, followed by a comma and required percent value. Omitting the comma or percent invalidates the value.

--- a/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
@@ -21,7 +21,7 @@ Let's consider a large image, a 2982x2808 Firefox logo image. We want (for some 
 
 ```css
 .tiledBackground {
-  background-image: url(https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png);
+  background-image: url("https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png");
   background-size: 150px;
   width: 300px;
   height: 300px;
@@ -54,7 +54,7 @@ On the other end of the spectrum, you can scale an image up in the background. H
 
 ```css
 .square2 {
-  background-image: url(favicon.png);
+  background-image: url("favicon.png");
   background-size: 300px;
   width: 300px;
   height: 300px;
@@ -86,7 +86,7 @@ The `contain` value specifies that, regardless of the size of the containing box
 
 ```css
 .bgSizeContain {
-  background-image: url(https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png);
+  background-image: url("https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png");
   background-size: contain;
   width: 160px;
   height: 160px;
@@ -116,7 +116,7 @@ The `cover` value specifies that the background image should be sized so that it
 
 ```css
 .bgSizeCover {
-  background-image: url(https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png);
+  background-image: url("https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png");
   background-size: cover;
   width: 160px;
   height: 160px;

--- a/files/en-us/web/css/css_backgrounds_and_borders/scaling_of_svg_backgrounds/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/scaling_of_svg_backgrounds/index.md
@@ -38,7 +38,7 @@ This SVG gradient image is both dimensionless and proportionless. It doesn't car
       <stop stop-color="goldenrod" offset="1" />
     </linearGradient>
   </defs>
-  <rect fill="url(#g)" width="100%" height="100%" />
+  <rect fill="url('#g')" width="100%" height="100%" />
 </svg>
 ```
 
@@ -57,7 +57,7 @@ This image specifies a width of 100 pixels but no height or intrinsic ratio. Thi
       <stop stop-color="lime" offset="1" />
     </linearGradient>
   </defs>
-  <rect fill="url(#g)" width="100%" height="100%" />
+  <rect fill="url('#g')" width="100%" height="100%" />
 </svg>
 ```
 
@@ -78,7 +78,7 @@ This is very much like specifying a specific width and height; since once you ha
       <stop stop-color="orange" offset="1" />
     </linearGradient>
   </defs>
-  <rect fill="url(#g)" width="100%" height="100%" />
+  <rect fill="url('#g')" width="100%" height="100%" />
 </svg>
 ```
 
@@ -97,7 +97,7 @@ This image doesn't specify either a width or a height; instead, it specifies an 
       <stop stop-color="maroon" offset="1" />
     </linearGradient>
   </defs>
-  <rect fill="url(#g)" width="100%" height="100%" />
+  <rect fill="url('#g')" width="100%" height="100%" />
 </svg>
 ```
 
@@ -139,7 +139,7 @@ div {
 
 ```css live-sample___scaling1
 div {
-  background-image: url(no-dimensions-or-ratio.svg);
+  background-image: url("no-dimensions-or-ratio.svg");
   background-size: 125px 175px;
 }
 ```
@@ -165,7 +165,7 @@ div {
 
 ```css live-sample___scaling2
 div {
-  background-image: url(100px-wide-no-height-or-ratio.svg);
+  background-image: url("100px-wide-no-height-or-ratio.svg");
   background-size: 250px 150px;
 }
 ```
@@ -191,7 +191,7 @@ div {
 
 ```css live-sample___scaling3
 div {
-  background-image: url(100px-height-3x4-ratio.svg);
+  background-image: url("100px-height-3x4-ratio.svg");
   background-size: 275px 125px;
 }
 ```
@@ -217,7 +217,7 @@ div {
 
 ```css live-sample___scaling4
 div {
-  background-image: url(no-dimensions-1x1-ratio.svg);
+  background-image: url("no-dimensions-1x1-ratio.svg");
   background-size: 250px 100px;
 }
 ```
@@ -249,7 +249,7 @@ div {
 
 ```css live-sample___cc1
 div {
-  background-image: url(no-dimensions-or-ratio.svg);
+  background-image: url("no-dimensions-or-ratio.svg");
   background-size: contain;
 }
 ```
@@ -275,7 +275,7 @@ div {
 
 ```css live-sample___cc2
 div {
-  background-image: url(100px-wide-no-height-or-ratio.svg);
+  background-image: url("100px-wide-no-height-or-ratio.svg");
   background-size: contain;
 }
 ```
@@ -307,7 +307,7 @@ div {
 
 ```css live-sample___cc3
 div {
-  background-image: url(100px-height-3x4-ratio.svg);
+  background-image: url("100px-height-3x4-ratio.svg");
   background-size: contain;
 }
 ```
@@ -333,7 +333,7 @@ div {
 
 ```css live-sample___cc5
 div {
-  background-image: url(100px-height-3x4-ratio.svg);
+  background-image: url("100px-height-3x4-ratio.svg");
   background-size: cover;
 }
 ```
@@ -363,7 +363,7 @@ div {
 
 ```css live-sample___cc6
 div {
-  background-image: url(no-dimensions-1x1-ratio.svg);
+  background-image: url("no-dimensions-1x1-ratio.svg");
   background-size: contain;
 }
 ```
@@ -389,7 +389,7 @@ div {
 
 ```css live-sample___cc7
 div {
-  background-image: url(no-dimensions-1x1-ratio.svg);
+  background-image: url("no-dimensions-1x1-ratio.svg");
   background-size: cover;
 }
 ```
@@ -421,7 +421,7 @@ div {
 
 ```css live-sample___both-auto1
 div {
-  background-image: url(no-dimensions-or-ratio.svg);
+  background-image: url("no-dimensions-or-ratio.svg");
   background-size: auto auto;
 }
 ```
@@ -447,7 +447,7 @@ div {
 
 ```css live-sample___both-auto2
 div {
-  background-image: url(100px-wide-no-height-or-ratio.svg);
+  background-image: url("100px-wide-no-height-or-ratio.svg");
   background-size: auto auto;
 }
 ```
@@ -475,7 +475,7 @@ div {
 
 ```css live-sample___both-auto3
 div {
-  background-image: url(100px-height-3x4-ratio.svg);
+  background-image: url("100px-height-3x4-ratio.svg");
   background-size: auto auto;
 }
 ```
@@ -503,7 +503,7 @@ div {
 
 ```css live-sample___both-auto4
 div {
-  background-image: url(no-dimensions-1x1-ratio.svg);
+  background-image: url("no-dimensions-1x1-ratio.svg");
   background-size: auto auto;
 }
 ```
@@ -533,7 +533,7 @@ div {
 
 ```css live-sample___auto0
 div {
-  background-image: url(no-dimensions-or-ratio.svg);
+  background-image: url("no-dimensions-or-ratio.svg");
   background-size: auto 140px;
 }
 ```
@@ -561,7 +561,7 @@ div {
 
 ```css live-sample___auto1
 div {
-  background-image: url(100px-wide-no-height-or-ratio.svg);
+  background-image: url("100px-wide-no-height-or-ratio.svg");
   background-size: 200px auto;
 }
 ```
@@ -585,7 +585,7 @@ div {
 
 ```css live-sample___auto2
 div {
-  background-image: url(100px-wide-no-height-or-ratio.svg);
+  background-image: url("100px-wide-no-height-or-ratio.svg");
   background-size: auto 125px;
 }
 ```
@@ -613,7 +613,7 @@ div {
 
 ```css live-sample___auto3
 div {
-  background-image: url(100px-height-3x4-ratio.svg);
+  background-image: url("100px-height-3x4-ratio.svg");
   background-size: 150px auto;
 }
 ```
@@ -641,7 +641,7 @@ div {
 
 ```css live-sample___auto4
 div {
-  background-image: url(no-dimensions-1x1-ratio.svg);
+  background-image: url("no-dimensions-1x1-ratio.svg");
   background-size: 150px auto;
 }
 ```

--- a/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -26,7 +26,7 @@ In this example, three backgrounds are stacked: the Firefox logo, an image of bu
   width: 100%;
   height: 400px;
   background-image:
-    url(firefox.png), url(bubbles.png),
+    url("firefox.png"), url("bubbles.png"),
     linear-gradient(to right, rgb(30 75 115 / 100%), rgb(255 255 255 / 0%));
   background-repeat: no-repeat, no-repeat, no-repeat;
   background-position:

--- a/files/en-us/web/css/css_cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/css_cascade/shorthand_properties/index.md
@@ -20,7 +20,7 @@ A value which is not specified is set to its initial value. That means that it *
 ```css
 p {
   background-color: red;
-  background: url(images/bg.gif) no-repeat left top;
+  background: url("images/bg.gif") no-repeat left top;
 }
 ```
 
@@ -67,7 +67,7 @@ Consider a background with the following properties
 
 ```css
 background-color: #000;
-background-image: url(images/bg.gif);
+background-image: url("images/bg.gif");
 background-repeat: no-repeat;
 background-position: left top;
 ```
@@ -75,7 +75,7 @@ background-position: left top;
 These four declarations can be shortened to just one:
 
 ```css
-background: #000 url(images/bg.gif) no-repeat left top;
+background: #000 url("images/bg.gif") no-repeat left top;
 ```
 
 (The shorthand form is actually the equivalent of the longhand properties above plus `background-attachment: scroll` and, in CSS3, some additional properties.)

--- a/files/en-us/web/css/css_filter_effects/using_filter_effects/index.md
+++ b/files/en-us/web/css/css_filter_effects/using_filter_effects/index.md
@@ -246,7 +246,7 @@ A single SVG can be used to define several filters, each with an `id`:
 The filter's `id` is referenced in the `url()` for both inline and external SVGs:
 
 ```css
-filter: url(#blur3);
+filter: url("#blur3");
 filter: url("https://example.com/svg/filters.svg#blur3");
 ```
 
@@ -309,7 +309,7 @@ The SVG `url()` filter value can be included as the value of the SVG [`<image>`]
   filter: blur(3.5px);
 }
 .svgFilter {
-  filter: url(#blur);
+  filter: url("#blur");
 }
 ```
 

--- a/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -17,7 +17,7 @@ Suppose an image is given to every item with class `tool-btn`:
 
 ```css
 .tool-btn {
-  background: url(myfile.png);
+  background: url("myfile.png");
   display: inline-block;
   height: 20px;
   width: 20px;

--- a/files/en-us/web/css/css_masking/clipping/index.md
+++ b/files/en-us/web/css/css_masking/clipping/index.md
@@ -421,7 +421,7 @@ The `id` of the `<clipPath>` is the parameter of the {{cssxref("url_function", "
   width: 200px;
   height: 200px;
   background: linear-gradient(rebeccapurple, magenta) blue;
-  clip-path: url(#heart);
+  clip-path: url("#heart");
 }
 ```
 

--- a/files/en-us/web/css/css_masking/mask_properties/index.md
+++ b/files/en-us/web/css/css_masking/mask_properties/index.md
@@ -23,8 +23,8 @@ In this example, we create five mask layers, including an imported image, two gr
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
 }
 ```
 
@@ -41,8 +41,8 @@ If a `mask-*` property has a single value, this value applies to all the layers.
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-repeat: repeat-x, repeat-y;
   mask-position:
     center,
@@ -162,8 +162,8 @@ Continuing with the `masked-element` example, if we don't explicitly set the `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
 }
 ```
@@ -173,15 +173,15 @@ or, using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) match-source,
+    url("alphaImage.png") match-source,
     linear-gradient(to right, black, transparent) match-source,
     radial-gradient(circle, white 50%, transparent 75%) match-source,
     none match-source,
-    url(#svg-mask) match-source;
+    url("#svg-mask") match-source;
 }
 ```
 
-The first mask layer, `url(alphaImage.png)`, references an image. As this isn't a `<mask>` element within an `<svg>`, the `mask-mode` resolves to `alpha`, with the opaque parts of this image making the corresponding parts of the element visible, while the transparent or semi-transparent parts are invisible or partially visible.
+The first mask layer, `url("alphaImage.png")`, references an image. As this isn't a `<mask>` element within an `<svg>`, the `mask-mode` resolves to `alpha`, with the opaque parts of this image making the corresponding parts of the element visible, while the transparent or semi-transparent parts are invisible or partially visible.
 
 The `linear-gradient(to right, black, transparent)` is the second mask layer and `radial-gradient(circle, white 50%, transparent 75%)` is the third. Again, these aren't `<mask>` elements, so the `match-source` value resolves to `alpha`. The masking effect of these layers is determined by the [opaqueness of the gradient mask](/en-US/docs/Web/CSS/CSS_masking/Masking#opaqueness_versus_transparency) by default.
 
@@ -194,8 +194,8 @@ If we don't declare the `mask-mode` property at all, and allow it default to `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: alpha, alpha, alpha, match-source, luminance;
 }
 ```
@@ -205,11 +205,11 @@ or, using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) alpha,
+    url("alphaImage.png") alpha,
     linear-gradient(to right, black, transparent) alpha,
     radial-gradient(circle, white 50%, transparent 75%) alpha,
     none match-source,
-    url(#svg-mask) luminance;
+    url("#svg-mask") luminance;
 }
 ```
 
@@ -278,7 +278,7 @@ img {
 
 ```css live-sample___position live-sample___position_no-repeat
 img {
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
 }
 .keywords img {
   mask-position: bottom right;
@@ -326,8 +326,8 @@ If we don't explicitly set the `mask-position` property, it will default to `0% 
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
   mask-position: 0% 0%;
 }
@@ -338,11 +338,11 @@ or, expanding on the example using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) 0% 0% match-source,
+    url("alphaImage.png") 0% 0% match-source,
     linear-gradient(to right, black, transparent) 0% 0% match-source,
     radial-gradient(circle, white 50%, transparent 75%) 0% 0% match-source,
     none 0% 0% match-source,
-    url(#svg-mask) 0% 0% match-source;
+    url("#svg-mask") 0% 0% match-source;
 }
 ```
 
@@ -393,7 +393,7 @@ In this example, the `mask-position` places the initial mask in the top left cor
 
 ```css live-sample___origin live-sample___clip
 img {
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
   mask-position: top left;
   padding: 15px;
   border: 15px solid;
@@ -421,8 +421,8 @@ Continuing with the `masked-element` example, if we don't explicitly set the `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
   mask-position: 0% 0%;
   mask-origin: border-box;
@@ -434,12 +434,12 @@ or, expanding on the example using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) 0% 0% border-box match-source,
+    url("alphaImage.png") 0% 0% border-box match-source,
     linear-gradient(to right, black, transparent) 0% 0% border-box match-source,
     radial-gradient(circle, white 50%, transparent 75%) 0% 0% border-box
       match-source,
     none 0% 0% border-box match-source,
-    url(#svg-mask) 0% 0% border-box match-source;
+    url("#svg-mask") 0% 0% border-box match-source;
 }
 ```
 
@@ -516,8 +516,8 @@ Continuing with the `masked-element` example, if we don't explicitly set the `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
   mask-position: 0% 0%;
   mask-origin: border-box;
@@ -530,13 +530,13 @@ or, expanding on the example using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) 0% 0% border-box border-box match-source,
+    url("alphaImage.png") 0% 0% border-box border-box match-source,
     linear-gradient(to right, black, transparent) 0% 0% border-box border-box
       match-source,
     radial-gradient(circle, white 50%, transparent 75%) 0% 0% border-box
       border-box match-source,
     none 0% 0% border-box border-box match-source,
-    url(#svg-mask) 0% 0% border-box border-box match-source;
+    url("#svg-mask") 0% 0% border-box border-box match-source;
 }
 ```
 
@@ -589,7 +589,7 @@ With `cover`, `contain`, and `<percentage>` values, the size is relative to the 
 
 ```css hidden live-sample___size
 img {
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
   mask-position: top left;
   padding: 15px;
   border: 15px solid;
@@ -629,8 +629,8 @@ Continuing with the `masked-element` example, if we don't explicitly set the `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
   mask-position: 0% 0%;
   mask-origin: border-box;
@@ -644,13 +644,13 @@ or, expanding on the example using the `mask` shorthand, with the `mask-size` co
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) 0% 0% / auto border-box border-box match-source,
+    url("alphaImage.png") 0% 0% / auto border-box border-box match-source,
     linear-gradient(to right, black, transparent) 0% 0% / auto border-box
       border-box match-source,
     radial-gradient(circle, white 50%, transparent 75%) 0% 0% / auto border-box
       border-box match-source,
     none 0% 0% / auto border-box border-box match-source,
-    url(#svg-mask) 0% 0% / auto border-box border-box match-source;
+    url("#svg-mask") 0% 0% / auto border-box border-box match-source;
 }
 ```
 
@@ -665,8 +665,8 @@ Continuing with the `masked-element` example, if we don't explicitly set the `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
   mask-position: 0% 0%;
   mask-origin: border-box;
@@ -681,13 +681,13 @@ or, expanding on the example using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) 0% 0% / auto repeat border-box border-box match-source,
+    url("alphaImage.png") 0% 0% / auto repeat border-box border-box match-source,
     linear-gradient(to right, black, transparent) 0% 0% / auto repeat border-box
       border-box match-source,
     radial-gradient(circle, white 50%, transparent 75%) 0% 0% / auto repeat
       border-box border-box match-source,
     none 0% 0% / auto repeat border-box border-box match-source,
-    url(#svg-mask) 0% 0% / auto repeat border-box border-box match-source;
+    url("#svg-mask") 0% 0% / auto repeat border-box border-box match-source;
 }
 ```
 
@@ -729,7 +729,7 @@ img {
       #f005 20px 40px,
       transparent 40px 60px
     ),
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
 }
 ```
 
@@ -771,7 +771,7 @@ The `mask-composite` property is only relevant in cases with two or more mask la
 ```css live-sample___composite3
 img {
   mask-image:
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg),
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
     repeating-linear-gradient(
       to bottom right,
       #f00 0 20px,
@@ -812,11 +812,11 @@ If we reverse the order of the mask layers, we can also get very different resul
       #f005 20px 40px,
       transparent 40px 60px
     ),
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
 }
 .starFirst {
   mask-image:
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg),
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
     repeating-linear-gradient(
       to bottom right,
       #f00 0 20px,
@@ -839,8 +839,8 @@ Continuing with the `masked-element` example, if we don't explicitly set the `ma
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
   mask-mode: match-source;
   mask-position: 0% 0%;
   mask-origin: border-box;
@@ -858,14 +858,14 @@ Like we saw with all the other component properties, we could have used the `mas
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png) 0% 0% / auto repeat border-box border-box add
+    url("alphaImage.png") 0% 0% / auto repeat border-box border-box add
       match-source,
     linear-gradient(to right, black, transparent) 0% 0% / auto repeat border-box
       border-box add match-source,
     radial-gradient(circle, white 50%, transparent 75%) 0% 0% / auto repeat
       border-box border-box add match-source,
     none 0% 0% / auto repeat border-box border-box add match-source,
-    url(#svg-mask) 0% 0% / auto repeat border-box border-box add match-source;
+    url("#svg-mask") 0% 0% / auto repeat border-box border-box add match-source;
 }
 ```
 

--- a/files/en-us/web/css/css_masking/masking/index.md
+++ b/files/en-us/web/css/css_masking/masking/index.md
@@ -111,11 +111,11 @@ In this case we use an external PNG. The image contains a colorful heart with a 
 
 ```css live-sample___image1 live-sample___luminance1
 .applied-mask {
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/colorful-heart.png);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/colorful-heart.png");
   mask-size: 220px 220px;
 }
 .mask-source {
-  background: url(https://mdn.github.io/shared-assets/images/examples/colorful-heart.png);
+  background: url("https://mdn.github.io/shared-assets/images/examples/colorful-heart.png");
   background-size: 220px 220px;
 }
 ```
@@ -204,12 +204,12 @@ In this example, we have a white moon against a black night sky.
 
 ```css live-sample___luminance3
 .applied-mask {
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/moon.jpg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/moon.jpg");
   mask-mode: luminance;
   mask-size: 220px;
 }
 .mask-source {
-  background: url(https://mdn.github.io/shared-assets/images/examples/moon.jpg);
+  background: url("https://mdn.github.io/shared-assets/images/examples/moon.jpg");
   background-size: 220px;
 }
 ```
@@ -260,10 +260,10 @@ In this example, we define an SVG with a `<mask>` element, an identical {{SVGEle
 
 ```css live-sample___svg1
 .applied-mask {
-  mask-image: url(#mask-heart);
+  mask-image: url("#mask-heart");
 }
 .applied-clip {
-  clip-path: url(#clip-heart);
+  clip-path: url("#clip-heart");
 }
 ```
 

--- a/files/en-us/web/css/css_masking/multiple_masks/index.md
+++ b/files/en-us/web/css/css_masking/multiple_masks/index.md
@@ -54,11 +54,11 @@ As long as a comma-separated {{cssxref("mask-image")}} property declaration incl
 }
 
 .raster-mask {
-  mask-image: url(alphaImage.png);
+  mask-image: url("alphaImage.png");
 }
 
 .mask-element-mask {
-  mask-image: url(#svg-mask);
+  mask-image: url("#svg-mask");
 }
 ```
 
@@ -99,8 +99,8 @@ Otherwise, as long as there is a `mask-image` declared that isn't set to `none`,
 ```css
 .masked-element {
   mask-image:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
 }
 ```
 
@@ -111,8 +111,8 @@ We can also create the layers using the `mask` shorthand:
 ```css
 .masked-element {
   mask:
-    url(alphaImage.png), linear-gradient(to right, black, transparent),
-    radial-gradient(circle, white 50%, transparent 75%), none, url(#svg-mask);
+    url("alphaImage.png"), linear-gradient(to right, black, transparent),
+    radial-gradient(circle, white 50%, transparent 75%), none, url("#svg-mask");
 }
 ```
 
@@ -176,23 +176,23 @@ In this case, the order is very important. If only one or a pair of {{cssxref("l
 
 ```css
 mask:
-  url(star.svg) bottom 2em right 4em / auto 2vw no-repeat padding-box
+  url("star.svg") bottom 2em right 4em / auto 2vw no-repeat padding-box
     content-box luminance,
-  url(circle.svg) 100px 100px / 50% repeat-x border-box padding-box alpha;
+  url("circle.svg") 100px 100px / 50% repeat-x border-box padding-box alpha;
 ```
 
 If a single pair of `<length-percentage>` values is present, it sets the `mask-position` property, and the `mask-size` will be `auto`. If a layer includes both a `mask-size` and a `mask-position`, the `mask-size` property value must come after the `mask-position` property value and the values must be separated by a forward slash (`/`). The slash is required even if the `mask-size` is set to a value that is not a valid `mask-position` value.
 
 ```css example-bad
-mask: url(star.svg) contain;
-mask: url(star.svg) 10px 10px cover;
-mask: url(star.svg) top right 100px 100px;
+mask: url("star.svg") contain;
+mask: url("star.svg") 10px 10px cover;
+mask: url("star.svg") top right 100px 100px;
 ```
 
 ```css example-good
-mask: url(star.svg) 10px 10px / cover;
-mask: url(star.svg) top 100px right 100px;
-mask: url(star.svg) top right / 100px 100px;
+mask: url("star.svg") 10px 10px / cover;
+mask: url("star.svg") top 100px right 100px;
+mask: url("star.svg") top right / 100px 100px;
 ```
 
 To include a `mask-size` in a mask layer using the `mask` shorthand, you must include a `mask-position` value with a slash immediately before it.

--- a/files/en-us/web/css/css_shapes/overview_of_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/overview_of_shapes/index.md
@@ -162,7 +162,7 @@ body {
 
 img {
   float: left;
-  shape-outside: url(https://mdn.github.io/shared-assets/images/examples/round-balloon.png);
+  shape-outside: url("https://mdn.github.io/shared-assets/images/examples/round-balloon.png");
 }
 ```
 

--- a/files/en-us/web/css/css_shapes/shapes_from_images/index.md
+++ b/files/en-us/web/css/css_shapes/shapes_from_images/index.md
@@ -39,7 +39,7 @@ body {
 }
 img {
   float: left;
-  shape-outside: url(https://mdn.github.io/shared-assets/images/examples/star-shape.png);
+  shape-outside: url("https://mdn.github.io/shared-assets/images/examples/star-shape.png");
 }
 ```
 
@@ -73,7 +73,7 @@ body {
 
 img {
   float: left;
-  shape-outside: url(https://mdn.github.io/shared-assets/images/examples/star-shape.png);
+  shape-outside: url("https://mdn.github.io/shared-assets/images/examples/star-shape.png");
   shape-margin: 20px;
 }
 ```
@@ -120,7 +120,7 @@ body {
 
 img {
   float: left;
-  shape-outside: url(https://mdn.github.io/shared-assets/images/examples/star-red-20.png);
+  shape-outside: url("https://mdn.github.io/shared-assets/images/examples/star-red-20.png");
   shape-image-threshold: 0.2;
 }
 ```
@@ -159,7 +159,7 @@ body {
   float: left;
   width: 400px;
   height: 300px;
-  shape-outside: url(https://mdn.github.io/shared-assets/images/examples/star-shape.png);
+  shape-outside: url("https://mdn.github.io/shared-assets/images/examples/star-shape.png");
   shape-image-threshold: 0.3;
 }
 ```

--- a/files/en-us/web/css/css_syntax/error_handling/index.md
+++ b/files/en-us/web/css/css_syntax/error_handling/index.md
@@ -43,7 +43,7 @@ Statement at-rules, such as {{cssxref("@import")}} and {{cssxref("@namespace")}}
 
 ```css
 @import "assets/fonts.css" layer(fonts);
-@namespace svg url(http://www.w3.org/2000/svg);
+@namespace svg url("http://www.w3.org/2000/svg");
 ```
 
 If the parser encounters a curly brace (`{`) before a semi-colon is encountered, the at-rule is parsed as a block at-rule. [Block at-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule#block_at-rules) like {{cssxref("@font-face")}} and {{cssxref("@keyframes")}}, contain a block of declarations surrounded by curly braces (`{}`). The opening curly brace informs the browser where the at-rule prelude ends and the at-rule's body starts. The parser looks forward, seeking matching blocks (content surrounded by `()`, `{}`, or `[]`) until it finds a closing curly brace (`}`) that isn't matched by any other curly braces: this closes the body of the at-rule.

--- a/files/en-us/web/css/cursor/index.md
+++ b/files/en-us/web/css/cursor/index.md
@@ -69,21 +69,21 @@ cursor: pointer;
 cursor: zoom-out;
 
 /* URL with mandatory keyword fallback */
-cursor: url(hand.cur), pointer;
+cursor: url("hand.cur"), pointer;
 
 /* URL and coordinates, with mandatory keyword fallback */
 cursor:
-  url(cursor_1.png) 4 12,
+  url("cursor_1.png") 4 12,
   auto;
 cursor:
-  url(cursor_2.png) 2 2,
+  url("cursor_2.png") 2 2,
   pointer;
 
 /* URLs and fallback URLs (some with coordinates), with mandatory keyword fallback */
 cursor:
-  url(cursor_1.svg) 4 5,
-  url(cursor_2.svg),
-  /* …, */ url(cursor_n.cur) 5 5,
+  url("cursor_1.svg") 4 5,
+  url("cursor_2.svg"),
+  /* …, */ url("cursor_n.cur") 5 5,
   progress;
 
 /* Global values */

--- a/files/en-us/web/css/fill/index.md
+++ b/files/en-us/web/css/fill/index.md
@@ -28,12 +28,12 @@ fill: red;
 fill: hsl(120deg 75% 25% / 60%);
 
 /* <url> values */
-fill: url(#gradientElementID);
-fill: url(star.png);
+fill: url("#gradientElementID");
+fill: url("star.png");
 
 /* <url> with fallback */
-fill: url(#gradientElementID) blue;
-fill: url(star.png) none;
+fill: url("#gradientElementID") blue;
+fill: url("star.png") none;
 
 /* Global values */
 fill: inherit;
@@ -159,7 +159,7 @@ svg {
 ```css
 path {
   stroke-width: 2px;
-  marker: url(#circle);
+  marker: url("#circle");
 }
 path:nth-of-type(1) {
   stroke: red;

--- a/files/en-us/web/css/filter-function/blur/index.md
+++ b/files/en-us/web/css/filter-function/blur/index.md
@@ -69,8 +69,8 @@ The following declarations produce the same effect:
 
 ```css
 filter: blur(1.1px);
-filter: url(#blur11); /* with embedded SVG */
-filter: url(folder/fileName.svg#blur11); /* external svg filter definition */
+filter: url("#blur11"); /* with embedded SVG */
+filter: url("folder/fileName.svg#blur11"); /* external svg filter definition */
 ```
 
 ## Formal syntax
@@ -95,7 +95,7 @@ This example shows three images: the image with a `blur()` filter function appli
   <image
     href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
     xlink:href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
-    filter="url(#blur)" />
+    filter="url('#blur')" />
 </svg>
 ```
 
@@ -130,7 +130,7 @@ svg:not([height]) {
           <image
             href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
             xlink:href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
-            filter="url(#svgBlur)" />
+            filter="url('#svgBlur')" />
         </svg>
       </td>
       <td>

--- a/files/en-us/web/css/filter-function/brightness/index.md
+++ b/files/en-us/web/css/filter-function/brightness/index.md
@@ -78,7 +78,7 @@ This example shows how to apply the `brightness()` filter to a paragraph via the
 
 ```css
 .container {
-  background: url(be_fierce.jpg) no-repeat right / contain #d4d5b2;
+  background: url("be_fierce.jpg") no-repeat right / contain #d4d5b2;
 }
 p {
   backdrop-filter: brightness(150%);

--- a/files/en-us/web/css/filter-function/contrast/index.md
+++ b/files/en-us/web/css/filter-function/contrast/index.md
@@ -76,7 +76,7 @@ This example applies a `contrast()` filter via the {{cssxref("backdrop-filter")}
 
 ```css
 .container {
-  background: url(unity_for_the_people.jpg) no-repeat center / contain #339;
+  background: url("unity_for_the_people.jpg") no-repeat center / contain #339;
 }
 p {
   backdrop-filter: contrast(0.5);

--- a/files/en-us/web/css/font-palette/index.md
+++ b/files/en-us/web/css/font-palette/index.md
@@ -76,7 +76,7 @@ The HTML contains a single paragraph of text to animate:
 In the CSS, we import a [color font](https://www.colorfonts.wtf/) called [Nabla](https://nabla.typearture.com/) from [Google Fonts](https://fonts.google.com/?coloronly=true), and define two custom `font-palette` values using the {{cssxref("@font-palette-values")}} at-rule. We then create {{cssxref("@keyframes")}} that animate between these two palettes, and apply this animation to our paragraph.
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Nabla&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Nabla&display=swap";
 
 @font-palette-values --blueNabla {
   font-family: Nabla;

--- a/files/en-us/web/css/font-palette/palette-mix/index.md
+++ b/files/en-us/web/css/font-palette/palette-mix/index.md
@@ -77,7 +77,7 @@ The HTML contains three paragraphs to apply our font information to:
 In the CSS, we import a color font from Google Fonts, and define two custom `font-palette` values using the {{cssxref("@font-palette-values")}} at-rule. We then apply three different `font-palette` values to the paragraphs — `--yellow`, `--blue`, and a new green palette, created using `palette-mix()` to blend the blue and yellow palettes together.
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Nabla&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Nabla&display=swap";
 
 @font-palette-values --blueNabla {
   font-family: Nabla;

--- a/files/en-us/web/css/font-synthesis-position/index.md
+++ b/files/en-us/web/css/font-synthesis-position/index.md
@@ -72,7 +72,7 @@ This example shows turning off synthesis of the superscript and subscript typefa
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Montserrat&display=swap";
 
 * {
   font-family: "Montserrat", sans-serif;

--- a/files/en-us/web/css/font-synthesis-small-caps/index.md
+++ b/files/en-us/web/css/font-synthesis-small-caps/index.md
@@ -63,7 +63,7 @@ This example shows turning off synthesis of the small-caps typeface by the brows
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Montserrat&display=swap";
 
 .english {
   font-family: "Montserrat", sans-serif;

--- a/files/en-us/web/css/font-synthesis-style/index.md
+++ b/files/en-us/web/css/font-synthesis-style/index.md
@@ -66,7 +66,7 @@ This example shows turning off synthesis of the oblique typeface by the browser 
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Montserrat&display=swap";
 
 .english {
   font-family: "Montserrat", sans-serif;
@@ -110,7 +110,7 @@ This example compares all the `font-synthesis-style` values using italic and obl
 #### CSS
 
 ```css hidden
-@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Montserrat&display=swap";
 
 p {
   font-family: "Montserrat", sans-serif;

--- a/files/en-us/web/css/font-synthesis-weight/index.md
+++ b/files/en-us/web/css/font-synthesis-weight/index.md
@@ -63,7 +63,7 @@ This example shows turning off synthesis of the bold typeface by the browser in 
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Montserrat&display=swap";
 
 .english {
   font-family: "Montserrat", sans-serif;

--- a/files/en-us/web/css/font-synthesis/index.md
+++ b/files/en-us/web/css/font-synthesis/index.md
@@ -253,8 +253,8 @@ This example shows the browser's default font-synthesis behavior and compares it
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Ma+Shan+Zheng&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Montserrat&display=swap";
+@import "https://fonts.googleapis.com/css2?family=Ma+Shan+Zheng&display=swap";
 
 .english {
   font-family: "Montserrat", sans-serif;

--- a/files/en-us/web/css/image/index.md
+++ b/files/en-us/web/css/image/index.md
@@ -68,29 +68,29 @@ Browsers do not provide any special information on background images to assistiv
 ### Valid images
 
 ```css example-good
-url(test.jpg)               /* A <url>, as long as test.jpg is an actual image */
+url("test.jpg")               /* A <url>, as long as test.jpg is an actual image */
 linear-gradient(blue, red)  /* A <gradient> */
 element(#real-id)            /* A part of the webpage, referenced with the element() function,
                                if "real-id" is an existing ID on the page */
-image(ltr 'arrow.png#xywh=0,0,16,16', red)
+image(ltr "arrow.png#xywh=0,0,16,16", red)
                             /* A section 16x16 section of <url>, starting from the top, left of the original
                                image as long as arrow.png is a supported image, otherwise a solid
                                red swatch. If language is rtl, the image will be horizontally flipped. */
-cross-fade(20% url(twenty.png), url(eighty.png))
+cross-fade(20% url("twenty.png"), url("eighty.png"))
                             /* cross faded images, with twenty being 20% opaque
                                and eighty being 80% opaque. */
-image-set('test.jpg' 1x, 'test-2x.jpg' 2x)
+image-set("test.jpg' 1x, 'test-2x.jpg" 2x)
                             /* a selection of images with varying resolutions */
 ```
 
 ### Invalid images
 
 ```css example-bad
-no-url.jpg           /* An image file must be defined using the url() function. */
-url(report.pdf)      /* A file pointed to by the url() function must be an image. */
+"no-url.jpg"           /* An image file must be defined using the url() function. */
+url("report.pdf")      /* A file pointed to by the url() function must be an image. */
 element(#fakeid)     /* An element ID must be an existing ID on the page. */
 image(z.jpg#xy=0,0)  /* The spatial fragment must be written in the format of xywh=#,#,#,# */
-image-set('cat.jpg' 1x, 'dog.jpg' 1x) /* every image in an image set must have a different resolution */
+image-set("cat.jpg" 1x, "dog.jpg" 1x) /* every image in an image set must have a different resolution */
 ```
 
 ## Specifications

--- a/files/en-us/web/css/marker-end/index.md
+++ b/files/en-us/web/css/marker-end/index.md
@@ -17,7 +17,7 @@ For many marker-supporting shapes, the first and last vertices are the same poin
 
 ```css
 marker-end: none;
-marker-end: url(markers.svg#arrow);
+marker-end: url("markers.svg#arrow");
 
 /* Global values */
 marker-end: inherit;
@@ -78,7 +78,7 @@ svg {
 
 ```css
 polyline#test {
-  marker-end: url(#triangle);
+  marker-end: url("#triangle");
 }
 ```
 

--- a/files/en-us/web/css/marker-mid/index.md
+++ b/files/en-us/web/css/marker-mid/index.md
@@ -17,7 +17,7 @@ The direction each marker points is defined as the direction halfway between the
 
 ```css
 marker-mid: none;
-marker-mid: url(markers.svg#arrow);
+marker-mid: url("markers.svg#arrow");
 
 /* Global values */
 marker-mid: inherit;
@@ -78,7 +78,7 @@ svg {
 
 ```css
 polyline#test {
-  marker-mid: url(#triangle);
+  marker-mid: url("#triangle");
 }
 ```
 

--- a/files/en-us/web/css/marker-start/index.md
+++ b/files/en-us/web/css/marker-start/index.md
@@ -17,7 +17,7 @@ For many marker-supporting shapes, the first and last vertices are in the same p
 
 ```css
 marker-start: none;
-marker-start: url(markers.svg#arrow);
+marker-start: url("markers.svg#arrow");
 
 /* Global values */
 marker-start: inherit;
@@ -78,7 +78,7 @@ svg {
 
 ```css
 polyline#test {
-  marker-start: url(#triangle);
+  marker-start: url("#triangle");
 }
 ```
 

--- a/files/en-us/web/css/marker/index.md
+++ b/files/en-us/web/css/marker/index.md
@@ -19,7 +19,7 @@ For the middle vertices, the direction each marker points is defined as the dire
 
 ```css
 marker: none;
-marker: url(markers.svg#arrow);
+marker: url("markers.svg#arrow");
 
 /* Global values */
 marker: inherit;
@@ -80,7 +80,7 @@ svg {
 
 ```css
 polyline#test {
-  marker: url(#triangle);
+  marker: url("#triangle");
 }
 ```
 

--- a/files/en-us/web/css/mask-border-source/index.md
+++ b/files/en-us/web/css/mask-border-source/index.md
@@ -17,7 +17,7 @@ The {{cssxref("mask-border-slice")}} property is used to divide the source image
 mask-border-source: none;
 
 /* <image> values */
-mask-border-source: url(image.jpg);
+mask-border-source: url("image.jpg");
 mask-border-source: linear-gradient(to top, red, yellow);
 
 /* Global values */
@@ -50,13 +50,13 @@ mask-border-source: unset;
 This property doesn't appear to be supported anywhere yet. When it eventually starts to be supported, it will serve to define the source of the border mask.
 
 ```css
-mask-border-source: url(image.jpg);
+mask-border-source: url("image.jpg");
 ```
 
 Chromium-based browsers support an outdated version of this property — `mask-box-image-source` — with a prefix:
 
 ```css
--webkit-mask-box-image-source: url(image.jpg);
+-webkit-mask-box-image-source: url("image.jpg");
 ```
 
 > [!NOTE]

--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -107,7 +107,7 @@ div {
   margin: 10px;
   border: 20px solid #8ca0ff;
   padding: 20px;
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mdn.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mdn.svg");
   mask-size: 100% 100%;
 }
 .content-box {

--- a/files/en-us/web/css/mask-composite/index.md
+++ b/files/en-us/web/css/mask-composite/index.md
@@ -81,8 +81,8 @@ div {
   background-color: red;
 
   mask-image:
-    url(https://mdn.github.io/shared-assets/images/examples/mdn.svg),
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+    url("https://mdn.github.io/shared-assets/images/examples/mdn.svg"),
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
   mask-size: 100% 100%;
 
   mask-composite: subtract;
@@ -237,11 +237,11 @@ We then apply the heart and circle masks as the comma-separated {{cssxref("mask-
 ```css
 /* apply the mask images */
 tr.alphaMaskType img {
-  mask-image: url(#heartAlpha), url(#circleAlpha);
+  mask-image: url("#heartAlpha"), url("#circleAlpha");
 }
 
 tr.luminanceMaskType img {
-  mask-image: url(#heartLuminance), url(#circleLuminance);
+  mask-image: url("#heartLuminance"), url("#circleLuminance");
 }
 ```
 

--- a/files/en-us/web/css/mask-image/index.md
+++ b/files/en-us/web/css/mask-image/index.md
@@ -15,14 +15,14 @@ The **`mask-image`** [CSS](/en-US/docs/Web/CSS) property sets the image that is 
 mask-image: none;
 
 /* <mask-source> value */
-mask-image: url(masks.svg#mask1);
+mask-image: url("masks.svg#mask1");
 
 /* <image> values */
 mask-image: linear-gradient(rgb(0 0 0 / 100%), transparent);
-mask-image: image(url(mask.png), skyblue);
+mask-image: image(url("mask.png"), skyblue);
 
 /* Multiple values */
-mask-image: url(mask.png), linear-gradient(black 25%, transparent 35%);
+mask-image: url("mask.png"), linear-gradient(black 25%, transparent 35%);
 
 /* Global values */
 mask-image: inherit;
@@ -135,7 +135,7 @@ We use `mask-star.svg` as a mask image on our first image:
 
 ```css
 img:first-of-type {
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
 }
 ```
 
@@ -166,7 +166,7 @@ img {
   mask-position: center;
   mask-repeat: no-repeat;
   mask-image:
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg),
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
     repeating-radial-gradient(transparent 0 5px, black 5px 10px);
 }
 ```
@@ -244,16 +244,16 @@ We apply a different `<mask>` to each `<img>`. No part of the last image, with t
 
 ```css
 #green {
-  mask-image: url(#greenMask);
+  mask-image: url("#greenMask");
 }
 #stroke {
-  mask-image: url(#strokeMask);
+  mask-image: url("#strokeMask");
 }
 #both {
-  mask-image: url(#bothMask);
+  mask-image: url("#bothMask");
 }
 #alphaMode {
-  mask-image: url(#black);
+  mask-image: url("#black");
 }
 
 body:has(:checked) img {

--- a/files/en-us/web/css/mask-mode/index.md
+++ b/files/en-us/web/css/mask-mode/index.md
@@ -96,7 +96,7 @@ Each `<div>` is provided with the same background and masking image. The only di
 ```css
 div {
   background: blue linear-gradient(red, blue);
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mdn.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mdn.svg");
 }
 
 .alpha {

--- a/files/en-us/web/css/mask-origin/index.md
+++ b/files/en-us/web/css/mask-origin/index.md
@@ -112,7 +112,7 @@ div {
   border: 10px solid blue;
   background-color: #8cffa0;
   padding: 10px;
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
 }
 section {
   border: 1px solid black;
@@ -194,9 +194,9 @@ div {
   background-color: #8cffa0;
   padding: 10px;
   mask-image:
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg),
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg),
-    url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
+    url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
   mask-position:
     top left,
     top right,

--- a/files/en-us/web/css/mask-position/index.md
+++ b/files/en-us/web/css/mask-position/index.md
@@ -154,7 +154,7 @@ div {
   margin-bottom: 10px;
   background: blue linear-gradient(red, blue);
 
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("/shared-assets/images/examples/mask-star.svg");
   mask-repeat: no-repeat;
   mask-position: top right;
 }

--- a/files/en-us/web/css/mask-repeat/index.md
+++ b/files/en-us/web/css/mask-repeat/index.md
@@ -174,7 +174,7 @@ div {
   height: 250px;
   background-image: linear-gradient(red, blue);
 
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("/shared-assets/images/examples/mask-star.svg");
   mask-size: 100px 100px;
 
   mask-repeat: round space;
@@ -205,7 +205,7 @@ div {
   height: 250px;
   background-image: linear-gradient(red, blue);
 
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("/shared-assets/images/examples/mask-star.svg");
   mask-size: 100px 100px;
 
   mask-repeat: round space;
@@ -271,7 +271,7 @@ div {
   height: 180px;
   background-image: linear-gradient(red, blue);
 
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("/shared-assets/images/examples/mask-star.svg");
 
   mask-size: 50px 50px;
   mask-position: bottom right;

--- a/files/en-us/web/css/mask-size/index.md
+++ b/files/en-us/web/css/mask-size/index.md
@@ -125,7 +125,7 @@ div {
   width: 200px;
   height: 400px;
   background: blue linear-gradient(red, blue);
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mdn.svg);
+  mask-image: url("/shared-assets/images/examples/mdn.svg");
 }
 ```
 
@@ -184,7 +184,7 @@ div {
   width: 200px;
   height: 400px;
   background: blue linear-gradient(red, blue);
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("/shared-assets/images/examples/mask-star.svg");
 }
 ```
 
@@ -251,7 +251,7 @@ Using the same HTML and CSS as above, with just a different origin box size, thi
 ```css hidden
 div {
   background: blue linear-gradient(red, blue);
-  mask-image: url(https://mdn.github.io/shared-assets/images/examples/mask-star.svg);
+  mask-image: url("/shared-assets/images/examples/mask-star.svg");
 }
 
 .auto div {

--- a/files/en-us/web/css/mask-type/index.md
+++ b/files/en-us/web/css/mask-type/index.md
@@ -136,11 +136,11 @@ mask#luminanceMask {
 }
 
 img.alphaMaskType {
-  mask-image: url(#alphaMask);
+  mask-image: url("#alphaMask");
 }
 
 img.luminanceMaskType {
-  mask-image: url(#luminanceMask);
+  mask-image: url("#luminanceMask");
 }
 ```
 

--- a/files/en-us/web/css/mask/index.md
+++ b/files/en-us/web/css/mask/index.md
@@ -28,21 +28,21 @@ This property is a shorthand for the following CSS properties:
 mask: none;
 
 /* Image values */
-mask: url(mask.png); /* Raster image used as mask */
-mask: url(masks.svg#star); /* SVG used as mask */
+mask: url("mask.png"); /* Raster image used as mask */
+mask: url("masks.svg#star"); /* SVG used as mask */
 
 /* Combined values */
-mask: url(masks.svg#star) luminance; /* Luminance mask */
-mask: url(masks.svg#star) 40px 20px; /* Mask positioned 40px from the top and 20px from the left */
-mask: url(masks.svg#star) 0 0/50px 50px; /* Mask with a width and height of 50px */
-mask: url(masks.svg#star) repeat-x; /* Horizontally-repeated mask */
-mask: url(masks.svg#star) stroke-box; /* Mask extends to the inside edge of the stroke box */
-mask: url(masks.svg#star) exclude; /* Mask combined with background using non-overlapping parts */
+mask: url("masks.svg#star") luminance; /* Luminance mask */
+mask: url("masks.svg#star") 40px 20px; /* Mask positioned 40px from the top and 20px from the left */
+mask: url("masks.svg#star") 0 0/50px 50px; /* Mask with a width and height of 50px */
+mask: url("masks.svg#star") repeat-x; /* Horizontally-repeated mask */
+mask: url("masks.svg#star") stroke-box; /* Mask extends to the inside edge of the stroke box */
+mask: url("masks.svg#star") exclude; /* Mask combined with background using non-overlapping parts */
 
 /* Multiple masks */
 mask:
-  url(masks.svg#star) left / 16px repeat-y,
-  /* 16px-wide mask on the left side */ url(masks.svg#circle) right / 16px
+  url("masks.svg#star") left / 16px repeat-y,
+  /* 16px-wide mask on the left side */ url("masks.svg#circle") right / 16px
     repeat-y; /* 16px-wide mask against right side */
 
 /* Global values */

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -656,19 +656,19 @@ body {
 .R {
   transform-origin: center;
   transform: rotate(-30deg);
-  fill: url(#red);
+  fill: url("#red");
 }
 
 .G {
   transform-origin: center;
   transform: rotate(90deg);
-  fill: url(#green);
+  fill: url("#green");
 }
 
 .B {
   transform-origin: center;
   transform: rotate(210deg);
-  fill: url(#blue);
+  fill: url("#blue");
 }
 
 .isolate .group {
@@ -828,7 +828,7 @@ This example uses `mix-blend-mode` to blend text color with the background color
 #### CSS
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Rubik+Moonrocks&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Rubik+Moonrocks&display=swap";
 
 .container {
   background-color: blue;

--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -91,7 +91,7 @@ offset-path: ray(contain 150deg at center center);
 offset-path: ray(45deg);
 
 /* URL */
-offset-path: url(#myCircle);
+offset-path: url("#my-circle");
 
 /* Basic shape */
 offset-path: circle(50% at 25% 25%);
@@ -348,7 +348,7 @@ The SVG rectangle that defines the path shape is shown here only to visually dem
   height: 50px;
   border-radius: 50%;
   background-color: green;
-  offset-path: url(#svgRect);
+  offset-path: url("#svgRect");
   offset-anchor: auto;
   animation: move 5s linear infinite;
 }

--- a/files/en-us/web/css/offset/index.md
+++ b/files/en-us/web/css/offset/index.md
@@ -109,18 +109,18 @@ offset: none;
 /* Offset path */
 offset: ray(45deg closest-side);
 offset: path("M 100 100 L 300 100 L 200 300 z");
-offset: url(arc.svg);
+offset: url("arc.svg");
 
 /* Offset path with distance and/or rotation */
-offset: url(circle.svg) 100px;
-offset: url(circle.svg) 40%;
-offset: url(circle.svg) 30deg;
-offset: url(circle.svg) 50px 20deg;
+offset: url("circle.svg") 100px;
+offset: url("circle.svg") 40%;
+offset: url("circle.svg") 30deg;
+offset: url("circle.svg") 50px 20deg;
 
 /* Including offset anchor */
 offset: ray(45deg closest-side) / 40px 20px;
-offset: url(arc.svg) 2cm / 0.5cm 3cm;
-offset: url(arc.svg) 30deg / 50px 100px;
+offset: url("arc.svg") 2cm / 0.5cm 3cm;
+offset: url("arc.svg") 30deg / 50px 100px;
 
 /* Global values */
 offset: inherit;

--- a/files/en-us/web/css/shape-outside/index.md
+++ b/files/en-us/web/css/shape-outside/index.md
@@ -19,7 +19,7 @@ shape-outside: ellipse(130px 140px at 20% 20%);
 ```
 
 ```css interactive-example-choice
-shape-outside: url(/shared-assets/images/examples/round-balloon.png);
+shape-outside: url("/shared-assets/images/examples/round-balloon.png");
 ```
 
 ```css interactive-example-choice
@@ -80,7 +80,7 @@ shape-outside: circle() border-box;
 shape-outside: margin-box ellipse();
 
 /* <url> value */
-shape-outside: url(image.png);
+shape-outside: url("image.png");
 
 /* <gradient> value */
 shape-outside: linear-gradient(45deg, #fff 150px, red 150px);

--- a/files/en-us/web/css/stroke/index.md
+++ b/files/en-us/web/css/stroke/index.md
@@ -100,7 +100,7 @@ The pattern is then referenced in the CSS with a URL value pointing to the ID of
 ```css
 rect,
 circle {
-  stroke: url(#star);
+  stroke: url("#star");
 }
 ```
 
@@ -131,7 +131,7 @@ In the CSS, we apply that SVG gradient to the rectangle using a URL value pointi
 
 ```css
 rect {
-  stroke: url(#greenwhite);
+  stroke: url("#greenwhite");
 }
 circle {
   stroke: linear-gradient(90deg, green, white);
@@ -181,10 +181,10 @@ We then write CSS to add a marker to both paths, and also to have a dusky purple
 ```css
 path {
   stroke: hsl(270deg 50% 40%);
-  marker: url(#circle);
+  marker: url("#circle");
 }
 path:nth-of-type(2) {
-  stroke: url(#orangered);
+  stroke: url("#orangered");
 }
 marker circle {
   stroke: context-stroke;

--- a/files/en-us/web/css/type_selectors/index.md
+++ b/files/en-us/web/css/type_selectors/index.md
@@ -54,7 +54,7 @@ span {
 In this example the selector will only match `<h1>` elements in the example namespace.
 
 ```css
-@namespace example url(http://www.example.com/);
+@namespace example url("http://www.example.com/");
 example|h1 {
   color: blue;
 }

--- a/files/en-us/web/css/universal_selectors/index.md
+++ b/files/en-us/web/css/universal_selectors/index.md
@@ -76,7 +76,7 @@ The asterisk is optional with simple selectors. For instance, `*.warning` and `.
 In this example the selector will only match elements in the example namespace.
 
 ```css
-@namespace example url(http://www.example.com/);
+@namespace example url("http://www.example.com/");
 example|* {
   color: blue;
 }

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -13,6 +13,14 @@ The **`url()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Va
 >
 > In CSS Level 1, the `url()` functional notation described only true URLs. In CSS Level 2, the definition of `url()` was extended to describe any URI, whether a URL or a URN. Confusingly, this meant that `url()` could be used to create a `<uri>` CSS data type. This change was not only awkward but, debatably, unnecessary, since URNs are almost never used in actual CSS. To alleviate the confusion, CSS Level 3 returned to the narrower, initial definition. Now, `url()` denotes only true `<url>`s.
 
+Relative URLs, if used, are relative to the URL of the stylesheet (not to the URL of the web page).
+
+The **`url()`** function can be included as a value for
+{{cssxref('background')}}, {{cssxref('background-image')}}, {{cssxref('border')}}, {{cssxref('border-image')}}, {{cssxref('border-image-source')}}, {{cssxref('content')}}, {{cssxref('cursor')}}, {{cssxref('filter')}}, {{cssxref('list-style')}}, {{cssxref('list-style-image')}}, {{cssxref('mask')}}, {{cssxref('mask-image')}}, {{cssxref('offset-path')}}, {{cssxref('clip-path')}},
+[src](/en-US/docs/Web/CSS/@font-face/src) as part of a [`@font-face`](/en-US/docs/Web/CSS/@font-face) block, and [@counter-style/`symbol`](/en-US/docs/Web/CSS/@counter-style/symbols)
+
+## Syntax
+
 ```css
 /* Basic usage */
 url("https://example.com/images/myImg.jpg");
@@ -50,19 +58,6 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 @document url("https://www.example.com/") { /* … */ }
 @import url("https://www.example.com/style.css");
 @namespace url(http://www.w3.org/1999/xhtml);
-```
-
-Relative URLs, if used, are relative to the URL of the stylesheet (not to the URL of the web page).
-
-The **`url()`** function can be included as a value for
-{{cssxref('background')}}, {{cssxref('background-image')}}, {{cssxref('border')}}, {{cssxref('border-image')}}, {{cssxref('border-image-source')}}, {{cssxref('content')}}, {{cssxref('cursor')}}, {{cssxref('filter')}}, {{cssxref('list-style')}}, {{cssxref('list-style-image')}}, {{cssxref('mask')}}, {{cssxref('mask-image')}}, {{cssxref('offset-path')}}, {{cssxref('clip-path')}},
-[src](/en-US/docs/Web/CSS/@font-face/src) as part of a [`@font-face`](/en-US/docs/Web/CSS/@font-face) block, and [@counter-style/`symbol`](/en-US/docs/Web/CSS/@counter-style/symbols)
-
-## Syntax
-
-```css
-url("https://example.com/image.png")
-url(https://example.com/image.png)
 ```
 
 ### Values
@@ -164,11 +159,11 @@ When a URL is used as a path for a filter, the URL must be one of the following:
 
 ```css
 .blur {
-  filter: url(my-file.svg#svg-blur); /* the URL of an SVG file used as a filter */
+  filter: url("my-file.svg#svg-blur"); /* the URL of an SVG file used as a filter */
 }
 
 .inline-blur {
-  filter: url(#svg-blur); /* the ID of an SVG that is embedded in the HTML page */
+  filter: url("#svg-blur"); /* the ID of an SVG that is embedded in the HTML page */
 }
 ```
 

--- a/files/en-us/web/html/reference/attributes/rel/preload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/preload/index.md
@@ -169,9 +169,9 @@ Let's look at an example (see it on GitHub — [source code](https://github.com/
     const header = document.querySelector("header");
 
     if (mediaQueryList.matches) {
-      header.style.backgroundImage = "url(bg-image-narrow.png)";
+      header.style.backgroundImage = 'url("bg-image-narrow.png")';
     } else {
-      header.style.backgroundImage = "url(bg-image-wide.png)";
+      header.style.backgroundImage = 'url("bg-image-wide.png")';
     }
   </script>
 </body>

--- a/files/en-us/web/http/reference/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/style-src-elem/index.md
@@ -76,7 +76,7 @@ Content-Security-Policy: style-src-elem https://example.com/
 </style>
 
 <style>
-  @import url("https://not-example.com/styles/print.css") print;
+  @import "https://not-example.com/styles/print.css" print;
 </style>
 ```
 

--- a/files/en-us/web/http/reference/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/style-src/index.md
@@ -75,7 +75,7 @@ the following stylesheets are blocked and won't load:
 </style>
 
 <style>
-  @import url("https://not-example.com/styles/print.css") print;
+  @import "https://not-example.com/styles/print.css" print;
 </style>
 ```
 

--- a/files/en-us/web/svg/guides/applying_svg_effects_to_html_content/index.md
+++ b/files/en-us/web/svg/guides/applying_svg_effects_to_html_content/index.md
@@ -19,7 +19,7 @@ To apply an SVG effect using CSS styles, you first need to create the CSS style 
 
 ```css
 p {
-  mask: url(#my-mask);
+  mask: url("#my-mask");
 }
 ```
 
@@ -44,7 +44,7 @@ For example, you can make a gradient mask for HTML content using SVG and CSS cod
 
 ```css
 .target {
-  mask: url(#mask-1);
+  mask: url("#mask-1");
 }
 p {
   width: 300px;
@@ -109,7 +109,7 @@ This example demonstrates using SVG to clip HTML content. Notice that even the c
 
 ```css
 .target {
-  clip-path: url(#clipping-path-1);
+  clip-path: url("#clipping-path-1");
 }
 p {
   width: 300px;
@@ -225,22 +225,22 @@ The five filters are applied using the following CSS:
 
 ```css
 p.target {
-  filter: url(#f3);
+  filter: url("#f3");
 }
 p.target:hover {
-  filter: url(#f5);
+  filter: url("#f5");
 }
 em.target {
-  filter: url(#f1);
+  filter: url("#f1");
 }
 em.target:hover {
-  filter: url(#f4);
+  filter: url("#f4");
 }
 pre.target {
-  filter: url(#f2);
+  filter: url("#f2");
 }
 pre.target:hover {
-  filter: url(#f3);
+  filter: url("#f3");
 }
 ```
 
@@ -265,7 +265,7 @@ You can apply the SVG and the CSS filter in the same class:
 
 ```css
 .blur {
-  filter: url(#wherearemyglasses);
+  filter: url("#wherearemyglasses");
 }
 ```
 
@@ -295,7 +295,7 @@ For example, if your CSS is in a file named `default.css`, it can look like this
 
 ```css
 .target {
-  clip-path: url(resources.svg#c1);
+  clip-path: url("resources.svg#c1");
 }
 ```
 

--- a/files/en-us/web/svg/reference/attribute/fill/index.md
+++ b/files/en-us/web/svg/reference/attribute/fill/index.md
@@ -99,7 +99,7 @@ The {{SVGElement('circle')}} has `stroke="context-stroke"` and `fill="context-fi
   <style>
     path {
       stroke-width: 2px;
-      marker: url(#circle);
+      marker: url("#circle");
     }
   </style>
   <path d="M 10 44.64 L 30 10 L 70 10 L 90 44.64 L 70 79.28 L 30 79.28 Z"

--- a/files/en-us/web/svg/reference/attribute/stroke/index.md
+++ b/files/en-us/web/svg/reference/attribute/stroke/index.md
@@ -68,7 +68,7 @@ The {{SVGElement('circle')}} has `stroke="context-stroke"` and `fill="context-fi
   <style>
     path {
       stroke-width: 2px;
-      marker: url(#circle);
+      marker: url("#circle");
     }
   </style>
   <path d="M 10 44.64 L 30 10 L 70 10 L 90 44.64 L 70 79.28 L 30 79.28 Z"

--- a/files/en-us/web/svg/reference/element/a/index.md
+++ b/files/en-us/web/svg/reference/element/a/index.md
@@ -51,7 +51,7 @@ This element implements the {{domxref("SVGAElement")}} interface.
 ## Example
 
 ```css hidden
-@namespace svg url(http://www.w3.org/2000/svg);
+@namespace svg url("http://www.w3.org/2000/svg");
 html,
 body,
 svg {
@@ -77,7 +77,7 @@ svg {
 /* As SVG does not provide a default visual style for links,
    it's considered best practice to add some */
 
-@namespace svg url(http://www.w3.org/2000/svg);
+@namespace svg url("http://www.w3.org/2000/svg");
 /* Necessary to select only SVG <a> elements, and not also HTML's.
    See warning below */
 

--- a/files/en-us/web/svg/reference/element/fecomponenttransfer/index.md
+++ b/files/en-us/web/svg/reference/element/fecomponenttransfer/index.md
@@ -103,7 +103,7 @@ This element implements the {{domxref("SVGFEComponentTransferElement")}} interfa
 
 ```css
 rect {
-  fill: url(#rainbow);
+  fill: url("#rainbow");
 }
 ```
 

--- a/files/en-us/web/svg/reference/element/femorphology/index.md
+++ b/files/en-us/web/svg/reference/element/femorphology/index.md
@@ -53,11 +53,11 @@ text {
 }
 
 #thin {
-  filter: url(#erode);
+  filter: url("#erode");
 }
 
 #thick {
-  filter: url(#dilate);
+  filter: url("#dilate");
 }
 ```
 
@@ -92,11 +92,11 @@ p {
 }
 
 #thin {
-  filter: url(#erode);
+  filter: url("#erode");
 }
 
 #thick {
-  filter: url(#dilate);
+  filter: url("#dilate");
 }
 ```
 

--- a/files/en-us/web/svg/reference/element/marker/index.md
+++ b/files/en-us/web/svg/reference/element/marker/index.md
@@ -177,7 +177,7 @@ The following example shows how to use the `context-fill` and `context-stroke` v
 
   <style>
     path {
-      marker: url(#circle);
+      marker: url("#circle");
     }
   </style>
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
@@ -33,7 +33,7 @@ Linear gradients change along a straight line. To insert one, you create a {{SVG
   </defs>
   <style>
     #rect1 {
-      fill: url(#Gradient1);
+      fill: url("#Gradient1");
     }
     .stop1 {
       stop-color: red;
@@ -67,11 +67,13 @@ Above is an example of a linear gradient being applied to a `<rect>` element. In
 <stop offset="100%" stop-color="yellow" stop-opacity="0.5"/>
 ```
 
-To use a gradient, you have to reference it from an object's `fill` or `stroke` attribute. This is done the same way you reference elements in CSS, using a `url`. In this case, the url is just a reference to our gradient, which has the creative ID, "Gradient1". To attach it, set the `fill` to `url(#Gradient1)`, and voilà! Our object is now multicolored. You can do the same with `stroke`.
+To use a gradient, you have to reference it from an object's `fill` or `stroke` attribute. This is done the same way you reference elements in CSS, using a `url`. In this case, the url is just a reference to our gradient, which has the creative ID, "Gradient1". To attach it, set the `fill` to `url("#Gradient1")`, and voilà! Our object is now multicolored. You can do the same with `stroke`.
 
 ```svg
 <style>
-  #rect1 { fill: url(#Gradient1); }
+  #rect1 {
+    fill: url("#Gradient1");
+  }
 </style>
 ```
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
@@ -402,7 +402,7 @@ Notes about this demonstration:
 
   ```html
   <style>
-    @import url(style8.css);
+    @import "style8.css";
   </style>
   ```
 


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. This PR adds double quotes to all `url()` functions, and changes `@import url(...)` to `@import "..."`.