### PR TITLE
FF143 GPU import external texture experimental relnote

### DIFF
--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -97,6 +97,10 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
   The **`text-autospace`** CSS property allows you to specify the space applied between Chinese/Japanese/Korean (CJK) and non-CJK characters. Currently these values are only parsed and there is no effect on the output. ([Firefox bug 1869577](https://bugzil.la/1869577)).
 
+- **WebGPU external textures**: `dom.webgpu.external-texture.enable`
+
+  The [`GPUExternalTexture`](/en-US/docs/Web/API/GPUExternalTexture) interface and [`GPUDevice.importExternalTexture()`](/en-US/docs/Web/API/GPUDevice/importExternalTexture) method are supported for importing external textures from video frames or elements. ([Firefox bug 1979100](https://bugzil.la/1979100)).
+
 These features are shipping in Firefox 143 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
FF143 adds support for [`GPUExternalTexture`](https://developer.mozilla.org/en-US/docs/Web/API/GPUExternalTexture) and [`GPUDevice.importExternalTexture()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/importExternalTexture) behind a pref in 143.

This adds a release note to the experimental section.

Note that I have not added an update to the Experimental features page as this has already shipped in the now current beta 144. So I expect in a few days I would have to remove that, which would be pointless effort.

Related docs work can be tracked in #40774