### PR TITLE
Bug-1960011 filter tabs.onUpdated results by cookieStoreId

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -39,7 +39,6 @@ Events have three functions:
 ### Parameters
 
 - `listener`
-
   - : The function called when this event occurs. The function is passed these arguments:
     - `tabId`
       - : `integer`. The ID of the updated tab.
@@ -49,15 +48,11 @@ Events have three functions:
       - : {{WebExtAPIRef('tabs.Tab')}}. The new state of the tab.
 
 - `filter` {{optional_inline}}
-
   - : `object`. A set of filters that restrict the events sent to this listener. This object can have one or more of these properties. Events are only sent if they satisfy all the filters provided.
-
     - `urls`
       - : `Array`. An array of [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). Fires the event only for tabs whose current `url` property matches any one of the patterns.
     - `properties`
-
       - : `Array`. An array of strings consisting of supported {{WebExtAPIRef("tabs.Tab")}} object property names. Fires the event only for changes to one of the properties named in the array. These properties can be used:
-
         - "attention"
         - "autoDiscardable"
         - "audible"

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -39,6 +39,7 @@ Events have three functions:
 ### Parameters
 
 - `listener`
+
   - : The function called when this event occurs. The function is passed these arguments:
     - `tabId`
       - : `integer`. The ID of the updated tab.
@@ -48,11 +49,15 @@ Events have three functions:
       - : {{WebExtAPIRef('tabs.Tab')}}. The new state of the tab.
 
 - `filter` {{optional_inline}}
+
   - : `object`. A set of filters that restrict the events sent to this listener. This object can have one or more of these properties. Events are only sent if they satisfy all the filters provided.
+
     - `urls`
       - : `Array`. An array of [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). Fires the event only for tabs whose current `url` property matches any one of the patterns.
     - `properties`
+
       - : `Array`. An array of strings consisting of supported {{WebExtAPIRef("tabs.Tab")}} object property names. Fires the event only for changes to one of the properties named in the array. These properties can be used:
+
         - "attention"
         - "autoDiscardable"
         - "audible"
@@ -75,6 +80,8 @@ Events have three functions:
       - : `Integer`. Fires this event only for the tab identified by this ID.
     - `windowId`
       - : `Integer`. Fires this event only for tabs in the window identified by this ID.
+    - `cookieStoreId`
+      - : `Integer`. Fires this event only for tabs in the cookie store identified by this ID.
 
 ## Additional objects
 

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -71,6 +71,7 @@ Firefox 141 was released on [July 22, 2025](https://whattrainisitnow.com/release
 ## Changes for add-on developers
 
 - Adds the {{WebExtAPIRef('i18n.getPreferredSystemLanguages')}} method to retrieve the preferred locales of the operating system. This complements {{WebExtAPIRef('i18n.getAcceptLanguages')}}, which returns details of the locales set in the browser. ([Firefox bug 1888486](https://bugzil.la/1888486))
+- Adds the ability to filter results in {{WebExtAPIRef('tabs.onUpdated')}} by cookie store ID. ([Firefox bug 1960011](https://bugzil.la/1960011))
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Documents that change is made in [Bug 1960011](https://bugzilla.mozilla.org/show_bug.cgi?id=1960011) Filter tabs.onUpdated events by cookieStoreId including a release note and update to the API documentation.

### Related issues and pull requests

Related BCD changes in https://github.com/mdn/browser-compat-data/pull/27643.