### PR TITLE
Bug-1679997 CSS origin for registered content scripts docs and release note

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -27,13 +27,15 @@ let registering = browser.contentScripts.register(
     - property names use {{Glossary("camel_case", "camel case")}}, rather than underscores ({{Glossary("snake_case", "snake case")}}) — for example, `excludeMatches`, not `exclude_matches`.
     - the `js` and `css` properties allow you to register strings as well as URLs, so their syntax has to distinguish these types.
 
-    The `RegisteredContentScriptOptions` object has the following properties:
+    The `RegisteredContentScriptOptions` object has these properties:
     - `allFrames` {{optional_inline}}
       - : Same as [`all_frames` in the `content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#all_frames) key.
     - `cookieStoreId` {{optional_inline}}
       - : A string or array of strings. Registers the content script in the tabs that belong to one or more cookie store IDs. This enables scripts to be registered for all default or non-contextual identity tabs, private browsing tabs (if the [extension is enabled in private browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing)), the tabs of a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities), or a combination of these. See [Work with contextual identities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) for more information.
     - `css` {{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a CSS file to register, or a property named `code`, which is some CSS code to register.
+    - `cssOrigin` {{optional_inline}}
+      - : `string`. The origin of the CSS to inject. This affects the cascading order (priority) of the injected stylesheets. Takes the values `"author"` and `"user"`. If not provided, defaults to `"author"`.
     - `excludeGlobs` {{optional_inline}}
       - : Same as [`exclude_globs` in the `content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#exclude_globs) key.
     - `excludeMatches` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -35,7 +35,7 @@ let registering = browser.contentScripts.register(
     - `css` {{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a CSS file to register, or a property named `code`, which is some CSS code to register.
     - `cssOrigin` {{optional_inline}}
-      - : `string`. The origin of the CSS to inject. This affects the cascading order (priority) of the injected stylesheets. Takes the values `"author"` and `"user"`. If not provided, defaults to `"author"`.
+      - : `string`. The origin of the CSS to inject. This affects the cascading order (priority) of the injected stylesheets. Takes the values `"author"` and `"user"`. Defaults to `"author"`.
     - `excludeGlobs` {{optional_inline}}
       - : Same as [`exclude_globs` in the `content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#exclude_globs) key.
     - `excludeMatches` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -17,7 +17,7 @@ Values of this type are objects. They contain these properties:
 - `css` {{optional_inline}}
   - : `array` of `string`. The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array.
 - `cssOrigin` {{optional_inline}}
-  - : `string`. The origin of the CSS to inject. This affects the cascading order (priority) of the injected stylesheets. Takes the values `"author"` and `"user"`. If not provided, defaults to `"author"`.
+  - : `string`. The origin of the CSS to inject. This affects the cascading order (priority) of the injected stylesheets. Takes the values `"author"` and `"user"`. Defaults to `"author"`.
 - `excludeMatches` {{optional_inline}}
   - : `array` of `string`. Array of pages that this content script is excluded from but would otherwise be injected into.
 - `id`

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -16,6 +16,8 @@ Values of this type are objects. They contain these properties:
   - : `boolean`. If specified `true`, the script is inject into all frames, even if the frame is not the top-most frame in the tab. Each frame is checked independently for URL requirements; it does not inject into child frames if the URL requirements are not met. Defaults to `false`, meaning that only the top frame is matched.
 - `css` {{optional_inline}}
   - : `array` of `string`. The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array.
+- `cssOrigin` {{optional_inline}}
+  - : `string`. The origin of the CSS to inject. This affects the cascading order (priority) of the injected stylesheets. Takes the values `"author"` and `"user"`. If not provided, defaults to `"author"`.
 - `excludeMatches` {{optional_inline}}
   - : `array` of `string`. Array of pages that this content script is excluded from but would otherwise be injected into.
 - `id`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -40,11 +40,11 @@ Instructs the browser to load [content scripts](/en-US/docs/Mozilla/Add-ons/WebE
 
 This key is an array. Each item is an object which:
 
-- **must** contain a key named **`matches`**, which specifies the URL patterns to be matched for the scripts to be loaded;
-- **may** contain keys named **`js`** and **`css`**, which list scripts and stylesheets to be loaded into matching pages; and
+- **must** contain a property named **`matches`**, which specifies the URL patterns to be matched for the scripts to be loaded;
+- **may** contain properties named **`js`** and **`css`**, which list scripts and stylesheets to be loaded into matching pages; and
 - **may** contain a number of other properties that control aspects of how and when content scripts are loaded.
 
-This table details all the keys you can include.
+This table details all the properties you can include.
 
 <table class="fullwidth-table standard-table">
   <thead>
@@ -110,6 +110,23 @@ This table details all the keys you can include.
             injected into.
           </p>
         </div>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a id="css_origin"><code>css_origin</code></a>
+        <br />{{optional_inline}}
+      </td>
+      <td><code>String</code></td>
+      <td>
+        <p>
+          The origin of the CSS to inject. This affects the cascading order 
+          (priority) of the injected stylesheets. This string takes these values:
+          <ul>
+            <li><code>"user"</code></li>
+            <li><code>"author"</code> (default)</li>
+          </ul>
+        </p>
       </td>
     </tr>
     <tr>
@@ -310,7 +327,7 @@ This table details all the keys you can include.
 Registered objects in `content_scripts` are injected into matching web pages at the time specified by `run_at` (first `document_start`, then `document_end`, and finally `document_idle`):
 
 - In the order specified in the `content_scripts` array, for each object with a matching `run_at` value, then:
-  - CSS is applied in the order specified in its `css` array.
+  - CSS is applied in the order specified in its `css` array. By default CSS from the `"author"` origin is given priority unless `css_origin` is set to `"user"`.
   - JavaScript code is executed in the order specified in its `js` array.
 
 For example, in this key specification:

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -120,7 +120,7 @@ This table details all the properties you can include.
       <td><code>String</code></td>
       <td>
         <p>
-          The origin of the CSS to inject. This affects the cascading order 
+          The origin of the CSS to inject. This affects the cascading order
           (priority) of the injected stylesheets. This string takes these values:
           <ul>
             <li><code>"user"</code></li>

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -70,6 +70,8 @@ Firefox 144 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- Adds the ability to determine the priority of CSS injected from the [`"content_scripts"` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts), in {{WebExtAPIRef("scripting.registerContentScripts()")}} with the `cssOrigin` property on {{WebExtAPIRef("scripting.RegisteredContentScript")}}, and the `cssOrigin` property in {{WebExtAPIRef("contentScripts.register")}}. By default, the `"author"` origin takes precedence. ([Firefox bug 1679997](https://bugzil.la/1679997))
+
 <!-- ### Removals -->
 
 <!-- ### Other -->


### PR DESCRIPTION
### Description

Add details of support added in Firefox 144 to determine the precedence of injected CSS in:

- ["content_scripts" manifest key](http://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts)
- [scripting.RegisteredContentScript](http://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript)
- [contentScripts.register](http://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contentScripts/register).

Along with a related release note.

This  addresses the dev-docs-needed requirements of [Bug 1679997](https://bugzilla.mozilla.org/show_bug.cgi?id=1679997) Add cssOrigin to declarative contentScripts API (manifest.json, scripting, contentScripts)

### Related issues and pull requests

Related browser compatibility data changes in https://github.com/mdn/browser-compat-data/pull/27716
