### PR TITLE
Fix typo. Navigator should be lower case here.

### DIFF
--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.language
 
 {{APIRef("HTML DOM")}}
 
-The **`navigator.language`** read-only property returns a string representing the preferred language of the user, usually the language of the browser UI.
+The **`language`** read-only property of the {{domxref("Navigator")}} interface returns a string representing the preferred language of the user, usually the language of the browser UI.
 
 ## Value
 

--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.language
 
 {{APIRef("HTML DOM")}}
 
-The **`Navigator.language`** read-only property returns a string representing the preferred language of the user, usually the language of the browser UI.
+The **`navigator.language`** read-only property returns a string representing the preferred language of the user, usually the language of the browser UI.
 
 ## Value
 

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.languages
 
 {{APIRef("HTML DOM")}}
 
-The **`navigator.languages`** read-only property
+The **`languages`** read-only property of the {{domxref("Navigator")}} interface
 returns an array of strings representing the user's preferred
 languages. The language is described using language tags according to
 {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. In the returned

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.languages
 
 {{APIRef("HTML DOM")}}
 
-The **`Navigator.languages`** read-only property
+The **`navigator.languages`** read-only property
 returns an array of strings representing the user's preferred
 languages. The language is described using language tags according to
 {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. In the returned


### PR DESCRIPTION
```javascript
Navigator.languages
=> undefined
navigator.languages
=> Array [ "en-US", "en" ]
```

### Description

Fix typo

### Motivation

Copy-pasting the snippet actually works.
