### PR TITLE
chore(Fx142): tidy webkitdirectory page

### DIFF
--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -8,14 +8,13 @@ browser-compat: api.HTMLInputElement.webkitdirectory
 
 {{APIRef("File and Directory Entries API")}}
 
-The **`webkitdirectory`** property of the {{domxref("HTMLInputElement")}} interface reflects the [`webkitdirectory`](/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) HTML attribute, which indicates that [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) elements should let the user select directories instead of files.
+The **`webkitdirectory`** property of the {{domxref("HTMLInputElement")}} interface reflects the [`webkitdirectory`](/en-US/docs/Web/HTML/Reference/Elements/input/file#webkitdirectory) HTML attribute, which indicates that [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) elements can only select directories instead of files.
 
 When a directory is selected, the directory and its entire hierarchy of contents are included in the set of selected items.
 The selected file system entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} property.
 
 > [!NOTE]
 > This property is called `webkitdirectory` in the specification due to its origins as a Google Chrome-specific API.
-> It's likely to be renamed someday.
 
 ## Value
 
@@ -23,36 +22,29 @@ A Boolean; `true` if the {{HTMLElement("input")}} element should allow picking o
 
 ## Description
 
-Setting `webkitdirectory` true causes the input to offer users directories to select instead of files.
-
-After the user makes a selection, each {{domxref("File")}} object in `files` has its {{domxref("File.webkitRelativePath")}} property set to the relative path within the selected directory at which the file is located.
-
+Setting `webkitdirectory` to `true` causes the input element to offer directories for the user to select instead of files.
+After the user chooses a directory, each {{domxref("File")}} object in the returned `files` has its {{domxref("File.webkitRelativePath")}} property set to a path relative to the selected ancestor directory.
 For example, consider this file system:
 
-- PhotoAlbums
-  - Birthdays
-    - Jamie's 1st birthday
-      - PIC1000.jpg
-      - PIC1004.jpg
-      - PIC1044.jpg
+```plain
+PhotoAlbums
+├── Birthdays
+│   ├── Jamie's 1st birthday
+│   │   ├── PIC1000.jpg
+│   │   └── PIC1044.jpg
+│   └── Don's 40th birthday
+│       ├── PIC2343.jpg
+│       └── PIC2356.jpg
+└── Vacations
+    └── Mars
+        ├── PIC5556.jpg
+        ├── PIC5684.jpg
+        └── PIC5712.jpg
+```
 
-    - Don's 40th birthday
-      - PIC2343.jpg
-      - PIC2344.jpg
-      - PIC2355.jpg
-      - PIC2356.jpg
-
-  - Vacations
-    - Mars
-      - PIC5533.jpg
-      - PIC5534.jpg
-      - PIC5556.jpg
-      - PIC5684.jpg
-      - PIC5712.jpg
-
-If the user chooses `PhotoAlbums`, then the list reported by files will contain {{domxref("File")}} objects for every file listed above—but not the directories.
+If the user chooses the `PhotoAlbums` directory, the list reported by files will contain {{domxref("File")}} objects for every file.
 The entry for `PIC2343.jpg` will have a `webkitRelativePath` of `PhotoAlbums/Birthdays/Don's 40th birthday/PIC2343.jpg`.
-This makes it possible to know the hierarchy even though the {{domxref("FileList")}} is flat.
+This makes it possible to determine the selected directory's hierarchy even though the {{domxref("FileList")}} is flat.
 
 > [!NOTE]
 > The behavior of `webkitRelativePath` is different in _Chromium < 72_.
@@ -61,7 +53,7 @@ This makes it possible to know the hierarchy even though the {{domxref("FileList
 ## Examples
 
 In this example, a directory picker is presented which lets the user choose one or more directories.
-When the {{domxref("HTMLElement/change_event", "change")}} event occurs, a list of all files contained within the selected directory hierarchies is generated and displayed.
+When the {{domxref("HTMLElement/change_event", "change")}} event occurs, a list of all files contained within the selected directory hierarchies is created and displayed.
 
 ### HTML
 
@@ -89,7 +81,7 @@ document.getElementById("file-picker").addEventListener(
 
 ### Result
 
-{{ EmbedLiveSample('Examples') }}
+{{EmbedLiveSample('Examples')}}
 
 ## Specifications
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -577,7 +577,7 @@
       "properties": [
         "File.webkitRelativePath",
         "HTMLInputElement.webkitdirectory",
-        "HTMLinputElement.webkitEntries"
+        "HTMLInputElement.webkitEntries"
       ],
       "events": []
     },


### PR DESCRIPTION
### Description

A few minor improvements to the `webkitdirectory` page

### Motivation

Checking for any additional improvements I can make while working on release docs for this.

### Bugs

- [webkitRelativePath is always the empty string for webkitdirectory on Android](https://bugzil.la/1973726)

### Additional details

- [x] Parent issue https://github.com/mdn/content/issues/40511
- [x] Relnote https://github.com/mdn/content/pull/40796
