### PR TITLE
Update Firefox 142 release notes for WebDriver conforming changes.

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -87,7 +87,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Marionette
 
-- Updated the Add Cookie command to throw an error when a target cookie has `sameSite=none` and `secure=false` attributes ([Firefox bug 1977205](https://bugzil.la/1977205)).
+- Updated the `WebDriver:AddCookie` command to throw an error when a target cookie has `sameSite=none` and `secure=false` attributes ([Firefox bug 1977205](https://bugzil.la/1977205)).
 - Removed the dialog text value from the `unexpected alert open` error message, since the dialog text is available now via the `data` field ([Firefox bug 1948236](https://bugzil.la/1948236)).
 
 ## Changes for add-on developers

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -81,7 +81,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### WebDriver BiDi
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
-- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an http proxy wouldn’t allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
+- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting a HTTP proxy wouldn’t allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
 - Fixed a bug where `browsingContext.create` would fail after a `browsingContext.print` command was interrupted by closing a tab with the `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
 - Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -87,7 +87,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Marionette
 
-- Updated the setting cookie command to throw an error when a target cookie has `sameSite=none` and `secure=false` attributes ([Firefox bug 1977205](https://bugzil.la/1977205)).
+- Updated the Add Cookie command to throw an error when a target cookie has `sameSite=none` and `secure=false` attributes ([Firefox bug 1977205](https://bugzil.la/1977205)).
 - Removed the dialog text value from the `unexpected alert open` error message, since the dialog text is available now via the `data` field ([Firefox bug 1948236](https://bugzil.la/1948236)).
 
 ## Changes for add-on developers

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -71,13 +71,24 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Removed FTP proxy support from WebDriver capabilities ([Firefox bug 1972670](https://bugzil.la/1972670)).
+- Updated the expiry value of all the cookies set via WebDriver BiDi and WebDriver classic (Marionette) to be limited to 400 days ([Firefox bug 1974394](https://bugzil.la/1974394)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi -->
+
+- Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
+- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an http proxy wouldn’t let to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
+- Fixed a bug when `browsingContext.create` would fail after `browsingContext.print` command would be interrupted by tab being closed via `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
+- Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
+
+#### Marionette
+
+- Updated the setting cookie command to throw an error when a target cookie has `sameSite=none` and `secure=false` attributes ([Firefox bug 1977205](https://bugzil.la/1977205)).
+- Removed the dialog text value from the `unexpected alert open` error message, since the dialog text is available now via the `data` field ([Firefox bug 1948236](https://bugzil.la/1948236)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -78,7 +78,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - Removed FTP proxy support from WebDriver capabilities ([Firefox bug 1972670](https://bugzil.la/1972670)).
 - Updated the expiry value of all the cookies set via WebDriver BiDi and WebDriver classic (Marionette) to be limited to 400 days ([Firefox bug 1974394](https://bugzil.la/1974394)).
 
-#### WebDriver BiDi -->
+#### WebDriver BiDi
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
 - Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an http proxy wouldn’t let to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -82,7 +82,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
 - Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an http proxy wouldn’t allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
-- Fixed a bug when `browsingContext.create` would fail after `browsingContext.print` command would be interrupted by tab being closed via `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
+- Fixed a bug where `browsingContext.create` would fail after a `browsingContext.print` command was interrupted by closing a tab with the `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
 - Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
 
 #### Marionette

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -81,7 +81,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### WebDriver BiDi
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
-- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an http proxy wouldn’t let to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
+- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an http proxy wouldn’t allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
 - Fixed a bug when `browsingContext.create` would fail after `browsingContext.print` command would be interrupted by tab being closed via `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
 - Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
 


### PR DESCRIPTION
Release notes update based on the following list of [relnote worthy bugs](https://bugzilla.mozilla.org/buglist.cgi?o2=notsubstring&f4=status_whiteboard&component=Agent&component=Marionette&component=WebDriver%20BiDi&o3=notequals&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&v4=%5Bwebdriver%3Arelnote%5D&product=Remote%20Protocol&v2=%5Bwptsync%20downstream%5D&f3=cf_status_firefox141&v3=fixed&o4=substring&f2=status_whiteboard&o1=equals&resolution=FIXED&query_format=advanced&v1=fixed&f1=cf_status_firefox142&list_id=17660555).