### PR TITLE
chore: align the output of the RangeError caused by invalid language tag

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -52,7 +52,7 @@ Intl.getCanonicalLocales("EN-US"); // ["en-US"]
 Intl.getCanonicalLocales(["EN-US", "Fr"]); // ["en-US", "fr"]
 
 Intl.getCanonicalLocales("EN_US");
-// RangeError:'EN_US' is not a structurally valid language tag
+// RangeError: invalid language tag: "EN_US"
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

align the output of the RangeError caused by invalid language tag

### Motivation

The output in example and `InteractiveExample` is not the same, this pr align the output of them.
