### PR TITLE
Fix curly quote

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -81,7 +81,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### WebDriver BiDi
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
-- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting a HTTP proxy wouldn’t allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
+- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting a HTTP proxy wouldn't allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
 - Fixed a bug where `browsingContext.create` would fail after a `browsingContext.print` command was interrupted by closing a tab with the `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
 - Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
 


### PR DESCRIPTION


### Description

Fixing the error reported in https://github.com/mdn/content/actions/runs/16916870556/job/47932869780?pr=40700:

> Warning: files/en-us/mozilla/firefox/releases/142/index.md:84:243 search-replace Custom rule [curly-single-quotes: Don't use curly single quotes] [Context: "column: 243 text:'’'"]


### Motivation

https://github.com/mdn/content/pull/40700

### Additional details

Also ran the command locally. This is the only error reported:

> (main)$ npx markdownlint-cli2 "**/*.md" && prettier -c "**/*.md"
> markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
> Finding: **/*.md !node_modules !.git !.github !tests
> Linting: 13836 file(s)
> Summary: 1 error(s)
> files/en-us/mozilla/firefox/releases/142/index.md:84:243 search-replace Custom rule [curly-single-quotes: Don't use curly single quotes] [Context: "column: 243 text:'’'"]