### PR TITLE
Changed "search term" to "username"

### DIFF
--- a/files/en-us/web/html/reference/elements/input/text/index.md
+++ b/files/en-us/web/html/reference/elements/input/text/index.md
@@ -265,7 +265,7 @@ This renders like so:
 
 {{EmbedLiveSample('Making_input_required', 600, 100)}}
 
-If you try to submit the form with no search term entered into it, the browser will show an error message.
+If you try to submit the form with no username entered into it, the browser will show an error message.
 
 ### Input value length
 


### PR DESCRIPTION
Small change for a small error I noticed:

The example for ### Making input required shows a form where one should choose a username, however the explanation below said search term.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The example for ### Making input required shows a form where one should choose a username, however the explanation below said search term.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Mainly new users could be confused as to what the text is referring to, so I edited it to be the correct form. Additionally, I have never contributed to an open-source project, so wanted to try it out with this basic edit.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
