### PR TITLE
Lint: use named color if possible (3)

### DIFF
--- a/files/en-us/web/html/reference/elements/a/index.md
+++ b/files/en-us/web/html/reference/elements/a/index.md
@@ -253,7 +253,7 @@ A **skip link** is a link placed as early as possible in {{HTMLElement("body")}}
 .skip-link {
   position: absolute;
   top: -3em;
-  background: #fff;
+  background: white;
 }
 .skip-link:focus {
   top: 0;
@@ -405,13 +405,13 @@ html {
   font-family: sans-serif;
 }
 canvas {
-  background: #fff;
+  background: white;
   border: 1px dashed;
 }
 a {
   display: inline-block;
   background: #69c;
-  color: #fff;
+  color: white;
   padding: 5px 10px;
 }
 ```

--- a/files/en-us/web/html/reference/elements/button/index.md
+++ b/files/en-us/web/html/reference/elements/button/index.md
@@ -26,7 +26,7 @@ By default, HTML buttons are presented in a style resembling the platform the {{
   color: white;
   text-shadow: 1px 1px 1px black;
   border-radius: 10px;
-  background-color: rgb(220 0 0);
+  background-color: tomato;
   background-image: linear-gradient(
     to top left,
     rgb(0 0 0 / 0.2),

--- a/files/en-us/web/html/reference/elements/button/index.md
+++ b/files/en-us/web/html/reference/elements/button/index.md
@@ -23,15 +23,15 @@ By default, HTML buttons are presented in a style resembling the platform the {{
   padding: 0 20px;
   font-size: 1rem;
   text-align: center;
-  color: #fff;
-  text-shadow: 1px 1px 1px #000;
+  color: white;
+  text-shadow: 1px 1px 1px black;
   border-radius: 10px;
   background-color: rgb(220 0 0);
   background-image: linear-gradient(
     to top left,
     rgb(0 0 0 / 0.2),
     rgb(0 0 0 / 0.2) 30%,
-    rgb(0 0 0 / 0)
+    transparent
   );
   box-shadow:
     inset 2px 2px 3px rgb(255 255 255 / 0.6),
@@ -162,7 +162,7 @@ To give an icon button an accessible name, put text in the `<button>` element th
 
 ```html
 <button name="favorite">
-  <svg fill="#000000" viewBox="0 0 42 42">
+  <svg fill="black" viewBox="0 0 42 42">
     <path
       d="M21,1c1.081,0,5.141,12.315,6.201,13.126s13.461,1.053,13.791,2.137 c0.34,1.087-9.561,8.938-9.961,10.252c-0.409,1.307,
       3.202,13.769,2.331,14.442c-0.879,0.673-11.05-6.79-12.361-6.79 c-1.311,0-11.481,7.463-12.36,6.79c-0.871-0.674,2.739-13.136,

--- a/files/en-us/web/html/reference/elements/caption/index.md
+++ b/files/en-us/web/html/reference/elements/caption/index.md
@@ -80,8 +80,8 @@ tr:nth-child(odd) td {
     1.4rem molot,
     sans-serif;
   text-shadow:
-    1px 1px 1px #fff,
-    2px 2px 1px #000;
+    1px 1px 1px white,
+    2px 2px 1px black;
 }
 
 .skeletor {
@@ -90,8 +90,8 @@ tr:nth-child(odd) td {
     fantasy;
   letter-spacing: 3px;
   text-shadow:
-    1px 1px 0 #fff,
-    0 0 9px #000;
+    1px 1px 0 white,
+    0 0 9px black;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -476,7 +476,7 @@ dialog {
 
 /* Transition the :backdrop when the dialog modal is promoted to the top layer */
 dialog::backdrop {
-  background-color: rgb(0 0 0 / 0%);
+  background-color: transparent;
   transition:
     display 0.7s allow-discrete,
     overlay 0.7s allow-discrete,
@@ -494,7 +494,7 @@ because the nesting selector cannot represent pseudo-elements. */
 
 @starting-style {
   dialog:open::backdrop {
-    background-color: rgb(0 0 0 / 0%);
+    background-color: transparent;
   }
 }
 ```
@@ -604,7 +604,7 @@ dialog:open::backdrop {
 
 @keyframes backdrop-fade-in {
   0% {
-    background-color: rgb(0 0 0 / 0%);
+    background-color: transparent;
   }
 
   100% {

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -569,6 +569,7 @@ dialog:open {
 }
 
 dialog:open::backdrop {
+  background-color: black;
   animation: backdrop-fade-in 0.7s ease-out forwards;
 }
 
@@ -604,11 +605,11 @@ dialog:open::backdrop {
 
 @keyframes backdrop-fade-in {
   0% {
-    background-color: transparent;
+    opacity: 0;
   }
 
   100% {
-    background-color: rgb(0 0 0 / 25%);
+    opacity: 0.25;
   }
 }
 

--- a/files/en-us/web/html/reference/elements/div/index.md
+++ b/files/en-us/web/html/reference/elements/div/index.md
@@ -21,8 +21,8 @@ The **`<div>`** [HTML](/en-US/docs/Web/HTML) element is the generic container fo
 
 ```css interactive-example
 .warning {
-  border: 10px ridge #f00;
-  background-color: #ff0;
+  border: 10px ridge red;
+  background-color: yellow;
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
@@ -91,7 +91,7 @@ This example creates a shadowed box by applying a style to the `<div>` using CSS
   border: 1px solid #333;
   box-shadow: 8px 8px 5px #444;
   padding: 8px 12px;
-  background-image: linear-gradient(180deg, #fff, #ddd 40%, #ccc);
+  background-image: linear-gradient(180deg, white, #ddd 40%, #ccc);
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/fieldset/index.md
+++ b/files/en-us/web/html/reference/elements/fieldset/index.md
@@ -29,8 +29,8 @@ The **`<fieldset>`** [HTML](/en-US/docs/Web/HTML) element is used to group sever
 
 ```css interactive-example
 legend {
-  background-color: #000;
-  color: #fff;
+  background-color: black;
+  color: white;
   padding: 3px 6px;
 }
 

--- a/files/en-us/web/html/reference/elements/figcaption/index.md
+++ b/files/en-us/web/html/reference/elements/figcaption/index.md
@@ -21,7 +21,7 @@ The **`<figcaption>`** [HTML](/en-US/docs/Web/HTML) element represents a caption
 
 ```css interactive-example
 figure {
-  border: thin #c0c0c0 solid;
+  border: thin silver solid;
   display: flex;
   flex-flow: column;
   padding: 5px;
@@ -36,7 +36,7 @@ img {
 
 figcaption {
   background-color: #222;
-  color: #fff;
+  color: white;
   font: italic smaller sans-serif;
   padding: 3px;
   text-align: center;

--- a/files/en-us/web/html/reference/elements/figure/index.md
+++ b/files/en-us/web/html/reference/elements/figure/index.md
@@ -21,7 +21,7 @@ The **`<figure>`** [HTML](/en-US/docs/Web/HTML) element represents self-containe
 
 ```css interactive-example
 figure {
-  border: thin #c0c0c0 solid;
+  border: thin silver solid;
   display: flex;
   flex-flow: column;
   padding: 5px;
@@ -36,7 +36,7 @@ img {
 
 figcaption {
   background-color: #222;
-  color: #fff;
+  color: white;
   font: italic smaller sans-serif;
   padding: 3px;
   text-align: center;

--- a/files/en-us/web/html/reference/elements/footer/index.md
+++ b/files/en-us/web/html/reference/elements/footer/index.md
@@ -36,7 +36,7 @@ footer {
   justify-content: center;
   padding: 5px;
   background-color: #45a1ff;
-  color: #fff;
+  color: white;
 }
 ```
 
@@ -80,7 +80,7 @@ footer {
   text-align: center;
   padding: 5px;
   background-color: #abbaba;
-  color: #000;
+  color: black;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/header/index.md
+++ b/files/en-us/web/html/reference/elements/header/index.md
@@ -39,7 +39,7 @@ The **`<header>`** [HTML](/en-US/docs/Web/HTML) element represents introductory 
     bold calc(1em + 2 * (100vw - 120px) / 100) "Dancing Script",
     fantasy;
   color: #ff0083;
-  text-shadow: #000 2px 2px 0.2rem;
+  text-shadow: black 2px 2px 0.2rem;
 }
 
 header > h1 {

--- a/files/en-us/web/html/reference/elements/hr/index.md
+++ b/files/en-us/web/html/reference/elements/hr/index.md
@@ -29,7 +29,7 @@ hr {
 }
 
 hr::after {
-  background: #fff;
+  background: white;
   content: "§";
   padding: 0 4px;
   position: relative;

--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -24,7 +24,7 @@ sidebar: htmlsidebar
   color: white;
   text-shadow: 1px 1px 1px black;
   border-radius: 10px;
-  background-color: rgb(220 0 0 / 100%);
+  background-color: tomato;
   background-image: linear-gradient(
     to top left,
     rgb(0 0 0 / 20%),

--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -21,15 +21,15 @@ sidebar: htmlsidebar
   padding: 0 20px;
   font-size: 1rem;
   text-align: center;
-  color: #fff;
-  text-shadow: 1px 1px 1px #000;
+  color: white;
+  text-shadow: 1px 1px 1px black;
   border-radius: 10px;
   background-color: rgb(220 0 0 / 100%);
   background-image: linear-gradient(
     to top left,
     rgb(0 0 0 / 20%),
     rgb(0 0 0 / 20%) 30%,
-    rgb(0 0 0 / 0%)
+    transparent
   );
   box-shadow:
     inset 2px 2px 3px rgb(255 255 255 / 60%),
@@ -37,7 +37,7 @@ sidebar: htmlsidebar
 }
 
 .styled:hover {
-  background-color: rgb(255 0 0 / 100%);
+  background-color: red;
 }
 
 .styled:active {

--- a/files/en-us/web/html/reference/elements/input/color/index.md
+++ b/files/en-us/web/html/reference/elements/input/color/index.md
@@ -127,7 +127,7 @@ First, there's some setup. Here we establish some variables, setting up a variab
 
 ```js
 let colorPicker;
-const defaultColor = "#0000ff";
+const defaultColor = "blue";
 
 window.addEventListener("load", startup, false);
 ```

--- a/files/en-us/web/html/reference/elements/input/tel/index.md
+++ b/files/en-us/web/html/reference/elements/input/tel/index.md
@@ -254,7 +254,7 @@ input:invalid + span::after {
   position: absolute;
   content: "✖";
   padding-left: 5px;
-  color: #8b0000;
+  color: darkred;
 }
 
 input:valid + span::after {
@@ -313,7 +313,7 @@ input:invalid + span::after {
   position: absolute;
   content: "✖";
   padding-left: 5px;
-  color: #8b0000;
+  color: darkred;
 }
 
 input:valid + span::after {
@@ -462,7 +462,7 @@ input:invalid + span::after {
   position: absolute;
   content: "✖";
   padding-left: 5px;
-  color: #8b0000;
+  color: darkred;
 }
 
 input:valid + span::after {

--- a/files/en-us/web/html/reference/elements/legend/index.md
+++ b/files/en-us/web/html/reference/elements/legend/index.md
@@ -29,8 +29,8 @@ In [customizable `<select>` elements](/en-US/docs/Learn_web_development/Extensio
 
 ```css interactive-example
 legend {
-  background-color: #000;
-  color: #fff;
+  background-color: black;
+  color: white;
   padding: 3px 6px;
 }
 

--- a/files/en-us/web/html/reference/elements/nav/index.md
+++ b/files/en-us/web/html/reference/elements/nav/index.md
@@ -42,7 +42,7 @@ nav {
 
 .crumb a::after {
   display: inline-block;
-  color: #000;
+  color: black;
   content: ">";
   font-size: 80%;
   font-weight: bold;

--- a/files/en-us/web/html/reference/elements/span/index.md
+++ b/files/en-us/web/html/reference/elements/span/index.md
@@ -25,7 +25,7 @@ The **`<span>`** [HTML](/en-US/docs/Web/HTML) element is a generic inline contai
 
 ```css interactive-example
 span.ingredient {
-  color: #f00;
+  color: red;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/style/index.md
+++ b/files/en-us/web/html/reference/elements/style/index.md
@@ -32,7 +32,7 @@ The **`<style>`** [HTML](/en-US/docs/Web/HTML) element contains style informatio
 
 ```css interactive-example
 p {
-  color: #f00;
+  color: red;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/table/index.md
+++ b/files/en-us/web/html/reference/elements/table/index.md
@@ -1016,7 +1016,7 @@ td {
 th {
   position: sticky;
   top: 0;
-  background: #fff;
+  background: white;
   vertical-align: bottom;
 }
 

--- a/files/en-us/web/html/reference/elements/tbody/index.md
+++ b/files/en-us/web/html/reference/elements/tbody/index.md
@@ -44,7 +44,7 @@ The **`<tbody>`** [HTML](/en-US/docs/Web/HTML) element encapsulates a set of tab
 thead,
 tfoot {
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 tbody {
@@ -235,7 +235,7 @@ tbody > tr > td:last-of-type {
 thead {
   border-bottom: 2px solid rgb(160 160 160);
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 ```
 
@@ -344,7 +344,7 @@ tbody {
 
 thead {
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/td/index.md
+++ b/files/en-us/web/html/reference/elements/td/index.md
@@ -47,7 +47,7 @@ td {
 
 th[scope="col"] {
   background-color: #505050;
-  color: #fff;
+  color: white;
 }
 
 th[scope="row"] {
@@ -254,7 +254,7 @@ The {{cssxref(":first-of-type")}} and {{cssxref(":last-of-type")}} pseudo-classe
 tr:first-of-type td:last-of-type {
   width: 60px;
   background-color: #505050;
-  color: #fff;
+  color: white;
   font-weight: bold;
   text-align: center;
 }

--- a/files/en-us/web/html/reference/elements/template/index.md
+++ b/files/en-us/web/html/reference/elements/template/index.md
@@ -133,10 +133,10 @@ The result is the original HTML table, with two new rows appended to it via Java
 
 ```css hidden
 table {
-  background: #000;
+  background: black;
 }
 table td {
-  background: #fff;
+  background: white;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/tfoot/index.md
+++ b/files/en-us/web/html/reference/elements/tfoot/index.md
@@ -44,7 +44,7 @@ The **`<tfoot>`** [HTML](/en-US/docs/Web/HTML) element encapsulates a set of tab
 thead,
 tfoot {
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 tbody {
@@ -165,7 +165,7 @@ Some basic CSS is used to style and highlight the table foot so that the foot ce
 tfoot {
   border-top: 3px dotted rgb(160 160 160);
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 tfoot th {
@@ -179,7 +179,7 @@ tfoot td {
 thead {
   border-bottom: 2px solid rgb(160 160 160);
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 tbody {

--- a/files/en-us/web/html/reference/elements/th/index.md
+++ b/files/en-us/web/html/reference/elements/th/index.md
@@ -47,7 +47,7 @@ td {
 
 th[scope="col"] {
   background-color: #505050;
-  color: #fff;
+  color: white;
 }
 
 th[scope="row"] {
@@ -196,7 +196,7 @@ td {
 
 th[scope="col"] {
   background-color: #505050;
-  color: #fff;
+  color: white;
 }
 
 th[scope="row"] {
@@ -294,7 +294,7 @@ td {
 
 th[scope="col"] {
   background-color: #505050;
-  color: #fff;
+  color: white;
 }
 
 th[scope="row"] {

--- a/files/en-us/web/html/reference/elements/thead/index.md
+++ b/files/en-us/web/html/reference/elements/thead/index.md
@@ -44,7 +44,7 @@ The **`<thead>`** [HTML](/en-US/docs/Web/HTML) element encapsulates a set of tab
 thead,
 tfoot {
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 tbody {
@@ -158,7 +158,7 @@ thead {
   border-bottom: 2px solid rgb(160 160 160);
   text-align: center;
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 tbody {
@@ -254,7 +254,7 @@ The CSS is unchanged from the [previous example](#basic_head_structure).
 thead {
   border-bottom: 2px solid rgb(160 160 160);
   background-color: #2c5e77;
-  color: #fff;
+  color: white;
 }
 
 table {

--- a/files/en-us/web/html/reference/elements/tr/index.md
+++ b/files/en-us/web/html/reference/elements/tr/index.md
@@ -47,7 +47,7 @@ td {
 
 th[scope="col"] {
   background-color: #505050;
-  color: #fff;
+  color: white;
 }
 
 th[scope="row"] {
@@ -233,7 +233,7 @@ tr:nth-of-type(odd) {
 
 tr th[scope="col"] {
   background-color: #505050;
-  color: #fff;
+  color: white;
 }
 
 tr th[scope="row"] {
@@ -401,7 +401,7 @@ td {
 
 th {
   background-color: #505050;
-  color: #fff;
+  color: white;
   cursor: pointer;
 }
 ```

--- a/files/en-us/web/html/reference/elements/u/index.md
+++ b/files/en-us/web/html/reference/elements/u/index.md
@@ -28,7 +28,7 @@ p {
 }
 
 u {
-  text-decoration: #f00 wavy underline;
+  text-decoration: red wavy underline;
 }
 ```
 

--- a/files/en-us/web/html/reference/global_attributes/id/index.md
+++ b/files/en-us/web/html/reference/global_attributes/id/index.md
@@ -20,7 +20,7 @@ The **`id`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes
 ```css interactive-example
 #exciting {
   background: linear-gradient(to bottom, #ffe8d4, #f69d3c);
-  border: 1px solid #696969;
+  border: 1px solid dimgrey;
   padding: 10px;
   border-radius: 10px;
   box-shadow: 2px 2px 1px black;

--- a/files/en-us/web/svg/guides/applying_svg_effects_to_html_content/index.md
+++ b/files/en-us/web/svg/guides/applying_svg_effects_to_html_content/index.md
@@ -48,7 +48,7 @@ For example, you can make a gradient mask for HTML content using SVG and CSS cod
 }
 p {
   width: 300px;
-  border: 1px solid #000;
+  border: 1px solid black;
   display: inline-block;
 }
 p.target {
@@ -113,7 +113,7 @@ This example demonstrates using SVG to clip HTML content. Notice that even the c
 }
 p {
   width: 300px;
-  border: 1px solid #000;
+  border: 1px solid black;
   display: inline-block;
 }
 p.target {

--- a/files/en-us/web/svg/guides/namespaces_crash_course/example/index.md
+++ b/files/en-us/web/svg/guides/namespaces_crash_course/example/index.md
@@ -38,7 +38,7 @@ br {
   <body onload='update()'>
     <svg:svg id='display' width='400' height='300'>
       <svg:circle id='cursor' cx='200'
-cy='150' r='7' fill='#0000ff' fill-opacity='0.5'/>
+cy='150' r='7' fill='blue' fill-opacity='0.5'/>
     </svg:svg>
 
     <p>A swarm of motes, governed by two basic principles.

--- a/files/en-us/web/svg/guides/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/guides/namespaces_crash_course/index.md
@@ -81,7 +81,7 @@ As an aside, it's useful to know that namespace prefixes can also be used for el
   <body>
     <h1>SVG embedded inline in XHTML</h1>
     <svg:svg width="300px" height="200px">
-      <svg:circle cx="150" cy="100" r="50" fill="#ff0000" />
+      <svg:circle cx="150" cy="100" r="50" fill="red" />
     </svg:svg>
   </body>
 </html>

--- a/files/en-us/web/svg/reference/attribute/exponent/index.md
+++ b/files/en-us/web/svg/reference/attribute/exponent/index.md
@@ -35,9 +35,9 @@ svg {
       y1="0"
       x2="200"
       y2="0">
-      <stop offset="0" stop-color="#ff0000" />
-      <stop offset="0.5" stop-color="#00ff00" />
-      <stop offset="1" stop-color="#0000ff" />
+      <stop offset="0" stop-color="red" />
+      <stop offset="0.5" stop-color="lime" />
+      <stop offset="1" stop-color="blue" />
     </linearGradient>
   </defs>
 

--- a/files/en-us/web/svg/reference/attribute/intercept/index.md
+++ b/files/en-us/web/svg/reference/attribute/intercept/index.md
@@ -60,9 +60,9 @@ svg {
       y1="0"
       x2="200"
       y2="0">
-      <stop offset="0" stop-color="#ff0000" />
-      <stop offset="0.5" stop-color="#00ff00" />
-      <stop offset="1" stop-color="#0000ff" />
+      <stop offset="0" stop-color="red" />
+      <stop offset="0.5" stop-color="lime" />
+      <stop offset="1" stop-color="blue" />
     </linearGradient>
   </defs>
 

--- a/files/en-us/web/svg/reference/attribute/marker-end/index.md
+++ b/files/en-us/web/svg/reference/attribute/marker-end/index.md
@@ -45,7 +45,7 @@ svg {
       markerWidth="10"
       markerHeight="10"
       orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f00" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/svg/reference/attribute/marker-mid/index.md
+++ b/files/en-us/web/svg/reference/attribute/marker-mid/index.md
@@ -37,7 +37,7 @@ svg {
 <svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <marker id="circle" markerWidth="8" markerHeight="8" refX="4" refY="4">
-      <circle cx="4" cy="4" r="4" stroke="none" fill="#f00" />
+      <circle cx="4" cy="4" r="4" stroke="none" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/svg/reference/attribute/marker-start/index.md
+++ b/files/en-us/web/svg/reference/attribute/marker-start/index.md
@@ -45,7 +45,7 @@ svg {
       markerWidth="10"
       markerHeight="10"
       orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f00" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/svg/reference/attribute/requiredfeatures/index.md
+++ b/files/en-us/web/svg/reference/attribute/requiredfeatures/index.md
@@ -774,12 +774,12 @@ The following are the feature strings for the `requiredFeatures` attribute. Thes
 }
 
 rect {
-  stroke: #000;
+  stroke: black;
   stroke-width: 2px;
 }
 
 text {
-  fill: #fff;
+  fill: white;
   font: 12px sans-serif;
 }
 ```

--- a/files/en-us/web/svg/reference/attribute/slope/index.md
+++ b/files/en-us/web/svg/reference/attribute/slope/index.md
@@ -73,8 +73,8 @@ In this example, a gradient box has two text elements with linear filters applie
       y1="0"
       x2="600"
       y2="0">
-      <stop offset="0" stop-color="#ff0000" />
-      <stop offset="1" stop-color="#0000ff" />
+      <stop offset="0" stop-color="red" />
+      <stop offset="1" stop-color="blue" />
     </linearGradient>
     <filter
       id="Linear1"

--- a/files/en-us/web/svg/reference/attribute/tablevalues/index.md
+++ b/files/en-us/web/svg/reference/attribute/tablevalues/index.md
@@ -35,9 +35,9 @@ svg {
       y1="0"
       x2="200"
       y2="0">
-      <stop offset="0" stop-color="#ff0000" />
-      <stop offset="0.5" stop-color="#00ff00" />
-      <stop offset="1" stop-color="#0000ff" />
+      <stop offset="0" stop-color="red" />
+      <stop offset="0.5" stop-color="lime" />
+      <stop offset="1" stop-color="blue" />
     </linearGradient>
   </defs>
 

--- a/files/en-us/web/svg/reference/element/fecomponenttransfer/index.md
+++ b/files/en-us/web/svg/reference/element/fecomponenttransfer/index.md
@@ -38,12 +38,12 @@ This element implements the {{domxref("SVGFEComponentTransferElement")}} interfa
       y1="0"
       x2="100%"
       y2="0">
-      <stop offset="0" stop-color="#ff0000"></stop>
-      <stop offset="0.2" stop-color="#ffff00"></stop>
-      <stop offset="0.4" stop-color="#00ff00"></stop>
-      <stop offset="0.6" stop-color="#00ffff"></stop>
-      <stop offset="0.8" stop-color="#0000ff"></stop>
-      <stop offset="1" stop-color="#800080"></stop>
+      <stop offset="0" stop-color="red"></stop>
+      <stop offset="0.2" stop-color="yellow"></stop>
+      <stop offset="0.4" stop-color="lime"></stop>
+      <stop offset="0.6" stop-color="cyan"></stop>
+      <stop offset="0.8" stop-color="blue"></stop>
+      <stop offset="1" stop-color="purple"></stop>
     </linearGradient>
     <filter id="identity" x="0" y="0" width="100%" height="100%">
       <feComponentTransfer>

--- a/files/en-us/web/svg/reference/element/fepointlight/index.md
+++ b/files/en-us/web/svg/reference/element/fepointlight/index.md
@@ -40,7 +40,7 @@ This element implements the {{domxref("SVGFEPointLightElement")}} interface.
         result="spotlight"
         specularConstant="1.5"
         specularExponent="80"
-        lighting-color="#FFF">
+        lighting-color="white">
         <fePointLight x="50" y="50" z="220" />
       </feSpecularLighting>
       <feComposite

--- a/files/en-us/web/svg/reference/element/fespotlight/index.md
+++ b/files/en-us/web/svg/reference/element/fespotlight/index.md
@@ -46,7 +46,7 @@ This element implements the {{domxref("SVGFESpotLightElement")}} interface.
         result="spotlight"
         specularConstant="1.5"
         specularExponent="4"
-        lighting-color="#FFF">
+        lighting-color="white">
         <feSpotLight x="600" y="600" z="400" limitingConeAngle="5.5" />
       </feSpecularLighting>
       <feComposite

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
@@ -77,7 +77,7 @@ Filters are defined by the {{SVGElement('filter')}} element, which should be put
     <path
       fill="#D90000"
       d="M60,56 c-30,0 -30,-40 0,-40 h80 c30,0 30,40 0,40z" />
-    <g fill="#FFFFFF" stroke="black" font-size="45" font-family="Verdana">
+    <g fill="white" stroke="black" font-size="45" font-family="Verdana">
       <text x="52" y="52">SVG</text>
     </g>
   </g>


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. As a starter, I'm porting all colors that have named equivalents to named colors, per our recommendation of using "common named colors". Afterwards, I'm going to convert the remaining colors to the preferred notation, such as preferring `rgb()` and preferring number parameters.