### PR TITLE
chore(jsondata): remove the prefix of {{js_property_attributes}} for zh-TW

### DIFF
--- a/files/jsondata/L10n-Template.json
+++ b/files/jsondata/L10n-Template.json
@@ -344,7 +344,8 @@
     "ko": "Property attributes of ",
     "pt-BR": "Property attributes of ",
     "ru": "Атрибуты свойства ",
-    "zh-CN": ""
+    "zh-CN": "",
+    "zh-TW": ""
   },
   "js_property_attributes_header_suffix": {
     "de": "",


### PR DESCRIPTION
### Description

The prefix is not necessary for zh-TW. Like Simplified Chinese, Traditional Chinese will put the translation of this prefix at the end (See Line 360).

### Motivation

The currrent display is not correct:

<img width="653" height="52" alt="image" src="https://github.com/user-attachments/assets/62d90c6d-3592-4dc7-b855-275283b49cc0" />

From: https://pr28342.review.mdn.allizom.net/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber

/cc @mdn/zh-content
