### PR TITLE
Fix read-only property labeling across DOM interfaces

### DIFF
--- a/files/en-us/web/api/htmlfieldsetelement/index.md
+++ b/files/en-us/web/api/htmlfieldsetelement/index.md
@@ -26,11 +26,11 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : A string reflecting the [`name`](/en-US/docs/Web/HTML/Reference/Elements/fieldset#name) HTML attribute, containing the name of the field set. This can be used when accessing the field set in JavaScript. It is _not_ part of the data which is sent to the server.
 - {{domxref("HTMLFieldSetElement.type")}} {{ReadOnlyInline}}
   - : The string `"fieldset"`.
-- {{domxref("HTMLFieldSetElement.validationMessage")}}
+- {{domxref("HTMLFieldSetElement.validationMessage")}} {{ReadOnlyInline}}
   - : A string representing a localized message that describes the validation constraints that the element does not satisfy (if any). This is the empty string if the element is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
-- {{domxref("HTMLFieldSetElement.validity")}}
+- {{domxref("HTMLFieldSetElement.validity")}} {{ReadOnlyInline}}
   - : A {{domxref("ValidityState")}} representing the validity states that this element is in.
-- {{domxref("HTMLFieldSetElement.willValidate")}}
+- {{domxref("HTMLFieldSetElement.willValidate")}} {{ReadOnlyInline}}
   - : A boolean value `false`, because {{HTMLElement("fieldset")}} objects are never candidates for constraint validation.
 
 ## Instance methods

--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -17,7 +17,7 @@ The {{domxref("HTMLVideoElement")}} and {{domxref("HTMLAudioElement")}} elements
 
 _This interface also inherits properties from its ancestors {{domxref("HTMLElement")}}, {{domxref("Element")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
 
-- {{domxref("HTMLMediaElement.audioTracks")}}
+- {{domxref("HTMLMediaElement.audioTracks")}} {{ReadOnlyInline}}
   - : An {{domxref("AudioTrackList")}} that lists the {{domxref("AudioTrack")}} objects contained in the element.
 - {{domxref("HTMLMediaElement.autoplay")}}
   - : A boolean value that reflects the [`autoplay`](/en-US/docs/Web/HTML/Reference/Elements/video#autoplay) HTML attribute, indicating whether playback should automatically begin as soon as enough media is available to do so without interruption.

--- a/files/en-us/web/api/htmltablecellelement/colspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/colspan/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableCellElement.colSpan
 
 {{ APIRef("HTML DOM") }}
 
-The **`colSpan`** read-only property of the {{domxref("HTMLTableCellElement")}} interface represents the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the [`colspan`](/en-US/docs/Web/HTML/Reference/Elements/td#colspan) attribute.
+The **`colSpan`** property of the {{domxref("HTMLTableCellElement")}} interface represents the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the [`colspan`](/en-US/docs/Web/HTML/Reference/Elements/td#colspan) attribute.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/rowspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/rowspan/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableCellElement.rowSpan
 
 {{ APIRef("HTML DOM") }}
 
-The **`rowSpan`** read-only property of the {{domxref("HTMLTableCellElement")}} interface represents the number of rows this cell must span; this lets the cell occupy space across multiple rows of the table. It reflects the [`rowspan`](/en-US/docs/Web/HTML/Reference/Elements/td#colspan) attribute.
+The **`rowSpan`** property of the {{domxref("HTMLTableCellElement")}} interface represents the number of rows this cell must span; this lets the cell occupy space across multiple rows of the table. It reflects the [`rowspan`](/en-US/docs/Web/HTML/Reference/Elements/td#colspan) attribute.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecolelement/span/index.md
+++ b/files/en-us/web/api/htmltablecolelement/span/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableColElement.span
 
 {{ APIRef("HTML DOM") }}
 
-The **`span`** read-only property of the {{domxref("HTMLTableColElement")}} interface represents the number of columns this {{htmlelement("col")}} or {{htmlelement("colgroup")}} must span; this lets the column occupy space across multiple columns of the table. It reflects the [`span`](/en-US/docs/Web/HTML/Reference/Elements/col#span) attribute.
+The **`span`** property of the {{domxref("HTMLTableColElement")}} interface represents the number of columns this {{htmlelement("col")}} or {{htmlelement("colgroup")}} must span; this lets the column occupy space across multiple columns of the table. It reflects the [`span`](/en-US/docs/Web/HTML/Reference/Elements/col#span) attribute.
 
 ## Value
 


### PR DESCRIPTION
### Description

Removed incorrect "read-only" labels from table span properties (colSpan, rowSpan, span) and added missing {{ReadOnlyInline}} macro to true read-only properties (HTMLFieldSetElement validation properties, HTMLMediaElement.audioTracks)

### Motivation

Correct the incorrect information.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes #40998 
