### PR TITLE
the example comment is out of date, now Chrome give the same message with Firefox/Safari

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -24,7 +24,7 @@ try {
   Intl.getCanonicalLocales("EN_US");
 } catch (err) {
   console.log(err.toString());
-  // Expected output (Firefox/Safari/Chrome): RangeError: invalid language tag: "EN_US"
+  // Expected output: RangeError: invalid language tag: "EN_US"
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -24,8 +24,7 @@ try {
   Intl.getCanonicalLocales("EN_US");
 } catch (err) {
   console.log(err.toString());
-  // Expected output (Firefox/Safari): RangeError: invalid language tag: "EN_US"
-  // Expected output (Chrome): RangeError: Incorrect locale information provided
+  // Expected output (Firefox/Safari/Chrome): RangeError: invalid language tag: "EN_US"
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
@@ -16,8 +16,7 @@ const deListFormatter = new Intl.ListFormat("de-DE", { type: "disjunction" });
 const options = deListFormatter.resolvedOptions();
 
 console.log(options.locale);
-// Expected output (Firefox / Safari): "de-DE"
-// Expected output (Chrome): "de"
+// Expected output: "de-DE"
 
 console.log(options.style);
 // Expected output: "long"

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -16,8 +16,7 @@ const numberFormat = new Intl.NumberFormat("de-DE");
 const options = numberFormat.resolvedOptions();
 
 console.log(options.locale);
-// Expected output (Firefox / Safari): "de-DE"
-// Expected output (Chrome): "de"
+// Expected output: "de-DE"
 
 console.log(options.numberingSystem);
 // Expected output: "latn"

--- a/files/en-us/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -22,7 +22,7 @@ console.log(new RegExp("bar", "g").toString());
 // Expected output: "/bar/g"
 
 console.log(new RegExp("\n", "g").toString());
-// Expected output (if your browser supports escaping): "/\n/g"
+// Expected output: "/\n/g"
 
 console.log(new RegExp("\\n", "g").toString());
 // Expected output: "/\n/g"


### PR DESCRIPTION


### Description

the example comment is out of date, now Chrome give the same message with Firefox/Safari

<img width="2646" height="1990" alt="CleanShot 2025-08-03 at 19 26 45@2x" src="https://github.com/user-attachments/assets/499d57c0-12e0-47c4-998a-0c7683ab0521" />


### Motivation

correct the outdated info

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

fixes [#28238](https://github.com/mdn/translated-content/issues/28238)
