### PR TITLE
FF142 Integrity-Policy can be enforced on stylesheets

### DIFF
--- a/files/en-us/web/http/reference/headers/integrity-policy-report-only/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy-report-only/index.md
@@ -15,10 +15,10 @@ The HTTP **`Integrity-Policy-Report-Only`** response header allows website admin
 
 Reports may be generated for requests on specified [request destinations](#blocked-destinations) that omit integrity metadata, or that are made in [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode.
 For reports to be sent to a reporting endpoint, the `Integrity-Policy-Report-Only` header must specify a valid reporting endpoint name that matches an endpoint declared using the {{HTTPHeader("Reporting-Endpoints")}} header.
-Reports are generated using the [Reporting API](/en-US/docs/Web/API/Reporting_API), and may also be observed in the page for which the integrity policy is being reported, using a [ReportingObserver](/en-US/docs/Web/API/ReportingObserver).
+Reports are generated using the [Reporting API](/en-US/docs/Web/API/Reporting_API), and may also be observed in the page for which the integrity policy is being reported, using a [`ReportingObserver`](/en-US/docs/Web/API/ReportingObserver).
 The format of the report body is given by the {{domxref("IntegrityViolationReportBody")}} dictionary (a JSON-serialized form of this body is sent in POSTs to reporting server endpoints).
 
-The header allow developers to test [integrity policies](/en-US/docs/Web/Security/Subresource_Integrity#integrity_policy) and fix any content issues before eventually deploying an {{HTTPHeader("Integrity-Policy")}} header to enforce the policy.
+The header allows developers to test [integrity policies](/en-US/docs/Web/Security/Subresource_Integrity#integrity_policy) and fix any content issues before eventually deploying an {{HTTPHeader("Integrity-Policy")}} header to enforce the policy.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/reference/headers/integrity-policy-report-only/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy-report-only/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP **`Integrity-Policy-Report-Only`** response header allows website administrators to report on resources that the user agent loads that would violate [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees if the integrity policy was enforced (using the {{HTTPHeader("Integrity-Policy")}} header).
 
-Reports may be generated for requests on specified [request destinations](/en-US/docs/Web/API/Request/destination) that omit integrity metadata, or that are made in [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode.
+Reports may be generated for requests on specified [request destinations](#blocked-destinations) that omit integrity metadata, or that are made in [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode.
 For reports to be sent to a reporting endpoint, the `Integrity-Policy-Report-Only` header must specify a valid reporting endpoint name that matches an endpoint declared using the {{HTTPHeader("Reporting-Endpoints")}} header.
 Reports are generated using the [Reporting API](/en-US/docs/Web/API/Reporting_API), and may also be observed in the page for which the integrity policy is being reported, using a [ReportingObserver](/en-US/docs/Web/API/ReportingObserver).
 The format of the report body is given by the {{domxref("IntegrityViolationReportBody")}} dictionary (a JSON-serialized form of this body is sent in POSTs to reporting server endpoints).
@@ -42,15 +42,22 @@ Integrity-Policy-Report-Only: blocked-destinations=(<destination>),sources=(<sou
 The header values are defined as structured field dictionaries with the following keys:
 
 - `blocked-destinations`
+
   - : A list of [request destinations](/en-US/docs/Web/API/Request/destination) that must include valid integrity metadata.
     Allowed values are:
+
     - `script`
       - : Script resources.
+    - `style`
+      - : Stylesheet resources.
 
 - `sources` {{optional_inline}}
+
   - : A list of integrity sources that must include integrity metadata.
     Allowed values are:
+
     - `inline`
+
       - : The integrity metadata source is inline to the content, such as the [integrity attribute](/en-US/docs/Web/API/HTMLScriptElement/integrity).
         This is the default.
 

--- a/files/en-us/web/http/reference/headers/integrity-policy/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP **`Integrity-Policy`** response header allows website administrators to ensure that all resources the user agent loads (of a certain type) have [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) guarantees.
 
-When set the user agent will block requests on specified [request destinations](/en-US/docs/Web/API/Request/destination) that omit integrity metadata, and will also block requests in [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode from ever being made.
+When set the user agent will block requests on specified [request destinations](#blocked-destinations) that omit integrity metadata, and will also block requests in [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode from ever being made.
 
 Violation reports may also be sent to if the header includes a reporting endpoint name that matches an endpoint declared using the {{HTTPHeader("Reporting-Endpoints")}} header.
 Reports are generated using the [Reporting API](/en-US/docs/Web/API/Reporting_API), and may also be observed in the page for which the integrity policy is being enforced, using a [ReportingObserver](/en-US/docs/Web/API/ReportingObserver).
@@ -45,13 +45,18 @@ The header values are defined as structured field dictionaries with the followin
 - `blocked-destinations`
   - : A list of [request destinations](/en-US/docs/Web/API/Request/destination) that must include valid integrity metadata.
     Allowed values are:
+
     - `script`
       - : Script resources.
-
+    - `style`
+      - : Stylesheet resources.
 - `sources` {{optional_inline}}
+
   - : A list of integrity sources that must include integrity metadata.
     Allowed values are:
+
     - `inline`
+
       - : The integrity metadata source is inline to the content, such as the [integrity attribute](/en-US/docs/Web/API/HTMLScriptElement/integrity).
         This is the default.
 

--- a/files/en-us/web/http/reference/headers/integrity-policy/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy/index.md
@@ -16,7 +16,7 @@ The HTTP **`Integrity-Policy`** response header allows website administrators to
 When set the user agent will block requests on specified [request destinations](#blocked-destinations) that omit integrity metadata, and will also block requests in [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode from ever being made.
 
 Violation reports may also be sent to if the header includes a reporting endpoint name that matches an endpoint declared using the {{HTTPHeader("Reporting-Endpoints")}} header.
-Reports are generated using the [Reporting API](/en-US/docs/Web/API/Reporting_API), and may also be observed in the page for which the integrity policy is being enforced, using a [ReportingObserver](/en-US/docs/Web/API/ReportingObserver).
+Reports are generated using the [Reporting API](/en-US/docs/Web/API/Reporting_API), and may also be observed in the page for which the integrity policy is being enforced, using a [`ReportingObserver`](/en-US/docs/Web/API/ReportingObserver).
 The format of the report body is given by the {{domxref("IntegrityViolationReportBody")}} dictionary (a JSON-serialized form of this body is sent in POSTs to reporting server endpoints).
 
 This helps guard against content manipulation of fetched subresources.

--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -122,7 +122,7 @@ Developers would typically use `Integrity-Policy-Report-Only` as a first deploym
 The header values are defined as structured field dictionaries with the following keys:
 
 - `blocked-destinations`
-  - : Defines a list of [request destinations](/en-US/docs/Web/API/Request/destination) to be blocked. The only allowed value is `script`.
+  - : Defines a list of [request destinations](/en-US/docs/Web/API/Request/destination) to be blocked. The only allowed values are `script` and `style`.
 - `sources` {{optional_inline}}
   - : Defines a list of integrity sources. The default and only currently supported value is `inline`. As a result, adding `sources=(inline)` to the header has a similar effect as omitting `sources`.
 - `endpoints` {{optional_inline}}

--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -112,12 +112,12 @@ Browsers handle SRI by doing the following:
 
 ## Integrity policy
 
-The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers enable a document to enforce a policy regarding the integrity metadata requirements on loaded subresources of specified types (currently scripts only).
+The {{httpheader("Integrity-Policy")}} and {{httpheader("Integrity-Policy-Report-Only")}} HTTP headers enable a document to enforce a policy regarding the integrity metadata requirements on loaded script and stylesheet subresources.
 
 When an `Integrity-Policy` header is specified, the browser blocks requests with [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode or without an `integrity` attribute from being made, and will also report violations if a valid reporting endpoint is specified.
-When an `Integrity-Policy-Report-Only` header is specified the browser allows requests that violate the policy, but will report violations to the reporting endpoint (if a valid reporting endpoint is specified).
+When an `Integrity-Policy-Report-Only` header is specified, the browser allows requests that violate the policy, but will report violations to the reporting endpoint (if a valid reporting endpoint is specified).
 
-Developers would typically use `Integrity-Policy-Report-Only` as a first deployment step in their Integrity Policy journey, to ensure that all the scripts loaded in their documents have appropriate integrity metadata. Once they'd see that no violation reports are being received, they'd know that they can enable blocking using the `Integrity-Policy` header without risking user-facing breakage.
+Developers would typically use `Integrity-Policy-Report-Only` as a first deployment step in their Integrity Policy journey, to ensure that all the scripts and stylesheets loaded in their documents have appropriate integrity metadata. Once they'd see that no violation reports are being received, they'd know that they can enable blocking using the `Integrity-Policy` header without risking user-facing breakage.
 
 The header values are defined as structured field dictionaries with the following keys:
 
@@ -165,13 +165,13 @@ You can use the following {{HTMLElement("script")}} element to tell a browser th
 
 ### Integrity enforcement with the `Integrity-Policy` header
 
-You can add the {{httpheader("Integrity-Policy")}} header to your document in order to ensure that all the external scripts it loads are loaded with integrity (and aren't loaded with [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode)
+You can add the {{httpheader("Integrity-Policy")}} header to your document to ensure that the external resources it loads (in this case, scripts) are loaded with integrity (and aren't loaded with [no-cors](/en-US/docs/Web/API/Request/mode#no-cors) mode)
 
 ```http
 Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint, some-other-integrity-endpoint)
 ```
 
-In case you're not sure all your the external scripts have integrity metadata, you can enable the report-only version of the feature and start getting reports of violations.
+If you're unsure that all the external scripts have integrity metadata, you can enable the report-only version of the feature and start getting reports of violations.
 You can do that with the {{httpheader("Integrity-Policy-Report-Only")}} header.
 
 ```http


### PR DESCRIPTION
FF142 adds support for specifying a style as a blocked destination (behind a preference) in https://bugzilla.mozilla.org/show_bug.cgi?id=1974247. This updates the docs to note that this is an allowed value for the `Integrity-Policy` and `Integrity-Policy-Report-Only` headers.

Related docs work can be tracked in #40667