### PR TITLE
Get user media constraints resizemode

### DIFF
--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
@@ -8,11 +8,9 @@ browser-compat: api.MediaDevices.getDisplayMedia
 
 {{APIRef("Screen Capture API")}}{{SecureContext_Header}}
 
-The **`getDisplayMedia()`** method of the {{domxref("MediaDevices")}} interface prompts the user to select and
-grant permission to capture the contents of a display or portion thereof (such as a window) as a {{domxref("MediaStream")}}.
+The **`getDisplayMedia()`** method of the {{domxref("MediaDevices")}} interface prompts the user to select and grant permission to capture the contents of a display or portion thereof (such as a window) as a {{domxref("MediaStream")}}.
 
-The resulting stream can then be
-recorded using the [MediaStream Recording API](/en-US/docs/Web/API/MediaStream_Recording_API) or transmitted as part of a [WebRTC](/en-US/docs/Web/API/WebRTC_API) session.
+The resulting stream can then be recorded using the [MediaStream Recording API](/en-US/docs/Web/API/MediaStream_Recording_API) or transmitted as part of a [WebRTC](/en-US/docs/Web/API/WebRTC_API) session.
 
 See [Using the Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture) for more details and an example.
 
@@ -26,86 +24,95 @@ getDisplayMedia(options)
 ### Parameters
 
 - `options` {{optional_inline}}
