### PR TITLE
Lint: always use long-form hex color (1)

### DIFF
--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -105,7 +105,7 @@ Let's again check the finished code for this part against what you've got, and h
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -109,7 +109,7 @@ At this point, the game has got a little more interesting again:
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -133,7 +133,7 @@ The collision detection of the ball is now checked on every frame, with every br
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -27,7 +27,7 @@ The HTML document structure is quite minimal, as the game will be rendered entir
         margin: 0;
       }
       canvas {
-        background: #eee;
+        background: #eeeeee;
         display: block;
         margin: 0 auto;
       }
@@ -109,7 +109,7 @@ Here's the full source code of the first lesson, running live:
 
 ```css
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -103,7 +103,7 @@ That's all — the final version of the game is ready and set to go!
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -88,7 +88,7 @@ See how your code compares to the live sample below:
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -47,7 +47,7 @@ This is the latest state of the code to compare against:
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -144,7 +144,7 @@ You can check the finished code for this article in the live demo below and play
 
 ```css
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -123,7 +123,7 @@ See how your code compares to the live sample below:
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -105,7 +105,7 @@ The latest code looks (and works) like this, in case you want to compare and con
 
 ```css hidden
 canvas {
-  background: #eee;
+  background: #eeeeee;
 }
 button {
   display: block;

--- a/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -42,7 +42,7 @@ We will be rendering our game on Canvas, but we won't do it manually — this wi
     <style>
       body {
         margin: 0;
-        background: #333;
+        background: #333333;
       }
     </style>
     <script src="src/phaser-arcade-physics.2.2.2.min.js"></script>

--- a/files/en-us/glossary/inline-level_content/index.md
+++ b/files/en-us/glossary/inline-level_content/index.md
@@ -31,11 +31,11 @@ In this example, the {{HTMLElement("p")}} element contains some text. Within tha
 body {
   margin: 0;
   padding: 4px;
-  border: 1px solid #333;
+  border: 1px solid #333333;
 }
 
 .highlight {
-  background-color: #ee3;
+  background-color: #eeee33;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/css_and_javascript/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/css_and_javascript/index.md
@@ -22,7 +22,7 @@ To complete the task, create new rules to make the links look and behave like li
 ```css hidden live-sample___css-js-ally-1 live-sample___css-js-ally-2 live-sample___css-js-ally-3
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,
@@ -53,7 +53,7 @@ body {
 ```css live-sample___css-js-ally-1
 a {
   text-decoration: none;
-  color: #666;
+  color: #666666;
   outline: none;
 }
 
@@ -138,7 +138,7 @@ main {
 h1,
 h2,
 p {
-  color: #999;
+  color: #999999;
 }
 
 h1 {

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
@@ -22,7 +22,7 @@ To complete the task, update the markup to use appropriate semantic HTML. You do
 ```css hidden live-sample___html-ally-1 live-sample___html-ally-2 live-sample___html-ally-3 live-sample___html-ally-4
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/wai-aria/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/wai-aria/index.md
@@ -22,7 +22,7 @@ To complete the task, add some WAI-ARIA semantics to make screen readers recogni
 ```css hidden live-sample___aria-1 live-sample___aria-2 live-sample___aria-3
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/wai-aria_basics/index.md
@@ -315,7 +315,7 @@ input[type="search"] {
 input[type="submit"] {
   flex: 1;
   margin-left: 1rem;
-  background: #333;
+  background: #333333;
   border: 0;
   color: white;
 }
@@ -568,7 +568,7 @@ input[type="search"] {
 input[type="submit"] {
   flex: 1;
   margin-left: 1rem;
-  background: #333;
+  background: #333333;
   border: 0;
   color: white;
 }
@@ -690,7 +690,7 @@ p {
 section {
   height: 100%;
   padding: 10px;
-  background: #666;
+  background: #666666;
   text-shadow: 1px 1px 1px black;
   color: white;
 }
@@ -861,7 +861,7 @@ function toggleMusician(bool) {
       "Instruments played field now enabled; use it to tell us what you play.";
   } else {
     instrument.input.disabled = true;
-    instrument.label.style.color = "#999";
+    instrument.label.style.color = "#999999";
     instrument.input.setAttribute("aria-disabled", "true");
     instrument.input.removeAttribute("aria-label");
     hiddenAlert.textContent = "Instruments played field now disabled.";

--- a/files/en-us/learn_web_development/core/challenges/index.md
+++ b/files/en-us/learn_web_development/core/challenges/index.md
@@ -107,21 +107,21 @@ The rules for the other colors all have more specific selectors, so they overrid
 
     ```css
     strong {
-      color: #f00; /* red */
-      background-color: #ddf; /* pale blue */
+      color: #ff0000; /* red */
+      background-color: #ddddff; /* pale blue */
       font: 200% serif;
     }
 
     .carrot {
-      color: #fa0; /* orange */
+      color: #ffaa00; /* orange */
     }
 
     .spinach {
-      color: #080; /* dark green */
+      color: #008800; /* dark green */
     }
 
     p {
-      color: #00f; /* blue */
+      color: #0000ff; /* blue */
     }
     ```
 
@@ -234,7 +234,7 @@ The challenges on page [Tables](/en-US/docs/Learn_web_development/Core/Styling_b
 
     ```css
     #demo-table tbody td {
-      border: 1px solid #7a7;
+      border: 1px solid #77aa77;
     }
     ```
 
@@ -279,7 +279,7 @@ The challenges on page [Media](/en-US/docs/Web/CSS/CSS_media_queries/Using_media
     // JavaScript demonstration
     function doDemo(button) {
       const square = document.getElementById("square");
-      square.style.backgroundColor = "#fa4";
+      square.style.backgroundColor = "#ffaa44";
       square.style.marginLeft = "20em";
       button.setAttribute("disabled", "true");
       setTimeout(clearDemo, 2000, button);

--- a/files/en-us/learn_web_development/core/css_layout/media_queries/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/media_queries/index.md
@@ -458,7 +458,7 @@ body {
 
 a:link,
 a:visited {
-  color: #333;
+  color: #333333;
 }
 
 nav ul,
@@ -474,7 +474,7 @@ nav a:visited {
   text-decoration: none;
   display: block;
   padding: 10px;
-  color: #333;
+  color: #333333;
   font-weight: bold;
 }
 
@@ -547,7 +547,7 @@ Add the following to the bottom of your CSS:
   }
 
   footer {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid #cccccc;
     margin-top: 2em;
   }
 }
@@ -612,7 +612,7 @@ body {
 }
 
 .grid li {
-  border: 1px solid #666;
+  border: 1px solid #666666;
   padding: 10px;
 }
 ```

