### PR TITLE
Fix: Calculation typo in `exp()`

### DIFF
--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -18,7 +18,7 @@ The `exp(number)` function contains a calculation which returns the same value a
 /* A <number> value */
 width: calc(100px * exp(-1)); /* 100px * 0.367879441171442 = 36px */
 width: calc(100px * exp(0)); /* 100px * 1 = 100px */
-width: calc(100px * exp(1)); /* 100px * 2.718281828459045 = 217px */
+width: calc(100px * exp(1)); /* 100px * 2.718281828459045 = 271px */
 ```
 
 ### Parameters

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -16,9 +16,9 @@ The `exp(number)` function contains a calculation which returns the same value a
 
 ```css
 /* A <number> value */
-width: calc(100px * exp(-1)); /* 100px * 0.367879441171442 = 36px */
+width: calc(100px * exp(-1)); /* 100px * 0.367879441171442 = 36.8px */
 width: calc(100px * exp(0)); /* 100px * 1 = 100px */
-width: calc(100px * exp(1)); /* 100px * 2.718281828459045 = 271px */
+width: calc(100px * exp(1)); /* 100px * 2.718281828459045 = 271.8px */
 ```
 
 ### Parameters


### PR DESCRIPTION
### Description

Fixes #41080 - Typo in syntax code block
