### PR TITLE
Fix grammar in captureEvents() note

### DIFF
--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Window.captureEvents
 The **`Window.captureEvents()`** method does nothing.
 
 > [!NOTE]
-> This is an method long removed from the specification. It is kept in browsers to prevent code breakage but does nothing.
+> This method was long removed from the specification. It is kept in browsers to prevent code breakage but does nothing.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -10,10 +10,7 @@ browser-compat: api.Window.captureEvents
 
 {{APIRef}} {{Deprecated_Header}}
 
-The **`Window.captureEvents()`** method does nothing.
-
-> [!NOTE]
-> This method was long removed from the specification. It is kept in browsers to prevent code breakage but does nothing.
+The **`Window.captureEvents()`** method does nothing. Its original behavior has been removed from the specification, but the method itself has been retained so as not to break code that calls it.
 
 ## Syntax
 


### PR DESCRIPTION

### Description

Fix grammar in the captureEvents() note by replacing “This is an method” with “This method was…”.

### Motivation

Readability and correctness of the documentation.
