### PR TITLE
fix: `::columns` -> `::column`

### DIFF
--- a/files/en-us/web/css/_doublecolon_column/index.md
+++ b/files/en-us/web/css/_doublecolon_column/index.md
@@ -36,7 +36,7 @@ While the styling that can be applied to `::column` is very limited, it may be e
 
 ### Scrolling column layout
 
-This demo creates a responsive container that snaps each "page" of content into place. It uses the {{cssxref("columns")}} property and the `::columns` pseudo-element to create content columns that span the full width of their parent {{glossary("scroll container")}}, which can be scrolled horizontally. Each column contains one or more list items, which vary in number depending on the viewport width.
+This demo creates a responsive container that snaps each "page" of content into place. It uses the {{cssxref("columns")}} property and the `::column` pseudo-element to create content columns that span the full width of their parent {{glossary("scroll container")}}, which can be scrolled horizontally. Each column contains one or more list items, which vary in number depending on the viewport width.
 
 #### HTML
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR fixes a pseudo-element mismatch (`::columns` → `::column`) found in the documentation.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
