### PR TITLE
Document Credential: isConditionalMediationAvailable() static method

### DIFF
--- a/files/en-us/web/api/credential/index.md
+++ b/files/en-us/web/api/credential/index.md
@@ -27,7 +27,7 @@ The **`Credential`** interface of the [Credential Management API](/en-US/docs/We
 ## Static methods
 
 - {{domxref("Credential.isConditionalMediationAvailable_static", "Credential.isConditionalMediationAvailable()")}}
-  - : Returns a {{jsxref("Promise")}} which always resolves to `false`. Sub classes may override this value.
+  - : Returns a {{jsxref("Promise")}} which always resolves to `false`. Subclasses may override this value.
 
 ## Examples
 

--- a/files/en-us/web/api/credential/index.md
+++ b/files/en-us/web/api/credential/index.md
@@ -24,9 +24,10 @@ The **`Credential`** interface of the [Credential Management API](/en-US/docs/We
 - {{domxref("Credential.type")}} {{ReadOnlyInline}}
   - : Returns a string containing the credential's type. Valid values are `password`, `federated`, `public-key`, `identity` and `otp`. (For {{domxref("PasswordCredential")}}, {{domxref("FederatedCredential")}}, {{domxref("PublicKeyCredential")}}, {{domxref("IdentityCredential")}} and {{domxref("OTPCredential")}})
 
-## Instance methods
+## Static methods
 
-None.
+- {{domxref("Credential.isConditionalMediationAvailable_static", "Credential.isConditionalMediationAvailable()")}}
+  - : Returns a {{jsxref("Promise")}} which always resolves to `false`. Sub classes may override this value.
 
 ## Examples
 

--- a/files/en-us/web/api/credential/isconditionalmediationavailable_static/index.md
+++ b/files/en-us/web/api/credential/isconditionalmediationavailable_static/index.md
@@ -1,0 +1,41 @@
+---
+title: "Credential: isConditionalMediationAvailable() static method"
+short-title: isConditionalMediationAvailable()
+slug: Web/API/Credential/isConditionalMediationAvailable_static
+page-type: web-api-static-method
+browser-compat: api.Credential.isConditionalMediationAvailable_static
+---
+
+{{APIRef("Web Authentication API")}}{{securecontext_header}}
+
+The **`isConditionalMediationAvailable()`** static method of the {{domxref("Credential")}} interface returns a {{jsxref("Promise")}} which resolves to `false`.
+
+Sub classes of {{domxref("Credential")}} override this method if they support conditional mediation. See {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}}, for example.
+
+## Syntax
+
+```js-nolint
+Credential.isConditionalMediationAvailable()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} which resolves to `false`.
+
+## Examples
+
+```js
+await Credential.isConditionalMediationAvailable(); // false
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/credential/isconditionalmediationavailable_static/index.md
+++ b/files/en-us/web/api/credential/isconditionalmediationavailable_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Credential.isConditionalMediationAvailable_static
 
 The **`isConditionalMediationAvailable()`** static method of the {{domxref("Credential")}} interface returns a {{jsxref("Promise")}} which resolves to `false`.
 
-Sub classes of {{domxref("Credential")}} override this method if they support conditional mediation. See {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}}, for example.
+Subclasses of {{domxref("Credential")}} override this method if they support conditional mediation. See {{domxref("PublicKeyCredential.isConditionalMediationAvailable_static", "PublicKeyCredential.isConditionalMediationAvailable()")}}, for example.
 
 ## Syntax
 


### PR DESCRIPTION
This is a bit of a strange missing page.

Spec: https://w3c.github.io/webappsec-credential-management/#dom-credential-isconditionalmediationavailable

Sub classes override this, so https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static is more meaningful here, but we should probably talk about the more abstract `Credential.isConditionalMediationAvailable()` static method so that no one gets confused by it.