### PR TITLE
Fix hyperlink

### DIFF
--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -88,7 +88,7 @@ Additional functions, including `calc-mix()`, `crossorigin()`, `first-valid()`, 
 
 #### Units
 
-- [`%` (percentage)](/en-US/docs/Web/CSS/length#cap)
+- [`%` (percentage)](/en-US/docs/Web/CSS/percentage)
 - [`cap`](/en-US/docs/Web/CSS/length#cap)
 - [`ch`](/en-US/docs/Web/CSS/length#ch)
 - [`cm`](/en-US/docs/Web/CSS/length#cm)


### PR DESCRIPTION
### Description

Fixed wrong CSS' `%` (percentage) unit hyperlink. I think the reason is self-explanatory.

### Motivation

It helps with docs navigation.