### PR TITLE
Bug-1986688 Cookies expirationDate in milliseconds

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -15,7 +15,7 @@ Values of this type are objects that can contain these properties:
 - `domain`
   - : A `string` representing the domain the cookie belongs to (e.g., "www.google.com" or "example.com").
 - `expirationDate` {{optional_inline}}
-  - : A `number` representing the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 includes millisecond in the fractional part. Not provided for session cookies.
+  - : A `number` representing the expiration date of the cookie as the seconds after the UNIX epoch. From Firefox 142 includes milliseconds in the fractional part. Not provided for session cookies.
 - `firstPartyDomain`
   - : A `string` representing the first-party domain associated with the cookie. This is an empty string if the cookie was set while first-party isolation was off. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
 - `hostOnly`

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -15,7 +15,7 @@ Values of this type are objects that can contain these properties:
 - `domain`
   - : A `string` representing the domain the cookie belongs to (e.g., "www.google.com" or "example.com").
 - `expirationDate` {{optional_inline}}
-  - : A `number` representing the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 includes millisecond. Not provided for session cookies.
+  - : A `number` representing the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 includes millisecond in the fractional part. Not provided for session cookies.
 - `firstPartyDomain`
   - : A `string` representing the first-party domain associated with the cookie. This is an empty string if the cookie was set while first-party isolation was off. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
 - `hostOnly`

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -15,7 +15,7 @@ Values of this type are objects that can contain these properties:
 - `domain`
   - : A `string` representing the domain the cookie belongs to (e.g., "www.google.com" or "example.com").
 - `expirationDate` {{optional_inline}}
-  - : A `number` representing the expiration date of the cookie as the seconds after the UNIX epoch. From Firefox 142 includes milliseconds in the fractional part. Not provided for session cookies.
+  - : A `number` representing the expiration date of the cookie as the seconds after the UNIX epoch. Includes milliseconds in the fractional part. Not provided for session cookies.
 - `firstPartyDomain`
   - : A `string` representing the first-party domain associated with the cookie. This is an empty string if the cookie was set while first-party isolation was off. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
 - `hostOnly`

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -15,7 +15,7 @@ Values of this type are objects that can contain these properties:
 - `domain`
   - : A `string` representing the domain the cookie belongs to (e.g., "www.google.com" or "example.com").
 - `expirationDate` {{optional_inline}}
