### PR TITLE
Fix typo in `StorageArea.getKeys()` documentation

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
@@ -49,7 +49,7 @@ Retrieve keys of all items in storage.local and log the result.
 browser.storage.local
   .getKeys()
   .then((keys) => console.log(keys)) // [ "kitten", "monster" ]
-  .catch((err) => console.error(`Error: ${error}`));
+  .catch((err) => console.error(`Error: ${err}`));
 ```
 
 {{WebExtExamples}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
The existing code sample uses the wrong variable name.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I ran into this code sample when looking into https://bugzilla.mozilla.org/show_bug.cgi?id=1979997, where the error case is hit.

### Additional details

N/A

### Related issues and pull requests

Introduced in #40560.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
