### PR TITLE
Bug-1542358 omnibox.onInputEntered is a user action trigger

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -143,7 +143,6 @@ These permissions are available in Manifest V2 and above unless otherwise noted:
 In most cases the permission just grants access to the API, with the following exceptions:
 
 - `tabs` gives you access to [privileged parts of the `tabs` API](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs) without the need for [host permissions](#host_permissions): `Tab.url`, `Tab.title`, and `Tab.faviconUrl`.
-
   - In Firefox 85 and earlier, you also need `tabs` if you want to include `url` in the `queryInfo` parameter to {{webextAPIref("tabs/query", "tabs.query()")}}. The rest of the `tabs` API can be used without requesting any permission.
   - As of Firefox 86 and Chrome 50, matching [host permissions](#host_permissions) can also be used instead of the "tabs" permission.
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -143,6 +143,7 @@ These permissions are available in Manifest V2 and above unless otherwise noted:
 In most cases the permission just grants access to the API, with the following exceptions:
 
 - `tabs` gives you access to [privileged parts of the `tabs` API](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs) without the need for [host permissions](#host_permissions): `Tab.url`, `Tab.title`, and `Tab.faviconUrl`.
+
   - In Firefox 85 and earlier, you also need `tabs` if you want to include `url` in the `queryInfo` parameter to {{webextAPIref("tabs/query", "tabs.query()")}}. The rest of the `tabs` API can be used without requesting any permission.
   - As of Firefox 86 and Chrome 50, matching [host permissions](#host_permissions) can also be used instead of the "tabs" permission.
 
@@ -152,13 +153,15 @@ In most cases the permission just grants access to the API, with the following e
 
 ## activeTab permission
 
-This permission is specified as `"activeTab"`. If an extension has the `activeTab` permission, then when the user interacts with the extension, the extension is granted extra privileges for the active tab only.
+If an extension has the `"activeTab"` permission, when a user interacts with the extension, the extension is granted extra privileges for the active tab only.
 
-"User interaction" includes:
+These interactions are known as [user actions](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions) and include the user:
 
-- the user clicks the extension's {{webextAPIref("browserAction", "browser action", "", 1)}} or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions)
-- the user selects its context menu item
-- the user activates a keyboard shortcut defined by the extension
+- clicking the extension's [toolbar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions).
+- selecting an extension's context menu item.
+- activating a keyboard shortcut defined by the extension (from Firefox 63).
+- clicking a button on a page bundled with the extension.
+- clicking an extension suggestion in the address bar (omnibox) (from Firefox 142).
 
 The extra privileges are:
 
@@ -174,9 +177,7 @@ For example, consider an extension that wants to run a script in the current pag
 
 The `activeTab` permission enables scripting access to the top level tab's page and same origin frames. Running scripts or modifying styles inside [cross-origin](/en-US/docs/Web/Security/Same-origin_policy#cross-origin_network_access) frames may require additional [host permissions](#host_permissions). Of course, [restrictions and limitations](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#permissions_restrictions_and_limitations) related to particular sites and URI schemes are applied as well.
 
-Usually the tab that's granted `activeTab` is just the currently active tab, except in one case. The {{webextAPIref("menus")}} API enables an extension to create a menu item which is shown if the user context-clicks on a tab (that is, on the element in the tabstrip that enables the user to switch from one tab to another).
-
-If the user clicks such an item, then the `activeTab` permission is granted for the tab the user clicked, even if it's not the currently active tab (as of Firefox 63, [Firefox bug 1446956](https://bugzil.la/1446956)).
+Usually, the tab that's granted `activeTab` is the active tab, with one exception. An extension can create a menu item with the {{webextAPIref("menus")}} API that displays when the user context-clicks a tab. That is, a menu on an element in the tabstrip that enables the user to switch from one tab to another. If the user clicks this menu, then the `activeTab` permission is granted for the tab the user clicked, even if it's not the active tab (as of Firefox 63, [Firefox bug 1446956](https://bugzil.la/1446956)).
 
 ## Clipboard access
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -18,7 +18,7 @@ The APIs enabled by a user action are:
 - The {{WebExtAPIRef("action.openPopup")}}, {{WebExtAPIRef("browserAction.openPopup")}}, and {{WebExtAPIRef("pageAction.openPopup")}} APIs that open an extension's browser or page action popup. Users do the same by clicking the browser or page action.
 - The {{WebExtAPIRef("sidebarAction.open")}}, {{WebExtAPIRef("sidebarAction.close")}}, and {{WebExtAPIRef("sidebarAction.toggle")}} APIs open and close an extension's sidebar. The user does this from some part of the browser's built-in user interface, such as the **View** > **Sidebar** menu.
 - The {{WebExtAPIRef("downloads.open")}} API opens a downloaded file. The user does this from some part of the browser's built-in user interface, such as the **Tools** > **Downloads** menu.
-- The {{WebExtAPIRef("management.setenabled")}} API. The user can turn off a theme extension from the extension's Add-on Manager page.
+- The {{WebExtAPIRef("management.setEnabled")}} API. The user can turn off a theme extension from the extension's Add-on Manager page.
 - The {{WebExtAPIRef("permissions.request")}} API. The user can grant permissions from the extension's Add-on Manager permissions and data tab.
 
 For example:

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -5,15 +5,7 @@ page-type: guide
 sidebar: addonsidebar
 ---
 
-Some WebExtension APIs perform functions that usually occur as a result of a user action. These APIs are:
-
-- The {{WebExtAPIRef("action.openPopup")}}, {{WebExtAPIRef("browserAction.openPopup")}}, and {{WebExtAPIRef("pageAction.openPopup")}} APIs that open an extension's browser or page action popup. Users do the same by clicking the browser or page action.
-- The {{WebExtAPIRef("sidebarAction.open")}}, {{WebExtAPIRef("sidebarAction.close")}}, and {{WebExtAPIRef("sidebarAction.toggle")}} APIs open and close an extension's sidebar. The user does this from some part of the browser's built-in user interface, such as the **View** > **Sidebar** menu.
-- The {{WebExtAPIRef("downloads.open")}} API opens a downloaded file. The user does this from some part of the browser's built-in user interface, such as the **Tools** > **Downloads** menu.
-- The {{WebExtAPIRef("management.setenabled")}} API. The user can turn off a theme extension from the extension's Add-on Manager page.
-- The {{WebExtAPIRef("permissions.request")}} API. The user can grant permissions from the extension's Add-on Manager permissions and data tab.
-
-Following the principle of "no surprises", these APIs can only be called from inside the handler for a user action. User actions include:
+Some WebExtension APIs perform functions that usually occur as a result of a user action (also referred to as user gestures and user activation). Following the principle of "no surprises", these APIs can only be called from inside the handler for a user action. These user actions are:
 
 - Clicking the extension's browser action or page action.
 - Selecting a context menu item defined by the extension.
@@ -21,7 +13,13 @@ Following the principle of "no surprises", these APIs can only be called from in
 - Clicking a button on a page bundled with the extension.
 - Clicking an extension suggestion in the address bar (omnibox) (this is only treated as a user action from Firefox 142).
 
-In addition to enabling the APIs, these actions also enable the [`"activeTab"` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). This permission grants extra privileges for the tab visible when the user action takes place.
+The APIs enabled by a user action are:
+
+- The {{WebExtAPIRef("action.openPopup")}}, {{WebExtAPIRef("browserAction.openPopup")}}, and {{WebExtAPIRef("pageAction.openPopup")}} APIs that open an extension's browser or page action popup. Users do the same by clicking the browser or page action.
+- The {{WebExtAPIRef("sidebarAction.open")}}, {{WebExtAPIRef("sidebarAction.close")}}, and {{WebExtAPIRef("sidebarAction.toggle")}} APIs open and close an extension's sidebar. The user does this from some part of the browser's built-in user interface, such as the **View** > **Sidebar** menu.
+- The {{WebExtAPIRef("downloads.open")}} API opens a downloaded file. The user does this from some part of the browser's built-in user interface, such as the **Tools** > **Downloads** menu.
+- The {{WebExtAPIRef("management.setenabled")}} API. The user can turn off a theme extension from the extension's Add-on Manager page.
+- The {{WebExtAPIRef("permissions.request")}} API. The user can grant permissions from the extension's Add-on Manager permissions and data tab.
 
 For example:
 
@@ -32,6 +30,8 @@ function handleClick() {
 
 browser.browserAction.onClicked.addListener(handleClick);
 ```
+
+In addition to enabling the APIs, these actions also enable the [`"activeTab"` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). This permission grants extra privileges for the tab visible when the user action takes place.
 
 User interactions in normal web pages aren't treated as user actions. For example, consider a button on a normal web page that uses a content script. This content script added a click handler for the button that sends a message to the extension's background page. When a user clicks the button, the background page message handler is not considered to be handling a user action.
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -5,17 +5,21 @@ page-type: guide
 sidebar: addonsidebar
 ---
 
-Some WebExtension APIs perform functions that are generally performed as a result of a user action. For example:
+Some WebExtension APIs perform functions that usually occur as a result of a user action. These APIs are:
 
-- a browser action with a popup will display the popup when the user clicks it, but there's also a {{WebExtAPIRef("browserAction.openPopup")}} API enabling an extension to open the popup programmatically.
-- if an extension adds a sidebar, it is typically opened by the user via some part of the browser's built-in user interface, such as the View/Sidebar menu. But there's also a {{WebExtAPIRef("sidebarAction.open")}} API enabling an extension to open their sidebar programmatically.
+- The {{WebExtAPIRef("action.openPopup")}}, {{WebExtAPIRef("browserAction.openPopup")}}), and {{WebExtAPIRef("pageAction.openPopup")}}) APIs that open an extension's browser or page action popup. Users do the same by clicking the browser or page action.
+- The {{WebExtAPIRef("sidebarAction.open")}}, {{WebExtAPIRef("sidebarAction.close")}}, and {{WebExtAPIRef("sidebarAction.toggle")}} APIs open and close an extensions sidebar. The user does this from some part of the browser's built-in user interface, such as the **View** > **Sidebar** menu.
+- The {{WebExtAPIRef("downloads.open")}} API opens a downloaded file. The user does this from some part of the browser's built-in user interface, such as the **Tools** > **Downloads** menu.
+- The {{WebExtAPIRef("management.setenabled")}} API. The user can disable a theme extension from the extension's Add-on Manager page.
+- The {{WebExtAPIRef("permissions.request")}} API. The user can grant permissions from the extension's Add-on Manager permissions and data tab.
 
-To follow the principle of "no surprises", APIs like this can only be called from inside the handler for a user action. User actions include the following:
+Following the principle of "no surprises", these APIs can only be called from inside the handler for a user action. User actions include:
 
 - Clicking the extension's browser action or page action.
 - Selecting a context menu item defined by the extension.
 - Activating a keyboard shortcut defined by the extension (this only treated as a user action from Firefox 63 onwards).
-- Clicking a button in a page bundled with the extension.
+- Clicking a button on a page bundled with the extension.
+- Clicking an extension suggestion in the address bar (omnibox). (This action also grants the `"activeTab"` permission.)
 
 For example:
 
@@ -27,7 +31,7 @@ function handleClick() {
 browser.browserAction.onClicked.addListener(handleClick);
 ```
 
-Note that user actions in normal web pages are not treated as user actions for this purpose. For example, if a user clicks a button in a normal web page, and a content script has added a click handler for that button and in that handler sends a message to the extension's background page, then the background page message handler is not considered to be handling a user action.
+User interactions in normal web pages aren't treated as user actions. For example, consider a button on a normal web page that uses a content script. This content script added a click handler for the button that sends a message to the extension's background page. When a user clicks the button, the background page message handler is not considered to be handling a user action.
 
 Also, if a user input handler waits on a [promise](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), then its status as a user input handler is lost. For example:
 
@@ -35,7 +39,7 @@ Also, if a user input handler waits on a [promise](/en-US/docs/Web/JavaScript/Re
 async function handleClick() {
   let result = await someAsyncFunction();
 
-  // this will fail, because the handler lost its "user action handler" status
+  // this fails, because the handler lost its "user action handler" status
   browser.sidebarAction.open();
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -7,19 +7,21 @@ sidebar: addonsidebar
 
 Some WebExtension APIs perform functions that usually occur as a result of a user action. These APIs are:
 
-- The {{WebExtAPIRef("action.openPopup")}}, {{WebExtAPIRef("browserAction.openPopup")}}), and {{WebExtAPIRef("pageAction.openPopup")}}) APIs that open an extension's browser or page action popup. Users do the same by clicking the browser or page action.
-- The {{WebExtAPIRef("sidebarAction.open")}}, {{WebExtAPIRef("sidebarAction.close")}}, and {{WebExtAPIRef("sidebarAction.toggle")}} APIs open and close an extensions sidebar. The user does this from some part of the browser's built-in user interface, such as the **View** > **Sidebar** menu.
+- The {{WebExtAPIRef("action.openPopup")}}, {{WebExtAPIRef("browserAction.openPopup")}}, and {{WebExtAPIRef("pageAction.openPopup")}} APIs that open an extension's browser or page action popup. Users do the same by clicking the browser or page action.
+- The {{WebExtAPIRef("sidebarAction.open")}}, {{WebExtAPIRef("sidebarAction.close")}}, and {{WebExtAPIRef("sidebarAction.toggle")}} APIs open and close an extension's sidebar. The user does this from some part of the browser's built-in user interface, such as the **View** > **Sidebar** menu.
 - The {{WebExtAPIRef("downloads.open")}} API opens a downloaded file. The user does this from some part of the browser's built-in user interface, such as the **Tools** > **Downloads** menu.
-- The {{WebExtAPIRef("management.setenabled")}} API. The user can disable a theme extension from the extension's Add-on Manager page.
+- The {{WebExtAPIRef("management.setenabled")}} API. The user can turn off a theme extension from the extension's Add-on Manager page.
 - The {{WebExtAPIRef("permissions.request")}} API. The user can grant permissions from the extension's Add-on Manager permissions and data tab.
 
 Following the principle of "no surprises", these APIs can only be called from inside the handler for a user action. User actions include:
 
 - Clicking the extension's browser action or page action.
 - Selecting a context menu item defined by the extension.
-- Activating a keyboard shortcut defined by the extension (this only treated as a user action from Firefox 63 onwards).
+- Activating a keyboard shortcut defined by the extension (this is only treated as a user action from Firefox 63).
 - Clicking a button on a page bundled with the extension.
-- Clicking an extension suggestion in the address bar (omnibox). (This action also grants the `"activeTab"` permission.)
+- Clicking an extension suggestion in the address bar (omnibox) (this is only treated as a user action from Firefox 142).
+
+In addition to enabling the APIs, these actions also enable the [`"activeTab"` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). This permission grants extra privileges for the tab visible when the user action takes place.
 
 For example:
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: addonsidebar
 ---
 
-Some WebExtension APIs perform functions that usually occur as a result of a user action (also referred to as user gestures and user activation). Following the principle of "no surprises", these APIs can only be called from inside the handler for a user action. These user actions are:
+Some WebExtension APIs perform functions that usually occur as a result of a user action. Following the principle of "no surprises", these APIs can only be called from inside the handler for a user action (also referred to as user gestures). These user actions are:
 
 - Clicking the extension's browser action or page action.
 - Selecting a context menu item defined by the extension.

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -71,6 +71,7 @@ Firefox 143 is the current [Nightly version of Firefox](https://www.firefox.com/
 ## Changes for add-on developers
 
 - Addition of {{WebExtAPIRef("storage.StorageArea.getKeys()")}}. This method returns an array containing all of the keys in a storage area. It's available for all storage areas, that is {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, and {{WebExtAPIRef("storage.managed", "managed")}}. ([Firefox bug 1910669](https://bugzil.la/1910669))
+- User selection of an extension suggestion in the address bar (omnibox), an action that fires {{WebExtAPIRef("omnibox.onInputEntered")}}, is now considered a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). In addition to enabling the APIs that require a user action, selecting an extension suggestion in the address bar also grants the `"activeTab"` permission.
 
 <!-- ### Removals -->
 


### PR DESCRIPTION
### Description

This change:

- adds the information that clicking an extension suggestion in the address bar (omnibox) is now a user action, including a release note.
- adds details of all the user action enabled APIs.
- tidies up the content on the user action page.

### Motivation

In addition to the change requested as part of a dev-doc-needed, the user actions page seemed hard to read and didn't provide a comprehensive guide to the related API's.

### Related issues and pull requests

[Bug 1542358](https://bugzilla.mozilla.org/show_bug.cgi?id=1542358) Allow omnibox.onInputEntered as a user action trigger e.g. for clipboard & browserAction.openPopup()
