### PR TITLE
fix grammar in SVG

### DIFF
--- a/files/en-us/web/svg/reference/attribute/d/index.md
+++ b/files/en-us/web/svg/reference/attribute/d/index.md
@@ -898,15 +898,15 @@ _Elliptical arc curves_ are curves defined as a portion of an ellipse. It is som
           </li>
           <li>
             <code><var>large-arc-flag</var></code> and
-            <code><var>sweep-flag</var></code> allows to chose which arc must be
+            <code><var>sweep-flag</var></code> allows to choose which arc must be
             drawn as 4 possible arcs can be drawn out of the other parameters.
             <ul>
               <li>
-                <code><var>large-arc-flag</var></code> allows to chose one of
+                <code><var>large-arc-flag</var></code> allows to choose one of
                 the large arc (<code>1</code>) or small arc (<code>0</code>),
               </li>
               <li>
-                <code><var>sweep-flag</var></code> allows to chose one of the
+                <code><var>sweep-flag</var></code> allows to choose one of the
                 clockwise turning arc (<code>1</code>) or counterclockwise
                 turning arc (<code>0</code>)
               </li>
@@ -948,7 +948,7 @@ _Elliptical arc curves_ are curves defined as a portion of an ellipse. It is som
           </li>
           <li>
             <code><var>large-arc-flag</var></code> and
-            <code><var>sweep-flag</var></code> allows to chose which arc must be
+            <code><var>sweep-flag</var></code> allows to choose which arc must be
             drawn as 4 possible arcs can be drawn out of the other parameters.
             <ul>
               <li>


### PR DESCRIPTION
### Description

Fix grammar in SVG markdown file `(files\en-us\web\svg\reference\attribute\d\index.md)` , changes `allows to chose` to `allows to choose`

### Motivation

This improves documentation grammar and help in better understanding to the user

### Additional details

NA

### Related issues and pull requests
Fixes #41129

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
