### PR TITLE
Clarify align-items: stretch behavior to include shrinking

### DIFF
--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -119,8 +119,9 @@ align-items: unset;
 - `baseline`, `first baseline`, `last baseline`
   - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
 
-- `stretch`
-  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
+- ### stretch
+- : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container (and vice-versa, overflowing items will be shrunk), respecting the items' width and height limits.
+
 
 - `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the items to the center of the associated anchor element in the block direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description
This PR updates the description for `align-items: stretch` to clarify that it not only enlarges smaller auto-sized items to fill the container, but will also shrink overflowing items, all while respecting their width and height limits.  

Fixes #39491.


<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The previous description only addressed the enlargement of smaller items, leaving out the behavior where overflowing items are proportionally reduced in size.  
This change ensures the documentation reflects the full, expected behavior of `align-items: stretch`, making it more accurate and useful for developers.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
- No code changes — documentation text only.
- Based on the discussion in #39491.
- Change made in `files/en-us/web/css/align-items/index.md`.

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes #39491

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
