### PR TITLE
Remove comma from the Integrity policy example list

### DIFF
--- a/files/en-us/web/http/reference/headers/integrity-policy/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy/index.md
@@ -73,7 +73,7 @@ Note that the `integrity-endpoint` used in `Integrity-Policy` is defined in the 
 
 ```http
 Reporting-Endpoints: integrity-endpoint=https://example.com/integrity, backup-integrity-endpoint=https://report-provider.example/integrity
-Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint, backup-integrity-endpoint)
+Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint backup-integrity-endpoint)
 ```
 
 The [report payload](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) might look like this.

--- a/files/en-us/web/http/reference/headers/integrity-policy/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy/index.md
@@ -72,7 +72,7 @@ This example shows a document that blocks and reports when any {{htmlelement("sc
 Note that the `integrity-endpoint` used in `Integrity-Policy` is defined in the {{httpheader("Reporting-Endpoints")}} header.
 
 ```http
-Reporting-Endpoints: integrity-endpoint=https://example.com/integrity, backup-integrity-endpoint=https://report-provider.example/integrity
+Reporting-Endpoints: integrity-endpoint="https://example.com/integrity", backup-integrity-endpoint="https://report-provider.example/integrity"
 Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint backup-integrity-endpoint)
 ```
 


### PR DESCRIPTION
Fix #40919 

Removed the comma inside the Integrity policy header Example.
