### PR TITLE
added ff release note for nested pseudo-elements

### DIFF
--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -30,7 +30,7 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{cssxref("::details-content")}} pseudo-element is now enabled by default. It lets you style the content of the {{htmlElement("details")}} element.
   ([Firefox bug 1941406](https://bugzil.la/1941406)).
-- The {{cssxref("::marker")}} pseudo-element can now be used to style a `list-item` that has been created using the {{cssxref("::before")}} or {{cssxref("::after")}} pseudo-elements. This is achieved using the [`::before::marker`](/en-US/docs/Web/CSS/::before#beforemarker_nested_pseudo-elements) and [`::after::marker`](/en-US/docs/Web/CSS/::after#aftermarker_nested_pseudo-elements) selectors.
+- The {{cssxref("::marker")}} pseudo-element can now be used to style a list item that has been created using the {{cssxref("::before")}} or the {{cssxref("::after")}} pseudo-element. This is achieved using the [`::before::marker`](/en-US/docs/Web/CSS/::before#beforemarker_nested_pseudo-elements) and [`::after::marker`](/en-US/docs/Web/CSS/::after#aftermarker_nested_pseudo-elements) selectors.
   ([Firefox bug 1980215](https://bugzil.la/1980215)).
 - Multi-pass grid track sizing is now enabled by default and follows the algorithm outlined in the CSS Grid specification. In the multi-pass algorithm, columns are sized first, then rows; percentage values are resolved after the container size is known. With this default support, [percentage-based](/en-US/docs/Web/CSS/grid-template-rows#percentage) row tracks and grid items with aspect ratios will now be sized correctly in more cases.
   ([Firefox bug 1957244](https://bugzil.la/1957244)).

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -30,6 +30,8 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{cssxref("::details-content")}} pseudo-element is now enabled by default. It lets you style the content of the {{htmlElement("details")}} element.
   ([Firefox bug 1941406](https://bugzil.la/1941406)).
+- The {{cssxref("::marker")}} pseudo-element can now be used to style a `list-item` that has been created using the {{cssxref("::before")}} or {{cssxref("::after")}} pseudo-elements. This is achieved using the [`::before::marker`](/en-US/docs/Web/CSS/::before#beforemarker_nested_pseudo-elements) and [`::after::marker`](/en-US/docs/Web/CSS/::after#aftermarker_nested_pseudo-elements) selectors.
+  ([Firefox bug 1980215](https://bugzil.la/1980215)).
 - Multi-pass grid track sizing is now enabled by default and follows the algorithm outlined in the CSS Grid specification. In the multi-pass algorithm, columns are sized first, then rows; percentage values are resolved after the container size is known. With this default support, [percentage-based](/en-US/docs/Web/CSS/grid-template-rows#percentage) row tracks and grid items with aspect ratios will now be sized correctly in more cases.
   ([Firefox bug 1957244](https://bugzil.la/1957244)).
 


### PR DESCRIPTION
### Description

- Added firefox release note for `::before::marker` and `::after::marker`

### Motivation

- Working on [MDN Issue #40779](https://github.com/mdn/content/issues/40779)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/27878)