### PR TITLE
Clarify Gecko vs JavaScript engine wording in JIT statement

### DIFF
--- a/files/en-us/web/performance/guides/fundamentals/index.md
+++ b/files/en-us/web/performance/guides/fundamentals/index.md
@@ -62,7 +62,7 @@ The `canvas` element offers a pixel buffer directly for developers to draw on. T
 
 ### Gecko rendering
 
-The Gecko JavaScript engine supports just-in-time (JIT) compilation. This enables application logic to perform comparably to other virtual machines — such as Java virtual machines — and in some cases even close to "native code".
+Gecko's JavaScript engine supports just-in-time (JIT) compilation. This enables application logic to perform comparably to other virtual machines — such as Java virtual machines — and in some cases even close to "native code".
 
 The graphics pipeline in Gecko that underpins HTML, CSS, and Canvas is optimized in several ways. The HTML/CSS layout and graphics code in Gecko reduces invalidation and repainting for common cases like scrolling; developers get this support "for free". Pixel buffers painted by both Gecko "automatically" and applications to `canvas` "manually" minimize copies when being drawn to the display framebuffer. This is done by avoiding intermediate surfaces where they would create overhead (such as per-application "back buffers" in many other operating systems), and by using special memory for graphics buffers that can be directly accessed by the compositor hardware. Complex scenes are rendered using the device's GPU for maximum performance. To improve power usage, simple scenes are rendered using special dedicated composition hardware, while the GPU idles or turns off.
 


### PR DESCRIPTION
### Fixes #40901
### Description
Rephrased a sentence in the Performance Fundamentals guide to clarify that JIT compilation is supported by the JavaScript engine used by Gecko, not Gecko itself.

### Motivation
The previous wording could mislead readers into thinking that Gecko itself is a JavaScript engine. This clarification ensures technical accuracy and prevents confusion about the role of Gecko versus its JS engine.

### Additional details
No additional references required. It is documented as Gecko's JavaScript engine.