### PR TITLE
Clarify frame-ancestors behavior in nested frames

### DIFF
--- a/files/en-us/web/http/reference/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/frame-ancestors/index.md
@@ -16,7 +16,7 @@ Setting this directive to `'none'` is similar to {{HTTPHeader("X-Frame-Options",
 > This differs from **`frame-src`**, which allows you to specify where iframes in a page may be loaded from.
 
 > [!NOTE]
-> **`frame-ancestors`** directive [checks each ancestor](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options). If any ancestor doesn't match, the load is cancelled. Therefore all ancestors should be allowed by the **`frame-ancestors`** directive of leaf frame when using nested frames.
+> The **`frame-ancestors`** directive [checks each ancestor](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options). If any ancestor doesn't match, the load is cancelled. Therefore all ancestors should be allowed by the **`frame-ancestors`** directive of leaf frames when using nested frames.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/reference/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/frame-ancestors/index.md
@@ -16,7 +16,7 @@ Setting this directive to `'none'` is similar to {{HTTPHeader("X-Frame-Options",
 > This differs from **`frame-src`**, which allows you to specify where iframes in a page may be loaded from.
 
 > [!NOTE]
-> **`frame-ancestors`** directive [checks each ancestor](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options). If any ancestor doesn’t match, the load is cancelled. Therefore all ancestors should be allowed by the **`frame-ancestors`** directive of leaf frame when using nested frames.
+> **`frame-ancestors`** directive [checks each ancestor](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options). If any ancestor doesn't match, the load is cancelled. Therefore all ancestors should be allowed by the **`frame-ancestors`** directive of leaf frame when using nested frames.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/reference/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/frame-ancestors/index.md
@@ -15,6 +15,9 @@ Setting this directive to `'none'` is similar to {{HTTPHeader("X-Frame-Options",
 > **`frame-ancestors`** allows you to specify what parent source may embed a page.
 > This differs from **`frame-src`**, which allows you to specify where iframes in a page may be loaded from.
 
+> [!NOTE]
+> **`frame-ancestors`** directive [checks each ancestor](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options). If any ancestor doesn’t match, the load is cancelled. Therefore all ancestors should be allowed by the **`frame-ancestors`** directive of leaf frame when using nested frames.
+
 <table class="properties">
   <tbody>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Added clarification on the behavior of the frame-ancestors directive in nested frames.

### Motivation

While CSP 2 spec is clear about the frame-ancestor behavior when it comes to nested frames, MDN docs don't have any mention of it. This could lead to CSP errors in production if someone sets `frame-ancestor` directive solely relying on MDN.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
