### PR TITLE
fix(workflows): pass changed files via bash array

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -47,7 +47,7 @@ jobs:
           echo "${EOF}" >> "$GITHUB_OUTPUT"
 
           # Also set a simple flag for whether we have files
-          if [ -n "${FILTERED_FILES}" ]; then
+          if [ -n "${FILTERED_MD_FILES// /}" ]; then  # Remove all spaces and check if anything remains
             echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
           else
             echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -34,21 +34,34 @@ jobs:
         run: |
           # Use the GitHub API to get the list of changed files
           # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
-          DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
-            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
-          # filter out files that are not markdown
-          DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)
-          echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> "$GITHUB_OUTPUT"
+
+          # Get files as newline-separated list
+          FILTERED_FILES=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
+            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename' | \
+            egrep -i "^files/.*\.md$")
+
+          # Store as multiline output
+          EOF="$(openssl rand -hex 8)"
+          echo "DIFF_DOCUMENTS<<${EOF}" >> "$GITHUB_OUTPUT"
+          echo "${FILTERED_FILES}" >> "$GITHUB_OUTPUT"
+          echo "${EOF}" >> "$GITHUB_OUTPUT"
+
+          # Also set a simple flag for whether we have files
+          if [ -n "${FILTERED_FILES}" ]; then
+            echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout HEAD
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
 
       - name: Get changed content from HEAD
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
@@ -64,14 +77,14 @@ jobs:
           git commit -m "Code from PR head"
 
       - name: Setup Node.js environment
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
@@ -79,7 +92,7 @@ jobs:
 
       - name: Lint and format markdown files
         id: lint
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         env:
           DIFF_DOCUMENTS: ${{ steps.check.outputs.DIFF_DOCUMENTS }}
         run: |
@@ -87,11 +100,17 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           EOF="$(openssl rand -hex 8)"
 
-          files_to_lint="$DIFF_DOCUMENTS"
+          # The DIFF_DOCUMENTS env var contains the clean newline-separated list
+          # Read into array, one filename per line
+          readarray -t files_to_lint <<< "$DIFF_DOCUMENTS"
+
+          # Debug: show what we got
+          printf "Files to process (%d files):\n" "${#files_to_lint[@]}"
+          printf "'%s'\n" "${files_to_lint[@]}"
 
           echo "crlf line ending check"
           CRLF_FAILED=true
-          CRLF_LOG=$(git ls-files --eol ${files_to_lint} | grep -E 'w/(mixed|crlf)') || CRLF_FAILED=false
+          CRLF_LOG=$(git ls-files --eol "${files_to_lint[@]}" | grep -E 'w/(mixed|crlf)') || CRLF_FAILED=false
           echo "CRLF_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${CRLF_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"
@@ -99,7 +118,7 @@ jobs:
 
           echo "Running markdownlint --fix"
           MD_LINT_FAILED=false
-          MD_LINT_LOG=$(yarn markdownlint-cli2 --fix ${files_to_lint} 2>&1) || MD_LINT_FAILED=true
+          MD_LINT_LOG=$(yarn markdownlint-cli2 --fix "${files_to_lint[@]}" 2>&1) || MD_LINT_FAILED=true
           echo "MD_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${MD_LINT_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"
@@ -107,7 +126,7 @@ jobs:
 
           echo "Linting front-matter"
           FM_LINT_FAILED=false
-          FM_LINT_LOG=$(node scripts/front-matter_linter.js --fix true ${files_to_lint} 2>&1) || FM_LINT_FAILED=true
+          FM_LINT_LOG=$(node scripts/front-matter_linter.js --fix true "${files_to_lint[@]}" 2>&1) || FM_LINT_FAILED=true
           echo "FM_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${FM_LINT_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"
@@ -115,12 +134,12 @@ jobs:
 
           echo "Running Prettier"
           PRETTIER_FAILED=false
-          PRETTIER_LOG=$(yarn prettier --check ${files_to_lint} 2>&1) || PRETTIER_FAILED=true
+          PRETTIER_LOG=$(yarn prettier --check "${files_to_lint[@]}" 2>&1) || PRETTIER_FAILED=true
           echo "PRETTIER_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${PRETTIER_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"
           echo "PRETTIER_FAILED=${PRETTIER_FAILED}" >> "$GITHUB_OUTPUT"
-          yarn prettier -w ${files_to_lint}
+          yarn prettier -w "${files_to_lint[@]}"
 
           if [[ -n $(git diff) ]]; then
             echo "FILES_MODIFIED=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -68,8 +68,6 @@ jobs:
           # Set the boolean outputs
           echo "HAS_MD_FILES=${HAS_MD_FILES}" >> "$GITHUB_OUTPUT"
           echo "HAS_IMAGE_FILES=${HAS_IMAGE_FILES}" >> "$GITHUB_OUTPUT"
-
-          # Set overall flag
           if [ "${HAS_MD_FILES}" = "true" ] || [ "${HAS_IMAGE_FILES}" = "true" ]; then
             echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
           else
@@ -141,8 +139,6 @@ jobs:
 
           # Read into array, one filename per line
           readarray -t files_to_build <<< "$GIT_DIFF_CONTENT"
-
-          # ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $PWD/files#g")
 
           ARGS=()
           for file in "${files_to_build[@]}"; do

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -139,8 +139,6 @@ jobs:
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
 
-          set -x
-
           # Read into array, one filename per line
           readarray -t files_to_build <<< "$GIT_DIFF_CONTENT"
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,29 +35,58 @@ jobs:
         id: check
         run: |
           # Use the GitHub API to get the list of changed files
