### PR TITLE
Add missing "optional" label to "transports" in PublicKeyCredentialRequestOptions doc page

### DIFF
--- a/files/en-us/web/api/publickeycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/index.md
@@ -21,7 +21,7 @@ It is used to request a {{domxref("PublicKeyCredential")}} provided by an {{glos
     - `id`
       - : An {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}} representing the ID of the public key credential to retrieve. This value is mirrored by the {{domxref("PublicKeyCredential.rawId", "rawId")}} property of the {{domxref("PublicKeyCredential")}} object returned by a successful `get()` call.
 
-    - `transports`
+    - `transports` {{optional_inline}}
       - : An array of strings providing hints as to the methods the client could use to communicate with the relevant authenticator of the public key credential to retrieve. Possible transports are: `"ble"`, `"hybrid"`, `"internal"`, `"nfc"`, and `"usb"`.
 
         > [!NOTE]


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Add missing "optional" label to "transports" parameter of "allowCredentials" array entry.

### Motivation

This parameter is optional, but was not marked with label, see below.

### Additional details

According to [Specification](https://w3c.github.io/webauthn/#dictionary-credential-descriptor)

> **transports, of type sequence<DOMString>**
This OPTIONAL member contains a hint as to how the client might communicate with the managing authenticator of the public key credential the caller is referring to. The values SHOULD be members of AuthenticatorTransport but client platforms MUST ignore unknown values.

