### PR TITLE
Lint: always use long-form hex color (3)

### DIFF
--- a/files/en-us/web/css/--_star_/index.md
+++ b/files/en-us/web/css/--_star_/index.md
@@ -48,8 +48,8 @@ Custom properties are scoped to the element(s) they are declared on, and partici
 
 ```css
 :root {
-  --first-color: #16f;
-  --second-color: #ff7;
+  --first-color: #1166ff;
+  --second-color: #ffff77;
 }
 
 #firstParagraph {
@@ -63,7 +63,7 @@ Custom properties are scoped to the element(s) they are declared on, and partici
 }
 
 #container {
-  --first-color: #290;
+  --first-color: #229900;
 }
 
 #thirdParagraph {

--- a/files/en-us/web/css/@font-palette-values/override-colors/index.md
+++ b/files/en-us/web/css/@font-palette-values/override-colors/index.md
@@ -18,7 +18,7 @@ override-colors: <index of color> <color>;
 override-colors: 0 red;
 
 /* using hex-color */
-override-colors: 0 #f00;
+override-colors: 0 #ff0000;
 
 /* using rgb */
 override-colors: 0 rgb(255 0 0);

--- a/files/en-us/web/css/@media/aspect-ratio/index.md
+++ b/files/en-us/web/css/@media/aspect-ratio/index.md
@@ -35,7 +35,7 @@ Note that, when none of the media query conditions are true, the background will
 /* Select aspect ratios 8/5 = 1.6 and above */
 @media (min-aspect-ratio: 8/5) {
   div {
-    background: #99f; /* blue */
+    background: #9999ff; /* blue */
   }
 }
 
@@ -43,14 +43,14 @@ Note that, when none of the media query conditions are true, the background will
 /* Select aspect ratios 3/2 = 1.5 and below */
 @media (max-aspect-ratio: 3/2) {
   div {
-    background: #9f9; /* green */
+    background: #99ff99; /* green */
   }
 }
 
 /* Exact aspect ratio, put it at the bottom to avoid override */
 @media (aspect-ratio: 1/1) {
   div {
-    background: #f99; /* red */
+    background: #ff9999; /* red */
   }
 }
 ```
@@ -66,7 +66,7 @@ Note that, when none of the media query conditions are true, the background will
 
 <iframe
   id="outer"
-  srcdoc="<style> @media (min-aspect-ratio: 8/5) { div { background: #99f; } } @media (max-aspect-ratio: 3/2) { div { background: #9f9; } } @media (aspect-ratio: 1/1) { div { background: #f99; } }</style><div id='inner'> Watch this element as you resize iframe viewport's width and height.</div>">
+  srcdoc="<style> @media (min-aspect-ratio: 8/5) { div { background: #9999ff; } } @media (max-aspect-ratio: 3/2) { div { background: #99ff99; } } @media (aspect-ratio: 1/1) { div { background: #ff9999; } }</style><div id='inner'> Watch this element as you resize iframe viewport's width and height.</div>">
 </iframe>
 ```
 

--- a/files/en-us/web/css/@media/display-mode/index.md
+++ b/files/en-us/web/css/@media/display-mode/index.md
@@ -59,7 +59,7 @@ In this example, we combine the `display-mode: picture-in-picture` value with th
 
 @media (display-mode: picture-in-picture) and (prefers-color-scheme: dark) {
   body {
-    background: #333;
+    background: #333333;
   }
 
   a {

--- a/files/en-us/web/css/@media/inverted-colors/index.md
+++ b/files/en-us/web/css/@media/inverted-colors/index.md
@@ -65,7 +65,7 @@ p {
 
 @media (inverted-colors: none) {
   p {
-    background: #eee;
+    background: #eeeeee;
     color: red;
   }
 }

--- a/files/en-us/web/css/@media/monochrome/index.md
+++ b/files/en-us/web/css/@media/monochrome/index.md
@@ -32,7 +32,7 @@ p {
 @media (monochrome) {
   p.mono {
     display: block;
-    color: #333;
+    color: #333333;
   }
 }
 

--- a/files/en-us/web/css/@media/prefers-color-scheme/index.md
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.md
@@ -62,13 +62,13 @@ Theme A (brown) uses a light color scheme by default, but will switch to a dark 
 
 ```css
 .theme-a {
-  background: #dca;
-  color: #731;
+  background: #ddccaa;
+  color: #773311;
 }
 @media (prefers-color-scheme: dark) {
   .theme-a.adaptive {
-    background: #753;
-    color: #dcb;
+    background: #775533;
+    color: #ddccbb;
     outline: 5px dashed black;
   }
 }
