### PR TITLE
Fix doubly-escaped characters in InteractiveExample titles

### DIFF
--- a/files/en-us/web/css/angle/index.md
+++ b/files/en-us/web/css/angle/index.md
@@ -8,7 +8,7 @@ sidebar: cssref
 
 The **`<angle>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types) represents an angle value expressed in degrees, gradians, radians, or turns. It is used, for example, in {{cssxref("&lt;gradient&gt;")}}s and in some {{cssxref("transform")}} functions.
 
-{{InteractiveExample("CSS Demo: &amp;lt;angle&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;angle&gt;")}}
 
 ```css interactive-example-choice
 transform: rotate(45deg);

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -8,7 +8,7 @@ sidebar: cssref
 
 The **`<basic-shape>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types) represents a shape used in the {{cssxref("clip-path")}}, {{cssxref("shape-outside")}}, and {{cssxref("offset-path")}} properties.
 
-{{InteractiveExample("CSS Demo: &amp;lt;basic-shape&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;basic-shape&gt;")}}
 
 ```css interactive-example-choice
 clip-path: inset(22% 12% 15px 35px);

--- a/files/en-us/web/css/gradient/index.md
+++ b/files/en-us/web/css/gradient/index.md
@@ -8,7 +8,7 @@ sidebar: cssref
 
 The **`<gradient>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Values_and_Units/CSS_data_types) is a special type of {{cssxref("&lt;image&gt;")}} that consists of a progressive transition between two or more colors.
 
-{{InteractiveExample("CSS Demo: &amp;lt;gradient&amp;gt;")}}
+{{InteractiveExample("CSS Demo: &lt;gradient&gt;")}}
 
 ```css interactive-example-choice
 background: linear-gradient(#f69d3c, #3f87a6);


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/41014