### PR TITLE
FF142 Expr/Relnote Integrity-Policy

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -772,6 +772,23 @@ Note that supported policies can be set through the [`allow`](/en-US/docs/Web/HT
 
 ## HTTP
 
+### Integrity-Policy and Integrity-Policy-Report-Only headers
+
+The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers are now supported, allowing websites to enforce [subresource integrity guarantees](/en-US/docs/Web/Security/Subresource_Integrity) for scripts, or just report on violations of the policy, respectively.
+These allow a website to ensure that the browser will block the loading of scripts into a document that don't have the [`integrity`](/en-US/docs/Web/HTML/Reference/Elements/script#integrity) attribute, or that have the attribute but where the hash doesn't match the script resource on the server.
+The browser will also stop requests in [`no-cors` mode](/en-US/docs/Web/API/Request/mode#no-cors) from ever being made, such as from a {{htmlelement("script")}} element without the [`crossorigin`](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) attribute.
+([Firefox bug 1976656](https://bugzil.la/1976656)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 142           | Yes                 |
+| Developer Edition | 142           | No                  |
+| Beta              | 142           | No                  |
+| Release           | 142           | No                  |
+
+- `security.integrity_policy.enabled`
+  - : Set to `true` to enable.
+
 ### Accept header with MIME type image/jxl
 
 The HTTP [`Accept`](/en-US/docs/Web/HTTP/Reference/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values) can be configured via a preference to indicate support for the `image/jxl` MIME type.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -774,9 +774,9 @@ Note that supported policies can be set through the [`allow`](/en-US/docs/Web/HT
 
 ### Integrity-Policy and Integrity-Policy-Report-Only headers
 
-The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers are now supported, allowing websites to enforce [subresource integrity guarantees](/en-US/docs/Web/Security/Subresource_Integrity) for scripts, or just report on violations of the policy, respectively.
-These allow a website to ensure that the browser will block the loading of scripts into a document that don't have the [`integrity`](/en-US/docs/Web/HTML/Reference/Elements/script#integrity) attribute, or that have the attribute but where the hash doesn't match the script resource on the server.
-The browser will also stop requests in [`no-cors` mode](/en-US/docs/Web/API/Request/mode#no-cors) from ever being made, such as from a {{htmlelement("script")}} element without the [`crossorigin`](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) attribute.
+The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers are now supported. These allow websites to either enforce [subresource integrity guarantees](/en-US/docs/Web/Security/Subresource_Integrity) for scripts or only report violations of the policy, respectively.
+When these headers are used, the browser blocks the loading of scripts that either lack the [`integrity`](/en-US/docs/Web/HTML/Reference/Elements/script#integrity) attribute or have an integrity hash that doesn't match the script resource on the server.
+The browser will also stop requests in [`no-cors` mode](/en-US/docs/Web/API/Request/mode#no-cors) from ever being made, such as those from a {{htmlelement("script")}} element without the [`crossorigin`](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) attribute.
 ([Firefox bug 1976656](https://bugzil.la/1976656)).
 
 | Release channel   | Version added | Enabled by default? |

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -89,7 +89,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - **`Integrity-Policy` and `Integrity-Policy-Report-Only`** (Nightly): `security.integrity_policy.enabled`
 
-  The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers are now supported, allowing websites to enforce [subresource integrity guarantees](/en-US/docs/Web/Security/Subresource_Integrity) for scripts, or just report on violations of the policy, respectively.
+  The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers are now supported. These allow websites to either enforce [subresource integrity guarantees](/en-US/docs/Web/Security/Subresource_Integrity) for scripts or only report violations of the policy, respectively.
   ([Firefox bug 1976656](https://bugzil.la/1976656)).
 
 These features are shipping in Firefox 142 but are disabled by default.

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -87,6 +87,11 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
   The CSS {{CSSXRef("anchor-size")}} function enables setting anchor-positioned element's size, position, and margins relative to the dimensions of anchor elements. ([Firefox bug 1972610](https://bugzil.la/1972610)).
 
+- **`Integrity-Policy` and `Integrity-Policy-Report-Only`** (Nightly): `security.integrity_policy.enabled`
+
+  The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers are now supported, allowing websites to enforce [subresource integrity guarantees](/en-US/docs/Web/Security/Subresource_Integrity) for scripts, or just report on violations of the policy, respectively.
+  ([Firefox bug 1976656](https://bugzil.la/1976656)).
+
 These features are shipping in Firefox 142 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
FF142 adds support for [Integrity-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy) and [Integrity-Policy-Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy-Report-Only) on nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1976656 [behind pref `security.integrity_policy.enabled` enabled in nightly).

This adds an experimental feature section and an entry in the FF142 release notes.

Related docs work can be tracked in #40667