### PR TITLE
Document IdentityCredentialError

### DIFF
--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -100,7 +100,7 @@ If a single credential cannot be unambiguously obtained, the promise resolves wi
 - `AbortError` {{domxref("DOMException")}}
   - : The request was aborted by a call to the {{domxref("AbortController.abort", "abort()")}} method of the {{domxref("AbortController")}} associated with this method's [`signal`](#signal) option.
 
-- `IdentityCredentialError` {{domxref("DOMException")}}
+- {{domxref("IdentityCredentialError")}}
   - : When requesting an {{domxref("IdentityCredential")}}, the request to the [ID assertion endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_id_assertion_endpoint) is unable to validate the authentication, and rejects with an error response containing information about the reason.
 
 - `NetworkError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -312,12 +312,12 @@ The error response fields are as follows:
 - `code` {{optional_inline}}
   - : A string. This can be either a known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
 - `url` {{optional_inline}}
-  - : A URL. This should be a web page containing human-readable information about the error to display to users, such as how to fix the error or contact customer. The URL must be same-site with the IdP's config URL.
+  - : A URL. This should be a web page containing human-readable information about the error to display to users, such as how to fix the error or contact customer service. The URL must be same-site with the IdP's config URL.
 
 This information can be used in a couple of different ways:
 
 - The browser can display a custom UI to the user informing them of what went wrong (see the [Chrome documentation](https://privacysandbox.google.com/blog/fedcm-chrome-120-updates#error-api) for an example). Bear in mind that if the request failed because the IdP server is unavailable, it obviously can't return any information. In such cases, the browser will report this via a generic message.
-- The associated RP {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call used to attempt sign-in will reject its promise with an `IdentityCredentialError`, which contains the error information. An RP can catch this error and then follow up the browser's custom UI with some information to help the user succeed in a future sign-in attempt.
+- The associated RP {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call used to attempt sign-in will reject its promise with an {{domxref("IdentityCredentialError")}}, which contains the error information. An RP can catch this error and then follow up the browser's custom UI with some information to help the user succeed in a future sign-in attempt.
 
 ## Update login status using the Login Status API
 

--- a/files/en-us/web/api/fedcm_api/index.md
+++ b/files/en-us/web/api/fedcm_api/index.md
@@ -60,6 +60,8 @@ The availability of FedCM within `<iframe>`s enables a couple of use cases:
 
 - {{domxref("IdentityCredential")}}
   - : Represents a user identity credential arising from successful federated authentication. A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call that includes an `identity` option fulfills with an {{domxref("IdentityCredential")}} instance.
+- {{domxref("IdentityCredentialError")}}
+  - : Represents an authentication error indicating that the user agent did not receive an identity assertion after the user has requested to use a federated account.
 - {{domxref("IdentityProvider")}}
   - : Represents an IdP and provides access to related information and functionality.
 - {{domxref("NavigatorLogin")}}

--- a/files/en-us/web/api/fedcm_api/index.md
+++ b/files/en-us/web/api/fedcm_api/index.md
@@ -61,7 +61,7 @@ The availability of FedCM within `<iframe>`s enables a couple of use cases:
 - {{domxref("IdentityCredential")}}
   - : Represents a user identity credential arising from successful federated authentication. A successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} call that includes an `identity` option fulfills with an {{domxref("IdentityCredential")}} instance.
 - {{domxref("IdentityCredentialError")}}
-  - : Represents an authentication error indicating that the user agent did not receive an identity assertion after the user has requested to use a federated account.
+  - : Represents an authentication error indicating that the user agent did not receive an identity assertion after the user has asked to authenticate using a federated credential.
 - {{domxref("IdentityProvider")}}
   - : Represents an IdP and provides access to related information and functionality.
 - {{domxref("NavigatorLogin")}}

--- a/files/en-us/web/api/identitycredentialerror/error/index.md
+++ b/files/en-us/web/api/identitycredentialerror/error/index.md
@@ -1,0 +1,48 @@
+---
+title: "IdentityCredentialError: error property"
+short-title: error
+slug: Web/API/IdentityCredentialError/error
+page-type: web-api-instance-property
+browser-compat: api.IdentityCredentialError.error
+---
+
+{{APIRef("FedCM API")}}{{AvailableInWorkers}}
+
+The **`error`** read-only property of the {{domxref("IdentityCredentialError")}} interface
+
+## Value
+
+A known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
+
+## Examples
+
+```js
+try {
+  const cred = await navigator.credentials.get({
+    identity: {
+      providers: [
+        {
+          configURL: "https://idp.example/manifest.json",
+          clientId: "1234",
+        },
+      ],
+    },
+  });
+} catch (e) {
+  const error = e.error;
+  const url = e.url;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CredentialsContainer.get()")}}
+- [ID assertion error responses](/en-US/docs/Web/API/FedCM_API/IDP_integration#id_assertion_error_responses)

--- a/files/en-us/web/api/identitycredentialerror/error/index.md
+++ b/files/en-us/web/api/identitycredentialerror/error/index.md
@@ -8,11 +8,11 @@ browser-compat: api.IdentityCredentialError.error
 
 {{APIRef("FedCM API")}}{{AvailableInWorkers}}
 
-The **`error`** read-only property of the {{domxref("IdentityCredentialError")}} interface
+The **`error`** read-only property of the {{domxref("IdentityCredentialError")}} interface is either one of the values listed in the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string giving more information about the error.
 
 ## Value
 
-A known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
+One of the values listed in the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
 
 ## Examples
 

--- a/files/en-us/web/api/identitycredentialerror/identitycredentialerror/index.md
+++ b/files/en-us/web/api/identitycredentialerror/identitycredentialerror/index.md
@@ -25,7 +25,7 @@ new IdentityCredentialError(message, options)
 - `options` {{optional_inline}}
   - : An object that can have the following properties:
     - `error` {{optional_inline}}
-      - : A string. This can be either a known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
+      - : A string. This can be either one of the values listed in the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
     - `url` {{optional_inline}}
       - : A URL pointing to human-readable information about the error to display to users, such as how to fix the error or contact customer service.
 

--- a/files/en-us/web/api/identitycredentialerror/identitycredentialerror/index.md
+++ b/files/en-us/web/api/identitycredentialerror/identitycredentialerror/index.md
@@ -1,0 +1,63 @@
+---
+title: "IdentityCredentialError: IdentityCredentialError() constructor"
+short-title: IdentityCredentialError()
+slug: Web/API/IdentityCredentialError/IdentityCredentialError
+page-type: web-api-constructor
+browser-compat: api.IdentityCredentialError.IdentityCredentialError
+---
+
+{{APIRef("Fetch API")}}{{AvailableInWorkers}}
+
+The **`IdentityCredentialError()`** constructor creates a new {{domxref("IdentityCredentialError")}} object.
+
+## Syntax
+
+```js-nolint
+new IdentityCredentialError()
+new IdentityCredentialError(message)
+new IdentityCredentialError(message, options)
+```
+
+### Parameters
+
+- `message`
+  - : A description of the error. If not present, the empty string `''` is used.
+- `options` {{optional_inline}}
+  - : An object that can have the following properties:
+    - `error` {{optional_inline}}
+      - : A string. This can be either a known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
+    - `url` {{optional_inline}}
+      - : A URL pointing to human-readable information about the error to display to users, such as how to fix the error or contact customer service.
+
+## Examples
+
+```js
+try {
+  const cred = await navigator.credentials.get({
+    identity: {
+      providers: [
+        {
+          configURL: "https://idp.example/manifest.json",
+          clientId: "1234",
+        },
+      ],
+    },
+  });
+} catch (e) {
+  const error = e.error;
+  const url = e.url;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CredentialsContainer.get()")}}
+- [ID assertion error responses](/en-US/docs/Web/API/FedCM_API/IDP_integration#id_assertion_error_responses)

--- a/files/en-us/web/api/identitycredentialerror/index.md
+++ b/files/en-us/web/api/identitycredentialerror/index.md
@@ -23,7 +23,7 @@ Browsers can use this error type to show the error message in the user interface
 _In addition to the properties below, `IdentityCredentialError` inherits properties from its parent, {{DOMxRef("DOMException")}}_.
 
 - {{domxref("IdentityCredentialError.error", "error")}} {{Experimental_Inline}} {{ReadOnlyInline}}
-  - : A string. This can be either a known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
+  - : A string. This can be either one of the values listed in the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
 - {{domxref("IdentityCredentialError.url", "url")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A URL pointing to human-readable information about the error to display to users, such as how to fix the error or contact customer service.
 

--- a/files/en-us/web/api/identitycredentialerror/index.md
+++ b/files/en-us/web/api/identitycredentialerror/index.md
@@ -1,0 +1,61 @@
+---
+title: IdentityCredentialError
+slug: Web/API/IdentityCredentialError
+page-type: web-api-interface
+browser-compat: api.IdentityCredentialError
+---
+
+{{APIRef("FedCM API")}}{{SecureContext_Header}}
+
+The **`IdentityCredentialError`** interface of the {{domxref("FedCM API", "FedCM API", "", "nocode")}} describes an authentication error indicating that the user agent did not receive an identity assertion after the user has requested to use a federated account. This can happen if the client is unauthorized or if the server is temporarily unavailable, for example.
+
+Browsers can use this error type to show the error message in the user interface.
+
+{{InheritanceDiagram}}
+
+## Constructor
+
+- {{domxref("IdentityCredentialError.IdentityCredentialError", "IdentityCredentialError()")}}
+  - : Creates a new `IdentityCredentialError` object instance.
+
+## Instance properties
+
+_In addition to the properties below, `IdentityCredentialError` inherits properties from its parent, {{DOMxRef("DOMException")}}_.
+
+- {{domxref("IdentityCredentialError.error", "error")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+  - : A string. This can be either a known error from the [OAuth 2.0 specified error list](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) or an arbitrary string.
+- {{domxref("IdentityCredentialError.url", "url")}} {{Experimental_Inline}} {{ReadOnlyInline}}
+  - : A URL pointing to human-readable information about the error to display to users, such as how to fix the error or contact customer service.
+
+## Examples
+
+```js
+try {
+  const cred = await navigator.credentials.get({
+    identity: {
+      providers: [
+        {
+          configURL: "https://idp.example/manifest.json",
+          clientId: "1234",
+        },
+      ],
+    },
+  });
+} catch (e) {
+  const error = e.error;
+  const url = e.url;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CredentialsContainer.get()")}}
+- [ID assertion error responses](/en-US/docs/Web/API/FedCM_API/IDP_integration#id_assertion_error_responses)

--- a/files/en-us/web/api/identitycredentialerror/url/index.md
+++ b/files/en-us/web/api/identitycredentialerror/url/index.md
@@ -1,0 +1,48 @@
+---
+title: "IdentityCredentialError: url property"
+short-title: url
+slug: Web/API/IdentityCredentialError/url
+page-type: web-api-instance-property
+browser-compat: api.IdentityCredentialError.url
+---
+
+{{APIRef("FedCM API")}}{{AvailableInWorkers}}
+
+The **`url`** read-only property of the {{domxref("IdentityCredentialError")}} interface is the URL pointing to human-readable information about the error to display to users, such as how to fix the error or contact customer service.
+
+## Value
+
+A string indicating the URL for more information about the error.
+
+## Examples
+
+```js
+try {
+  const cred = await navigator.credentials.get({
+    identity: {
+      providers: [
+        {
+          configURL: "https://idp.example/manifest.json",
+          clientId: "1234",
+        },
+      ],
+    },
+  });
+} catch (e) {
+  const error = e.error;
+  const url = e.url;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CredentialsContainer.get()")}}
+- [ID assertion error responses](/en-US/docs/Web/API/FedCM_API/IDP_integration#id_assertion_error_responses)

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -516,6 +516,7 @@
       ],
       "interfaces": [
         "IdentityCredential",
+        "IdentityCredentialError",
         "IdentityCredentialRequestOptions",
         "IdentityProvider",
         "NavigatorLogin"


### PR DESCRIPTION
### Description

Document the `IdentityCredentialError` interface (aka "FedCM Error API").

### Motivation

Complete the Authentication reference docs.

### Additional details

Specification: https://w3c-fedid.github.io/FedCM/#browser-api-identity-credential-error-interface
Some (outdated) docs are here: https://privacysandbox.google.com/blog/fedcm-chrome-120-updates#error-api
An (outdated) explainer is here: https://github.com/w3c-fedid/FedCM/issues/488#issuecomment-1679742999

### Related issues and pull requests

Chrome is probably not implementing according to the spec. I've asked about this in https://github.com/w3c-fedid/FedCM/issues/780