### PR TITLE
FF142Relnote: RTCRtpSender.get/setParameters - encodings.codec property

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -54,7 +54,11 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{domxref("Selection.getComposedRanges()")}} method is now supported, allowing developers to accurately get selected text ranges across shadow DOM boundaries. In addition, the methods {{domxref("Selection.setBaseAndExtent()","setBaseAndExtent()")}}, {{domxref("Selection.collapse()","collapse()")}}, and {{domxref("Selection.extend()","extend()")}} of the {{domxref("Selection")}} interface have been modified to accept nodes inside a shadow root. ([Firefox bug 1903870](https://bugzil.la/1903870)).
 
-<!-- #### Media, WebRTC, and Web Audio -->
+#### Media, WebRTC, and Web Audio
+
+- The {{domxref("RTCRtpSender.setParameters()","setParameters()")}} and {{domxref("RTCRtpSender.getParameters()","getParameters()")}} methods of the {{domxref("RTCRtpSender")}} interface now support setting and getting the specific [`codec`](/en-US/docs/Web/API/RTCRtpSender/setParameters#codec) that is used for each `encoding`.
+  A specific `codec` can also be set for each encoding specified in the [`init.sendEncodings`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings) array passed to the {{domxref("RTCPeerConnection/addTransceiver","addTransceiver()")}} method of the {{domxref("RTCPeerConnection")}} interface.
+  ([Firefox bug 1894137](https://bugzil.la/1894137)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -56,8 +56,8 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
-- The {{domxref("RTCRtpSender.setParameters()","setParameters()")}} and {{domxref("RTCRtpSender.getParameters()","getParameters()")}} methods of the {{domxref("RTCRtpSender")}} interface now support setting and getting the specific [`codec`](/en-US/docs/Web/API/RTCRtpSender/setParameters#codec) that is used for each `encoding`.
-  A specific `codec` can also be set for each encoding specified in the [`init.sendEncodings`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings) array passed to the {{domxref("RTCPeerConnection/addTransceiver","addTransceiver()")}} method of the {{domxref("RTCPeerConnection")}} interface.
+- The {{domxref("RTCRtpSender.setParameters()","setParameters()")}} and {{domxref("RTCRtpSender.getParameters()","getParameters()")}} methods of the {{domxref("RTCRtpSender")}} interface now support setting and getting the specific [`codec`](/en-US/docs/Web/API/RTCRtpSender/setParameters#codecs) used for each `encoding`.
+  You can also set a `codec` for each encoding in the [`init.sendEncodings`](/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings) array that's passed to the {{domxref("RTCPeerConnection/addTransceiver","addTransceiver()")}} method of the {{domxref("RTCPeerConnection")}} interface.
   ([Firefox bug 1894137](https://bugzil.la/1894137)).
 
 <!-- #### Removals -->


### PR DESCRIPTION
FF142 adds support for the dictionary property `RTCRtpEncodingParameters.codec` in https://bugzilla.mozilla.org/show_bug.cgi?id=1894137

This is used when setting encodings in [`RTCRtpSender.setParameters(parameter.encodings)`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters#encodings) and [`RTCPeerConnection.addTransceiver(sendencodings)`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTransceiver#sendencodings), and returned in [`RTCRtpSender/getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters#encodings) (`encodings.codec`).

This adds a release note.

Related docs work can be tracked in #40477
