### PR TITLE
Disambiguate between custom elements and customized built-in elements

### DIFF
--- a/files/en-us/web/api/document/createelement/index.md
+++ b/files/en-us/web/api/document/createelement/index.md
@@ -83,7 +83,7 @@ function addElement() {
 ### Web component example
 
 > [!NOTE]
-> Check the [browser compatibility](#browser_compatibility) section for support, and the [`is`](/en-US/docs/Web/HTML/Reference/Global_attributes/is) attribute reference for caveats on implementation reality of custom built-in elements.
+> Check the [browser compatibility](#browser_compatibility) section for support, and the [`is`](/en-US/docs/Web/HTML/Reference/Global_attributes/is) attribute reference for caveats on implementation reality of customized built-in elements.
 
 The following example snippet is taken from our [expanding-list-web-component](https://github.com/mdn/web-components-examples/tree/main/expanding-list-web-component) example ([see it live also](https://mdn.github.io/web-components-examples/expanding-list-web-component/)). In this case, our custom element extends the {{domxref("HTMLUListElement")}}, which represents the {{htmlelement("ul")}} element.
 

--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -60,12 +60,12 @@ The basic approach for implementing a web component generally looks something li
     - `attributeChangedCallback()`
       - : Invoked when one of the custom element's attributes is added, removed, or changed.
 
-- Extensions for creating custom built-in elements
+- Extensions for creating customized built-in elements
   - : The following extensions are defined:
     - The [`is`](/en-US/docs/Web/HTML/Reference/Global_attributes/is) global HTML attribute
-      - : Allows you to specify that a standard HTML element should behave like a registered custom built-in element.
+      - : Allows you to specify that a standard HTML element should behave like a registered customized built-in element.
     - The "is" option of the {{domxref("Document.createElement()")}} method
-      - : Allows you to create an instance of a standard HTML element that behaves like a given registered custom built-in element.
+      - : Allows you to create an instance of a standard HTML element that behaves like a given registered customized built-in element.
 
 - CSS pseudo-classes
   - : Pseudo-classes relating specifically to custom elements:

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -455,7 +455,7 @@ Now let's have a look at a customized built in element example. This example ext
 - [See the source code](https://github.com/mdn/web-components-examples/tree/main/expanding-list-web-component)
 
 > [!NOTE]
-> Please see the [`is`](/en-US/docs/Web/HTML/Reference/Global_attributes/is) attribute reference for caveats on implementation reality of custom built-in elements.
+> Please see the [`is`](/en-US/docs/Web/HTML/Reference/Global_attributes/is) attribute reference for caveats on implementation reality of customized built-in elements.
 
 First of all, we define our element's class:
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -19,7 +19,7 @@ There are two types of custom element:
 - **Customized built-in elements** inherit from standard HTML elements such as {{domxref("HTMLImageElement")}} or {{domxref("HTMLParagraphElement")}}. Their implementation extends the behavior of select instances of the standard element.
 
   > [!NOTE]
-  > Safari does not plan to support custom built-in elements. See the [`is` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/is) for more information.
+  > Safari does not plan to support customized built-in elements. See the [`is` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/is) for more information.
 
 ## Implementing a custom element
 

--- a/files/en-us/web/html/reference/global_attributes/index.md
+++ b/files/en-us/web/html/reference/global_attributes/index.md
@@ -63,7 +63,7 @@ In addition to the basic HTML global attributes, the following global attributes
 - [`inputmode`](/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode)
   - : Provides a hint to browsers about the type of virtual keyboard configuration to use when editing this element or its contents. Used primarily on {{HTMLElement("input")}} elements, but is usable on any element while in [`contenteditable`](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) mode.
 - [`is`](/en-US/docs/Web/HTML/Reference/Global_attributes/is)
-  - : Allows you to specify that a standard HTML element should behave like a registered custom built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
+  - : Allows you to specify that a standard HTML element should behave like a registered customized built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
 
 > [!NOTE]
 > The `item*` attributes are part of the [WHATWG HTML Microdata feature](https://html.spec.whatwg.org/multipage/microdata.html#microdata).

--- a/files/en-us/web/html/reference/global_attributes/is/index.md
+++ b/files/en-us/web/html/reference/global_attributes/is/index.md
@@ -8,7 +8,7 @@ sidebar: htmlsidebar
 ---
 
 > [!NOTE]
-> [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
+> [Safari does not plan to support customized built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
 
 The **`is`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) allows you to specify that a standard HTML element should behave like a defined custom built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
 

--- a/files/en-us/web/html/reference/global_attributes/is/index.md
+++ b/files/en-us/web/html/reference/global_attributes/is/index.md
@@ -10,7 +10,7 @@ sidebar: htmlsidebar
 > [!NOTE]
 > [Safari does not plan to support customized built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
 
-The **`is`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) allows you to specify that a standard HTML element should behave like a defined custom built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
+The **`is`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) allows you to specify that a standard HTML element should behave like a defined customized built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
 
 This attribute can only be used if the specified custom element name has been successfully [defined](/en-US/docs/Web/API/CustomElementRegistry/define) in the current document, and extends the element type it is being applied to.
 


### PR DESCRIPTION
### Description

Clarify that Safari does not intend to support custom**ized** built-in elements, leaving it clear that Safari _does_ support "custom" elements.

### Motivation

This note was unclear to me on first reading.

### Additional details

- [HTML Standard § 4.13 Custom elements](https://html.spec.whatwg.org/multipage/custom-elements.html) is consistent in its use of "custom" vs "customized" when referring to autonomous vs built-in elements, respectively.

### Related issues and pull requests

- Relates to #30968