### PR TITLE
Safari also supports SVG WebExtension icons

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -70,7 +70,7 @@ You can use SVG, and the browser scales your icon appropriately. There are two c
    ```
 
 > [!NOTE]
-> Only Firefox and Safari are known to support SVG icons. Chromium has a bug about [unsupported SVG icons](https://crbug.com/29683).
+> Chromium-based browsers don't support this feature. See [Chromium bug 29683](https://crbug.com/29683).
 
 > [!NOTE]
 > Remember to include the `xmlns` attribute when creating the SVG. Otherwise, Firefox won't display the icon.

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -70,7 +70,7 @@ You can use SVG, and the browser scales your icon appropriately. There are two c
    ```
 
 > [!NOTE]
-> Only Firefox is known to support SVG icons. Chromium has a bug about [unsupported SVG icons](https://crbug.com/29683).
+> Only Firefox and Safari are known to support SVG icons. Chromium has a bug about [unsupported SVG icons](https://crbug.com/29683).
 
 > [!NOTE]
 > Remember to include the `xmlns` attribute when creating the SVG. Otherwise, Firefox won't display the icon.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Safari also supports SVG WebExtension icons so the note should be updated to include it.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The page currently contradicts itself: the note about SVG WebExtension icon support says the feature is only available in Firefox, while the compatibility notes say support was added to Safari a couple of months later.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
The compatibility notes state the feature is available in Safari: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons#browser_compatibility

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
