### PR TITLE
Change location type from string to number

### DIFF
--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.md
@@ -30,7 +30,7 @@ new KeyboardEvent(type, options)
     - `code` {{optional_inline}}
       - : A string, defaulting to `""`, that sets the value of {{domxref("KeyboardEvent.code")}}.
     - `location` {{optional_inline}}
-      - : A string, defaulting to `0`, that sets the value of {{domxref("KeyboardEvent.location")}}.
+      - : A number, defaulting to `0`, that sets the value of {{domxref("KeyboardEvent.location")}}.
     - `repeat` {{optional_inline}}
       - : A boolean value, defaulting to `false`, that sets the value of {{domxref("KeyboardEvent.repeat")}}.
     - `isComposing` {{optional_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes the `location` argument type for `KeyboardEvent`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
