### PR TITLE
Lint: use named color if possible (4)

### DIFF
--- a/files/en-us/web/css/--_star_/index.md
+++ b/files/en-us/web/css/--_star_/index.md
@@ -16,7 +16,7 @@ Custom properties are scoped to the element(s) they are declared on, and partici
 
 ```css
 --some-keyword: left;
---some-color: #0000ff;
+--some-color: #123456;
 --some-complex-value: 3px 6px rgb(20 32 54);
 ```
 

--- a/files/en-us/web/css/-webkit-text-fill-color/index.md
+++ b/files/en-us/web/css/-webkit-text-fill-color/index.md
@@ -13,7 +13,7 @@ The **`-webkit-text-fill-color`** [CSS](/en-US/docs/Web/CSS) property specifies 
 ```css
 /* <color> values */
 -webkit-text-fill-color: red;
--webkit-text-fill-color: #000000;
+-webkit-text-fill-color: #123456;
 -webkit-text-fill-color: rgb(100 200 0);
 
 /* Global values */

--- a/files/en-us/web/css/-webkit-text-stroke-color/index.md
+++ b/files/en-us/web/css/-webkit-text-stroke-color/index.md
@@ -55,7 +55,7 @@ p {
   margin: 0;
   font-size: 4em;
   -webkit-text-stroke-width: 3px;
-  -webkit-text-stroke-color: #ff0000; /* Can be changed in the live sample */
+  -webkit-text-stroke-color: red; /* Can be changed in the live sample */
 }
 ```
 

--- a/files/en-us/web/css/@font-palette-values/override-colors/index.md
+++ b/files/en-us/web/css/@font-palette-values/override-colors/index.md
@@ -25,15 +25,9 @@ override-colors: 0 rgb(255 0 0);
 
 /* overriding multiple colors */
 override-colors:
-  0 #f00,
-  1 #0f0,
-  2 #00f;
-
-/* overriding multiple colors with readability */
-override-colors:
-  0 #f00,
-  1 #0f0,
-  2 #00f;
+  0 red,
+  1 green,
+  2 blue;
 ```
 
 The `override-colors` [descriptor](/en-US/docs/Glossary/CSS_Descriptor) takes a comma-separated list of the color index and new color value.

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -51,7 +51,7 @@ div.box {
   display: inline-block;
   padding: 1em;
   margin: 6px;
-  outline: 2px solid #000;
+  outline: 2px solid black;
   width: 12em;
   height: 2em;
   vertical-align: middle;
@@ -69,7 +69,7 @@ Theme A (brown) uses a light color scheme by default, but will switch to a dark 
   .theme-a.adaptive {
     background: #753;
     color: #dcb;
-    outline: 5px dashed #000;
+    outline: 5px dashed black;
   }
 }
 ```
@@ -85,7 +85,7 @@ Theme B (blue) uses a dark color scheme by default, but will switch to a light s
   .theme-b.adaptive {
     background: #bcd;
     color: #334;
-    outline: 5px dotted #000;
+    outline: 5px dotted black;
   }
 }
 ```

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -68,7 +68,7 @@ This example uses a scaling animation for the purpose of demonstrating `prefers-
 
 ```css hidden
 .animation {
-  color: #fff;
+  color: white;
   font: 1.2em sans-serif;
   width: 10em;
   padding: 1em;

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -329,17 +329,18 @@ const sectionElem = document.querySelector("section");
 
 btn.addEventListener("click", createColumn);
 
-function randomColor() {
+function randomBackground() {
   function randomNum() {
     return Math.floor(Math.random() * 255);
   }
+  const baseColor = `${randomNum()} ${randomNum()} ${randomNum()}`;
 
-  return `rgb(${randomNum()} ${randomNum()} ${randomNum()})`;
+  return `linear-gradient(to right, rgb(${baseColor} / 0), rgb(${baseColor} / 0.5))`;
 }
 
 function createColumn() {
   const divElem = document.createElement("div");
-  divElem.style.backgroundColor = randomColor();
+  divElem.style.background = randomBackground();
 
   const closeBtn = document.createElement("button");
   closeBtn.textContent = "✖";
@@ -399,7 +400,6 @@ div {
   flex: 1;
   border: 1px solid gray;
   position: relative;
-  background: linear-gradient(to right, transparent, rgb(255 255 255 / 50%));
   opacity: 1;
   scale: 1 1;
 

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -262,7 +262,7 @@ html {
 
 /* Transition for the popover's backdrop */
 [popover]::backdrop {
-  background-color: rgb(0 0 0 / 0%);
+  background-color: transparent;
   transition:
     display 0.7s allow-discrete,
     overlay 0.7s allow-discrete,
@@ -279,7 +279,7 @@ html {
 so specify a standalone starting-style block. */
 @starting-style {
   [popover]:popover-open::backdrop {
-    background-color: rgb(0 0 0 / 0%);
+    background-color: transparent;
   }
 }
 ```
