### PR TITLE
Lint: spaces around CSS comments, from/to keyframe selectors

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_todo_list_beginning/index.md
@@ -465,7 +465,7 @@ body {
     line-height: 1.31579;
   }
 }
-/*END RESETS*/
+/* END RESETS */
 
 /* GLOBAL STYLES */
 .form-group > input[type="text"] {

--- a/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
@@ -61,7 +61,7 @@ While this tutorial will not be using such tools, it's good to know that when in
 Add the following contents to the `reset.css` file:
 
 ```css
-/*reset.css*/
+/* reset.css */
 /* RESETS */
 *,
 *::before,
@@ -137,7 +137,7 @@ body {
     line-height: 1.31579;
   }
 }
-/*END RESETS*/
+/* END RESETS */
 ```
 
 Next, in your `src/main.js` file, import the `reset.css` file like so:

--- a/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/getting_started/index.md
@@ -563,9 +563,9 @@ div p + p {
 "Commenting out" code is also useful for temporarily disabling sections of code for testing. In the example below, the rules for `.special` are disabled by "commenting out" the code.
 
 ```css
-/*.special {
+/* .special {
   color: red;
-}*/
+} */
 
 p {
   color: blue;

--- a/files/en-us/web/accessibility/guides/colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/guides/colors_and_luminance/index.md
@@ -82,7 +82,7 @@ color: hsl(300deg 100% 50% / 100%);
 color: hwb(300deg 0% 0%);
 color: hwb(300 0% 0% / 1);
 
-/* by LAB representation of the sRGB value*/
+/* by LAB representation of the sRGB value */
 color: lab(60 93.56 -60.5);
 color: lab(60 93.56 -60.5 / 1);
 

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -113,13 +113,13 @@ Declarations in a keyframe qualified with `!important` are ignored.
 
 ```css
 @keyframes important1 {
-  from {
+  0% {
     margin-top: 50px;
   }
   50% {
     margin-top: 150px !important; /* ignored */
   }
-  to {
+  100% {
     margin-top: 100px;
   }
 }

--- a/files/en-us/web/css/all/index.md
+++ b/files/en-us/web/css/all/index.md
@@ -11,7 +11,7 @@ The **`all`** [shorthand](/en-US/docs/Web/CSS/CSS_cascade/Shorthand_properties) 
 {{InteractiveExample("CSS Demo: all")}}
 
 ```css interactive-example-choice
-/*no all property*/
+/* no all property */
 ```
 
 ```css interactive-example-choice

--- a/files/en-us/web/css/basic-shape/path/index.md
+++ b/files/en-us/web/css/basic-shape/path/index.md
@@ -150,7 +150,7 @@ svg {
   height: 100%;
 }
 
-/* This path is displayed on hover*/
+/* This path is displayed on hover */
 #svg_css_ex1:hover path {
   d: path("M20,80 L50,20 L80,80");
 }

--- a/files/en-us/web/css/font-style/index.md
+++ b/files/en-us/web/css/font-style/index.md
@@ -110,7 +110,7 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground.
   font:
     2rem "AmstelvarAlpha",
     sans-serif;
-  /*font-variation-settings: "slnt" 12;*/
+  /* font-variation-settings: "slnt" 12; */
   font-style: oblique 23deg;
 }
 ```

--- a/files/en-us/web/css/transform-function/matrix3d/index.md
+++ b/files/en-us/web/css/transform-function/matrix3d/index.md
@@ -210,7 +210,7 @@ Another `transform3d()` example, which implements an animated combined translate
 
 #### CSS
 
-```css-nolint
+```css
 html {
   width: 100%;
 }
@@ -236,7 +236,7 @@ body {
 }
 
 @keyframes MotionScale {
-  from {
+  0% {
     /*
       Identity matrix is used as basis here.
       The matrix below describes the
@@ -246,6 +246,7 @@ body {
         Translates every Z point by 0
         Scales down by 10%
     */
+    /* prettier-ignore */
     transform: matrix3d(
       1, 0, 0, 0,
       0, 1, 0, 0,
@@ -254,6 +255,7 @@ body {
     );
   }
   50% {
+    /* prettier-ignore */
     transform: matrix3d(
       1, 0, 0, 0,
       0, 1, 0, 0,
@@ -261,8 +263,9 @@ body {
       0, 0, 0, 0.9
     );
   }
-  to {
-     transform: matrix3d(
+  100% {
+    /* prettier-ignore */
+    transform: matrix3d(
       1, 0, 0, 0,
       0, 1, 0, 0,
       0, 0, 1, 0,

--- a/files/en-us/web/html/reference/elements/input/index.md
+++ b/files/en-us/web/html/reference/elements/input/index.md
@@ -895,7 +895,7 @@ It is possible to target different types of form controls based on their [`type`
 input[type="password"] {
 }
 
-/* matches a form control whose valid values are limited to a range of values*/
+/* matches a form control whose valid values are limited to a range of values */
 input[min][max] {
 }
 

--- a/files/en-us/web/svg/reference/attribute/d/index.md
+++ b/files/en-us/web/svg/reference/attribute/d/index.md
@@ -78,7 +78,7 @@ svg {
   height: 100%;
 }
 
-/* This path is displayed on hover*/
+/* This path is displayed on hover */
 #svg_css_ex1:hover path {
   d: path(
     "M10,30 A20,20 0,0,1 50,30 A20,20 0,0,1 90,30 Q90,60 50,90 Q10,60 10,30 z M5,5 L90,90"


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. This PR fixes two basic things: comments should start and end with a space, and the use of `from` and `to` selectors should follow our style guide.