### PR TITLE
adding example-bad to code that shows a mistake

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/build_your_own_function/index.md
+++ b/files/en-us/learn_web_development/core/scripting/build_your_own_function/index.md
@@ -172,7 +172,7 @@ Here's the steps you should follow to get this working:
 
 You might be wondering why we haven't included the parentheses after the function name. This is because we don't want to call the function immediately — only after the button has been clicked. If you try changing the line to
 
-```js
+```js example-bad
 btn.addEventListener("click", displayMessage());
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Just added example-bad to a block of code that shows an example of how not to write. The article below explains that this piece of code will not perform the expected behavior.

### Motivation

I added this parameter because I thought it would be more clear that this is not the code the developer expects.

When reading quickly, the user has the opportunity to copy the wrong piece of code and get the wrong result.

### Additional details

-

### Related issues and pull requests

-