### PR TITLE
Add text shadow guide to the sidebar

### DIFF
--- a/files/en-us/web/css/css_text_decoration/text_shadows/index.md
+++ b/files/en-us/web/css/css_text_decoration/text_shadows/index.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to text shadows
+short-title: Text shadows
 slug: Web/CSS/CSS_text_decoration/Text_shadows
 page-type: guide
 sidebar: cssref

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -313,6 +313,10 @@ sidebar:
     details: closed
     children:
       - /Web/CSS/CSS_text/Wrapping_breaking_text
+  - title: Text decoration
+    details: closed
+    children:
+      - /Web/CSS/CSS_text_decoration/Text_shadows
   - title: Transforms
     details: closed
     children:


### PR DESCRIPTION
### Description

As a follow-up from https://github.com/mdn/content/pull/40402, this PR adds the text shadow guide to the CSS sidebar

### Motivation

Make our pages discoverable


