### PR TITLE
The form attribute: link to the form ref page

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -37,7 +37,7 @@ We already met this in the previous article.
 > [!WARNING]
 > It's strictly forbidden to nest a form inside another form. Nesting can cause forms to behave unpredictably, so it is a bad idea.
 
-It's always possible to use a form control outside of a {{HTMLElement("form")}} element. If you do so, by default that control has nothing to do with any form unless you associate it with a form using its [`form`](/en-US/docs/Web/HTML/Reference/Elements/input#form) attribute. This was introduced to let you explicitly bind a control with a form even if it is not nested inside it.
+It's always possible to use a form control outside of a {{HTMLElement("form")}} element. If you do so, by default that control has nothing to do with any form unless you associate it with a form using its [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute. This was introduced to let you explicitly bind a control with a form even if it is not nested inside it.
 
 Let's move forward and cover the structural elements you'll find nested in a form.
 

--- a/files/en-us/web/api/htmlbuttonelement/form/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/form/index.md
@@ -27,5 +27,5 @@ An {{domxref("HTMLFormElement")}} or `null`.
 - {{domxref("HTMLButtonElement")}}
 - {{domxref("HTMLFormElement")}}
 - {{HTMLElement("button")}}
-- HTML [`form`](/en-US/docs/Web/HTML/Reference/Elements/button#form) attribute
+- HTML [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)

--- a/files/en-us/web/api/htmlfieldsetelement/form/index.md
+++ b/files/en-us/web/api/htmlfieldsetelement/form/index.md
@@ -27,5 +27,5 @@ An {{domxref("HTMLFormElement")}} or `null`.
 - {{domxref("HTMLFieldSetElement")}}
 - {{domxref("HTMLFormElement")}}
 - {{HTMLElement("fieldset")}}
-- HTML [`form`](/en-US/docs/Web/HTML/Reference/Elements/fieldset#form) attribute
+- HTML [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)

--- a/files/en-us/web/api/htmlinputelement/form/index.md
+++ b/files/en-us/web/api/htmlinputelement/form/index.md
@@ -27,5 +27,5 @@ An {{domxref("HTMLFormElement")}} or `null`.
 - {{domxref("HTMLInputElement")}}
 - {{domxref("HTMLFormElement")}}
 - {{HTMLElement("input")}}
-- HTML [`form`](/en-US/docs/Web/HTML/Reference/Elements/input#form) attribute
+- HTML [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)

--- a/files/en-us/web/api/htmloutputelement/form/index.md
+++ b/files/en-us/web/api/htmloutputelement/form/index.md
@@ -27,5 +27,5 @@ An {{domxref("HTMLFormElement")}} or `null`.
 - {{domxref("HTMLOutputElement")}}
 - {{domxref("HTMLFormElement")}}
 - {{HTMLElement("output")}}
-- HTML [`form`](/en-US/docs/Web/HTML/Reference/Elements/output#form) attribute
+- HTML [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)

--- a/files/en-us/web/api/htmlselectelement/form/index.md
+++ b/files/en-us/web/api/htmlselectelement/form/index.md
@@ -27,5 +27,5 @@ An {{domxref("HTMLFormElement")}} or `null`.
 - {{domxref("HTMLSelectElement")}}
 - {{domxref("HTMLFormElement")}}
 - {{HTMLElement("select")}}
-- HTML [`form`](/en-US/docs/Web/HTML/Reference/Elements/select#form) attribute
+- HTML [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)

--- a/files/en-us/web/api/htmltextareaelement/form/index.md
+++ b/files/en-us/web/api/htmltextareaelement/form/index.md
@@ -27,5 +27,5 @@ An {{domxref("HTMLFormElement")}} or `null`.
 - {{domxref("HTMLTextAreaElement")}}
 - {{domxref("HTMLFormElement")}}
 - {{HTMLElement("textarea")}}
-- HTML [`form`](/en-US/docs/Web/HTML/Reference/Elements/textarea#form) attribute
+- HTML [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)

--- a/files/en-us/web/html/reference/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/reference/attributes/autocomplete/index.md
@@ -46,7 +46,7 @@ The `autocomplete` attribute provides a hint to the user agent specifying how to
 <input autocomplete="section-user1 billing postal-code" />
 ```
 
-If an {{HTMLElement("input")}}, {{HTMLElement("select")}} or {{HTMLElement("textarea")}} element has no `autocomplete` attribute, the browser will use the [`autocomplete` attribute of the element's **owning form**](/en-US/docs/Web/HTML/Reference/Elements/form#autocomplete). The owning form is either the {{HTMLElement("form")}} matching the `id` specified by the [`form`](/en-US/docs/Web/HTML/Reference/Elements/input#form) attribute of the element (if present) or, more commonly, the `<form>` the element is nested in.
+If an {{HTMLElement("input")}}, {{HTMLElement("select")}} or {{HTMLElement("textarea")}} element has no `autocomplete` attribute, the browser will use the [`autocomplete` attribute of the element's **owning form**](/en-US/docs/Web/HTML/Reference/Elements/form#autocomplete). The owning form is either the {{HTMLElement("form")}} matching the `id` specified by the [`form`](/en-US/docs/Web/HTML/Reference/Attributes/form) attribute of the element (if present) or, more commonly, the `<form>` the element is nested in.
 
 > [!NOTE]
 > In order to provide autocompletion, user-agents might require `<input>`/`<select>`/`<textarea>` elements to:


### PR DESCRIPTION
In the list of attributes on the form control pages, the form attribute itself links to the form attribute page, so might as well go there directly,.