### PR TITLE
Lint: use named color if possible (6)

### DIFF
--- a/files/en-us/web/css/margin-block-end/index.md
+++ b/files/en-us/web/css/margin-block-end/index.md
@@ -55,7 +55,7 @@ writing-mode: vertical-lr;
   display: inline-block;
   border: solid #ce7777 10px;
   background-color: #2b3a55;
-  color: #ffffff;
+  color: white;
   flex-shrink: 0;
 }
 

--- a/files/en-us/web/css/margin-block-start/index.md
+++ b/files/en-us/web/css/margin-block-start/index.md
@@ -55,7 +55,7 @@ writing-mode: vertical-lr;
   display: inline-block;
   border: solid #ce7777 10px;
   background-color: #2b3a55;
-  color: #ffffff;
+  color: white;
   flex-shrink: 0;
 }
 

--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -55,7 +55,7 @@ writing-mode: vertical-lr;
   display: inline-block;
   border: solid #ce7777 10px;
   background-color: #2b3a55;
-  color: #ffffff;
+  color: white;
   flex-shrink: 0;
 }
 

--- a/files/en-us/web/css/marker-end/index.md
+++ b/files/en-us/web/css/marker-end/index.md
@@ -65,7 +65,7 @@ svg {
       refY="5"
       markerUnits="strokeWidth"
       orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f00" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/css/marker-mid/index.md
+++ b/files/en-us/web/css/marker-mid/index.md
@@ -65,7 +65,7 @@ svg {
       refY="5"
       markerUnits="strokeWidth"
       orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f00" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/css/marker-start/index.md
+++ b/files/en-us/web/css/marker-start/index.md
@@ -65,7 +65,7 @@ svg {
       refY="5"
       markerUnits="strokeWidth"
       orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f00" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/css/marker/index.md
+++ b/files/en-us/web/css/marker/index.md
@@ -67,7 +67,7 @@ svg {
       refY="5"
       markerUnits="strokeWidth"
       orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#f00" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="red" />
     </marker>
   </defs>
   <polyline

--- a/files/en-us/web/css/mask-image/index.md
+++ b/files/en-us/web/css/mask-image/index.md
@@ -18,7 +18,7 @@ mask-image: none;
 mask-image: url("masks.svg#mask1");
 
 /* <image> values */
-mask-image: linear-gradient(rgb(0 0 0 / 100%), transparent);
+mask-image: linear-gradient(black, transparent);
 mask-image: image(url("mask.png"), skyblue);
 
 /* Multiple values */

--- a/files/en-us/web/css/max-block-size/index.md
+++ b/files/en-us/web/css/max-block-size/index.md
@@ -51,7 +51,7 @@ writing-mode: vertical-lr;
   flex-direction: column;
   background-color: #5b6dcd;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 
@@ -164,7 +164,7 @@ After that come the classes `horizontal` and `vertical`, which add the {{cssxref
 .standard-box {
   padding: 4px;
   background-color: #abcdef;
-  color: #000;
+  color: black;
   font:
     16px "Open Sans",
     "Helvetica",

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -41,7 +41,7 @@ max-height: 10px;
   flex-direction: column;
   background-color: #5b6dcd;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/max-inline-size/index.md
+++ b/files/en-us/web/css/max-inline-size/index.md
@@ -47,7 +47,7 @@ writing-mode: vertical-lr;
   background-color: #5b6dcd;
   height: 80%;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -41,7 +41,7 @@ max-width: 20ch;
   background-color: #5b6dcd;
   height: 80%;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/min-block-size/index.md
+++ b/files/en-us/web/css/min-block-size/index.md
@@ -48,7 +48,7 @@ writing-mode: vertical-lr;
   flex-direction: column;
   background-color: #5b6dcd;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/min-height/index.md
+++ b/files/en-us/web/css/min-height/index.md
@@ -42,7 +42,7 @@ min-height: 10px;
   flex-direction: column;
   background-color: #5b6dcd;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/min-inline-size/index.md
+++ b/files/en-us/web/css/min-inline-size/index.md
@@ -43,7 +43,7 @@ writing-mode: vertical-lr;
   background-color: #5b6dcd;
   height: 80%;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/min-width/index.md
+++ b/files/en-us/web/css/min-width/index.md
@@ -41,7 +41,7 @@ min-width: 40ch;
   background-color: #5b6dcd;
   height: 80%;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -625,7 +625,7 @@ body {
 .cell {
   margin: 0.5em;
   padding: 0.5em;
-  background-color: #fff;
+  background-color: white;
   overflow: hidden;
   text-align: center;
 }
@@ -646,8 +646,8 @@ body {
 .container {
   position: relative;
   background:
-    linear-gradient(to right, #000 0%, transparent 50%, #fff 100%),
-    linear-gradient(to bottom, #ff0 0%, #f0f 50%, #0ff 100%);
+    linear-gradient(to right, black 0%, transparent 50%, white 100%),
+    linear-gradient(to bottom, yellow 0%, magenta 50%, cyan 100%);
   width: 150px;
   height: 150px;
   margin: 0 auto;

--- a/files/en-us/web/css/object-fit/index.md
+++ b/files/en-us/web/css/object-fit/index.md
@@ -141,7 +141,7 @@ h2 {
 img {
   width: 150px;
   height: 100px;
-  border: 1px solid #000;
+  border: 1px solid black;
   margin: 10px 0;
 }
 

--- a/files/en-us/web/css/offset-anchor/index.md
+++ b/files/en-us/web/css/offset-anchor/index.md
@@ -54,8 +54,8 @@ offset-anchor: 20% 80%;
     to bottom,
     transparent,
     transparent 49%,
-    #000 50%,
-    #000 51%,
+    black 50%,
+    black 51%,
     transparent 52%
   );
   border: 1px solid #ccc;
@@ -181,8 +181,8 @@ section {
     to bottom,
     transparent,
     transparent 49%,
-    #000 50%,
-    #000 51%,
+    black 50%,
+    black 51%,
     transparent 52%
   );
   border: 1px solid #ccc;

--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -111,7 +111,7 @@ Color contrast ratio is determined by comparing the luminosity of the text and b
 ```css
 p {
   outline: 2px solid; /* Set the outline width and style */
-  outline-color: #0000ff; /* Make the outline blue */
+  outline-color: blue;
   margin: 5px;
 }
 ```

--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -111,7 +111,7 @@ Color contrast ratio is determined by comparing the luminosity of the text and b
 ```css
 p {
   outline: 2px solid; /* Set the outline width and style */
-  outline-color: blue;
+  outline-color: blue; /* Set the outline color */
   margin: 5px;
 }
 ```

--- a/files/en-us/web/css/overflow-wrap/index.md
+++ b/files/en-us/web/css/overflow-wrap/index.md
@@ -40,7 +40,7 @@ overflow-wrap: break-word;
 ```css interactive-example
 .example-container {
   background-color: rgb(255 0 200 / 0.2);
-  border: 3px solid #663399;
+  border: 3px solid rebeccapurple;
   padding: 0.75em;
   width: min-content;
   max-width: 11em;

--- a/files/en-us/web/css/overlay/index.md
+++ b/files/en-us/web/css/overlay/index.md
@@ -105,7 +105,7 @@ html {
 /* Transition for the popover's backdrop */
 
 [popover]::backdrop {
-  background-color: rgb(0 0 0 / 0%);
+  background-color: transparent;
   transition:
     display 0.7s allow-discrete,
     overlay 0.7s allow-discrete,
@@ -123,7 +123,7 @@ html {
 
 @starting-style {
   [popover]:popover-open::backdrop {
-    background-color: rgb(0 0 0 / 0%);
+    background-color: transparent;
   }
 }
 ```

--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -78,8 +78,8 @@ main {
   background-color: white;
   background-image: repeating-linear-gradient(
     to bottom,
-    rgb(0 0 0 / 0%) 0px,
-    rgb(0 0 0 / 0%) 19px,
+    transparent 0px,
+    transparent 19px,
     rgb(0 0 0 / 50%) 20px
   );
 }
@@ -100,8 +100,8 @@ div > div {
   background-color: yellow;
   background-image: repeating-linear-gradient(
     to bottom,
-    rgb(0 0 0 / 0%) 0px,
-    rgb(0 0 0 / 0%) 19px,
+    transparent 0px,
+    transparent 19px,
     rgb(0 0 0 / 50%) 20px
   );
 }

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -78,8 +78,8 @@ main {
   background-color: white;
   background-image: repeating-linear-gradient(
     to right,
-    rgb(0 0 0 / 0%) 0px,
-    rgb(0 0 0 / 0%) 19px,
+    transparent 0px,
+    transparent 19px,
     rgb(0 0 0 / 50%) 20px
   );
 }
@@ -100,8 +100,8 @@ div > div {
   background-color: yellow;
   background-image: repeating-linear-gradient(
     to right,
-    rgb(0 0 0 / 0%) 0px,
-    rgb(0 0 0 / 0%) 19px,
+    transparent 0px,
+    transparent 19px,
     rgb(0 0 0 / 50%) 20px
   );
 }

--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -423,7 +423,7 @@ You must specify a threshold with at least one of `top`, `right`, `bottom`, or `
 }
 
 dl > div {
-  background: #fff;
+  background: white;
   padding: 24px 0 0 0;
 }
 
@@ -431,7 +431,7 @@ dt {
   background: #b8c1c8;
   border-bottom: 1px solid #989ea4;
   border-top: 1px solid #717d85;
-  color: #fff;
+  color: white;
   font:
     bold 18px/21px Helvetica,
     Arial,

--- a/files/en-us/web/css/resize/index.md
+++ b/files/en-us/web/css/resize/index.md
@@ -34,13 +34,13 @@ resize: none;
 
 ```css interactive-example
 #example-element {
-  background: linear-gradient(135deg, #0ff 0%, #0ff 94%, #fff 95%);
+  background: linear-gradient(135deg, cyan 0%, cyan 94%, white 95%);
   border: 3px solid #c5c5c5;
   overflow: auto;
   width: 250px;
   height: 250px;
   font-weight: bold;
-  color: #000;
+  color: black;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/files/en-us/web/css/scroll-margin-block-end/index.md
+++ b/files/en-us/web/css/scroll-margin-block-end/index.md
@@ -56,7 +56,7 @@ scroll-margin-block-end: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-margin-block-end: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin-block-start/index.md
+++ b/files/en-us/web/css/scroll-margin-block-start/index.md
@@ -56,7 +56,7 @@ scroll-margin-block-start: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-margin-block-start: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin-block/index.md
+++ b/files/en-us/web/css/scroll-margin-block/index.md
@@ -56,7 +56,7 @@ scroll-margin-block: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-margin-block: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin-bottom/index.md
+++ b/files/en-us/web/css/scroll-margin-bottom/index.md
@@ -56,7 +56,7 @@ scroll-margin-bottom: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-margin-bottom: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin-inline-end/index.md
+++ b/files/en-us/web/css/scroll-margin-inline-end/index.md
@@ -59,7 +59,7 @@ scroll-margin-inline-end: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-margin-inline-end: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```
@@ -134,7 +134,7 @@ Let's walk through the CSS. The outer container is styled like this:
   overflow-x: scroll;
   display: flex;
   box-sizing: border-box;
-  border: 1px solid #000;
+  border: 1px solid black;
   scroll-snap-type: x mandatory;
 }
 ```
@@ -147,8 +147,8 @@ The child elements are styled as follows:
 .scroller > div {
   flex: 0 0 250px;
   width: 250px;
-  background-color: #663399;
-  color: #fff;
+  background-color: rebeccapurple;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -157,8 +157,8 @@ The child elements are styled as follows:
 }
 
 .scroller > div:nth-child(2n) {
-  background-color: #fff;
-  color: #663399;
+  background-color: white;
+  color: rebeccapurple;
 }
 ```
 

--- a/files/en-us/web/css/scroll-margin-inline-start/index.md
+++ b/files/en-us/web/css/scroll-margin-inline-start/index.md
@@ -59,7 +59,7 @@ scroll-margin-inline-start: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-margin-inline-start: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```
@@ -134,7 +134,7 @@ Let's walk through the CSS. The outer container is styled like this:
   overflow-x: scroll;
   display: flex;
   box-sizing: border-box;
-  border: 1px solid #000;
+  border: 1px solid black;
   scroll-snap-type: x mandatory;
 }
 ```
@@ -147,8 +147,8 @@ The child elements are styled as follows:
 .scroller > div {
   flex: 0 0 250px;
   width: 250px;
-  background-color: #663399;
-  color: #fff;
+  background-color: rebeccapurple;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -157,8 +157,8 @@ The child elements are styled as follows:
 }
 
 .scroller > div:nth-child(2n) {
-  background-color: #fff;
-  color: #663399;
+  background-color: white;
+  color: rebeccapurple;
 }
 ```
 

--- a/files/en-us/web/css/scroll-margin-inline/index.md
+++ b/files/en-us/web/css/scroll-margin-inline/index.md
@@ -63,7 +63,7 @@ scroll-margin-inline: 0px 3em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -72,7 +72,7 @@ scroll-margin-inline: 0px 3em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```
@@ -149,7 +149,7 @@ Let's walk through the CSS. The outer container is styled like this:
   overflow-x: scroll;
   display: flex;
   box-sizing: border-box;
-  border: 1px solid #000;
+  border: 1px solid black;
   scroll-snap-type: x mandatory;
 }
 ```
@@ -162,8 +162,8 @@ The child elements are styled as follows:
 .scroller > div {
   flex: 0 0 250px;
   width: 250px;
-  background-color: #663399;
-  color: #fff;
+  background-color: rebeccapurple;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -172,8 +172,8 @@ The child elements are styled as follows:
 }
 
 .scroller > div:nth-child(2n) {
-  background-color: #fff;
-  color: #663399;
+  background-color: white;
+  color: rebeccapurple;
 }
 ```
 

--- a/files/en-us/web/css/scroll-margin-left/index.md
+++ b/files/en-us/web/css/scroll-margin-left/index.md
@@ -59,7 +59,7 @@ scroll-margin-left: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-margin-left: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin-right/index.md
+++ b/files/en-us/web/css/scroll-margin-right/index.md
@@ -59,7 +59,7 @@ scroll-margin-right: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-margin-right: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin-top/index.md
+++ b/files/en-us/web/css/scroll-margin-top/index.md
@@ -56,7 +56,7 @@ scroll-margin-top: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-margin-top: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-margin/index.md
+++ b/files/en-us/web/css/scroll-margin/index.md
@@ -56,7 +56,7 @@ scroll-margin: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-margin: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```
@@ -146,7 +146,7 @@ Let's walk through the CSS. The outer container is styled like this:
   overflow-x: scroll;
   display: flex;
   box-sizing: border-box;
-  border: 1px solid #000;
+  border: 1px solid black;
   scroll-snap-type: x mandatory;
 }
 ```
@@ -159,8 +159,8 @@ The child elements are styled as follows:
 .scroller > div {
   flex: 0 0 250px;
   width: 250px;
-  background-color: #663399;
-  color: #fff;
+  background-color: rebeccapurple;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -169,8 +169,8 @@ The child elements are styled as follows:
 }
 
 .scroller > div:nth-child(2n) {
-  background-color: #fff;
-  color: #663399;
+  background-color: white;
+  color: rebeccapurple;
 }
 ```
 

--- a/files/en-us/web/css/scroll-padding-block-end/index.md
+++ b/files/en-us/web/css/scroll-padding-block-end/index.md
@@ -56,7 +56,7 @@ scroll-padding-block-end: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-padding-block-end: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-block-start/index.md
+++ b/files/en-us/web/css/scroll-padding-block-start/index.md
@@ -56,7 +56,7 @@ scroll-padding-block-start: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-padding-block-start: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-block/index.md
+++ b/files/en-us/web/css/scroll-padding-block/index.md
@@ -56,7 +56,7 @@ scroll-padding-block: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-padding-block: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-bottom/index.md
+++ b/files/en-us/web/css/scroll-padding-bottom/index.md
@@ -56,7 +56,7 @@ scroll-padding-bottom: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-padding-bottom: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-inline-end/index.md
+++ b/files/en-us/web/css/scroll-padding-inline-end/index.md
@@ -59,7 +59,7 @@ scroll-padding-inline-end: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-padding-inline-end: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-inline-start/index.md
+++ b/files/en-us/web/css/scroll-padding-inline-start/index.md
@@ -59,7 +59,7 @@ scroll-padding-inline-start: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-padding-inline-start: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-inline/index.md
+++ b/files/en-us/web/css/scroll-padding-inline/index.md
@@ -59,7 +59,7 @@ scroll-padding-inline: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-padding-inline: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-left/index.md
+++ b/files/en-us/web/css/scroll-padding-left/index.md
@@ -59,7 +59,7 @@ scroll-padding-left: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-padding-left: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-right/index.md
+++ b/files/en-us/web/css/scroll-padding-right/index.md
@@ -59,7 +59,7 @@ scroll-padding-right: 2em;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ scroll-padding-right: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding-top/index.md
+++ b/files/en-us/web/css/scroll-padding-top/index.md
@@ -56,7 +56,7 @@ scroll-padding-top: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-padding-top: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-padding/index.md
+++ b/files/en-us/web/css/scroll-padding/index.md
@@ -56,7 +56,7 @@ scroll-padding: 2em;
 .scroller > div {
   flex: 0 0 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -65,7 +65,7 @@ scroll-padding: 2em;
 }
 
 .scroller > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-snap-align/index.md
+++ b/files/en-us/web/css/scroll-snap-align/index.md
@@ -59,7 +59,7 @@ scroll-snap-align: center;
   flex: 0 0 66%;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -67,7 +67,7 @@ scroll-snap-align: center;
 }
 
 #example-parent > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-snap-stop/index.md
+++ b/files/en-us/web/css/scroll-snap-stop/index.md
@@ -69,7 +69,7 @@ scroll-snap-stop: always;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -78,7 +78,7 @@ scroll-snap-stop: always;
 }
 
 .snap-container > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -58,7 +58,7 @@ scroll-snap-type: x proximity;
   flex: 0 0 250px;
   width: 250px;
   background-color: rebeccapurple;
-  color: #fff;
+  color: white;
   font-size: 30px;
   display: flex;
   align-items: center;
@@ -67,7 +67,7 @@ scroll-snap-type: x proximity;
 }
 
 #example-element > div:nth-child(even) {
-  background-color: #fff;
+  background-color: white;
   color: rebeccapurple;
 }
 ```

--- a/files/en-us/web/css/shape-outside/index.md
+++ b/files/en-us/web/css/shape-outside/index.md
@@ -83,7 +83,7 @@ shape-outside: margin-box ellipse();
 shape-outside: url("image.png");
 
 /* <gradient> value */
-shape-outside: linear-gradient(45deg, #fff 150px, red 150px);
+shape-outside: linear-gradient(45deg, white 150px, red 150px);
 
 /* Global values */
 shape-outside: inherit;

--- a/files/en-us/web/css/sibling-index/index.md
+++ b/files/en-us/web/css/sibling-index/index.md
@@ -61,7 +61,7 @@ The **`sibling-index()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/
   padding: 2px;
   border-radius: 8px;
   width: var(--width, calc(sibling-index() * 30px));
-  color: #fff;
+  color: white;
   background-color: hsl(
     calc(360deg / sibling-count() * sibling-index()) 50% 50%
   );

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -56,7 +56,7 @@ transform: translateX(calc(cos(-45deg) * 140px))
   border: 2px solid #666;
   background-image:
     radial-gradient(black var(--dot-size), transparent var(--dot-size)),
-    linear-gradient(135deg, #0000ff, #00c9ff, #92fe9d, #e6e6fa, #f0fff0);
+    linear-gradient(135deg, blue, deepskyblue, lightgreen, lavender, honeydew);
 }
 .dot {
   display: block;

--- a/files/en-us/web/css/stop-color/index.md
+++ b/files/en-us/web/css/stop-color/index.md
@@ -54,21 +54,21 @@ We have an SVG with three {{SVGElement("rect")}} squares and three {{SVGElement(
 <svg viewBox="0 0 264 100" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="myGradient1">
-      <stop offset="25%" stop-color="#000" />
-      <stop offset="40%" stop-color="#fff" />
-      <stop offset="60%" stop-color="#fff" />
+      <stop offset="25%" stop-color="black" />
+      <stop offset="40%" stop-color="white" />
+      <stop offset="60%" stop-color="white" />
       <stop offset="75%" stop-color="#333" />
     </linearGradient>
     <linearGradient id="myGradient2">
-      <stop offset="25%" stop-color="#000" />
-      <stop offset="40%" stop-color="#fff" />
-      <stop offset="60%" stop-color="#fff" />
+      <stop offset="25%" stop-color="black" />
+      <stop offset="40%" stop-color="white" />
+      <stop offset="60%" stop-color="white" />
       <stop offset="75%" stop-color="#333" />
     </linearGradient>
     <linearGradient id="myGradient3">
-      <stop offset="25%" stop-color="#000" />
-      <stop offset="40%" stop-color="#fff" />
-      <stop offset="60%" stop-color="#fff" />
+      <stop offset="25%" stop-color="black" />
+      <stop offset="40%" stop-color="white" />
+      <stop offset="60%" stop-color="white" />
       <stop offset="75%" stop-color="#333" />
     </linearGradient>
   </defs>
@@ -114,10 +114,10 @@ rect {
 }
 #myGradient3 {
   stop:first-of-type {
-    stop-color: hsl(0deg 100% 50%);
+    stop-color: hsl(0deg 90% 50%);
   }
   stop:last-of-type {
-    stop-color: hsl(20deg 100% 50%);
+    stop-color: hsl(20deg 60% 50%);
   }
 }
 ```

--- a/files/en-us/web/css/stroke/index.md
+++ b/files/en-us/web/css/stroke/index.md
@@ -68,7 +68,7 @@ Via CSS, we then apply a dusky purple color to the rectangle and a red to the ci
 
 ```css
 rect {
-  stroke: hsl(270deg 50% 40%);
+  stroke: rebeccapurple;
 }
 circle {
   stroke: red;
@@ -180,7 +180,7 @@ We then write CSS to add a marker to both paths, and also to have a dusky purple
 
 ```css
 path {
-  stroke: hsl(270deg 50% 40%);
+  stroke: rebeccapurple;
   marker: url("#circle");
 }
 path:nth-of-type(2) {

--- a/files/en-us/web/css/text-decoration-thickness/index.md
+++ b/files/en-us/web/css/text-decoration-thickness/index.md
@@ -37,7 +37,7 @@ font-size: 2rem;
 ```css interactive-example
 p {
   font: 1.5em sans-serif;
-  text-decoration-color: #ff0000;
+  text-decoration-color: red;
 }
 ```
 

--- a/files/en-us/web/css/text-indent/index.md
+++ b/files/en-us/web/css/text-indent/index.md
@@ -53,14 +53,14 @@ text-indent: 3em hanging each-line;
 ```css interactive-example
 section {
   font-size: 1.25em;
-  background-color: #483d8b;
+  background-color: darkslateblue;
   align-items: start;
 }
 
 #example-element {
   text-align: left;
   margin: 0 0 0 3em;
-  background-color: #6a5acd;
+  background-color: slateblue;
   color: white;
 }
 ```

--- a/files/en-us/web/css/text-underline-offset/index.md
+++ b/files/en-us/web/css/text-underline-offset/index.md
@@ -32,7 +32,7 @@ text-underline-offset: -0.5rem;
 p {
   font: 1.5em sans-serif;
   text-decoration-line: underline;
-  text-decoration-color: #ff0000;
+  text-decoration-color: red;
 }
 ```
 

--- a/files/en-us/web/css/transform-function/index.md
+++ b/files/en-us/web/css/transform-function/index.md
@@ -199,7 +199,7 @@ main {
   position: absolute;
   backface-visibility: inherit;
   font-size: 60px;
-  color: #fff;
+  color: white;
 }
 
 .front {

--- a/files/en-us/web/css/transform-function/matrix3d/index.md
+++ b/files/en-us/web/css/transform-function/matrix3d/index.md
@@ -156,7 +156,7 @@ a `matrix3d()` transform to it.
   position: absolute;
   backface-visibility: inherit;
   font-size: 60px;
-  color: #fff;
+  color: white;
 }
 
 .front {

--- a/files/en-us/web/css/transform-origin/index.md
+++ b/files/en-us/web/css/transform-origin/index.md
@@ -76,7 +76,7 @@ transform-origin: bottom right 60px;
   align-items: center;
   justify-content: center;
   background: #f7ebee;
-  color: #000000;
+  color: black;
   font-size: 1.2rem;
   text-transform: uppercase;
 }

--- a/files/en-us/web/css/transform-style/index.md
+++ b/files/en-us/web/css/transform-style/index.md
@@ -38,7 +38,7 @@ transform-style: preserve-3d;
 .numeral {
   background-color: #ffba08;
   border-radius: 0.2rem;
-  color: #000;
+  color: black;
   margin: 1rem;
   padding: 0.2rem;
   transform: rotate3d(1, 1, 1, 45deg);
@@ -141,7 +141,7 @@ We also provide a checkbox allowing you to toggle between this, and `transform-s
   position: absolute;
   backface-visibility: inherit;
   font-size: 60px;
-  color: #fff;
+  color: white;
 }
 
 .front {

--- a/files/en-us/web/css/transition-delay/index.md
+++ b/files/en-us/web/css/transition-delay/index.md
@@ -39,7 +39,7 @@ transition-property: margin-right, color;
 ```css interactive-example
 #example-element {
   background-color: #e4f0f5;
-  color: #000;
+  color: black;
   padding: 1rem;
   border-radius: 0.5rem;
   font: 1em monospace;
@@ -49,7 +49,7 @@ transition-property: margin-right, color;
 
 #default-example:hover > #example-element {
   background-color: #909;
-  color: #fff;
+  color: white;
   margin-right: 40%;
 }
 ```

--- a/files/en-us/web/css/transition-duration/index.md
+++ b/files/en-us/web/css/transition-duration/index.md
@@ -39,7 +39,7 @@ transition-property: margin-right, color;
 ```css interactive-example
 #example-element {
   background-color: #e4f0f5;
-  color: #000;
+  color: black;
   padding: 1rem;
   border-radius: 0.5rem;
   font: 1em monospace;
@@ -49,7 +49,7 @@ transition-property: margin-right, color;
 
 #default-example:hover > #example-element {
   background-color: #909;
-  color: #fff;
+  color: white;
   margin-right: 40%;
 }
 ```

--- a/files/en-us/web/css/transition-property/index.md
+++ b/files/en-us/web/css/transition-property/index.md
@@ -35,7 +35,7 @@ transition-property: none;
 ```css interactive-example
 #example-element {
   background-color: #e4f0f5;
-  color: #000;
+  color: black;
   padding: 1rem;
   border-radius: 0.5rem;
   font: 1em monospace;
@@ -45,7 +45,7 @@ transition-property: none;
 
 #default-example:hover > #example-element {
   background-color: #909;
-  color: #fff;
+  color: white;
   margin-right: 40%;
 }
 ```

--- a/files/en-us/web/css/transition-timing-function/index.md
+++ b/files/en-us/web/css/transition-timing-function/index.md
@@ -35,7 +35,7 @@ transition-timing-function: cubic-bezier(0.29, 1.01, 1, -0.68);
 ```css interactive-example
 #example-element {
   background-color: #e4f0f5;
-  color: #000;
+  color: black;
   padding: 1rem;
   border-radius: 0.5rem;
   font: 1em monospace;
@@ -45,7 +45,7 @@ transition-timing-function: cubic-bezier(0.29, 1.01, 1, -0.68);
 
 #default-example:hover > #example-element {
   background-color: #909;
-  color: #fff;
+  color: white;
   margin-right: 40%;
 }
 ```

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -45,7 +45,7 @@ transition: all 1s ease-out;
 ```css interactive-example
 #example-element {
   background-color: #e4f0f5;
-  color: #000;
+  color: black;
   padding: 1rem;
   border-radius: 0.5rem;
   font: 1em monospace;
@@ -55,7 +55,7 @@ transition: all 1s ease-out;
 
 #default-example:hover > #example-element {
   background-color: #909;
-  color: #fff;
+  color: white;
   margin-right: 40%;
 }
 ```

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -49,7 +49,7 @@ border-image: url("/media/diamonds.png") 30 fill / 30px / 30px space;
 
 /* As a parameter in another CSS function */
 background-image: cross-fade(20% url(first.png), url(second.png));
-mask-image: image(url(mask.png), skyblue, linear-gradient(rgb(0 0 0 / 100%), transparent));
+mask-image: image(url(mask.png), skyblue, linear-gradient(black, transparent));
 
 /* as part of a non-shorthand multiple value */
 content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -39,7 +39,7 @@ border-color: var(--color-c);
 }
 
 #example-element {
-  border: 10px solid #000;
+  border: 10px solid black;
   padding: 10px;
 }
 ```
@@ -55,7 +55,7 @@ var(--custom-prop);
 /* With fallback */
 var(--custom-prop,);  /* empty value as fallback */
 var(--custom-prop, initial); /* initial value of the property as fallback */
-var(--custom-prop, #FF0000);
+var(--custom-prop, red);
 var(--custom-prop, var(--default-value));
 var(--custom-prop, var(--default-value, red));
 ```

--- a/files/en-us/web/css/white-space/index.md
+++ b/files/en-us/web/css/white-space/index.md
@@ -247,7 +247,7 @@ pre {
 }
 
 #css-code {
-  background-color: rgb(220 220 220);
+  background-color: gainsboro;
   font-size: 16px;
   font-family: monospace;
 }

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -41,7 +41,7 @@ width: auto;
   background-color: #5b6dcd;
   height: 80%;
   justify-content: center;
-  color: #ffffff;
+  color: white;
 }
 ```
 


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. As a starter, I'm porting all colors that have named equivalents to named colors, per our recommendation of using "common named colors". Afterwards, I'm going to convert the remaining colors to the preferred notation, such as preferring `rgb()` and preferring number parameters.