### PR TITLE
Fix WebSocketStream `close()` example

### DIFF
--- a/files/en-us/web/api/websocketstream/close/index.md
+++ b/files/en-us/web/api/websocketstream/close/index.md
@@ -51,7 +51,7 @@ const wss = new WebSocketStream(wsURL);
 
 setTimeout(() => {
   wss.close({
-    code: 1000,
+    closeCode: 1000,
     reason: "That's all folks",
   });
 }, 10000);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

The docs were right, but the example was still wrong.

### Description

`code` → `closeCode`

### Motivation

Reflecting an API change.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
