### PR TITLE
Add dashed outline to checkbox checked state

### DIFF
--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -88,6 +88,7 @@ question-box::part(checkbox) {
 
 question-box::part(checkbox):state(checked) {
   color: green;
+  outline: dashed 1px green;
 }
 ```
 


### PR DESCRIPTION
Added a dashed outline to the checked state of the question box so that color is not the only change (currently red/green change is not visible to 10% of the population)