### PR TITLE
Clarify auto-generation of background service worker in Safari

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -185,7 +185,9 @@ Support for the `scripts`, `page`, and `service_worker` properties varies betwee
   - `background.service_worker` is not supported (see [Firefox bug 1573659](https://bugzil.la/1573659)).
   - supports `background.scripts` (or `background.page`) if `service_worker` is not specified or the service worker feature is disabled. Before Firefox 120, Firefox did not start the background page if `service_worker` was present (see [Firefox bug 1860304](https://bugzil.la/1860304)). From Firefox 121, the background page starts as expected, regardless of the presence of `service_worker`.
 - Safari:
-  - supports `background.scripts` (or `background.page`) and `background.service_worker`. If both are specified, uses `background.scripts` (or `background.page`), unless `preferred_environment` is set to `service_worker`.
+  - supports `background.scripts` (or `background.page`) and `background.service_worker`. 
+  - when both are specified, Safari uses `background.scripts` (or `background.page`) unless `preferred_environment` is set to `service_worker`.
+  - when `preferred_environment` is set to `service_worker` and `background.service_worker` isn't specified, Safari generates a service worker from `background.scripts` if present.
 
 To illustrate, this is an example of a cross-browser extension that supports `scripts` and `service_worker`. The example has this manifest.json file:
 


### PR DESCRIPTION
### Description
This PR addresses the feedback originally posted by @carlosjeurissen in https://github.com/mdn/browser-compat-data/issues/25808#issuecomment-2627793381

> @rebloor can we add a note stating Firefox does not support generating a `service_worker` based in the `scripts` key? This is something currently only supported by Apple.

#### Related issues

- #25808
- [Bugzilla 1930334: Implement background.preferred_environment](https://bugzilla.mozilla.org/show_bug.cgi?id=1930334)
- Supersede  https://github.com/mdn/browser-compat-data/pull/26164#top
