### PR TITLE
relnote(Fx143): details-content pseudo is enabled by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -284,16 +284,15 @@ Work has started on allowing [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elemen
 This will allow users to, for example, style the first letter of the {{htmlElement("details")}} element by using the CSS selector `::details-content::first-letter` or add content before an {{HTMLElement("input") }} of [`type="file"`](/en-US/docs/Web/HTML/Reference/Elements/input/file) using the CSS selector `::file-selector-button::before`.
 
 Currently, only support for `::details-content::first-letter` can be parsed using `@supports(::details-content::first-letter)`.
-The `::file-selector-button` pseudo-element is not yet marked as an element-based pseudo-element, so there is no way for testing this.
+The `::file-selector-button` pseudo-element is not yet marked as an element-based pseudo-element, so there is no way to test this.
 ([Firefox bug 1953557](https://bugzil.la/1953557), [Firefox bug 1941406](https://bugzil.la/1941406)).
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 143           | Yes                 |
-| Developer Edition | 143           | Yes                 |
-| Beta              | 143           | Yes                 |
-| Release           | 143           | Yes                 |
-
+| Nightly           | 138           | No                  |
+| Developer Edition | 138           | No                  |
+| Beta              | 138           | No                  |
+| Release           | 138           | No                  |
 
 ### `:active-view-transition` pseudo-class
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -277,34 +277,22 @@ The parts that have been implemented include [`CSSPositionTryRule`](/en-US/docs/
 - `layout.css.anchor-positioning.enabled`
   - : Set to `true` to enable.
 
-### `::details-content` pseudo-element
-
-The CSS {{cssxref("::details-content")}} pseudo-element enables you to style the content of the {{htmlElement("details")}} element ([Firefox bug 1901037](https://bugzil.la/1901037)).
-
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 138           | No                  |
-| Developer Edition | 138           | No                  |
-| Beta              | 138           | No                  |
-| Release           | 138           | No                  |
-
-- `layout.css.details-content.enabled`
-  - : Set to `true` to enable.
-
 ### Allow pseudo-elements after element-backed pseudo-elements
 
 Work has started on allowing [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) such as {{cssxref("::first-letter")}} and {{cssxref("::before")}} to be appended to [element-backed pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements#element-backed_pseudo-elements) such as {{cssxref("::details-content")}} and {{cssxref("::file-selector-button")}}.
 
 This will allow users to, for example, style the first letter of the {{htmlElement("details")}} element by using the CSS selector `::details-content::first-letter` or add content before an {{HTMLElement("input") }} of [`type="file"`](/en-US/docs/Web/HTML/Reference/Elements/input/file) using the CSS selector `::file-selector-button::before`.
 
-Currently only support for `::details-content::first-letter` can be parsed, using `@supports(::details-content::first-letter)` and the preference for [::details-content pseudo-element](#details-content_pseudo-element) needs enabling for this to be tested. The `::file-selector-button` pseudo-element is not yet marked as an element-based pseudo-element so there is no current way of testing this. ([Firefox bug 1953557](https://bugzil.la/1953557)).
+Currently only support for `::details-content::first-letter` can be parsed, using `@supports(::details-content::first-letter)`.
+The `::file-selector-button` pseudo-element is not yet marked as an element-based pseudo-element so there is no current way of testing this.
+([Firefox bug 1953557](https://bugzil.la/1953557), [Firefox bug 1941406](https://bugzil.la/1941406)).
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 138           | No                  |
-| Developer Edition | 138           | No                  |
-| Beta              | 138           | No                  |
-| Release           | 138           | No                  |
+| Nightly           | 143           | Yes                 |
+| Developer Edition | 143           | Yes                 |
+| Beta              | 143           | Yes                 |
+| Release           | 143           | Yes                 |
 
 - `layout.css.details-content.enabled`
   - : Set to `true` to enable.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -283,8 +283,8 @@ Work has started on allowing [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elemen
 
 This will allow users to, for example, style the first letter of the {{htmlElement("details")}} element by using the CSS selector `::details-content::first-letter` or add content before an {{HTMLElement("input") }} of [`type="file"`](/en-US/docs/Web/HTML/Reference/Elements/input/file) using the CSS selector `::file-selector-button::before`.
 
-Currently only support for `::details-content::first-letter` can be parsed, using `@supports(::details-content::first-letter)`.
-The `::file-selector-button` pseudo-element is not yet marked as an element-based pseudo-element so there is no current way of testing this.
+Currently, only support for `::details-content::first-letter` can be parsed using `@supports(::details-content::first-letter)`.
+The `::file-selector-button` pseudo-element is not yet marked as an element-based pseudo-element, so there is no way for testing this.
 ([Firefox bug 1953557](https://bugzil.la/1953557), [Firefox bug 1941406](https://bugzil.la/1941406)).
 
 | Release channel   | Version added | Enabled by default? |

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -294,8 +294,6 @@ The `::file-selector-button` pseudo-element is not yet marked as an element-base
 | Beta              | 143           | Yes                 |
 | Release           | 143           | Yes                 |
 
-- `layout.css.details-content.enabled`
-  - : Set to `true` to enable.
 
 ### `:active-view-transition` pseudo-class
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -102,7 +102,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   > [!NOTE]
   > The preference for this feature works in reverse: it's set to `false` in the Nightly build, which removes the UA styling for headings nested in sectioning elements. It's set to `true` in all other channels, which retains the existing UA styling for the nested headings.
 
-- **::details-content CSS pseudo-element:** `layout.css.details-content.enabled`.
+- **`::details-content` CSS pseudo-element:** `layout.css.details-content.enabled`.
 
   The CSS {{cssxref("::details-content")}} pseudo-element enables you to style the content of the {{htmlElement("details")}} element ([Firefox bug 1901037](https://bugzil.la/1901037)).
 
@@ -112,7 +112,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   ([Firefox bug 1953557](https://bugzil.la/1953557)).
 
   > [!NOTE]
-  > This feature depends on support for the element-backed pseudo-element being targeted, for example: [`::details-content`](/en-US/docs/Mozilla/Firefox/Experimental_features#details-content_pseudo-element), which is behind the `layout.css.details-content.enabled` preference.
+  > This feature depends on support for the element-backed pseudo-element being targeted, for example: {{cssxref("::details-content")}}, which is behind the `layout.css.details-content.enabled` preference.
 
 - **`MutationEvent` on path to removal**: `dom.mutation_events.enabled`
 
@@ -128,4 +128,4 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **HTML Sanitizer API**: `dom.security.sanitizer.enabled`
 
-  The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document's DOM. ([Firefox bug 1950605](https://bugzil.la/1950605)), ([Firefox bug 1952250](https://bugzil.la/1952250)).
+  The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developers to take untrusted strings of HTML and sanitize them for safe insertion into a document's DOM. ([Firefox bug 1950605](https://bugzil.la/1950605), [Firefox bug 1952250](https://bugzil.la/1952250)).

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -108,7 +108,11 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **Allow pseudo-elements after element-backed pseudo-elements**
 
-  Work has begun on allowing [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) such as {{cssxref("::first-letter")}} and {{cssxref("::before")}} to be appended to [element-backed pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements#element-backed_pseudo-elements) such as {{cssxref("::details-content")}} and {{cssxref("::file-selector-button")}}. ([Firefox bug 1953557](https://bugzil.la/1953557)).
+  Work has begun on allowing [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) such as {{cssxref("::first-letter")}} and {{cssxref("::before")}} to be appended to [element-backed pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements#element-backed_pseudo-elements) such as {{cssxref("::details-content")}} and {{cssxref("::file-selector-button")}}.
+  ([Firefox bug 1953557](https://bugzil.la/1953557)).
+
+  > [!NOTE]
+  > This feature depends on support for the element-backed pseudo-element being targeted, for example: [`::details-content`](/en-US/docs/Mozilla/Firefox/Experimental_features#details-content_pseudo-element), which is behind the `layout.css.details-content.enabled` preference.
 
 - **`MutationEvent` on path to removal**: `dom.mutation_events.enabled`
 

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -110,9 +110,6 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
   Work has begun on allowing [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) such as {{cssxref("::first-letter")}} and {{cssxref("::before")}} to be appended to [element-backed pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements#element-backed_pseudo-elements) such as {{cssxref("::details-content")}} and {{cssxref("::file-selector-button")}}. ([Firefox bug 1953557](https://bugzil.la/1953557)).
 
-  > [!NOTE]
-  > The preference for this feature depends upon the element-backed pseudo-element being targeted, for example: [`::details-content`](/en-US/docs/Mozilla/Firefox/Experimental_features#details-content_pseudo-element).
-
 - **`MutationEvent` on path to removal**: `dom.mutation_events.enabled`
 
   {{domxref("MutationEvent")}} and its associated events (`DOMSubtreeModified`, `DOMNodeInserted`, `DOMNodeRemoved`, `DOMCharacterDataModified`, `DOMAttrModified`) are now disabled on Firefox Nightly by default. ([Firefox bug 1951772](https://bugzil.la/1951772)).

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -26,7 +26,7 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### CSS
 
-- The {{cssxref("::details-content")}} pseudo-element is now enabled by default, which lets you style the content of the {{htmlElement("details")}} element.
+- The {{cssxref("::details-content")}} pseudo-element is now enabled by default. It lets you style the content of the {{htmlElement("details")}} element.
   ([Firefox bug 1941406](https://bugzil.la/1941406)).
 
 <!-- #### Removals -->

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -24,9 +24,10 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### CSS -->
+### CSS
 
-<!-- No notable changes. -->
+- The {{cssxref("::details-content")}} pseudo-element is now enabled by default, which lets you style the content of the {{htmlElement("details")}} element.
+  ([Firefox bug 1941406](https://bugzil.la/1941406)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
### Description

The `::details-content` pseudo-element is now enabled by default.

### Bugs

- [Let 'layout.details.force-block-layout:false' and 'layout.css.details-content.enabled:true' ride the trains to release](https://bugzilla.mozilla.org/show_bug.cgi?id=1941406)

### Additional details

- [x] Parent issue https://github.com/mdn/content/issues/40777



