### PR TITLE
remove deleted docs from CSSRef macro

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -29,9 +29,6 @@ sidebar:
       - /Learn_web_development/Core/Styling_basics/Images_media_forms
       - /Learn_web_development/Core/Styling_basics/Tables
       - /Learn_web_development/Core/Styling_basics/Debugging_CSS
-      - /Learn_web_development/Core/Styling_basics/Fundamental_CSS_comprehension
-      - /Learn_web_development/Core/Styling_basics/Fancy_letterheaded_paper
-      - /Learn_web_development/Core/Styling_basics
   - link: /Learn_web_development/Core/Text_styling
     title: CSS_text_styling
     details: closed


### PR DESCRIPTION
The following links in the CSSRef macro needs to be removed
      - /Learn_web_development/Core/Styling_basics/Fundamental_CSS_comprehension
      - /Learn_web_development/Core/Styling_basics/Fancy_letterheaded_paper
      - /Learn_web_development/Core/Styling_basics

The first two docs have been removed and the links are now in redirects' file.

