### PR TITLE
FF142 Relnote Animation.commitStyles no longer requires fill

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -53,6 +53,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### DOM
 
 - The {{domxref("Selection.getComposedRanges()")}} method is now supported, allowing developers to accurately get selected text ranges across shadow DOM boundaries. In addition, the methods {{domxref("Selection.setBaseAndExtent()","setBaseAndExtent()")}}, {{domxref("Selection.collapse()","collapse()")}}, and {{domxref("Selection.extend()","extend()")}} of the {{domxref("Selection")}} interface have been modified to accept nodes inside a shadow root. ([Firefox bug 1903870](https://bugzil.la/1903870)).
+- The {{domxref("Animation.commitStyles()")}} method no longer requires that [`fill`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) is set on an animation in order to commit the computed styles after the animation has finished. Note that until more browsers support this change, code should continue to set `fill`. ([Firefox bug 19197320303870](https://bugzil.la/1973203)).
 
 <!-- #### Media, WebRTC, and Web Audio -->
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -53,7 +53,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### DOM
 
 - The {{domxref("Selection.getComposedRanges()")}} method is now supported, allowing developers to accurately get selected text ranges across shadow DOM boundaries. In addition, the methods {{domxref("Selection.setBaseAndExtent()","setBaseAndExtent()")}}, {{domxref("Selection.collapse()","collapse()")}}, and {{domxref("Selection.extend()","extend()")}} of the {{domxref("Selection")}} interface have been modified to accept nodes inside a shadow root. ([Firefox bug 1903870](https://bugzil.la/1903870)).
-- The {{domxref("Animation.commitStyles()")}} method no longer requires that [`fill`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) is set on an animation in order to commit the computed styles after the animation has finished. Note that until more browsers support this change, code should continue to set `fill`. ([Firefox bug 19197320303870](https://bugzil.la/1973203)).
+- The {{domxref("Animation.commitStyles()")}} method no longer requires [`fill`](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#fill) to be set on an animation to commit the computed styles after the animation has finished. Note that until more browsers support this change, you should continue to set `fill`. ([Firefox bug 1973203](https://bugzil.la/1973203)).
 
 <!-- #### Media, WebRTC, and Web Audio -->
 


### PR DESCRIPTION
FF142 [`Animation/commitStyles()`](https://developer.mozilla.org/en-US/docs/Web/API/Animation/commitStyles) allows animations to capture the final styles without specifying a `fill` in latest spec  - in https://bugzilla.mozilla.org/show_bug.cgi?id=1973203

This adds a release note. 

Related docs work in #40482