### PR TITLE
remove superflous middle

### DIFF
--- a/files/en-us/web/css/clamp/index.md
+++ b/files/en-us/web/css/clamp/index.md
@@ -6,7 +6,7 @@ browser-compat: css.types.clamp
 sidebar: cssref
 ---
 
-The **`clamp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_Value_Functions) clamps a middle value within a range of values between a defined minimum bound and a maximum bound. The function takes three parameters: a minimum value, a preferred value, and a maximum allowed value.
+The **`clamp()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_Value_Functions) clamps a value within a range of values between a defined minimum bound and a maximum bound. The function takes three parameters: a minimum value, a preferred value, and a maximum allowed value.
 
 {{InteractiveExample("CSS Demo: clamp()")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Remove the superfluous word "middle" in the phrase "middle value". 

### Motivation

the word middle in the phrase "middle value" is confusing. The phrase "middle value" could be confused with median or average both which are not correct. Function just returns a value.

### Additional details

- [Wikipedia on Median](https://en.wikipedia.org/wiki/Median)
- [W3 calles it central ](https://www.w3.org/TR/css-values-4/#funcdef-clamp)which imho is also confusing. The resulting value must not (at all) be at the *center* of the range.

### Related issues and pull requests
