### PR TITLE
update compatibility path for javascript/classes.static_initialization_blocks

### DIFF
--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -2,7 +2,7 @@
 title: Static initialization blocks
 slug: Web/JavaScript/Reference/Classes/Static_initialization_blocks
 page-type: javascript-language-feature
-browser-compat: javascript.classes.static_initialization_blocks
+browser-compat: javascript.classes.static.initialization_blocks
 sidebar: jssidebar
 ---
 


### PR DESCRIPTION
### Description

Fixes missing compatibility data for javascript.classes.static_initialization_blocks that exists elsewhere.

### Motivation

Fixes missing compatibility data that exists elsewhere.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks/

### Related issues and pull requests

Fixes https://github.com/mdn/browser-compat-data/issues/27702