### PR TITLE
Add `for...of` loop with `const` as modern best practice to "Creating closures in loops: A common mistake"

### DIFF
--- a/files/en-us/web/javascript/guide/closures/index.md
+++ b/files/en-us/web/javascript/guide/closures/index.md
@@ -438,28 +438,6 @@ setupHelp();
 
 This works as expected. Rather than the callbacks all sharing a single lexical environment, the `makeHelpCallback` function creates _a new lexical environment_ for each callback, in which `help` refers to the corresponding string from the `helpText` array.
 
-If the index is not needed during iteration, using the **for...of** statement with the `const` modifier is the most modern and concise solution:
-
-```js
-function setupHelp() {
-  const helpText = [
-    { id: "email", help: "Your email address" },
-    { id: "name", help: "Your full name" },
-    { id: "age", help: "Your age (you must be over 16)" },
-  ];
-
-  for (const item of helpText) {
-    document.getElementById(item.id).onfocus = () => {
-      document.getElementById("help").textContent = item.help;
-    };
-  }
-}
-
-setupHelp();
-```
-
-This example's **for...of** statement with the `const` modifier effectively redeclares a new `item` variable on each iteration that has no connection to the `item` variable of previous iterations; closures inside the loop body will reference their own definition of `item` at the time of their creation, not one shared accross iterations.
-
 One other way to write the above using anonymous closures is:
 
 ```js
@@ -514,28 +492,20 @@ setupHelp();
 
 This example uses `const` instead of `var`, so every closure binds the block-scoped variable, meaning that no additional closures are required.
 
-Another alternative could be to use `forEach()` to iterate over the `helpText` array and attach a listener to each [`<input>`](/en-US/docs/Web/HTML/Reference/Elements/input), as shown:
+If you are writing modern JavaScript anyway, you can consider more alternatives to the plain `for` loop, such as using {{jsxref("Statements/for...of", "for...of")}} loop and declaring `item` as `let` or `const`, or using the {{jsxref("Array/forEach", "forEach()")}} method, which both avoid the closure problem.
 
 ```js
-function showHelp(help) {
-  document.getElementById("help").textContent = help;
+for (const item of helpText) {
+  document.getElementById(item.id).onfocus = () => {
+    document.getElementById("help").textContent = item.help;
+  };
 }
 
-function setupHelp() {
-  var helpText = [
-    { id: "email", help: "Your email address" },
-    { id: "name", help: "Your full name" },
-    { id: "age", help: "Your age (you must be over 16)" },
-  ];
-
-  helpText.forEach(function (text) {
-    document.getElementById(text.id).onfocus = function () {
-      showHelp(text.help);
-    };
-  });
-}
-
-setupHelp();
+helpText.forEach((item) => {
+  document.getElementById(item.id).onfocus = () => {
+    showHelp(item.help);
+  };
+});
 ```
 
 ## Performance considerations

--- a/files/en-us/web/javascript/guide/closures/index.md
+++ b/files/en-us/web/javascript/guide/closures/index.md
@@ -438,6 +438,28 @@ setupHelp();
 
 This works as expected. Rather than the callbacks all sharing a single lexical environment, the `makeHelpCallback` function creates _a new lexical environment_ for each callback, in which `help` refers to the corresponding string from the `helpText` array.
 
+If the index is not needed during iteration, using the **for...of** statement with the `const` modifier is the most modern and concise solution:
+
+```js
+function setupHelp() {
+  const helpText = [
+    { id: "email", help: "Your email address" },
+    { id: "name", help: "Your full name" },
+    { id: "age", help: "Your age (you must be over 16)" },
+  ];
+
+  for (const item of helpText) {
+    document.getElementById(item.id).onfocus = () => {
+      document.getElementById("help").textContent = item.help;
+    };
+  }
+}
+
+setupHelp();
+```
+
+This **for...of** statement with the `const` modifier effectively redeclares a new `item` variable on each iteration that has no connection to the `item` variable of previous iterations, closures inside the loop will reference their own definition of `item`, not to a shared one.
+
 One other way to write the above using anonymous closures is:
 
 ```js

--- a/files/en-us/web/javascript/guide/closures/index.md
+++ b/files/en-us/web/javascript/guide/closures/index.md
@@ -458,7 +458,7 @@ function setupHelp() {
 setupHelp();
 ```
 
-This **for...of** statement with the `const` modifier effectively redeclares a new `item` variable on each iteration that has no connection to the `item` variable of previous iterations, closures inside the loop will reference their own definition of `item`, not to a shared one.
+This example's **for...of** statement with the `const` modifier effectively redeclares a new `item` variable on each iteration that has no connection to the `item` variable of previous iterations; closures inside the loop body will reference their own definition of `item` at the time of their creation, not one shared accross iterations.
 
 One other way to write the above using anonymous closures is:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

As the PR title suggests, using `for (const <varname> of <iterable>) { ... }` should be a highly recommended syntax for developers when creating closures in loops (in general, it should probably be the most recommended way to loop on iterables, but that's not the scope of this PR).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

 This syntax is the most concise (and arguably intuitive) out of all the other options, it should be highly recommended:
 
 * the iteration variable is defined with `const`: immutability is a good practice for a loop variable by default
 * it is the behavior a naive user may intuitively expect from the `let` and `var` variant of the loop, which don't work that way, but `const` does

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
