### PR TITLE
color-mix(): includes parameters not values

### DIFF
--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -32,9 +32,15 @@ color-mix(in --swop5c, red, blue)
 color-mix(in lch longer hue, hsl(200deg 50% 80%), coral)
 ```
 
-### Values
+### Parameters
 
-Functional notation: `color-mix(<color-interpolation-method>, <color>[<percentage>], <color>[<percentage>])`
+The `color-mix()` function's syntax is as follows:
+
+```css
+color-mix(<color-interpolation-method>, <color>[<percentage>], <color>[<percentage>])
+```
+
+The parameters are:
 
 - {{CSSXref("&lt;color-interpolation-method&gt;")}}
   - : Specifies what interpolation method should be used to mix the colors. It consists of the `in` keyword followed by a {{glossary("color space")}} name. The following three types are available:

--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -34,13 +34,7 @@ color-mix(in lch longer hue, hsl(200deg 50% 80%), coral)
 
 ### Parameters
 
-The `color-mix()` function's syntax is as follows:
-
-```plain
-color-mix(<color-interpolation-method>, <color>[<percentage>], <color>[<percentage>])
-```
-
-The parameters are:
+The `color-mix()` function parameters are:
 
 - {{CSSXref("&lt;color-interpolation-method&gt;")}}
   - : Specifies what interpolation method should be used to mix the colors. It consists of the `in` keyword followed by a {{glossary("color space")}} name. The following three types are available:

--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -34,7 +34,7 @@ color-mix(in lch longer hue, hsl(200deg 50% 80%), coral)
 
 ### Parameters
 
-The `color-mix()` function parameters are:
+The `color-mix(<color-interpolation-method>, <color>[<percentage>], <color>[<percentage>])` function parameters are:
 
 - {{CSSXref("&lt;color-interpolation-method&gt;")}}
   - : Specifies what interpolation method should be used to mix the colors. It consists of the `in` keyword followed by a {{glossary("color space")}} name. The following three types are available:

--- a/files/en-us/web/css/color_value/color-mix/index.md
+++ b/files/en-us/web/css/color_value/color-mix/index.md
@@ -36,7 +36,7 @@ color-mix(in lch longer hue, hsl(200deg 50% 80%), coral)
 
 The `color-mix()` function's syntax is as follows:
 
-```css
+```plain
 color-mix(<color-interpolation-method>, <color>[<percentage>], <color>[<percentage>])
 ```
 


### PR DESCRIPTION
Updated section title from 'Values' to 'Parameters' and clarified the syntax and parameters of the color-mix() function.

syntax copies `anchor()`

