### PR TITLE
Improve caret color demo contrast

### DIFF
--- a/files/en-us/web/css/caret-shape/index.md
+++ b/files/en-us/web/css/caret-shape/index.md
@@ -140,7 +140,7 @@ label {
   background: #092104;
   display: block;
   padding: 10px 20px;
-  color: green;
+  color: #00ad00;
   font-weight: bold;
   font-family: monospace;
 }
@@ -162,7 +162,7 @@ label {
 span {
   display: inline-block;
   padding: 2px 5px;
-  color: green;
+  color: #00ad00;
   font-weight: bold;
   margin-right: 8px;
 }
@@ -171,7 +171,7 @@ span {
   background: transparent;
   height: 100%;
   border: none;
-  color: green;
+  color: #00ad00;
   font-family: inherit;
   font-size: 1rem;
   outline: none;
@@ -190,7 +190,7 @@ span {
 @keyframes old-caret {
   from,
   50% {
-    caret-color: green;
+    caret-color: #00ad00;
   }
   75%,
   to {

--- a/files/en-us/web/css/caret/index.md
+++ b/files/en-us/web/css/caret/index.md
@@ -150,7 +150,7 @@ label {
   background: #092104;
   display: block;
   padding: 10px 20px;
-  color: green;
+  color: #00ad00;
   font-weight: bold;
   font-family: monospace;
 }
@@ -172,7 +172,7 @@ label {
 span {
   display: inline-block;
   padding: 2px 5px;
-  color: green;
+  color: #00ad00;
   font-weight: bold;
   margin-right: 8px;
 }
@@ -181,7 +181,7 @@ span {
   background: transparent;
   height: 100%;
   border: none;
-  color: green;
+  color: #00ad00;
   font-family: inherit;
   font-size: 1rem;
   outline: none;
@@ -199,7 +199,7 @@ span {
 @keyframes vintage-caret {
   from,
   50% {
-    caret-color: green;
+    caret-color: #00ad00;
   }
   75%,
   to {


### PR DESCRIPTION
### Description

Makes the text color in the terminal demos lighter.

### Motivation

To improve the demo’s color contrast:

<details>
<summary>Before: 2.75 (–)</summary>
<img width="697" height="407" alt="Screenshot 2025-09-11 at 16 46 15" src="https://github.com/user-attachments/assets/76fa71d4-7dc0-46e2-b385-e79b8b5734f4" />
<img width="731" height="395" alt="Screenshot 2025-09-11 at 16 48 40" src="https://github.com/user-attachments/assets/918cd33c-b903-4c11-b58f-a075bbe94f12" />
</details>

<details>
<summary>After: 4.7 (AA+)</summary>
<img width="692" height="408" alt="Screenshot 2025-09-11 at 16 44 44" src="https://github.com/user-attachments/assets/4c1b0e1a-267c-4c0b-98af-9b769fb72535" />
<img width="744" height="396" alt="Screenshot 2025-09-11 at 16 48 58" src="https://github.com/user-attachments/assets/648e1052-34f4-41ac-b2c2-9f95c364adf9" />
</details>

### Related issues and pull requests

- Follow up for the #41084

/cc @yashrajbharti