--- a/files/en-us/learn_web_development/core/css_layout/responsive_design/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/responsive_design/index.md
@@ -154,7 +154,7 @@ body {
   font: 1.2em / 1.5 sans-serif;
   margin: 20px;
   padding: 0;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 .wrapper {
   max-width: 960px;
@@ -232,7 +232,7 @@ body {
   font: 1.2em / 1.5 sans-serif;
   margin: 20px;
   padding: 0;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 .wrapper {
   max-width: 960px;
@@ -347,7 +347,7 @@ body {
     sans-serif;
   margin: 20px;
   padding: 0;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 .wrapper {
   max-width: 960px;
@@ -432,7 +432,7 @@ body {
   font: 1.2em / 1.5 sans-serif;
   margin: 20px;
   padding: 0;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 .wrapper {

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/grid/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/grid/index.md
@@ -305,7 +305,7 @@ body {
 }
 
 .tags > * {
-  background-color: #999;
+  background-color: #999999;
   color: white;
   padding: 0.2em 0.8em;
   border-radius: 0.2em;

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/position/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/position/index.md
@@ -47,7 +47,7 @@ body {
 
 .container {
   padding: 0.5em;
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
 }
 
 .target {
@@ -141,7 +141,7 @@ body {
 .container {
   height: 400px;
   padding: 0.5em;
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
   overflow: auto;
 }
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/angular_item_component/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/angular_item_component/index.md
@@ -410,7 +410,7 @@ Paste the following styles into `item.component.css`.
 .sm-text-input {
   width: 100%;
   padding: 0.5rem;
-  border: 2px solid #555;
+  border: 2px solid #555555;
   display: block;
   box-sizing: border-box;
   font-size: 1rem;
@@ -442,7 +442,7 @@ Adapted from https://css-tricks.com/the-checkbox-hack/#custom-designed-radio-but
   top: 0;
   width: 1.25em;
   height: 1.25em;
-  border: 2px solid #ccc;
+  border: 2px solid #cccccc;
   background: white;
 }
 

--- a/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/vue_styling/index.md
@@ -373,7 +373,7 @@ Next, copy the following CSS into the newly created `<style>` element:
   appearance: none;
 }
 .custom-checkbox > input:focus {
-  outline: 3px dashed #fd0;
+  outline: 3px dashed #ffdd00;
   outline-offset: 0;
   box-shadow: inset 0 0 0 2px;
 }

--- a/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
@@ -154,7 +154,7 @@ We're using CSS to hide elements with the `"hidden"` class set.
 div {
   width: 100%;
   height: 100%;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 .hidden {
@@ -239,7 +239,7 @@ All we're doing here is calling `stopPropagation()` on the event object in the h
 div {
   width: 100%;
   height: 100%;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 .hidden {

--- a/files/en-us/learn_web_development/core/scripting/loops/index.md
+++ b/files/en-us/learn_web_development/core/scripting/loops/index.md
@@ -46,7 +46,7 @@ Suppose we wanted to draw 100 random circles on a {{htmlelement("canvas")}} elem
 html {
   width: 100%;
   height: inherit;
-  background: #ddd;
+  background: #dddddd;
 }
 
 canvas {

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/advanced_html_text/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/advanced_html_text/index.md
@@ -48,7 +48,7 @@ The finished example should look like this:
 ```css hidden live-sample___advanced-text
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/audio_and_video/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/audio_and_video/index.md
@@ -32,7 +32,7 @@ To complete this task:
 ```css hidden live-sample___video-1 live-sample___audio-1
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/forms_and_buttons/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/forms_and_buttons/index.md
@@ -26,7 +26,7 @@ To complete the task:
 ```css hidden live-sample___forms-buttons-1 live-sample___forms-buttons-2 live-sample___forms-buttons-3 live-sample___forms-buttons-4 live-sample___forms-buttons-5 live-sample___forms-buttons-6
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/html_text_basics/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/html_text_basics/index.md
@@ -38,7 +38,7 @@ The crafty anaconda likes to slither around the page, traveling rapidly by way o
 ```css hidden live-sample___text-basics-1 live-sample___text-basics-2 live-sample___text-basics-3 live-sample___text-basics-4
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/images/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/images/index.md
@@ -32,7 +32,7 @@ To complete the task:
 ```css hidden live-sample___images-1 live-sample___images-2 live-sample___images-3
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/structuring_content/test_your_skills/links/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/test_your_skills/links/index.md
@@ -42,7 +42,7 @@ To complete the task, update the links as follows:
 ```css hidden live-sample___links-1
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,
@@ -122,7 +122,7 @@ To complete the task, update the links as follows:
 ```css hidden live-sample___links-2
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,
@@ -209,7 +209,7 @@ To complete the task:
 ```css hidden live-sample___links-3
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,

--- a/files/en-us/learn_web_development/core/styling_basics/advanced_styling_effects/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/advanced_styling_effects/index.md
@@ -137,7 +137,7 @@ button {
   line-height: 2;
   border-radius: 10px;
   border: none;
-  background-image: linear-gradient(to bottom right, #777, #ddd);
+  background-image: linear-gradient(to bottom right, #777777, #dddddd);
   box-shadow:
     1px 1px 1px black,
     inset 2px 3px 5px rgb(0 0 0 / 30%),
@@ -146,7 +146,7 @@ button {
 
 button:focus,
 button:hover {
-  background-image: linear-gradient(to bottom right, #888, #eee);
+  background-image: linear-gradient(to bottom right, #888888, #eeeeee);
 }
 
 button:active {

--- a/files/en-us/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
@@ -89,7 +89,7 @@ This example demonstrates two things about background images. By default, the la
   width: 200px;
   height: 80px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 20px;
 }
 
@@ -129,7 +129,7 @@ Try these values out in the example below. We have set the value to `no-repeat` 
   width: 200px;
   height: 80px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 20px;
 }
 ```
@@ -171,7 +171,7 @@ Try the following:
   width: 500px;
   height: 100px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 10px;
 }
 ```
@@ -246,7 +246,7 @@ Use the example below to play around with these values and move the star around 
   width: 500px;
   height: 80px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 20px;
 }
 ```
@@ -288,7 +288,7 @@ Try some different gradient values in the example below. Initially, we have a li
   width: 400px;
   height: 80px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 20px;
 }
 
@@ -360,7 +360,7 @@ Let's play. The example below includes two background images. Try editing the ex
   width: 500px;
   height: 80px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 20px;
 }
 

--- a/files/en-us/learn_web_development/core/styling_basics/basic_selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/basic_selectors/index.md
@@ -193,7 +193,7 @@ body {
 }
 
 .notebox {
-  border: 4px solid #666;
+  border: 4px solid #666666;
   padding: 0.5em;
   margin: 0.5em;
 }

--- a/files/en-us/learn_web_development/core/styling_basics/cascade_layers/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/cascade_layers/index.md
@@ -181,7 +181,7 @@ In the example below, we've used four `@layer` block at-rules and one `@layer` s
 
 /* unlayered styles */
 body {
-  color: #333;
+  color: #333333;
 }
 
 /* creates the first layer: `layout` */
@@ -227,7 +227,7 @@ Anonymous layers are created by assigning styles to a layer without naming the l
 
 The `@layer` at-rule creates a layer, named or not, or appends styles to a layer if the named layer already exists. We called the first anonymous layer `<anonymous(01)>` and the second `<anonymous(02)>`, this is just so we can explain them. These are actually unnamed layers. There is no way to reference them or add additional styles to them.
 
-All styles declared outside of a layer are joined together in an implicit layer. In the example code above, the first declaration set the `color: #333` property on `body`. This was declared outside of any layer. Normal unlayered declarations take precedence over normal layered declarations even if the unlayered styles have a lower specificity and come first in the order of appearance. This explains why even though the unlayered CSS was declared first in the code block, the implicit layer containing these unlayered styles takes precedence as if it was the last declared layer.
+All styles declared outside of a layer are joined together in an implicit layer. In the example code above, the first declaration set the `color: #333333` property on `body`. This was declared outside of any layer. Normal unlayered declarations take precedence over normal layered declarations even if the unlayered styles have a lower specificity and come first in the order of appearance. This explains why even though the unlayered CSS was declared first in the code block, the implicit layer containing these unlayered styles takes precedence as if it was the last declared layer.
 
 In the line `@layer theme, layout, utilities;`, in which a series of layers were declared, only the `theme` and `utilities` layers were created; `layout` was already created in the first line. Note that this declaration does not change the order of already created layers. There is currently no way to re-order layers once declared.
 

--- a/files/en-us/learn_web_development/core/styling_basics/combinators/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/combinators/index.md
@@ -129,7 +129,7 @@ body {
 
 h1 + p {
   font-weight: bold;
-  background-color: #333;
+  background-color: #333333;
   color: white;
   padding: 0.5em;
 }
@@ -170,7 +170,7 @@ body {
 
 h1 ~ p {
   font-weight: bold;
-  background-color: #333;
+  background-color: #333333;
   color: white;
   padding: 0.5em;
 }

--- a/files/en-us/learn_web_development/core/styling_basics/handling_conflicts/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/handling_conflicts/index.md
@@ -171,7 +171,7 @@ The `color` property is an inherited property. So, the `color` property value is
 ```css live-sample___inheritance
 .main {
   color: rebeccapurple;
-  border: 2px solid #ccc;
+  border: 2px solid #cccccc;
   padding: 1em;
 }
 

--- a/files/en-us/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/handling_different_text_directions/index.md
@@ -98,7 +98,7 @@ body {
 }
 
 .box {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   padding: 0.5em;
   margin: 10px;
 }
@@ -161,7 +161,7 @@ body {
 }
 
 .box {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   padding: 0.5em;
   margin: 10px;
   width: 100px;
@@ -205,7 +205,7 @@ The property mapped to `width` when in a horizontal writing mode is called {{css
 }
 
 .box {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   padding: 0.5em;
   margin: 10px;
   inline-size: 100px;
@@ -252,7 +252,7 @@ You can also see that the {{htmlelement("Heading_Elements", "h2")}} has a black 
 ```css live-sample___logical-mbp
 .wrapper {
   display: flex;
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
 }
 
 .box {
@@ -320,7 +320,7 @@ Change the writing mode on this example to `vertical-rl` to see what happens to 
 .box {
   margin: 10px;
   padding: 0.5em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   inline-size: 200px;
   writing-mode: horizontal-tb;
 }

--- a/files/en-us/learn_web_development/core/styling_basics/images_media_forms/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/images_media_forms/index.md
@@ -241,8 +241,8 @@ input[type="email"] {
 }
 
 input[type="submit"] {
-  border: 3px solid #333;
-  background-color: #999;
+  border: 3px solid #333333;
+  background-color: #999999;
   border-radius: 5px;
   padding: 10px 2em;
   font-weight: bold;
@@ -251,7 +251,7 @@ input[type="submit"] {
 
 input[type="submit"]:hover,
 input[type="submit"]:focus {
-  background-color: #333;
+  background-color: #333333;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/styling_basics/organizing/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/organizing/index.md
@@ -201,7 +201,7 @@ If you create very specific selectors, you will often find that you need to dupl
 
 ```css
 article.main p.box {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
 }
 ```
 
@@ -209,7 +209,7 @@ If you then wanted to apply the same rules to something outside of `main`, or to
 
 ```css
 .box {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/styling_basics/tables/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/tables/index.md
@@ -216,7 +216,7 @@ caption {
   padding: 20px;
   font-style: italic;
   caption-side: bottom;
-  color: #666;
+  color: #666666;
   text-align: right;
   letter-spacing: 1px;
 }
@@ -328,7 +328,7 @@ The table is looking much better already, but we should add some borders to prov
 
 ```css
 tfoot {
-  border-top: 1px solid #999;
+  border-top: 1px solid #999999;
 }
 ```
 
@@ -341,8 +341,8 @@ table {
   min-width: 1000px;
   margin: 0 auto;
   border-collapse: collapse;
-  border-top: 1px solid #999;
-  border-bottom: 1px solid #999;
+  border-top: 1px solid #999999;
+  border-bottom: 1px solid #999999;
 }
 ```
 
@@ -354,7 +354,7 @@ We wanted to dedicate a separate section to showing you how to implement **zebra
 
 ```css
 tbody tr:nth-child(odd) {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/images/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/images/index.md
@@ -171,7 +171,7 @@ To complete the task:
 
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,
@@ -234,7 +234,7 @@ select,
 button {
   display: block;
   padding: 5px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 3px;
 }
 
@@ -246,12 +246,12 @@ button {
   margin: 0 auto;
   padding: 5px 20px;
   line-height: 1.5;
-  background: #eee;
+  background: #eeeeee;
 }
 
 button:hover,
 button:focus {
-  background: #ddd;
+  background: #dddddd;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
@@ -145,7 +145,7 @@ To complete the task:
 
 1. Style links, making the link-state orange, visited links green, and remove the underline on hover.
 2. Make the first element inside the container `font-size: 150%` and the first line of that element red.
-3. Stripe every other row in the table by selecting these rows and giving them a background color of `#333` and foreground white.
+3. Stripe every other row in the table by selecting these rows and giving them a background color of `#333333` and foreground white.
 
 Your final result should look like the image below:
 
@@ -246,7 +246,7 @@ a:hover {
 }
 
 tr:nth-child(even) {
-  background-color: #333;
+  background-color: #333333;
   color: white;
 }
 ```
@@ -309,7 +309,7 @@ h2 + p {
 
 .list > li {
   list-style: none;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #cccccc;
 }
 ```
 

--- a/files/en-us/learn_web_development/extensions/advanced_javascript_objects/adding_bouncing_balls_features/index.md
+++ b/files/en-us/learn_web_development/extensions/advanced_javascript_objects/adding_bouncing_balls_features/index.md
@@ -167,7 +167,7 @@ To implement the score counter, follow the following steps:
      margin: 0;
      top: 35px;
      right: 5px;
-     color: #aaa;
+     color: #aaaaaa;
    }
    ```
 

--- a/files/en-us/learn_web_development/extensions/client-side_apis/video_and_audio_apis/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/video_and_audio_apis/index.md
@@ -153,7 +153,7 @@ button::before {
   font-size: 20px;
   position: relative;
   content: attr(data-icon);
-  color: #aaa;
+  color: #aaaaaa;
   text-shadow: 1px 1px 0px black;
 }
 ```

--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -216,7 +216,7 @@ input[type="checkbox"]:checked::before {
 
 input[type="checkbox"]:disabled {
   border-color: black;
-  background: #ddd;
+  background: #dddddd;
   color: gray;
 }
 ```
@@ -300,7 +300,7 @@ input[type="text"],
 input[type="datetime-local"],
 input[type="color"],
 select {
-  box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #cccccc;
   border-radius: 5px;
 }
 
@@ -348,7 +348,7 @@ input[type="text"],
 input[type="datetime-local"],
 input[type="color"],
 select {
-  box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #cccccc;
   border-radius: 5px;
 }
 ```
@@ -473,8 +473,8 @@ And then style the label to act like a button, which, when pressed, will open th
 
 ```css
 label[for="file"] {
-  box-shadow: 1px 1px 3px #ccc;
-  background: linear-gradient(to bottom, #eee, #ccc);
+  box-shadow: 1px 1px 3px #cccccc;
+  background: linear-gradient(to bottom, #eeeeee, #cccccc);
   border: 1px solid darkgrey;
   border-radius: 5px;
   text-align: center;
@@ -482,11 +482,11 @@ label[for="file"] {
 }
 
 label[for="file"]:hover {
-  background: linear-gradient(to bottom, white, #ddd);
+  background: linear-gradient(to bottom, white, #dddddd);
 }
 
 label[for="file"]:active {
-  box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #cccccc;
 }
 ```
 

--- a/files/en-us/learn_web_development/extensions/forms/customizable_select/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/customizable_select/index.md
@@ -170,15 +170,15 @@ You are now free to style this in any way you want. To begin with, the `<select>
 
 ```css live-sample___second-render live-sample___third-render live-sample___fourth-render live-sample___full-render
 select {
-  border: 2px solid #ddd;
-  background: #eee;
+  border: 2px solid #dddddd;
+  background: #eeeeee;
   padding: 10px;
   transition: 0.4s;
 }
 
 select:hover,
 select:focus {
-  background: #ddd;
+  background: #dddddd;
 }
 ```
 
@@ -188,7 +188,7 @@ To style the icon inside the select button — the arrow that points down when t
 
 ```css live-sample___second-render live-sample___third-render live-sample___fourth-render live-sample___full-render
 select::picker-icon {
-  color: #999;
+  color: #999999;
   transition: 0.4s rotate;
 }
 ```
@@ -225,8 +225,8 @@ option {
   justify-content: flex-start;
   gap: 20px;
 
-  border: 2px solid #ddd;
-  background: #eee;
+  border: 2px solid #dddddd;
+  background: #eeeeee;
   padding: 10px;
   transition: 0.4s;
 }

--- a/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
@@ -384,7 +384,7 @@ input[type="number"],
 textarea,
 fieldset {
   width: 100%;
-  border: 1px solid #333;
+  border: 1px solid #333333;
   box-sizing: border-box;
 }
 
@@ -584,7 +584,7 @@ input[type="email"] {
   appearance: none;
 
   width: 100%;
-  border: 1px solid #333;
+  border: 1px solid #333333;
   margin: 0;
 
   font-family: inherit;
@@ -595,8 +595,8 @@ input[type="email"] {
 
 /* invalid fields */
 input:invalid {
-  border-color: #900;
-  background-color: #fdd;
+  border-color: #990000;
+  background-color: #ffdddd;
 }
 
 input:focus:invalid {
@@ -610,7 +610,7 @@ input:focus:invalid {
 
   font-size: 80%;
   color: white;
-  background-color: #900;
+  background-color: #990000;
   border-radius: 0 0 5px 5px;
 
   box-sizing: border-box;
@@ -742,7 +742,7 @@ p * {
 input {
   appearance: none;
   width: 100%;
-  border: 1px solid #333;
+  border: 1px solid #333333;
   margin: 0;
 
   font-family: inherit;
@@ -753,8 +753,8 @@ input {
 
 /* invalid fields */
 input.invalid {
-  border: 2px solid #900;
-  background-color: #fdd;
+  border: 2px solid #990000;
+  background-color: #ffdddd;
 }
 
 input:focus.invalid {
@@ -768,7 +768,7 @@ input:focus.invalid {
   width: 100%;
   font-size: 80%;
   color: white;
-  background-color: #900;
+  background-color: #990000;
   border-radius: 0 0 5px 5px;
   box-sizing: border-box;
 }

--- a/files/en-us/learn_web_development/extensions/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_build_custom_form_controls/index.md
@@ -2058,7 +2058,7 @@ We'll do a little styling of the radio button list (not the legend/fieldset) to 
   box-shadow: 0 0.1em 0.2em rgb(0 0 0 / 45%);
 }
 .styledSelect:focus-within input:checked + label {
-  background-color: #333;
+  background-color: #333333;
   color: white;
   width: 100%;
 }

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
@@ -120,7 +120,7 @@ form {
   margin: 0 auto;
   width: 400px;
   padding: 1em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 1em;
 }
 
@@ -134,7 +134,7 @@ fieldset {
   font: 1em sans-serif;
   width: 250px;
   box-sizing: border-box;
-  border: 1px solid #999;
+  border: 1px solid #999999;
 }
 
 input[type="checkbox"],

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -330,7 +330,7 @@ Let's put these ideas into practice and build a slightly more involved form — 
      margin: 0 auto;
      width: 400px;
      padding: 1em;
-     border: 1px solid #ccc;
+     border: 1px solid #cccccc;
      border-radius: 1em;
    }
 
@@ -348,7 +348,7 @@ Let's put these ideas into practice and build a slightly more involved form — 
      font: 1em sans-serif;
      width: 250px;
      box-sizing: border-box;
-     border: 1px solid #999;
+     border: 1px solid #999999;
    }
 
    input[type="checkbox"],
@@ -371,7 +371,7 @@ Let's put these ideas into practice and build a slightly more involved form — 
    fieldset {
      width: 250px;
      box-sizing: border-box;
-     border: 1px solid #999;
+     border: 1px solid #999999;
    }
 
    button {

--- a/files/en-us/learn_web_development/extensions/forms/html_forms_in_legacy_browsers/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/html_forms_in_legacy_browsers/index.md
@@ -78,7 +78,7 @@ If we remove the border on all inputs, we can restore the default appearance for
 input {
   /* This rule turns off the default rendering for the input types that have a border,
      including buttons defined with an input element */
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
 }
 input[type="button"] {
   /* Revert the last border declaration */
@@ -90,7 +90,7 @@ input[type="button"] {
 
 One of the big issues with HTML Forms is styling form widgets with CSS. Form controls appearance is browser and operating system specific. For example, the input of color type looks different in Safari, Chrome and Firefox browser, but the color picker widget is the same in all browsers on a device as it opens up the operating system's native color picker.
 
-It's generally a good idea to not alter the default appearance of form control because altering one CSS property value may alter some input types but not others. For example, if you declare `input { font-size: 2rem; }`, it will impact `number`, `date`, and `text`, but not `color` or `range`. If you alter a property, that may impact the appearance of the widget in unexpected ways. For example, `[value] { background-color: #ccc; }` may have been used to target every {{HTMLElement("input")}} with a `value` attribute, but changing the background-color or border radius on a {{HTMLElement("meter")}} will lead to likely unexpected results that differ across browsers. You can declare {{cssxref('appearance', 'appearance: none;')}} to remove the browser styles, but that generally defeats the purpose: as you lose all styling, removing the default look and feel your visitors are used to.
+It's generally a good idea to not alter the default appearance of form control because altering one CSS property value may alter some input types but not others. For example, if you declare `input { font-size: 2rem; }`, it will impact `number`, `date`, and `text`, but not `color` or `range`. If you alter a property, that may impact the appearance of the widget in unexpected ways. For example, `[value] { background-color: #cccccc; }` may have been used to target every {{HTMLElement("input")}} with a `value` attribute, but changing the background-color or border radius on a {{HTMLElement("meter")}} will lead to likely unexpected results that differ across browsers. You can declare {{cssxref('appearance', 'appearance: none;')}} to remove the browser styles, but that generally defeats the purpose: as you lose all styling, removing the default look and feel your visitors are used to.
 
 To summarize, when it comes to styling form control widgets, the side effects of styling them with CSS can be unpredictable. So don't. Even if it's still possible to do a few adjustments on text elements (such as sizing or font color), there are always side effects. The best approach remains to not style HTML Form widgets at all. But you can still apply styles to all the surrounding items. And, if you must alter the default styles of your form widgets, define a style guide to ensure consistency among all your form controls so user experience is not destroyed. You can also investigate some hard techniques such as [rebuilding widgets with JavaScript](/en-US/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls). But in that case, do not hesitate to [charge your client for such foolishness](https://www.smashingmagazine.com/2011/11/but-the-client-wants-ie-6-support/).
 

--- a/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -240,7 +240,7 @@ body {
   font: 1.3rem sans-serif;
   padding: 0.5em;
   margin: 0;
-  background: #222;
+  background: #222222;
 }
 
 form {
@@ -349,7 +349,7 @@ The {{HTMLElement("button")}} element is really convenient to style with CSS; yo
 button {
   padding: 5px;
   font: bold 0.6em sans-serif;
-  border: 2px solid #333;
+  border: 2px solid #333333;
   border-radius: 5px;
   background: none;
   cursor: pointer;

--- a/files/en-us/learn_web_development/extensions/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/ui_pseudo-classes/index.md
@@ -118,13 +118,13 @@ input {
 }
 
 input {
-  box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #cccccc;
   border-radius: 5px;
 }
 
 input:hover,
 input:focus {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 button {
@@ -442,12 +442,12 @@ Now onto the CSS. The most relevant parts of this example are as follows:
 
 ```css
 input[type="text"]:disabled {
-  background: #eee;
-  border: 1px solid #ccc;
+  background: #eeeeee;
+  border: 1px solid #cccccc;
 }
 
 label:has(+ :disabled) {
-  color: #aaa;
+  color: #aaaaaa;
 }
 ```
 
@@ -513,7 +513,7 @@ textarea:read-only {
 }
 
 textarea:read-write {
-  box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #cccccc;
   border-radius: 5px;
 }
 ```

--- a/files/en-us/learn_web_development/extensions/forms/your_first_form/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/your_first_form/index.md
@@ -197,7 +197,7 @@ form {
   display: inline-block;
   /* Form outline */
   padding: 1em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 1em;
 }
 
@@ -221,7 +221,7 @@ textarea {
   width: 300px;
   box-sizing: border-box;
   /* Match form field borders */
-  border: 1px solid #999;
+  border: 1px solid #999999;
 }
 
 input:focus,
@@ -330,7 +330,7 @@ form {
 
   /* To see the limits of the form */
   padding: 1em;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 1em;
 }
 
@@ -358,7 +358,7 @@ textarea {
   box-sizing: border-box;
 
   /* To harmonize the look & feel of text field border */
-  border: 1px solid #999;
+  border: 1px solid #999999;
 }
 
 input:focus,

--- a/files/en-us/learn_web_development/extensions/server-side/django/django_assessment_blog/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/django_assessment_blog/index.md
@@ -280,7 +280,7 @@ Some general hints:
              """
              Add author and associated blog to form data before setting it as valid (so it is saved to model)
              """
-             #Add logged-in user as author of comment
+             # Add logged-in user as author of comment
              form.instance.author = self.request.user
              #Associate comment with blog based on passed id
              form.instance.blog=get_object_or_404(Blog, pk = self.kwargs['pk'])

--- a/files/en-us/learn_web_development/extensions/testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/your_own_automation_environment/index.md
@@ -74,7 +74,7 @@ To set your `PATH` variable on a macOS system and on most Linux systems:
 2. Paste the following into the bottom of your file (updating the path as it actually is on your machine):
 
    ```bash
-   #Add WebDriver browser drivers to PATH
+   # Add WebDriver browser drivers to PATH
    export PATH=$PATH:/Users/bob
    ```
 

--- a/files/en-us/learn_web_development/howto/solve_css_problems/create_fancy_boxes/index.md
+++ b/files/en-us/learn_web_development/howto/solve_css_problems/create_fancy_boxes/index.md
@@ -294,7 +294,7 @@ Let's create some partial drop-shadow effects. The {{cssxref("box-shadow")}} pro
 ```css
 .fancy {
   position: relative;
-  background-color: #ffc;
+  background-color: #ffffcc;
   padding: 2rem;
   text-align: center;
   max-width: 200px;


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. In this batch of PRs, I'm converting all short hex to long hex. The benefit is: readers can more easily understand the syntax; there's one less syntactic variability; if I want to grep all occurrences of one hex color, I can do that more easily without `#aaa` also matching `#aaaddd`.