### PR TITLE
Bug-1946600 Add webextension.api.browserSetting.verticalTabs documentation and release note

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -10,7 +10,7 @@ Enables an extension to modify certain global browser settings. Each property of
 
 Because these are global settings, it's possible for extensions to conflict. See the documentation for [`BrowserSetting.set()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set) for details of how conflicts are handled.
 
-To use this API you need to have the "browserSettings" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
+To use this API, you need the "browserSettings" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
 
 ## Properties
 
@@ -27,17 +27,17 @@ To use this API you need to have the "browserSettings" [permission](/en-US/docs/
 - {{WebExtAPIRef("browserSettings.ftpProtocolEnabled")}}
   - : Determines whether the FTP protocol is enabled.
 - {{WebExtAPIRef("browserSettings.homepageOverride")}}
-  - : Read the value of the browser's home page.
+  - : Reads the value of the browser's home page.
 - {{WebExtAPIRef("browserSettings.imageAnimationBehavior")}}
   - : Determines how the browser treats animated images.
 - {{WebExtAPIRef("browserSettings.newTabPageOverride")}}
   - : Reads the value of the browser's new tab page.
 - {{WebExtAPIRef("browserSettings.newTabPosition")}}
-  - : Controls the position of newly opened tabs relative to already open tabs.
+  - : Controls the position of new tabs relative to the open tabs.
 - {{WebExtAPIRef("browserSettings.openBookmarksInNewTabs")}}
-  - : Determines whether bookmarks are opened in the current tab or a new tab.
+  - : Determines whether bookmarks open in the current tab or a new tab.
 - {{WebExtAPIRef("browserSettings.openSearchResultsInNewTabs")}}
-  - : Determines whether search results are opened in the current tab or a new tab.
+  - : Determines whether search results open in the current tab or a new tab.
 - {{WebExtAPIRef("browserSettings.openUrlbarResultsInNewTabs")}}
   - : Determines whether address bar autocomplete suggestions are opened in the current tab or a new tab.
 - {{WebExtAPIRef("browserSettings.overrideContentColorScheme")}}
@@ -45,9 +45,11 @@ To use this API you need to have the "browserSettings" [permission](/en-US/docs/
 - {{WebExtAPIRef("browserSettings.overrideDocumentColors")}}
   - : Controls whether the user-chosen colors override the page's colors.
 - {{WebExtAPIRef("browserSettings.tlsVersionRestrictionConfig")}}
-  - : Read the highest and lowest versions of TLS supported by the browser.
+  - : Reads the highest and lowest versions of TLS supported by the browser.
 - {{WebExtAPIRef("browserSettings.useDocumentFonts")}}
-  - : Controls whether the browser will use the fonts specified by a web page or use only built-in fonts.
+  - : Controls whether the browser uses the fonts specified by a web page or uses only built-in fonts.
+- {{WebExtAPIRef("browserSettings.verticalTabs")}}
+  - : Controls whether the browser displays the tab bar horizontally or vertically.
 - {{WebExtAPIRef("browserSettings.webNotificationsDisabled")}}
   - : Prevents websites from showing notifications using the [`Notification`](/en-US/docs/Web/API/Notification) Web API.
 - {{WebExtAPIRef("browserSettings.zoomFullPage")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/verticaltabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/verticaltabs/index.md
@@ -1,0 +1,27 @@
+---
+title: browserSettings.verticalTabs
+slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/verticalTabs
+page-type: webextension-api-property
+browser-compat: webextensions.api.browserSettings.verticalTabs
+sidebar: addonsidebar
+---
+
+A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that represents whether the browser has vertical tabs enabled. The object's underlying value is a boolean.
+
+## Examples
+
+Set the setting to `false`, reverting to horizontal tabs:
+
+```js
+
+  browser.browserSettings.verticalTabs
+    .set({ value: false })
+    .then((result) => console.log(`Tabs setting was modified: ${result}`));
+
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/verticaltabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/verticaltabs/index.md
@@ -13,11 +13,9 @@ A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that represe
 Set the setting to `false`, reverting to horizontal tabs:
 
 ```js
-
-  browser.browserSettings.verticalTabs
-    .set({ value: false })
-    .then((result) => console.log(`Tabs setting was modified: ${result}`));
-
+browser.browserSettings.verticalTabs
+  .set({ value: false })
+  .then((result) => console.log(`Tabs setting was modified: ${result}`));
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -75,6 +75,7 @@ No notable changes.
 
 - Cookies created with {{WebExtAPIRef("cookies.set()")}} in Nightly are now validated, and invalid cookies are rejected. The implementation in Nightly is to enable monitoring for any issues. The intention is to enforce validation in all channels in a future release. ([Firefox bug 1976197](https://bugzil.la/1976197))
 - Adds the {{WebExtAPIRef("browserAction.onUserSettingsChanged")}} and {{WebExtAPIRef("action.onUserSettingsChanged")}} events that listen for changes in the user-specified settings that affect an extension's action. ([Firefox bug 1828220](https://bugzil.la/1828220))
+- Adds {{WebExtAPIRef("browserSettings.verticalTabs")}}, which enables extensions to control whether the browser displays the tab bar horizontally or vertically. ([Firefox bug 1946600](https://bugzil.la/1946600))
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Add documentation and a release note for `browserSetting.verticalTabs` introduced by [Bug 1946600](https://bugzilla.mozilla.org/show_bug.cgi?id=1946600) Add a new browserSetting property that determines whether vertical tabs are enabled.

### Related issues and pull requests

Browser compatibility data changes are included in https://github.com/mdn/browser-compat-data/pull/27657