### PR TITLE
fix: correct SubtleCrypto.deriveKey and its related dictionaries

### DIFF
--- a/files/en-us/web/api/aesderivedkeyparams/index.md
+++ b/files/en-us/web/api/aesderivedkeyparams/index.md
@@ -1,0 +1,33 @@
+---
+title: AesDerivedKeyParams
+slug: Web/API/AesDerivedKeyParams
+page-type: web-api-interface
+spec-urls: https://w3c.github.io/webcrypto/#dfn-AesDerivedKeyParams
+---
+
+{{ APIRef("Web Crypto API") }}
+
+The **`AesDerivedKeyParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `derivedKeyType` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when deriving an AES key: that is, when the algorithm is identified as any of [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
+
+## Instance properties
+
+- `name`
+  - : A string. This should be set to `AES-CBC`, `AES-CTR`, `AES-GCM`, or `AES-KW`, depending on the algorithm you want to use.
+- `length`
+  - : A `Number` — the length in bits of the key to generate. This must be one of: 128, 192, or 256.
+
+## Examples
+
+See the examples for {{domxref("SubtleCrypto.deriveKey()")}}.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+Browsers that support any of the AES-based algorithms for the {{domxref("SubtleCrypto.deriveKey()")}} method will support this type.
+
+## See also
+
+- {{domxref("SubtleCrypto.generateKey()")}}.

--- a/files/en-us/web/api/hmacimportparams/index.md
+++ b/files/en-us/web/api/hmacimportparams/index.md
@@ -7,7 +7,7 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-HmacImportParams
 
 {{ APIRef("Web Crypto API") }}
 
-The **`HmacImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when generating a key for the [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) algorithm.
+The **`HmacImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}}, as the `unwrappedKeyAlgorithm` parameter into {{domxref("SubtleCrypto.unwrapKey()")}}, or as the `derivedKeyType` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when importing, unwrapping, or deriving a key for the [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) algorithm.
 
 ## Instance properties
 
@@ -27,7 +27,7 @@ The **`HmacImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/AP
 
 ## Examples
 
-See the examples for {{domxref("SubtleCrypto.importKey()")}}.
+See the examples for {{domxref("SubtleCrypto.importKey()")}}, {{domxref("SubtleCrypto.unwrapKey()")}}, or {{domxref("SubtleCrypto.deriveKey()")}}.
 
 ## Specifications
 
@@ -35,9 +35,10 @@ See the examples for {{domxref("SubtleCrypto.importKey()")}}.
 
 ## Browser compatibility
 
-Browsers that support the "HMAC" algorithm for the {{domxref("SubtleCrypto.importKey()")}}, {{domxref("SubtleCrypto.unwrapKey()")}} methods will support this type.
+Browsers that support the "HMAC" algorithm for the {{domxref("SubtleCrypto.importKey()")}}, {{domxref("SubtleCrypto.unwrapKey()")}}, or {{domxref("SubtleCrypto.deriveKey()")}} methods will support this type.
 
 ## See also
 
 - {{domxref("SubtleCrypto.importKey()")}}.
 - {{domxref("SubtleCrypto.unwrapKey()")}}.
+- {{domxref("SubtleCrypto.deriveKey()")}}.

--- a/files/en-us/web/api/hmacimportparams/index.md
+++ b/files/en-us/web/api/hmacimportparams/index.md
@@ -7,7 +7,11 @@ spec-urls: https://w3c.github.io/webcrypto/#dfn-HmacImportParams
 
 {{ APIRef("Web Crypto API") }}
 
-The **`HmacImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}}, as the `unwrappedKeyAlgorithm` parameter into {{domxref("SubtleCrypto.unwrapKey()")}}, or as the `derivedKeyType` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when importing, unwrapping, or deriving a key for the [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) algorithm.
+The **`HmacImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed when importing, unwrapping, or deriving a key for the [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) algorithm, as:
+
+- The `algorithm` parameter to {{domxref("SubtleCrypto.importKey()")}}
+- The `unwrappedKeyAlgorithm` parameter to {{domxref("SubtleCrypto.unwrapKey()")}}
+- The `derivedKeyType` parameter to {{domxref("SubtleCrypto.deriveKey()")}}.
 
 ## Instance properties
 

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -19,7 +19,7 @@ See [Supported algorithms](#supported_algorithms) for some more detail on this.
 ## Syntax
 
 ```js-nolint
-deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
+deriveKey(algorithm, baseKey, derivedKeyType, extractable, keyUsages)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -36,10 +36,8 @@ deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
     Otherwise it will be the initial key material for the derivation function: for example, for PBKDF2 it might be a password, imported as a `CryptoKey` using [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
 - `derivedKeyAlgorithm`
   - : An object defining the algorithm the derived key will be used for:
-    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) pass an [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object.
-    - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw), pass an [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams) object.
-    - For [HKDF](#hkdf), pass an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
-    - For [PBKDF2](#pbkdf2), pass a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params) object.
+    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) pass an [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams) object.
+    - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw), pass an [`AesDerivedKeyParams`](/en-US/docs/Web/API/AesDerivedKeyParams) object.
 - `extractable`
   - : A boolean value indicating whether it will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or {{domxref("SubtleCrypto.wrapKey()")}}.
 - `keyUsages`

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -34,7 +34,7 @@ deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
   - : A {{domxref("CryptoKey")}} representing the input to the derivation algorithm.
     If `algorithm` is ECDH or X25519, then this will be the ECDH or X25519 private key.
     Otherwise it will be the initial key material for the derivation function: for example, for PBKDF2 it might be a password, imported as a `CryptoKey` using [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
-- `derivedKeyAlgorithm`
+- `derivedKeyType`
   - : An object defining the algorithm the derived key will be used for:
     - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) pass an [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams) object.
     - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw), pass an [`AesDerivedKeyParams`](/en-US/docs/Web/API/AesDerivedKeyParams) object.


### PR DESCRIPTION
### Description

This PR fixes https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey in a number of ways

- removes HKDF and PBKDF2 as supported derived key algorithm, because it isn't and per the spec all implementations using this guidance result in OperationError.
- adds AesDerivedKeyParams to link to from the fixed deriveKey
- updates HmacImportParams to mention its use in deriveKey

### Motivation

Readers are mislead into thinking they can use deriveKey into getting a KDF key.

### Additional details

- https://w3c.github.io/webcrypto/#aes-ctr-registration (or any of the AES-registrations)
- https://w3c.github.io/webcrypto/#hmac-registration
- https://w3c.github.io/webcrypto/#hkdf-registration
- https://w3c.github.io/webcrypto/#pbkdf2-registration

### Related issues and pull requests

https://github.com/nodejs/node/issues/56931