### PR TITLE
Lint: always use long-form hex color (4)

### DIFF
--- a/files/en-us/web/css/css_anchor_positioning/try_options_hiding/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/try_options_hiding/index.md
@@ -84,7 +84,7 @@ The anchor-positioned element is given fixed positioning and tethered to the anc
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -157,7 +157,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -223,7 +223,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -311,7 +311,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -440,7 +440,7 @@ We include a custom try fallback option — `--custom-bottom` — which position
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -570,7 +570,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/css_anchor_positioning/using/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/using/index.md
@@ -60,7 +60,7 @@ Converting an element to an anchor-positioned element requires two steps: It nee
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -222,7 +222,7 @@ The infobox is associated with the anchor via the anchor name and given fixed po
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -387,7 +387,7 @@ The infobox is given fixed positioning and associated with the anchor using CSS.
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -486,7 +486,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -611,7 +611,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -734,7 +734,7 @@ body {
   align-content: center;
   color: darkblue;
   background-color: azure;
-  outline: 1px solid #ddd;
+  outline: 1px solid #dddddd;
   font-size: 1rem;
   text-align: center;
 }

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -157,7 +157,7 @@ i:nth-of-type(7n + 1) {
 }
 .ground {
   bottom: 0;
-  background-image: linear-gradient(to top, white 97%, 99%, #bbb 100%);
+  background-image: linear-gradient(to top, white 97%, 99%, #bbbbbb 100%);
   background-position: center 580px;
   animation: snowfall linear 300s forwards;
   border: 1px solid grey;

--- a/files/en-us/web/css/css_basic_user_interface/index.md
+++ b/files/en-us/web/css/css_basic_user_interface/index.md
@@ -46,7 +46,7 @@ body {
 [contenteditable] {
   cursor: copy;
   caret-color: magenta;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
 }
 :focus {
   outline: dashed magenta 3px;

--- a/files/en-us/web/css/css_box_sizing/understanding_aspect-ratio/index.md
+++ b/files/en-us/web/css/css_box_sizing/understanding_aspect-ratio/index.md
@@ -223,7 +223,7 @@ Next, we designate the container as a grid, where each item has an aspect ratio 
 
 div div {
   aspect-ratio: 5 / 2;
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -295,7 +295,7 @@ To highlight the issue with setting a non-replaced element's aspect ratio via si
 
 ```css hidden live-sample___alder
 blockquote {
-  border: 3px dotted #ccc;
+  border: 3px dotted #cccccc;
   padding: 0 3px;
   margin: 20px 0;
   font-size: 1.25rem;
@@ -352,7 +352,7 @@ blockquote {
 
 ```css hidden live-sample___words
 blockquote {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   padding: 1px;
   margin: 20px 0;
   background-color: #ededed;
@@ -526,7 +526,7 @@ div {
 }
 
 div div {
-  background-color: #ccc;
+  background-color: #cccccc;
   aspect-ratio: 1;
   counter-increment: items;
 }

--- a/files/en-us/web/css/css_colors/color_values/index.md
+++ b/files/en-us/web/css/css_colors/color_values/index.md
@@ -55,7 +55,7 @@ These two hex colors are equivalent color values; they're both red:
 
 ```css
 color: #ff0000;
-color: #f00;
+color: #ff0000;
 ```
 
 All components _must_ be specified using the same number of digits. If you use the single-digit notation, the final color is computed by using each component's digit twice; that is, `"#D"` becomes `"#DD"` when drawing.
@@ -64,7 +64,7 @@ To make the values 25% opaque, add in the alpha channel value as shown below:
 
 ```css
 color: #ff000044;
-color: #f004;
+color: #ff000044;
 ```
 
 See the {{cssxref("hex-color")}} data type for more information on hexadecimal string notation for colors.

--- a/files/en-us/web/css/css_colors/color_values/index.md
+++ b/files/en-us/web/css/css_colors/color_values/index.md
@@ -55,7 +55,7 @@ These two hex colors are equivalent color values; they're both red:
 
 ```css
 color: #ff0000;
-color: #ff0000;
+color: #f00;
 ```
 
 All components _must_ be specified using the same number of digits. If you use the single-digit notation, the final color is computed by using each component's digit twice; that is, `"#D"` becomes `"#DD"` when drawing.
@@ -64,7 +64,7 @@ To make the values 25% opaque, add in the alpha channel value as shown below:
 
 ```css
 color: #ff000044;
-color: #ff000044;
+color: #f004;
 ```
 
 See the {{cssxref("hex-color")}} data type for more information on hexadecimal string notation for colors.

--- a/files/en-us/web/css/css_conditional_rules/container_scroll-state_queries/index.md
+++ b/files/en-us/web/css/css_conditional_rules/container_scroll-state_queries/index.md
@@ -284,8 +284,8 @@ img {
 .back-to-top {
   text-decoration: none;
   border-radius: 50%;
-  border: 1px solid #0007;
-  background-color: #0007;
+  border: 1px solid #00000077;
+  background-color: #00000077;
   color: white;
   font-size: 3rem;
   text-shadow: 0 0 2px black;
@@ -294,7 +294,7 @@ img {
 
 .back-to-top:hover,
 .back-to-top:focus {
-  background: #0009;
+  background: #00000099;
 }
 ```
 
@@ -501,7 +501,7 @@ section {
   width: 100%;
   height: 100%;
   border-radius: 5px;
-  background: #eee;
+  background: #eeeeee;
   box-shadow:
     inset 1px 1px 4px rgb(255 255 255 / 0.5),
     inset -1px -1px 4px rgb(0 0 0 / 0.5);
@@ -820,8 +820,8 @@ Next, we define a {{cssxref("@container")}} block that sets the container name w
 @container sticky-heading scroll-state(stuck: top) {
   h2,
   p {
-    background: #ccc;
-    box-shadow: 0 5px 2px #0007;
+    background: #cccccc;
+    box-shadow: 0 5px 2px #00000077;
   }
 }
 ```

--- a/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
@@ -236,7 +236,7 @@ In this case, other color values equivalent to sRGB `blue` (such as the hexadeci
 }
 ```
 
-In this case, if the value of `--accent-color` were set to `blue`, `#0000ff`, `#0000ff`, `rgb(0 0 255 / 1)`, or `rgb(0% 0% 100%)` it would return true for `@container style(--accent-color: blue)`.
+In this case, if the value of `--accent-color` were set to `blue`, `#00f`, `#0000ff`, `rgb(0 0 255 / 1)`, or `rgb(0% 0% 100%)` it would return true for `@container style(--accent-color: blue)`.
 
 ##### Example
 
@@ -290,7 +290,7 @@ color.addEventListener("input", (e) => {
 });
 ```
 
-We use the `@property` at-rule to define a CSS variable `--theme` to be a {{cssxref("color_value", "&lt;color&gt;")}} value and set the `initial-value` to `red`, ensuring equivalent colors are a match regardless of what syntax is used (for example, `red` is equal to `rgb(255 0 0)`, `#ff0000`, and `#ff0000`).
+We use the `@property` at-rule to define a CSS variable `--theme` to be a {{cssxref("color_value", "&lt;color&gt;")}} value and set the `initial-value` to `red`, ensuring equivalent colors are a match regardless of what syntax is used (for example, `red` is equal to `rgb(255 0 0)`, `#ff0000`, and `#f00`).
 
 ```css
 @property --theme {

--- a/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
@@ -232,11 +232,11 @@ In this case, other color values equivalent to sRGB `blue` (such as the hexadeci
 @property --accent-color {
   syntax: "<color>";
   inherits: true;
-  initial-value: #00f;
+  initial-value: #0000ff;
 }
 ```
 
-In this case, if the value of `--accent-color` were set to `blue`, `#00f`, `#0000ff`, `rgb(0 0 255 / 1)`, or `rgb(0% 0% 100%)` it would return true for `@container style(--accent-color: blue)`.
+In this case, if the value of `--accent-color` were set to `blue`, `#0000ff`, `#0000ff`, `rgb(0 0 255 / 1)`, or `rgb(0% 0% 100%)` it would return true for `@container style(--accent-color: blue)`.
 
 ##### Example
 
@@ -290,7 +290,7 @@ color.addEventListener("input", (e) => {
 });
 ```
 
-We use the `@property` at-rule to define a CSS variable `--theme` to be a {{cssxref("color_value", "&lt;color&gt;")}} value and set the `initial-value` to `red`, ensuring equivalent colors are a match regardless of what syntax is used (for example, `red` is equal to `rgb(255 0 0)`, `#ff0000`, and `#f00`).
+We use the `@property` at-rule to define a CSS variable `--theme` to be a {{cssxref("color_value", "&lt;color&gt;")}} value and set the `initial-value` to `red`, ensuring equivalent colors are a match regardless of what syntax is used (for example, `red` is equal to `rgb(255 0 0)`, `#ff0000`, and `#ff0000`).
 
 ```css
 @property --theme {
@@ -307,13 +307,13 @@ output {
 }
 ```
 
-The first style feature query is a custom property with no value. This query type returns true when the computed value for the custom property value is different from the `initial-value` for that property. In this case, it will be true when the value of `--theme` is any value other than any syntax equivalent value of `red` (such as `#f00`). When true, the {{htmlelement("output")}} will have a 5px dotted outline. The outline color is the current value of `--theme`. The default text {{cssxref("color")}} is grey.
+The first style feature query is a custom property with no value. This query type returns true when the computed value for the custom property value is different from the `initial-value` for that property. In this case, it will be true when the value of `--theme` is any value other than any syntax equivalent value of `red` (such as `#ff0000`). When true, the {{htmlelement("output")}} will have a 5px dotted outline. The outline color is the current value of `--theme`. The default text {{cssxref("color")}} is grey.
 
 ```css
 @container style(--theme) {
   output {
     outline: 5px dotted var(--theme);
-    color: #777;
+    color: #777777;
   }
 }
 ```

--- a/files/en-us/web/css/css_display/in_flow_and_out_of_flow/index.md
+++ b/files/en-us/web/css/css_display/in_flow_and_out_of_flow/index.md
@@ -93,7 +93,7 @@ body {
   font: 1.2em sans-serif;
 }
 p {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 
 .float {

--- a/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
+++ b/files/en-us/web/css/css_display/multi-keyword_syntax_of_display/index.md
@@ -38,7 +38,7 @@ body {
   font: 1.2em / 1.5 sans-serif;
 }
 .flex {
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
   display: flex;
   justify-content: space-between;
 }
@@ -67,7 +67,7 @@ body {
 }
 
 .flex {
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
   display: inline-flex;
 }
 ```
@@ -106,7 +106,7 @@ body {
   font: 1.2em / 1.5 sans-serif;
 }
 .flex {
-  border: 5px solid #ccc;
+  border: 5px solid #cccccc;
   gap: 10px;
 }
 

--- a/files/en-us/web/css/css_display/visual_formatting_model/index.md
+++ b/files/en-us/web/css/css_display/visual_formatting_model/index.md
@@ -134,7 +134,7 @@ body {
 }
 
 .following {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -203,14 +203,14 @@ body {
   margin: 20px;
 }
 .container {
-  background-color: #333;
+  background-color: #333333;
   color: white;
 }
 
 .item {
   background-color: white;
-  border: 1px solid #999;
-  color: #333;
+  border: 1px solid #999999;
+  color: #333333;
   width: 100px;
   height: 100px;
   padding: 10px;

--- a/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -410,7 +410,7 @@ Flexbox makes this type of layout easy to achieve. The `<label>`, `<input>` and 
   color: white;
 }
 .wrapper label {
-  background-color: #666;
+  background-color: #666666;
 }
 ```
 

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_grid_layout/index.md
@@ -547,7 +547,7 @@ body {
   max-width: 800px;
 }
 .wrapper li {
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
 }
 
 .wrapper li img {

--- a/files/en-us/web/css/css_masking/mask_properties/index.md
+++ b/files/en-us/web/css/css_masking/mask_properties/index.md
@@ -121,7 +121,7 @@ img {
   mask-image: repeating-linear-gradient(
     to bottom right,
     red 0 20px,
-    #f005 20px 40px,
+    #ff000055 20px 40px,
     transparent 40px 60px
   );
 }
@@ -129,7 +129,7 @@ img {
   background: repeating-linear-gradient(
     to bottom right,
     red 0 20px,
-    #f005 20px 40px,
+    #ff000055 20px 40px,
     transparent 40px 60px
   );
 }
@@ -726,7 +726,7 @@ img {
     repeating-linear-gradient(
       to bottom right,
       red 0 20px,
-      #f005 20px 40px,
+      #ff000055 20px 40px,
       transparent 40px 60px
     ),
     url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
@@ -775,7 +775,7 @@ img {
     repeating-linear-gradient(
       to bottom right,
       red 0 20px,
-      #f005 20px 40px,
+      #ff000055 20px 40px,
       transparent 40px 60px
     ),
     none;
@@ -809,7 +809,7 @@ If we reverse the order of the mask layers, we can also get very different resul
     repeating-linear-gradient(
       to bottom right,
       red 0 20px,
-      #f005 20px 40px,
+      #ff000055 20px 40px,
       transparent 40px 60px
     ),
     url("https://mdn.github.io/shared-assets/images/examples/mask-star.svg");
@@ -820,7 +820,7 @@ If we reverse the order of the mask layers, we can also get very different resul
     repeating-linear-gradient(
       to bottom right,
       red 0 20px,
-      #f005 20px 40px,
+      #ff000055 20px 40px,
       transparent 40px 60px
     );
 }

--- a/files/en-us/web/css/css_masking/masking/index.md
+++ b/files/en-us/web/css/css_masking/masking/index.md
@@ -85,7 +85,7 @@ With alpha masks, the color of the mask doesn't matter, only the transparency. I
   mask-image: repeating-linear-gradient(
     to bottom right,
     red 0 20px,
-    #f005 20px 40px,
+    #ff000055 20px 40px,
     transparent 40px 60px
   );
 }
@@ -93,7 +93,7 @@ With alpha masks, the color of the mask doesn't matter, only the transparency. I
   background: repeating-linear-gradient(
     to bottom right,
     red 0 20px,
-    #f005 20px 40px,
+    #ff000055 20px 40px,
     transparent 40px 60px
   );
 }

--- a/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/handling_content_breaks_in_multicol_layout/index.md
@@ -65,7 +65,7 @@ figure {
 }
 figcaption {
   font-weight: bold;
-  border-bottom: 2px solid #999;
+  border-bottom: 2px solid #999999;
 }
 .container {
   column-width: 200px;

--- a/files/en-us/web/css/css_multicol_layout/index.md
+++ b/files/en-us/web/css/css_multicol_layout/index.md
@@ -202,7 +202,7 @@ article {
   widows: 3;
   orphans: 3;
   gap: 1em;
-  column-rule: 2px dashed #666;
+  column-rule: 2px dashed #666666;
   height: 50em;
 }
 .title {

--- a/files/en-us/web/css/css_overflow/css_carousels/index.md
+++ b/files/en-us/web/css/css_overflow/css_carousels/index.md
@@ -105,8 +105,8 @@ Now it's time to style the list items. The first declarations provide rudimentar
 ```css live-sample___first-example live-sample___first-example-step1 live-sample___first-example-step2
 li {
   list-style-type: none;
-  background-color: #eee;
-  border: 1px solid #ddd;
+  background-color: #eeeeee;
+  border: 1px solid #dddddd;
   padding: 20px;
 
   flex: 0 0 100%;
@@ -424,8 +424,8 @@ li {
   height: 100%;
   width: 200px;
 
-  background-color: #eee;
-  border: 1px solid #ddd;
+  background-color: #eeeeee;
+  border: 1px solid #dddddd;
   padding: 20px;
   margin: 0 10px;
 

--- a/files/en-us/web/css/css_positioned_layout/stacking_context/index.md
+++ b/files/en-us/web/css/css_positioned_layout/stacking_context/index.md
@@ -121,34 +121,34 @@ h1 {
 }
 #container1,
 #container2 {
-  border: 1px dashed #696;
+  border: 1px dashed #669966;
   padding: 10px;
-  background-color: #cfc;
+  background-color: #ccffcc;
 }
 #container1 {
   margin-bottom: 190px;
 }
 #container3 {
-  border: 1px dashed #900;
-  background-color: #fdd;
+  border: 1px dashed #990000;
+  background-color: #ffdddd;
   padding: 40px 20px 20px;
   width: 330px;
 }
 #container4 {
-  border: 1px dashed #996;
-  background-color: #ffc;
+  border: 1px dashed #999966;
+  background-color: #ffffcc;
   padding: 25px 10px 5px;
   margin-bottom: 15px;
 }
 #container5 {
-  border: 1px dashed #996;
-  background-color: #ffc;
+  border: 1px dashed #999966;
+  background-color: #ffffcc;
   margin-top: 15px;
   padding: 5px 10px;
 }
 #container6 {
-  background-color: #ddf;
-  border: 1px dashed #009;
+  background-color: #ddddff;
+  border: 1px dashed #000099;
   padding-left: 20px;
   padding-top: 125px;
   width: 150px;

--- a/files/en-us/web/css/css_positioned_layout/stacking_floating_elements/index.md
+++ b/files/en-us/web/css/css_positioned_layout/stacking_floating_elements/index.md
@@ -63,14 +63,14 @@ strong {
   height: 200px;
   top: 10px;
   right: 140px;
-  border: 1px dashed #900;
-  background-color: #fdd;
+  border: 1px dashed #990000;
+  background-color: #ffdddd;
 }
 
 #sta1 {
   height: 100px;
-  border: 1px dashed #996;
-  background-color: #ffc;
+  border: 1px dashed #999966;
+  background-color: #ffffcc;
   margin: 0px 10px 0px 10px;
   text-align: left;
 }
@@ -80,8 +80,8 @@ strong {
   float: left;
   width: 150px;
   height: 200px;
-  border: 1px dashed #090;
-  background-color: #cfc;
+  border: 1px dashed #009900;
+  background-color: #ccffcc;
 }
 
 #flo2 {
@@ -89,8 +89,8 @@ strong {
   float: right;
   width: 150px;
   height: 200px;
-  border: 1px dashed #090;
-  background-color: #cfc;
+  border: 1px dashed #009900;
+  background-color: #ccffcc;
 }
 
 #abs2 {
@@ -99,14 +99,14 @@ strong {
   height: 100px;
   top: 80px;
   left: 100px;
-  border: 1px dashed #990;
-  background-color: #fdd;
+  border: 1px dashed #999900;
+  background-color: #ffdddd;
 }
 
 #rel1 {
   position: relative;
-  border: 1px dashed #996;
-  background-color: #cff;
+  border: 1px dashed #999966;
+  background-color: #ccffff;
   margin: 0px 10px 0px 10px;
   text-align: left;
 }

--- a/files/en-us/web/css/css_positioned_layout/stacking_without_z-index/index.md
+++ b/files/en-us/web/css/css_positioned_layout/stacking_without_z-index/index.md
@@ -56,24 +56,24 @@ div {
 .static {
   position: static;
   height: 80px;
-  background-color: #ffc;
-  border-color: #996;
+  background-color: #ffffcc;
+  border-color: #999966;
 }
 
 .absolute {
   position: absolute;
   width: 150px;
   height: 350px;
-  background-color: #fdd;
-  border-color: #900;
+  background-color: #ffdddd;
+  border-color: #990000;
   opacity: 0.7;
 }
 
 .relative {
   position: relative;
   height: 80px;
-  background-color: #cfc;
-  border-color: #696;
+  background-color: #ccffcc;
+  border-color: #669966;
   opacity: 0.7;
 }
 
@@ -99,7 +99,7 @@ div {
 }
 
 #sta1 {
-  background-color: #ffc;
+  background-color: #ffffcc;
   margin: 0px 50px 0px 50px;
 }
 ```

--- a/files/en-us/web/css/css_positioned_layout/using_z-index/index.md
+++ b/files/en-us/web/css/css_positioned_layout/using_z-index/index.md
@@ -75,8 +75,8 @@ strong {
   height: 350px;
   top: 10px;
   left: 10px;
-  border: 1px dashed #900;
-  background-color: #fdd;
+  border: 1px dashed #990000;
+  background-color: #ffdddd;
 }
 
 #rel1 {
@@ -84,8 +84,8 @@ strong {
   height: 100px;
   position: relative;
   top: 30px;
-  border: 1px dashed #696;
-  background-color: #cfc;
+  border: 1px dashed #669966;
+  background-color: #ccffcc;
   margin: 0px 50px 0px 50px;
 }
 
@@ -95,8 +95,8 @@ strong {
   position: relative;
   top: 15px;
   left: 20px;
-  border: 1px dashed #696;
-  background-color: #cfc;
+  border: 1px dashed #669966;
+  background-color: #ccffcc;
   margin: 0px 50px 0px 50px;
 }
 
@@ -107,15 +107,15 @@ strong {
   height: 350px;
   top: 10px;
   right: 10px;
-  border: 1px dashed #900;
-  background-color: #fdd;
+  border: 1px dashed #990000;
+  background-color: #ffdddd;
 }
 
 #sta1 {
   z-index: 8;
   height: 70px;
-  border: 1px dashed #996;
-  background-color: #ffc;
+  border: 1px dashed #999966;
+  background-color: #ffffcc;
   margin: 0px 50px 0px 50px;
 }
 ```

--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -44,7 +44,7 @@ body {
 }
 
 .scroller {
-  border: 4px solid #333;
+  border: 4px solid #333333;
   width: 300px;
 }
 
@@ -54,7 +54,7 @@ body {
 }
 
 .scroller section:nth-child(odd) {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -124,7 +124,7 @@ body {
 }
 
 .scroller {
-  border: 4px solid #333;
+  border: 4px solid #333333;
   width: 300px;
 }
 
@@ -134,7 +134,7 @@ body {
 }
 
 .scroller section:nth-child(odd) {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -197,7 +197,7 @@ body {
 }
 
 .scroller {
-  border: 4px solid #333;
+  border: 4px solid #333333;
   width: 300px;
 }
 
@@ -207,7 +207,7 @@ body {
 }
 
 .scroller section:nth-child(odd) {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -253,7 +253,7 @@ body {
 }
 
 .scroller {
-  border: 4px solid #333;
+  border: 4px solid #333333;
   width: 300px;
 }
 
@@ -263,7 +263,7 @@ body {
 }
 
 .scroller section:nth-child(odd) {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -305,7 +305,7 @@ body {
 }
 
 .scroller {
-  border: 4px solid #333;
+  border: 4px solid #333333;
   width: 300px;
 }
 
@@ -315,7 +315,7 @@ body {
 }
 
 .scroller section:nth-child(odd) {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 
@@ -373,7 +373,7 @@ body {
 }
 
 .scroller {
-  border: 4px solid #333;
+  border: 4px solid #333333;
   width: 300px;
 }
 
@@ -383,7 +383,7 @@ body {
 }
 
 .scroller section:nth-child(odd) {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 ```
 

--- a/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
+++ b/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
@@ -146,7 +146,7 @@ h2 {
 section {
   font-family: Arial, Helvetica, sans-serif;
   border-radius: 5px;
-  background: #eee;
+  background: #eeeeee;
   box-shadow:
     inset 1px 1px 4px rgb(255 255 255 / 0.5),
     inset -1px -1px 4px rgb(0 0 0 / 0.5);
@@ -185,7 +185,7 @@ The style changes mentioned above will be applied through classes applied to the
 
 ```css
 .pending {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 
 .select-section {
@@ -285,7 +285,7 @@ body {
 section {
   font-family: Arial, Helvetica, sans-serif;
   border-radius: 5px;
-  background: #eee;
+  background: #eeeeee;
   box-shadow:
     inset 1px 1px 4px rgb(255 255 255 / 0.5),
     inset -1px -1px 4px rgb(0 0 0 / 0.5);
@@ -342,12 +342,12 @@ The {{cssxref("@keyframes")}} animate from a gray background and black (default)
 }
 
 .pending {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 
 @keyframes select {
   from {
-    background: #eee;
+    background: #eeeeee;
     color: black;
   }
 
@@ -365,13 +365,13 @@ The {{cssxref("@keyframes")}} animate from a gray background and black (default)
   }
 
   80% {
-    background: #eee;
+    background: #eeeeee;
     color: black;
     opacity: 0.1;
   }
 
   100% {
-    background: #eee;
+    background: #eeeeee;
     color: black;
     opacity: 1;
   }

--- a/files/en-us/web/css/css_text/wrapping_breaking_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_breaking_text/index.md
@@ -148,7 +148,7 @@ In the example below there is a checkbox and label. Let's say, you want the labe
 ```css live-sample___word-break-checkbox
 .field {
   inline-size: 150px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin-block-end: 1em;
   padding: 10px;
 }

--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -517,7 +517,7 @@ legend {
 button {
   font-size: 18px;
   border-radius: 50%;
-  border: #ccc solid 1px;
+  border: #cccccc solid 1px;
   padding: 0;
   width: 26px;
   height: 26px;

--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -522,7 +522,7 @@ This example shows cubes with popular `perspective-origin` values.
 
 /* Make the layout a little nicer */
 section {
-  background-color: #eee;
+  background-color: #eeeeee;
   padding: 10px;
   font-family: sans-serif;
   text-align: left;

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -164,7 +164,7 @@ nav {
 
 a {
   flex: 1;
-  background-color: #333;
+  background-color: #333333;
   color: white;
   border: 1px solid;
   padding: 0.5rem;
@@ -176,7 +176,7 @@ a {
 a:hover,
 a:focus {
   background-color: white;
-  color: #333;
+  color: #333333;
 }
 ```
 
@@ -321,7 +321,7 @@ With CSS, you can smooth the styles applied through JavaScript. Add a transition
 ```css hidden live-sample___js-transitions
 body {
   background-color: white;
-  color: #333;
+  color: #333333;
   font:
     1.2em / 1.5 Helvetica Neue,
     Helvetica,
@@ -342,7 +342,7 @@ main {
   align-items: center;
   max-width: 660px;
   height: 400px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   padding: 20px;
 }
 ```
@@ -352,7 +352,7 @@ main {
   border-radius: 25px;
   width: 50px;
   height: 50px;
-  background: #c00;
+  background: #cc0000;
   position: absolute;
   top: 0;
   left: 0;

--- a/files/en-us/web/css/d/index.md
+++ b/files/en-us/web/css/d/index.md
@@ -74,7 +74,7 @@ svg {
 }
 
 path {
-  fill: #f338;
+  fill: #ff333388;
   stroke: black;
 }
 

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -57,7 +57,7 @@ display: grid;
 }
 
 code {
-  background: #8888;
+  background: #88888888;
 }
 
 #example-element {

--- a/files/en-us/web/css/empty-cells/index.md
+++ b/files/en-us/web/css/empty-cells/index.md
@@ -48,7 +48,7 @@ empty-cells: hide;
 ```css interactive-example
 th,
 td {
-  border: 2px solid #a19;
+  border: 2px solid #aa1199;
   padding: 0.25rem 0.5rem;
 }
 ```

--- a/files/en-us/web/css/env/index.md
+++ b/files/en-us/web/css/env/index.md
@@ -91,7 +91,7 @@ body {
 
 main {
   flex: 1;
-  background-color: #eee;
+  background-color: #eeeeee;
   padding: 1em;
 }
 

--- a/files/en-us/web/css/fill-opacity/index.md
+++ b/files/en-us/web/css/fill-opacity/index.md
@@ -85,7 +85,7 @@ svg {
   background: repeating-linear-gradient(
     to bottom right,
     transparent 0 10px,
-    #ccc 10px 11px
+    #cccccc 10px 11px
   );
 }
 ```

--- a/files/en-us/web/css/fill/index.md
+++ b/files/en-us/web/css/fill/index.md
@@ -76,17 +76,17 @@ This example demonstrates how a `fill` is declared, the effect of the property, 
 
 #### HTML
 
-We have an SVG with two complex shapes defined using the SVG {{SVGElement('polygon')}} and {{SVGElement('path')}} elements. Both have the `fill` attribute set to the default `black`. We add a dark grey stroke of `#666` using the SVG {{SVGAttr("stroke")}} attribute but could have used the {{CSSXRef("stroke")}} property.
+We have an SVG with two complex shapes defined using the SVG {{SVGElement('polygon')}} and {{SVGElement('path')}} elements. Both have the `fill` attribute set to the default `black`. We add a dark grey stroke of `#666666` using the SVG {{SVGAttr("stroke")}} attribute but could have used the {{CSSXRef("stroke")}} property.
 
 ```html
 <svg viewBox="0 0 220 120" xmlns="http://www.w3.org/2000/svg">
   <path
     d="M 10,5 l 90,0 -80,80 0,-60 80,80 -90,0 z"
-    stroke="#666"
+    stroke="#666666"
     fill="black" />
   <polygon
     points="180,10 150,100 220,40 140,40 210,100"
-    stroke="#666"
+    stroke="#666666"
     fill="black" />
 </svg>
 ```

--- a/files/en-us/web/css/filter-function/contrast/index.md
+++ b/files/en-us/web/css/filter-function/contrast/index.md
@@ -76,7 +76,7 @@ This example applies a `contrast()` filter via the {{cssxref("backdrop-filter")}
 
 ```css
 .container {
-  background: url("unity_for_the_people.jpg") no-repeat center / contain #339;
+  background: url("unity_for_the_people.jpg") no-repeat center / contain #333399;
 }
 p {
   backdrop-filter: contrast(0.5);

--- a/files/en-us/web/css/filter-function/drop-shadow/index.md
+++ b/files/en-us/web/css/filter-function/drop-shadow/index.md
@@ -58,7 +58,7 @@ drop-shadow(5px 5px 15px red)
 
 /* The order of color and length values can be changed */
 /* drop-shadow( <color> <length> <length> <length> ) */
-drop-shadow(#e23 0.5rem 0.5rem 1rem)
+drop-shadow(#ee2233 0.5rem 0.5rem 1rem)
 
 /* Pass multiple drop-shadows to a filter to stack them */
 drop-shadow(10px 10px red) drop-shadow(-5px -5px yellow)
@@ -101,7 +101,7 @@ div {
   height: 100px;
   width: 190px;
   vertical-align: top;
-  background-color: #222;
+  background-color: #222222;
 
   color: lime;
 }

--- a/files/en-us/web/css/fit-content/index.md
+++ b/files/en-us/web/css/fit-content/index.md
@@ -47,7 +47,7 @@ block-size: fit-content;
 
 ```css
 .container {
-  border: 2px solid #ccc;
+  border: 2px solid #cccccc;
   padding: 10px;
   width: 20em;
 }

--- a/files/en-us/web/css/flex-basis/index.md
+++ b/files/en-us/web/css/flex-basis/index.md
@@ -156,7 +156,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
   top: 100%;
   margin-top: 10px;
   width: 100%;
-  color: #333;
+  color: #333333;
   font-size: 12px;
 }
 

--- a/files/en-us/web/css/flood-color/index.md
+++ b/files/en-us/web/css/flood-color/index.md
@@ -87,7 +87,7 @@ We then apply different flood color values to the `<feFlood>` elements using the
   flood-color: rebeccapurple;
 }
 #flood2 feFlood {
-  flood-color: #f36;
+  flood-color: #ff3366;
 }
 ```
 

--- a/files/en-us/web/css/flood-opacity/index.md
+++ b/files/en-us/web/css/flood-opacity/index.md
@@ -81,7 +81,7 @@ svg {
   background-image: repeating-linear-gradient(
     45deg,
     transparent 0 9px,
-    #ccc 0px 10px
+    #cccccc 0px 10px
   );
 }
 rect {

--- a/files/en-us/web/css/forced-color-adjust/index.md
+++ b/files/en-us/web/css/forced-color-adjust/index.md
@@ -59,7 +59,7 @@ By using the {{cssxref("@media/forced-colors", "forced-colors")}} media feature,
 ```css
 .box {
   border: 5px solid grey;
-  background-color: #ccc;
+  background-color: #cccccc;
   width: 300px;
   margin: 20px;
   padding: 10px;

--- a/files/en-us/web/css/gap/index.md
+++ b/files/en-us/web/css/gap/index.md
@@ -260,7 +260,7 @@ If the container has a fixed size set, then gap percentage value calculations ar
 
 ```css hidden
 body > div {
-  background-color: #ccc;
+  background-color: #cccccc;
   width: 200px;
   flex-flow: column;
 }
@@ -316,7 +316,7 @@ If size is not explicitly set on the container, then the percentage gap behaves 
 
 ```css hidden
 body > div {
-  background-color: #ccc;
+  background-color: #cccccc;
   width: 200px;
 }
 

--- a/files/en-us/web/css/gradient/conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/conic-gradient/index.md
@@ -140,8 +140,8 @@ conic-gradient(red 40grad, 80grad, blue 360grad);
 If two or more color stops are at the same location, the transition will be a hard line between the first and last colors declared at that location. To use conic gradients to create pie charts — which is NOT the correct way to create pie charts as background images are not accessible — use hard color stops, where the color stop angles for two adjacent color stops are the same. The easiest way to do this is to use multiple position colors stops. The following two declarations are equivalent:
 
 ```css
-conic-gradient(white 0.09turn, #bbb 0.09turn, #bbb 0.27turn, #666 0.27turn, #666 0.54turn, black 0.54turn);
-conic-gradient(white 0turn 0.09turn, #bbb 0.09turn 0.27turn, #666 0.27turn 0.54turn, black 0.54turn 1turn);
+conic-gradient(white 0.09turn, #bbbbbb 0.09turn, #bbbbbb 0.27turn, #666666 0.27turn, #666666 0.54turn, black 0.54turn);
+conic-gradient(white 0turn 0.09turn, #bbbbbb 0.09turn 0.27turn, #666666 0.27turn 0.54turn, black 0.54turn 1turn);
 ```
 
 Color stops should be listed in ascending order. Subsequent color stops of lower value will override the value of the previous color stop creating a hard transition. The following changes from red to yellow at the 30% mark, and then transitions from yellow to blue over 35% of the gradient:

--- a/files/en-us/web/css/gradient/linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/linear-gradient/index.md
@@ -19,7 +19,7 @@ background: linear-gradient(0.25turn, #3f87a6, #ebf8e1, #f69d3c);
 ```
 
 ```css interactive-example-choice
-background: linear-gradient(to left, #333, #333 50%, #eee 75%, #333 75%);
+background: linear-gradient(to left, #333333, #333333 50%, #eeeeee 75%, #333333 75%);
 ```
 
 ```css interactive-example-choice

--- a/files/en-us/web/css/gradient/linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/linear-gradient/index.md
@@ -19,7 +19,13 @@ background: linear-gradient(0.25turn, #3f87a6, #ebf8e1, #f69d3c);
 ```
 
 ```css interactive-example-choice
-background: linear-gradient(to left, #333333, #333333 50%, #eeeeee 75%, #333333 75%);
+background: linear-gradient(
+  to left,
+  #333333,
+  #333333 50%,
+  #eeeeee 75%,
+  #333333 75%
+);
 ```
 
 ```css interactive-example-choice

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -19,7 +19,13 @@ background: radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c);
 ```
 
 ```css interactive-example-choice
-background: radial-gradient(circle at 100%, #333, #333 50%, #eee 75%, #333 75%);
+background: radial-gradient(
+  circle at 100%,
+  #333333,
+  #333333 50%,
+  #eeeeee 75%,
+  #333333 75%
+);
 ```
 
 ```css interactive-example-choice
@@ -147,8 +153,8 @@ Color-stop points are positioned on a _virtual gradient ray_ that extends horizo
 .radial-gradient {
   background-image: radial-gradient(
     farthest-corner at 40px 40px,
-    #f35 0%,
-    #43e 100%
+    #ff3355 0%,
+    #4433ee 100%
   );
 }
 ```

--- a/files/en-us/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-linear-gradient/index.md
@@ -182,7 +182,7 @@ body {
 ```css hidden
 div {
   height: 50vh;
-  color: #330;
+  color: #333300;
   font-weight: bolder;
   padding-left: 1.5rem;
 }

--- a/files/en-us/web/css/gradient/repeating-radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-radial-gradient/index.md
@@ -21,10 +21,10 @@ background: repeating-radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c);
 ```css interactive-example-choice
 background: repeating-radial-gradient(
   circle at 100%,
-  #333,
-  #333 10px,
-  #eee 10px,
-  #eee 20px
+  #333333,
+  #333333 10px,
+  #eeeeee 10px,
+  #eeeeee 20px
 );
 ```
 

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -195,7 +195,7 @@ div {
 
 .child {
   margin: 1rem;
-  background: #0999;
+  background: #00999999;
 }
 
 .stretch {

--- a/files/en-us/web/css/hyphenate-character/index.md
+++ b/files/en-us/web/css/hyphenate-character/index.md
@@ -32,7 +32,7 @@ hyphenate-character: "—";
 
 ```css interactive-example
 #example-element {
-  border: 2px dashed #999;
+  border: 2px dashed #999999;
   font-size: 1.5rem;
   text-align: left;
   width: 7rem;

--- a/files/en-us/web/css/hyphenate-limit-chars/index.md
+++ b/files/en-us/web/css/hyphenate-limit-chars/index.md
@@ -91,7 +91,7 @@ In this example, we have four boxes each containing the same text. For the purpo
 p {
   margin: 1rem;
   width: 120px;
-  border: 2px dashed #999;
+  border: 2px dashed #999999;
   font-size: 1.5rem;
   hyphens: auto;
 }

--- a/files/en-us/web/css/hyphens/index.md
+++ b/files/en-us/web/css/hyphens/index.md
@@ -30,7 +30,7 @@ hyphens: auto;
 
 ```css interactive-example
 #example-element {
-  border: 2px dashed #999;
+  border: 2px dashed #999999;
   font-size: 1.5rem;
   text-align: left;
   width: 7rem;

--- a/files/en-us/web/css/if/index.md
+++ b/files/en-us/web/css/if/index.md
@@ -16,7 +16,7 @@ The **`if()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Val
 
 ```css-nolint
 /* Single <if-test> */
-if(style(--scheme: dark): #eee;)
+if(style(--scheme: dark): #eeeeee;)
 if(media(print): black;)
 if(media(width > 700px): 0 auto;)
 if(supports(color: lch(7.1% 60.23 300.16)): lch(7.1% 60.23 300.16);)
@@ -193,12 +193,12 @@ if(
 
 A [media query](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) `<if-test>` can be used to set a value for a property depending on whether a media query test returns true.
 
-You can use media types. For example, the following `<if-test> : <value>` pair returns a value of `white` on print media, while the `else` clause causes `#eee` to be returned on non-print media.
+You can use media types. For example, the following `<if-test> : <value>` pair returns a value of `white` on print media, while the `else` clause causes `#eeeeee` to be returned on non-print media.
 
 ```css-nolint
 background-color: if(
   media(print): white;
-  else: #eee;
+  else: #eeeeee;
 )
 ```
 

--- a/files/en-us/web/css/interpolate-size/index.md
+++ b/files/en-us/web/css/interpolate-size/index.md
@@ -118,7 +118,7 @@ section {
   font-family: Arial, Helvetica, sans-serif;
   width: 175px;
   border-radius: 5px;
-  background: #eee;
+  background: #eeeeee;
   box-shadow:
     inset 1px 1px 4px rgb(255 255 255 / 0.5),
     inset -1px -1px 4px rgb(0 0 0 / 0.5);
@@ -126,7 +126,7 @@ section {
 
 header {
   padding: 0.7rem;
-  border-bottom: 2px solid #ccc;
+  border-bottom: 2px solid #cccccc;
 }
 
 main {

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -106,7 +106,7 @@ img {
 }
 
 .card {
-  border: 1px solid #999;
+  border: 1px solid #999999;
   border-radius: 3px;
 
   display: grid;
@@ -129,7 +129,7 @@ img {
 }
 
 .card footer {
-  background-color: #333;
+  background-color: #333333;
   color: white;
   padding: 0.5rem;
 }

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -48,13 +48,13 @@ body {
   list-style: none;
   margin: 0;
   padding: 0;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 0.5em;
   width: 20em;
 }
 
 .list-group li {
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #cccccc;
   padding: 0.5em;
   display: flex;
   justify-content: space-between;

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -66,7 +66,7 @@ Click "Play" in the code blocks below to edit the example in the MDN Playground:
 }
 
 nav {
-  border-top: 1px solid #eee;
+  border-top: 1px solid #eeeeee;
   margin-top: 1em;
   padding-top: 0.5em;
   font: 1.2em sans-serif;
@@ -89,13 +89,13 @@ nav {
 .pagination a {
   display: block;
   padding: 0.5em 1em;
-  border: 1px solid #999;
+  border: 1px solid #999999;
   border-radius: 0.2em;
   text-decoration: none;
 }
 
 .pagination a[aria-current="page"] {
-  background-color: #333;
+  background-color: #333333;
   color: white;
 }
 ```

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -230,13 +230,13 @@ html {
 .outer {
   width: 100%;
   height: 50px;
-  background-color: #eee;
+  background-color: #eeeeee;
   position: relative;
 }
 
 .inner {
   height: 50px;
-  background-color: #999;
+  background-color: #999999;
   box-shadow:
     inset 3px 3px 5px rgb(255 255 255 / 50%),
     inset -3px -3px 5px rgb(0 0 0 / 50%);

--- a/files/en-us/web/css/lighting-color/index.md
+++ b/files/en-us/web/css/lighting-color/index.md
@@ -77,7 +77,7 @@ svg {
   background-image: repeating-linear-gradient(
     45deg,
     transparent 0 9px,
-    #ccc 0px 10px
+    #cccccc 0px 10px
   );
 }
 
@@ -101,7 +101,7 @@ feDiffuseLighting {
 }
 
 feSpecularLighting {
-  lighting-color: #f09;
+  lighting-color: #ff0099;
 }
 ```
 

--- a/files/en-us/web/css/line-break/index.md
+++ b/files/en-us/web/css/line-break/index.md
@@ -37,7 +37,7 @@ line-break: loose;
 ```css interactive-example
 #example-element {
   font-family: "Yu Gothic", YuGothic, Meiryo, "ＭＳ ゴシック", sans-serif;
-  border: 2px dashed #999;
+  border: 2px dashed #999999;
   text-align: left;
   width: 240px;
   font-size: 16px;

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -598,7 +598,7 @@ html,
 body {
   height: 100%;
   box-sizing: border-box;
-  background: #eee;
+  background: #eeeeee;
 }
 
 .grid {

--- a/files/en-us/web/css/object-fit/index.md
+++ b/files/en-us/web/css/object-fit/index.md
@@ -48,7 +48,7 @@ object-fit: scale-down;
 #example-element {
   height: 100%;
   width: 100%;
-  border: 2px dotted #888;
+  border: 2px dotted #888888;
 }
 ```
 

--- a/files/en-us/web/css/offset-anchor/index.md
+++ b/files/en-us/web/css/offset-anchor/index.md
@@ -58,7 +58,7 @@ offset-anchor: 20% 80%;
     black 51%,
     transparent 52%
   );
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   width: 90%;
 }
 
@@ -185,7 +185,7 @@ section {
     black 51%,
     transparent 52%
   );
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   margin-bottom: 10px;
 }
 

--- a/files/en-us/web/css/outline/index.md
+++ b/files/en-us/web/css/outline/index.md
@@ -62,7 +62,7 @@ This property is a shorthand for the following CSS properties:
 outline: solid;
 
 /* style | color */
-outline: dashed #f66;
+outline: dashed #ff6666;
 
 /* width | style */
 outline: thick inset;
@@ -137,9 +137,9 @@ a {
 }
 
 a:focus {
-  outline: 4px dotted #e73;
+  outline: 4px dotted #ee7733;
   outline-offset: 4px;
-  background: #ffa;
+  background: #ffffaa;
 }
 ```
 

--- a/files/en-us/web/css/position-anchor/index.md
+++ b/files/en-us/web/css/position-anchor/index.md
@@ -216,7 +216,7 @@ Each of the positioned elements is given a `position-anchor` property with a val
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/position-area/index.md
+++ b/files/en-us/web/css/position-area/index.md
@@ -335,7 +335,7 @@ form {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 5px 2px;
   border-radius: 5px;
   font-size: 1rem;

--- a/files/en-us/web/css/position-try-fallbacks/index.md
+++ b/files/en-us/web/css/position-try-fallbacks/index.md
@@ -170,7 +170,7 @@ We include a `position-try-fallbacks` list (and re-declare it with the `position
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -244,7 +244,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;
@@ -317,7 +317,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/position-try-order/index.md
+++ b/files/en-us/web/css/position-try-order/index.md
@@ -133,7 +133,7 @@ In the CSS, the anchor is given an {{cssxref("anchor-name")}} and has a large {{
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/position-try/index.md
+++ b/files/en-us/web/css/position-try/index.md
@@ -110,7 +110,7 @@ In the CSS, the anchor is given an {{cssxref("anchor-name")}} and has a {{cssxre
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/position-visibility/index.md
+++ b/files/en-us/web/css/position-visibility/index.md
@@ -177,7 +177,7 @@ form {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -518,7 +518,8 @@ p {
 
 div {
   /* mark area defined by the inset boundaries using gray color */
-  background: linear-gradient(#99999999, #99999999) 100px 50px / 192px 100px no-repeat;
+  background: linear-gradient(#99999999, #99999999) 100px 50px / 192px 100px
+    no-repeat;
 }
 ```
 

--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -454,7 +454,7 @@ dd {
 }
 
 dd + dd {
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #cccccc;
 }
 ```
 
@@ -518,7 +518,7 @@ p {
 
 div {
   /* mark area defined by the inset boundaries using gray color */
-  background: linear-gradient(#9999, #9999) 100px 50px / 192px 100px no-repeat;
+  background: linear-gradient(#99999999, #99999999) 100px 50px / 192px 100px no-repeat;
 }
 ```
 

--- a/files/en-us/web/css/print-color-adjust/index.md
+++ b/files/en-us/web/css/print-color-adjust/index.md
@@ -70,7 +70,7 @@ For whatever reason, this is the desired appearance in any rendering environment
 .my-box {
   background-color: black;
   background-image: linear-gradient(rgb(0 0 180 / 50%), rgb(70 140 220 / 50%));
-  color: #900;
+  color: #990000;
   width: 15rem;
   height: 6rem;
   text-align: center;

--- a/files/en-us/web/css/scroll-marker-group/index.md
+++ b/files/en-us/web/css/scroll-marker-group/index.md
@@ -109,7 +109,7 @@ Next, we style the `<li>` elements, using the {{cssxref("flex")}} property to ma
 ```css
 li {
   list-style-type: none;
-  background-color: #eee;
+  background-color: #eeeeee;
   flex: 0 0 33%;
   scroll-snap-align: start;
   text-align: center;

--- a/files/en-us/web/css/scroll-snap-stop/index.md
+++ b/files/en-us/web/css/scroll-snap-stop/index.md
@@ -214,7 +214,7 @@ div[class] {
 
 div > div {
   flex: none;
-  outline: 1px solid #333;
+  outline: 1px solid #333333;
 }
 
 .x > div {

--- a/files/en-us/web/css/scrollbar-color/index.md
+++ b/files/en-us/web/css/scrollbar-color/index.md
@@ -82,7 +82,7 @@ When using `scrollbar-color` property with specific color values, authors should
   width: 300px;
   height: 100px;
   overflow-y: scroll;
-  scrollbar-color: #007 #bada55;
+  scrollbar-color: #000077 #bada55;
 }
 ```
 

--- a/files/en-us/web/css/sibling-index/index.md
+++ b/files/en-us/web/css/sibling-index/index.md
@@ -109,7 +109,7 @@ This example demonstrates how to dynamically increase the width of each {{htmlel
 ```css
 li {
   width: calc(sibling-index() * 50px);
-  background-color: #faa;
+  background-color: #ffaaaa;
 }
 ```
 

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -53,7 +53,7 @@ transform: translateX(calc(cos(-45deg) * 140px))
   width: calc(var(--radius) * 2);
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 2px solid #666;
+  border: 2px solid #666666;
   background-image:
     radial-gradient(black var(--dot-size), transparent var(--dot-size)),
     linear-gradient(135deg, blue, deepskyblue, lightgreen, lavender, honeydew);
@@ -63,8 +63,8 @@ transform: translateX(calc(cos(-45deg) * 140px))
   width: var(--dot-size);
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 2px solid #666;
-  background-color: #f66;
+  border: 2px solid #666666;
+  background-color: #ff6666;
   transform: translateX(calc(cos(0deg) * var(--radius)))
     translateY(calc(sin(0deg) * var(--radius) * -1));
 }

--- a/files/en-us/web/css/stop-color/index.md
+++ b/files/en-us/web/css/stop-color/index.md
@@ -57,19 +57,19 @@ We have an SVG with three {{SVGElement("rect")}} squares and three {{SVGElement(
       <stop offset="25%" stop-color="black" />
       <stop offset="40%" stop-color="white" />
       <stop offset="60%" stop-color="white" />
-      <stop offset="75%" stop-color="#333" />
+      <stop offset="75%" stop-color="#333333" />
     </linearGradient>
     <linearGradient id="myGradient2">
       <stop offset="25%" stop-color="black" />
       <stop offset="40%" stop-color="white" />
       <stop offset="60%" stop-color="white" />
-      <stop offset="75%" stop-color="#333" />
+      <stop offset="75%" stop-color="#333333" />
     </linearGradient>
     <linearGradient id="myGradient3">
       <stop offset="25%" stop-color="black" />
       <stop offset="40%" stop-color="white" />
       <stop offset="60%" stop-color="white" />
-      <stop offset="75%" stop-color="#333" />
+      <stop offset="75%" stop-color="#333333" />
     </linearGradient>
   </defs>
   <rect x="2" y="10" width="80" height="80" fill="url('#myGradient1')" />
@@ -92,7 +92,7 @@ svg {
 
 ```css
 rect {
-  stroke: #333;
+  stroke: #333333;
   stroke-width: 1px;
 }
 

--- a/files/en-us/web/css/stop-opacity/index.md
+++ b/files/en-us/web/css/stop-opacity/index.md
@@ -108,7 +108,7 @@ svg {
 
 ```css
 polygon {
-  stroke: #333;
+  stroke: #333333;
   stroke-width: 1px;
 }
 polygon:nth-of-type(1) {

--- a/files/en-us/web/css/stroke-dashoffset/index.md
+++ b/files/en-us/web/css/stroke-dashoffset/index.md
@@ -56,7 +56,7 @@ To show how dashes can be offset, we first set up five identical paths, all of w
 
 ```html
 <svg viewBox="0 0 100 50" width="500" height="250">
-  <rect x="10" y="5" width="80" height="30" fill="#EEE" />
+  <rect x="10" y="5" width="80" height="30" fill="#eeeeee" />
   <g stroke="dodgerblue" stroke-width="2" stroke-dasharray="20,3">
     <path d="M 10,10 h 80" />
     <path d="M 10,15 h 80" />

--- a/files/en-us/web/css/stroke-linecap/index.md
+++ b/files/en-us/web/css/stroke-linecap/index.md
@@ -57,7 +57,7 @@ We first set up a light-gray rectangle. Then, in a group, three paths are define
 
 ```html
 <svg viewBox="0 0 100 50" width="500" height="250">
-  <rect x="10" y="5" width="80" height="30" fill="#DDD" />
+  <rect x="10" y="5" width="80" height="30" fill="#dddddd" />
   <g stroke="dodgerblue" stroke-width="7">
     <path d="M 10,10 h 80" />
     <path d="M 10,20 h 80" />

--- a/files/en-us/web/css/table-layout/index.md
+++ b/files/en-us/web/css/table-layout/index.md
@@ -59,12 +59,12 @@ width: 100%;
 
 ```css interactive-example
 table {
-  border: 1px solid #139;
+  border: 1px solid #113399;
 }
 
 th,
 td {
-  border: 2px solid #a19;
+  border: 2px solid #aa1199;
   padding: 0.25rem 0.5rem;
 }
 ```

--- a/files/en-us/web/css/text-emphasis-color/index.md
+++ b/files/en-us/web/css/text-emphasis-color/index.md
@@ -49,7 +49,7 @@ p {
 text-emphasis-color: currentColor;
 
 /* <color> */
-text-emphasis-color: #555;
+text-emphasis-color: #555555;
 text-emphasis-color: blue;
 text-emphasis-color: rgb(90 200 160 / 80%);
 text-emphasis-color: transparent;

--- a/files/en-us/web/css/text-emphasis/index.md
+++ b/files/en-us/web/css/text-emphasis/index.md
@@ -66,7 +66,7 @@ text-emphasis: none; /* No emphasis marks */
 text-emphasis: "x";
 text-emphasis: "点";
 text-emphasis: "\25B2";
-text-emphasis: "*" #555;
+text-emphasis: "*" #555555;
 text-emphasis: "foo"; /* Should NOT use. It may be computed to or rendered as 'f' only */
 
 /* Keywords value */
@@ -76,7 +76,7 @@ text-emphasis: filled sesame;
 text-emphasis: open sesame;
 
 /* Keywords value combined with a color */
-text-emphasis: filled sesame #555;
+text-emphasis: filled sesame #555555;
 
 /* Global values */
 text-emphasis: inherit;
@@ -127,7 +127,7 @@ This example draws a heading with triangles used to emphasize each character.
 
 ```css
 h2 {
-  text-emphasis: triangle #d55;
+  text-emphasis: triangle #dd5555;
 }
 ```
 

--- a/files/en-us/web/css/text-shadow/index.md
+++ b/files/en-us/web/css/text-shadow/index.md
@@ -15,7 +15,7 @@ text-shadow: 1px 1px 2px pink;
 ```
 
 ```css interactive-example-choice
-text-shadow: #fc0 1px 0 10px;
+text-shadow: #ffcc00 1px 0 10px;
 ```
 
 ```css interactive-example-choice
@@ -61,7 +61,7 @@ p {
 text-shadow: 1px 1px 2px black;
 
 /* color | offset-x | offset-y | blur-radius */
-text-shadow: #fc0 1px 0 10px;
+text-shadow: #ffcc00 1px 0 10px;
 
 /* offset-x | offset-y | color */
 text-shadow: 5px 5px #558abb;

--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -190,7 +190,7 @@ div {
   transform: rotate(135deg);
 }
 .one {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 .two {
   background-color: #d6bb72;

--- a/files/en-us/web/css/transition-delay/index.md
+++ b/files/en-us/web/css/transition-delay/index.md
@@ -48,7 +48,7 @@ transition-property: margin-right, color;
 }
 
 #default-example:hover > #example-element {
-  background-color: #909;
+  background-color: #990099;
   color: white;
   margin-right: 40%;
 }

--- a/files/en-us/web/css/transition-duration/index.md
+++ b/files/en-us/web/css/transition-duration/index.md
@@ -48,7 +48,7 @@ transition-property: margin-right, color;
 }
 
 #default-example:hover > #example-element {
-  background-color: #909;
+  background-color: #990099;
   color: white;
   margin-right: 40%;
 }

--- a/files/en-us/web/css/transition-property/index.md
+++ b/files/en-us/web/css/transition-property/index.md
@@ -44,7 +44,7 @@ transition-property: none;
 }
 
 #default-example:hover > #example-element {
-  background-color: #909;
+  background-color: #990099;
   color: white;
   margin-right: 40%;
 }
@@ -119,7 +119,7 @@ html {
 button {
   font-size: 1.4rem;
   padding: 10px 20px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 10px;
   outline: none;
 }
@@ -129,12 +129,12 @@ button {
 .target {
   transition-property: background-color;
   transition-duration: 1s;
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 
 .target:hover,
 .target:focus {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/css/transition-timing-function/index.md
+++ b/files/en-us/web/css/transition-timing-function/index.md
@@ -44,7 +44,7 @@ transition-timing-function: cubic-bezier(0.29, 1.01, 1, -0.68);
 }
 
 #default-example:hover > #example-element {
-  background-color: #909;
+  background-color: #990099;
   color: white;
   margin-right: 40%;
 }

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -54,7 +54,7 @@ transition: all 1s ease-out;
 }
 
 #default-example:hover > #example-element {
-  background-color: #909;
+  background-color: #990099;
   color: white;
   margin-right: 40%;
 }

--- a/files/en-us/web/css/url_function/index.md
+++ b/files/en-us/web/css/url_function/index.md
@@ -81,7 +81,7 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 ```css
 body {
   background: url("https://mdn.github.io/shared-assets/images/examples/leopard.jpg")
-    #00d no-repeat fixed;
+    #0000dd no-repeat fixed;
 }
 ```
 

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -185,7 +185,7 @@ The background color of the HTML body will be pink in this case even though the 
 
 /* In the larger application's style: */
 .component {
-  --text-color: #080;
+  --text-color: #008800;
 }
 ```
 

--- a/files/en-us/web/css/vector-effect/index.md
+++ b/files/en-us/web/css/vector-effect/index.md
@@ -50,7 +50,7 @@ Here, we start with a 200x100 SVG image that contains two rectangles inside a gr
     transform-origin="100 50"
     stroke-width="3"
     stroke="orange"
-    fill="#DEF8">
+    fill="#ddeeff88">
     <rect x=" 60" y="20" width="30" height="60" />
     <rect x="110" y="20" width="30" height="60" class="thinned" />
   </g>
@@ -83,7 +83,7 @@ In this case, we start with a similar SVG image to the one used in the previous 
     transform-origin="100 50"
     stroke-width="3"
     stroke="orange"
-    fill="#DEF8">
+    fill="#ddeeff88">
     <rect
       x=" 60"
       y="20"

--- a/files/en-us/web/css/white-space-collapse/index.md
+++ b/files/en-us/web/css/white-space-collapse/index.md
@@ -120,7 +120,7 @@ User agents handle white space collapsing as follows:
 h2 {
   font-size: 1.6rem;
   font-family: monospace;
-  border-bottom: 1px dotted #ccc;
+  border-bottom: 1px dotted #cccccc;
 }
 ```
 

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -238,7 +238,7 @@ p.min-blue {
 }
 
 .child {
-  background: #0999;
+  background: #00999999;
   margin: 1rem;
 }
 


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. In this batch of PRs, I'm converting all short hex to long hex. The benefit is: readers can more easily understand the syntax; there's one less syntactic variability; if I want to grep all occurrences of one hex color, I can do that more easily without `#aaa` also matching `#aaaddd`.