### PR TITLE
ci(pr-check-lint_content): fix typo in env variable

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -47,7 +47,7 @@ jobs:
           echo "${EOF}" >> "$GITHUB_OUTPUT"
 
           # Also set a simple flag for whether we have files
-          if [ -n "${FILTERED_MD_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+          if [ -n "${FILTERED_FILES// /}" ]; then  # Remove all spaces and check if anything remains
             echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
           else
             echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌

Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information. -->

### Description

Fixes a typo in an environment variable.

### Motivation

This caused the the workflow to always skip linting, as if there were no files to lint.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
