### PR TITLE
Fix(list-style-position): remove stray text inside <ul> in example

### DIFF
--- a/files/en-us/web/css/list-style-position/index.md
+++ b/files/en-us/web/css/list-style-position/index.md
@@ -115,22 +115,22 @@ It is often more convenient to use the shorthand {{cssxref("list-style")}}.
 #### HTML
 
 ```html
+<p>List 1</p>
 <ul class="inside">
-  List 1
   <li>List Item 1-1</li>
   <li>List Item 1-2</li>
   <li>List Item 1-3</li>
   <li>List Item 1-4</li>
 </ul>
+<p>List 2</p>
 <ul class="outside">
-  List 2
   <li>List Item 2-1</li>
   <li>List Item 2-2</li>
   <li>List Item 2-3</li>
   <li>List Item 2-4</li>
 </ul>
+<p>List 3</p>
 <ul class="inside-img">
-  List 3
   <li>List Item 3-1</li>
   <li>List Item 3-2</li>
   <li>List Item 3-3</li>


### PR DESCRIPTION
### Description

Fix invalid HTML in the "Setting list item position" example by moving the "List 1/2/3" labels outside of the `<ul>` elements. This ensures the example validates correctly and renders properly.

### Motivation

The original example had stray text inside `<ul>` elements, which is invalid HTML. Correcting this helps readers and contributors understand proper HTML list structure without browser validation errors.

### Additional details

No CSS changes were made. The example still uses `.inside`, `.outside`, and `.inside-img` classes to demonstrate `list-style-position`. This fix only restructures the HTML to be valid.

### Related issues and pull requests

Fixes #41011