### PR TITLE
fix: coep reference to corp cross-origin

### DIFF
--- a/files/en-us/web/http/reference/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/reference/headers/cross-origin-embedder-policy/index.md
@@ -10,7 +10,7 @@ sidebar: http
 The HTTP **`Cross-Origin-Embedder-Policy`** (COEP) {{Glossary("response header")}} configures the current document's policy for loading and embedding cross-origin resources.
 
 The policy for whether a particular resource is embeddable cross-site may be defined for that resource using the {{HTTPHeader("Cross-Origin-Resource-Policy")}} (CORP) header for a `no-cors` fetch, or using [CORS](/en-US/docs/Web/HTTP/Guides/CORS).
-If neither of these policies are set, then by default, resources can be loaded or embedded into a document as though they had a CORP value of `cross-site`.
+If neither of these policies are set, then by default, resources can be loaded or embedded into a document as though they had a CORP value of `cross-origin`.
 
 The **`Cross-Origin-Embedder-Policy`** allows you to require that CORP or CORS headers be set in order to load cross-site resources into the current document.
 You can also set the policy to keep the default behavior, or to allow the resources to be loaded, but strip any credentials that might otherwise be sent.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Change the Cross-Origin-Embedder-Policy (COEP) header description which references the Cross-Origin-Resource-Policy (CORP) header value `cross-site` to `cross-origin`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

There is no `cross-site` value for CORP.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