-          # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 
-          # filter out files that are not markdown files
-          GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(md)$" | xargs)
-          echo "GIT_DIFF_CONTENT=${GIT_DIFF_CONTENT}" >> "$GITHUB_OUTPUT"
+          FILTERED_MD_FILES=$(echo "$DIFF_DOCUMENTS" | egrep -i "^files/.*\.md$" || true)
+          FILTERED_IMAGE_FILES=$(echo "$DIFF_DOCUMENTS" | egrep -i "^files/.*\.(png|jpeg|jpg|gif|svg|webp)$" || true)
 
-          # filter out files that are not attachments
-          GIT_DIFF_FILES=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(png|jpeg|jpg|gif|svg|webp)$" | xargs)
-          echo "GIT_DIFF_FILES=${GIT_DIFF_FILES}" >> "$GITHUB_OUTPUT"
+          HAS_MD_FILES=false
+          HAS_IMAGE_FILES=false
+
+          # Check if we actually have content (not just empty strings)
+          if [ -n "${FILTERED_MD_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+            HAS_MD_FILES=true
+            EOF_MD="$(openssl rand -hex 8)"
+            echo "GIT_DIFF_CONTENT<<${EOF_MD}" >> "$GITHUB_OUTPUT"
+            echo "${FILTERED_MD_FILES}" >> "$GITHUB_OUTPUT"
+            echo "${EOF_MD}" >> "$GITHUB_OUTPUT"
+          else
+            echo "GIT_DIFF_CONTENT=" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "${FILTERED_IMAGE_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+            HAS_IMAGE_FILES=true
+            EOF_IMG="$(openssl rand -hex 8)"
+            echo "GIT_DIFF_FILES<<${EOF_IMG}" >> "$GITHUB_OUTPUT"
+            echo "${FILTERED_IMAGE_FILES}" >> "$GITHUB_OUTPUT"
+            echo "${EOF_IMG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "GIT_DIFF_FILES=" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Set the boolean outputs
+          echo "HAS_MD_FILES=${HAS_MD_FILES}" >> "$GITHUB_OUTPUT"
+          echo "HAS_IMAGE_FILES=${HAS_IMAGE_FILES}" >> "$GITHUB_OUTPUT"
+
+          # Set overall flag
+          if [ "${HAS_MD_FILES}" = "true" ] || [ "${HAS_IMAGE_FILES}" = "true" ]; then
+            echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js environment
-        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
+        if: steps.check.outputs.HAS_FILES == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages
-        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
+        if: steps.check.outputs.HAS_FILES == 'true'
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
@@ -65,7 +94,7 @@ jobs:
 
       - name: Build changed content
         id: build-content
-        if: steps.check.outputs.GIT_DIFF_CONTENT
+        if: steps.check.outputs.HAS_MD_FILES == 'true'
         env:
           GIT_DIFF_CONTENT: ${{ steps.check.outputs.GIT_DIFF_CONTENT }}
 
@@ -109,8 +138,20 @@ jobs:
           # you don't need that script as a writer. It's only used in CI
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
-          ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $PWD/files#g")
-          yarn rari build --no-basic --json-issues --data-issues $ARGS
+
+          set -x
+
+          # Read into array, one filename per line
+          readarray -t files_to_build <<< "$GIT_DIFF_CONTENT"
+
+          # ARGS=$(echo $GIT_DIFF_CONTENT | sed -E -e "s#(^| )files#\1-f $PWD/files#g")
+
+          ARGS=()
+          for file in "${files_to_build[@]}"; do
+            ARGS+=("-f" "$PWD/$file")
+          done
+
+          yarn rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
           yarn yari-render-html
 
           echo "Disk usage size of the build"
@@ -126,7 +167,7 @@ jobs:
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
       - name: Merge static assets with built documents
-        if: steps.check.outputs.GIT_DIFF_CONTENT
+        if: steps.check.outputs.HAS_MD_FILES == 'true'
         run: |
           # Exclude the .map files, as they're used for debugging JS and CSS.
           rsync -a --exclude "*.map" node_modules/@mdn/yari/client/build/ $BUILD_OUT_ROOT
@@ -134,17 +175,17 @@ jobs:
           du -sh $BUILD_OUT_ROOT
 
       - uses: actions/upload-artifact@v4
-        if: steps.check.outputs.GIT_DIFF_CONTENT
+        if: steps.check.outputs.HAS_MD_FILES == 'true'
         with:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
 
       - name: Check changed files
-        if: steps.check.outputs.GIT_DIFF_FILES
+        if: steps.check.outputs.HAS_IMAGE_FILES == 'true'
         env:
           GIT_DIFF_FILES: ${{ steps.check.outputs.GIT_DIFF_FILES }}
         run: |
-          echo $GIT_DIFF_FILES
+          readarray -t files_to_check <<< "$GIT_DIFF_FILES"
 
           export CONTENT_ROOT=$(pwd)/files
-          yarn filecheck $GIT_DIFF_FILES
+          yarn filecheck "${files_to_check[@]}"


### PR DESCRIPTION
### Description

Replaces the use of `xargs` in github actions with a bash array

### Motivation

`xargs` usage considered harmful

### Additional details

File names with special characters an spaces caused the action to fail.

### Related issues and pull requests

Fixes [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1980970)

Same as:

- https://github.com/mdn/translated-content/pull/28301
- https://github.com/mdn/translated-content-de/pull/112