### PR TITLE
Fix HTMLOptionElement Option() constructor example

### DIFF
--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -65,15 +65,11 @@ options.forEach((element, key) => {
 
 ### Append options with different parameters
 
-```js
-/* assuming we have the following HTML
-<select id="s">
-    <option>First</option>
-    <option>Second</option>
-    <option>Third</option>
-</select>
-*/
+```html
+<select id="s"></select>
+```
 
+```js
 const s = document.getElementById("s");
 const options = ["zero", "one", "two"];
 
@@ -88,14 +84,17 @@ options.forEach((element, key) => {
     s[key] = new Option(element, key, false, true); // Just will be selected in "view"
   }
 });
+```
 
-/* Result
+Result:
+
+```html
 <select id="s">
   <option value="0">zero</option>
   <option value="1" selected="">one</option>
-  <option value="2">two</option> // User will see this as 'selected'
+  <option value="2">two</option>
+  <!-- User will see this as 'selected' -->
 </select>
-*/
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -79,13 +79,13 @@ const options = ["zero", "one", "two"];
 
 options.forEach((element, key) => {
   if (element === "zero") {
-    s[key] = new Option(element, s.options.length, false, false);
+    s[key] = new Option(element, key, false, false);
   }
   if (element === "one") {
-    s[key] = new Option(element, s.options.length, true, false); // Will add the "selected" attribute
+    s[key] = new Option(element, key, true, false); // Will add the "selected" attribute
   }
   if (element === "two") {
-    s[key] = new Option(element, s.options.length, false, true); // Just will be selected in "view"
+    s[key] = new Option(element, key, false, true); // Just will be selected in "view"
   }
 });
 

--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -75,13 +75,13 @@ const options = ["zero", "one", "two"];
 
 options.forEach((element, key) => {
   if (element === "zero") {
-    s[key] = new Option(element, key, false, false);
+    s[key] = new Option(element, s.options.length, false, false);
   }
   if (element === "one") {
-    s[key] = new Option(element, key, true, false); // Will add the "selected" attribute
+    s[key] = new Option(element, s.options.length, true, false); // Will add the "selected" attribute
   }
   if (element === "two") {
-    s[key] = new Option(element, key, false, true); // Just will be selected in "view"
+    s[key] = new Option(element, s.options.length, false, true); // Will actually be selected in the view
   }
 });
 ```
@@ -91,9 +91,9 @@ Result:
 ```html
 <select id="s">
   <option value="0">zero</option>
-  <option value="1" selected="">one</option>
+  <option value="1" selected>one</option>
   <option value="2">two</option>
-  <!-- User will see this as 'selected' -->
+  <!-- User will see two as 'selected' -->
 </select>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description
Corrected the option value parameter and separated HTML/JS code blocks.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The existing example code was using `s.options.length` instead of key which caused all the options to have same value. Additionally, the HTML was embedded in JS comments making it less readable.
<!-- ❓ Why are you making these changes and how do they help readers? -->

<!-- ### Additional details

🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes #40665 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
