### PR TITLE
Fix AbortController being reused in multiple fetch requests in some o…

### DIFF
--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -32,9 +32,16 @@ None ({{jsxref("undefined")}}).
 
 In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-We first create a controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+We first define a variable for our `AbortController`.
 
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling `AbortController.abort()`, as seen below in the second event listener.
+Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+
+> [!NOTE]
+> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
+
+When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+
+When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
 
 ```js
 let controller;

--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -30,51 +30,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
-
-We first define a variable for our `AbortController`.
-
-Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
-
-> [!NOTE]
-> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
-
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
-
-When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
-
-```js
-let controller;
-const url = "video.mp4";
-
-const downloadBtn = document.querySelector(".download");
-const abortBtn = document.querySelector(".abort");
-
-downloadBtn.addEventListener("click", fetchVideo);
-
-abortBtn.addEventListener("click", () => {
-  if (controller) {
-    controller.abort();
-    console.log("Download aborted");
-  }
-});
-
-async function fetchVideo() {
-  controller = new AbortController();
-  const signal = controller.signal;
-
-  try {
-    const response = await fetch(url, { signal });
-    console.log("Download complete", response);
-    // process response further
-  } catch (err) {
-    console.error(`Download error: ${err.message}`);
-  }
-}
-```
-
-> [!NOTE]
-> When `abort()` is called, the `fetch()` promise rejects with an `Error` of type `DOMException`, with name `AbortError`.
+See the [`AbortSignal` page](/en-US/docs/Web/API/AbortSignal#examples) for usage examples.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -37,28 +37,32 @@ We first create a controller using the {{domxref("AbortController.AbortControlle
 When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling `AbortController.abort()`, as seen below in the second event listener.
 
 ```js
-const controller = new AbortController();
-const signal = controller.signal;
-
+let controller;
 const url = "video.mp4";
+
 const downloadBtn = document.querySelector(".download");
 const abortBtn = document.querySelector(".abort");
 
 downloadBtn.addEventListener("click", fetchVideo);
 
 abortBtn.addEventListener("click", () => {
-  controller.abort();
-  console.log("Download aborted");
+  if (controller) {
+    controller.abort();
+    console.log("Download aborted");
+  }
 });
 
