### PR TITLE
docs(Fx142): css ampersand in at-scope content and `:scope`

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -30,7 +30,7 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The [`&` selector](/en-US/docs/Web/CSS/Nesting_selector) inside {{cssxref("@scope")}} blocks no longer inherits the scope start
   selector's [specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity).
-  This makes the behavior of `&` selectors in `@scope` consistent with [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) without adding unexpected specificity (see [CSS nesting and specificity](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity)).
+  This makes `&` selectors in `@scope` consistent with [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting), avoiding unexpected specificity (see [CSS nesting and specificity](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity)).
   ([Firefox bug 1975531](https://bugzil.la/1975531)).
 
 <!-- #### Removals -->

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -26,9 +26,12 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{HTMLElement('object')}} element no longer supports the deprecated `codebase` attribute. Use the [`data`](/en-US/docs/Web/HTML/Reference/Elements/object#data) attribute instead. (See [Firefox bug 1973900](https://bugzil.la/1973900) for more details.)
 
-<!-- ### CSS -->
+### CSS
 
-<!-- No notable changes. -->
+- The [`&` selector](/en-US/docs/Web/CSS/Nesting_selector) inside {{cssxref("@scope")}} blocks no longer inherits the scope start
+  selector's [specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity).
+  This makes the behavior of `&` selectors in `@scope` consistent with [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) without adding unexpected specificity (see [CSS nesting and specificity](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity)).
+  ([Firefox bug 1975531](https://bugzil.la/1975531)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -26,12 +26,9 @@ Firefox 142 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{HTMLElement('object')}} element no longer supports the deprecated `codebase` attribute. Use the [`data`](/en-US/docs/Web/HTML/Reference/Elements/object#data) attribute instead. (See [Firefox bug 1973900](https://bugzil.la/1973900) for more details.)
 
-### CSS
+<!-- ### CSS -->
 
-- The [`&` selector](/en-US/docs/Web/CSS/Nesting_selector) inside {{cssxref("@scope")}} blocks no longer inherits the scope start
-  selector's [specificity](/en-US/docs/Web/CSS/CSS_cascade/Specificity).
-  This makes `&` selectors in `@scope` consistent with [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting), avoiding unexpected specificity (see [CSS nesting and specificity](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity)).
-  ([Firefox bug 1975531](https://bugzil.la/1975531)).
+<!-- No notable changes. -->
 
 <!-- #### Removals -->
 

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -199,8 +199,7 @@ Because [`:where()`](/en-US/docs/Web/CSS/:where) has zero specificity, the only 
 }
 ```
 
-By contrast, using `:scope` explicitly selects the scope root with class specificity.
-Like other pseudo-classes, `:scope` has a specificity of `0-1-0`.
+By contrast, using `:scope` explicitly selects the scope root and adds class-level specificity (`0-1-0`), since `:scope` is a pseudo-class.
 In the following example, `:scope img` has a specificity of `0-1-1`:
 
 ```css

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -115,9 +115,9 @@ Or you could include your `@scope` block inline inside a `<style>` element, whic
 > [!NOTE]
 > It is important to understand that, while `@scope` allows you to isolate the application of selectors to specific DOM subtrees, it does not completely isolate the applied styles to within those subtrees. This is most noticeable with inheritance — properties that are inherited by children (for example {{cssxref("color")}} or {{cssxref("font-family")}}) will still be inherited, beyond any set scope limit.
 
-### The `:scope` pseudo-class
+### `:scope` pseudo-class within `@scope` blocks
 
-In the context of a `@scope` block, the {{cssxref(":scope")}} pseudo-class represents the scope root — it provides an easy way to apply styles to the scope root itself, from inside the scope:
+In the context of an `@scope` block, the {{cssxref(":scope")}} pseudo-class provides a convenient way to directly apply styles to the scope root, like so:
 
 ```css
 @scope (.feature) {
@@ -129,25 +129,9 @@ In the context of a `@scope` block, the {{cssxref(":scope")}} pseudo-class repre
 }
 ```
 
-In the following code snippet, the three rules select the same element, but differ in specificity (see [Specificity in @scope](#specificity_in_scope) for details):
+Here's some considerations for `:scope` within `@scope` blocks:
 
-```css
-@scope (.feature) {
-  img {
-    /* … */
-  }
-
-  & img {
-    /* … */
-  }
-
-  :scope img {
-    /* … */
-  }
-}
-```
-
-### Notes on scoped selector usage
+- `:scope` adds class-level specificity (see [Specificity in @scope](#specificity_in_scope) for details).
 
 - A scope limit can use `:scope` to specify a specific relationship requirement between the scope limit and root. For example:
 
@@ -182,8 +166,11 @@ In the following code snippet, the three rules select the same element, but diff
 
 ### Specificity in `@scope`
 
-Inside an `@scope` rule, both bare selectors and `&` are treated as if `:where(:scope)` were prepended, meaning they select the scope root with zero specificity.
-Because [`:where()`](/en-US/docs/Web/CSS/:where) has zero specificity, the only specificity comes from `img` (`0-0-1`).
+Inside an `@scope` rule, both bare selectors and `&` behave as if `:where(:scope)` were prepended to the selector.
+Because [`:where()`](/en-US/docs/Web/CSS/:where) has zero specificity, bare selectors and `&` add zero weight and only the specificity of the rest of the selector counts.
+An `& img` selector is the equivalent to writing `:where(:scope) img`.
+
+In both cases in the following example, the only specificity comes from `img` (`0-0-1`):
 
 ```css
 @scope (.article-body) {

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -193,9 +193,9 @@ Including a ruleset inside a `@scope` block does not affect the specificity of i
 }
 ```
 
-When using the `&` selector inside a `@scope` block, `&` represents the implicit context (calculated as `:where(:scope)`) which has zero specificity.
-In the following example, `& img` is essentially equivalent to `:where(:scope) img`.
-Because `:where()` always has zero specificity, the only specificity comes from `img` (i.e., 0-0-1):
+The `&` nesting selector, when prepended to a selector inside an `@scope` block, represents the implicit scope context (`:where(:scope)`), which has zero specificity.
+In the following example, `& img` is equivalent to writing `:where(:scope) img`.
+Because [`:where()`](/en-US/docs/Web/CSS/:where) has zero specificity, the only specificity comes from `img` (`0-0-1`).
 
 ```css
 @scope (figure, #primary) {

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -206,7 +206,7 @@ Because `:where()` always has zero specificity, the only specificity comes from 
 }
 ```
 
-However, if you decide to explicitly prepend the `:scope` pseudo-class to your scoped selectors, you'll need to factor it in when calculating their specificity. `:scope`, like all regular pseudo-classes, has a specificity of 0-1-0. For example:
+If you explicitly prepend the `:scope` pseudo-class to the selectors inside the `@scope` block, you need to factor in its specificity. Like other pseudo-classes, `:scope` has a specificity of `0-1-0`. In the following example, `:scope img` has a specificity of `0-1-1`:
 
 ```css
 @scope (.article-body) {

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -137,11 +137,11 @@ In the following code snippet, the three rules select the same element, but diff
     /* … */
   }
 
-  :scope img {
+  & img {
     /* … */
   }
 
-  & img {
+  :scope img {
     /* … */
   }
 }
@@ -182,7 +182,8 @@ In the following code snippet, the three rules select the same element, but diff
 
 ### Specificity in `@scope`
 
-Including a ruleset inside a `@scope` block does not affect the specificity of its selector, regardless of the selectors used inside the scope root and limit. For example:
+Inside an `@scope` rule, both bare selectors and `&` are treated as if `:where(:scope)` were prepended, meaning they select the scope root with zero specificity.
+Because [`:where()`](/en-US/docs/Web/CSS/:where) has zero specificity, the only specificity comes from `img` (`0-0-1`).
 
 ```css
 @scope (.article-body) {
@@ -190,45 +191,21 @@ Including a ruleset inside a `@scope` block does not affect the specificity of i
   img {
     /* … */
   }
-}
-```
 
-The `&` nesting selector, when prepended to a selector inside an `@scope` block, represents the implicit scope context (`:where(:scope)`), which has zero specificity.
-In the following example, `& img` is equivalent to writing `:where(:scope) img`.
-Because [`:where()`](/en-US/docs/Web/CSS/:where) has zero specificity, the only specificity comes from `img` (`0-0-1`).
-
-```css
-@scope (figure, #primary) {
+  /* & img also has a specificity of 0-0-1 */
   & img {
     /* … */
   }
 }
 ```
 
-If you explicitly prepend the `:scope` pseudo-class to the selectors inside the `@scope` block, you need to factor in its specificity. Like other pseudo-classes, `:scope` has a specificity of `0-1-0`. In the following example, `:scope img` has a specificity of `0-1-1`:
+By contrast, using `:scope` explicitly selects the scope root with class specificity.
+Like other pseudo-classes, `:scope` has a specificity of `0-1-0`.
+In the following example, `:scope img` has a specificity of `0-1-1`:
 
 ```css
 @scope (.article-body) {
   /* :scope img has a specificity of 0-1-0 + 0-0-1 = 0-1-1 */
-  :scope img {
-    /* … */
-  }
-}
-```
-
-### The difference between `:scope` and `&` inside `@scope`
-
-Inside an `@scope` rule, both bare selectors and `&` are treated as if `:where(:scope)` were prepended, meaning they select the scope root with zero specificity.
-By contrast, using `:scope` explicitly selects the scope root with class specificity.
-
-```css
-@scope (.feature) {
-  /* Selects any <img> inside the scope root, with zero specificity */
-  & img {
-    /* … */
-  }
-
-  /* Same selection, but adds specificity 0-1-0 */
   :scope img {
     /* … */
   }

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -129,9 +129,8 @@ In the context of a `@scope` block, the {{cssxref(":scope")}} pseudo-class repre
 }
 ```
 
-In fact, `:scope` is implicitly prepended to all scoped style rules. If you want, you can explicitly prepend `:scope` or prepend the [nesting](/en-US/docs/Web/CSS/CSS_nesting) selector (`&`) to get the same effect if you find these representations easier to understand.
-
-The three rules in the following block are all equivalent in what they select:
+If you want, you can explicitly prepend `:scope` or prepend the [nesting](/en-US/docs/Web/CSS/CSS_nesting) selector (`&`) to get the same effect if you find these representations easier to understand.
+The three rules in the following block are equivalent in what they select, but note that they differ in specificity, see [Specificity in @scope](#specificity_in_scope) for details:
 
 ```css
 @scope (.feature) {
@@ -195,6 +194,18 @@ Including a ruleset inside a `@scope` block does not affect the specificity of i
 }
 ```
 
+When using the `&` selector inside a `@scope` block, `&` represents the implicit context (calculated as `:where(:scope)`) which has zero specificity.
+In the following example, `& img` is essentially equivalent to `:where(:scope) img`.
+Because `:where()` always has zero specificity, the only specificity comes from `img` (i.e., 0-0-1):
+
+```css
+@scope (figure, #primary) {
+  & img {
+    /* … */
+  }
+}
+```
+
 However, if you decide to explicitly prepend the `:scope` pseudo-class to your scoped selectors, you'll need to factor it in when calculating their specificity. `:scope`, like all regular pseudo-classes, has a specificity of 0-1-0. For example:
 
 ```css
@@ -206,31 +217,20 @@ However, if you decide to explicitly prepend the `:scope` pseudo-class to your s
 }
 ```
 
-When using the `&` selector inside a `@scope` block, `&` represents the scope root selector; it is internally calculated as that selector wrapped inside an {{cssxref(":is", ":is()")}} pseudo-class function. So for example, in:
-
-```css
-@scope (figure, #primary) {
-  & img {
-    /* … */
-  }
-}
-```
-
-`& img` is equivalent to `:is(figure, #primary) img`. Since `:is()` takes the specificity of its most specific argument (`#primary`, in this case), the specificity of the scoped `& img` selector is therefore 1-0-0 + 0-0-1 = 1-0-1.
-
 ### The difference between `:scope` and `&` inside `@scope`
 
-`:scope` represents the matched scope root, whereas `&` represents the selector used to match the scope root. Because of this, it is possible to chain `&` multiple times. However, you can only use `:scope` once — you can't match a scope root inside a scope root.
+Inside an `@scope` rule, both bare selectors and `&` are treated as if `:where(:scope)` were prepended, meaning they select the scope root with zero specificity.
+By contrast, using `:scope` explicitly selects the scope root with class specificity.
 
 ```css
 @scope (.feature) {
-  /* Selects a .feature inside the matched root .feature */
-  & & {
+  /* Selects any <img> inside the scope root, with zero specificity */
+  & img {
     /* … */
   }
 
-  /* Doesn't work */
-  :scope :scope {
+  /* Same selection, but adds specificity 0-1-0 */
+  :scope img {
     /* … */
   }
 }
@@ -370,7 +370,7 @@ div {
 
 The above code renders like this:
 
-{{ EmbedLiveSample("Basic style inside scope roots", "100%", "150") }}
+{{EmbedLiveSample("Basic style inside scope roots", "100%", "150")}}
 
 ### Scope roots and scope limits
 
@@ -481,7 +481,7 @@ In our CSS, we have two `@scope` blocks:
 
 In the rendered code, note how all of the `<img>` elements are styled with the thick border and golden background, except for the one inside the `<figure>` element (labeled "My infographic").
 
-{{ EmbedLiveSample("Scope roots and scope limits", "100%", "400") }}
+{{EmbedLiveSample("Scope roots and scope limits", "100%", "400")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -129,7 +129,6 @@ In the context of a `@scope` block, the {{cssxref(":scope")}} pseudo-class repre
 }
 ```
 
-If you want, you can explicitly prepend `:scope` or prepend the [nesting](/en-US/docs/Web/CSS/CSS_nesting) selector (`&`) to get the same effect if you find these representations easier to understand.
 In the following code snippet, the three rules select the same element, but differ in specificity (see [Specificity in @scope](#specificity_in_scope) for details):
 
 ```css

--- a/files/en-us/web/css/@scope/index.md
+++ b/files/en-us/web/css/@scope/index.md
@@ -130,7 +130,7 @@ In the context of a `@scope` block, the {{cssxref(":scope")}} pseudo-class repre
 ```
 
 If you want, you can explicitly prepend `:scope` or prepend the [nesting](/en-US/docs/Web/CSS/CSS_nesting) selector (`&`) to get the same effect if you find these representations easier to understand.
-The three rules in the following block are equivalent in what they select, but note that they differ in specificity, see [Specificity in @scope](#specificity_in_scope) for details:
+In the following code snippet, the three rules select the same element, but differ in specificity (see [Specificity in @scope](#specificity_in_scope) for details):
 
 ```css
 @scope (.feature) {


### PR DESCRIPTION
### Description

Using `&` inside `@scope` changes according to spec updates (and relation to `:scope`).

This makes `& &` redundant as far as I can see. The explainer has good context and I hope I've conveyed that in these changes.

**Explainer:** https://css.oddbird.net/scope/parent-selector/

### Bugs

- [Change `&` behaviour inside `@scope` block as per spec resolution](https://bugzilla.mozilla.org/show_bug.cgi?id=1975531)

### Additional details

- [ ] Parent issue https://github.com/mdn/content/issues/40481
- [x] relnote https://github.com/mdn/content/pull/40809



