### PR TITLE
Remove redundant indefinite articles from var/param/etc names

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -366,19 +366,19 @@ const express = require("express");
 const app = express();
 
 // An example middleware function
-function aMiddlewareFunction(req, res, next) {
+function middlewareFunction(req, res, next) {
   // Perform some operations
   next(); // Call next() so Express will call the next middleware function in the chain.
 }
 
 // Function added with use() for all routes and verbs
-app.use(aMiddlewareFunction);
+app.use(middlewareFunction);
 
 // Function added with use() for a specific route
-app.use("/some-route", aMiddlewareFunction);
+app.use("/some-route", middlewareFunction);
 
 // A middleware function added for a specific HTTP verb and route
-app.get("/", aMiddlewareFunction);
+app.get("/", middlewareFunction);
 
 app.listen(3000);
 ```

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
@@ -127,7 +127,7 @@ The code in the asynchronous function then executes until either another `await`
 
 You can see how this works in the example below.
 `myFunction()` is an asynchronous function that is called within a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block.
-When `myFunction()` is run, code execution is paused at `methodThatReturnsPromise()` until the promise resolves, at which point the code continues to `aFunctionThatReturnsPromise()` and waits again.
+When `myFunction()` is run, code execution is paused at `methodThatReturnsPromise()` until the promise resolves, at which point the code continues to `functionThatReturnsPromise()` and waits again.
 The code in the `catch` block runs if an error is thrown in the asynchronous function, and this will happen if the promise returned by either of the methods is rejected.
 
 ```js
@@ -135,7 +135,7 @@ async function myFunction() {
   // …
   await someObject.methodThatReturnsPromise();
   // …
-  await aFunctionThatReturnsPromise();
+  await functionThatReturnsPromise();
   // …
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -37,14 +37,14 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfi
 This example registers a content script that injects the file `"script.js"`:
 
 ```js
-const aScript = {
+const script = {
   id: "a-script",
   js: ["script.js"],
   matches: ["https://example.com/*"],
 };
 
 try {
-  await browser.scripting.registerContentScripts([aScript]);
+  await browser.scripting.registerContentScripts([script]);
 } catch (err) {
   console.error(`failed to register content scripts: ${err}`);
 }

--- a/files/en-us/web/api/document/body/index.md
+++ b/files/en-us/web/api/document/body/index.md
@@ -26,10 +26,10 @@ One of the following:
 // Given this HTML: <body id="oldBodyElement"></body>
 alert(document.body.id); // "oldBodyElement"
 
-const aNewBodyElement = document.createElement("body");
+const newBodyElement = document.createElement("body");
 
-aNewBodyElement.id = "newBodyElement";
-document.body = aNewBodyElement;
+newBodyElement.id = "newBodyElement";
+document.body = newBodyElement;
 alert(document.body.id); // "newBodyElement"
 ```
 

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -25,12 +25,12 @@ Most commands affect the document's [selection](/en-US/docs/Web/API/Selection). 
 ## Syntax
 
 ```js-nolint
-execCommand(aCommandName, aShowDefaultUI, aValueArgument)
+execCommand(commandName, showDefaultUI, valueArgument)
 ```
 
 ### Parameters
 
-- `aCommandName`
+- `commandName`
   - : A string specifying the name of the command to execute. The following commands are specified:
     - `backColor`
       - : Changes the document background color. In `styleWithCss` mode, it affects the background color of the containing block instead. This requires a {{cssxref("&lt;color&gt;")}} value string to be passed in as a value argument.
@@ -132,9 +132,9 @@ execCommand(aCommandName, aShowDefaultUI, aValueArgument)
     - `AutoUrlDetect`
       - : Changes the browser auto-link behavior.
 
-- `aShowDefaultUI`
+- `showDefaultUI`
   - : A boolean value indicating whether the default user interface should be shown. This is not implemented in Mozilla.
-- `aValueArgument`
+- `valueArgument`
   - : For commands which require an input argument, is a string providing that information. For example, `insertImage` requires the URL of the image to insert. Specify `null` if no argument is needed.
 
 ### Return value

--- a/files/en-us/web/api/domtokenlist/item/index.md
+++ b/files/en-us/web/api/domtokenlist/item/index.md
@@ -13,7 +13,7 @@ determined by its position in the list, its index.
 
 > [!NOTE]
 > This method is equivalent as the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation).
-> So `aList.item(i)` is the same as `aList[i]`.
+> So `list.item(i)` is the same as `list[i]`.
 
 ## Syntax
 

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
@@ -148,12 +148,12 @@ dataProvider.prototype = {
       return this;
     throw Components.results.NS_NOINTERFACE;
   },
-  getFlavorData(aTransferable, aFlavor, aData, aDataLen) {
-    if (aFlavor === "application/x-moz-file-promise") {
+  getFlavorData(transferable, flavor, data, dataLen) {
+    if (flavor === "application/x-moz-file-promise") {
       const urlPrimitive = {};
       const dataSize = {};
 
-      aTransferable.getTransferData(
+      transferable.getTransferData(
         "application/x-moz-file-promise-url",
         urlPrimitive,
         dataSize,
@@ -164,7 +164,7 @@ dataProvider.prototype = {
       console.log(`URL file original is = ${url}`);
 
       const namePrimitive = {};
-      aTransferable.getTransferData(
+      transferable.getTransferData(
         "application/x-moz-file-promise-dest-filename",
         namePrimitive,
         dataSize,
@@ -176,7 +176,7 @@ dataProvider.prototype = {
       console.log(`target filename is = ${name}`);
 
       const dirPrimitive = {};
-      aTransferable.getTransferData(
+      transferable.getTransferData(
         "application/x-moz-file-promise-dir",
         dirPrimitive,
         dataSize,

--- a/files/en-us/web/api/node/appendchild/index.md
+++ b/files/en-us/web/api/node/appendchild/index.md
@@ -23,29 +23,29 @@ If the given child is a {{domxref("DocumentFragment")}}, the entire contents of 
 ## Syntax
 
 ```js-nolint
-appendChild(aChild)
+appendChild(child)
 ```
 
 ### Parameters
 
-- `aChild`
+- `child`
   - : The node to append to the given parent node (commonly an element).
 
 ### Return value
 
-A {{domxref("Node")}} that is the appended child (`aChild`), except when `aChild` is a {{domxref("DocumentFragment")}}, in which case the empty {{domxref("DocumentFragment")}} is returned.
+A {{domxref("Node")}} that is the appended child (`child`), except when `child` is a {{domxref("DocumentFragment")}}, in which case the empty {{domxref("DocumentFragment")}} is returned.
 
 ### Exceptions
 
 - `HierarchyRequestError` {{domxref("DOMException")}}
   - : Thrown when the constraints of the DOM tree are violated, that is if one of the following cases occurs:
-    - If the parent of `aChild` is not a {{domxref("Document")}}, {{domxref("DocumentFragment")}}, or an {{domxref("Element")}}.
-    - If the insertion of `aChild` would lead to a cycle, that is if `aChild` is an ancestor of the node.
-    - If `aChild` is not a {{domxref("DocumentFragment")}}, a {{domxref("DocumentType")}}, an {{domxref("Element")}}, or a {{domxref("CharacterData")}}.
+    - If the parent of `child` is not a {{domxref("Document")}}, {{domxref("DocumentFragment")}}, or an {{domxref("Element")}}.
+    - If the insertion of `child` would lead to a cycle, that is if `child` is an ancestor of the node.
+    - If `child` is not a {{domxref("DocumentFragment")}}, a {{domxref("DocumentType")}}, an {{domxref("Element")}}, or a {{domxref("CharacterData")}}.
     - If the current node is a {{domxref("Text")}}, and its parent is a {{domxref("Document")}}.
     - If the current node is a {{domxref("DocumentType")}} and its parent is _not_ a {{domxref("Document")}}, as a _doctype_ should always be a direct descendant of a _document_.
-    - If the parent of the node is a {{domxref("Document")}} and `aChild` is a {{domxref("DocumentFragment")}} with more than one {{domxref("Element")}} child, or that has a {{domxref("Text")}} child.
-    - If the insertion of `aChild` would lead to {{domxref("Document")}} with more than one {{domxref("Element")}} as child.
+    - If the parent of the node is a {{domxref("Document")}} and `child` is a {{domxref("DocumentFragment")}} with more than one {{domxref("Element")}} child, or that has a {{domxref("Text")}} child.
+    - If the insertion of `child` would lead to {{domxref("Document")}} with more than one {{domxref("Element")}} as child.
 
 ## Description
 

--- a/files/en-us/web/api/node/isdefaultnamespace/index.md
+++ b/files/en-us/web/api/node/isdefaultnamespace/index.md
@@ -48,14 +48,14 @@ Is "http://www.w3.org/2000/svg" the default namespace for &lt;svg&gt;:
 ```js
 const button = document.querySelector("button");
 button.addEventListener("click", () => {
-  const aHtmlElt = document.querySelector("output");
-  const aSvgElt = document.querySelector("svg");
+  const htmlElt = document.querySelector("output");
+  const svgElt = document.querySelector("svg");
 
   const result = document.getElementsByTagName("output");
-  result[0].value = aHtmlElt.isDefaultNamespace(""); // true
-  result[1].value = aHtmlElt.isDefaultNamespace("http://www.w3.org/2000/svg"); // false
-  result[2].value = aSvgElt.isDefaultNamespace(""); // false
-  result[3].value = aSvgElt.isDefaultNamespace("http://www.w3.org/2000/svg"); // true
+  result[0].value = htmlElt.isDefaultNamespace(""); // true
+  result[1].value = htmlElt.isDefaultNamespace("http://www.w3.org/2000/svg"); // false
+  result[2].value = svgElt.isDefaultNamespace(""); // false
+  result[3].value = svgElt.isDefaultNamespace("http://www.w3.org/2000/svg"); // true
 });
 ```
 

--- a/files/en-us/web/api/node/lookupprefix/index.md
+++ b/files/en-us/web/api/node/lookupprefix/index.md
@@ -58,21 +58,19 @@ Prefix for <code>http://www.w3.org/XML/1998/namespace</code> on &lt;svg&gt;:
 ```js
 const button = document.querySelector("button");
 button.addEventListener("click", () => {
-  const aHtmlElt = document.querySelector("output");
-  const aSvgElt = document.querySelector("svg");
+  const htmlElt = document.querySelector("output");
+  const svgElt = document.querySelector("svg");
 
   const result = document.getElementsByTagName("output");
-  result[0].value = aHtmlElt.lookupPrefix("http://www.w3.org/2000/svg"); // true
-  result[1].value = aHtmlElt.lookupPrefix(
+  result[0].value = htmlElt.lookupPrefix("http://www.w3.org/2000/svg"); // true
+  result[1].value = htmlElt.lookupPrefix(
     "http://www.w3.org/XML/1998/namespace",
   ); // false
-  result[2].value = aHtmlElt.lookupPrefix("http://www.w3.org/TR/html4/"); // true
-  result[3].value = aHtmlElt.lookupPrefix("https://www.w3.org/1999/xlink"); // false
-  result[4].value = aSvgElt.lookupPrefix("http://www.w3.org/2000/svg"); // true
-  result[5].value = aSvgElt.lookupPrefix("https://www.w3.org/1999/xlink"); // true
-  result[6].value = aSvgElt.lookupPrefix(
-    "http://www.w3.org/XML/1998/namespace",
-  ); // false
+  result[2].value = htmlElt.lookupPrefix("http://www.w3.org/TR/html4/"); // true
+  result[3].value = htmlElt.lookupPrefix("https://www.w3.org/1999/xlink"); // false
+  result[4].value = svgElt.lookupPrefix("http://www.w3.org/2000/svg"); // true
+  result[5].value = svgElt.lookupPrefix("https://www.w3.org/1999/xlink"); // true
+  result[6].value = svgElt.lookupPrefix("http://www.w3.org/XML/1998/namespace"); // false
 });
 ```
 

--- a/files/en-us/web/api/presentation/receiver/index.md
+++ b/files/en-us/web/api/presentation/receiver/index.md
@@ -51,9 +51,9 @@ to build and display a list of those connections' ID strings.
 const listElem = document.getElementById("connection-view");
 
 navigator.presentation.receiver.connectionList.then((connections) => {
-  connections.forEach((aConnection) => {
+  connections.forEach((connection) => {
     listElem.appendChild(document.createElement("li")).textContent =
-      aConnection.id;
+      connection.id;
   });
 });
 ```

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -21,14 +21,14 @@ script must obey the [same-origin policy](/en-US/docs/Web/Security/Same-origin_p
 ## Syntax
 
 ```js-nolint
-new SharedWorker(aURL)
-new SharedWorker(aURL, name)
-new SharedWorker(aURL, options)
+new SharedWorker(url)
+new SharedWorker(url, name)
+new SharedWorker(url, options)
 ```
 
 ### Parameters
 
-- `aURL`
+- `url`
   - : A string representing the URL of the script the worker will
     execute. It must obey the same-origin policy.
 - `name` {{optional_inline}}
@@ -68,7 +68,7 @@ new SharedWorker(aURL, options)
 - `NetworkError` {{domxref("DOMException")}}
   - : Thrown if the MIME type of the worker script is incorrect. It should _always_ be `text/javascript` (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Guides/MIME_types#textjavascript) may be accepted).
 - `SyntaxError` {{domxref("DOMException")}}
-  - : Thrown if `aURL` cannot be parsed.
+  - : Thrown if `url` cannot be parsed.
 
 ## Examples
 

--- a/files/en-us/web/api/storageaccesshandle/sharedworker/index.md
+++ b/files/en-us/web/api/storageaccesshandle/sharedworker/index.md
@@ -14,14 +14,14 @@ browser-compat: api.StorageAccessHandle.SharedWorker
 ## Syntax
 
 ```js-nolint
-SharedWorker(aURL)
-SharedWorker(aURL, name)
-SharedWorker(aURL, options)
+SharedWorker(url)
+SharedWorker(url, name)
+SharedWorker(url, options)
 ```
 
 ### Parameters
 
-- `aURL`
+- `url`
   - : See {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}}.
 - `name` {{optional_inline}}
   - : See {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}}.

--- a/files/en-us/web/api/window/cleartimeout/index.md
+++ b/files/en-us/web/api/window/cleartimeout/index.md
@@ -39,8 +39,8 @@ one second, the alert only appears once.
 
 ```js
 const alarm = {
-  remind(aMessage) {
-    alert(aMessage);
+  remind(message) {
+    alert(message);
     this.timeoutID = undefined;
   },
 

--- a/files/en-us/web/api/window/prompt/index.md
+++ b/files/en-us/web/api/window/prompt/index.md
@@ -93,7 +93,7 @@ The result is a string, which means you should sometimes cast the value given by
 For example, if their answer should be a Number, you should cast the value to Number.
 
 ```js
-const aNumber = Number(window.prompt("Type a number", ""));
+const number = Number(window.prompt("Type a number", ""));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -92,7 +92,7 @@ You can use the {{domxref("DOMParser")}} to create an XML document from a string
 
 ```js
 const parser = new DOMParser();
-const doc = parser.parseFromString(aStr, "text/xml");
+const doc = parser.parseFromString(str, "text/xml");
 ```
 
 ### Performing the transformation

--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -23,7 +23,7 @@ lch(52.2345% 72.2 56.2 / .5);
 lch(from green l c h / 0.5)
 lch(from #123456 calc(l + 10) c h)
 lch(from hsl(180 100% 50%) calc(l - 10) c h)
-lch(from var(--aColorValue) l c h / calc(alpha - 0.1))
+lch(from var(--color-value) l c h / calc(alpha - 0.1))
 ```
 
 ### Values

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -23,7 +23,7 @@ oklch(59.69% 0.156 49.77 / .5)
 oklch(from green l c h / 0.5)
 oklch(from #123456 calc(l + 0.1) c h)
 oklch(from hsl(180 100% 50%) calc(l - 0.1) c h)
-oklch(from var(--aColor) l c h / calc(alpha - 0.1))
+oklch(from var(--color) l c h / calc(alpha - 0.1))
 ```
 
 ### Values

--- a/files/en-us/web/http/guides/mime_types/index.md
+++ b/files/en-us/web/http/guides/mime_types/index.md
@@ -227,21 +227,21 @@ As a multipart document format, it consists of different parts, delimited by a b
 Each part is its own entity with its own HTTP headers, {{HTTPHeader("Content-Disposition")}}, and {{HTTPHeader("Content-Type")}} for file uploading fields.
 
 ```http
-Content-Type: multipart/form-data; boundary=aBoundaryString
+Content-Type: multipart/form-data; boundary=boundaryString
 (other headers associated with the multipart document as a whole)
 
---aBoundaryString
+--boundaryString
 Content-Disposition: form-data; name="myFile"; filename="img.jpg"
 Content-Type: image/jpeg
 
 (data)
---aBoundaryString
+--boundaryString
 Content-Disposition: form-data; name="myField"
 
 (data)
---aBoundaryString
+--boundaryString
 (more subparts)
---aBoundaryString--
+--boundaryString--
 ```
 
 The following `<form>`:

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -166,9 +166,9 @@ const obj1 = {
 };
 
 Object.freeze(obj1);
-obj1.internal.a = "aValue";
+obj1.internal.a = "value";
 
-obj1.internal.a; // 'aValue'
+obj1.internal.a; // 'value'
 ```
 
 To be a constant object, the entire reference graph (direct and indirect references to

--- a/files/en-us/web/javascript/reference/global_objects/object/valueof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/valueof/index.md
@@ -41,7 +41,7 @@ None.
 The `this` value, converted to an object.
 
 > [!NOTE]
-> In order for `valueOf` to be useful during type conversion, it must return a primitive. Because all primitive types have their own `valueOf()` methods, calling `aPrimitiveValue.valueOf()` generally does not invoke `Object.prototype.valueOf()`.
+> In order for `valueOf` to be useful during type conversion, it must return a primitive. Because all primitive types have their own `valueOf()` methods, calling `primitiveValue.valueOf()` generally does not invoke `Object.prototype.valueOf()`.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -138,7 +138,7 @@ The JavaScript ecosystem had made multiple Promise implementations long before i
 To interoperate with the existing Promise implementations, the language allows using thenables in place of promises. For example, [`Promise.resolve`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve) will not only resolve promises, but also trace thenables.
 
 ```js
-const aThenable = {
+const thenable = {
   then(onFulfilled, onRejected) {
     onFulfilled({
       // The thenable is fulfilled with another thenable
@@ -149,7 +149,7 @@ const aThenable = {
   },
 };
 
-Promise.resolve(aThenable); // A promise fulfilled with 42
+Promise.resolve(thenable); // A promise fulfilled with 42
 ```
 
 ### Promise concurrency

--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -207,17 +207,17 @@ class Secret {
   }
 }
 
-const aSecret = new Secret("123456");
-console.log(aSecret.secret); // [REDACTED]
+const secret = new Secret("123456");
+console.log(secret.secret); // [REDACTED]
 // Looks like a no-op forwarding...
-const proxy = new Proxy(aSecret, {});
+const proxy = new Proxy(secret, {});
 console.log(proxy.secret); // TypeError: Cannot read private member #secret from an object whose class did not declare it
 ```
 
 This is because when the proxy's `get` trap is invoked, the `this` value is the `proxy` instead of the original `secret`, so `#secret` is not accessible. To fix this, use the original `secret` as `this`:
 
 ```js
-const proxy = new Proxy(aSecret, {
+const proxy = new Proxy(secret, {
   get(target, prop, receiver) {
     // By default, it looks like Reflect.get(target, prop, receiver)
     // which has a different value of `this`
@@ -237,8 +237,8 @@ class Secret {
   }
 }
 
-const aSecret = new Secret();
-const proxy = new Proxy(aSecret, {
+const secret = new Secret();
+const proxy = new Proxy(secret, {
   get(target, prop, receiver) {
     const value = target[prop];
     if (value instanceof Function) {

--- a/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
@@ -66,16 +66,16 @@ Although you are encouraged to avoid using `substr()`, there is no trivial way t
 <!-- cSpell:ignore ozilla -->
 
 ```js
-const aString = "Mozilla";
+const string = "Mozilla";
 
-console.log(aString.substr(0, 1)); // 'M'
-console.log(aString.substr(1, 0)); // ''
-console.log(aString.substr(-1, 1)); // 'a'
-console.log(aString.substr(1, -1)); // ''
-console.log(aString.substr(-3)); // 'lla'
-console.log(aString.substr(1)); // 'ozilla'
-console.log(aString.substr(-20, 2)); // 'Mo'
-console.log(aString.substr(20, 2)); // ''
+console.log(string.substr(0, 1)); // 'M'
+console.log(string.substr(1, 0)); // ''
+console.log(string.substr(-1, 1)); // 'a'
+console.log(string.substr(1, -1)); // ''
+console.log(string.substr(-3)); // 'lla'
+console.log(string.substr(1)); // 'ozilla'
+console.log(string.substr(-20, 2)); // 'Mo'
+console.log(string.substr(20, 2)); // ''
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -77,19 +77,19 @@ const myIterator = {
 Such object is called an _iterable iterator_. Doing so allows an iterator to be consumed by the various syntaxes expecting iterables — therefore, it is seldom useful to implement the Iterator Protocol without also implementing Iterable. (In fact, almost all syntaxes and APIs expect _iterables_, not _iterators_.) The [generator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) is an example:
 
 ```js
-const aGeneratorObject = (function* () {
+const generatorObject = (function* () {
   yield 1;
   yield 2;
   yield 3;
 })();
 
-console.log(typeof aGeneratorObject.next);
+console.log(typeof generatorObject.next);
 // "function" — it has a next method (which returns the right result), so it's an iterator
 
-console.log(typeof aGeneratorObject[Symbol.iterator]);
+console.log(typeof generatorObject[Symbol.iterator]);
 // "function" — it has an [Symbol.iterator] method (which returns the right iterator), so it's an iterable
 
-console.log(aGeneratorObject[Symbol.iterator]() === aGeneratorObject);
+console.log(generatorObject[Symbol.iterator]() === generatorObject);
 // true — its [Symbol.iterator] method returns itself (an iterator), so it's an iterable iterator
 ```
 

--- a/files/en-us/web/xml/xpath/guides/snippets/index.md
+++ b/files/en-us/web/xml/xpath/guides/snippets/index.md
@@ -14,17 +14,17 @@ The following custom utility function can be used to evaluate XPath expressions 
 #### Example: Defining a custom node-specific `evaluateXPath()` utility function
 
 ```js
-// Evaluate an XPath expression aExpression against a given DOM node
-// or Document object (aNode), returning the results as an array
+// Evaluate an XPath expression `expr` against a given DOM node
+// or Document object `node`, returning the results as an array
 // thanks wanderingstan at morethanwarm dot mail dot com for the
 // initial work.
-function evaluateXPath(aNode, aExpr) {
+function evaluateXPath(node, expr) {
   const xpe = new XPathEvaluator();
   const nsResolver =
-    aNode.ownerDocument === null
-      ? aNode.documentElement
-      : aNode.ownerDocument.documentElement;
-  const result = xpe.evaluate(aExpr, aNode, nsResolver, 0, null);
+    node.ownerDocument === null
+      ? node.documentElement
+      : node.ownerDocument.documentElement;
+  const result = xpe.evaluate(expr, node, nsResolver, 0, null);
   const found = [];
   let res;
   while ((res = result.iterateNext())) found.push(res);


### PR DESCRIPTION
### Description

Remove redundant indefinite articles `a` from var/param/etc names (e.g. `aCar` -> `car`).

Mostly this is just grepping `\ba([A-Z])(\w{2,30}(?![+/=])\b)` and replacing with `\l$1$2`, with a few context-sensitive exceptions.

Excluded cases where the `a` had a clear purpose (e.g. `aElem` = an anchor element), as well as files under `mozilla/firefox/releases` (release notes) and `webgl*,webxr*` (I don't know if webgl has some convention around this or if the `a`s there had some significance).

### Motivation

Per linked issue

### Additional details

Bikeshedding — does MDN have a general style preference between `showDefaultUI` vs `showDefaultUi` style for camel-cased vars? The [writing guide](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Code_style_guide/JavaScript#variable_names) currently doesn't seem to mention it.

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/40794