### PR TITLE
Docs: Clarify direct import option for ListView in Django examples

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/generic_views/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/generic_views/index.md
@@ -73,6 +73,7 @@ class BookListView(generic.ListView):
 > [!NOTE]
 > You can also import the class directly. Using `ListView` after direct import is equivalent to using `generic.ListView`:
 
+
 ```python
 from django.views.generic import ListView
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/generic_views/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/generic_views/index.md
@@ -72,6 +72,7 @@ class BookListView(generic.ListView):
 
 > [!NOTE]
 > You can also import the class directly. Using `ListView` after direct import is equivalent to using `generic.ListView`:
+
 ```python
 from django.views.generic import ListView
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/generic_views/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/generic_views/index.md
@@ -70,6 +70,15 @@ class BookListView(generic.ListView):
     model = Book
 ```
 
+> [!NOTE]
+> You can also import the class directly. Using `ListView` after direct import is equivalent to using `generic.ListView`:
+```python
+from django.views.generic import ListView
+
+class BookListView(ListView):
+    model = Book
+```
+
 That's it! The generic view will query the database to get all records for the specified model (`Book`) then render a template located at **/django-locallibrary-tutorial/catalog/templates/catalog/book_list.html** (which we will create below). Within the template you can access the list of books with the template variable named `object_list` OR `book_list` (i.e., generically `<the model name>_list`).
 
 > [!NOTE]


### PR DESCRIPTION
Description

I added a small clarification to the Django ListView example.
Along with using generic.ListView, I noted that developers can also directly import ListView from django.views.generic.

Motivation

This helps beginners who may find the longer generic.ListView import confusing. By showing the shorter direct import, the docs become a little clearer and more practical.

Additional details

No functional changes, only documentation improvement.

Related issues and pull requests

N/A