-  - : An optional object specifying requirements for the returned {{domxref("MediaStream")}}. The options for `getDisplayMedia()` work in the same as the [constraints](/en-US/docs/Web/API/MediaDevices/getUserMedia#parameters) for the {{domxref("MediaDevices.getUserMedia()")}} method, although in that case only `audio` and `video` can be specified. The list of possible option properties for `getDisplayMedia()` is as follows:
+  - : An optional object specifying requirements for the returned {{domxref("MediaStream")}}.
+    The options for `getDisplayMedia()` work in the same as the [constraints](/en-US/docs/Web/API/MediaDevices/getUserMedia#parameters) for the {{domxref("MediaDevices.getUserMedia()")}} method, although in that case only `audio` and `video` can be specified.
+    The list of possible option properties for `getDisplayMedia()` is as follows:
     - `video` {{optional_inline}}
-      - : A boolean or a {{domxref("MediaTrackConstraints")}} instance; the default value is `true`. If this option is omitted or set to `true`, the returned {{domxref("MediaStream")}} will contain a video track. Since `getDisplayMedia()` requires a video track, if this option is set to `false` the promise will reject with a `TypeError`.
+      - : A boolean or a {{domxref("MediaTrackConstraints")}} instance; the default value is `true`.
+        If this option is omitted or set to `true`, the returned {{domxref("MediaStream")}} will contain a video track.
+        Since `getDisplayMedia()` requires a video track, if this option is set to `false` the promise will reject with a `TypeError`.
     - `audio` {{optional_inline}}
-      - : A boolean or a {{domxref("MediaTrackConstraints")}} instance; the default value is `false`. A value of `true` indicates that the returned {{domxref("MediaStream")}} will contain an audio track, if audio is supported and available for the display surface chosen by the user.
+      - : A boolean or a {{domxref("MediaTrackConstraints")}} instance; the default value is `false`.
+        A value of `true` indicates that the returned {{domxref("MediaStream")}} will contain an audio track, if audio is supported and available for the display surface chosen by the user.
     - `controller` {{Experimental_Inline}} {{optional_inline}}
       - : A {{domxref("CaptureController")}} object instance containing methods that can be used to further manipulate the capture session if included.
     - `monitorTypeSurfaces` {{Experimental_Inline}} {{optional_inline}}
-      - : An enumerated value specifying whether the browser should offer entire screens in the screen capture options presented to the user alongside tab and window options. This option is intended to protect companies from leakage of private information through employee error when using video conferencing apps. Possible values are `include`, which hints that the browser should include screen options, and `exclude`, which hints that they should be excluded. A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
+      - : An enumerated value specifying whether the browser should offer entire screens in the screen capture options presented to the user alongside tab and window options.
+        This option is intended to protect companies from leakage of private information through employee error when using video conferencing apps.
+        Possible values are `include`, which hints that the browser should include screen options, and `exclude`, which hints that they should be excluded.
+        A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
 
         > [!NOTE]
-        > You cannot set `monitorTypeSurfaces: "exclude"` at the same time as [`displaySurface: "monitor"`](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface) as the two settings are contradictory. Trying to do so will result in the `getDisplayMedia()` call failing with a `TypeError`.
+        > You cannot set `monitorTypeSurfaces: "exclude"` at the same time as [`displaySurface: "monitor"`](/en-US/docs/Web/API/MediaTrackConstraints/displaySurface) as the two settings are contradictory.
+        > Trying to do so will result in the `getDisplayMedia()` call failing with a `TypeError`.
 
     - `preferCurrentTab` {{non-standard_inline}} {{Experimental_Inline}} {{optional_inline}}
-      - : A boolean; a value of `true` instructs the browser to offer the current tab as the most prominent capture source, i.e., as a separate "This Tab" option in the "Choose what to share" options presented to the user. This is useful as many app types generally just want to share the current tab. For example, a slide deck app might want to let the user stream the current tab containing the presentation to a virtual conference. A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
+      - : A boolean; a value of `true` instructs the browser to offer the current tab as the most prominent capture source, i.e., as a separate "This Tab" option in the "Choose what to share" options presented to the user.
+        This is useful as many app types generally just want to share the current tab.
+        For example, a slide deck app might want to let the user stream the current tab containing the presentation to a virtual conference.
+        A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
     - `selfBrowserSurface` {{Experimental_Inline}} {{optional_inline}}
-      - : An enumerated value specifying whether the browser should allow the user to select the current tab for capture. This helps to avoid the "infinite hall of mirrors" effect experienced when a video conferencing app inadvertently shares its own display. Possible values are `include`, which hints that the browser should include the current tab in the choices offered for capture, and `exclude`, which hints that it should be excluded. A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
+      - : An enumerated value specifying whether the browser should allow the user to select the current tab for capture.
+        This helps to avoid the "infinite hall of mirrors" effect experienced when a video conferencing app inadvertently shares its own display.
+        Possible values are `include`, which hints that the browser should include the current tab in the choices offered for capture, and `exclude`, which hints that it should be excluded.
+        A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
     - `surfaceSwitching` {{Experimental_Inline}} {{optional_inline}}
-      - : An enumerated value specifying whether the browser should display a control to allow the user to dynamically switch the shared tab during screen-sharing. This is much more convenient than having to go through the whole sharing process again each time a user wants to switch the shared tab. Possible values are `include`, which hints that the browser should include the control, and `exclude`, which hints that it should not be shown. A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
+      - : An enumerated value specifying whether the browser should display a control to allow the user to dynamically switch the shared tab during screen-sharing.
+        This is much more convenient than having to go through the whole sharing process again each time a user wants to switch the shared tab.
+        Possible values are `include`, which hints that the browser should include the control, and `exclude`, which hints that it should not be shown.
+        A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
     - `systemAudio` {{Experimental_Inline}} {{optional_inline}}
-      - : An enumerated value specifying whether the browser should include the system audio among the possible audio sources offered to the user. Possible values are `include`, which hints that the browser should include the system audio in the list of choices, and `exclude`, which hints that it should be excluded. A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
+      - : An enumerated value specifying whether the browser should include the system audio among the possible audio sources offered to the user.
+        Possible values are `include`, which hints that the browser should include the system audio in the list of choices, and `exclude`, which hints that it should be excluded.
+        A default value is not mandated by the spec; see the [Browser compatibility](#browser_compatibility) section for browser-specific defaults.
 
 > [!NOTE]
 > See the article [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Constraints) for a lot more detail on how these options work.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a {{domxref("MediaStream")}} containing a
-video track whose contents come from a user-selected screen area, as well as an optional
-audio track.
+A {{jsxref("Promise")}} that resolves to a {{domxref("MediaStream")}} containing a video track whose contents come from a user-selected screen area, as well as an optional audio track.
 
 > [!NOTE]
-> Browser support for audio tracks varies, both in terms of whether or not they're supported at all by the media recorder and in terms of the audio sources supported. Check the [compatibility table](#browser_compatibility) for details for each browser.
+> Browser support for audio tracks varies, both in terms of whether or not they're supported at all by the media recorder and in terms of the audio sources supported.
+> Check the [compatibility table](#browser_compatibility) for details for each browser.
 
 ### Exceptions
 
 - `AbortError` {{domxref("DOMException")}}
   - : Thrown if an error or failure does not match any of the other exceptions listed here.
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the call to `getDisplayMedia()` was not made from code running due to a
-    {{glossary("transient activation")}}, such as an event handler. Or if the browser context is
-    not fully active or does not focused. Or if the `controller` options has been already used in creating
-    another {{domxref("MediaStream")}}.
+  - : Thrown if the call to `getDisplayMedia()` was not made from code running due to a {{glossary("transient activation")}}, such as an event handler.
+    Or if the browser context is not fully active or does not focused.
+    Or if the `controller` options has been already used in creating another {{domxref("MediaStream")}}.
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if the permission to access a screen area was denied by the user, or the current browsing instance is not permitted access to screen sharing (for example by a [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy)).
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if no sources of screen video are available for capture.
 - `NotReadableError` {{domxref("DOMException")}}
-  - : Thrown if the user selected a screen, window, tab, or another source of screen data, but a
-    hardware or operating system level error or lockout occurred, preventing the sharing
-    of the selected source.
+  - : Thrown if the user selected a screen, window, tab, or another source of screen data, but a hardware or operating system level error or lockout occurred, preventing the sharing of the selected source.
 - `OverconstrainedError` {{domxref("DOMException")}}
-  - : Thrown if, after creating the stream, applying any specified constraints fails
-    because no compatible stream could be generated.
+  - : Thrown if, after creating the stream, applying any specified constraints fails because no compatible stream could be generated.
 - {{jsxref("TypeError")}}
-  - : Thrown if the specified `options` include values that are not permitted
-    when calling `getDisplayMedia()`, for example a `video` property set to false, or if any specified {{domxref("MediaTrackConstraints")}} are not permitted. `min` and `exact` values are not permitted in constraints used in `getDisplayMedia()` calls.
+  - : Thrown if the specified `options` include values that are not permitted when calling `getDisplayMedia()`, for example a `video` property set to false, or if any specified {{domxref("MediaTrackConstraints")}} are not permitted.
+    `min` and `exact` values are not permitted in constraints used in `getDisplayMedia()` calls.
 
 ## Security
 
-Because `getDisplayMedia()` could be used in nefarious ways, it can be a
-source of significant privacy and security concerns. For that reason, the specification
-details measures browsers are required to take in order to fully support
-`getDisplayMedia()`.
+Because `getDisplayMedia()` could be used in nefarious ways, it can be a source of significant privacy and security concerns.
+For that reason, the specification details measures browsers are required to take in order to fully support `getDisplayMedia()`.
 
-- The specified options can't be used to limit the choices available
-  to the user. Instead, they must be applied after the user chooses a source, in order
-  to generate output that matches the options.
-- The go-ahead permission to use `getDisplayMedia()` cannot be persisted
-  for reuse. The user must be prompted for permission every time.
-- [Transient user activation](/en-US/docs/Web/Security/User_activation) is required. The user has to interact with the page or a UI element in order for this feature to work.
-- Browsers are encouraged to provide a warning to users about sharing displays or
-  windows that contain browsers, and to keep a close eye on what other content might be
-  getting captured and shown to other users.
+- The specified options can't be used to limit the choices available to the user.
+  Instead, they must be applied after the user chooses a source, in order to generate output that matches the options.
+- The go-ahead permission to use `getDisplayMedia()` cannot be persisted for reuse.
+  The user must be prompted for permission every time.
+- [Transient user activation](/en-US/docs/Web/Security/User_activation) is required.
+  The user has to interact with the page or a UI element in order for this feature to work.
+- Browsers are encouraged to provide a warning to users about sharing displays or windows that contain browsers, and to keep a close eye on what other content might be getting captured and shown to other users.
 
 ## Examples
 
-In the example below a `startCapture()` method is created, which initiates
-screen capture given a set of options specified by the `displayMediaOptions`
-parameter.
+In the example below a `startCapture()` method is created, which initiates screen capture given a set of options specified by the `displayMediaOptions` parameter.
 
 ```js
 const displayMediaOptions = {
@@ -135,11 +142,8 @@ async function startCapture(displayMediaOptions) {
 }
 ```
 
-This uses {{jsxref("Operators/await", "await")}} to asynchronously wait for `getDisplayMedia()`
-to resolve with a {{domxref("MediaStream")}} which contains the display contents as
-requested by the specified options. The stream is then returned to the caller for use,
-perhaps for adding to a WebRTC call using {{domxref("RTCPeerConnection.addTrack()")}} to
-add the video track from the stream.
+This uses {{jsxref("Operators/await", "await")}} to asynchronously wait for `getDisplayMedia()` to resolve with a {{domxref("MediaStream")}} which contains the display contents as requested by the specified options.
+The stream is then returned to the caller for use, perhaps for adding to a WebRTC call using {{domxref("RTCPeerConnection.addTrack()")}} to add the video track from the stream.
 
 > [!NOTE]
 > The [Screen sharing controls](https://chrome.dev/screen-sharing-controls/) demo provides a complete implementation that allows you to create a screen capture with your choice of `getDisplayMedia()` constraints and options.

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -213,8 +213,8 @@ getUserMedia({
 ```
 
 The browser will try to honor the constraints, and will return a matching track if supported by the underlying hardware.
-If not supported, the browser may attempt to crop and downscale a higher resolution stream from the underlying hardware in order to match the constraint.
-This will commonly be the default behavior, but can be forced by setting the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint to `crop-and-scale` (or disabled by setting it to `none`):
+If not supported, the browser may attempt to crop and downscale a higher resolution stream from the underlying hardware in order to match the constraint (and might also reduce the frame rate if that was constrained).
+This behavior can be forced by setting the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint to `crop-and-scale` (or disabled by setting it to `none`):
 
 ```js
 getUserMedia({
@@ -223,7 +223,7 @@ getUserMedia({
 });
 ```
 
-The browser may return another resolutions if an exact match is not available and the source is not to be scaled.
+The browser may return another resolution if an exact match is not available and the source is not to be scaled.
 
 To _require_ a capability and fail if it is not available, use the keywords `min`, `max`, or `exact` (a.k.a. `min === max`).
 The following demands a minimum resolution of 1280x720:

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -27,122 +27,86 @@ getUserMedia(constraints)
 ### Parameters
 
 - `constraints`
-  - : An object specifying the types of media to
-    request, along with any requirements for each type.
+  - : An object specifying the types of media to request, along with any requirements for each type.
 
-    The `constraints` parameter is an object with two members: `video` and
-    `audio`, describing the media types requested. Either or both must be
-    specified. If the browser cannot find all media tracks with the specified types that
-    meet the constraints given, then the returned promise is rejected with
-    `NotFoundError` {{domxref("DOMException")}}.
+    The `constraints` parameter is an object with two members: `video` and `audio`, describing the media types requested.
+    Either or both must be specified.
+    If the browser cannot find all media tracks with the specified types that meet the constraints given, then the returned promise is rejected with `NotFoundError` {{domxref("DOMException")}}.
 
-    For both `video` and `audio`, its value is either a boolean or an object. The default value is `false`.
-    - If `true` is specified for a media type, the resulting stream is _required_ to have that type of track in it. If one cannot be included for any reason, the returned promise will reject.
-    - If `false` is specified for a media type, the resulting stream _must not_ have that type of track, or the returned promise will reject. Because both `video` and `audio` default to `false`, if the `constraints` object contains neither property or if it's not present at all, the returned promise will always reject.
+    For both `video` and `audio`, its value is either a boolean or an object.
+    The default value is `false`.
+    - If `true` is specified for a media type, the resulting stream is _required_ to have that type of track in it.
+      If one cannot be included for any reason, the returned promise will reject.
+    - If `false` is specified for a media type, the resulting stream _must not_ have that type of track, or the returned promise will reject.
+      Because both `video` and `audio` default to `false`, if the `constraints` object contains neither property or if it's not present at all, the returned promise will always reject.
     - If an object is specified for a media type, the object is read as a {{domxref("MediaTrackConstraints")}} dictionary.
 
 ### Return value
 
-A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref("MediaStream")}}
-object when the requested media has successfully been obtained.
+A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref("MediaStream")}} object when the requested media has successfully been obtained.
 
 ### Exceptions
 
 - `AbortError` {{domxref("DOMException")}}
-  - : Although the user and operating system both granted access to the hardware device,
-    and no hardware issues occurred that would cause a `NotReadableError` {{domxref("DOMException")}}, throw if some
-    problem occurred which prevented the device from being used.
+  - : Although the user and operating system both granted access to the hardware device, and no hardware issues occurred that would cause a `NotReadableError` {{domxref("DOMException")}}, throw if some problem occurred which prevented the device from being used.
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if current document is not fully active.
 
 - `NotAllowedError` {{domxref("DOMException")}}
-  - : Thrown if one or more of the requested source devices cannot be used at this time. This will
-    happen if the browsing context is insecure (that is, the page was loaded using HTTP
-    rather than HTTPS). It also happens if the user has specified that the current
-    browsing instance is not permitted access to the device, the user has denied access
-    for the current session, or the user has denied all access to user media devices
-    globally. On browsers that support managing media permissions with [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy), this error is
-    returned if Permissions Policy is not configured to allow access to the input source(s).
+  - : Thrown if one or more of the requested source devices cannot be used at this time.
+    This will happen if the browsing context is insecure (that is, the page was loaded using HTTP rather than HTTPS).
+    It also happens if the user has specified that the current browsing instance is not permitted access to the device, the user has denied access for the current session, or the user has denied all access to user media devices globally.
+    On browsers that support managing media permissions with [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy), this error is returned if Permissions Policy is not configured to allow access to the input source(s).
 
     > [!NOTE]
-    > Older versions of the specification used `SecurityError`
-    > for this instead; `SecurityError` has taken on a new meaning.
+    > Older versions of the specification used `SecurityError` for this instead; `SecurityError` has taken on a new meaning.
 
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if no media tracks of the type specified were found that satisfy the given constraints.
 - `NotReadableError` {{domxref("DOMException")}}
-  - : Thrown if, although the user granted permission to use the matching devices, a hardware error
-    occurred at the operating system, browser, or Web page level which prevented access to
-    the device.
+  - : Thrown if, although the user granted permission to use the matching devices, a hardware error occurred at the operating system, browser, or Web page level which prevented access to the device.
 - `OverconstrainedError` {{domxref("DOMException")}}
-  - : Thrown if the specified constraints resulted in no candidate devices which met the criteria
-    requested. The error is an object of type `OverconstrainedError`, and has a
-    `constraint` property whose string value is the name of a constraint which
-    was impossible to meet, and a `message` property containing a
-    human-readable string explaining the problem.
+  - : Thrown if the specified constraints resulted in no candidate devices which met the criteria requested.
+    The error is an object of type `OverconstrainedError`, and has a `constraint` property whose string value is the name of a constraint which was impossible to meet, and a `message` property containing a human-readable string explaining the problem.
 
     > [!NOTE]
-    > Because this error can occur even when the user has not yet granted
-    > permission to use the underlying device, it can potentially be used as a
-    > [fingerprinting](/en-US/docs/Glossary/Fingerprinting) surface.
+    > Because this error can occur even when the user has not yet granted permission to use the underlying device, it can potentially be used as a [fingerprinting](/en-US/docs/Glossary/Fingerprinting) surface.
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if user media support is disabled on the {{domxref("Document")}} on which
-    `getUserMedia()` was called. The mechanism by which user media support is
-    enabled and disabled is left up to the individual user agent.
+  - : Thrown if user media support is disabled on the {{domxref("Document")}} on which `getUserMedia()` was called.
+    The mechanism by which user media support is enabled and disabled is left up to the individual user agent.
 - {{jsxref("TypeError")}}
-  - : Thrown if the list of constraints specified is empty, or has all constraints set to
-    `false`. This can also happen if you try to call
-    `getUserMedia()` in an insecure context, since
-    {{domxref("navigator.mediaDevices")}} is `undefined` in an insecure
-    context.
+  - : Thrown if the list of constraints specified is empty, or has all constraints set to `false`.
+    This can also happen if you try to call `getUserMedia()` in an insecure context, since {{domxref("navigator.mediaDevices")}} is `undefined` in an insecure context.
 
 ## Privacy and security
 
-As an API that may involve significant privacy concerns, `getUserMedia()`'s
-specification lays out a wide array of privacy and security requirements that browsers
-are obligated to meet.
+As an API that may involve significant privacy concerns, `getUserMedia()`'s specification lays out a wide array of privacy and security requirements that browsers are obligated to meet.
 
-`getUserMedia()` is a powerful feature that can only be used in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts); in insecure
-contexts, `navigator.mediaDevices` is `undefined`, preventing
-access to `getUserMedia()`. A secure context is, in short, a page loaded
-using HTTPS or the `file:///` URL scheme, or a page loaded from
-`localhost`.
+`getUserMedia()` is a powerful feature that can only be used in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts); in insecure contexts, `navigator.mediaDevices` is `undefined`, preventing access to `getUserMedia()`.
+A secure context is, in short, a page loaded using HTTPS or the `file:///` URL scheme, or a page loaded from `localhost`.
 
-In addition, user permission is always required to access the user's audio and video
-inputs. Only a window's top-level document context for a valid origin can even request
-permission to use `getUserMedia()`, unless the top-level context expressly
-grants permission for a given {{HTMLElement("iframe")}} to do so using [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy). Otherwise, the user
-will never even be asked for permission to use the input devices.
+In addition, user permission is always required to access the user's audio and video inputs.
+Only a window's top-level document context for a valid origin can even request permission to use `getUserMedia()`, unless the top-level context expressly grants permission for a given {{HTMLElement("iframe")}} to do so using [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy).
+Otherwise, the user will never even be asked for permission to use the input devices.
 
-For additional details on these requirements and rules, how they are reflected in the
-context in which your code is running, and about how browsers manage user privacy and
-security issues, read on.
+For additional details on these requirements and rules, how they are reflected in the context in which your code is running, and about how browsers manage user privacy and security issues, read on.
 
 ### User privacy
 
-As an API that may involve significant privacy concerns, `getUserMedia()` is
-held by the specification to very specific requirements for user notification and
-permission management. First, `getUserMedia()` must always get user
-permission before opening any media gathering input such as a webcam or microphone.
-Browsers may offer a once-per-domain permission feature, but they must ask at least the
-first time, and the user must specifically grant ongoing permission if they choose to do
-so.
+As an API that may involve significant privacy concerns, `getUserMedia()` is held by the specification to very specific requirements for user notification and permission management.
+First, `getUserMedia()` must always get user permission before opening any media gathering input such as a webcam or microphone.
+Browsers may offer a once-per-domain permission feature, but they must ask at least the first time, and the user must specifically grant ongoing permission if they choose to do so.
 
-Of equal importance are the rules around notification. Browsers are required to display
-an indicator that shows that a camera or microphone is in use, above and beyond any
-hardware indicator that may exist. They must also show an indicator that permission has
-been granted to use a device for input, even if the device is not actively recording at
-the moment.
+Of equal importance are the rules around notification.
+Browsers are required to display an indicator that shows that a camera or microphone is in use, above and beyond any hardware indicator that may exist.
+They must also show an indicator that permission has been granted to use a device for input, even if the device is not actively recording at the moment.
 
-For example in Firefox, the URL bar displays a pulsing red icon to indicate that
-recording is underway. The icon is gray if the permission is in place but recording is
-not currently underway. The device's physical light is used to indicate whether or not
-recording is currently active. If you've muted your camera (so-called "facemuting"),
-your camera's activity light goes out to indicate that the camera is not actively
-recording you, without discarding the permission to resume using the camera once muting
-is over.
+For example in Firefox, the URL bar displays a pulsing red icon to indicate that recording is underway.
+The icon is gray if the permission is in place but recording is not currently underway.
+The device's physical light is used to indicate whether or not recording is currently active.
+If you've muted your camera (so-called "facemuting"), your camera's activity light goes out to indicate that the camera is not actively recording you, without discarding the permission to resume using the camera once muting is over.
 
 ### Security
 
@@ -150,28 +114,22 @@ There are a number of ways security management and controls in a {{Glossary("use
 
 #### Permissions Policy
 
-The two [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) directives that apply to `getUserMedia()` are `camera`
-and `microphone`.
+The two [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) directives that apply to `getUserMedia()` are `camera` and `microphone`.
 
-For example, this HTTP header will enable use of a camera by the document
-and any embedded {{HTMLElement("iframe")}} elements that are loaded from the same
-origin:
+For example, this HTTP header will enable use of a camera by the document and any embedded {{HTMLElement("iframe")}} elements that are loaded from the same origin:
 
 ```http
 Permissions-Policy: camera=(self)
 ```
 
-This will request access to the microphone for the current origin and the specific
-origin `https://developer.mozilla.org`:
+This will request access to the microphone for the current origin and the specific origin `https://developer.mozilla.org`:
 
 ```http
 Permissions-Policy: microphone=(self "https://developer.mozilla.org")
 ```
 
-If you're using `getUserMedia()` within an `<iframe>`, you
-can request permission just for that frame, which is clearly more secure than requesting
-a more general permission. Here, indicate we need the ability to use both camera and
-microphone:
+If you're using `getUserMedia()` within an `<iframe>`, you can request permission just for that frame, which is clearly more secure than requesting a more general permission.
+Here, indicate we need the ability to use both camera and microphone:
 
 ```html
 <iframe src="https://mycode.example.net/etc" allow="camera; microphone">
@@ -180,33 +138,22 @@ microphone:
 
 #### Encryption based security
 
-The `getUserMedia()` method is only available in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts). A secure context
-is one the browser is reasonably confident contains a document which was loaded
-securely, using HTTPS/TLS, and has limited exposure to insecure contexts. If a document
-isn't loaded in a secure context, the {{domxref("navigator.mediaDevices")}} property is
-`undefined`, making access to `getUserMedia()` impossible.
+The `getUserMedia()` method is only available in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
+A secure context is one the browser is reasonably confident contains a document which was loaded securely, using HTTPS/TLS, and has limited exposure to insecure contexts.
+If a document isn't loaded in a secure context, the {{domxref("navigator.mediaDevices")}} property is `undefined`, making access to `getUserMedia()` impossible.
 
-Attempting to access `getUserMedia()` in this situation will result in a
-{{jsxref("TypeError")}}.
+Attempting to access `getUserMedia()` in this situation will result in a {{jsxref("TypeError")}}.
 
 #### Document source security
 
-Because of the obvious security concern associated with `getUserMedia()` if
-used unexpectedly or without security being carefully managed, it can only be used in
-secure contexts. There are a number of insecure ways to load a document that might, in
-turn, attempt to call `getUserMedia()`. The following are examples of
-situations in which `getUserMedia()` is not permitted to be called:
+Because of the obvious security concern associated with `getUserMedia()` if used unexpectedly or without security being carefully managed, it can only be used in secure contexts.
+There are a number of insecure ways to load a document that might, in turn, attempt to call `getUserMedia()`.
+The following are examples of situations in which `getUserMedia()` is not permitted to be called:
 
-- A document loaded into a sandboxed {{HTMLElement("iframe")}} element cannot call
-  `getUserMedia()` unless the `<iframe>` has its
-  [`sandbox`](/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox) attribute set to `allow-same-origin`.
-- A document loaded using a `data://` or `blob://` URL which has
-  no origin (such as when one of these URLs is typed by the user into the address bar)
-  cannot call `getUserMedia()`. These kinds of URLs loaded from JavaScript
-  code inherit the script's permissions.
-- Any other situation in which there is no origin, such as when the
-  [`srcdoc`](/en-US/docs/Web/HTML/Reference/Elements/iframe#srcdoc) attribute is used to specify the contents of a
-  frame.
+- A document loaded into a sandboxed {{HTMLElement("iframe")}} element cannot call `getUserMedia()` unless the `<iframe>` has its [`sandbox`](/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox) attribute set to `allow-same-origin`.
+- A document loaded using a `data://` or `blob://` URL which has no origin (such as when one of these URLs is typed by the user into the address bar) cannot call `getUserMedia()`.
+  These kinds of URLs loaded from JavaScript code inherit the script's permissions.
+- Any other situation in which there is no origin, such as when the [`srcdoc`](/en-US/docs/Web/HTML/Reference/Elements/iframe#srcdoc) attribute is used to specify the contents of a frame.
 
 ## Examples
 
@@ -241,10 +188,8 @@ navigator.mediaDevices
 ```
 
 > [!NOTE]
-> If the current document isn't loaded securely,
-> `navigator.mediaDevices` will be `undefined`, and you cannot use
-> `getUserMedia()`. See [Security](#security) for more information on this and
-> other security issues related to using `getUserMedia()`.
+> If the current document isn't loaded securely, `navigator.mediaDevices` will be `undefined`, and you cannot use `getUserMedia()`.
+> See [Security](#security) for more information on this and other security issues related to using `getUserMedia()`.
 
 Below are some examples of the `constraints` parameter.
 
@@ -257,10 +202,8 @@ getUserMedia({
 });
 ```
 
-While information about a user's cameras and microphones are inaccessible for
-privacy reasons, an application can request the camera and microphone capabilities
-it needs and wants, using additional constraints. The following expresses a
-preference for 1280x720 camera resolution:
+While information about a user's cameras and microphones are inaccessible for privacy reasons, an application can request the camera and microphone capabilities it needs and wants, using additional constraints.
+The following expresses a preference for 1280x720 camera resolution:
 
 ```js
 getUserMedia({
@@ -269,12 +212,10 @@ getUserMedia({
 });
 ```
 
-The browser will try to honor this, but may return other
-resolutions if an exact match is not available, or the user overrides it.
+The browser will try to honor this, but may return other resolutions if an exact match is not available, or the user overrides it.
 
-To _require_ a capability, use the keywords `min`,
-`max`, or `exact` (a.k.a. `min === max`). The
-following demands a minimum resolution of 1280x720:
+To _require_ a capability, use the keywords `min`, `max`, or `exact` (a.k.a. `min === max`).
+The following demands a minimum resolution of 1280x720:
 
 ```js
 getUserMedia({
@@ -286,13 +227,10 @@ getUserMedia({
 });
 ```
 
-If no camera exists with this resolution or higher, then the returned promise will
-be rejected with `OverconstrainedError`, and the user will not be
-prompted.
+If no camera exists with this resolution or higher, then the returned promise will be rejected with `OverconstrainedError`, and the user will not be prompted.
 
-The reason for the difference in behavior is that the keywords `min`,
-`max`, and `exact` are inherently mandatory — whereas plain
-values and a keyword called `ideal` are not. Here's a full example:
+The reason for the difference in behavior is that the keywords `min`, `max`, and `exact` are inherently mandatory — whereas plain values and a keyword called `ideal` are not.
+Here's a full example:
 
 ```js
 getUserMedia({
@@ -304,12 +242,9 @@ getUserMedia({
 });
 ```
 
-An `ideal` value, when used, has gravity — which means that the browser
-will try to find the setting (and camera, if you have more than one), with the
-smallest [fitness distance](https://w3c.github.io/mediacapture-main/#dfn-fitness-distance) from the ideal values given.
+An `ideal` value, when used, has gravity — which means that the browser will try to find the setting (and camera, if you have more than one), with the smallest [fitness distance](https://w3c.github.io/mediacapture-main/#dfn-fitness-distance) from the ideal values given.
 
-Plain values are inherently ideal, which means that the first of our resolution
-examples above could have been written like this:
+Plain values are inherently ideal, which means that the first of our resolution examples above could have been written like this:
 
 ```js
 getUserMedia({
@@ -321,8 +256,8 @@ getUserMedia({
 });
 ```
 
-Not all constraints are numbers. For example, on mobile devices, the following will
-prefer the front camera (if one is available) over the rear one:
+Not all constraints are numbers.
+For example, on mobile devices, the following will prefer the front camera (if one is available) over the rear one:
 
 ```js
 getUserMedia({
@@ -342,9 +277,8 @@ getUserMedia({
 });
 ```
 
-Another non-number constraint is the `deviceId` constraint. If you have
-a `deviceId` from {{domxref("mediaDevices.enumerateDevices()")}}, you can
-use it to request a specific device:
+Another non-number constraint is the `deviceId` constraint.
+If you have a `deviceId` from {{domxref("mediaDevices.enumerateDevices()")}}, you can use it to request a specific device:
 
 ```js
 getUserMedia({
@@ -354,9 +288,8 @@ getUserMedia({
 });
 ```
 
-The above will return the camera you requested, or a different camera if that
-specific camera is no longer available. Again, to _require_ the specific
-camera, you would use:
+The above will return the camera you requested, or a different camera if that specific camera is no longer available.
+Again, to _require_ the specific camera, you would use:
 
 ```js
 getUserMedia({
@@ -370,8 +303,7 @@ getUserMedia({
 
 ### Width and height
 
-This example gives a preference for camera resolution, and assigns the resulting
-{{domxref("MediaStream")}} object to a video element.
+This example gives a preference for camera resolution, and assigns the resulting {{domxref("MediaStream")}} object to a video element.
 
 ```js
 // Prefer camera resolution nearest to 1280x720.
@@ -397,8 +329,7 @@ navigator.mediaDevices
 
 ### Frame rate
 
-Lower frame-rates may be desirable in some cases, like WebRTC transmissions with
-bandwidth restrictions.
+Lower frame-rates may be desirable in some cases, like WebRTC transmissions with bandwidth restrictions.
 
 ```js
 const constraints = {
@@ -422,7 +353,8 @@ const constraints = {
 ```
 
 > [!NOTE]
-> In certain cases, it may be necessary to release the current camera facing mode before you can switch to a different one. To ensure the camera switch, it is advisable to free up the media resources by invoking the "stop()" method on the track before requesting a different facing mode.
+> In certain cases, it may be necessary to release the current camera facing mode before you can switch to a different one.
+> To ensure the camera switch, it is advisable to free up the media resources by invoking the "stop()" method on the track before requesting a different facing mode.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -212,9 +212,20 @@ getUserMedia({
 });
 ```
 
-The browser will try to honor this, but may return other resolutions if an exact match is not available, or the user overrides it.
+The browser will try to honor the constraints, and will return a matching track if supported by the underlying hardware.
+If not supported, the browser may attempt to crop and downscale a higher resolution stream from the underlying hardware in order to match the constraint.
+This will commonly be the default behavior, but can be forced by setting the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint to `crop-and-scale` (or disabled with `none`):
 
-To _require_ a capability, use the keywords `min`, `max`, or `exact` (a.k.a. `min === max`).
+```js
+getUserMedia({
+  audio: true,
+  video: { width: 1280, height: 720, resizeMode: "crop-and-scale" },
+});
+```
+
+The browser may return another resolutions if an exact match is not available and the source is not to be scaled.
+
+To _require_ a capability and fail if it is not available, use the keywords `min`, `max`, or `exact` (a.k.a. `min === max`).
 The following demands a minimum resolution of 1280x720:
 
 ```js

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -214,7 +214,7 @@ getUserMedia({
 
 The browser will try to honor the constraints, and will return a matching track if supported by the underlying hardware.
 If not supported, the browser may attempt to crop and downscale a higher resolution stream from the underlying hardware in order to match the constraint.
-This will commonly be the default behavior, but can be forced by setting the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint to `crop-and-scale` (or disabled with `none`):
+This will commonly be the default behavior, but can be forced by setting the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint to `crop-and-scale` (or disabled by setting it to `none`):
 
 ```js
 getUserMedia({

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -7,8 +7,11 @@ spec-urls: https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
 
 {{APIRef("Media Capture and Streams")}}
 
-The **`MediaTrackConstraints`** dictionary is used to describe a set of capabilities and the value or values each can take on.
-A constraints dictionary is passed into {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
+The **`MediaTrackConstraints`** dictionary is used to describe a set of media capabilities and the value or values each can take on.
+
+A constraints dictionary is passed into the {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} method of the {{domxref("MediaStreamTrack")}} interface to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
+
+Objects of this type may also be passed to the {{domxref("MediaDevices/getUserMedia","getUserMedia()")}} and {{domxref("MediaDevices/getDisplayMedia","getDisplayMedia()")}} methods of the {{domxref("MediaDevices")}} interface in order to specify constraints on a media stream requested from hardware such as a camera or microphone, and from a screen or window capture, respectively.
 
 ## Constraints
 
@@ -157,9 +160,12 @@ For example, because {{Glossary("RTP")}} doesn't provide some of these values du
   - : A [`ConstrainULong`](#constrainulong) specifying the video width or range of widths which are acceptable and/or required.
 - `resizeMode`
   - : A [`ConstrainDOMString`](#constraindomstring) object specifying a mode or an array of modes the UA can use to derive the resolution of a video track.
-    Allowed values are `none` and `crop-and-scale`.
-    `none` means that the user agent uses the resolution provided by the camera, its driver or the OS.
-    `crop-and-scale` means that the user agent can use cropping and downscaling on the camera output in order to satisfy other constraints that affect the resolution.
+    Allowed values are:
+    - `crop-and-scale`
+      - : The user agent can use cropping and downscaling of resolution or frame rate on the raw output from the hardware/OS, in order to satisfy other constraints.
+        This constraint allows developers to get a downscaled video even if the particular format indicated by their constraints is not natively supported by the hardware.
+    - `none`
+      - : The user agent uses the resolution provided by the underlying hardware, such as a camera or its driver, or the OS.
 
 ### Instance properties of shared screen tracks
 
@@ -193,9 +199,10 @@ These constraints apply to the `video` property of the object passed into {{domx
 - [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Constraints)
 - [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API)
 - [Using the Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture)
-- {{domxref("MediaDevices.getUserMedia()")}}
 - {{domxref("MediaStreamTrack.getConstraints()")}}
 - {{domxref("MediaStreamTrack.applyConstraints()")}}
+- {{domxref("MediaDevices.getUserMedia()")}}
+- {{domxref("MediaDevices.getDisplayMedia()")}}
 - {{domxref("MediaDevices.getSupportedConstraints()")}}
 - {{domxref("MediaTrackSupportedConstraints")}}
 - {{domxref("MediaStreamTrack.getSettings()")}}

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -9,9 +9,15 @@ spec-urls: https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
 
 The **`MediaTrackConstraints`** dictionary is used to describe a set of media capabilities and the value or values each can take on.
 
-A constraints dictionary is passed into the {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} method of the {{domxref("MediaStreamTrack")}} interface to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
+A constraints dictionary is passed into the {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} method of the {{domxref("MediaStreamTrack")}} interface to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track.
 
-Objects of this type may also be passed to the {{domxref("MediaDevices/getUserMedia","getUserMedia()")}} and {{domxref("MediaDevices/getDisplayMedia","getDisplayMedia()")}} methods of the {{domxref("MediaDevices")}} interface in order to specify constraints on a media stream requested from hardware such as a camera or microphone, and from a screen or window capture, respectively.
+ The most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
+
+Objects of this type may also be passed to:
+
+- The {{domxref("MediaDevices.getUserMedia()")}} method, to specify constraints on a media stream requested from hardware such as a camera or microphone.
+
+- The {{domxref("MediaDevices.getDisplayMedia()")}} method, to specify constraints on a media stream requested from a screen or window capture.
 
 ## Constraints
 

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -7,11 +7,14 @@ spec-urls: https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
 
 {{APIRef("Media Capture and Streams")}}
 
-The **`MediaTrackConstraints`** dictionary is used to describe a set of capabilities and the value or values each can take on. A constraints dictionary is passed into {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
+The **`MediaTrackConstraints`** dictionary is used to describe a set of capabilities and the value or values each can take on.
+A constraints dictionary is passed into {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
 
 ## Constraints
 
-The following types are used to specify a constraint for a property. They allow you to specify one or more `exact` values from which one must be the parameter's value, or a set of `ideal` values which should be used if possible. You can also specify a single value (or an array of values) which the user agent will do its best to match once all more stringent constraints have been applied.
+The following types are used to specify a constraint for a property.
+They allow you to specify one or more `exact` values from which one must be the parameter's value, or a set of `ideal` values which should be used if possible.
+You can also specify a single value (or an array of values) which the user agent will do its best to match once all more stringent constraints have been applied.
 
 To learn more about how constraints work, see [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Constraints).
 
@@ -20,51 +23,67 @@ To learn more about how constraints work, see [Capabilities, constraints, and se
 
 ### ConstrainBoolean
 
-The `ConstrainBoolean` constraint type is used to specify a constraint for a property whose value is a Boolean value. Its value may either be set to a Boolean (`true` or `false`) or an object containing the following properties:
+The `ConstrainBoolean` constraint type is used to specify a constraint for a property whose value is a Boolean value.
+Its value may either be set to a Boolean (`true` or `false`) or an object containing the following properties:
 
 - `exact`
-  - : A Boolean which must be the value of the property. If the property can't be set to this value, matching will fail.
+  - : A Boolean which must be the value of the property.
+    If the property can't be set to this value, matching will fail.
 - `ideal`
-  - : A Boolean specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
+  - : A Boolean specifying an ideal value for the property.
+    If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
 
 ### ConstrainDouble
 
-The `ConstrainDouble` constraint type is used to specify a constraint for a property whose value is a double-precision floating-point number. Its value may either be set to a number or an object containing the following properties:
+The `ConstrainDouble` constraint type is used to specify a constraint for a property whose value is a double-precision floating-point number.
+Its value may either be set to a number or an object containing the following properties:
 
 - `max`
-  - : A decimal number specifying the largest permissible value of the property it describes. If the value cannot remain equal to or less than this value, matching will fail.
+  - : A decimal number specifying the largest permissible value of the property it describes.
+    If the value cannot remain equal to or less than this value, matching will fail.
 - `min`
-  - : A decimal number specifying the smallest permissible value of the property it describes. If the value cannot remain equal to or greater than this value, matching will fail.
+  - : A decimal number specifying the smallest permissible value of the property it describes.
+    If the value cannot remain equal to or greater than this value, matching will fail.
 - `exact`
   - : A decimal number specifying a specific, required, value the property must have to be considered acceptable.
 - `ideal`
-  - : A decimal number specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
+  - : A decimal number specifying an ideal value for the property.
+    If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
 
 ### ConstrainDOMString
 
-The `ConstrainDOMString` constraint type is used to specify a constraint for a property whose value is a string. Its value may either be set to a string, an array of strings, or an object containing the following properties:
+The `ConstrainDOMString` constraint type is used to specify a constraint for a property whose value is a string.
+Its value may either be set to a string, an array of strings, or an object containing the following properties:
 
 - `exact`
-  - : A string or an array of strings, one of which must be the value of the property. If the property can't be set to one of the listed values, matching will fail.
+  - : A string or an array of strings, one of which must be the value of the property.
+    If the property can't be set to one of the listed values, matching will fail.
 - `ideal`
-  - : A string or an array of strings, specifying ideal values for the property. If possible, one of the listed values will be used, but if it's not possible, the user agent will use the closest possible match.
+  - : A string or an array of strings, specifying ideal values for the property.
+    If possible, one of the listed values will be used, but if it's not possible, the user agent will use the closest possible match.
 
 ### ConstrainULong
 
-The `ConstrainULong` constraint type is used to specify a constraint for a property whose value is an integer. Its value may either be set to a number or an object containing the following properties:
+The `ConstrainULong` constraint type is used to specify a constraint for a property whose value is an integer.
+Its value may either be set to a number or an object containing the following properties:
 
 - `max`
-  - : An integer specifying the largest permissible value of the property it describes. If the value cannot remain equal to or less than this value, matching will fail.
+  - : An integer specifying the largest permissible value of the property it describes.
+    If the value cannot remain equal to or less than this value, matching will fail.
 - `min`
-  - : An integer specifying the smallest permissible value of the property it describes. If the value cannot remain equal to or greater than this value, matching will fail.
+  - : An integer specifying the smallest permissible value of the property it describes.
+    If the value cannot remain equal to or greater than this value, matching will fail.
 - `exact`
   - : An integer specifying a specific, required, value the property must have to be considered acceptable.
 - `ideal`
-  - : An integer specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
+  - : An integer specifying an ideal value for the property.
+    If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
 
 ## Instance properties
 
-Some combination—but not necessarily all—of the following properties will exist on the object. This may be because a given browser doesn't support the property, or because it doesn't apply. For example, because {{Glossary("RTP")}} doesn't provide some of these values during negotiation of a WebRTC connection, a track associated with a {{domxref("RTCPeerConnection")}} will not include certain values, such as {{domxref("MediaTrackConstraints.facingMode", "facingMode")}} or {{domxref("MediaTrackConstraints.groupId", "groupId")}}.
+Some combination—but not necessarily all—of the following properties will exist on the object.
+This may be because a given browser doesn't support the property, or because it doesn't apply
+For example, because {{Glossary("RTP")}} doesn't provide some of these values during negotiation of a WebRTC connection, a track associated with a {{domxref("RTCPeerConnection")}} will not include certain values, such as {{domxref("MediaTrackConstraints.facingMode", "facingMode")}} or {{domxref("MediaTrackConstraints.groupId", "groupId")}}.
 
 ### Instance properties of all media tracks
 
@@ -94,33 +113,34 @@ Some combination—but not necessarily all—of the following properties will ex
 
 ### Instance properties of image tracks
 
-- whiteBalanceMode
+- `whiteBalanceMode`
   - : A {{jsxref("String")}} specifying one of `"none"`, `"manual"`, `"single-shot"`, or `"continuous"`.
-- exposureMode
+- `exposureMode`
   - : A {{jsxref("String")}} specifying one of `"none"`, `"manual"`, `"single-shot"`, or `"continuous"`.
-- focusMode
+- `focusMode`
   - : A {{jsxref("String")}} specifying one of `"none"`, `"manual"`, `"single-shot"`, or `"continuous"`.
-- pointsOfInterest
-  - : The pixel coordinates on the sensor of one or more points of interest. This is either an object in the form { x:_value_, y:_value_ } or an array of such objects, where _value_ is a double-precision integer.
-- exposureCompensation
+- `pointsOfInterest`
+  - : The pixel coordinates on the sensor of one or more points of interest.
+    This is either an object in the form { x:_value_, y:_value_ } or an array of such objects, where _value_ is a double-precision integer.
+- `exposureCompensation`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying f-stop adjustment by up to ±3.
-- colorTemperature
+- `colorTemperature`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying a desired color temperature in degrees kelvin.
-- iso
+- `iso`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying a desired iso setting.
-- brightness
+- `brightness`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying a desired brightness setting.
-- contrast
+- `contrast`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying the degree of difference between light and dark.
-- saturation
+- `saturation`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying the degree of color intensity.
-- sharpness
+- `sharpness`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying the intensity of edges.
-- focusDistance
+- `focusDistance`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying distance to a focused object.
-- zoom
+- `zoom`
   - : A [`ConstrainDouble`](#constraindouble) (a double-precision integer) specifying the desired focal length.
-- torch
+- `torch`
   - : A boolean value defining whether the fill light is continuously connected, meaning it stays on as long as the track is active.
 
 ### Instance properties of video tracks
@@ -135,15 +155,19 @@ Some combination—but not necessarily all—of the following properties will ex
   - : A [`ConstrainULong`](#constrainulong) specifying the video height or range of heights which are acceptable and/or required.
 - {{domxref("MediaTrackConstraints.width", "width")}}
   - : A [`ConstrainULong`](#constrainulong) specifying the video width or range of widths which are acceptable and/or required.
-- resizeMode
-  - : A [`ConstrainDOMString`](#constraindomstring) object specifying a mode or an array of modes the UA can use to derive the resolution of a video track. Allowed values are `none` and `crop-and-scale`. `none` means that the user agent uses the resolution provided by the camera, its driver or the OS. `crop-and-scale` means that the user agent can use cropping and downscaling on the camera output in order to satisfy other constraints that affect the resolution.
+- `resizeMode`
+  - : A [`ConstrainDOMString`](#constraindomstring) object specifying a mode or an array of modes the UA can use to derive the resolution of a video track.
+    Allowed values are `none` and `crop-and-scale`.
+    `none` means that the user agent uses the resolution provided by the camera, its driver or the OS.
+    `crop-and-scale` means that the user agent can use cropping and downscaling on the camera output in order to satisfy other constraints that affect the resolution.
 
 ### Instance properties of shared screen tracks
 
 These constraints apply to the `video` property of the object passed into {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} to obtain a stream for screen sharing.
 
 - {{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}}
-  - : A [`ConstrainDOMString`](#constraindomstring) which specifies the types of display surface that may be selected by the user. This may be a single one of the following strings, or a list of them to allow multiple source surfaces:
+  - : A [`ConstrainDOMString`](#constraindomstring) which specifies the types of display surface that may be selected by the user.
+    This may be a single one of the following strings, or a list of them to allow multiple source surfaces:
     - `browser`
       - : The stream contains the contents of a single browser tab selected by the user.
     - `monitor`
@@ -152,10 +176,12 @@ These constraints apply to the `video` property of the object passed into {{domx
       - : The stream contains a single window selected by the user for sharing.
 
 - {{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}}
-  - : A [`ConstrainBoolean`](#constrainboolean) value which may contain a single Boolean value or a set of them, indicating whether or not to allow the user to choose source surfaces which do not directly correspond to display areas. These may include backing buffers for windows to allow capture of window contents that are hidden by other windows in front of them, or buffers containing larger documents that need to be scrolled through to see the entire contents in their windows.
+  - : A [`ConstrainBoolean`](#constrainboolean) value which may contain a single Boolean value or a set of them, indicating whether or not to allow the user to choose source surfaces which do not directly correspond to display areas.
+    These may include backing buffers for windows to allow capture of window contents that are hidden by other windows in front of them, or buffers containing larger documents that need to be scrolled through to see the entire contents in their windows.
 
 - {{domxref("MediaTrackConstraints.suppressLocalAudioPlayback", "suppressLocalAudioPlayback")}} {{Experimental_Inline}}
-  - : A [`ConstrainBoolean`](#constrainboolean) value describing the requested or mandatory constraints placed upon the value of the {{domxref("MediaTrackSettings.suppressLocalAudioPlayback","suppressLocalAudioPlayback")}} constrainable property. This property controls whether the audio playing in a tab will continue to be played out of a user's local speakers when the tab is captured.
+  - : A [`ConstrainBoolean`](#constrainboolean) value describing the requested or mandatory constraints placed upon the value of the {{domxref("MediaTrackSettings.suppressLocalAudioPlayback","suppressLocalAudioPlayback")}} constrainable property.
+    This property controls whether the audio playing in a tab will continue to be played out of a user's local speakers when the tab is captured.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -11,7 +11,7 @@ The **`MediaTrackConstraints`** dictionary is used to describe a set of media ca
 
 A constraints dictionary is passed into the {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} method of the {{domxref("MediaStreamTrack")}} interface to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track.
 
- The most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
+The most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
 
 Objects of this type may also be passed to:
 
@@ -165,13 +165,15 @@ For example, because {{Glossary("RTP")}} doesn't provide some of these values du
 - {{domxref("MediaTrackConstraints.width", "width")}}
   - : A [`ConstrainULong`](#constrainulong) specifying the video width or range of widths which are acceptable and/or required.
 - `resizeMode`
-  - : A [`ConstrainDOMString`](#constraindomstring) object specifying a mode or an array of modes the UA can use to derive the resolution of a video track.
+  - : A [`ConstrainDOMString`](#constraindomstring) object specifying a mode or an array of modes the UA can use to derive the resolution and frame rate of a video track.
     Allowed values are:
     - `crop-and-scale`
       - : The user agent can use cropping and downscaling of resolution or frame rate on the raw output from the hardware/OS, in order to satisfy other constraints.
         This constraint allows developers to get a downscaled video even if the particular format indicated by their constraints is not natively supported by the hardware.
     - `none`
       - : The user agent uses the resolution provided by the underlying hardware, such as a camera or its driver, or the OS.
+
+    If `resizeMode` is unspecified the browser will choose a resolution based on a [fitness distance](https://w3c.github.io/mediacapture-main/#dfn-fitness-distance) that considers the specified constraints and _both_ of the allowed values.
 
 ### Instance properties of shared screen tracks
 


### PR DESCRIPTION
FF144 added a new constraint parameter `resizeMode` for use with [`MediaDevices.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) and `getDisplayMedia()`.

This allows a developer to specify whether the video from the camera should be cropped and/or downscaled to match other constraints, which may be natively supported by the camera - essentially gives them what they ask for rather than what the camera is capable of delivering. It also allows them to specify that it doesn't want scaling.

This updates the relevant docs (First two commits are layout only).

The main changes are to:
- Better cross-link `MediaTrackConstraints` which is where the constraint is documented to make it clear that it is also used in these methods (not just some others).
- Provide an example explaining the downscaling.

Related docs work can be tracked in #41132