@@ -78,13 +78,13 @@ Theme B (blue) uses a dark color scheme by default, but will switch to a light s
 
 ```css
 .theme-b {
-  background: #447;
-  color: #bbd;
+  background: #444477;
+  color: #bbbbdd;
 }
 @media (prefers-color-scheme: light) {
   .theme-b.adaptive {
-    background: #bcd;
-    color: #334;
+    background: #bbccdd;
+    color: #333344;
     outline: 5px dotted black;
   }
 }

--- a/files/en-us/web/css/@position-try/index.md
+++ b/files/en-us/web/css/@position-try/index.md
@@ -142,7 +142,7 @@ The anchor is given an {{cssxref("anchor-name")}} and has a {{cssxref("position"
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -258,11 +258,11 @@ If you wrote the theme CSS like so, you'd run into trouble:
 
 ```css
 .light-theme {
-  background: #ccc;
+  background: #cccccc;
 }
 
 .dark-theme {
-  background: #333;
+  background: #333333;
 }
 
 .light-theme p {
@@ -281,7 +281,7 @@ To fix this, you can use `@scope` as follows:
 ```css
 @scope (.light-theme) {
   :scope {
-    background: #ccc;
+    background: #cccccc;
   }
   p {
     color: black;
@@ -290,7 +290,7 @@ To fix this, you can use `@scope` as follows:
 
 @scope (.dark-theme) {
   :scope {
-    background: #333;
+    background: #333333;
   }
   p {
     color: white;

--- a/files/en-us/web/css/_colon_active/index.md
+++ b/files/en-us/web/css/_colon_active/index.md
@@ -83,7 +83,7 @@ a:active {
 
 /* Active paragraphs */
 p:active {
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/css/_colon_checked/index.md
+++ b/files/en-us/web/css/_colon_checked/index.md
@@ -180,7 +180,7 @@ This example utilizes the `:checked` pseudo-class to let the user toggle content
 /* Hide expandable content by default */
 .expandable {
   visibility: collapse;
-  background: #ddd;
+  background: #dddddd;
 }
 
 /* Style the button */
@@ -188,7 +188,7 @@ This example utilizes the `:checked` pseudo-class to let the user toggle content
   display: inline-block;
   margin-top: 12px;
   padding: 5px 11px;
-  background-color: #ff7;
+  background-color: #ffff77;
   border: 1px solid;
   border-radius: 3px;
 }
@@ -200,7 +200,7 @@ This example utilizes the `:checked` pseudo-class to let the user toggle content
 
 /* Style the button when the checkbox is checked */
 #expand-toggle:checked ~ #expand-btn {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 

--- a/files/en-us/web/css/_colon_defined/index.md
+++ b/files/en-us/web/css/_colon_defined/index.md
@@ -64,7 +64,7 @@ custom-element {
 }
 
 code {
-  background: #ccc;
+  background: #cccccc;
 }
 
 #btn {

--- a/files/en-us/web/css/_colon_disabled/index.md
+++ b/files/en-us/web/css/_colon_disabled/index.md
@@ -81,7 +81,7 @@ This example shows a basic shipping form. It uses the [JavaScript](/en-US/docs/W
 
 ```css
 input[type="text"]:disabled {
-  background: #ccc;
+  background: #cccccc;
 }
 ```
 

--- a/files/en-us/web/css/_colon_enabled/index.md
+++ b/files/en-us/web/css/_colon_enabled/index.md
@@ -70,11 +70,11 @@ The following example makes the color of text and button {{htmlElement("input")}
 
 ```css
 input:enabled {
-  color: #2b2;
+  color: #22bb22;
 }
 
 input:disabled {
-  color: #aaa;
+  color: #aaaaaa;
 }
 ```
 

--- a/files/en-us/web/css/_colon_focus-within/index.md
+++ b/files/en-us/web/css/_colon_focus-within/index.md
@@ -75,7 +75,7 @@ form {
 }
 
 form:focus-within {
-  background: #ff8;
+  background: #ffff88;
   color: black;
 }
 

--- a/files/en-us/web/css/_colon_read-only/index.md
+++ b/files/en-us/web/css/_colon_read-only/index.md
@@ -156,7 +156,7 @@ input:hover,
 input:focus,
 textarea:hover,
 textarea:focus {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 button {
@@ -170,7 +170,7 @@ input:read-only,
 textarea:read-only {
   border: 0;
   box-shadow: none;
-  background-color: #ddd;
+  background-color: #dddddd;
 }
 
 textarea:read-write {

--- a/files/en-us/web/css/_colon_read-write/index.md
+++ b/files/en-us/web/css/_colon_read-write/index.md
@@ -106,7 +106,7 @@ textarea:read-only {
 }
 
 textarea:read-write {
-  box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #cccccc;
   border-radius: 5px;
 }
 ```

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -52,7 +52,13 @@ body {
 }
 
 #styled::-webkit-meter-even-less-good-value {
-  background: linear-gradient(to bottom, #f77, #900 45%, #900 55%, #f77);
+  background: linear-gradient(
+    to bottom,
+    #ff7777,
+    #990000 45%,
+    #990000 55%,
+    #ff7777
+  );
   height: 100%;
   box-sizing: border-box;
 }

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -48,7 +48,7 @@ body {
 #styled::-webkit-meter-inner-element {
   -webkit-appearance: inherit;
   box-sizing: inherit;
-  border: 1px dashed #aaa;
+  border: 1px dashed #aaaaaa;
 }
 ```
 

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -54,7 +54,13 @@ body {
 }
 
 #styled::-webkit-meter-optimum-value {
-  background: linear-gradient(to bottom, #7f7, #090 45%, #090 55%, #7f7);
+  background: linear-gradient(
+    to bottom,
+    #77ff77,
+    #009900 45%,
+    #009900 55%,
+    #77ff77
+  );
   height: 100%;
   box-sizing: border-box;
 }

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -54,7 +54,13 @@ body {
 }
 
 #styled::-webkit-meter-suboptimum-value {
-  background: linear-gradient(to bottom, #ff7, #990 45%, #990 55%, #ff7);
+  background: linear-gradient(
+    to bottom,
+    #ffff77,
+    #999900 45%,
+    #999900 55%,
+    #ffff77
+  );
   height: 100%;
   box-sizing: border-box;
 }

--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -71,7 +71,7 @@ Authors should avoid styling scrollbars, as changing the appearance of scrollbar
 .mostly-customized-scrollbar::-webkit-scrollbar {
   width: 5px;
   height: 8px;
-  background-color: #aaa; /* or add it to the track */
+  background-color: #aaaaaa; /* or add it to the track */
 }
 
 /* Add a thumb */

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -98,7 +98,7 @@ We add a background to the backdrop, creating a colorful donut using [CSS gradie
       white 0 5vw,
       transparent 5vw 20vw,
       white 20vw 22.5vw,
-      #eee 22.5vw
+      #eeeeee 22.5vw
     ),
     conic-gradient(
       #272b66 0 50grad,

--- a/files/en-us/web/css/_doublecolon_checkmark/index.md
+++ b/files/en-us/web/css/_doublecolon_checkmark/index.md
@@ -41,8 +41,8 @@ select,
 }
 
 select {
-  border: 2px solid #ddd;
-  background: #eee;
+  border: 2px solid #dddddd;
+  background: #eeeeee;
   padding: 10px;
 }
 
@@ -51,8 +51,8 @@ select {
 }
 
 option {
-  border: 2px solid #ddd;
-  background: #eee;
+  border: 2px solid #dddddd;
+  background: #eeeeee;
   padding: 10px;
 }
 

--- a/files/en-us/web/css/_doublecolon_column/index.md
+++ b/files/en-us/web/css/_doublecolon_column/index.md
@@ -147,8 +147,8 @@ li {
   width: 200px;
   text-align: left;
 
-  background-color: #eee;
-  outline: 1px solid #ddd;
+  background-color: #eeeeee;
+  outline: 1px solid #dddddd;
   padding: 0 20px;
   margin: 0 10px;
 }

--- a/files/en-us/web/css/_doublecolon_picker-icon/index.md
+++ b/files/en-us/web/css/_doublecolon_picker-icon/index.md
@@ -48,7 +48,7 @@ You could then, for example, target the `::picker-icon` and give it a custom {{c
 
 ```css
 select::picker-icon {
-  color: #999;
+  color: #999999;
   transition: 0.4s rotate;
 }
 ```

--- a/files/en-us/web/css/_doublecolon_scroll-button/index.md
+++ b/files/en-us/web/css/_doublecolon_scroll-button/index.md
@@ -104,7 +104,7 @@ Next, we style the `<li>` elements, using the {{cssxref("flex")}} property to ma
 ```css live-sample___creating-scroll-buttons live-sample___positioning-scroll-buttons
 li {
   list-style-type: none;
-  background-color: #eee;
+  background-color: #eeeeee;
   flex: 0 0 100%;
   height: 100px;
   padding-top: 20px;

--- a/files/en-us/web/css/_doublecolon_scroll-marker-group/index.md
+++ b/files/en-us/web/css/_doublecolon_scroll-marker-group/index.md
@@ -90,7 +90,7 @@ Next, we style the `<li>` elements, using the {{cssxref("flex")}} property to ma
 ```css live-sample___carousel-example live-sample___carousel-example_final
 li {
   list-style-type: none;
-  background-color: #eee;
+  background-color: #eeeeee;
   flex: 0 0 100%;
   height: 200px;
   padding-top: 20px;

--- a/files/en-us/web/css/_doublecolon_scroll-marker/index.md
+++ b/files/en-us/web/css/_doublecolon_scroll-marker/index.md
@@ -76,7 +76,7 @@ Next, we style the `<li>` elements, using the {{cssxref("flex")}} property to ma
 ```css live-sample___creating-scroll-markers live-sample___custom-numbering
 li {
   list-style-type: none;
-  background-color: #eee;
+  background-color: #eeeeee;
   flex: 0 0 33%;
   height: 100px;
   padding-top: 20px;
@@ -145,7 +145,7 @@ li::scroll-marker {
   text-decoration: none;
   border: 2px solid rgb(0 0 0 / 0.15);
   border-radius: 0.5em;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 ```
 
@@ -165,7 +165,7 @@ To improve user experience, we set a different color on the markers on {{cssxref
 
 ```css live-sample___custom-numbering
 ::scroll-marker:hover {
-  background-color: #dcc;
+  background-color: #ddcccc;
 }
 
 ::scroll-marker:target-current {

--- a/files/en-us/web/css/anchor-name/index.md
+++ b/files/en-us/web/css/anchor-name/index.md
@@ -139,7 +139,7 @@ We associate the second `<div>` with the anchor element by setting its anchor na
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -237,7 +237,7 @@ Each of the two positioned elements are associated with the anchor element by se
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -334,7 +334,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/anchor-size/index.md
+++ b/files/en-us/web/css/anchor-size/index.md
@@ -239,7 +239,7 @@ body {
   align-content: center;
   color: darkblue;
   background-color: azure;
-  outline: 1px solid #ddd;
+  outline: 1px solid #dddddd;
   font-size: 1rem;
   text-align: center;
 }

--- a/files/en-us/web/css/anchor/index.md
+++ b/files/en-us/web/css/anchor/index.md
@@ -328,7 +328,7 @@ form div:last-child {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -417,7 +417,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/animation-delay/index.md
+++ b/files/en-us/web/css/animation-delay/index.md
@@ -35,7 +35,7 @@ animation-delay: -2s;
   color: white;
   margin: auto;
   margin-left: 0;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   width: 150px;
   height: 150px;
   border-radius: 50%;

--- a/files/en-us/web/css/animation-direction/index.md
+++ b/files/en-us/web/css/animation-direction/index.md
@@ -42,7 +42,7 @@ animation-direction: alternate-reverse;
   animation-timing-function: ease-in;
   background-color: #1766aa;
   border-radius: 50%;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   color: white;
   height: 150px;
   margin: auto;

--- a/files/en-us/web/css/animation-duration/index.md
+++ b/files/en-us/web/css/animation-duration/index.md
@@ -38,7 +38,7 @@ animation-duration: 0s;
   animation-timing-function: ease-in;
   background-color: #1766aa;
   border-radius: 50%;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   color: white;
   height: 150px;
   margin: auto;

--- a/files/en-us/web/css/animation-fill-mode/index.md
+++ b/files/en-us/web/css/animation-fill-mode/index.md
@@ -43,7 +43,7 @@ animation-delay: 1s;
   color: white;
   margin: auto;
   margin-left: 0;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   width: 150px;
   height: 150px;
   border-radius: 50%;
@@ -200,7 +200,7 @@ You can see the effect of `animation-fill-mode` in the following example. It dem
 
 ```css
 .demo {
-  border-top: 100px solid #ccc;
+  border-top: 100px solid #cccccc;
   height: 300px;
 }
 

--- a/files/en-us/web/css/animation-iteration-count/index.md
+++ b/files/en-us/web/css/animation-iteration-count/index.md
@@ -34,7 +34,7 @@ animation-iteration-count: 1.5;
   align-items: center;
   background-color: #1766aa;
   border-radius: 50%;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   color: white;
   display: flex;
   flex-direction: column;

--- a/files/en-us/web/css/animation-name/index.md
+++ b/files/en-us/web/css/animation-name/index.md
@@ -36,7 +36,7 @@ animation-name: bounce;
   animation-timing-function: ease-in;
   background-color: #1766aa;
   border-radius: 50%;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   color: white;
   height: 150px;
   margin: auto;

--- a/files/en-us/web/css/animation-play-state/index.md
+++ b/files/en-us/web/css/animation-play-state/index.md
@@ -30,7 +30,7 @@ animation-play-state: running;
   color: white;
   margin: auto;
   margin-left: 0;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   width: 150px;
   height: 150px;
   border-radius: 50%;

--- a/files/en-us/web/css/animation-timing-function/index.md
+++ b/files/en-us/web/css/animation-timing-function/index.md
@@ -41,7 +41,7 @@ animation-timing-function: cubic-bezier(0.1, -0.6, 0.2, 0);
   animation-play-state: paused;
   background-color: #1766aa;
   border-radius: 50%;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   color: white;
   height: 150px;
   margin: auto;

--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -36,7 +36,7 @@ animation: 0.5s linear 1s infinite alternate slide-in;
 #example-element {
   background-color: #1766aa;
   margin: 20px;
-  border: 5px solid #333;
+  border: 5px solid #333333;
   width: 150px;
   height: 150px;
   border-radius: 50%;

--- a/files/en-us/web/css/attr/index.md
+++ b/files/en-us/web/css/attr/index.md
@@ -439,7 +439,7 @@ The cards are laid out in a flex container:
 @layer warning {
   .warning {
     padding: 1em;
-    border: 1px solid #ccc;
+    border: 1px solid #cccccc;
     background: rgb(255 255 205 / 0.8);
     text-align: center;
     order: -1;

--- a/files/en-us/web/css/background-clip/index.md
+++ b/files/en-us/web/css/background-clip/index.md
@@ -40,7 +40,7 @@ text-shadow: none;
   color: white;
   text-shadow: 2px 2px black;
   padding: 20px;
-  border: 10px dashed #333;
+  border: 10px dashed #333333;
   font-size: 2em;
   font-weight: bold;
 }

--- a/files/en-us/web/css/background-image/index.md
+++ b/files/en-us/web/css/background-image/index.md
@@ -64,7 +64,7 @@ background-image: url("cat-front.png");
 
 /* multiple images */
 background-image:
-  radial-gradient(circle, #0000 45%, #000f 48%),
+  radial-gradient(circle, transparent 45%, black 48%),
   radial-gradient(ellipse farthest-corner, #fc1c14 20%, #cf15cf 80%);
 
 /* Global values */

--- a/files/en-us/web/css/background-origin/index.md
+++ b/files/en-us/web/css/background-origin/index.md
@@ -37,7 +37,7 @@ background-repeat: no-repeat;
   color: #d73611;
   text-shadow: 2px 2px black;
   padding: 20px;
-  border: 10px dashed #333;
+  border: 10px dashed #333333;
   font-size: 2em;
   font-weight: bold;
 }

--- a/files/en-us/web/css/background-repeat/index.md
+++ b/files/en-us/web/css/background-repeat/index.md
@@ -42,7 +42,7 @@ background-repeat: space repeat;
 
 ```css interactive-example
 #example-element {
-  background: #ccc url("/shared-assets/images/examples/moon.jpg") center / 120px;
+  background: #cccccc url("/shared-assets/images/examples/moon.jpg") center / 120px;
   min-width: 100%;
   min-height: 100%;
 }

--- a/files/en-us/web/css/background-repeat/index.md
+++ b/files/en-us/web/css/background-repeat/index.md
@@ -42,7 +42,8 @@ background-repeat: space repeat;
 
 ```css interactive-example
 #example-element {
-  background: #cccccc url("/shared-assets/images/examples/moon.jpg") center / 120px;
+  background: #cccccc url("/shared-assets/images/examples/moon.jpg") center /
+    120px;
   min-width: 100%;
   min-height: 100%;
 }

--- a/files/en-us/web/css/background/index.md
+++ b/files/en-us/web/css/background/index.md
@@ -31,7 +31,7 @@ background: left 5% / 15% 60% repeat-x
 background:
   center / contain no-repeat
     url("/shared-assets/images/examples/firefox-logo.svg"),
-  #eee 35% url("/shared-assets/images/examples/lizard.png");
+  #eeeeee 35% url("/shared-assets/images/examples/lizard.png");
 ```
 
 ```html interactive-example
@@ -163,7 +163,7 @@ Browsers do not provide any special information on background images to assistiv
 }
 
 .top-banner {
-  background: url("star-solid.gif") #99f repeat-y fixed;
+  background: url("star-solid.gif") #9999ff repeat-y fixed;
 }
 ```
 

--- a/files/en-us/web/css/basic-shape/circle/index.md
+++ b/files/en-us/web/css/basic-shape/circle/index.md
@@ -38,11 +38,11 @@ clip-path: circle(farthest-side);
 
 ```css interactive-example
 #default-example {
-  background: #fe9;
+  background: #ffee99;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #f52, #05f);
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
   width: 100%;
   height: 100%;
 }

--- a/files/en-us/web/css/basic-shape/ellipse/index.md
+++ b/files/en-us/web/css/basic-shape/ellipse/index.md
@@ -34,11 +34,11 @@ clip-path: ellipse(closest-side farthest-side);
 
 ```css interactive-example
 #default-example {
-  background: #fe9;
+  background: #ffee99;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #f52, #05f);
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
   width: 100%;
   height: 100%;
 }

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -49,11 +49,11 @@ clip-path: path("M 50,245 A 160,160 0,0,1 360,120 z");
 
 ```css interactive-example
 #default-example {
-  background: #fe9;
+  background: #ffee99;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #f52, #05f);
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
   width: 100%;
   height: 100%;
 }

--- a/files/en-us/web/css/basic-shape/inset/index.md
+++ b/files/en-us/web/css/basic-shape/inset/index.md
@@ -34,11 +34,11 @@ clip-path: inset(4rem 20% round 1rem 2rem 3rem 4rem);
 
 ```css interactive-example
 #default-example {
-  background: #fe9;
+  background: #ffee99;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #f52, #05f);
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
   width: 100%;
   height: 100%;
 }

--- a/files/en-us/web/css/basic-shape/path/index.md
+++ b/files/en-us/web/css/basic-shape/path/index.md
@@ -37,11 +37,11 @@ clip-path: path(
 
 ```css interactive-example
 #default-example {
-  background: #fe9;
+  background: #ffee99;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #f52, #05f);
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
   width: 100%;
   height: 100%;
 }

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -34,11 +34,11 @@ clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
 
 ```css interactive-example
 #default-example {
-  background: #fe9;
+  background: #ffee99;
 }
 
 #example-element {
-  background: linear-gradient(to bottom right, #f52, #05f);
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
   width: 100%;
   height: 100%;
 }

--- a/files/en-us/web/css/border-block-color/index.md
+++ b/files/en-us/web/css/border-block-color/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-block-end-color/index.md
+++ b/files/en-us/web/css/border-block-end-color/index.md
@@ -40,7 +40,7 @@ writing-mode: vertical-lr;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-block-end-style/index.md
+++ b/files/en-us/web/css/border-block-end-style/index.md
@@ -40,7 +40,7 @@ writing-mode: vertical-lr;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-block-end/index.md
+++ b/files/en-us/web/css/border-block-end/index.md
@@ -40,7 +40,7 @@ writing-mode: vertical-lr;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-start-color/index.md
+++ b/files/en-us/web/css/border-block-start-color/index.md
@@ -40,7 +40,7 @@ writing-mode: vertical-lr;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-block-start-style/index.md
+++ b/files/en-us/web/css/border-block-start-style/index.md
@@ -40,7 +40,7 @@ writing-mode: vertical-lr;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-block-start/index.md
+++ b/files/en-us/web/css/border-block-start/index.md
@@ -40,7 +40,7 @@ writing-mode: vertical-lr;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-block-style/index.md
+++ b/files/en-us/web/css/border-block-style/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-block/index.md
+++ b/files/en-us/web/css/border-block/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-bottom-color/index.md
+++ b/files/en-us/web/css/border-bottom-color/index.md
@@ -40,7 +40,7 @@ border-bottom-color: transparent;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-bottom-style/index.md
+++ b/files/en-us/web/css/border-bottom-style/index.md
@@ -44,7 +44,7 @@ border-bottom-style: inset;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-bottom/index.md
+++ b/files/en-us/web/css/border-bottom/index.md
@@ -40,7 +40,7 @@ border-bottom: 4mm ridge rgb(211 220 50 / 0.6);
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-color/index.md
+++ b/files/en-us/web/css/border-color/index.md
@@ -40,7 +40,7 @@ border-color: red yellow green transparent;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-image-outset/index.md
+++ b/files/en-us/web/css/border-image-outset/index.md
@@ -114,9 +114,9 @@ The `border-image-outset` property may be specified as one, two, three, or four 
 ```css
 #outset {
   width: 10rem;
-  background: #cef;
+  background: #cceeff;
   border: 1.4rem solid;
-  border-image: radial-gradient(#ff2, #55f) 40;
+  border-image: radial-gradient(#ffff22, #5555ff) 40;
   border-image-outset: 1.5; /* 1.5 × 1.4rem = 2.1rem */
   margin: 2.1rem;
 }

--- a/files/en-us/web/css/border-image/index.md
+++ b/files/en-us/web/css/border-image/index.md
@@ -178,7 +178,8 @@ To match the size of a single diamond, we will use a value of 81 divided by 3, o
 #gradient {
   width: 200px;
   border: 30px solid;
-  border-image: repeating-linear-gradient(45deg, #ff3333, #33bbff, #ff3333 30px) 60;
+  border-image: repeating-linear-gradient(45deg, #ff3333, #33bbff, #ff3333 30px)
+    60;
   padding: 20px;
 }
 ```

--- a/files/en-us/web/css/border-image/index.md
+++ b/files/en-us/web/css/border-image/index.md
@@ -148,7 +148,7 @@ To match the size of a single diamond, we will use a value of 81 divided by 3, o
 ```css
 #bitmap {
   width: 200px;
-  background-color: #ffa;
+  background-color: #ffffaa;
   border: 36px solid orange;
   margin: 30px;
   padding: 10px;
@@ -178,7 +178,7 @@ To match the size of a single diamond, we will use a value of 81 divided by 3, o
 #gradient {
   width: 200px;
   border: 30px solid;
-  border-image: repeating-linear-gradient(45deg, #f33, #3bf, #f33 30px) 60;
+  border-image: repeating-linear-gradient(45deg, #ff3333, #33bbff, #ff3333 30px) 60;
   padding: 20px;
 }
 ```

--- a/files/en-us/web/css/border-inline-color/index.md
+++ b/files/en-us/web/css/border-inline-color/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-inline-end-color/index.md
+++ b/files/en-us/web/css/border-inline-end-color/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-inline-end-style/index.md
+++ b/files/en-us/web/css/border-inline-end-style/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-inline-end/index.md
+++ b/files/en-us/web/css/border-inline-end/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-start-color/index.md
+++ b/files/en-us/web/css/border-inline-start-color/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-inline-start-style/index.md
+++ b/files/en-us/web/css/border-inline-start-style/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-inline-start/index.md
+++ b/files/en-us/web/css/border-inline-start/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-inline-style/index.md
+++ b/files/en-us/web/css/border-inline-style/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-inline/index.md
+++ b/files/en-us/web/css/border-inline/index.md
@@ -36,7 +36,7 @@ direction: rtl;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-left-color/index.md
+++ b/files/en-us/web/css/border-left-color/index.md
@@ -40,7 +40,7 @@ border-left-color: transparent;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-left-style/index.md
+++ b/files/en-us/web/css/border-left-style/index.md
@@ -44,7 +44,7 @@ border-left-style: inset;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-left/index.md
+++ b/files/en-us/web/css/border-left/index.md
@@ -40,7 +40,7 @@ border-left: 4mm ridge rgb(211 220 50 / 0.6);
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-right-color/index.md
+++ b/files/en-us/web/css/border-right-color/index.md
@@ -40,7 +40,7 @@ border-right-color: transparent;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-right-style/index.md
+++ b/files/en-us/web/css/border-right-style/index.md
@@ -44,7 +44,7 @@ border-right-style: inset;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-right/index.md
+++ b/files/en-us/web/css/border-right/index.md
@@ -40,7 +40,7 @@ border-right: 4mm ridge rgb(211 220 50 / 0.6);
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-style/index.md
+++ b/files/en-us/web/css/border-style/index.md
@@ -44,7 +44,7 @@ border-style: dashed groove none dotted;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-top-color/index.md
+++ b/files/en-us/web/css/border-top-color/index.md
@@ -40,7 +40,7 @@ border-top-color: transparent;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-top-style/index.md
+++ b/files/en-us/web/css/border-top-style/index.md
@@ -44,7 +44,7 @@ border-top-style: inset;
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: black;
   border: 0.75em solid;
   padding: 0.75em;

--- a/files/en-us/web/css/border-top/index.md
+++ b/files/en-us/web/css/border-top/index.md
@@ -40,7 +40,7 @@ border-top: 4mm ridge rgb(211 220 50 / 0.6);
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;

--- a/files/en-us/web/css/border-width/index.md
+++ b/files/en-us/web/css/border-width/index.md
@@ -138,7 +138,7 @@ The `border-width` property may be specified using one, two, three, or four valu
 
 ```css
 #one-value {
-  border: ridge #ccc;
+  border: ridge #cccccc;
   border-width: 6px;
 }
 #two-values {

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -40,7 +40,7 @@ border: 4mm ridge rgb(211 220 50 / 0.6);
 
 ```css interactive-example
 #example-element {
-  background-color: #eee;
+  background-color: #eeeeee;
   color: darkmagenta;
   padding: 0.75em;
   width: 80%;
@@ -66,7 +66,7 @@ border: solid;
 border: 2px dotted;
 
 /* style | color */
-border: outset #f33;
+border: outset #ff3333;
 
 /* width | style | color */
 border: medium dashed green;

--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -44,7 +44,7 @@ box-shadow:
 #example-element {
   margin: 20px auto;
   padding: 0;
-  border: 2px solid #333;
+  border: 2px solid #333333;
   width: 80%;
   text-align: center;
 }

--- a/files/en-us/web/css/calc-size/index.md
+++ b/files/en-us/web/css/calc-size/index.md
@@ -278,7 +278,7 @@ section {
   font-family: Arial, Helvetica, sans-serif;
   width: 175px;
   border-radius: 5px;
-  background: #eee;
+  background: #eeeeee;
   box-shadow:
     inset 1px 1px 4px rgb(255 255 255 / 0.5),
     inset -1px -1px 4px rgb(0 0 0 / 0.5);
@@ -286,7 +286,7 @@ section {
 
 header {
   padding: 10px;
-  border-bottom: 2px solid #ccc;
+  border-bottom: 2px solid #cccccc;
 }
 
 main {
@@ -380,8 +380,8 @@ body {
 section {
   margin-top: 20px;
   font-family: Arial, Helvetica, sans-serif;
-  background: #eee;
-  border: 2px solid #ccc;
+  background: #eeeeee;
+  border: 2px solid #cccccc;
   padding: 0 20px;
   position: relative;
 }
@@ -506,8 +506,8 @@ form {
   margin-top: 20px;
   padding: 20px;
   font-family: Arial, Helvetica, sans-serif;
-  background: #eee;
-  border: 2px solid #ccc;
+  background: #eeeeee;
+  border: 2px solid #cccccc;
 }
 
 div {

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -61,16 +61,16 @@ td {
 }
 
 caption {
-  background: #fc3;
+  background: #ffcc33;
   padding: 0.5rem 1rem;
 }
 
 tr {
-  background: #eee;
+  background: #eeeeee;
 }
 
 tr:nth-child(even) {
-  background: #ccc;
+  background: #cccccc;
 }
 ```
 

--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -71,16 +71,16 @@ that contain characters which must be escaped in CSS -->
 
 ```css
 .red {
-  color: #f33;
+  color: #ff3333;
 }
 
 .yellow-bg {
-  background: #ffa;
+  background: #ffffaa;
 }
 
 .fancy {
   font-weight: bold;
-  text-shadow: 4px 4px 3px #77f;
+  text-shadow: 4px 4px 3px #7777ff;
 }
 ```
 

--- a/files/en-us/web/css/clip-rule/index.md
+++ b/files/en-us/web/css/clip-rule/index.md
@@ -183,7 +183,7 @@ In this SVG image, we have two rectangles that are clipped, once with each clipp
 
 ```html
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50">
-  <g stroke="#123" fill="#BCD">
+  <g stroke="#112233" fill="#bbccdd">
     <!-- basic rectangle and clipping path visualization follow -->
     <rect x="10" y="10" width="30" height="30" />
     <path
@@ -229,7 +229,7 @@ This example uses the same SVG as the previous example, with the change that the
 
 ```html
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50">
-  <g stroke="#123" fill="#BCD">
+  <g stroke="#112233" fill="#bbccdd">
     <!-- basic rectangle and clipping path visualization follow -->
     <rect x="10" y="10" width="30" height="30" />
     <path

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -210,7 +210,7 @@ body {
 
 ```css
 body {
-  background: repeating-linear-gradient(-45deg, #eee 0 2px, white 2px 6px);
+  background: repeating-linear-gradient(-45deg, #eeeeee 0 2px, white 2px 6px);
   padding: 10px;
 }
 

--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -92,7 +92,7 @@ The specification defines a `balance-all` value, in which content is equally div
 ```css
 p {
   height: 7em;
-  background: #ff9;
+  background: #ffff99;
   columns: 3;
   column-rule: 1px solid;
 }

--- a/files/en-us/web/css/column-rule-style/index.md
+++ b/files/en-us/web/css/column-rule-style/index.md
@@ -28,7 +28,7 @@ column-rule-style: double;
 
 ```css interactive-example-choice
 column-rule-style: ridge;
-column-rule-color: #88f;
+column-rule-color: #8888ff;
 ```
 
 ```html interactive-example

--- a/files/en-us/web/css/column-rule/index.md
+++ b/files/en-us/web/css/column-rule/index.md
@@ -131,9 +131,9 @@ p.abc {
 ```css
 .content-box {
   padding: 0.3em;
-  background: #ff7;
+  background: #ffff77;
   column-count: 3;
-  column-rule: inset 2px #33f;
+  column-rule: inset 2px #3333ff;
 }
 ```
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -221,7 +221,7 @@ q::before,
 q::after {
   font-size: larger;
   color: red;
-  background: #ccc;
+  background: #cccccc;
 }
 
 q::before {
@@ -389,7 +389,7 @@ This example demonstrates how an element's contents can be replaced by any type 
 ```css
 div {
   border: 1px solid;
-  background-color: #ccc;
+  background-color: #cccccc;
   min-height: 100px;
   min-width: 100px;
 }

--- a/files/en-us/web/css/cos/index.md
+++ b/files/en-us/web/css/cos/index.md
@@ -53,7 +53,7 @@ transform: translateX(calc(cos(-45deg) * 140px))
   width: calc(var(--radius) * 2);
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 2px solid #666;
+  border: 2px solid #666666;
   background-image:
     radial-gradient(black var(--dot-size), transparent var(--dot-size)),
     linear-gradient(135deg, blue, deepskyblue, lightgreen, lavender, honeydew);
@@ -63,8 +63,8 @@ transform: translateX(calc(cos(-45deg) * 140px))
   width: var(--dot-size);
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 2px solid #666;
-  background-color: #f66;
+  border: 2px solid #666666;
+  background-color: #ff6666;
   transform: translateX(calc(cos(0deg) * var(--radius)))
     translateY(calc(sin(0deg) * var(--radius) * -1));
 }


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. In this batch of PRs, I'm converting all short hex to long hex. The benefit is: readers can more easily understand the syntax; there's one less syntactic variability; if I want to grep all occurrences of one hex color, I can do that more easily without `#aaa` also matching `#aaaddd`.