### PR TITLE
Lint: always use long-form hex color (5)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -37,7 +37,7 @@ const sunTheme = {
   },
   colors: {
     frame: "#CF723F",
-    tab_background_text: "#111",
+    tab_background_text: "#111111",
   },
 };
 
@@ -53,7 +53,7 @@ const day = {
   },
   colors: {
     frame: "#CF723F",
-    tab_background_text: "#111",
+    tab_background_text: "#111111",
   },
 };
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -257,8 +257,8 @@ let pattern = "https://developer.mozilla.org/*";
 
 let image = `
   <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
-    <rect style="stroke-width: 10; stroke: #666;" width="100%" height="100%" fill="#d4d0c8" />
-    <text transform="translate(0, 9)" x="50%" y="50%" width="100%" fill="#666" height="100%" style="text-anchor: middle; font: bold 10pt 'Segoe UI', Arial, Helvetica, Sans-serif;">Blocked</text>
+    <rect style="stroke-width: 10; stroke: #666666;" width="100%" height="100%" fill="#d4d0c8" />
+    <text transform="translate(0, 9)" x="50%" y="50%" width="100%" fill="#666666" height="100%" style="text-anchor: middle; font: bold 10pt 'Segoe UI', Arial, Helvetica, Sans-serif;">Blocked</text>
   </svg>
 `;
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -392,7 +392,7 @@ button.panel-section-tabs-button {
 }
 
 .panel-list-item.disabled {
-  color: #999;
+  color: #999999;
 }
 
 .panel-list-item > .icon {

--- a/files/en-us/web/accessibility/aria/reference/roles/menuitemradio_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/menuitemradio_role/index.md
@@ -125,7 +125,7 @@ The visual appearance of the selected state is a checked radio button which we c
   width: 1em;
   height: 1em;
   padding: 0.1em;
-  border: 2px solid #333;
+  border: 2px solid #333333;
   border-radius: 50%;
   box-sizing: border-box;
   background-clip: content-box;

--- a/files/en-us/web/accessibility/aria/reference/roles/switch_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/switch_role/index.md
@@ -153,13 +153,13 @@ button.switch span {
 
 [role="switch"][aria-checked="false"] :first-child,
 [role="switch"][aria-checked="true"] :last-child {
-  background: #262;
-  color: #eef;
+  background: #226622;
+  color: #eeeeff;
 }
 
 [role="switch"][aria-checked="false"] :last-child,
 [role="switch"][aria-checked="true"] :first-child {
-  color: #bbd;
+  color: #bbbbdd;
 }
 
 label.switch {

--- a/files/en-us/web/html/reference/attributes/pattern/index.md
+++ b/files/en-us/web/html/reference/attributes/pattern/index.md
@@ -153,7 +153,7 @@ div {
 
 p {
   font-size: 80%;
-  color: #999;
+  color: #999999;
 }
 
 input + span {

--- a/files/en-us/web/html/reference/elements/a/index.md
+++ b/files/en-us/web/html/reference/elements/a/index.md
@@ -410,7 +410,7 @@ canvas {
 }
 a {
   display: inline-block;
-  background: #69c;
+  background: #6699cc;
   color: white;
   padding: 5px 10px;
 }

--- a/files/en-us/web/html/reference/elements/article/index.md
+++ b/files/en-us/web/html/reference/elements/article/index.md
@@ -32,7 +32,7 @@ The **`<article>`** [HTML](/en-US/docs/Web/HTML) element represents a self-conta
 .forecast {
   margin: 0;
   padding: 0.3rem;
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 .forecast > h1,

--- a/files/en-us/web/html/reference/elements/code/index.md
+++ b/files/en-us/web/html/reference/elements/code/index.md
@@ -19,7 +19,7 @@ The **`<code>`** [HTML](/en-US/docs/Web/HTML) element displays its contents styl
 
 ```css interactive-example
 code {
-  background-color: #eee;
+  background-color: #eeeeee;
   border-radius: 3px;
   font-family: courier, monospace;
   padding: 0 3px;

--- a/files/en-us/web/html/reference/elements/del/index.md
+++ b/files/en-us/web/html/reference/elements/del/index.md
@@ -20,8 +20,8 @@ The **`<del>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text 
 ```css interactive-example
 del {
   text-decoration: line-through;
-  background-color: #fbb;
-  color: #555;
+  background-color: #ffbbbb;
+  color: #555555;
 }
 
 ins {

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -21,7 +21,7 @@ A disclosure widget is typically presented onscreen using a small triangle that 
 
 ```css interactive-example
 details {
-  border: 1px solid #aaa;
+  border: 1px solid #aaaaaa;
   border-radius: 4px;
   padding: 0.5em 0.5em 0;
 }
@@ -37,7 +37,7 @@ details[open] {
 }
 
 details[open] summary {
-  border-bottom: 1px solid #aaa;
+  border-bottom: 1px solid #aaaaaa;
   margin-bottom: 0.5em;
 }
 ```
@@ -180,7 +180,7 @@ details {
 details > summary {
   padding: 2px 6px;
   width: 15em;
-  background-color: #ddd;
+  background-color: #dddddd;
   border: none;
   box-shadow: 3px 3px 4px black;
   cursor: pointer;
@@ -188,14 +188,14 @@ details > summary {
 
 details > p {
   border-radius: 0 0 10px 10px;
-  background-color: #ddd;
+  background-color: #dddddd;
   padding: 2px 6px;
   margin: 0;
   box-shadow: 3px 3px 4px black;
 }
 
 details:open > summary {
-  background-color: #ccf;
+  background-color: #ccccff;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/div/index.md
+++ b/files/en-us/web/html/reference/elements/div/index.md
@@ -88,10 +88,10 @@ This example creates a shadowed box by applying a style to the `<div>` using CSS
 ```css
 .shadowbox {
   width: 15em;
-  border: 1px solid #333;
-  box-shadow: 8px 8px 5px #444;
+  border: 1px solid #333333;
+  box-shadow: 8px 8px 5px #444444;
   padding: 8px 12px;
-  background-image: linear-gradient(180deg, white, #ddd 40%, #ccc);
+  background-image: linear-gradient(180deg, white, #dddddd 40%, #cccccc);
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/figcaption/index.md
+++ b/files/en-us/web/html/reference/elements/figcaption/index.md
@@ -35,7 +35,7 @@ img {
 }
 
 figcaption {
-  background-color: #222;
+  background-color: #222222;
   color: white;
   font: italic smaller sans-serif;
   padding: 3px;

--- a/files/en-us/web/html/reference/elements/figure/index.md
+++ b/files/en-us/web/html/reference/elements/figure/index.md
@@ -35,7 +35,7 @@ img {
 }
 
 figcaption {
-  background-color: #222;
+  background-color: #222222;
   color: white;
   font: italic smaller sans-serif;
   padding: 3px;

--- a/files/en-us/web/html/reference/elements/hr/index.md
+++ b/files/en-us/web/html/reference/elements/hr/index.md
@@ -21,8 +21,8 @@ The **`<hr>`** [HTML](/en-US/docs/Web/HTML) element represents a thematic break 
 ```css interactive-example
 hr {
   border: none;
-  border-top: 3px double #333;
-  color: #333;
+  border-top: 3px double #333333;
+  color: #333333;
   overflow: visible;
   text-align: center;
   height: 5px;

--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -237,13 +237,13 @@ The below example shows a very basic drawing app created using a {{htmlelement("
 
 ```css hidden
 body {
-  background: #ccc;
+  background: #cccccc;
   margin: 0;
   overflow: hidden;
 }
 
 .toolbar {
-  background: #ccc;
+  background: #cccccc;
   width: 150px;
   height: 75px;
   padding: 5px;

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -255,7 +255,7 @@ html {
 }
 
 form {
-  background: #ccc;
+  background: #cccccc;
   margin: 0 auto;
   padding: 20px;
   border: 1px solid black;
@@ -267,7 +267,7 @@ form ol {
 
 form li,
 div > p {
-  background: #eee;
+  background: #eeeeee;
   display: flex;
   justify-content: space-between;
   margin-bottom: 10px;

--- a/files/en-us/web/html/reference/elements/input/image/index.md
+++ b/files/en-us/web/html/reference/elements/input/image/index.md
@@ -300,7 +300,7 @@ label {
 #image {
   object-position: right top;
   object-fit: contain;
-  background-color: #ddd;
+  background-color: #dddddd;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/input/radio/index.md
+++ b/files/en-us/web/html/reference/elements/input/radio/index.md
@@ -273,7 +273,7 @@ input {
   width: 16px;
   height: 16px;
 
-  border: 2px solid #999;
+  border: 2px solid #999999;
   transition: 0.2s all linear;
   margin-right: 5px;
 
@@ -297,7 +297,7 @@ legend {
 
 button:hover,
 button:focus {
-  color: #999;
+  color: #999999;
 }
 
 button:active {

--- a/files/en-us/web/html/reference/elements/input/text/index.md
+++ b/files/en-us/web/html/reference/elements/input/text/index.md
@@ -357,7 +357,7 @@ div {
 
 p {
   font-size: 80%;
-  color: #999;
+  color: #999999;
 }
 
 input + span {

--- a/files/en-us/web/html/reference/elements/ins/index.md
+++ b/files/en-us/web/html/reference/elements/ins/index.md
@@ -29,7 +29,7 @@ ins {
 }
 
 del {
-  background-color: #fbb;
+  background-color: #ffbbbb;
 }
 
 ins {

--- a/files/en-us/web/html/reference/elements/kbd/index.md
+++ b/files/en-us/web/html/reference/elements/kbd/index.md
@@ -19,13 +19,13 @@ The **`<kbd>`** [HTML](/en-US/docs/Web/HTML) element represents a span of inline
 
 ```css interactive-example
 kbd {
-  background-color: #eee;
+  background-color: #eeeeee;
   border-radius: 3px;
   border: 1px solid #b4b4b4;
   box-shadow:
     0 1px 1px rgb(0 0 0 / 0.2),
     0 2px 0 0 rgb(255 255 255 / 0.7) inset;
-  color: #333;
+  color: #333333;
   display: inline-block;
   font-size: 0.85em;
   font-weight: 700;

--- a/files/en-us/web/html/reference/elements/p/index.md
+++ b/files/en-us/web/html/reference/elements/p/index.md
@@ -28,7 +28,7 @@ Paragraphs are [block-level elements](/en-US/docs/Glossary/Block-level_content),
 p {
   margin: 10px 0;
   padding: 5px;
-  border: 1px solid #999;
+  border: 1px solid #999999;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/samp/index.md
+++ b/files/en-us/web/html/reference/elements/samp/index.md
@@ -83,7 +83,7 @@ The CSS that achieves the appearance we want is:
 
 ```css
 .prompt {
-  color: #b00;
+  color: #bb0000;
 }
 
 samp > kbd {
@@ -91,7 +91,7 @@ samp > kbd {
 }
 
 .cursor {
-  color: #00b;
+  color: #0000bb;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/summary/index.md
+++ b/files/en-us/web/html/reference/elements/summary/index.md
@@ -22,7 +22,7 @@ The **`<summary>`** [HTML](/en-US/docs/Web/HTML) element specifies a summary, ca
 
 ```css interactive-example
 details {
-  border: 1px solid #aaa;
+  border: 1px solid #aaaaaa;
   border-radius: 4px;
   padding: 0.5em 0.5em 0;
 }
@@ -38,7 +38,7 @@ details[open] {
 }
 
 details[open] summary {
-  border-bottom: 1px solid #aaa;
+  border-bottom: 1px solid #aaaaaa;
   margin-bottom: 0.5em;
 }
 ```

--- a/files/en-us/web/html/reference/elements/td/index.md
+++ b/files/en-us/web/html/reference/elements/td/index.md
@@ -59,7 +59,7 @@ td {
 }
 
 tr:nth-of-type(even) {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 table {
@@ -183,7 +183,7 @@ th {
 }
 
 tr:nth-of-type(odd) td {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 tr th[scope="row"] {
@@ -266,7 +266,7 @@ th {
 }
 
 tr:nth-of-type(odd) td {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 tr th[scope="row"] {

--- a/files/en-us/web/html/reference/elements/textarea/index.md
+++ b/files/en-us/web/html/reference/elements/textarea/index.md
@@ -30,8 +30,8 @@ textarea {
   max-width: 100%;
   line-height: 1.5;
   border-radius: 5px;
-  border: 1px solid #ccc;
-  box-shadow: 1px 1px 1px #999;
+  border: 1px solid #cccccc;
+  box-shadow: 1px 1px 1px #999999;
 }
 
 label {

--- a/files/en-us/web/html/reference/elements/th/index.md
+++ b/files/en-us/web/html/reference/elements/th/index.md
@@ -59,7 +59,7 @@ td {
 }
 
 tr:nth-of-type(even) {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 table {
@@ -204,7 +204,7 @@ th[scope="row"] {
 }
 
 tr:nth-of-type(odd) td {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 ```
 
@@ -302,7 +302,7 @@ th[scope="row"] {
 }
 
 tr:nth-of-type(odd) td {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 ```
 

--- a/files/en-us/web/html/reference/elements/tr/index.md
+++ b/files/en-us/web/html/reference/elements/tr/index.md
@@ -59,7 +59,7 @@ td {
 }
 
 tr:nth-of-type(even) {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 table {
@@ -152,7 +152,7 @@ The CSS {{cssxref(":nth-of-type")}} pseudo-class is used to select every `odd` r
 
 ```css
 tr:nth-of-type(odd) {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 tr th[scope="row"] {
@@ -228,7 +228,7 @@ The CSS is nearly unchanged from the [previous example](#basic_row_setup), excep
 
 ```css
 tr:nth-of-type(odd) {
-  background-color: #eee;
+  background-color: #eeeeee;
 }
 
 tr th[scope="col"] {

--- a/files/en-us/web/html/reference/elements/wbr/index.md
+++ b/files/en-us/web/html/reference/elements/wbr/index.md
@@ -24,7 +24,7 @@ The **`<wbr>`** [HTML](/en-US/docs/Web/HTML) element represents a word break opp
   overflow: hidden;
   resize: horizontal;
   width: 9rem;
-  border: 2px dashed #999;
+  border: 2px dashed #999999;
 }
 ```
 

--- a/files/en-us/web/html/reference/global_attributes/anchor/index.md
+++ b/files/en-us/web/html/reference/global_attributes/anchor/index.md
@@ -80,7 +80,7 @@ body {
 .infobox {
   color: darkblue;
   background-color: azure;
-  border: 1px solid #ddd;
+  border: 1px solid #dddddd;
   padding: 10px;
   border-radius: 10px;
   font-size: 1rem;

--- a/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/reference/global_attributes/contenteditable/index.md
@@ -21,7 +21,7 @@ The **`contenteditable`** [global attribute](/en-US/docs/Web/HTML/Reference/Glob
 
 ```css interactive-example
 blockquote {
-  background: #eee;
+  background: #eeeeee;
   border-radius: 5px;
   margin: 16px 0;
 }

--- a/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/en-us/web/html/reference/global_attributes/data-_star_/index.md
@@ -49,7 +49,7 @@ li::after {
   background: black;
   color: white;
   padding: 2px;
-  border: 1px solid #eee;
+  border: 1px solid #eeeeee;
   opacity: 0;
   transition: 0.5s opacity;
 }

--- a/files/en-us/web/media/guides/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -108,7 +108,7 @@ No image is used for the captions button, so it is styled as:
   text-indent: 0;
   font-size: 1rem;
   font-weight: bold;
-  color: #666;
+  color: #666666;
   background: black;
   border-radius: 2px;
 }
@@ -234,7 +234,7 @@ We also added some rudimentary styling for the newly created subtitles menu:
   position: absolute;
   bottom: 14.8%;
   right: 20px;
-  background: #666;
+  background: #666666;
   list-style-type: none;
   margin: 0;
   width: 100px;
@@ -277,7 +277,7 @@ For example, to change the text color of the text track cues you can write:
 
 ```css
 ::cue {
-  color: #ccc;
+  color: #cccccc;
 }
 ```
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -150,14 +150,14 @@ We'll use the following CSS to style the buffering display:
 .buffered {
   height: 20px;
   position: relative;
-  background: #555;
+  background: #555555;
   width: 300px;
 }
 
 #buffered-amount {
   display: block;
   height: 100%;
-  background-color: #777;
+  background-color: #777777;
   width: 0;
 }
 
@@ -171,7 +171,7 @@ We'll use the following CSS to style the buffering display:
 #progress-amount {
   display: block;
   height: 100%;
-  background-color: #595;
+  background-color: #559955;
   width: 0;
 }
 ```

--- a/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -68,7 +68,7 @@ figure {
   height: 100%;
   margin: 1.25rem auto;
   padding: 1.051%;
-  background-color: #666;
+  background-color: #666666;
 }
 ```
 

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/html_and_css/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/html_and_css/index.md
@@ -210,7 +210,7 @@ We can now style the static HTML using CSS. Our final CSS is:
 ```css
 body {
   margin: 1vh 1vw;
-  background-color: #efe;
+  background-color: #eeffee;
 }
 ul,
 fieldset,
@@ -226,7 +226,7 @@ li,
 legend {
   list-style-type: none;
   padding: 0.2em 0.5em;
-  background-color: #cfc;
+  background-color: #ccffcc;
 }
 li:nth-of-type(even) {
   background-color: inherit;
@@ -239,13 +239,13 @@ If every line is familiar to you, you can copy the above CSS, or write your own 
 
 ### CSS explained
 
-We use the {{CSSXref("background-color")}} property to set a light green (`#efe`) background color on the `body`. Then on the unordered list, fieldset, and legend, we use a white background color, along with a thin solid border added with the {{CSSXref("border")}} property. We override the `background-color` for the legend, making the legend and the list items a darker green (`#cfc`).
+We use the {{CSSXref("background-color")}} property to set a light green (`#eeffee`) background color on the `body`. Then on the unordered list, fieldset, and legend, we use a white background color, along with a thin solid border added with the {{CSSXref("border")}} property. We override the `background-color` for the legend, making the legend and the list items a darker green (`#ccffcc`).
 
 We use the [`:nth-of-type(even)`](/en-US/docs/Web/CSS/:nth-of-type) pseudo-class [selector](/en-US/docs/Web/CSS/CSS_selectors) to set every even-numbered list item to {{CSSXref("inherit")}} the background color from its parent; in this case, inheriting the `white` background color from the unordered list.
 
 ```css
 body {
-  background-color: #efe;
+  background-color: #eeffee;
 }
 ul,
 fieldset,
@@ -255,7 +255,7 @@ legend {
 }
 li,
 legend {
-  background-color: #cfc;
+  background-color: #ccffcc;
 }
 li:nth-of-type(even) {
   background-color: inherit;
@@ -293,7 +293,7 @@ We can combine the above, putting multiple properties in each selector declarati
 ```css
 body {
   margin: 1vh 1vw;
-  background-color: #efe;
+  background-color: #eeffee;
 }
 ul,
 fieldset,
@@ -309,7 +309,7 @@ li,
 legend {
   list-style-type: none;
   padding: 0.2em 0.5em;
-  background-color: #cfc;
+  background-color: #ccffcc;
 }
 li:nth-of-type(even) {
   background-color: inherit;

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/manifest_file/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/manifest_file/index.md
@@ -85,7 +85,7 @@ Add presentation definitions to the manifest file you began creating in the prev
 
 As the example application is a single page, we can use `"/"` as the `start_url`, or omit the member altogether. For that same reason, we can display the app without the browser UI by setting the `display` to `standalone`.
 
-In [our CSS](/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/HTML_and_CSS#css_content), the `background-color: #efe;` is set on the `body` element selector. We use `#eeffee` to ensure a smooth transition from placeholder appearance to app load.
+In [our CSS](/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/HTML_and_CSS#css_content), the `background-color: #eeffee;` is set on the `body` element selector. We use `#eeffee` to ensure a smooth transition from placeholder appearance to app load.
 
 ```json
 {

--- a/files/en-us/web/svg/guides/svg_in_html/index.md
+++ b/files/en-us/web/svg/guides/svg_in_html/index.md
@@ -65,7 +65,7 @@ If the SVG can be labeled by visible text, reference that text with an [`aria-la
     <style>
       rect {
         fill: #cccccc;
-        stroke: #666;
+        stroke: #666666;
         transform-origin: top;
       }
     </style>

--- a/files/en-us/web/svg/reference/attribute/in/index.md
+++ b/files/en-us/web/svg/reference/attribute/in/index.md
@@ -100,7 +100,7 @@ You can use this attribute with the following SVG elements:
     cx="50%"
     cy="40%"
     r="40%"
-    fill="#c00"
+    fill="#cc0000"
     filter="url(#backgroundMultiply)" />
 </svg>
 
@@ -119,7 +119,12 @@ You can use this attribute with the following SVG elements:
       <feBlend in2="SourceGraphic" mode="multiply" />
     </filter>
   </defs>
-  <circle cx="50%" cy="40%" r="40%" fill="#c00" filter="url(#imageMultiply)" />
+  <circle
+    cx="50%"
+    cy="40%"
+    r="40%"
+    fill="#cc0000"
+    filter="url(#imageMultiply)" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/reference/attribute/paint-order/index.md
+++ b/files/en-us/web/svg/reference/attribute/paint-order/index.md
@@ -56,8 +56,8 @@ You can use this attribute with the following SVG elements:
 ```html
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
   <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
-    <stop stop-color="#888" />
-    <stop stop-color="#ccc" offset="1" />
+    <stop stop-color="#888888" />
+    <stop stop-color="#cccccc" offset="1" />
   </linearGradient>
   <rect width="400" height="200" fill="url(#g)" />
   <g

--- a/files/en-us/web/svg/reference/attribute/requiredfeatures/index.md
+++ b/files/en-us/web/svg/reference/attribute/requiredfeatures/index.md
@@ -766,11 +766,11 @@ The following are the feature strings for the `requiredFeatures` attribute. Thes
 
 ```css
 .ko {
-  fill: #900;
+  fill: #990000;
 }
 
 .ok {
-  fill: #060;
+  fill: #006600;
 }
 
 rect {

--- a/files/en-us/web/svg/reference/element/fecomposite/index.md
+++ b/files/en-us/web/svg/reference/element/fecomposite/index.md
@@ -185,23 +185,48 @@ This example defines filters for each of the supported operations (`over`, `atop
     </filter>
   </defs>
   <g transform="translate(0,25)">
-    <circle cx="90px" cy="80px" r="70px" fill="#c00" filter="url(#imageOver)" />
+    <circle
+      cx="90px"
+      cy="80px"
+      r="70px"
+      fill="#cc0000"
+      filter="url(#imageOver)" />
     <text x="80" y="-5">over</text>
   </g>
   <g transform="translate(200,25)">
-    <circle cx="90px" cy="80px" r="70px" fill="#c00" filter="url(#imageIn)" />
+    <circle
+      cx="90px"
+      cy="80px"
+      r="70px"
+      fill="#cc0000"
+      filter="url(#imageIn)" />
     <text x="80" y="-5">in</text>
   </g>
   <g transform="translate(400,25)">
-    <circle cx="90px" cy="80px" r="70px" fill="#c00" filter="url(#imageOut)" />
+    <circle
+      cx="90px"
+      cy="80px"
+      r="70px"
+      fill="#cc0000"
+      filter="url(#imageOut)" />
     <text x="80" y="-5">out</text>
   </g>
   <g transform="translate(600,25)">
-    <circle cx="90px" cy="80px" r="70px" fill="#c00" filter="url(#imageAtop)" />
+    <circle
+      cx="90px"
+      cy="80px"
+      r="70px"
+      fill="#cc0000"
+      filter="url(#imageAtop)" />
     <text x="80" y="-5">atop</text>
   </g>
   <g transform="translate(0,240)">
-    <circle cx="90px" cy="80px" r="70px" fill="#c00" filter="url(#imageXor)" />
+    <circle
+      cx="90px"
+      cy="80px"
+      r="70px"
+      fill="#cc0000"
+      filter="url(#imageXor)" />
     <text x="80" y="-5">xor</text>
   </g>
   <g transform="translate(200,240)">
@@ -209,7 +234,7 @@ This example defines filters for each of the supported operations (`over`, `atop
       cx="90px"
       cy="80px"
       r="70px"
-      fill="#c00"
+      fill="#cc0000"
       filter="url(#imageArithmetic)" />
     <text x="70" y="-5">arithmetic</text>
   </g>
@@ -218,7 +243,7 @@ This example defines filters for each of the supported operations (`over`, `atop
       cx="90px"
       cy="80px"
       r="70px"
-      fill="#c00"
+      fill="#cc0000"
       filter="url(#imageLighter)" />
     <text x="80" y="-5">lighter</text>
   </g>

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/basic_transformations/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/basic_transformations/index.md
@@ -36,7 +36,7 @@ It may be necessary to move an element around, even though you can position it w
 
 ```css hidden
 svg {
-  background-color: #bff;
+  background-color: #bbffff;
 }
 ```
 
@@ -77,7 +77,7 @@ Transformations can be concatenated easily just by separating them with spaces. 
 
 ```css hidden
 svg {
-  background-color: #bff;
+  background-color: #bbffff;
 }
 ```
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/paths/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/paths/index.md
@@ -738,7 +738,7 @@ body {
   position: fixed;
   width: 100%;
   height: 100%;
-  background: #eee;
+  background: #eeeeee;
 }
 
 .ui {
@@ -759,7 +759,7 @@ body {
 }
 
 svg {
-  background: #ddd;
+  background: #dddddd;
 }
 ```
 


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now have systematic rules surrounding the preferred color notations. In this batch of PRs, I'm converting all short hex to long hex. The benefit is: readers can more easily understand the syntax; there's one less syntactic variability; if I want to grep all occurrences of one hex color, I can do that more easily without `#aaa` also matching `#aaaddd`.