### PR TITLE
Editorial review: Document RTCEncodedAudioFrame.getMetadata() audioLevel return property

### DIFF
--- a/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
@@ -27,7 +27,7 @@ None.
 An object with the following properties:
 
 - `audioLevel`
-  - : A number representing the audio level of this frame. The value is between 0 and 1 inclusive (linear), where 1 represents 0 dBov, 0 represents silence, and 0.5 represents approximately 6 dBSPL change in the sound pressure level from 0 dBov. The value is converted from the -127 to 0 range specified in [RFC6464](https://www.rfc-editor.org/rfc/rfc6464) via the equation `10^(-rfc_level/20)`. If the RFC6464 header extension is not present in the received packets of the frame, `audioLevel` will be `undefined`.
+  - : A number representing the audio level of this frame. The value is between 0 and 1 inclusive (linear), where 1.0 represents 0 dBov ([decibels relative to full scale (DBFS)](https://en.wikipedia.org/wiki/DBFS)), 0 represents silence, and 0.5 represents approximately 6 dB SPL change in the [sound pressure level](https://en.wikipedia.org/wiki/Sound_pressure#Sound_pressure_level) from 0 dBov. The value is converted from the -127 to 0 range specified in [RFC6464](https://www.rfc-editor.org/rfc/rfc6464) via the equation `10^(-rfc_level/20)`. If the RFC6464 header extension is not present in the received packets of the frame, `audioLevel` will be `undefined`.
 - `synchronizationSource`
   - : A positive integer value indicating synchronization source ("ssrc") of the stream of RTP packets that are described by this frame.
     A source might be something like a microphone, or a mixer application that combines multiple sources.

--- a/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
@@ -26,6 +26,8 @@ None.
 
 An object with the following properties:
 
+- `audioLevel`
+  - : A number representing the audio level of this frame. The value is between 0 and 1 inclusive (linear), where 1 represents 0 dBov, 0 represents silence, and 0.5 represents approximately 6 dBSPL change in the sound pressure level from 0 dBov. The value is converted from the -127 to 0 range specified in [RFC6464](https://www.rfc-editor.org/rfc/rfc6464) via the equation `10^(-rfc_level/20)`. If the RFC6464 header extension is not present in the received packets of the frame, `audioLevel` will be `undefined`.
 - `synchronizationSource`
   - : A positive integer value indicating synchronization source ("ssrc") of the stream of RTP packets that are described by this frame.
     A source might be something like a microphone, or a mixer application that combines multiple sources.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 139 updates the [`RTCEncodedAudioFrame.getMetadata()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCEncodedAudioFrame/getMetadata) method so that the [`audioLevel`](https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframemetadata-audiolevel) property is available in its return object. See https://chromestatus.com/feature/5206106602995712.

This PR adds content for this new return property.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
