### PR TITLE
ci(pr-review-companion): use PR number from event payload

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -30,9 +30,12 @@ jobs:
   review:
     environment: review
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number
+    env:
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+      PREFIX: pr${{ github.event.workflow_run.pull_requests[0].number }}
     steps:
-      - name: "Download artifact"
+      - name: Download artifact
         uses: actions/download-artifact@v5
         with:
           pattern: build
@@ -44,11 +47,7 @@ jobs:
       - name: Check for artifacts
         id: check
         if: hashFiles('build/') != ''
-        run: |
-          echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
-          PR_NUMBER=`cat build/NR | tr -dc '0-9'`
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "PREFIX=pr$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        run: echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate with GCP
         if: steps.check.outputs.HAS_ARTIFACT
@@ -67,7 +66,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "build"
-          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ steps.check.outputs.PREFIX }}"
+          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
           resumable: false
           headers: |-
             cache-control: no-store
@@ -99,8 +98,6 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
-          PREFIX: ${{ steps.check.outputs.PREFIX }}
-          PR_NUMBER: ${{ steps.check.outputs.PR_NUMBER }}
         working-directory: content
         run: |
           echo "Pull request:"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -155,9 +155,6 @@ jobs:
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT
 
-          # Save the PR number into the build
-          echo ${{ github.event.number }} > ${BUILD_OUT_ROOT}/NR
-
           # Download the raw diff blob and store that inside the build
           # directory.
           # The purpose of this is for the PR Review Companion to later


### PR DESCRIPTION
### Description

Updates the `pr-review-companion` workflow to use the PR number from the payload of the event that triggered the workflow run, instead of extracting it from the artifact.

### Motivation

Improves security.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
