### PR TITLE
FF144 RTCDataChannel release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -54,8 +54,8 @@ Firefox 144 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 #### Media, WebRTC, and Web Audio
 
-- {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker) ([Firefox bug 1209163](https://bugzil.la/1209163)).
-- The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and `onclosing()` event handler of the {{domxref("RTCDataChannel")}} interface are now supported ([Firefox bug 1611953](https://bugzil.la/1611953)).
+- {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
+- The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -52,7 +52,10 @@ Firefox 144 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 <!-- #### DOM -->
 
-<!-- #### Media, WebRTC, and Web Audio -->
+#### Media, WebRTC, and Web Audio
+
+- {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker) ([Firefox bug 1209163](https://bugzil.la/1209163)).
+- The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and `onclosing()` event handler of the {{domxref("RTCDataChannel")}} interface are now supported ([Firefox bug 1611953](https://bugzil.la/1611953)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -48,7 +48,7 @@ Firefox 144 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
 <!-- #### DOM -->
 

--- a/files/en-us/web/api/web_workers_api/transferable_objects/index.md
+++ b/files/en-us/web/api/web_workers_api/transferable_objects/index.md
@@ -79,20 +79,20 @@ Interfaces that can be transferred should include this information in their intr
 Some of the items that various specifications indicate can be _transferred_ are listed below (this list may not be exhaustive!):
 
 - {{jsxref("ArrayBuffer")}}
-- {{domxref("MessagePort")}}
-- {{domxref("ReadableStream")}}
-- {{domxref("WritableStream")}}
-- {{domxref("TransformStream")}}
-- {{domxref("WebTransportReceiveStream")}}
-- {{domxref("WebTransportSendStream")}}
 - {{domxref("AudioData")}}
 - {{domxref("ImageBitmap")}}
-- {{domxref("VideoFrame")}}
-- {{domxref("OffscreenCanvas")}}
-- {{domxref("RTCDataChannel")}}
 - {{domxref("MediaSourceHandle")}}
-- {{domxref("MIDIAccess")}}
 - {{domxref("MediaStreamTrack")}}
+- {{domxref("MessagePort")}}
+- {{domxref("MIDIAccess")}}
+- {{domxref("OffscreenCanvas")}}
+- {{domxref("ReadableStream")}}
+- {{domxref("RTCDataChannel")}}
+- {{domxref("TransformStream")}}
+- {{domxref("VideoFrame")}}
+- {{domxref("WebTransportReceiveStream")}}
+- {{domxref("WebTransportSendStream")}}
+- {{domxref("WritableStream")}}
 
 > [!NOTE]
 > Transferable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Transferable]`.


### PR DESCRIPTION
FF144 makes [`RTCDataChannel`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel) transferrable in https://bugzilla.mozilla.org/show_bug.cgi?id=1209163. It also adds support for the `closing` event in https://bugzilla.mozilla.org/show_bug.cgi?id=1611953

This adds a release note and minor tweak to docs.

Related docs work can be tracked in #41135