### PR TITLE
relnote(Fx143): remove CompositionEvent/locale

### DIFF
--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -48,13 +48,16 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
 <!-- #### DOM -->
 
 <!-- #### Media, WebRTC, and Web Audio -->
 
-<!-- #### Removals -->
+#### Removals
+
+- The deprecated {{domxref("CompositionEvent.locale")}} property is no longer supported.
+  ([Firefox bug 1700969](https://bugzil.la/1700969))
 
 <!-- ### WebAssembly -->
 

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -57,7 +57,7 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### Removals
 
 - The deprecated {{domxref("CompositionEvent.locale")}} property is no longer supported.
-  ([Firefox bug 1700969](https://bugzil.la/1700969))
+  ([Firefox bug 1700969](https://bugzil.la/1700969)).
 
 <!-- ### WebAssembly -->
 


### PR DESCRIPTION
### Description

The `CompositionEvent.locale` property is no longer supported.

>It's [removed from the spec in 2013](https://github.com/w3c/uievents/commit/cb2e9ff0394742744190335b2496ebe976962f06) and not implemented by anyone else.

### Bugs

- [Remove CompositionEvent#locale](https://bugzilla.mozilla.org/show_bug.cgi?id=1700969)

### Additional details

- [x] Parent issue https://github.com/mdn/content/issues/40874



