### PR TITLE
Update HTMLLabelElement 'form' property

### DIFF
--- a/files/en-us/web/api/htmllabelelement/form/index.md
+++ b/files/en-us/web/api/htmllabelelement/form/index.md
@@ -8,12 +8,9 @@ browser-compat: api.HTMLLabelElement.form
 
 {{APIRef("HTML DOM")}}
 
-The **`form`** read-only property of the {{domxref("HTMLLabelElement")}} interface returns an {{domxref("HTMLFormElement")}} object that owns the {{domxref("HTMLLabelElement.control", "control")}} associated with this {{HTMLElement("label")}}, or `null` if this label is not associated with a listed form-associated element, either a {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("object")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}}, that is owned by a form.
+The **`form`** read-only property of the {{domxref("HTMLLabelElement")}} interface returns an {{domxref("HTMLFormElement")}} object that owns the {{domxref("HTMLLabelElement.control", "control")}} associated with this {{HTMLElement("label")}}, or `null` if this label is not associated with a [labelable](/en-US/docs/Web/HTML/Guides/Content_categories#labelable) [form-associated](/en-US/docs/Web/HTML/Guides/Content_categories#form-associated_content) element ({{htmlelement("button")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, {{htmlelement("textarea")}}, or [form-associated custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-element)) that is owned by a form.
 
-This property is just a shortcut for `label.control.form`.
-
-> [!NOTE]
-> The `form` property on the `<label>` element is different from the `form` property on [listed form-associated elements](/en-US/docs/Web/HTML/Reference/Attributes/form#usage) as the `<label>` element does not have a [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute.
+Unlike [form-associated elements](/en-US/docs/Web/HTML/Guides/Content_categories#form-associated_content), the `<label>` element does not have a [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute. This property does not reflect any HTML attribute, but is just a shortcut for `label.control.form`.
 
 ## Value
 

--- a/files/en-us/web/api/htmllabelelement/form/index.md
+++ b/files/en-us/web/api/htmllabelelement/form/index.md
@@ -8,12 +8,12 @@ browser-compat: api.HTMLLabelElement.form
 
 {{APIRef("HTML DOM")}}
 
-The **`form`** read-only property of the {{domxref("HTMLLabelElement")}} interface returns an {{domxref("HTMLFormElement")}} object that owns the {{domxref("HTMLLabelElement.control", "control")}} associated with this {{HTMLElement("label")}}, or `null` if this label is not associated with listed form-associated element, either a {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("object")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}}, that is owned by a form.
+The **`form`** read-only property of the {{domxref("HTMLLabelElement")}} interface returns an {{domxref("HTMLFormElement")}} object that owns the {{domxref("HTMLLabelElement.control", "control")}} associated with this {{HTMLElement("label")}}, or `null` if this label is not associated with a listed form-associated element, either a {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("object")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}}, that is owned by a form.
 
 This property is just a shortcut for `label.control.form`.
 
 > [!NOTE]
-> The `form` property on the `<label>` element is different from the `form` property on listed form-associated elements and the `<label>` element does not have a [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute.
+> The `form` property on the `<label>` element is different from the `form` property on [listed form-associated elements](/en-US/docs/Web/HTML/Reference/Attributes/form#usage) as the `<label>` element does not have a [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute.
 
 ## Value
 

--- a/files/en-us/web/api/htmllabelelement/form/index.md
+++ b/files/en-us/web/api/htmllabelelement/form/index.md
@@ -8,9 +8,12 @@ browser-compat: api.HTMLLabelElement.form
 
 {{APIRef("HTML DOM")}}
 
-The **`form`** read-only property of the {{domxref("HTMLLabelElement")}} interface returns an {{domxref("HTMLFormElement")}} object that owns the {{domxref("HTMLLabelElement.control", "control")}} associated with this {{HTMLElement("label")}}, or `null` if this label is not associated with a control owned by a form.
+The **`form`** read-only property of the {{domxref("HTMLLabelElement")}} interface returns an {{domxref("HTMLFormElement")}} object that owns the {{domxref("HTMLLabelElement.control", "control")}} associated with this {{HTMLElement("label")}}, or `null` if this label is not associated with listed form-associated element, either a {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("object")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}}, that is owned by a form.
 
 This property is just a shortcut for `label.control.form`.
+
+> [!NOTE]
+> The `form` property on the `<label>` element is different from the `form` property on listed form-associated elements and the `<label>` element does not have a [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute.
 
 ## Value
 


### PR DESCRIPTION
Clarified the definition of the 'form' property to include all form-associated elements which is different from "all form controls", so should be enumerated.
