### PR TITLE
Fix supported algorithms for HKDF and PBKDF2

### DIFF
--- a/files/en-us/web/api/subtlecrypto/index.md
+++ b/files/en-us/web/api/subtlecrypto/index.md
@@ -295,8 +295,8 @@ The table below summarizes which algorithms are suitable for which cryptographic
       <td></td>
       <td>✓</td>
       <td></td>
-      <td>✓</td>
       <td></td>
+      <td>✓</td>
     </tr>
     <tr>
       <th scope="row"><a href="/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2">PBKDF2</a></th>
@@ -305,8 +305,8 @@ The table below summarizes which algorithms are suitable for which cryptographic
       <td></td>
       <td>✓</td>
       <td></td>
-      <td>✓</td>
       <td></td>
+      <td>✓</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
### Description

Fixes the supported algorithms table.

HKDF and PBKDF2 currently has a checkmark in the generateKey / exportKey column which is incorrect as HKDF and PBKDF2 aren't supported for generateKey / exportKey.
HKDF and PBKDF2 however are supported for importKey which is currently missing a checkmark.

### Motivation

Correcting the information provided by the table.