### PR TITLE
Fix issue #40919: update Integrity-Policy-Report-Only documentation

### DIFF
--- a/files/en-us/web/http/reference/headers/integrity-policy-report-only/index.md
+++ b/files/en-us/web/http/reference/headers/integrity-policy-report-only/index.md
@@ -36,7 +36,9 @@ The header allows developers to test [integrity policies](/en-US/docs/Web/Securi
 ## Syntax
 
 ```http
-Integrity-Policy-Report-Only: blocked-destinations=(<destination>),sources=(<source>),endpoints=(<endpoint>)
+Integrity-Policy: blocked-destinations=(script), endpoints=(integrity-endpoint some-other-integrity-endpoint)
+
+
 ```
 
 The header values are defined as structured field dictionaries with the following keys:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR updates the documentation for the `Integrity-Policy-Report-Only` HTTP header. 
It fixes inaccuracies in the syntax and clarifies the usage section.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The previous content was outdated and did not match current specification details. 
Fixing this improves accuracy and helps developers correctly implement the header.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

- Based on discussion in #40919.
- Verified the header behavior in Chrome 127 and Firefox 128.
- Confirmed spec details from: https://w3c.github.io/webappsec-subresource-integrity/
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
