### PR TITLE
Firefox 143 release

### DIFF
--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -1,8 +1,8 @@
 ---
 title: Firefox 142 for developers
-short-title: Firefox 142 (Stable)
+short-title: Firefox 142
 slug: Mozilla/Firefox/Releases/142
-page-type: firefox-release-notes-active
+page-type: firefox-release-notes
 sidebar: firefox
 ---
 

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -1,30 +1,19 @@
 ---
 title: Firefox 143 for developers
-short-title: Firefox 143 (Beta)
+short-title: Firefox 143 (Stable)
 slug: Mozilla/Firefox/Releases/143
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
 This article provides information about the changes in Firefox 143 that affect developers.
-Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [September 16, 2025](https://whattrainisitnow.com/release/?version=143).
-
-> [!NOTE]
-> The release notes for this Firefox version are still a work in progress.
-
-<!-- Authors: Please uncomment any headings you are writing notes for -->
+Firefox 143 was released on [September 16, 2025](https://whattrainisitnow.com/release/?version=143).
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
-
-<!-- ### HTML -->
+### HTML
 
 - The [`type="color"`](/en-US/docs/Web/HTML/Reference/Elements/input/color) {{HTMLElement("input")}} element now accepts not only HEX colors like `#ff6699` but also all CSS [`<color>`](/en-US/docs/Web/CSS/color_value) values, for example `oklab(50% 0.1 0.1 / 0.5)`. ([Firefox bug 1965029](https://bugzil.la/1965029)).
-
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
 
 ### CSS
 
@@ -35,40 +24,16 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - Multi-pass grid track sizing is now enabled by default and follows the algorithm outlined in the CSS Grid specification. In the multi-pass algorithm, columns are sized first, then rows; percentage values are resolved after the container size is known. With this default support, [percentage-based](/en-US/docs/Web/CSS/grid-template-rows#percentage) row tracks and grid items with aspect ratios will now be sized correctly in more cases.
   ([Firefox bug 1957244](https://bugzil.la/1957244)).
 
-<!-- #### Removals -->
+### JavaScript
 
-<!-- ### JavaScript -->
-
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
-
-<!-- ### SVG -->
-
-<!-- #### Removals -->
-
-<!-- ### HTTP -->
-
-<!-- #### Removals -->
-
-<!-- ### Security -->
-
-<!-- #### Removals -->
+No notable changes.
 
 ### APIs
-
-<!-- #### DOM -->
-
-<!-- #### Media, WebRTC, and Web Audio -->
 
 #### Removals
 
 - The deprecated {{domxref("CompositionEvent.locale")}} property is no longer supported.
   ([Firefox bug 1700969](https://bugzil.la/1700969)).
-
-<!-- ### WebAssembly -->
-
-<!-- #### Removals -->
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -88,10 +53,6 @@ Firefox 143 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Addition of {{WebExtAPIRef("storage.StorageArea.getKeys()")}}. This method returns an array containing all of the keys in a storage area. It's available for all storage areas, that is {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, and {{WebExtAPIRef("storage.managed", "managed")}}. ([Firefox bug 1910669](https://bugzil.la/1910669))
 - User selection of an extension suggestion in the address bar (omnibox), an action that fires {{WebExtAPIRef("omnibox.onInputEntered")}}, is now considered a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). In addition to enabling the APIs that require a user action, selecting an extension suggestion in the address bar also grants the `"activeTab"` permission.
-
-<!-- ### Removals -->
-
-<!-- ### Other -->
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -1,13 +1,13 @@
 ---
-title: Firefox 144 for developers
-short-title: Firefox 144 (Beta)
-slug: Mozilla/Firefox/Releases/144
+title: Firefox 145 for developers
+short-title: Firefox 145 (Nightly)
+slug: Mozilla/Firefox/Releases/145
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
-This article provides information about the changes in Firefox 144 that affect developers.
-Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [October 14, 2025](https://whattrainisitnow.com/release/?version=144).
+This article provides information about the changes in Firefox 145 that affect developers.
+Firefox 145 is the current [Nightly version of Firefox](https://www.firefox.com/en-US/channel/desktop/#nightly) and ships on [November 11, 2025](https://whattrainisitnow.com/release/?version=145).
 
 > [!NOTE]
 > The release notes for this Firefox version are still a work in progress.
@@ -70,14 +70,12 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for add-on developers
 
-- Adds the ability to determine the priority of CSS injected from the [`"content_scripts"` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts), in {{WebExtAPIRef("scripting.registerContentScripts()")}} with the `cssOrigin` property on {{WebExtAPIRef("scripting.RegisteredContentScript")}}, and the `cssOrigin` property in {{WebExtAPIRef("contentScripts.register")}}. By default, the `"author"` origin takes precedence. ([Firefox bug 1679997](https://bugzil.la/1679997))
-
 <!-- ### Removals -->
 
 <!-- ### Other -->
 
 ## Experimental web features
 
-These features are shipping in Firefox 144 but are disabled by default.
+These features are shipping in Firefox 145 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
Release notes for Firefox 143

* Adds nightly 145
* Updates 144 to beta
* Updates 143 to stable
* Removes 142 as active