### PR TITLE
Cross-reference `:target` and `::target-text` pages

### DIFF
--- a/files/en-us/web/css/_colon_target/index.md
+++ b/files/en-us/web/css/_colon_target/index.md
@@ -111,3 +111,4 @@ p:target i {
 ## See also
 
 - [Using the :target pseudo-class in selectors](/en-US/docs/Web/CSS/CSS_selectors/Using_the_:target_pseudo-class_in_selectors)
+- {{cssxref("::target-text")}} (for highlighting text fragments)

--- a/files/en-us/web/css/_doublecolon_target-text/index.md
+++ b/files/en-us/web/css/_doublecolon_target-text/index.md
@@ -42,3 +42,4 @@ To see this CSS in action follow the link to [scroll-to-text demo](https://mdn.g
 ## See also
 
 - [Text fragments](/en-US/docs/Web/URI/Reference/Fragment/Text_fragments)
+- {{cssxref(":target")}} (for highlighting target elements)


### PR DESCRIPTION
### Description

Cross-reference `:target` and `::target-text` pages under their respective _See also_ sections.

### Motivation

Closely conceptually related APIs that don't currently cross-reference each other. Also useful to have a handy reference to each other's syntax, given that `:target` is a single-colon pseudo-class whereas `::target-text` is a double-colon pseudo-element.