### PR TITLE
Add BCD to webextensions.api.types.BrowserSetting methods (BCD Issue 26521)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -2,6 +2,7 @@
 title: clear()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/clear
 page-type: webextension-api-function
+browser-compat: webextensions.api.types.BrowserSetting.clear
 sidebar: addonsidebar
 ---
 
@@ -49,7 +50,7 @@ clearing.then(onCleared);
 
 ## Browser compatibility
 
-See {{WebExtAPIRef("types.BrowserSetting")}}.
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -2,6 +2,7 @@
 title: get()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/get
 page-type: webextension-api-function
+browser-compat: webextensions.api.types.BrowserSetting.get
 sidebar: addonsidebar
 ---
 
@@ -70,7 +71,7 @@ getting.then((got) => {
 
 ## Browser compatibility
 
-See {{WebExtAPIRef("types.BrowserSetting")}}.
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -2,6 +2,7 @@
 title: set()
 slug: Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set
 page-type: webextension-api-function
+browser-compat: webextensions.api.types.BrowserSetting.set
 sidebar: addonsidebar
 ---
 
@@ -67,7 +68,7 @@ browser.browserAction.onClicked.addListener(() => {
 
 ## Browser compatibility
 
-See {{WebExtAPIRef("types.BrowserSetting")}}.
+{{Compat}}
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.


### PR DESCRIPTION
### Description

Amend the webextensions.api.types.BrowserSetting methods to use the BCD provided in https://github.com/mdn/browser-compat-data/pull/27737.