### PR TITLE
Lint: use named color if possible (5)

### DIFF
--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -38,7 +38,7 @@ width: calc(var(--variable-width) + 20px);
 }
 
 #example-element {
-  border: 10px solid #000;
+  border: 10px solid black;
   padding: 10px;
 }
 ```

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -52,7 +52,7 @@ caption-side: bottom;
 table {
   font-size: 1.2rem;
   text-align: left;
-  color: #000;
+  color: black;
 }
 
 th,

--- a/files/en-us/web/css/clear/index.md
+++ b/files/en-us/web/css/clear/index.md
@@ -154,7 +154,7 @@ clear: unset;
   float: left;
   margin: 0;
   background-color: black;
-  color: #fff;
+  color: white;
   width: 20%;
 }
 .red {
@@ -200,7 +200,7 @@ p {
   float: right;
   margin: 0;
   background-color: black;
-  color: #fff;
+  color: white;
   width: 20%;
 }
 .red {
@@ -250,7 +250,7 @@ p {
   float: left;
   margin: 0;
   background-color: black;
-  color: #fff;
+  color: white;
   width: 20%;
 }
 .red {

--- a/files/en-us/web/css/clip-rule/index.md
+++ b/files/en-us/web/css/clip-rule/index.md
@@ -93,7 +93,7 @@ svg {
 
 #star3 path {
   fill: none;
-  stroke: #000;
+  stroke: black;
   stroke-width: 1;
 }
 ```

--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -24,9 +24,9 @@ color-mix(in hsl, hsl(200 50 80), coral 80%)
 color-mix(in lch longer hue, hsl(200deg 50% 80%), coral)
 
 /* color-mix(in <rectangular-color-space>, <color>, <color>) */
