### PR TITLE
Throttling scroll events with requestAnimationFrame is useless

### DIFF
--- a/files/en-us/web/api/document/scroll_event/index.md
+++ b/files/en-us/web/api/document/scroll_event/index.md
@@ -30,9 +30,9 @@ A generic {{domxref("Event")}}.
 
 ### Scroll event throttling
 
-Since `scroll` events can fire at a high rate, the event handler shouldn't execute computationally expensive operations such as DOM modifications. Instead, it is recommended to {{glossary("throttle")}} the event using {{DOMxRef("Window.requestAnimationFrame()", "requestAnimationFrame()")}}, {{DOMxRef("Window.setTimeout", "setTimeout()")}}, or a {{DOMxRef("CustomEvent")}}, as follows.
+Since `scroll` events can fire at a high rate, the event handler shouldn't execute computationally expensive operations such as DOM modifications. If you notice a {{glossary("jank")}} while fast scrolling, you should consider {{glossary("throttle", "throttling")}} the event.
 
-Note, however, that input events and animation frames are fired at about the same rate, and therefore the optimization below is often unnecessary. This example optimizes the `scroll` event for `requestAnimationFrame`.
+Note that you may see code that throttles the `scroll` event handler using {{domxref("Window.requestAnimationFrame()", "requestAnimationFrame()")}}. This is _useless_ because animation frame callbacks are fired at the same rate as `scroll` event handlers. Instead, you must measure the timeout yourself, such as by using {{domxref("Window.setTimeout", "setTimeout()")}}.
 
 ```js
 let lastKnownScrollPosition = 0;
@@ -46,15 +46,18 @@ document.addEventListener("scroll", (event) => {
   lastKnownScrollPosition = window.scrollY;
 
   if (!ticking) {
-    window.requestAnimationFrame(() => {
+    // Throttle the event to "do something" every 20ms
+    setTimeout(() => {
       doSomething(lastKnownScrollPosition);
       ticking = false;
-    });
+    }, 20);
 
     ticking = true;
   }
 });
 ```
+
+Alternatively, consider using {{domxref("IntersectionObserver")}} instead, which allows threshold-based listening.
 
 ## Specifications
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/12701. Our current content is very confusing: it says that rAF is useless for throttling but then goes ahead to show an example of throttling with rAF. Instead, we should demonstrate alternatives. I still kept the mention of rAF because it's a common myth that should be called out.