### PR TITLE
Update 418 status code docs with RFC 9110 reference

### DIFF
--- a/files/en-us/web/http/reference/status/418/index.md
+++ b/files/en-us/web/http/reference/status/418/index.md
@@ -12,8 +12,7 @@ The HTTP **`418 I'm a teapot`** status response code indicates that the server r
 A combined coffee/tea pot that is temporarily out of coffee should instead return {{HTTPStatus("503")}}.
 This error is a reference to Hyper Text Coffee Pot Control Protocol defined in April Fools' jokes in 1998 and 2014.
 
-> [!NOTE]
-> While originally defined in [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324) as an April Fools' joke, this status code was formally reserved in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110).
+While originally defined in [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324) as an April Fools' joke, this status code was formally reserved in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110).
 
 Some websites use this response for requests they do not wish to handle, such as automated queries.
 

--- a/files/en-us/web/http/reference/status/418/index.md
+++ b/files/en-us/web/http/reference/status/418/index.md
@@ -2,7 +2,9 @@
 title: 418 I'm a teapot
 slug: Web/HTTP/Reference/Status/418
 page-type: http-status-code
-spec-urls: https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2
+spec-urls:
+  - https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2
+  - https://www.rfc-editor.org/rfc/rfc9110#name-418-unused
 sidebar: http
 ---
 

--- a/files/en-us/web/http/reference/status/418/index.md
+++ b/files/en-us/web/http/reference/status/418/index.md
@@ -12,6 +12,9 @@ The HTTP **`418 I'm a teapot`** status response code indicates that the server r
 A combined coffee/tea pot that is temporarily out of coffee should instead return {{HTTPStatus("503")}}.
 This error is a reference to Hyper Text Coffee Pot Control Protocol defined in April Fools' jokes in 1998 and 2014.
 
+> [!NOTE]
+> While originally defined in [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324) as an April Fools' joke, this status code was formally reserved in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110).
+
 Some websites use this response for requests they do not wish to handle, such as automated queries.
 
 ## Status

--- a/files/en-us/web/http/reference/status/418/index.md
+++ b/files/en-us/web/http/reference/status/418/index.md
@@ -12,7 +12,7 @@ The HTTP **`418 I'm a teapot`** status response code indicates that the server r
 A combined coffee/tea pot that is temporarily out of coffee should instead return {{HTTPStatus("503")}}.
 This error is a reference to Hyper Text Coffee Pot Control Protocol defined in April Fools' jokes in 1998 and 2014.
 
-While originally defined in [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324) as an April Fools' joke, this status code was formally reserved in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110).
+While originally defined in [RFC 2324](https://www.rfc-editor.org/rfc/rfc2324) as an April Fools' joke, this status code was formally reserved in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) due to its wide deployment as a joke, so it cannot be assigned any non-joke semantics for the foreseeable future.
 
 Some websites use this response for requests they do not wish to handle, such as automated queries.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description
Updated the HTTP 418 status code documentation to include its formal reservation in RFC 9110 while maintaining reference to its original humorous origin in RFC 2324.

### Related issues and pull requests
Fixes #39354
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
