### PR TITLE
change flex-basis to flex-grow

### DIFF
--- a/files/en-us/web/css/flex-grow/index.md
+++ b/files/en-us/web/css/flex-grow/index.md
@@ -11,7 +11,7 @@ The **`flex-grow`** [CSS](/en-US/docs/Web/CSS) property sets the flex grow facto
 When the flex-container's main size is larger than the combined main sizes of its flex items, this positive free space can be distributed among the flex items, with each item's growth being their growth factor value as a proportion of the sum total of all the flex items' flex grow factors.
 
 > [!NOTE]
-> It is recommended to use the {{cssxref("flex")}} shorthand with a keyword value like `auto` or `initial` instead of setting `flex-basis` on its own. The [keyword values](/en-US/docs/Web/CSS/flex#values) expand to reliable combinations of `flex-grow`, {{cssxref("flex-shrink")}}, and {{cssxref("flex-basis")}}, which help to achieve the commonly desired flex behaviors.
+> It is recommended to use the {{cssxref("flex")}} shorthand with a keyword value like `auto` or `initial` instead of setting `flex-grow` on its own. The [keyword values](/en-US/docs/Web/CSS/flex#values) expand to reliable combinations of `flex-grow`, {{cssxref("flex-shrink")}}, and {{cssxref("flex-basis")}}, which help to achieve the commonly desired flex behaviors.
 
 {{InteractiveExample("CSS Demo: flex-grow")}}
 


### PR DESCRIPTION
the topic of the page is `flex-grow` not `flex-basis`. The text was apparently copy-pasted

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

change flex-basis to flex-grow

### Description

The topic of the article is `flex-grow` not `flex-basis`. The text appears to have been copy pasted from there.

### Motivation

Confusing mention of flex-basis.