-function fetchVideo() {
-  fetch(url, { signal })
-    .then((response) => {
-      console.log("Download complete", response);
-    })
-    .catch((err) => {
-      console.error(`Download error: ${err.message}`);
-    });
+async function fetchVideo() {
+  controller = new AbortController();
+  const signal = controller.signal;
+
+  try {
+    const response = await fetch(url, { signal });
+    console.log("Download complete", response);
+    // process response further
+  } catch (err) {
+    console.error(`Download error: ${err.message}`);
+  }
 }
 ```
 

--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -29,28 +29,32 @@ We first create a controller using the `AbortController()` constructor, then gra
 When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{ signal }` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 
 ```js
-const controller = new AbortController();
-const signal = controller.signal;
-
+let controller;
 const url = "video.mp4";
+
 const downloadBtn = document.querySelector(".download");
 const abortBtn = document.querySelector(".abort");
 
 downloadBtn.addEventListener("click", fetchVideo);
 
 abortBtn.addEventListener("click", () => {
-  controller.abort();
-  console.log("Download aborted");
+  if (controller) {
+    controller.abort();
+    console.log("Download aborted");
+  }
 });
 
-function fetchVideo() {
-  fetch(url, { signal })
-    .then((response) => {
-      console.log("Download complete", response);
-    })
-    .catch((err) => {
-      console.error(`Download error: ${err.message}`);
-    });
+async function fetchVideo() {
+  controller = new AbortController();
+  const signal = controller.signal;
+
+  try {
+    const response = await fetch(url, { signal });
+    console.log("Download complete", response);
+    // process response further
+  } catch (err) {
+    console.error(`Download error: ${err.message}`);
+  }
 }
 ```
 

--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -24,9 +24,16 @@ None.
 
 In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-We first create a controller using the `AbortController()` constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+We first define a variable for our `AbortController`.
 
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{ signal }` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+
+> [!NOTE]
+> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
+
+When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+
+When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
 
 ```js
 let controller;

--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -22,51 +22,7 @@ None.
 
 ## Examples
 
-In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
-
-We first define a variable for our `AbortController`.
-
-Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
-
-> [!NOTE]
-> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
-
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
-
-When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
-
-```js
-let controller;
-const url = "video.mp4";
-
-const downloadBtn = document.querySelector(".download");
-const abortBtn = document.querySelector(".abort");
-
-downloadBtn.addEventListener("click", fetchVideo);
-
-abortBtn.addEventListener("click", () => {
-  if (controller) {
-    controller.abort();
-    console.log("Download aborted");
-  }
-});
-
-async function fetchVideo() {
-  controller = new AbortController();
-  const signal = controller.signal;
-
-  try {
-    const response = await fetch(url, { signal });
-    console.log("Download complete", response);
-    // process response further
-  } catch (err) {
-    console.error(`Download error: ${err.message}`);
-  }
-}
-```
-
-> [!NOTE]
-> When `abort()` is called, the `fetch()` promise rejects with an `AbortError`.
+See the [`AbortSignal` page](/en-US/docs/Web/API/AbortSignal#examples) for usage examples.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -28,68 +28,7 @@ You can create a new `AbortController` object using the {{domxref("AbortControll
 
 ## Examples
 
-> [!NOTE]
-> There are additional examples in the {{domxref("AbortSignal")}} reference.
-
-In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
-
-We first define a variable for our `AbortController`.
-
-Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
-
-> [!NOTE]
-> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
-
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
-
-When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
-
-```js
-let controller;
-const url = "video.mp4";
-
-const downloadBtn = document.querySelector(".download");
-const abortBtn = document.querySelector(".abort");
-
-downloadBtn.addEventListener("click", fetchVideo);
-
-abortBtn.addEventListener("click", () => {
-  if (controller) {
-    controller.abort();
-    console.log("Download aborted");
-  }
-});
-
-async function fetchVideo() {
-  controller = new AbortController();
-  const signal = controller.signal;
-
-  try {
-    const response = await fetch(url, { signal });
-    console.log("Download complete", response);
-    // process response further
-  } catch (err) {
-    console.error(`Download error: ${err.message}`);
-  }
-}
-```
-
-If the request is aborted after the `fetch()` call has been fulfilled but before the response body has been read, then attempting to read the response body will reject with an `AbortError` exception.
-
-```js
-async function get() {
-  const controller = new AbortController();
-  const request = new Request("https://example.org/get", {
-    signal: controller.signal,
-  });
-
-  const response = await fetch(request);
-  controller.abort();
-  // The next line will throw `AbortError`
-  const text = await response.text();
-  console.log(text);
-}
-```
+See the [`AbortSignal` page](/en-US/docs/Web/API/AbortSignal#examples) for usage examples.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -33,7 +33,12 @@ You can create a new `AbortController` object using the {{domxref("AbortControll
 
 In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-We first create a controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+We first define a variable for our `AbortController`.
+
+Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+
+> [!NOTE]
+> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
 
 When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 

--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -23,28 +23,32 @@ We first create a controller using the {{domxref("AbortController.AbortControlle
 When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 
 ```js
-const controller = new AbortController();
-const signal = controller.signal;
-
+let controller;
 const url = "video.mp4";
+
 const downloadBtn = document.querySelector(".download");
 const abortBtn = document.querySelector(".abort");
 
 downloadBtn.addEventListener("click", fetchVideo);
 
 abortBtn.addEventListener("click", () => {
-  controller.abort();
-  console.log("Download aborted");
+  if (controller) {
+    controller.abort();
+    console.log("Download aborted");
+  }
 });
 
-function fetchVideo() {
-  fetch(url, { signal })
-    .then((response) => {
-      console.log("Download complete", response);
-    })
-    .catch((err) => {
-      console.error(`Download error: ${err.message}`);
-    });
+async function fetchVideo() {
+  controller = new AbortController();
+  const signal = controller.signal;
+
+  try {
+    const response = await fetch(url, { signal });
+    console.log("Download complete", response);
+    // process response further
+  } catch (err) {
+    console.error(`Download error: ${err.message}`);
+  }
 }
 ```
 

--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -16,51 +16,7 @@ An {{domxref("AbortSignal")}} object instance.
 
 ## Examples
 
-In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
-
-We first define a variable for our `AbortController`.
-
-Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
-
-> [!NOTE]
-> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
-
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
-
-When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
-
-```js
-let controller;
-const url = "video.mp4";
-
-const downloadBtn = document.querySelector(".download");
-const abortBtn = document.querySelector(".abort");
-
-downloadBtn.addEventListener("click", fetchVideo);
-
-abortBtn.addEventListener("click", () => {
-  if (controller) {
-    controller.abort();
-    console.log("Download aborted");
-  }
-});
-
-async function fetchVideo() {
-  controller = new AbortController();
-  const signal = controller.signal;
-
-  try {
-    const response = await fetch(url, { signal });
-    console.log("Download complete", response);
-    // process response further
-  } catch (err) {
-    console.error(`Download error: ${err.message}`);
-  }
-}
-```
-
-> [!NOTE]
-> When `abort()` is called, the `fetch()` promise rejects with an `AbortError`.
+See the [`AbortSignal` page](/en-US/docs/Web/API/AbortSignal#examples) for usage examples.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -18,9 +18,16 @@ An {{domxref("AbortSignal")}} object instance.
 
 In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-We first create a controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the `AbortController.signal` property.
+We first define a variable for our `AbortController`.
+
+Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+
+> [!NOTE]
+> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected with a `DOMException` named `AbortError`.
 
 When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+
+When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
 
 ```js
 let controller;

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -56,7 +56,7 @@ The following snippet shows how we might use a signal to abort downloading a vid
 
 We first define a variable for our `AbortController`.
 
-Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create a new controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
 
 > [!NOTE]
 > An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected.

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -54,10 +54,14 @@ Listen to this event using {{domxref("EventTarget.addEventListener", "addEventLi
 
 The following snippet shows how we might use a signal to abort downloading a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-We first create an abort controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated `AbortSignal` object using the {{domxref("AbortController.signal")}} property.
+We first define a variable for our `AbortController`.
 
-When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request, and allows us to abort it by calling {{domxref("AbortController.abort()")}}.
-Below you can see that the fetch operation is aborted in the second event listener, which triggered when the abort button (`abortBtn`) is clicked.
+Before each [fetch request](/en-US/docs/Web/API/Window/fetch) we create new instance of controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
+
+> [!NOTE]
+> An `AbortSignal` can only be used once. After it is aborted, any fetch call using the same signal will be immediately rejected.
+
+When the [fetch request](/en-US/docs/Web/API/Window/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{ signal }` below). This associates the signal and controller with the fetch request and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
 
 When `abort()` is called, the `fetch()` promise rejects with a `DOMException` named `AbortError`.
 


### PR DESCRIPTION
### Description

The AbortController [examples](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/AbortController#examples) include code that reused the same AbortController instance across multiple fetch calls, which causes them to be instantly cancelled.

### Motivation

The documentation should be updated to help developers understand that an AbortController instance cannot be reused.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