-color-mix(in srgb, plum, #f00)
+color-mix(in srgb, plum, #123456)
 /* color-mix(in <rectangular-color-space>, <color> <percentage>, <color> <percentage> */
-color-mix(in lab, plum 60%, #f00 50%)
+color-mix(in lab, plum 60%, #123456 50%)
 
 /* color-mix(in <custom-color-space>, <color>, <color>) */
 color-mix(in --swop5c, red, blue)

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -23,7 +23,7 @@ color(display-p3 1 0.5 0 / .5);
 
 /* Relative values */
 color(from green srgb r g b / 0.5)
-color(from #0000FF xyz calc(x + 0.75) y calc(z - 0.35))
+color(from #123456 xyz calc(x + 0.75) y calc(z - 0.35))
 ```
 
 ### Values

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -59,7 +59,7 @@ hsl(none 75% 25%)
 
 /* Relative values */
 hsl(from green h s l / 0.5)
-hsl(from #0000FF h s calc(l + 20))
+hsl(from #123456 h s calc(l + 20))
 hsl(from rgb(200 0 0) calc(h + 30) s calc(l + 30))
 
 /* Legacy 'hsla()' alias */

--- a/files/en-us/web/css/color_value/hwb/index.md
+++ b/files/en-us/web/css/color_value/hwb/index.md
@@ -52,7 +52,7 @@ hwb(194 0% 0% / .5)
 
 /* Relative values */
 hwb(from green h w b / 0.5)
-hwb(from #0000FF h calc(w + 30) b)
+hwb(from #123456 h calc(w + 30) b)
 hwb(from lch(40% 70 240deg) h w calc(b - 30))
 ```
 

--- a/files/en-us/web/css/color_value/lab/index.md
+++ b/files/en-us/web/css/color_value/lab/index.md
@@ -23,7 +23,7 @@ lab(52.2345% 40.1645 59.9971 / .5);
 
 /* Relative values */
 lab(from green l a b / 0.5)
-lab(from #0000FF calc(l + 10) a b)
+lab(from #123456 calc(l + 10) a b)
 lab(from hsl(180 100% 50%) calc(l - 10) a b)
 ```
 

--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -21,7 +21,7 @@ lch(52.2345% 72.2 56.2 / .5);
 
 /* Relative values */
 lch(from green l c h / 0.5)
-lch(from #0000FF calc(l + 10) c h)
+lch(from #123456 calc(l + 10) c h)
 lch(from hsl(180 100% 50%) calc(l - 10) c h)
 lch(from var(--aColorValue) l c h / calc(alpha - 0.1))
 ```

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -29,7 +29,7 @@ oklab(59.69% 0.1007 0.1191 / 0.5);
 
 /* Relative values */
 oklab(from green l a b / 0.5)
-oklab(from #0000FF calc(l + 0.1) a b / calc(alpha * 0.9))
+oklab(from #123456 calc(l + 0.1) a b / calc(alpha * 0.9))
 oklab(from hsl(180 100% 50%) calc(l - 0.1) a b)
 ```
 

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -21,7 +21,7 @@ oklch(59.69% 0.156 49.77 / .5)
 
 /* Relative values */
 oklch(from green l c h / 0.5)
-oklch(from #0000FF calc(l + 0.1) c h)
+oklch(from #123456 calc(l + 0.1) c h)
 oklch(from hsl(180 100% 50%) calc(l - 0.1) c h)
 oklch(from var(--aColor) l c h / calc(alpha - 0.1))
 ```

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -55,7 +55,7 @@ rgb(255 255 255 / 50%)
 
 /* Relative values */
 rgb(from green r g b / 0.5)
-rgb(from #0000FF calc(r + 40) calc(g + 40) b)
+rgb(from #123456 calc(r + 40) calc(g + 40) b)
 rgb(from hwb(120deg 10% 20%) r g calc(b + 200))
 
 /* Legacy 'rgba()' alias */
@@ -210,7 +210,7 @@ body {
 
 ```css
 body {
-  background: repeating-linear-gradient(-45deg, #eee 0 2px, #fff 2px 6px);
+  background: repeating-linear-gradient(-45deg, #eee 0 2px, white 2px 6px);
   padding: 10px;
 }
 

--- a/files/en-us/web/css/column-span/index.md
+++ b/files/en-us/web/css/column-span/index.md
@@ -50,7 +50,7 @@ column-span: all;
 #example-element {
   background-color: rebeccapurple;
   padding: 10px;
-  color: #fff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/content-visibility/index.md
+++ b/files/en-us/web/css/content-visibility/index.md
@@ -258,24 +258,24 @@ div {
 @keyframes show {
   0% {
     content-visibility: hidden;
-    color: rgb(0 0 0 / 0%);
+    color: transparent;
   }
 
   100% {
     content-visibility: visible;
-    color: rgb(0 0 0 / 100%);
+    color: black;
   }
 }
 
 @keyframes hide {
   0% {
     content-visibility: visible;
-    color: rgb(0 0 0 / 100%);
+    color: black;
   }
 
   100% {
     content-visibility: hidden;
-    color: rgb(0 0 0 / 0%);
+    color: transparent;
   }
 }
 ```

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -214,13 +214,13 @@ This example inserts differently colored quotation marks around quotes.
 
 ```css
 q {
-  color: #00f;
+  color: blue;
 }
 
 q::before,
 q::after {
   font-size: larger;
-  color: #f00;
+  color: red;
   background: #ccc;
 }
 

--- a/files/en-us/web/css/cos/index.md
+++ b/files/en-us/web/css/cos/index.md
@@ -56,7 +56,7 @@ transform: translateX(calc(cos(-45deg) * 140px))
   border: 2px solid #666;
   background-image:
     radial-gradient(black var(--dot-size), transparent var(--dot-size)),
-    linear-gradient(135deg, #0000ff, #00c9ff, #92fe9d, #e6e6fa, #f0fff0);
+    linear-gradient(135deg, blue, deepskyblue, lightgreen, lavender, honeydew);
 }
 .dot {
   display: block;

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -145,7 +145,7 @@ i:nth-of-type(7n + 1) {
 .cloud {
   width: 100%;
   height: 150px;
-  background: #ffffff;
+  background: white;
   border-radius: 0 0 90px 33% / 0 0 45px 50px;
   box-shadow:
     5px 15px 15px white,
@@ -157,7 +157,7 @@ i:nth-of-type(7n + 1) {
 }
 .ground {
   bottom: 0;
-  background-image: linear-gradient(to top, #fff 97%, 99%, #bbb 100%);
+  background-image: linear-gradient(to top, white 97%, 99%, #bbb 100%);
   background-position: center 580px;
   animation: snowfall linear 300s forwards;
   border: 1px solid grey;

--- a/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -27,7 +27,7 @@ In this example, three backgrounds are stacked: the Firefox logo, an image of bu
   height: 400px;
   background-image:
     url("firefox.png"), url("bubbles.png"),
-    linear-gradient(to right, rgb(30 75 115 / 100%), rgb(255 255 255 / 0%));
+    linear-gradient(to right, rgb(30 75 115 / 100%), transparent);
   background-repeat: no-repeat, no-repeat, no-repeat;
   background-position:
     bottom right,

--- a/files/en-us/web/css/css_box_sizing/understanding_aspect-ratio/index.md
+++ b/files/en-us/web/css/css_box_sizing/understanding_aspect-ratio/index.md
@@ -393,7 +393,7 @@ div {
 p {
   aspect-ratio: 1;
   text-align: center;
-  border: 10px solid #ffffff;
+  border: 10px solid white;
   background-color: #f4aab9;
 }
 ```
@@ -418,7 +418,7 @@ div {
 
 p {
   text-align: center;
-  border: 10px solid #ffffff;
+  border: 10px solid white;
   background-color: #f4aab9;
 }
 ```

--- a/files/en-us/web/css/css_cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/css_cascade/shorthand_properties/index.md
@@ -66,7 +66,7 @@ Similarly, shorthands handling properties related to corners of a box, like {{cs
 Consider a background with the following properties
 
 ```css
-background-color: #000;
+background-color: black;
 background-image: url("images/bg.gif");
 background-repeat: no-repeat;
 background-position: left top;
@@ -75,7 +75,7 @@ background-position: left top;
 These four declarations can be shortened to just one:
 
 ```css
-background: #000 url("images/bg.gif") no-repeat left top;
+background: black url("images/bg.gif") no-repeat left top;
 ```
 
 (The shorthand form is actually the equivalent of the longhand properties above plus `background-attachment: scroll` and, in CSS3, some additional properties.)
@@ -111,13 +111,13 @@ With borders, the width, color, and style can be simplified into one declaration
 ```css
 border-width: 1px;
 border-style: solid;
-border-color: #000;
+border-color: black;
 ```
 
 It can be simplified as:
 
 ```css
-border: 1px solid #000;
+border: 1px solid black;
 ```
 
 ## Margin and padding properties

--- a/files/en-us/web/css/css_colors/applying_color/index.md
+++ b/files/en-us/web/css/css_colors/applying_color/index.md
@@ -152,7 +152,7 @@ The `.boxLeft` class, used to style the box on the left, sets up the color of th
 .boxRight {
   background-color: hwb(270deg 63% 13%);
   outline: 4px dashed #6e1478;
-  color: hsl(0deg 100% 100%);
+  color: hsl(0deg 95% 95%);
   text-decoration-line: underline;
   text-decoration-style: wavy;
   text-decoration-color: #8f8;
@@ -168,7 +168,7 @@ Finally, the `.boxRight` class sets several styles on the box that's drawn to th
 
 - The `background-color` is set using {{CSSXref("color_value/hwb", "hwb()")}} functional notation — `hwb(270deg 63% 13%)`. This is a medium purple color.
 - The box's `outline` is used to specify that the box should be enclosed in a four-pixel thick dashed line whose color is a somewhat deeper purple using the six-digit {{cssxref("hex-color")}} `#6e1478`.
-- The foreground (text) color is specified by setting the {{cssxref("color")}} property using {{CSSXref("color_value/hsl", "hsl()")}} functional notation — `hsl(0deg 100% 100%)`. This is one of many ways to specify the color white.
+- The foreground (text) color is specified by setting the {{cssxref("color")}} property using {{CSSXref("color_value/hsl", "hsl()")}} functional notation — `hsl(0deg 95% 95%)`. This is a very light pinkish color.
 - We add a green wavy line under the text with the {{cssxref("text-decoration")}} shorthand, along with the longhand component for browser compatibility. We used the 3-digit {{cssxref("hex-color")}} `#8f8`, which is the equivalent of `#88ff88`.
 - Finally, a bit of a shadow is added to the text using {{cssxref("text-shadow")}}. Its `color` parameter is set to `black`, a {{cssxref("named-color")}} value.
 

--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -489,7 +489,7 @@ fieldset {
 
 #container {
   /* Default value */
-  --base-color: #ff0000;
+  --base-color: red;
 
   display: flex;
   width: 100vw;

--- a/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
@@ -290,13 +290,13 @@ color.addEventListener("input", (e) => {
 });
 ```
 
-We use the `@property` at-rule to define a CSS variable `--theme` to be a {{cssxref("color_value", "&lt;color&gt;")}} value and set the `initial-value` to `#00F`, ensuring equivalent colors are a match regardless of what syntax is used (for example, `#F00` is equal to `rgb(255 0 0)`, `#ff0000`, and `red`).
+We use the `@property` at-rule to define a CSS variable `--theme` to be a {{cssxref("color_value", "&lt;color&gt;")}} value and set the `initial-value` to `red`, ensuring equivalent colors are a match regardless of what syntax is used (for example, `red` is equal to `rgb(255 0 0)`, `#ff0000`, and `#f00`).
 
 ```css
 @property --theme {
   syntax: "<color>";
   inherits: true;
-  initial-value: #f00;
+  initial-value: red;
 }
 ```
 
@@ -307,7 +307,7 @@ output {
 }
 ```
 
-The first style feature query is a custom property with no value. This query type returns true when the computed value for the custom property value is different from the `initial-value` for that property. In this case, it will be true when the value of `--theme` is any value other than any syntax equivalent value of `#f00` ( such as `red`). When true, the {{htmlelement("output")}} will have a 5px dotted outline. The outline color is the current value of `--theme`. The default text {{cssxref("color")}} is grey.
+The first style feature query is a custom property with no value. This query type returns true when the computed value for the custom property value is different from the `initial-value` for that property. In this case, it will be true when the value of `--theme` is any value other than any syntax equivalent value of `red` (such as `#f00`). When true, the {{htmlelement("output")}} will have a 5px dotted outline. The outline color is the current value of `--theme`. The default text {{cssxref("color")}} is grey.
 
 ```css
 @container style(--theme) {

--- a/files/en-us/web/css/css_display/in_flow_and_out_of_flow/index.md
+++ b/files/en-us/web/css/css_display/in_flow_and_out_of_flow/index.md
@@ -147,7 +147,7 @@ p {
 .abspos {
   position: absolute;
   background-color: green;
-  color: #fff;
+  color: white;
   top: 30px;
   right: 30px;
   width: 400px;
@@ -198,7 +198,7 @@ p {
 .relative {
   position: relative;
   background-color: green;
-  color: #fff;
+  color: white;
   bottom: 50px;
   left: 50px;
   width: 400px;

--- a/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
+++ b/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
@@ -252,7 +252,7 @@ p {
 }
 .inline-block {
   background-color: rgb(0 0 0 / 0.4);
-  color: #fff;
+  color: white;
   padding: 10px;
   display: inline-block;
 }

--- a/files/en-us/web/css/css_display/visual_formatting_model/index.md
+++ b/files/en-us/web/css/css_display/visual_formatting_model/index.md
@@ -204,11 +204,11 @@ body {
 }
 .container {
   background-color: #333;
-  color: #fff;
+  color: white;
 }
 
 .item {
-  background-color: #fff;
+  background-color: white;
   border: 1px solid #999;
   color: #333;
   width: 100px;

--- a/files/en-us/web/css/css_filter_effects/using_filter_effects/index.md
+++ b/files/en-us/web/css/css_filter_effects/using_filter_effects/index.md
@@ -134,7 +134,7 @@ p {
 }
 p {
   padding: 0.5rem;
-  color: #ffffff;
+  color: white;
   font-size: 2rem;
   font-family: sans-serif;
 }
@@ -167,10 +167,8 @@ img {
 
 ```css
 img {
-  filter: drop-shadow(2px 2px 0 hsl(300deg 100% 50%))
-    drop-shadow(-2px -2px 0 hsl(210deg 100% 50%))
-    drop-shadow(2px 2px 0 hsl(120deg 100% 50%))
-    drop-shadow(-2px -2px 0 hsl(30deg 100% 50%));
+  filter: drop-shadow(2px 2px 0 magenta) drop-shadow(-2px -2px 0 royalblue)
+    drop-shadow(2px 2px 0 lime) drop-shadow(-2px -2px 0 darkorange);
 }
 img + img {
   filter: none;

--- a/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -42,7 +42,7 @@ nav {
 
 nav a {
   text-decoration: none;
-  color: #000;
+  color: black;
   border: 2px solid rgb(96 139 168);
   border-radius: 5px;
   background-color: rgb(96 139 168 / 0.2);
@@ -93,7 +93,7 @@ nav ul {
 
 nav a {
   text-decoration: none;
-  color: #000;
+  color: black;
   border: 2px solid rgb(96 139 168);
   border-radius: 5px;
   background-color: rgb(96 139 168 / 0.2);
@@ -132,7 +132,7 @@ nav {
 
 nav a {
   text-decoration: none;
-  color: #000;
+  color: black;
   border: 2px solid rgb(96 139 168);
   border-radius: 5px;
   background-color: rgb(96 139 168 / 0.2);
@@ -398,7 +398,7 @@ Flexbox makes this type of layout easy to achieve. The `<label>`, `<input>` and 
 .wrapper > * {
   padding: 10px;
   border: none;
-  color: #fff;
+  color: white;
 }
 .wrapper > input[type="text"] {
   background-color: rgb(96 139 168 / 0.5);
@@ -407,7 +407,7 @@ Flexbox makes this type of layout easy to achieve. The `<label>`, `<input>` and 
 }
 .wrapper input[type="submit"] {
   background-color: rgb(96 139 168);
-  color: #fff;
+  color: white;
 }
 .wrapper label {
   background-color: #666;

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
@@ -451,7 +451,7 @@ a:visited {
 
 h2 {
   background-color: #f08c00;
-  color: #fff;
+  color: white;
   text-align: center;
   margin: 0;
   padding: 20px;
@@ -561,7 +561,7 @@ a:visited {
 
 h2 {
   background-color: #f08c00;
-  color: #fff;
+  color: white;
   text-align: center;
   margin: 0;
   padding: 20px;

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout_with_other_layout_methods/index.md
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout_with_other_layout_methods/index.md
@@ -458,7 +458,7 @@ We have given `.box3` position relative and then positioned the sub-item with th
   left: 40px;
   background-color: rgb(255 255 255 / 50%);
   border: 1px solid rgb(0 0 0 / 50%);
-  color: #000;
+  color: black;
   padding: 10px;
 }
 ```

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.md
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.md
@@ -245,7 +245,7 @@ body {
 
 .subitem {
   background-color: #d9480f;
-  color: #fff;
+  color: white;
   border-radius: 5px;
 }
 ```
@@ -311,7 +311,7 @@ body {
 
 .subitem {
   background-color: #d9480f;
-  color: #fff;
+  color: white;
   border-radius: 5px;
 }
 ```

--- a/files/en-us/web/css/css_images/using_css_gradients/index.md
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.md
@@ -352,9 +352,9 @@ div {
 ```css
 .stacked-linear {
   background:
-    linear-gradient(217deg, rgb(255 0 0 / 80%), rgb(255 0 0 / 0%) 70.71%),
-    linear-gradient(127deg, rgb(0 255 0 / 80%), rgb(0 255 0 / 0%) 70.71%),
-    linear-gradient(336deg, rgb(0 0 255 / 80%), rgb(0 0 255 / 0%) 70.71%);
+    linear-gradient(217deg, rgb(255 0 0 / 80%), transparent 70.71%),
+    linear-gradient(127deg, rgb(0 255 0 / 80%), transparent 70.71%),
+    linear-gradient(336deg, rgb(0 0 255 / 80%), transparent 70.71%);
 }
 ```
 
@@ -447,7 +447,7 @@ div {
 
 ```css
 .radial-gradient {
-  background: radial-gradient(red 10px, yellow 30%, #1e90ff 50%);
+  background: radial-gradient(red 10px, yellow 30%, dodgerblue 50%);
 }
 ```
 
@@ -470,7 +470,7 @@ div {
 
 ```css
 .radial-gradient {
-  background: radial-gradient(at 0% 30%, red 10px, yellow 30%, #1e90ff 50%);
+  background: radial-gradient(at 0% 30%, red 10px, yellow 30%, dodgerblue 50%);
 }
 ```
 
@@ -501,7 +501,7 @@ div {
     ellipse closest-side,
     red,
     yellow 10%,
-    #1e90ff 50%,
+    dodgerblue 50%,
     beige
   );
 }
@@ -530,7 +530,7 @@ div {
     ellipse farthest-corner at 90% 90%,
     red,
     yellow 10%,
-    #1e90ff 50%,
+    dodgerblue 50%,
     beige
   );
 }
@@ -559,7 +559,7 @@ div {
     circle closest-side at 25% 75%,
     red,
     yellow 10%,
-    #1e90ff 50%,
+    dodgerblue 50%,
     beige
   );
 }
@@ -588,7 +588,7 @@ div {
     ellipse 50% 50px,
     red,
     yellow 10%,
-    #1e90ff 50%,
+    dodgerblue 50%,
     beige
   );
 }
@@ -613,7 +613,13 @@ div {
 
 ```css
 .radial-circle-size {
-  background: radial-gradient(circle 50px, red, yellow 10%, #1e90ff 50%, beige);
+  background: radial-gradient(
+    circle 50px,
+    red,
+    yellow 10%,
+    dodgerblue 50%,
+    beige
+  );
 }
 ```
 
@@ -637,21 +643,9 @@ div {
 ```css
 .stacked-radial {
   background:
-    radial-gradient(
-      circle at 50% 0,
-      rgb(255 0 0 / 50%),
-      rgb(255 0 0 / 0%) 70.71%
-    ),
-    radial-gradient(
-      circle at 6.7% 75%,
-      rgb(0 0 255 / 50%),
-      rgb(0 0 255 / 0%) 70.71%
-    ),
-    radial-gradient(
-        circle at 93.3% 75%,
-        rgb(0 255 0 / 50%),
-        rgb(0 255 0 / 0%) 70.71%
-      )
+    radial-gradient(circle at 50% 0, rgb(255 0 0 / 50%), transparent 70.71%),
+    radial-gradient(circle at 6.7% 75%, rgb(0 0 255 / 50%), transparent 70.71%),
+    radial-gradient(circle at 93.3% 75%, rgb(0 255 0 / 50%), transparent 70.71%)
       beige;
   border-radius: 50%;
 }
@@ -707,7 +701,7 @@ div {
 
 ```css
 .conic-gradient {
-  background: conic-gradient(at 0% 30%, red 10%, yellow 30%, #1e90ff 50%);
+  background: conic-gradient(at 0% 30%, red 10%, yellow 30%, dodgerblue 50%);
 }
 ```
 

--- a/files/en-us/web/css/css_masking/mask_properties/index.md
+++ b/files/en-us/web/css/css_masking/mask_properties/index.md
@@ -96,9 +96,9 @@ body {
   gap: 20px;
   padding: 15px;
   background-image: conic-gradient(
-    rgb(0 0 0 / 0) 90deg,
+    transparent 90deg,
     rgb(0 0 0 / 0.05) 90deg 180deg,
-    rgb(0 0 0 / 0) 180deg 270deg,
+    transparent 180deg 270deg,
     rgb(0 0 0 / 0.05) 270deg
   );
   background-size: 30px 30px;
@@ -120,7 +120,7 @@ We declare a [`repeating-linear-gradient`](/en-US/docs/Web/CSS/gradient/repeatin
 img {
   mask-image: repeating-linear-gradient(
     to bottom right,
-    #f00 0 20px,
+    red 0 20px,
     #f005 20px 40px,
     transparent 40px 60px
   );
@@ -128,7 +128,7 @@ img {
 .gradient {
   background: repeating-linear-gradient(
     to bottom right,
-    #f00 0 20px,
+    red 0 20px,
     #f005 20px 40px,
     transparent 40px 60px
   );
@@ -725,7 +725,7 @@ img {
   mask-image:
     repeating-linear-gradient(
       to bottom right,
-      #f00 0 20px,
+      red 0 20px,
       #f005 20px 40px,
       transparent 40px 60px
     ),
@@ -774,7 +774,7 @@ img {
     url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
     repeating-linear-gradient(
       to bottom right,
-      #f00 0 20px,
+      red 0 20px,
       #f005 20px 40px,
       transparent 40px 60px
     ),
@@ -808,7 +808,7 @@ If we reverse the order of the mask layers, we can also get very different resul
   mask-image:
     repeating-linear-gradient(
       to bottom right,
-      #f00 0 20px,
+      red 0 20px,
       #f005 20px 40px,
       transparent 40px 60px
     ),
@@ -819,7 +819,7 @@ If we reverse the order of the mask layers, we can also get very different resul
     url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg"),
     repeating-linear-gradient(
       to bottom right,
-      #f00 0 20px,
+      red 0 20px,
       #f005 20px 40px,
       transparent 40px 60px
     );

--- a/files/en-us/web/css/css_masking/masking/index.md
+++ b/files/en-us/web/css/css_masking/masking/index.md
@@ -45,8 +45,8 @@ body {
   gap: 20px;
   padding: 15px;
   background-image:
-    linear-gradient(to right, rgb(0 0 0 / 0) 50%, rgb(0 0 0 / 0.05) 50%),
-    linear-gradient(to bottom, rgb(0 0 0 / 0) 50%, rgb(0 0 0 / 0.05) 50%);
+    linear-gradient(to right, transparent 50%, rgb(0 0 0 / 0.05) 50%),
+    linear-gradient(to bottom, transparent 50%, rgb(0 0 0 / 0.05) 50%);
   background-size: 20px 20px;
 }
 div,
@@ -67,10 +67,10 @@ In this case, the top-right corner of the mask is fully opaque, the top-left qua
 
 ```css live-sample___gradient1
 .applied-mask {
-  mask-image: conic-gradient(rgb(0 0 0 / 1) 90deg, rgb(0 0 0 / 0) 270deg);
+  mask-image: conic-gradient(black 90deg, transparent 270deg);
 }
 .mask-source {
-  background: conic-gradient(rgb(0 0 0 / 1) 90deg, rgb(0 0 0 / 0) 270deg);
+  background: conic-gradient(black 90deg, transparent 270deg);
 }
 ```
 
@@ -84,7 +84,7 @@ With alpha masks, the color of the mask doesn't matter, only the transparency. I
 .applied-mask {
   mask-image: repeating-linear-gradient(
     to bottom right,
-    #f00 0 20px,
+    red 0 20px,
     #f005 20px 40px,
     transparent 40px 60px
   );
@@ -92,7 +92,7 @@ With alpha masks, the color of the mask doesn't matter, only the transparency. I
 .mask-source {
   background: repeating-linear-gradient(
     to bottom right,
-    #f00 0 20px,
+    red 0 20px,
     #f005 20px 40px,
     transparent 40px 60px
   );

--- a/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
+++ b/files/en-us/web/css/css_multicol_layout/spanning_balancing_columns/index.md
@@ -49,7 +49,7 @@ body {
 h2 {
   column-span: all;
   background-color: #4d4e53;
-  color: #fff;
+  color: white;
 }
 ```
 
@@ -93,7 +93,7 @@ body {
 h2 {
   column-span: all;
   background-color: #4d4e53;
-  color: #fff;
+  color: white;
 }
 ```
 
@@ -148,7 +148,7 @@ article {
 }
 h2 {
   background-color: #4d4e53;
-  color: #fff;
+  color: white;
   column-span: all;
 }
 ```
@@ -189,7 +189,7 @@ body {
 }
 h2 {
   background-color: #4d4e53;
-  color: #fff;
+  color: white;
 }
 img {
   max-width: 100%;
@@ -227,7 +227,7 @@ body {
 }
 h2 {
   background-color: #4d4e53;
-  color: #fff;
+  color: white;
 }
 img {
   max-width: 100%;

--- a/files/en-us/web/css/css_overflow/css_carousels/index.md
+++ b/files/en-us/web/css/css_overflow/css_carousels/index.md
@@ -164,13 +164,14 @@ ul::scroll-button(*) {
   border: 0;
   font-size: 2rem;
   background: none;
-  color: rgb(0 0 0 / 0.7);
+  color: black;
+  opacity: 0.7;
   cursor: pointer;
 }
 
 ul::scroll-button(*):hover,
 ul::scroll-button(*):focus {
-  color: rgb(0 0 0 / 1);
+  opacity: 1;
 }
 
 ul::scroll-button(*):active {
@@ -178,7 +179,7 @@ ul::scroll-button(*):active {
 }
 
 ul::scroll-button(*):disabled {
-  color: rgb(0 0 0 / 0.2);
+  opacity: 0.2;
   cursor: unset;
 }
 ```
@@ -455,13 +456,14 @@ ul::scroll-button(*) {
   border: 0;
   font-size: 2rem;
   background: none;
-  color: rgb(0 0 0 / 0.7);
+  color: black;
+  opacity: 0.7;
   cursor: pointer;
 }
 
 ul::scroll-button(*):hover,
 ul::scroll-button(*):focus {
-  color: rgb(0 0 0 / 1);
+  opacity: 1;
 }
 
 ul::scroll-button(*):active {
@@ -469,7 +471,7 @@ ul::scroll-button(*):active {
 }
 
 ul::scroll-button(*):disabled {
-  color: rgb(0 0 0 / 0.2);
+  opacity: 0.2;
   cursor: unset;
 }
 

--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -324,8 +324,8 @@ body {
   position: sticky;
   top: 0;
   min-height: 40px;
-  background-color: #000;
-  color: #fff;
+  background-color: black;
+  color: white;
   margin: 0;
   padding: 0;
 }

--- a/files/en-us/web/css/css_text_decoration/text_shadows/index.md
+++ b/files/en-us/web/css/css_text_decoration/text_shadows/index.md
@@ -180,7 +180,7 @@ p {
 }
 
 .opaque {
-  color: rgb(0 0 0);
+  color: black;
 }
 
 .semitransparent {
@@ -188,11 +188,11 @@ p {
 }
 
 .transparent {
-  color: rgb(0 0 0 / 0);
+  color: transparent;
 }
 
 .white {
-  color: rgb(255 255 255);
+  color: white;
 }
 
 .semi-white {

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -203,7 +203,7 @@ The CSS establishes classes that can be used to set the perspective to different
 }
 
 .back {
-  background: rgb(0 255 0 / 100%);
+  background: lime;
   color: black;
   transform: rotateY(180deg) translateZ(50px);
 }
@@ -499,7 +499,7 @@ This example shows cubes with popular `perspective-origin` values.
   transform: translateZ(50px);
 }
 .back {
-  background: rgb(0 255 0 / 100%);
+  background: lime;
   color: black;
   transform: rotateY(180deg) translateZ(50px);
 }

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -83,7 +83,7 @@ This example performs a four-second font size transition with a two-second delay
   display: block;
   width: 100px;
   height: 100px;
-  background-color: #0000ff;
+  background-color: blue;
   transition:
     width 2s,
     height 2s,
@@ -165,7 +165,7 @@ nav {
 a {
   flex: 1;
   background-color: #333;
-  color: #fff;
+  color: white;
   border: 1px solid;
   padding: 0.5rem;
   text-align: center;
@@ -175,7 +175,7 @@ a {
 
 a:hover,
 a:focus {
-  background-color: #fff;
+  background-color: white;
   color: #333;
 }
 ```
@@ -320,7 +320,7 @@ With CSS, you can smooth the styles applied through JavaScript. Add a transition
 
 ```css hidden live-sample___js-transitions
 body {
-  background-color: #fff;
+  background-color: white;
   color: #333;
   font:
     1.2em / 1.5 Helvetica Neue,

--- a/files/en-us/web/css/d/index.md
+++ b/files/en-us/web/css/d/index.md
@@ -75,7 +75,7 @@ svg {
 
 path {
   fill: #f338;
-  stroke: #000;
+  stroke: black;
 }
 
 path:last-of-type {

--- a/files/en-us/web/css/dashed-ident/index.md
+++ b/files/en-us/web/css/dashed-ident/index.md
@@ -67,7 +67,7 @@ When `<dashed-ident>` is used with the [@font-palette-values](/en-US/docs/Web/CS
 @font-palette-values --my-palette {
   font-family: Bixa;
   base-palette: 1;
-  override-colors: 0 #ff0000;
+  override-colors: 0 red;
 }
 
 h1,

--- a/files/en-us/web/css/fill/index.md
+++ b/files/en-us/web/css/fill/index.md
@@ -76,18 +76,18 @@ This example demonstrates how a `fill` is declared, the effect of the property, 
 
 #### HTML
 
-We have an SVG with two complex shapes defined using the SVG {{SVGElement('polygon')}} and {{SVGElement('path')}} elements. Both have the `fill` attribute set to `#000` (equivalent to the default, `black`). We add a dark grey stroke of `#666` using the SVG {{SVGAttr("stroke")}} attribute but could have used the {{CSSXRef("stroke")}} property.
+We have an SVG with two complex shapes defined using the SVG {{SVGElement('polygon')}} and {{SVGElement('path')}} elements. Both have the `fill` attribute set to the default `black`. We add a dark grey stroke of `#666` using the SVG {{SVGAttr("stroke")}} attribute but could have used the {{CSSXRef("stroke")}} property.
 
 ```html
 <svg viewBox="0 0 220 120" xmlns="http://www.w3.org/2000/svg">
   <path
     d="M 10,5 l 90,0 -80,80 0,-60 80,80 -90,0 z"
     stroke="#666"
-    fill="#000" />
+    fill="black" />
   <polygon
     points="180,10 150,100 220,40 140,40 210,100"
     stroke="#666"
-    fill="#000" />
+    fill="black" />
 </svg>
 ```
 

--- a/files/en-us/web/css/filter-function/brightness/index.md
+++ b/files/en-us/web/css/filter-function/brightness/index.md
@@ -82,7 +82,7 @@ This example shows how to apply the `brightness()` filter to a paragraph via the
 }
 p {
   backdrop-filter: brightness(150%);
-  text-shadow: 2px 2px #ffffff;
+  text-shadow: 2px 2px white;
 }
 ```
 
@@ -93,7 +93,7 @@ p {
 }
 p {
   padding: 0.5rem;
-  color: #000000;
+  color: black;
   font-size: 2rem;
   font-family: sans-serif;
 }

--- a/files/en-us/web/css/filter-function/contrast/index.md
+++ b/files/en-us/web/css/filter-function/contrast/index.md
@@ -93,7 +93,7 @@ code {
 }
 p {
   padding: 0.5rem;
-  color: #ffffff;
+  color: white;
   font-family: sans-serif;
 }
 ```

--- a/files/en-us/web/css/filter-function/hue-rotate/index.md
+++ b/files/en-us/web/css/filter-function/hue-rotate/index.md
@@ -88,7 +88,7 @@ p {
 }
 p {
   padding: 0.5rem;
-  color: #ffffff;
+  color: white;
   font-size: 2rem;
   font-family: sans-serif;
 }

--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -49,7 +49,7 @@ filter: drop-shadow(16px 16px 20px red) invert(75%);
 
 ```css interactive-example
 .example-container {
-  background-color: #fff;
+  background-color: white;
   width: 260px;
   height: 260px;
   display: flex;

--- a/files/en-us/web/css/flex-wrap/index.md
+++ b/files/en-us/web/css/flex-wrap/index.md
@@ -120,7 +120,7 @@ The `flex-wrap` property is specified as a single keyword chosen from the follow
 .content,
 .content1,
 .content2 {
-  color: #fff;
+  color: white;
   font: 100 24px/100px sans-serif;
   height: 150px;
   width: 897px;

--- a/files/en-us/web/css/gradient/conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/conic-gradient/index.md
@@ -140,8 +140,8 @@ conic-gradient(red 40grad, 80grad, blue 360grad);
 If two or more color stops are at the same location, the transition will be a hard line between the first and last colors declared at that location. To use conic gradients to create pie charts — which is NOT the correct way to create pie charts as background images are not accessible — use hard color stops, where the color stop angles for two adjacent color stops are the same. The easiest way to do this is to use multiple position colors stops. The following two declarations are equivalent:
 
 ```css
-conic-gradient(#fff 0.09turn, #bbb 0.09turn, #bbb 0.27turn, #666 0.27turn, #666 0.54turn, #000 0.54turn);
-conic-gradient(#fff 0turn 0.09turn, #bbb 0.09turn 0.27turn, #666 0.27turn 0.54turn, #000 0.54turn 1turn);
+conic-gradient(white 0.09turn, #bbb 0.09turn, #bbb 0.27turn, #666 0.27turn, #666 0.54turn, black 0.54turn);
+conic-gradient(white 0turn 0.09turn, #bbb 0.09turn 0.27turn, #666 0.27turn 0.54turn, black 0.54turn 1turn);
 ```
 
 Color stops should be listed in ascending order. Subsequent color stops of lower value will override the value of the previous color stop creating a hard transition. The following changes from red to yellow at the 30% mark, and then transitions from yellow to blue over 35% of the gradient:
@@ -153,7 +153,7 @@ conic-gradient(red .8rad, yellow .6rad, blue 1.3rad);
 There are other effects you can create with conic gradients. Oddly, a checkerboard is one of them. By creating quadrants with an upper left and lower right white quadrant and lower left and upper right black quadrants, then repeating the gradient 16 times (four times across and four times down) you can make a checkerboard.
 
 ```css
-conic-gradient(#fff 90deg, #000 0.25turn 0.5turn, #fff 1rad 1.5rad, #000 300grad);
+conic-gradient(white 90deg, black 0.25turn 0.5turn, white 1rad 1.5rad, black 300grad);
 background-size: 25% 25%;
 ```
 
@@ -187,7 +187,7 @@ div {
 
 ```css
 div {
-  background-image: conic-gradient(from 40deg, #fff, #000);
+  background-image: conic-gradient(from 40deg, white, black);
 }
 ```
 
@@ -254,10 +254,10 @@ div {
 ```css
 div {
   background: conic-gradient(
-      #fff 0.25turn,
-      #000 0.25turn 0.5turn,
-      #fff 0.5turn 0.75turn,
-      #000 0.75turn
+      white 0.25turn,
+      black 0.25turn 0.5turn,
+      white 0.5turn 0.75turn,
+      black 0.75turn
     )
     top left / 25% 25% repeat;
   border: 1px solid;

--- a/files/en-us/web/css/gradient/index.md
+++ b/files/en-us/web/css/gradient/index.md
@@ -123,7 +123,7 @@ div {
 
 ```css
 .radial-gradient {
-  background: radial-gradient(red, yellow, rgb(30 144 255));
+  background: radial-gradient(red, yellow, dodgerblue);
 }
 ```
 

--- a/files/en-us/web/css/gradient/linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/linear-gradient/index.md
@@ -24,9 +24,9 @@ background: linear-gradient(to left, #333, #333 50%, #eee 75%, #333 75%);
 
 ```css interactive-example-choice
 background:
-  linear-gradient(217deg, rgb(255 0 0 / 0.8), rgb(255 0 0 / 0) 70.71%),
-  linear-gradient(127deg, rgb(0 255 0 / 0.8), rgb(0 255 0 / 0) 70.71%),
-  linear-gradient(336deg, rgb(0 0 255 / 0.8), rgb(0 0 255 / 0) 70.71%);
+  linear-gradient(217deg, rgb(255 0 0 / 0.8), transparent 70.71%),
+  linear-gradient(127deg, rgb(0 255 0 / 0.8), transparent 70.71%),
+  linear-gradient(336deg, rgb(0 0 255 / 0.8), transparent 70.71%);
 ```
 
 ```html interactive-example

--- a/files/en-us/web/css/gradient/repeating-conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient/index.md
@@ -151,7 +151,7 @@ div {
 
 ```css
 div {
-  background-image: repeating-conic-gradient(#fff 0 9deg, #000 9deg 18deg);
+  background-image: repeating-conic-gradient(white 0 9deg, black 9deg 18deg);
 }
 ```
 

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -40,7 +40,7 @@ height: auto;
   flex-direction: column;
   background-color: #5b6dcd;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/if/index.md
+++ b/files/en-us/web/css/if/index.md
@@ -17,7 +17,7 @@ The **`if()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Val
 ```css-nolint
 /* Single <if-test> */
 if(style(--scheme: dark): #eee;)
-if(media(print): #000;)
+if(media(print): black;)
 if(media(width > 700px): 0 auto;)
 if(supports(color: lch(7.1% 60.23 300.16)): lch(7.1% 60.23 300.16);)
 
@@ -30,8 +30,8 @@ if(
   else: #03045e;
 )
 if(
-  supports(color: lch(77.7% 0 0)): 3px solid lch(77.7% 0 0);
-  else: 3px solid #c0c0c0;
+  supports(color: lch(75% 0 0)): 3px solid lch(75% 0 0);
+  else: 3px solid silver;
 )
 
 /* Multiple <if-test>s */
@@ -240,8 +240,8 @@ For example, the following returns an {{cssxref("color_value/lch()")}} color if 
 
 ```css-nolint
 color: if(
-  supports(color: lch(77.7% 0 0)): lch(77.7% 0 0);
-  else: rgb(192 192 192);
+  supports(color: lch(75% 0 0)): lch(75% 0 0);
+  else: rgb(185 185 185);
 )
 ```
 
@@ -292,8 +292,8 @@ An `if()` function can be set as the value of any CSS property, but it can also 
 
 ```css-nolint
 border: if(
-  supports(color: lch(77.7% 0 0)): 3px solid lch(77.7% 0 0);
-  else: 3px solid #c0c0c0;
+  supports(color: lch(75% 0 0)): 3px solid lch(75% 0 0);
+  else: 3px solid silver;
 );
 ```
 
@@ -302,7 +302,7 @@ However, we could use the `if()` function to determine the {{cssxref("border-col
 ```css-nolint
 border: 3px solid
   if(
-    supports(color: lch(77.7% 0 0)): lch(77.7% 0 0); else: #c0c0c0;
+    supports(color: lch(75% 0 0)): lch(75% 0 0); else: silver;
   );
 ```
 

--- a/files/en-us/web/css/inline-size/index.md
+++ b/files/en-us/web/css/inline-size/index.md
@@ -45,7 +45,7 @@ writing-mode: vertical-lr;
   background-color: #5b6dcd;
   height: 80%;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/isolation/index.md
+++ b/files/en-us/web/css/isolation/index.md
@@ -109,13 +109,13 @@ The `isolation` property is specified as one of the keyword values listed below.
 }
 
 .big-square {
-  background-color: rgb(0 255 0);
+  background-color: lime;
   width: 200px;
   height: 210px;
 }
 
 .small-square {
-  background-color: rgb(0 255 0);
+  background-color: lime;
   width: 100px;
   height: 100px;
   border: 1px solid black;

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -130,7 +130,7 @@ img {
 
 .card footer {
   background-color: #333;
-  color: #fff;
+  color: white;
   padding: 0.5rem;
 }
 ```

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -67,7 +67,7 @@ body {
 
 .list-group .badge {
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-weight: bold;
   font-size: 80%;
   border-radius: 10em;

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -96,7 +96,7 @@ nav {
 
 .pagination a[aria-current="page"] {
   background-color: #333;
-  color: #fff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -56,7 +56,7 @@ body {
 .page-header,
 .page-footer {
   background-color: rgb(75 70 74);
-  color: #fff;
+  color: white;
   padding: 20px;
 }
 
@@ -123,7 +123,7 @@ body {
 .page-header,
 .page-footer {
   background-color: rgb(75 70 74);
-  color: #fff;
+  color: white;
   padding: 20px;
 
   flex-grow: 0;

--- a/files/en-us/web/css/line-style/index.md
+++ b/files/en-us/web/css/line-style/index.md
@@ -153,7 +153,7 @@ p + p {
   columns: 3;
   column-gap: 20px;
   column-rule: double 7px;
-  border-color: #000000;
+  border-color: black;
 }
 .none p {
   border-style: none;


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. As a starter, I'm porting all colors that have named equivalents to named colors, per our recommendation of using "common named colors". Afterwards, I'm going to convert the remaining colors to the preferred notation, such as preferring `rgb()` and preferring number parameters.