### PR TITLE
Add enterprise-focused guidance note for storage.managed API

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -8,6 +8,9 @@ sidebar: addonsidebar
 
 A {{WebExtAPIRef("storage.StorageArea")}} object that represents the `managed` storage area. Items in `managed` storage are set by the domain administrator or other native applications installed on the user's computer and are read-only for the extension. Trying to modify this storage area results in an error.
 
+> [!NOTE]
+> Enterprise intent: Managed storage is provisioned and controlled by administrators (for example via a managed storage native manifest or the Firefox Enterprise Policy [`3rdparty`](https://mozilla.github.io/policy-templates/#3rdparty) policy) and is read-only to extensions and end users. Extensions should treat managed values as authoritative configuration provided by the administrator and may fall back to other storage (for example {{WebExtAPIRef("storage.local")}}) only when a managed key is absent. To change managed values, administrators must update the native manifest or enterprise policy. See the [Enterprise Policy templates](https://mozilla.github.io/policy-templates/) for details.
+
 ## Provisioning managed storage
 
 The procedure for provisioning managed storage varies between browsers. For Chrome instructions, see the ["Manifest for storage areas"](https://developer.chrome.com/docs/extensions/reference/manifest/storage) article.


### PR DESCRIPTION
### Description

Adds enterprise focused guidance note to the storage.managed API documentation clarifying administrative control and proper extension behavior patterns.


### Motivation

Resolves widespread confusion about enterprise policy implementation in WebExtensions. Many developers incorrectly assume managed storage should be user-editable, leading to   disagreements and improper implementations. This note provides authoritative guidance that managed storage is administrator-controlled and read-only, helping developers build compliant enterprise extensions.

### Additional details

 - References Mozilla's Enterprise Policy templates: https://mozilla.github.io/policy-templates/
  - Aligns with Firefox Enterprise Policy `3rdparty` documentation
  - Provides clear fallback patterns for extensions when managed keys are absent
  - Establishes that administrators control changes through native manifests or enterprise policies

### Related issues and pull requests

Fixes #40018
