### PR TITLE
Update Firefox 143 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -68,13 +68,19 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### WebDriver BiDi
 
-<!-- #### WebDriver BiDi -->
-
-<!-- #### Marionette -->
+- Updated the `browsingContext.contextCreated` event to be emitted for all open contexts when subscribing to the event ([Firefox bug 1754273](https://bugzil.la/1754273)).
+- Implemented new commands for the `network` module to enable recording network data:
+  - `network.addDataCollector` adds a network data collector to `contexts`, `userContexts` or globally. The collector will record network data corresponding to the provided `dataTypes`. At the moment, only the "response" data type is supported. A `maxEncodedDataSize` must also be provided, network data exceeding this size will not be recorded ([Firefox bug 1971778](https://bugzil.la/1971778)).
+  - `network.removeDataCollector` removes a previously added network data collector ([Firefox bug 1971781](https://bugzil.la/1971781)).
+  - `network.getData` retrieves the data collected for a provided `request` id, `dataType` and optionally `collector` id. When providing a `collector` id, clients may also pass the `disown` flag to release the network data from the collector. Note that data is deleted when it is no longer owned by any collector ([Firefox bug 1971780](https://bugzil.la/1971780)).
+  - `network.disownData` releases the data for a given `request` id and `dataType` from the provided `collector` id ([Firefox bug 1971779](https://bugzil.la/1971779)).
+- Fixed a bug where `emulation.setLocaleOverride` did not apply the override to newly created cross-origin iframes ([Firefox bug 1978533](https://bugzil.la/1978533)).
+- Fixed a bug where several commands such as `session.subscribe` would fail if any tab was unloaded ([Firefox bug 1949037](https://bugzil.la/1949037)).
+- Fixed the `browsingContext.navigationCommitted` event so that the `url` property now includes basic auth credentials. ([Firefox bug 1980137](https://bugzil.la/1980137)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Release notes update based on the following list of [relnote worthy bugs](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox142&query_format=advanced&o1=equals&f1=cf_status_firefox143&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=17627247).