### PR TITLE
Typo fix on code example on "attribute reflection" page

### DIFF
--- a/files/en-us/web/api/document_object_model/reflected_attributes/index.md
+++ b/files/en-us/web/api/document_object_model/reflected_attributes/index.md
@@ -190,7 +190,7 @@ Setting the attribute value restores the relationship between the attribute and 
 Continuing the example from above:
 
 ```js
-inputElement.setAttribute("aria-labelledby", "input1");
+inputElement.setAttribute("aria-labelledby", "label_1");
 
 attributeValue = inputElement.getAttribute("aria-labelledby");
 console.log(attributeValue);


### PR DESCRIPTION
correcting typo mistake with span id name in code example
