### PR TITLE
Docs: Clarify that javascript: URLs throw a TypeError

### DIFF
--- a/files/en-us/web/api/navigation/navigate/index.md
+++ b/files/en-us/web/api/navigation/navigate/index.md
@@ -57,7 +57,8 @@ Either one of these promises rejects if the navigation has failed for some reaso
   - : Thrown if the `history` option is set to `push`, and any of the following special circumstances are true:
     - The browser is currently showing the initial `about:blank` document.
     - The `url`'s scheme is `javascript`.
-
+- `TypeError`
+  - : Thrown if the URL specified is a `javascript:` URL. For security reasons, this API explicitly disallows `javascript:` URLs.
 ## Examples
 
 ### Set up home button


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Description
This PR updates the Exceptions section for the navigation.navigate() method to accurately reflect that using javascript: URLs throws a TypeError. It also removes an outdated and contradictory reference to javascript: schemes under NotSupportedError.

Motivation
The current documentation is ambiguous regarding the handling of javascript: URLs, leading to potential confusion for developers. The WHATWG HTML specification clearly states that navigation.navigate() must throw a TypeError when a javascript: URL is provided, primarily for security reasons.

This change aligns the documentation with the official specification, ensuring developers have clear, accurate, and up-to-date information.

Additional details
This change is based on the decision and specification details discussed in the WHATWG HTML repository.

WHATWG HTML Issue: [https://github.com/whatwg/html/issues/11533](https://github.com/whatwg/html/pull/11533)


### Related issues and pull requests

Related issues and pull requests
#40806