### PR TITLE
Bug-1978643 describe amended tab group collapse behavior

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/query/index.md
@@ -22,7 +22,7 @@ let group = await browser.tabGroups.query(
   - : An object containing details of the property values to be matched in returned tab groups.
     - `collapsed` {{optional_inline}}
       - : `boolean`. Whether the returned tab groups are collapsed or expanded in the tab strip.
-        - In Firefox, a collapsed group can contain the active tab. The inactive tabs are collapsed.
+        - In Firefox, a collapsed group can contain the active tab. The active tab remains visible and inactive tabs are collapsed.
         - In Chrome, groups are collapsed completely. If the group contains the active tab when it's collapsed, the active tab is moved to the first tab to the right of the group. If there is no tab to the right of the group, it's moved to the tab immediately to the left of the group.
     - `color` {{optional_inline}}
       - : {{WebExtAPIRef("tabGroups.Color")}}. The name of the color returned tab groups are using.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/query/index.md
@@ -22,6 +22,8 @@ let group = await browser.tabGroups.query(
   - : An object containing details of the property values to be matched in returned tab groups.
     - `collapsed` {{optional_inline}}
       - : `boolean`. Whether the returned tab groups are collapsed or expanded in the tab strip.
+        - In Firefox, a collapsed group can contain the active tab. The inactive tabs are collapsed.
+        - In Chrome, groups are collapsed completely. If the group contains the active tab when it's collapsed, the active tab is moved to the first tab to the right of the group. If there is no tab to the right of the group, it's moved to the tab immediately to the left of the group.
     - `color` {{optional_inline}}
       - : {{WebExtAPIRef("tabGroups.Color")}}. The name of the color returned tab groups are using.
     - `shared` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/tabgroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/tabgroup/index.md
@@ -14,6 +14,8 @@ Values of this type are strings. Possible values are:
 
 - `collapsed`
   - : `boolean`. Whether the tab group is collapsed or expanded in the tab strip.
+      - In Firefox, a collapsed group can contain the active tab. The inactive tabs are collapsed.
+      - In Chrome, groups are collapsed completely. If the group contains the active tab when it's collapsed, the active tab is moved to the first tab to the right of the group. If there is no tab to the right of the group, it's moved to the tab immediately to the left of the group.
 - `color`
   - : {{WebExtAPIRef("tabGroups.Color")}}. The name of the user-selected color for the tab group's label and icons.
 - `id`

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabgroups/update/index.md
@@ -26,6 +26,9 @@ let updatedTabGroup = await browser.tabGroups.update(
   - : An object containing details of the properties to update for this tab group. Properties that aren't specified aren't modified.
     - `collapsed` {{optional_inline}}
       - : `boolean`. Whether the tab group is collapsed or expanded in the tab strip.
+        If the active tab is in a group that is collapsed:
+        - In Firefox, the tab remains active and only the inactive tabs are collapsed.
+        - In Chrome, the active tab is moved to the first tab to the right of the group. If there is no tab to the right of the group, it's moved to the tab immediately to the left of the group.
     - `color` {{optional_inline}}
       - : {{WebExtAPIRef("tabGroups.Color")}}. The name of the color to use for the tab group.
     - `title` {{optional_inline}}


### PR DESCRIPTION
### Description

Add details to the `tabGroups` API to describe the difference in tab group behavior between Firefox and Chrome, following the change in Firefox 142 to leave active tabs within a collapsed tab group.

### Related issues and pull requests

Addresses the dev-doc-needed requirements of [Bug 1978643](https://bugzilla.mozilla.org/show_bug.cgi?id=1978643) Verify that active tab stays active when tabGroups.collapsed is set to true with tabGroups.update()