### PR TITLE
Lint: always use long-form hex color (2)

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -128,13 +128,13 @@ In this example, we'll draw a background of four different colored squares. On t
 function draw() {
   const ctx = document.getElementById("canvas").getContext("2d");
   // draw background
-  ctx.fillStyle = "#FD0";
+  ctx.fillStyle = "#ffdd00";
   ctx.fillRect(0, 0, 75, 75);
-  ctx.fillStyle = "#6C0";
+  ctx.fillStyle = "#66cc00";
   ctx.fillRect(75, 0, 75, 75);
-  ctx.fillStyle = "#09F";
+  ctx.fillStyle = "#0099ff";
   ctx.fillRect(0, 75, 75, 75);
-  ctx.fillStyle = "#F30";
+  ctx.fillStyle = "#ff3300";
   ctx.fillRect(75, 75, 75, 75);
   ctx.fillStyle = "white";
 
@@ -287,7 +287,7 @@ function draw() {
   const ctx = document.getElementById("canvas").getContext("2d");
 
   // Draw guides
-  ctx.strokeStyle = "#09f";
+  ctx.strokeStyle = "#0099ff";
   ctx.beginPath();
   ctx.moveTo(10, 10);
   ctx.lineTo(140, 10);
@@ -386,7 +386,7 @@ function draw() {
   ctx.clearRect(0, 0, 150, 150);
 
   // Draw guides
-  ctx.strokeStyle = "#09f";
+  ctx.strokeStyle = "#0099ff";
   ctx.lineWidth = 2;
   ctx.strokeRect(-5, 50, 160, 50);
 

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
@@ -52,7 +52,7 @@ function draw() {
   ctx.fillRect(0, 0, 150, 150); // Draw a Black rectangle with default settings
   ctx.save(); // Save the original default state
 
-  ctx.fillStyle = "#0099FF"; // Make changes to saved settings
+  ctx.fillStyle = "#0099ff"; // Make changes to saved settings
   ctx.fillRect(15, 15, 120, 120); // Draw a Blue rectangle with new settings
   ctx.save(); // Save the current state
 

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
@@ -52,7 +52,7 @@ function draw() {
   ctx.fillRect(0, 0, 150, 150); // Draw a Black rectangle with default settings
   ctx.save(); // Save the original default state
 
-  ctx.fillStyle = "#09F"; // Make changes to saved settings
+  ctx.fillStyle = "#0099FF"; // Make changes to saved settings
   ctx.fillRect(15, 15, 120, 120); // Draw a Blue rectangle with new settings
   ctx.save(); // Save the current state
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -82,7 +82,7 @@ const ctx = canvas.getContext("2d");
 
 // Draw yellow background
 ctx.beginPath();
-ctx.fillStyle = "#ff6";
+ctx.fillStyle = "#ffff66";
 ctx.fillRect(0, 0, canvas.width, canvas.height);
 
 // Draw blue triangle

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -102,7 +102,7 @@ patternCanvas.width = 50;
 patternCanvas.height = 50;
 
 // Give the pattern a background color and draw an arc
-patternContext.fillStyle = "#fec";
+patternContext.fillStyle = "#ffeecc";
 patternContext.fillRect(0, 0, patternCanvas.width, patternCanvas.height);
 patternContext.arc(0, 0, 50, 0, 0.5 * Math.PI);
 patternContext.stroke();

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -11,8 +11,7 @@ browser-compat: api.CanvasRenderingContext2D.fillStyle
 The
 **`CanvasRenderingContext2D.fillStyle`**
 property of the [Canvas 2D API](/en-US/docs/Web/API/Canvas_API) specifies the
-color, gradient, or pattern to use inside shapes. The default style is `#000`
-(black).
+color, gradient, or pattern to use inside shapes. The default style is `black`.
 
 > [!NOTE]
 > For more examples of fill and stroke styles, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).

--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
@@ -144,7 +144,7 @@ image.addEventListener("load", (e) => {
   ctx.drawImage(image, 0, 0, image.width * 0.6, image.height * 0.6);
 
   // Draw image with filter
-  ctx.filter = "contrast(1.4) sepia(1) drop-shadow(-9px 9px 3px #e81)";
+  ctx.filter = "contrast(1.4) sepia(1) drop-shadow(-9px 9px 3px #ee8811)";
   ctx.drawImage(image, 400, 0, -image.width * 0.6, image.height * 0.6);
 });
 ```

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
@@ -73,13 +73,13 @@ const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
 // Draw background
-ctx.fillStyle = "#FD0";
+ctx.fillStyle = "#ffdd00";
 ctx.fillRect(0, 0, 75, 75);
-ctx.fillStyle = "#6C0";
+ctx.fillStyle = "#66cc00";
 ctx.fillRect(75, 0, 75, 75);
-ctx.fillStyle = "#09F";
+ctx.fillStyle = "#0099ff";
 ctx.fillRect(0, 75, 75, 75);
-ctx.fillStyle = "#F30";
+ctx.fillStyle = "#ff3300";
 ctx.fillRect(75, 75, 75, 75);
 ctx.fillStyle = "white";
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -410,7 +410,7 @@ const createInterlace = (size, color1, color2) => {
   return pattern;
 };
 
-const op_8x8 = createInterlace(8, "white", "#eee");
+const op_8x8 = createInterlace(8, "white", "#eeeeee");
 ```
 
 #### Result

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -138,9 +138,9 @@ The following properties control how text is laid out.
 Fill styling is used for colors and styles inside shapes and stroke styling is used for the lines around shapes.
 
 - {{domxref("CanvasRenderingContext2D.fillStyle")}}
-  - : Color or style to use inside shapes. Default `#000` (black).
+  - : Color or style to use inside shapes. Default is `black`.
 - {{domxref("CanvasRenderingContext2D.strokeStyle")}}
-  - : Color or style to use for the lines around shapes. Default `#000` (black).
+  - : Color or style to use for the lines around shapes. Default is `black`.
 
 ### Gradients and patterns
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -80,7 +80,7 @@ const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
 // Draw guides
-ctx.strokeStyle = "#09f";
+ctx.strokeStyle = "#0099ff";
 ctx.beginPath();
 ctx.moveTo(10, 10);
 ctx.lineTo(140, 10);

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
@@ -88,11 +88,11 @@ This example draws a rectangle with a drop shadow and thick, beveled outlines.
 ```js
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
-ctx.shadowColor = "#d53";
+ctx.shadowColor = "#dd5533";
 ctx.shadowBlur = 20;
 ctx.lineJoin = "bevel";
 ctx.lineWidth = 15;
-ctx.strokeStyle = "#38f";
+ctx.strokeStyle = "#3388ff";
 ctx.strokeRect(30, 30, 160, 90);
 ```
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CanvasRenderingContext2D.strokeStyle
 
 The **`CanvasRenderingContext2D.strokeStyle`** property of the
 Canvas 2D API specifies the color, gradient, or pattern to use for the strokes
-(outlines) around shapes. The default is `#000` (black).
+(outlines) around shapes. The default is `black`.
 
 > [!NOTE]
 > For more examples of stroke and fill styles, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).

--- a/files/en-us/web/api/css_custom_highlight_api/index.md
+++ b/files/en-us/web/api/css_custom_highlight_api/index.md
@@ -213,7 +213,7 @@ Finally, the `::highlight()` pseudo-element is used in CSS to style the highligh
 
 ```css
 ::highlight(search-results) {
-  background-color: #f06;
+  background-color: #ff0066;
   color: white;
 }
 ```

--- a/files/en-us/web/api/cssstyledeclaration/length/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/length/index.md
@@ -23,7 +23,7 @@ The following gets the number of explicitly set styles on the following HTML ele
 ```html
 <div
   id="div1"
-  style="margin: 0 10px; background-color: #CA1; font-family: monospace"></div>
+  style="margin: 0 10px; background-color: #ccaa11; font-family: monospace"></div>
 ```
 
 JavaScript code:

--- a/files/en-us/web/api/device_orientation_events/detecting_device_orientation/index.md
+++ b/files/en-us/web/api/device_orientation_events/detecting_device_orientation/index.md
@@ -78,7 +78,7 @@ This garden is 200 pixel wide (yes, it's a tiny one), and the ball is in the cen
   position: relative;
   width: 200px;
   height: 200px;
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
   border-radius: 10px;
 }
 

--- a/files/en-us/web/api/document_object_model/whitespace/index.md
+++ b/files/en-us/web/api/document_object_model/whitespace/index.md
@@ -232,7 +232,7 @@ Consider this example (again, we've included an HTML comment that shows the whit
   display: inline-block;
   width: 2em;
   height: 2em;
-  background: #f06;
+  background: #ff0066;
   border: 1px solid;
 }
 ```

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -151,7 +151,7 @@ In [our demo](https://mdn.github.io/dom-examples/document-picture-in-picture/), 
 
 @media (display-mode: picture-in-picture) and (prefers-color-scheme: dark) {
   body {
-    background: #333;
+    background: #333333;
   }
 
   a {

--- a/files/en-us/web/api/dommatrix/scaleself/index.md
+++ b/files/en-us/web/api/dommatrix/scaleself/index.md
@@ -51,8 +51,8 @@ This SVG contains two semi-opaque squares, one red and one blue, each positioned
 
 ```html
 <svg viewBox="0 0 50 50" height="200">
-  <rect width="25" height="25" fill="#f009" />
-  <rect id="transformed" width="25" height="25" fill="#00f9" />
+  <rect width="25" height="25" fill="#ff000099" />
+  <rect id="transformed" width="25" height="25" fill="#0000ff99" />
 </svg>
 ```
 

--- a/files/en-us/web/api/element/ariacontrolselements/index.md
+++ b/files/en-us/web/api/element/ariacontrolselements/index.md
@@ -57,7 +57,7 @@ The references to the controlled panels are listed in the button's `aria-control
 ```css
 .panel {
   display: none; /* Initially hidden */
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   padding: 5px;
   margin-top: 5px;
 }

--- a/files/en-us/web/api/element/dblclick_event/index.md
+++ b/files/en-us/web/api/element/dblclick_event/index.md
@@ -107,7 +107,7 @@ card.addEventListener("dblclick", (e) => {
 
 ```css
 aside {
-  background: #fe9;
+  background: #ffee99;
   border-radius: 1em;
   display: inline-block;
   padding: 1em;

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -49,7 +49,7 @@ custom namespace.
 <svg xmlns="http://www.w3.org/2000/svg"
     xmlns:test="http://www.example.com/2014/test" width="40" height="40">
 
-  <circle id="target" cx="12" cy="12" r="10" stroke="#444"
+  <circle id="target" cx="12" cy="12" r="10" stroke="#444444"
       stroke-width="2" fill="none" test:foo="Hello namespaced attribute!"/>
 
   <script>
@@ -75,7 +75,7 @@ namespaces are not supported.
     cx="12"
     cy="12"
     r="10"
-    stroke="#444"
+    stroke="#444444"
     stroke-width="2"
     fill="none"
     test:foo="Foo value" />

--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -39,7 +39,7 @@ namespaceURI = "${circle.namespaceURI}"`;
   <svg:svg version="1.1"
     width="100px" height="100px"
     viewBox="0 0 100 100">
-    <svg:circle cx="50" cy="50" r="30" fill="#aaa" id="circle"/>
+    <svg:circle cx="50" cy="50" r="30" fill="#aaaaaa" id="circle"/>
   </svg:svg>
   <textarea id="text" rows="4" cols="55"/>
 </body>

--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -125,7 +125,7 @@ Styling the `div` to make it more visible.
 #mouseTarget {
   box-sizing: border-box;
   width: 15rem;
-  border: 1px solid #333;
+  border: 1px solid #333333;
 }
 ```
 
@@ -144,7 +144,7 @@ mouseTarget.addEventListener("mouseenter", (e) => {
 });
 
 mouseTarget.addEventListener("mouseleave", (e) => {
-  mouseTarget.style.border = "1px solid #333";
+  mouseTarget.style.border = "1px solid #333333";
   leaveEventCount++;
   addListItem(`This is mouseleave event ${leaveEventCount}.`);
 });

--- a/files/en-us/web/api/element/mouseleave_event/index.md
+++ b/files/en-us/web/api/element/mouseleave_event/index.md
@@ -122,7 +122,7 @@ Styling the `<div>` to make it more visible.
 #mouseTarget {
   box-sizing: border-box;
   width: 15rem;
-  border: 1px solid #333;
+  border: 1px solid #333333;
 }
 ```
 
@@ -141,7 +141,7 @@ mouseTarget.addEventListener("mouseenter", (e) => {
 });
 
 mouseTarget.addEventListener("mouseleave", (e) => {
-  mouseTarget.style.border = "1px solid #333";
+  mouseTarget.style.border = "1px solid #333333";
   leaveEventCount++;
   addListItem(`This is mouseleave event ${leaveEventCount}.`);
 });

--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -54,7 +54,7 @@ div {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #fbe;
+  background: #ffbbee;
 }
 ```
 

--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -150,7 +150,7 @@ body {
 }
 
 video::backdrop {
-  background-color: #448;
+  background-color: #444488;
 }
 button {
   display: block;

--- a/files/en-us/web/api/element/scrollleft/index.md
+++ b/files/en-us/web/api/element/scrollleft/index.md
@@ -38,13 +38,13 @@ The `scrollLeft` property can be set, which causes the element to scroll to the 
 #container {
   width: 100px;
   height: 100px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   overflow-x: scroll;
 }
 
 #content {
   width: 250px;
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 

--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -59,7 +59,7 @@ div {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #fbe;
+  background: #ffbbee;
   touch-action: none;
 }
 ```

--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -86,7 +86,7 @@ body {
 div {
   width: 105px;
   height: 105px;
-  background: #cdf;
+  background: #ccddff;
   padding: 5px;
 }
 ```

--- a/files/en-us/web/api/event/stopimmediatepropagation/index.md
+++ b/files/en-us/web/api/event/stopimmediatepropagation/index.md
@@ -69,7 +69,7 @@ div {
 
 button {
   width: 100px;
-  color: #008;
+  color: #000088;
   padding: 5px;
   background-color: white;
   border: 2px solid black;

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -586,7 +586,7 @@ also available to the event handler when using an arrow function.
 .demo-logs {
   width: 530px;
   height: 16rem;
-  background-color: #ddd;
+  background-color: #dddddd;
   overflow-x: auto;
   padding: 1rem;
 }

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -51,7 +51,7 @@ canvas.height = height;
 
 const ctx = canvas.getContext("2d");
 
-ctx.strokeStyle = "#090";
+ctx.strokeStyle = "#009900";
 ctx.beginPath();
 ctx.arc(width / 2, height / 2, width / 2 - width / 10, 0, Math.PI * 2);
 ctx.stroke();

--- a/files/en-us/web/api/highlightregistry/highlightsfrompoint/index.md
+++ b/files/en-us/web/api/highlightregistry/highlightsfrompoint/index.md
@@ -78,7 +78,7 @@ In the CSS, we define styling for three custom highlights named `highlight1`, `h
 
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1em / 1.4 Helvetica Neue,
     Helvetica,
@@ -97,8 +97,8 @@ section {
 .highlightable-text,
 article {
   padding: 10px;
-  background-color: #eee;
-  border: 2px solid #ddd;
+  background-color: #eeeeee;
+  border: 2px solid #dddddd;
   border-radius: 5px;
 }
 

--- a/files/en-us/web/api/htmlbuttonelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/reportvalidity/index.md
@@ -53,17 +53,17 @@ We add a bit of CSS, including `:valid` and `:invalid` styles for our button:
 ```css
 input[type="submit"],
 button {
-  background-color: #33a;
+  background-color: #3333aa;
   border: none;
   font-size: 1.3rem;
   padding: 5px 10px;
   color: white;
 }
 button:invalid {
-  background-color: #a33;
+  background-color: #aa3333;
 }
 button:valid {
-  background-color: #3a3;
+  background-color: #33aa33;
 }
 ```
 

--- a/files/en-us/web/api/htmlelement/hidden/index.md
+++ b/files/en-us/web/api/htmlelement/hidden/index.md
@@ -56,7 +56,7 @@ The content is styled using the CSS below.
     Helvetica,
     Arial,
     sans-serif;
-  border: 1px solid #22d;
+  border: 1px solid #2222dd;
   padding: 12px;
   width: 500px;
   text-align: center;

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -97,8 +97,8 @@ article {
 article img {
   display: block;
   max-width: 100%;
-  border: 1px solid #888;
-  box-shadow: 0 0.5em 0.3em #888;
+  border: 1px solid #888888;
+  box-shadow: 0 0.5em 0.3em #888888;
   margin-bottom: 1.25em;
 }
 ```

--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -384,7 +384,7 @@ p {
   min-width: 195px;
   min-height: 99px;
   margin-right: 10px;
-  background-color: #eee; /* Placeholder background */
+  background-color: #eeeeee; /* Placeholder background */
 }
 
 #log {

--- a/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
+++ b/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
@@ -163,7 +163,7 @@ Finally, the ads have the following initial styling. Individual ads may customiz
 .ad {
   height: 96px;
   padding: 6px;
-  border-color: #555;
+  border-color: #555555;
   border-style: solid;
   border-width: 1px;
 }
@@ -464,7 +464,7 @@ The `loadRandomAd()` function simulates loading an ad and adding it to the page.
 function loadRandomAd(replaceBox) {
   const ads = [
     {
-      bgcolor: "#cec",
+      bgcolor: "#cceecc",
       title: "Eat Green Beans",
       body: "Make your mother proud—they're good for you!",
     },
@@ -479,7 +479,7 @@ function loadRandomAd(replaceBox) {
       body: "Love really does make the world go round…",
     },
     {
-      bgcolor: "#fee",
+      bgcolor: "#ffeeee",
       title: "Flexbox Florist",
       body: "When life's layout gets complicated, send flowers.",
     },

--- a/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/scrollmargin/index.md
@@ -132,7 +132,7 @@ p {
   min-width: 195px;
   min-height: 99px;
   margin-right: 10px;
-  background-color: #eee; /* Placeholder background */
+  background-color: #eeeeee; /* Placeholder background */
 }
 
 .controls {

--- a/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -231,7 +231,7 @@ Clearing the photo box involves creating an image, then converting it into a for
 ```js live-sample___photo-capture live-sample___photo-capture-with-filters
 function clearPhoto() {
   const context = canvas.getContext("2d");
-  context.fillStyle = "#AAA";
+  context.fillStyle = "#aaaaaa";
   context.fillRect(0, 0, canvas.width, canvas.height);
 
   const data = canvas.toDataURL("image/png");
@@ -241,7 +241,7 @@ function clearPhoto() {
 clearPhoto();
 ```
 
-We start by getting a reference to the hidden {{HTMLElement("canvas")}} element that we use for offscreen rendering. Next we set the `fillStyle` to `#AAA` (a fairly light grey), and fill the entire canvas with that color by calling {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
+We start by getting a reference to the hidden {{HTMLElement("canvas")}} element that we use for offscreen rendering. Next we set the `fillStyle` to `#aaaaaa` (a fairly light grey), and fill the entire canvas with that color by calling {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
 
 Last in this function, we convert the canvas into a PNG image and call {{domxref("Element.setAttribute", "photo.setAttribute()")}} to make our captured still box display the image.
 

--- a/files/en-us/web/api/mediaquerylist/media/index.md
+++ b/files/en-us/web/api/mediaquerylist/media/index.md
@@ -48,9 +48,9 @@ A `<span>` to receive the output.
     18px arial,
     sans-serif;
   font-weight: bold;
-  color: #88f;
+  color: #8888ff;
   padding: 0.4em;
-  border: 1px solid #dde;
+  border: 1px solid #ddddee;
 }
 ```
 

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -88,7 +88,7 @@ aside {
   height: 100%;
   transform: translateX(100%);
   transition: 0.6s all;
-  background-color: #999;
+  background-color: #999999;
   background-image: linear-gradient(
     to top right,
     transparent,

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.md
@@ -41,7 +41,7 @@ In this example, event handlers are established for the `mute` and {{domxref("Me
 musicTrack.addEventListener(
   "mute",
   (event) => {
-    document.getElementById("timeline-widget").style.backgroundColor = "#aaa";
+    document.getElementById("timeline-widget").style.backgroundColor = "#aaaaaa";
   },
   false,
 );
@@ -55,13 +55,13 @@ musicTrack.addEventListener(
 );
 ```
 
-With these event handlers in place, when the track `musicTrack` enters its {{domxref("MediaStreamTrack.muted", "muted")}} state, the element with the ID `timeline-widget` gets its background color changed to `#aaa`. When the track exits the muted state—detected by the arrival of an `unmute` event—the background color is restored to white.
+With these event handlers in place, when the track `musicTrack` enters its {{domxref("MediaStreamTrack.muted", "muted")}} state, the element with the ID `timeline-widget` gets its background color changed to `#aaaaaa`. When the track exits the muted state—detected by the arrival of an `unmute` event—the background color is restored to white.
 
 You can also use the `onmute` event handler property to set up a handler for this event; similarly, the {{domxref("MediaStreamTrack.unmute_event", "onunmute")}} event handler is available for setting up a handler for the `unmute` event. The following example shows this:
 
 ```js
 musicTrack.onmute = (event) => {
-  document.getElementById("timeline-widget").style.backgroundColor = "#aaa";
+  document.getElementById("timeline-widget").style.backgroundColor = "#aaaaaa";
 };
 
 musicTrack.onunmute = (event) => {

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.md
@@ -41,7 +41,8 @@ In this example, event handlers are established for the `mute` and {{domxref("Me
 musicTrack.addEventListener(
   "mute",
   (event) => {
-    document.getElementById("timeline-widget").style.backgroundColor = "#aaaaaa";
+    const widget = document.getElementById("timeline-widget");
+    widget.style.backgroundColor = "#aaaaaa";
   },
   false,
 );

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -39,7 +39,7 @@ In this example, event handlers are established for the {{domxref("MediaStreamTr
 musicTrack.addEventListener(
   "mute",
   (event) => {
-    document.getElementById("timeline-widget").style.backgroundColor = "#aaa";
+    document.getElementById("timeline-widget").style.backgroundColor = "#aaaaaa";
   },
   false,
 );
@@ -53,13 +53,13 @@ musicTrack.addEventListener(
 );
 ```
 
-With these event handlers in place, when the track `musicTrack` enters its {{domxref("MediaStreamTrack.muted", "muted")}} state, the element with the ID `timeline-widget` gets its background color changed to `#aaa`. When the track exits the muted state—detected by the arrival of an `unmuted` event—the background color is restored to white.
+With these event handlers in place, when the track `musicTrack` enters its {{domxref("MediaStreamTrack.muted", "muted")}} state, the element with the ID `timeline-widget` gets its background color changed to `#aaaaaa`. When the track exits the muted state—detected by the arrival of an `unmuted` event—the background color is restored to white.
 
 You can also use the `onunmute` event handler property to set up a handler for this event; similarly, the {{domxref("MediaStreamTrack.mute_event", "onmute")}} event handler is available for setting up a handler for the `mute` event. The following example shows this:
 
 ```js
 musicTrack.onmute = (event) => {
-  document.getElementById("timeline-widget").style.backgroundColor = "#aaa";
+  document.getElementById("timeline-widget").style.backgroundColor = "#aaaaaa";
 };
 
 musicTrack.onunmute = (event) => {

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -40,7 +40,7 @@ musicTrack.addEventListener(
   "mute",
   (event) => {
     const widget = document.getElementById("timeline-widget");
-	  widget.style.backgroundColor = "#aaaaaa";
+    widget.style.backgroundColor = "#aaaaaa";
   },
   false,
 );

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -39,7 +39,8 @@ In this example, event handlers are established for the {{domxref("MediaStreamTr
 musicTrack.addEventListener(
   "mute",
   (event) => {
-    document.getElementById("timeline-widget").style.backgroundColor = "#aaaaaa";
+    const widget = document.getElementById("timeline-widget");
+	  widget.style.backgroundColor = "#aaaaaa";
   },
   false,
 );

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -156,7 +156,7 @@ Assume the following basic HTML:
 #demo-logs {
   width: 90%;
   height: 100px;
-  background-color: #ddd;
+  background-color: #dddddd;
   overflow-x: auto;
   padding: 10px;
   margin-top: 10px;

--- a/files/en-us/web/api/offscreencanvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/offscreencanvasrenderingcontext2d/index.md
@@ -138,9 +138,9 @@ The following properties control how text is laid out.
 Fill styling is used for colors and styles inside shapes and stroke styling is used for the lines around shapes.
 
 - {{domxref("CanvasRenderingContext2D.fillStyle")}}
-  - : Color or style to use inside shapes. Default `#000` (black).
+  - : Color or style to use inside shapes. Default to `black`.
 - {{domxref("CanvasRenderingContext2D.strokeStyle")}}
-  - : Color or style to use for the lines around shapes. Default `#000` (black).
+  - : Color or style to use for the lines around shapes. Default to `black`.
 
 ### Gradients and patterns
 

--- a/files/en-us/web/api/range/commonancestorcontainer/index.md
+++ b/files/en-us/web/api/range/commonancestorcontainer/index.md
@@ -75,7 +75,7 @@ The `.highlight` class created below uses a set of CSS
     outline: 1px solid red;
   }
   to {
-    outline: 1px solid #f000;
+    outline: 1px solid transparent;
   }
 }
 ```

--- a/files/en-us/web/api/screen_capture_api/element_region_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/element_region_capture/index.md
@@ -78,7 +78,7 @@ body {
 
 video,
 #demo > p {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin: 0;
 }
 

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -315,7 +315,7 @@ The CSS is entirely cosmetic in this example. The video is given a border, and i
 
 ```css
 #video {
-  border: 1px solid #999;
+  border: 1px solid #999999;
   width: 98%;
   max-width: 860px;
 }

--- a/files/en-us/web/api/svganimationelement/beginevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/beginevent_event/index.md
@@ -57,7 +57,7 @@ A {{domxref("TimeEvent")}}. Inherits from {{domxref("Event")}}.
 ```css
 ul {
   height: 100px;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   overflow-y: scroll;
   padding: 10px 30px;
 }

--- a/files/en-us/web/api/svganimationelement/endevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/endevent_event/index.md
@@ -60,7 +60,7 @@ A {{domxref("TimeEvent")}}. Inherits from {{domxref("Event")}}.
 ```css
 ul {
   height: 100px;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   overflow-y: scroll;
   padding: 10px 30px;
 }

--- a/files/en-us/web/api/svganimationelement/repeatevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/repeatevent_event/index.md
@@ -58,7 +58,7 @@ A {{domxref("TimeEvent")}}. Inherits from {{domxref("Event")}}.
 ```css
 ul {
   height: 100px;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   overflow-y: scroll;
   padding: 10px 30px;
 }

--- a/files/en-us/web/api/textformat/index.md
+++ b/files/en-us/web/api/textformat/index.md
@@ -52,7 +52,7 @@ In the following example, the `textformatupdate` event is used to log the variou
 ```css hidden
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/api/textformat/rangeend/index.md
+++ b/files/en-us/web/api/textformat/rangeend/index.md
@@ -29,7 +29,7 @@ The following example shows how to use the `textformatupdate` event's `rangeStar
 ```css hidden
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/api/textformat/rangestart/index.md
+++ b/files/en-us/web/api/textformat/rangestart/index.md
@@ -29,7 +29,7 @@ The following example shows how to use the `textformatupdate` event's `rangeStar
 ```css hidden
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/api/textformat/underlinestyle/index.md
+++ b/files/en-us/web/api/textformat/underlinestyle/index.md
@@ -36,7 +36,7 @@ The following example shows how to use the `textformatupdate` event's `underline
 ```css hidden
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/api/textformat/underlinethickness/index.md
+++ b/files/en-us/web/api/textformat/underlinethickness/index.md
@@ -33,7 +33,7 @@ The following example shows how to use the `textformatupdate` event's `underline
 ```css hidden
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/api/textupdateevent/selectionend/index.md
+++ b/files/en-us/web/api/textupdateevent/selectionend/index.md
@@ -25,7 +25,7 @@ This example shows how to use the `selectionEnd` property to render the selected
 ```css
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
   color: black;
 }
 

--- a/files/en-us/web/api/textupdateevent/selectionstart/index.md
+++ b/files/en-us/web/api/textupdateevent/selectionstart/index.md
@@ -25,7 +25,7 @@ This example shows how to use the `selectionStart` property to render the select
 ```css
 #editor {
   height: 200px;
-  background: #eee;
+  background: #eeeeee;
   color: black;
 }
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -60,7 +60,7 @@ Log:
   height: 200px;
   width: 600px;
   overflow: scroll;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
 }
 ```
 
@@ -235,7 +235,7 @@ function colorForTouch(touch) {
 ```
 
 The result from this function is a string that can be used when calling {{HTMLElement("canvas")}} functions to set drawing colors.
-For example, for a {{domxref("Touch.identifier")}} value of 10, the resulting string is "#a31".
+For example, for a {{domxref("Touch.identifier")}} value of 10, the resulting string is "#aa3311".
 
 #### Copying a touch object
 

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -129,7 +129,7 @@ On the right side of the settings bar, we place a label and a {{HTMLElement("sel
 }
 
 .key:hover {
-  background-color: #eef;
+  background-color: #eeeeff;
 }
 
 .key:active,

--- a/files/en-us/web/api/web_components/using_templates_and_slots/index.md
+++ b/files/en-us/web/api/web_components/using_templates_and_slots/index.md
@@ -66,7 +66,7 @@ So for example:
   <style>
     p {
       color: white;
-      background-color: #666;
+      background-color: #666666;
       padding: 5px;
     }
   </style>
@@ -129,7 +129,7 @@ The `name` and `slot` attributes both default to the empty string, so elements w
   <style>
     p {
       color: white;
-      background-color: #666;
+      background-color: #666666;
       padding: 5px;
     }
   </style>

--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
@@ -238,9 +238,9 @@ A really easy way to start using a matrix is to use the CSS {{cssxref("transform
   width: 200px;
   height: 200px;
   overflow-y: scroll;
-  background: #4cc;
+  background: #44cccc;
   padding: 10px;
-  border: 2px solid #333;
+  border: 2px solid #333333;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/files/en-us/web/api/window/blur_event/index.md
+++ b/files/en-us/web/api/window/blur_event/index.md
@@ -53,8 +53,8 @@ This example changes the appearance of a document when it loses focus. It uses {
 
 ```css
 .paused {
-  background: #ddd;
-  color: #555;
+  background: #dddddd;
+  color: #555555;
 }
 ```
 

--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -104,10 +104,10 @@ body {
 }
 
 #container {
-  border: 2px solid #22d;
+  border: 2px solid #2222dd;
   margin: 1rem auto;
   padding: 1rem;
-  background-color: #a9f;
+  background-color: #aa99ff;
 }
 ```
 

--- a/files/en-us/web/api/window/focus_event/index.md
+++ b/files/en-us/web/api/window/focus_event/index.md
@@ -53,8 +53,8 @@ This example changes the appearance of a document when it loses focus. It uses {
 
 ```css
 .paused {
-  background: #ddd;
-  color: #555;
+  background: #dddddd;
+  color: #555555;
 }
 ```
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -79,9 +79,9 @@ A simple `<span>` to receive the output.
     18px arial,
     sans-serif;
   font-weight: bold;
-  color: #88f;
+  color: #8888ff;
   padding: 0.4em;
-  border: 1px solid #dde;
+  border: 1px solid #ddddee;
 }
 ```
 


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. In this batch of PRs, I'm converting all short hex to long hex. The benefit is: readers can more easily understand the syntax; there's one less syntactic variability; if I want to grep all occurrences of one hex color, I can do that more easily without `#aaa` also matching `#aaaddd`.