### PR TITLE
Fix the note callout format

### DIFF
--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -64,7 +64,8 @@ el.innerHTML = name; // shows the alert
 You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup before it is injected.
 
-> [!NOTE] > {{domxref("Node.textContent")}} should be used when you know that the user provided content should be plain text.
+> [!NOTE]
+> {{domxref("Node.textContent")}} should be used when you know that the user provided content should be plain text.
 > This prevents it being parsed as HTML.
 
 ## Examples


### PR DESCRIPTION
### Description


```plain
Warning: files/en-us/web/api/element/innerhtml/index.md:67:1 search-replace Custom rule [bad-gfm-alert: Use the correct GFM syntax: `> [!NOTE]`] [Context: "column: 1 text:'> [!NOTE]'"]
```

### Motivation

To fix the the Markdown lint error reported in:
https://github.com/mdn/content/actions/runs/16902756019/job/47885311997?pr=40700

