### PR TITLE
Update video to image in interactive example for <embed>

### DIFF
--- a/files/en-us/web/html/reference/elements/embed/index.md
+++ b/files/en-us/web/html/reference/elements/embed/index.md
@@ -12,8 +12,8 @@ The **`<embed>`** [HTML](/en-US/docs/Web/HTML) element embeds external content a
 
 ```html interactive-example
 <embed
-  type="video/mp4"
-  src="/shared-assets/videos/flower.mp4"
+  type="image/jpeg"
+  src="/shared-assets/images/examples/flowers.jpg"
   width="250"
   height="200" />
 ```


### PR DESCRIPTION
### Description

This PR changes the type from video to image in the "Try it" section because the video does not display in Safari.
Reported by @argl.

### Motivation

Have working examples in browsers

### Additional details

Checked in Safari 18.5, Firefox 141, and Chrome 138

