### PR TITLE
fix: replace "fragment" with "query" in URI query ref

### DIFF
--- a/files/en-us/web/uri/reference/query/index.md
+++ b/files/en-us/web/uri/reference/query/index.md
@@ -16,7 +16,7 @@ It contains non-hierarchical data to identify a resource within the scope of the
 ?query
 ```
 
-- `fragment`
+- `query`
   - : A sequence of any characters, except for the `#` character, which starts the [fragment](/en-US/docs/Web/URI/Reference/Fragment).
     The exact format of the query is defined by the resource itself.
 


### PR DESCRIPTION
### Description

This PR fixes a typo in the argument name used in URI/reference/query.
The current line seems to be copypasta from the "fragment" reference page.

### Motivation

This caught my eyes while reading the page, and I've interpreted as a simple typo that could cause some confusion.

### Additional details

I couldn't find any open issue about this.