### PR TITLE
Fix typos (#40768)

### DIFF
--- a/files/en-us/mozilla/firefox/index.md
+++ b/files/en-us/mozilla/firefox/index.md
@@ -5,9 +5,9 @@ page-type: landing-page
 sidebar: firefox
 ---
 
-[Firefox](https://www.firefox.com/en-US/) is Mozilla's popular Web browser, available for multiple platforms including Windows, macOS, and Linux on the desktop and all Android and iOS mobile devices. With broad compatibility, the latest in Web technologies, and powerful development tools, Firefox is a great choice for both Web developers and end users.
+[Firefox](https://www.firefox.com/en-US/) is Mozilla's popular web browser, available for multiple platforms including Windows, macOS, and Linux on the desktop and all Android and iOS mobile devices. With broad compatibility, the latest in web technologies, and powerful development tools, Firefox is a great choice for both web developers and end users.
 
-Firefox is an open source project; much of the code is contributed by our huge community of volunteers. Here you can learn about how to contribute to the Firefox project and you will also find links to information about the construction of Firefox add-ons, using the developer tools in Firefox, and other topics.
+Firefox is an open-source project; much of the code is contributed by our huge community of volunteers. Here you can learn about how to contribute to the Firefox project and you will also find links to information about the construction of Firefox add-ons, using the developer tools in Firefox, and other topics.
 
 Learn how to create add-ons for [Firefox](https://www.firefox.com/en-US/), how to develop and build Firefox itself, and how the internals of Firefox and its subprojects work.
 
@@ -26,7 +26,7 @@ Firefox is available in five **channels**.
 
 ### Firefox Nightly
 
-Each night we build Firefox from the latest code in [mozilla-central](https://hg-edge.mozilla.org/mozilla-central/). These builds are for Firefox developers or those who want to try out the very latest cutting edge features while they're still under active development.
+Each night we build Firefox from the latest code in [mozilla-central](https://hg-edge.mozilla.org/mozilla-central/). These builds are for Firefox developers or those who want to try out the very latest cutting-edge features while they're still under active development.
 
 [Download Firefox Nightly](https://www.firefox.com/en-US/channel/desktop/#nightly)
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/totalinterframedelay/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/totalinterframedelay/index.md
@@ -11,7 +11,7 @@ browser-compat: api.RTCStatsReport.type_inbound-rtp.totalInterFrameDelay
 The **`totalInterFrameDelay`** property of the {{domxref("RTCInboundRtpStreamStats")}} dictionary indicates the total accumulated time between consecutively rendered frames, in seconds.
 It is recorded after each frame is rendered.
 
-The interframe delay variance be calculated from `totalInterFrameDelay`, {{domxref("RTCInboundRtpStreamStats.totalSquaredInterFrameDelay","totalSquaredInterFrameDelay")}} , and {{domxref("RTCInboundRtpStreamStats.framesRendered","framesRendered")}} according to the formula: `(totalSquaredInterFrameDelay - totalInterFrameDelay^2/ framesRendered)/framesRendered`.
+The interframe delay variance can be calculated from `totalInterFrameDelay`, {{domxref("RTCInboundRtpStreamStats.totalSquaredInterFrameDelay","totalSquaredInterFrameDelay")}} , and {{domxref("RTCInboundRtpStreamStats.framesRendered","framesRendered")}} according to the formula: `(totalSquaredInterFrameDelay - totalInterFrameDelay^2/ framesRendered)/framesRendered`.
 
 > [!NOTE]
 > The property is undefined for audio streams.

--- a/files/en-us/web/html/reference/elements/label/index.md
+++ b/files/en-us/web/html/reference/elements/label/index.md
@@ -208,7 +208,7 @@ An {{HTMLElement("input")}} element with a `type="button"` declaration and a val
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>None, both the starting and ending tag are mandatory.</td>
+      <td>None, both the starting and ending tags are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>


### PR DESCRIPTION
### Weekly spelling check #40768 

### Description
Made a few Typo fixes across the index.md files of MDN Web Docs.

### Summary
1. For the file -> files/en-us/web/api/rtcinboundrtpstreamstats/totalinterframedelay/index.md  --> "variance be calculated" to "variance can be calculated".

2. For the file -> files/en-us/web/html/reference/elements/label/index.md  -->  "the starting and ending tag are mandatory" to "the starting and ending tags are mandatory".

3. For the file -> files/en-us/mozilla/firefox/index.md  -->  "cutting edge"  to  "cutting-edge;" and "open source project" to "open-source project".

4. For the file -> files/en-us/mdn/index.md. --> No typos found.

### Motivation

For clarity , accuracy and to improve the technical precision and to give the readers a clean and unambiguous reference.
