### PR TITLE
typo fix in example code for sizes attribute

### DIFF
--- a/files/en-us/web/html/reference/elements/picture/index.md
+++ b/files/en-us/web/html/reference/elements/picture/index.md
@@ -118,7 +118,7 @@ For example:
 <picture>
   <source
     srcset="small.jpg 480w, medium.jpg 800w, large.jpg 1200w"
-    sizes="(max-width: 600px) 400px, 600px"
+    sizes="(max-width: 600px) 400px, 800px"
     type="image/jpeg" />
   <img src="fallback.jpg" alt="Example image" />
 </picture>


### PR DESCRIPTION
### Description

Fixed the example code based on below explanation (If the viewport is 600px wide or less, the slot size is 400px; otherwise, it is 800px.)

### Motivation

### Additional details

### Related issues and pull requests

