### PR TITLE
fix(fred): js/css wasn't loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:typos-words-only": "cspell --no-progress --gitignore --words-only --unique --config .vscode/cspell.json \"**/*.md\"",
     "lint:yml": "prettier -c \"**/*.yml\"",
     "start": "yarn -s info:rari && yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build rari-server",
-    "start:fred": "yarn -s info:fred && yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build NODE_ENV=production fred-server",
+    "start:fred": "yarn -s info:fred && yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files NODE_ENV=production FRED_WRITER_MODE=true fred-server",
     "up-to-date-check": "node scripts/up-to-date-check.js",
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "test:front-matter-linter": "yarn jest tests"
@@ -46,7 +46,7 @@
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
     "@caporal/core": "^2.0.7",
-    "@mdn/fred": "1.1.1",
+    "@mdn/fred": "1.2.0",
     "@mdn/yari": "5.0.3",
     "@octokit/rest": "^22.0.0",
     "ajv": "^8.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,10 +1613,10 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-6.0.28.tgz#e99a2cb1693fec9255c3cf1cfe1b02fcfd0de12d"
   integrity sha512-UE4uV0VK+HfGyXCNdq3Lyy0xNJ6bJI9Y8XtVnnv7+oFda3xtV3PQJIMPHEtC+ou1qrrHdrtaLNQ9cJSj4hi94Q==
 
-"@mdn/fred@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@mdn/fred/-/fred-1.1.1.tgz#2d1ae1815f2768176c7a553e52050cec6052ddc5"
-  integrity sha512-a8Ha/exY77olGhP7Yp2Y09FjnlYWoolYAZJ1lVNbEbzMy7AK1KlY0Kfa3TbEpR/c+q4WCJwbWEAHkh2OdxYyTw==
+"@mdn/fred@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@mdn/fred/-/fred-1.2.0.tgz#574dc5125e070fb5ca7b7ef4653df9bd3c332ef0"
+  integrity sha512-snc/RP90gbybmt+BFXTufynzoaNBCQ9TY/9IhDy/fMAyXj5ygMJe0XXtv69k7zB+PYg2AbNXKgfnf57qO9B8mQ==
   dependencies:
     "@codemirror/lang-css" "^6.3.1"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
### Description

Updates fred to the latest version and sets FRED_WRITER_MODE=true as it's now a runtime environment variable.

### Motivation

js/css weren't loading with the previous version of fred.

### Additional details

https://github.com/mdn/fred/blob/main/CHANGELOG.md#120-2025-08-28
