### PR TITLE
Fix formatting of valid duration string microsyntax

### DIFF
--- a/files/en-us/web/html/reference/elements/time/index.md
+++ b/files/en-us/web/html/reference/elements/time/index.md
@@ -151,7 +151,7 @@ The _datetime value_ (the machine-readable value of the datetime) is the value o
       <td>Valid duration string</td>
       <td>
         <code>P<em>d</em>DT<em>h</em>H<em>m</em>M<em>s</em>S</code><br />
-        <code>P<em>d</em>DT<em>h</em>H<em>m</em>M<em>s</em>.<em>X</em>S<br />
+        <code>P<em>d</em>DT<em>h</em>H<em>m</em>M<em>s</em>.<em>X</em>S</code><br />
         <code>P<em>d</em>DT<em>h</em>H<em>m</em>M<em>s</em>.<em>XX</em>S</code><br />
         <code>P<em>d</em>DT<em>h</em>H<em>m</em>M<em>s</em>.<em>XXX</em>S</code><br />
         <code>PT<em>h</em>H<em>m</em>M<em>s</em>S</code><br />


### PR DESCRIPTION
### Description

This PR fixes formatting errors in the **Valid duration string** microsyntaxes on the `<time>` element reference page https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time .

### Motivation

The existing microsyntaxes contained formatting mistakes (extra spaces, inconsistent code markup), which could confuse readers. Correcting these helps ensure developers use valid ISO 8601 durations when working with the `datetime` attribute.

### Additional details

The closing tag for the second `<code>` element in the cell was missing, which caused display issues.

### Related issues and pull requests

None.
