### PR TITLE
More fixes for socket stream close documentation

### DIFF
--- a/files/en-us/web/api/websocketstream/close/index.md
+++ b/files/en-us/web/api/websocketstream/close/index.md
@@ -13,8 +13,6 @@ browser-compat: api.WebSocketStream.close
 The **`close()`** method of the
 {{domxref("WebSocketStream")}} interface closes the WebSocket connection. The method optionally accepts an object containing a custom code and/or reason indicating why the connection was closed.
 
-An alternative mechanism for closing a `WebSocketStream` is to specify an {{domxref("AbortSignal")}} in the [`signal`](/en-US/docs/Web/API/WebSocketStream/WebSocketStream#signal) option of the constructor upon creation. The associated {{domxref("AbortController")}} can then be used to close the WebSocket connection. This is generally the preferred mechanism. However, `close()` can be used if you wish to specify a custom code and/or reason.
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/websocketstream/websocketstream/index.md
+++ b/files/en-us/web/api/websocketstream/websocketstream/index.md
@@ -31,7 +31,6 @@ new WebSocketStream(url, options)
     - `signal` {{optional_inline}}
       - : An {{domxref("AbortSignal")}}, which can be used to abort the connection before the [handshake](/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#the_websocket_handshake) has completed (that is, before the {{domxref("WebSocketStream.opened", "opened")}} promise resolves). This is primarily intended to help implement connection timeouts. As such, it does nothing after the connection is established.
 
-
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
@@ -39,35 +38,35 @@ new WebSocketStream(url, options)
 
 ## Examples
 
+### Creating a `WebSocketStream`
+
 The most basic example takes the URL of a WebSocket server as an argument:
 
 ```js
 const wss = new WebSocketStream("wss://example.com/wss");
 ```
 
-A more advanced example could also include an options object containing custom protocols and/or an {{domxref("AbortSignal")}}. The following example will time out if the connection is not established within 5 seconds:
+### Creating a `WebSocketStream` with a connection timeout
+
+The following example uses the `signal` option to implement a timeout if the connection is not established within 5 seconds:
 
 ```js
 const queueWSS = new WebSocketStream("wss://example.com/queue", {
-  protocols: ["amqp", "mqtt"],
   signal: AbortSignal.timeout(5000),
 });
 ```
 
-If you're connecting to localhost, it's likely to succeed or fail almost instantly, so this will have no effect.
+Note that if you're connecting to localhost, it's likely to succeed or fail before the connection attempt times out.
 
-You can use the {{domxref("WebSocketStream.close()")}} method to close a connection.
-
-`WritableStream.close()` and `WritableStreamDefaultWriter.close()` from the `writable` of the fulfilled `opened` `Promise` also closes the connection.
+Once the connection is established, `signal` has no effect: to close a connection that's already established, call the {{domxref("WebSocketStream.close()")}} method. Closing the underlying {{domxref("WritableStream")}} or {{domxref("WritableStreamDefaultWriter")}} also closes the socket.
 
 See [Using WebSocketStream to write a client](/en-US/docs/Web/API/WebSockets_API/Using_WebSocketStream) for a complete example with full explanation.
 
 ## Specifications
 
-Not currently a part of any specification. See https://github.com/whatwg/websockets/pull/48 for standardization progress. 
+Not currently a part of any specification. See https://github.com/whatwg/websockets/pull/48 for standardization progress.
 
 [WebSocketStream API design](https://docs.google.com/document/d/1La1ehXw76HP6n1uUeks-WJGFgAnpX2tCjKts7QFJ57Y/edit?pli=1&tab=t.0).
-
 
 ## Browser compatibility
 


### PR DESCRIPTION
Follow-up to https://github.com/mdn/content/pull/40782 and https://github.com/mdn/content/pull/40789.

Main point being that you _can't_ use the `signal` option to close an already-established connection, you can only use it to cancel a connection attempt before it has been established.

cc @tomayac .

This PR:
- updates the guide page at https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Using_WebSocketStream to give correct info about usage of `signal` and how to close a connection. 
- adds some subheadings to the examples in https://developer.mozilla.org/en-US/docs/Web/API/WebSocketStream/WebSocketStream#examples, to make the structure clearer, and provides a bit of context for the stuff about closing a connection.