### PR TITLE
correction of a code-example property, use `prefix` instead of `namespaceURI`

### DIFF
--- a/files/en-us/web/api/cssnamespacerule/prefix/index.md
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.md
@@ -25,8 +25,8 @@ The stylesheet includes two namespace rules. The first has no prefix the second 
 
 ```js
 let myRules = document.styleSheets[0].cssRules;
-console.log(myRules[0].namespaceURI); // an empty string ""
-console.log(myRules[1].namespaceURI); // "svg"
+console.log(myRules[0].prefix); // an empty string ""
+console.log(myRules[1].prefix); // "svg"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Correction of a code-example property. The property `prefix` should have been used instead of `namespaceURI`. 

### Motivation

I think it was a plain copy/paste mistake

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