@@ -399,11 +399,7 @@ div {
   flex: 1;
   border: 1px solid gray;
   position: relative;
-  background: linear-gradient(
-    to right,
-    rgb(255 255 255 / 0%),
-    rgb(255 255 255 / 50%)
-  );
+  background: linear-gradient(to right, transparent, rgb(255 255 255 / 50%));
   opacity: 1;
   scale: 1 1;
 

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -77,11 +77,11 @@ function init() {
 /* Changes paragraph text color from black to white when
    a .dark-theme class is applied to the document body */
 p {
-  color: #000;
+  color: black;
 }
 
 :host-context(body.dark-theme) p {
-  color: #fff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/_colon_invalid/index.md
+++ b/files/en-us/web/css/_colon_invalid/index.md
@@ -110,7 +110,7 @@ form:valid {
 }
 
 input:required {
-  border-color: #800000;
+  border-color: maroon;
   border-width: 3px;
 }
 

--- a/files/en-us/web/css/_colon_required/index.md
+++ b/files/en-us/web/css/_colon_required/index.md
@@ -102,7 +102,7 @@ label {
 }
 
 input:required {
-  border-color: #800000;
+  border-color: maroon;
   border-width: 3px;
 }
 

--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -76,7 +76,7 @@ Authors should avoid styling scrollbars, as changing the appearance of scrollbar
 
 /* Add a thumb */
 .mostly-customized-scrollbar::-webkit-scrollbar-thumb {
-  background: #000;
+  background: black;
 }
 ```
 

--- a/files/en-us/web/css/_doublecolon_after/index.md
+++ b/files/en-us/web/css/_doublecolon_after/index.md
@@ -161,7 +161,7 @@ We can also support keyboard users with this technique, by adding a `tabindex` o
 span[data-description] {
   position: relative;
   text-decoration: underline;
-  color: #00f;
+  color: blue;
   cursor: help;
 }
 
@@ -176,7 +176,7 @@ span[data-description]:focus::after {
   border-radius: 10px;
   background-color: #ffffcc;
   padding: 12px;
-  color: #000000;
+  color: black;
   font-size: 14px;
   z-index: 1;
 }

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -95,9 +95,9 @@ We add a background to the backdrop, creating a colorful donut using [CSS gradie
   background-image:
     radial-gradient(
       circle,
-      #fff 0 5vw,
+      white 0 5vw,
       transparent 5vw 20vw,
-      #fff 20vw 22.5vw,
+      white 20vw 22.5vw,
       #eee 22.5vw
     ),
     conic-gradient(

--- a/files/en-us/web/css/_doublecolon_before/index.md
+++ b/files/en-us/web/css/_doublecolon_before/index.md
@@ -12,7 +12,7 @@ In CSS, **`::before`** creates a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-ele
 
 ```css interactive-example
 a {
-  color: #0000ff;
+  color: blue;
   text-decoration: none;
 }
 

--- a/files/en-us/web/css/_doublecolon_checkmark/index.md
+++ b/files/en-us/web/css/_doublecolon_checkmark/index.md
@@ -65,7 +65,7 @@ option:last-of-type {
 }
 
 option:nth-of-type(odd) {
-  background: #fff;
+  background: white;
 }
 
 option:not(option:last-of-type) {

--- a/files/en-us/web/css/_doublecolon_cue/index.md
+++ b/files/en-us/web/css/_doublecolon_cue/index.md
@@ -95,7 +95,7 @@ The following CSS sets the cue style so that the text is white and the backgroun
 
 ```css
 ::cue {
-  color: #fff;
+  color: white;
   background-color: rgb(0 0 0 / 60%);
 }
 ```

--- a/files/en-us/web/css/_doublecolon_highlight/index.md
+++ b/files/en-us/web/css/_doublecolon_highlight/index.md
@@ -47,31 +47,31 @@ In particular, {{CSSxRef("background-image")}} is ignored.
 }
 
 ::highlight(rainbow-color-1) {
-  color: #ad26ad;
+  color: violet;
   text-decoration: underline;
 }
 ::highlight(rainbow-color-2) {
-  color: #5d0a99;
+  color: purple;
   text-decoration: underline;
 }
 ::highlight(rainbow-color-3) {
-  color: #0000ff;
+  color: blue;
   text-decoration: underline;
 }
 ::highlight(rainbow-color-4) {
-  color: #07c607;
+  color: green;
   text-decoration: underline;
 }
 ::highlight(rainbow-color-5) {
-  color: #b3b308;
+  color: yellow;
   text-decoration: underline;
 }
 ::highlight(rainbow-color-6) {
-  color: #ffa500;
+  color: orange;
   text-decoration: underline;
 }
 ::highlight(rainbow-color-7) {
-  color: #ff0000;
+  color: red;
   text-decoration: underline;
 }
 ```

--- a/files/en-us/web/css/_doublecolon_scroll-button/index.md
+++ b/files/en-us/web/css/_doublecolon_scroll-button/index.md
@@ -122,13 +122,14 @@ ul::scroll-button(*) {
   border: 0;
   font-size: 2rem;
   background: none;
-  color: rgb(0 0 0 / 0.7);
+  color: black;
+  opacity: 0.7;
   cursor: pointer;
 }
 
 ul::scroll-button(*):hover,
 ul::scroll-button(*):focus {
-  color: black;
+  opacity: 1;
 }
 
 ul::scroll-button(*):active {
@@ -136,7 +137,7 @@ ul::scroll-button(*):active {
 }
 
 ul::scroll-button(*):disabled {
-  color: rgb(0 0 0 / 0.2);
+  opacity: 0.2;
   cursor: unset;
 }
 ```

--- a/files/en-us/web/css/_doublecolon_scroll-button/index.md
+++ b/files/en-us/web/css/_doublecolon_scroll-button/index.md
@@ -128,7 +128,7 @@ ul::scroll-button(*) {
 
 ul::scroll-button(*):hover,
 ul::scroll-button(*):focus {
-  color: rgb(0 0 0 / 1);
+  color: black;
 }
 
 ul::scroll-button(*):active {

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -222,7 +222,7 @@ select {
 
 div > div {
   box-sizing: border-box;
-  border: 2px solid #fff;
+  border: 2px solid white;
   width: 100px;
   display: flex;
   align-items: center;

--- a/files/en-us/web/css/backface-visibility/index.md
+++ b/files/en-us/web/css/backface-visibility/index.md
@@ -207,7 +207,7 @@ This example shows a cube with transparent faces, and one with opaque faces.
 }
 
 .back {
-  background: rgb(0 255 0 / 100%);
+  background: lime;
   color: black;
   transform: rotateY(180deg) translateZ(50px);
 }

--- a/files/en-us/web/css/background-attachment/index.md
+++ b/files/en-us/web/css/background-attachment/index.md
@@ -69,8 +69,8 @@ body {
   overflow: auto;
   padding: 20px;
   text-shadow:
-    0 0 0.6rem #000,
-    0 0 0.6rem #000;
+    0 0 0.6rem black,
+    0 0 0.6rem black;
 }
 ```
 

--- a/files/en-us/web/css/background-color/index.md
+++ b/files/en-us/web/css/background-color/index.md
@@ -138,7 +138,7 @@ This example demonstrates the applying `background-color` to HTML {{HTMLelement(
 
 .example-three {
   background-color: #777799;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/background-origin/index.md
+++ b/files/en-us/web/css/background-origin/index.md
@@ -122,7 +122,7 @@ In this example the box has a thick dotted border. The first gradient uses the `
 ```css
 .box {
   margin: 10px 0;
-  color: #fff;
+  color: white;
   background:
     linear-gradient(
       90deg,
@@ -130,7 +130,7 @@ In this example the box has a thick dotted border. The first gradient uses the `
       rgb(253 29 29 / 60%) 60%,
       rgb(252 176 69 / 100%) 100%
     ),
-    radial-gradient(circle, rgb(255 255 255 / 100%) 0%, rgb(0 0 0 / 100%) 28%);
+    radial-gradient(circle, white 0%, black 28%);
   border: 20px dashed black;
   padding: 20px;
   width: 400px;

--- a/files/en-us/web/css/block-size/index.md
+++ b/files/en-us/web/css/block-size/index.md
@@ -44,7 +44,7 @@ writing-mode: vertical-lr;
   flex-direction: column;
   background-color: #5b6dcd;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/border-block-color/index.md
+++ b/files/en-us/web/css/border-block-color/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-end-color/index.md
+++ b/files/en-us/web/css/border-block-end-color/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-end-style/index.md
+++ b/files/en-us/web/css/border-block-end-style/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-end-width/index.md
+++ b/files/en-us/web/css/border-block-end-width/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-end/index.md
+++ b/files/en-us/web/css/border-block-end/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-block-start-color/index.md
+++ b/files/en-us/web/css/border-block-start-color/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-start-style/index.md
+++ b/files/en-us/web/css/border-block-start-style/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-start-width/index.md
+++ b/files/en-us/web/css/border-block-start-width/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-start/index.md
+++ b/files/en-us/web/css/border-block-start/index.md
@@ -41,7 +41,7 @@ writing-mode: vertical-lr;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-block-style/index.md
+++ b/files/en-us/web/css/border-block-style/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-width/index.md
+++ b/files/en-us/web/css/border-block-width/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block/index.md
+++ b/files/en-us/web/css/border-block/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-bottom-color/index.md
+++ b/files/en-us/web/css/border-bottom-color/index.md
@@ -41,7 +41,7 @@ border-bottom-color: transparent;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-bottom-style/index.md
+++ b/files/en-us/web/css/border-bottom-style/index.md
@@ -45,7 +45,7 @@ border-bottom-style: inset;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;
@@ -53,7 +53,7 @@ border-bottom-style: inset;
 }
 
 body {
-  background-color: #fff;
+  background-color:;
 }
 ```
 

--- a/files/en-us/web/css/border-bottom-style/index.md
+++ b/files/en-us/web/css/border-bottom-style/index.md
@@ -53,7 +53,7 @@ border-bottom-style: inset;
 }
 
 body {
-  background-color:;
+  background-color: white;
 }
 ```
 

--- a/files/en-us/web/css/border-bottom-width/index.md
+++ b/files/en-us/web/css/border-bottom-width/index.md
@@ -41,7 +41,7 @@ border-bottom-width: 0;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-bottom/index.md
+++ b/files/en-us/web/css/border-bottom/index.md
@@ -41,7 +41,7 @@ border-bottom: 4mm ridge rgb(211 220 50 / 0.6);
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-color/index.md
+++ b/files/en-us/web/css/border-color/index.md
@@ -41,7 +41,7 @@ border-color: red yellow green transparent;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-end-end-radius/index.md
+++ b/files/en-us/web/css/border-end-end-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color: #fff;
+  background-color:;
   border-end-end-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-end-end-radius/index.md
+++ b/files/en-us/web/css/border-end-end-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color:;
+  background-color: white;
   border-end-end-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-end-start-radius/index.md
+++ b/files/en-us/web/css/border-end-start-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color: #fff;
+  background-color:;
   border-end-start-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-end-start-radius/index.md
+++ b/files/en-us/web/css/border-end-start-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color:;
+  background-color: white;
   border-end-start-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-image-outset/index.md
+++ b/files/en-us/web/css/border-image-outset/index.md
@@ -43,7 +43,7 @@ border-image-outset: 40px;
   justify-content: center;
   padding: 50px;
   background: #fff3d4;
-  color: #000;
+  color: black;
   border: 30px solid;
   border-image: url("/shared-assets/images/examples/border-diamonds.png") 30
     round;

--- a/files/en-us/web/css/border-image-repeat/index.md
+++ b/files/en-us/web/css/border-image-repeat/index.md
@@ -45,7 +45,7 @@ border-image-repeat: round stretch;
   justify-content: center;
   padding: 50px;
   background: #fff3d4;
-  color: #000;
+  color: black;
   border: 30px solid;
   border-image: url("/shared-assets/images/examples/border-diamonds.png") 30
     round;

--- a/files/en-us/web/css/border-image-slice/index.md
+++ b/files/en-us/web/css/border-image-slice/index.md
@@ -43,7 +43,7 @@ border-image-width: 30px 48px;
   justify-content: center;
   padding: 50px;
   background: #fff3d4;
-  color: #000;
+  color: black;
   border: 30px solid;
   border-image: url("/shared-assets/images/examples/border-diamonds.png") 30
     round;

--- a/files/en-us/web/css/border-image-source/index.md
+++ b/files/en-us/web/css/border-image-source/index.md
@@ -45,7 +45,7 @@ border-image-source: none;
   justify-content: center;
   padding: 50px;
   background: #fff3d4;
-  color: #000;
+  color: black;
   border: 30px solid;
   border-image: url("/shared-assets/images/examples/border-diamonds.png") 30
     round;

--- a/files/en-us/web/css/border-image-width/index.md
+++ b/files/en-us/web/css/border-image-width/index.md
@@ -41,7 +41,7 @@ border-image-width: 20% 8%;
   justify-content: center;
   padding: 50px;
   background: #fff3d4;
-  color: #000;
+  color: black;
   border: 30px solid;
   border-image: url("/shared-assets/images/examples/border-diamonds.png") 30
     round;

--- a/files/en-us/web/css/border-image/index.md
+++ b/files/en-us/web/css/border-image/index.md
@@ -48,7 +48,7 @@ border-image: repeating-linear-gradient(30deg, #4d9f0c, #9198e5, #4d9f0c 20px)
   justify-content: center;
   padding: 50px;
   background: #fff3d4;
-  color: #000;
+  color: black;
   border: 30px solid;
   border-image: url("/shared-assets/images/examples/border-diamonds.png") 30
     round;

--- a/files/en-us/web/css/border-inline-color/index.md
+++ b/files/en-us/web/css/border-inline-color/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-end-color/index.md
+++ b/files/en-us/web/css/border-inline-end-color/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-end-style/index.md
+++ b/files/en-us/web/css/border-inline-end-style/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-end-width/index.md
+++ b/files/en-us/web/css/border-inline-end-width/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-end/index.md
+++ b/files/en-us/web/css/border-inline-end/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-inline-start-color/index.md
+++ b/files/en-us/web/css/border-inline-start-color/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-start-style/index.md
+++ b/files/en-us/web/css/border-inline-start-style/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-start-width/index.md
+++ b/files/en-us/web/css/border-inline-start-width/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-start/index.md
+++ b/files/en-us/web/css/border-inline-start/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-inline-style/index.md
+++ b/files/en-us/web/css/border-inline-style/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-width/index.md
+++ b/files/en-us/web/css/border-inline-width/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline/index.md
+++ b/files/en-us/web/css/border-inline/index.md
@@ -37,7 +37,7 @@ direction: rtl;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-left-color/index.md
+++ b/files/en-us/web/css/border-left-color/index.md
@@ -41,7 +41,7 @@ border-left-color: transparent;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-left-style/index.md
+++ b/files/en-us/web/css/border-left-style/index.md
@@ -45,7 +45,7 @@ border-left-style: inset;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;
@@ -53,7 +53,7 @@ border-left-style: inset;
 }
 
 body {
-  background-color: #fff;
+  background-color:;
 }
 ```
 

--- a/files/en-us/web/css/border-left-style/index.md
+++ b/files/en-us/web/css/border-left-style/index.md
@@ -53,7 +53,7 @@ border-left-style: inset;
 }
 
 body {
-  background-color:;
+  background-color: white;
 }
 ```
 

--- a/files/en-us/web/css/border-left-width/index.md
+++ b/files/en-us/web/css/border-left-width/index.md
@@ -41,7 +41,7 @@ border-left-width: 0;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-left/index.md
+++ b/files/en-us/web/css/border-left/index.md
@@ -41,7 +41,7 @@ border-left: 4mm ridge rgb(211 220 50 / 0.6);
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-right-color/index.md
+++ b/files/en-us/web/css/border-right-color/index.md
@@ -41,7 +41,7 @@ border-right-color: transparent;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-right-style/index.md
+++ b/files/en-us/web/css/border-right-style/index.md
@@ -45,7 +45,7 @@ border-right-style: inset;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;
@@ -53,7 +53,7 @@ border-right-style: inset;
 }
 
 body {
-  background-color: #fff;
+  background-color:;
 }
 ```
 

--- a/files/en-us/web/css/border-right-style/index.md
+++ b/files/en-us/web/css/border-right-style/index.md
@@ -53,7 +53,7 @@ border-right-style: inset;
 }
 
 body {
-  background-color:;
+  background-color: white;
 }
 ```
 

--- a/files/en-us/web/css/border-right-width/index.md
+++ b/files/en-us/web/css/border-right-width/index.md
@@ -41,7 +41,7 @@ border-right-width: 0;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-right/index.md
+++ b/files/en-us/web/css/border-right/index.md
@@ -41,7 +41,7 @@ border-right: 4mm ridge rgb(211 220 50 / 0.6);
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-start-end-radius/index.md
+++ b/files/en-us/web/css/border-start-end-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color: #fff;
+  background-color:;
   border-start-end-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-start-end-radius/index.md
+++ b/files/en-us/web/css/border-start-end-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color:;
+  background-color: white;
   border-start-end-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-start-start-radius/index.md
+++ b/files/en-us/web/css/border-start-start-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color: #fff;
+  background-color:;
   border-start-start-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-start-start-radius/index.md
+++ b/files/en-us/web/css/border-start-start-radius/index.md
@@ -109,7 +109,7 @@ div {
 .exampleText {
   writing-mode: vertical-rl;
   padding: 10px;
-  background-color:;
+  background-color: white;
   border-start-start-radius: 10px;
 }
 ```

--- a/files/en-us/web/css/border-style/index.md
+++ b/files/en-us/web/css/border-style/index.md
@@ -53,7 +53,7 @@ border-style: dashed groove none dotted;
 }
 
 body {
-  background-color:;
+  background-color: white;
 }
 ```
 

--- a/files/en-us/web/css/border-style/index.md
+++ b/files/en-us/web/css/border-style/index.md
@@ -45,7 +45,7 @@ border-style: dashed groove none dotted;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;
@@ -53,7 +53,7 @@ border-style: dashed groove none dotted;
 }
 
 body {
-  background-color: #fff;
+  background-color:;
 }
 ```
 

--- a/files/en-us/web/css/border-top-color/index.md
+++ b/files/en-us/web/css/border-top-color/index.md
@@ -41,7 +41,7 @@ border-top-color: transparent;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-top-style/index.md
+++ b/files/en-us/web/css/border-top-style/index.md
@@ -45,7 +45,7 @@ border-top-style: inset;
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #000;
+  color: black;
   border: 0.75em solid;
   padding: 0.75em;
   width: 80%;
@@ -53,7 +53,7 @@ border-top-style: inset;
 }
 
 body {
-  background-color: #fff;
+  background-color:;
 }
 ```
 

--- a/files/en-us/web/css/border-top-style/index.md
+++ b/files/en-us/web/css/border-top-style/index.md
@@ -53,7 +53,7 @@ border-top-style: inset;
 }
 
 body {
-  background-color:;
+  background-color: white;
 }
 ```
 

--- a/files/en-us/web/css/border-top-width/index.md
+++ b/files/en-us/web/css/border-top-width/index.md
@@ -41,7 +41,7 @@ border-top-width: 0;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-top/index.md
+++ b/files/en-us/web/css/border-top/index.md
@@ -41,7 +41,7 @@ border-top: 4mm ridge rgb(211 220 50 / 0.6);
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/border-width/index.md
+++ b/files/en-us/web/css/border-width/index.md
@@ -41,7 +41,7 @@ border-width: 0 4px 8px 12px;
 ```css interactive-example
 #example-element {
   background-color: palegreen;
-  color: #000;
+  color: black;
   border: 0 solid crimson;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -41,7 +41,7 @@ border: 4mm ridge rgb(211 220 50 / 0.6);
 ```css interactive-example
 #example-element {
   background-color: #eee;
-  color: #8b008b;
+  color: darkmagenta;
   padding: 0.75em;
   width: 80%;
   height: 100px;

--- a/files/en-us/web/css/box-decoration-break/index.md
+++ b/files/en-us/web/css/box-decoration-break/index.md
@@ -34,12 +34,12 @@ box-decoration-break: clone;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #6f6f6f, #000);
+  background: linear-gradient(to bottom right, #6f6f6f, black);
   color: white;
   box-shadow:
     8px 8px 10px 0 #ff1492,
-    -5px -5px 5px 0 #00f,
-    5px 5px 15px 0 #ff0;
+    -5px -5px 5px 0 blue,
+    5px 5px 15px 0 yellow;
   padding: 0 1em;
   border-radius: 16px;
   border-style: solid;


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. As a starter, I'm porting all colors that have named equivalents to named colors, per our recommendation of using "common named colors". Afterwards, I'm going to convert the remaining colors to the preferred notation, such as preferring `rgb()` and preferring number parameters.