### PR TITLE
Fix syntax highlighting for code blocks in speculative loading

### DIFF
--- a/files/en-us/web/performance/guides/speculative_loading/index.md
+++ b/files/en-us/web/performance/guides/speculative_loading/index.md
@@ -100,7 +100,7 @@ Browser support for `<link rel="preload">`/`<link rel="modulepreload">` is wides
 
 For example:
 
-```js
+```html
 <link rel="modulepreload" href="main.js" />
 ```
 
@@ -116,7 +116,7 @@ It is a specialized version of `<link rel="preload">` for [JavaScript modules](/
 
 For example:
 
-```js
+```html
 <link rel="prefetch" href="main.js" />
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

I fixed the incorrect language for syntax highlighting code blocks on the Speculative Loading guide.
https://developer.mozilla.org/en-US/docs/Web/Performance/Guides/Speculative_loading

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The syntax highlighting will be correct.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

It is a minor fix, so I created a pull request without creating an issue.
