### PR TITLE
Document fetching a range of a blob

### DIFF
--- a/files/en-us/web/http/reference/headers/range/index.md
+++ b/files/en-us/web/http/reference/headers/range/index.md
@@ -135,6 +135,22 @@ Content-Type: image/jpeg
 Accept-Ranges: bytes
 ```
 
+### Fetching a range from a blob URL
+
+The [`blob:`](/en-US/docs/Web/URI/Reference/Schemes/blob) URL also supports range requests by using [`fetch()`](/en-US/docs/Web/API/Window/fetch).
+
+```js
+const blob = new Blob(["Hello, world!"], { type: "text/plain" });
+const url = URL.createObjectURL(blob);
+fetch(url, {
+  headers: {
+    Range: "bytes=7-11",
+  },
+})
+  .then((response) => response.text())
+  .then((text) => console.log(text)); // "world"
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/uri/reference/schemes/blob/index.md
+++ b/files/en-us/web/uri/reference/schemes/blob/index.md
@@ -57,6 +57,10 @@ In older versions of the Media Source specification, attaching a stream to a {{H
 > [!WARNING]
 > If you still have code that relies on `createObjectURL()` to attach streams to media elements, you need to update your code to set {{domxref("HTMLMediaElement.srcObject", "srcObject")}} to the `MediaStream` directly.
 
+### Fetching with the Range header
+
+Blob URLs support fetching with the [`Range`](/en-US/docs/Web/HTTP/Reference/Headers/Range) header to request partial content. This is particularly useful when working with large blobs, allowing you to fetch only the necessary parts of the blob instead of the entire content. For an example, see [fetching a range from a blob URL](/en-US/docs/Web/HTTP/Reference/Headers/Range#fetching_a_range_from_a_blob_url).
+
 ## Examples
 
 ### Valid blob URLs


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/24625. Although this was added to the `fetch()`/`XMLHttpRequest` machinery, we don't document anything about the request specifics in `fetch()`. So instead, I'm just documenting it in the two relevant places.