-  - : A `number` representing the expiration date of the cookie as the number of seconds since the UNIX epoch. Not provided for session cookies.
+  - : A `number` representing the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 includes millisecond. Not provided for session cookies.
 - `firstPartyDomain`
   - : A `string` representing the first-party domain associated with the cookie. This is an empty string if the cookie was set while first-party isolation was off. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
 - `hostOnly`

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -27,7 +27,7 @@ let setting = browser.cookies.set(
     - `domain` {{optional_inline}}
       - : A `string` representing the domain of the cookie. If omitted, the cookie becomes a host-only cookie.
     - `expirationDate` {{optional_inline}}
-      - : A `number` that represents the expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.
+      - : A `number` that represents the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 can include millisecond. If omitted, the cookie becomes a session cookie.
     - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie is associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
     - `httpOnly` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -27,7 +27,7 @@ let setting = browser.cookies.set(
     - `domain` {{optional_inline}}
       - : A `string` representing the domain of the cookie. If omitted, the cookie becomes a host-only cookie.
     - `expirationDate` {{optional_inline}}
-      - : A `number` that represents the expiration date of the cookie as the seconds after the UNIX epoch. From Firefox 142 can include milliseconds in the fractional part. If omitted, the cookie becomes a session cookie.
+      - : A `number` that represents the expiration date of the cookie as the seconds after the UNIX epoch. Can include milliseconds in the fractional part. If omitted, the cookie becomes a session cookie.
     - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie is associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
     - `httpOnly` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -27,7 +27,7 @@ let setting = browser.cookies.set(
     - `domain` {{optional_inline}}
       - : A `string` representing the domain of the cookie. If omitted, the cookie becomes a host-only cookie.
     - `expirationDate` {{optional_inline}}
-      - : A `number` that represents the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 can include millisecond. If omitted, the cookie becomes a session cookie.
+      - : A `number` that represents the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 can include millisecond in the fractional part. If omitted, the cookie becomes a session cookie.
     - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie is associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
     - `httpOnly` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -27,7 +27,7 @@ let setting = browser.cookies.set(
     - `domain` {{optional_inline}}
       - : A `string` representing the domain of the cookie. If omitted, the cookie becomes a host-only cookie.
     - `expirationDate` {{optional_inline}}
-      - : A `number` that represents the expiration date of the cookie as the seconds since the UNIX epoch. From Firefox 142 can include millisecond in the fractional part. If omitted, the cookie becomes a session cookie.
+      - : A `number` that represents the expiration date of the cookie as the seconds after the UNIX epoch. From Firefox 142 can include milliseconds in the fractional part. If omitted, the cookie becomes a session cookie.
     - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie is associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
     - `httpOnly` {{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -76,6 +76,7 @@ No notable changes.
 - Cookies created with {{WebExtAPIRef("cookies.set()")}} in Nightly are now validated, and invalid cookies are rejected. The implementation in Nightly is to enable monitoring for any issues. The intention is to enforce validation in all channels in a future release. ([Firefox bug 1976197](https://bugzil.la/1976197))
 - Adds the {{WebExtAPIRef("browserAction.onUserSettingsChanged")}} and {{WebExtAPIRef("action.onUserSettingsChanged")}} events that listen for changes in the user-specified settings that affect an extension's action. ([Firefox bug 1828220](https://bugzil.la/1828220))
 - Adds {{WebExtAPIRef("browserSettings.verticalTabs")}}, which enables extensions to control whether the browser displays the tab bar horizontally or vertically. ([Firefox bug 1946600](https://bugzil.la/1946600))
+- The {{WebExtAPIRef("cookies")}} methods now accept and return milliseconds in `expirationDate`. ([Firefox bug 1946600](https://bugzil.la/1946600))
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -74,7 +74,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - Cookies created with {{WebExtAPIRef("cookies.set()")}} in Nightly are now validated, and invalid cookies are rejected. The implementation in Nightly is to enable monitoring for any issues. The intention is to enforce validation in all channels in a future release. ([Firefox bug 1976197](https://bugzil.la/1976197))
-- The {{WebExtAPIRef("cookies")}} methods now accept and return milliseconds in `expirationDate`. ([Firefox bug 1972757](https://bugzil.la/1972757))
+- The {{WebExtAPIRef("cookies")}} methods now accept and return milliseconds in the fractional part of `expirationDate`. ([Firefox bug 1972757](https://bugzil.la/1972757))
 - Adds the {{WebExtAPIRef("browserAction.onUserSettingsChanged")}} and {{WebExtAPIRef("action.onUserSettingsChanged")}} events that listen for changes in the user-specified settings that affect an extension's action. ([Firefox bug 1828220](https://bugzil.la/1828220))
 - Adds {{WebExtAPIRef("browserSettings.verticalTabs")}}, which enables extensions to control whether the browser displays the tab bar horizontally or vertically. ([Firefox bug 1946600](https://bugzil.la/1946600))
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -74,9 +74,9 @@ No notable changes.
 ## Changes for add-on developers
 
 - Cookies created with {{WebExtAPIRef("cookies.set()")}} in Nightly are now validated, and invalid cookies are rejected. The implementation in Nightly is to enable monitoring for any issues. The intention is to enforce validation in all channels in a future release. ([Firefox bug 1976197](https://bugzil.la/1976197))
+- The {{WebExtAPIRef("cookies")}} methods now accept and return milliseconds in `expirationDate`. ([Firefox bug 1972757](https://bugzil.la/1972757))
 - Adds the {{WebExtAPIRef("browserAction.onUserSettingsChanged")}} and {{WebExtAPIRef("action.onUserSettingsChanged")}} events that listen for changes in the user-specified settings that affect an extension's action. ([Firefox bug 1828220](https://bugzil.la/1828220))
 - Adds {{WebExtAPIRef("browserSettings.verticalTabs")}}, which enables extensions to control whether the browser displays the tab bar horizontally or vertically. ([Firefox bug 1946600](https://bugzil.la/1946600))
-- The {{WebExtAPIRef("cookies")}} methods now accept and return milliseconds in `expirationDate`. ([Firefox bug 1946600](https://bugzil.la/1946600))
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Addresses the dev-docs-needed requirement of [Bug 1986688](https://bugzilla.mozilla.org/show_bug.cgi?id=1986688) Cookies are returned with a fractional expirationDate for the change made in [Bug 1972757](https://bugzilla.mozilla.org/show_bug.cgi?id=1972757) Store cookie expiry value as msec.

Related BCD changes in TBC.