### PR TITLE
Fix hsl() example to use percentage values for lightness adjustments …

### DIFF
--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -271,7 +271,7 @@ These variants are defined using relative colors — the `--base-color` [custom 
    hence currently using calculations like l + 0.2 instead of l + 20 */
 
 #one {
-  background-color: hsl(from var(--base-color) h s calc(l + 0.2));
+  background-color: hsl(from var(--base-color) h s calc(l + 20%));
 }
 
 #two {
@@ -279,12 +279,12 @@ These variants are defined using relative colors — the `--base-color` [custom 
 }
 
 #three {
-  background-color: hsl(from var(--base-color) h s calc(l - 0.2));
+  background-color: hsl(from var(--base-color) h s calc(l - 20%));
 }
 
 /* Use @supports to add in support for old syntax that requires % units to
    be specified in lightness calculations. This is required for
-   Safari 16.4+ */
+   Safari 18.0 */
 @supports (color: hsl(from red h s calc(l - 20%))) {
   #one {
     background-color: hsl(from var(--base-color) h s calc(l + 20%));

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -266,12 +266,8 @@ These variants are defined using relative colors — the `--base-color` [custom 
   --base-color: orange;
 }
 
-/* As per the spec, s and l values should resolve to a number between 0-100
-   However, Chrome 121+ incorrectly resolves them to numbers between 0-1
-   hence currently using calculations like l + 0.2 instead of l + 20 */
-
 #one {
-  background-color: hsl(from var(--base-color) h s calc(l + 20%));
+  background-color: hsl(from var(--base-color) h s calc(l + 20));
 }
 
 #two {
@@ -279,12 +275,11 @@ These variants are defined using relative colors — the `--base-color` [custom 
 }
 
 #three {
-  background-color: hsl(from var(--base-color) h s calc(l - 20%));
+  background-color: hsl(from var(--base-color) h s calc(l - 20));
 }
 
 /* Use @supports to add in support for old syntax that requires % units to
-   be specified in lightness calculations. This is required for
-   Safari 18.0 */
+   be specified in lightness calculations */
 @supports (color: hsl(from red h s calc(l - 20%))) {
   #one {
     background-color: hsl(from var(--base-color) h s calc(l + 20%));


### PR DESCRIPTION


### Description

 Updated the hsl() relative color example to use percentage values (l + 20% and l - 20%) for lightness adjustments so changes are visible in all modern browsers. Cleaned up the Safari support comment to refer only to Safari < 18.0. 

### Motivation

Recent browser implementations resolve the l (lightness) component as a number from 0–100, so adjusting by small decimals like 0.2 is visually negligible. Using percentage adjustments matches the CSS spec and fixes the documented behavior for all readers. 

### Additional details

See the [CSS Color Module Level 5 spec](https://drafts.csswg.org/css-color-5/#relative-HSL).
Release notes for Chrome’s update: [Chrome 125](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl#browser_compatibility). 

### Related issues and pull requests

 Fixes #40980 (Relative color example with hsl() is no longer accurate).


