### PR TITLE
Cross link  color (property) and color() (function) and <color> (type) See also's

### DIFF
--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -189,5 +189,6 @@ p {
 - The {{cssxref("&lt;color&gt;")}} data type
 - Other color-related properties: {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}}, {{cssxref("column-rule-color")}}, and {{cssxref("print-color-adjust")}}
 - SVG {{SVGAttr("color")}} attribute
+- {{CSSXref("color_value/color")}} function
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/CSS/CSS_colors/Applying_color)
 - [WCAG: color contrast](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast)

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -380,6 +380,7 @@ The output is as follows:
 
 ## See also
 
+- {{CSSXref("color")}} property
 - [The `<color>` data type](/en-US/docs/Web/CSS/color_value) for a list of all color notations
 - [Using relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors)
 - [sRGB color picker and conversion tool](/en-US/docs/Web/CSS/CSS_colors/Color_picker_tool)

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -459,6 +459,7 @@ div:nth-child(6) {
 - {{CSSXref("opacity")}}: the property defining transparency at the element level
 - {{CSSXref("&lt;hue&gt;")}}: the data type representing the hue angle of a color
 - {{CSSXref("color")}} property, {{CSSXref("background-color")}}, {{CSSXref("border-color")}}, {{CSSXref("box-shadow")}}, {{CSSXref("outline-color")}}, {{CSSXref("text-shadow")}}: common properties that use `<color>`
+- {{CSSXref("color_value/color")}} function
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/CSS/CSS_colors/Applying_color)
 - [Using relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors)
 - [New functions, gradients, and hues in CSS colors (Level 4)](/en-US/blog/css-color-module-level-4/) on MDN blog (2023)

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -458,7 +458,7 @@ div:nth-child(6) {
 
 - {{CSSXref("opacity")}}: the property defining transparency at the element level
 - {{CSSXref("&lt;hue&gt;")}}: the data type representing the hue angle of a color
-- {{CSSXref("color")}}, {{CSSXref("background-color")}}, {{CSSXref("border-color")}}, {{CSSXref("box-shadow")}}, {{CSSXref("outline-color")}}, {{CSSXref("text-shadow")}}: common properties that use `<color>`
+- {{CSSXref("color")}} property, {{CSSXref("background-color")}}, {{CSSXref("border-color")}}, {{CSSXref("box-shadow")}}, {{CSSXref("outline-color")}}, {{CSSXref("text-shadow")}}: common properties that use `<color>`
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/CSS/CSS_colors/Applying_color)
 - [Using relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors)
 - [New functions, gradients, and hues in CSS colors (Level 4)](/en-US/blog/css-color-module-level-4/) on MDN blog (2023)

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -458,7 +458,7 @@ div:nth-child(6) {
 
 - {{CSSXref("opacity")}}: the property defining transparency at the element level
 - {{CSSXref("&lt;hue&gt;")}}: the data type representing the hue angle of a color
-- {{CSSXref("color")}} property, {{CSSXref("background-color")}}, {{CSSXref("border-color")}}, {{CSSXref("box-shadow")}}, {{CSSXref("outline-color")}}, {{CSSXref("text-shadow")}}: common properties that use `<color>`
+- {{CSSXref("color")}}, {{CSSXref("background-color")}}, {{CSSXref("border-color")}}, {{CSSXref("box-shadow")}}, {{CSSXref("outline-color")}}, {{CSSXref("text-shadow")}}: common properties that use `<color>`
 - {{CSSXref("color_value/color")}} function
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/CSS/CSS_colors/Applying_color)
 - [Using relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors)


### PR DESCRIPTION
### Description

The [`color()` (`color_value/color`)](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color) is currently the top result for the query [`color site:developer.mozilla.org` on DDG](https://duckduckgo.com/?q=site%253Adeveloper.mozilla.org+color), and I've observed there is no clear organic path to (intended) [`color` property (`CSS/color`)](https://developer.mozilla.org/en-US/docs/Web/CSS/color) from there, what "See also" seems fit.

----

##### Motivation

I am (ab)using DDG's "bang" («I'm feeling lucky»") feature through a keyword search to get to MDN references as quickly as possible, and `https://duckduckgo.com/?q=!%20site:developer.mozilla.org%20color` kicked me to a page I was not expecting, though, arguably, has more "color" keywords in the URL than any other page.  

##### Additional details

Also, I have the "See also" section pulled up before main content with userstyle, because quite often continuing elsewhere related is what I am coming for.  That's why I've hit addressed issue and why it knocked me off.

