### PR TITLE
drawImage: negative width/height does not flip the image

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -46,9 +46,11 @@ drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
     destination context. If not specified, the entire rectangle from the coordinates
     specified by `sx` and `sy` to the bottom-right corner of the
     image is used. Use the 3- or 5-argument syntax to omit this argument.
+    Negative values will grow the sub-rectangle in the opposite direction.
 - `sHeight` {{optional_inline}}
   - : The height of the sub-rectangle of the source `image` to draw into the
     destination context. Use the 3- or 5-argument syntax to omit this argument.
+    Negative values will grow the sub-rectangle in the opposite direction.
 - `dx`
   - : The x-axis coordinate in the destination canvas at which to place the top-left
     corner of the source `image`.

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -46,11 +46,11 @@ drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
     destination context. If not specified, the entire rectangle from the coordinates
     specified by `sx` and `sy` to the bottom-right corner of the
     image is used. Use the 3- or 5-argument syntax to omit this argument.
-    Negative values will grow the sub-rectangle in the opposite direction.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
 - `sHeight` {{optional_inline}}
   - : The height of the sub-rectangle of the source `image` to draw into the
     destination context. Use the 3- or 5-argument syntax to omit this argument.
-    Negative values will grow the sub-rectangle in the opposite direction.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
 - `dx`
   - : The x-axis coordinate in the destination canvas at which to place the top-left
     corner of the source `image`.
@@ -61,10 +61,12 @@ drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
   - : The width to draw the `image` in the destination canvas. This allows
     scaling of the drawn image. If not specified, the image is not scaled in width when
     drawn. Note that this argument is not included in the 3-argument syntax.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
 - `dHeight`
   - : The height to draw the `image` in the destination canvas. This allows
     scaling of the drawn image. If not specified, the image is not scaled in height when
     drawn. Note that this argument is not included in the 3-argument syntax.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
 
 ### Return value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -46,11 +46,9 @@ drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
     destination context. If not specified, the entire rectangle from the coordinates
     specified by `sx` and `sy` to the bottom-right corner of the
     image is used. Use the 3- or 5-argument syntax to omit this argument.
-    A negative value will flip the image.
 - `sHeight` {{optional_inline}}
   - : The height of the sub-rectangle of the source `image` to draw into the
     destination context. Use the 3- or 5-argument syntax to omit this argument.
-    A negative value will flip the image.
 - `dx`
   - : The x-axis coordinate in the destination canvas at which to place the top-left
     corner of the source `image`.

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -46,11 +46,11 @@ drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
     destination context. If not specified, the entire rectangle from the coordinates
     specified by `sx` and `sy` to the bottom-right corner of the
     image is used. Use the 3- or 5-argument syntax to omit this argument.
-    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and the image is not flipped.
 - `sHeight` {{optional_inline}}
   - : The height of the sub-rectangle of the source `image` to draw into the
     destination context. Use the 3- or 5-argument syntax to omit this argument.
-    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and the image is not flipped.
 - `dx`
   - : The x-axis coordinate in the destination canvas at which to place the top-left
     corner of the source `image`.
@@ -61,12 +61,12 @@ drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
   - : The width to draw the `image` in the destination canvas. This allows
     scaling of the drawn image. If not specified, the image is not scaled in width when
     drawn. Note that this argument is not included in the 3-argument syntax.
-    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and the image is not flipped.
 - `dHeight`
   - : The height to draw the `image` in the destination canvas. This allows
     scaling of the drawn image. If not specified, the image is not scaled in height when
     drawn. Note that this argument is not included in the 3-argument syntax.
-    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and are not flipped.
+    Negative values grow the sub-rectangle in the opposite direction, but pixels are always processed in the original direction and the image is not flipped.
 
 ### Return value
 


### PR DESCRIPTION
### Description
Negative sWidth and sHeight in drawImage do not actually flip the resulting image. As such, I removed the lines claiming otherwise.

### Motivation
This is something that I personally got confused by when working with drawImage, wondering what I was doing wrong. Decided I should try and get this resolved so others don't run in to the same issue.

### Related issues and pull requests
Fixes #37873