### PR TITLE
Use percentages instead of absolute units for view progress timeline …

### DIFF
--- a/files/en-us/web/css/animation-timeline/view/index.md
+++ b/files/en-us/web/css/animation-timeline/view/index.md
@@ -165,13 +165,13 @@ To aid the understanding of the result, extra elements `subject-container`, `top
 
 .top {
   top: 0;
-  height: 244px;
+  height: 50%;
   align-items: end;
 }
 
 .bottom {
-  top: 432px;
-  height: 48px;
+  bottom: 0;
+  height: 10%;
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Bug description

The view progress scroll timeline example is broken on MDN playground because it uses absolute units (stumped me for quite a bit!). Here's a screenshot of how it looks like before my changes on Chrome v140:

<img width="460" height="315" alt="Screenshot before changes" src="https://github.com/user-attachments/assets/3bea9592-436d-4d9b-9582-109d5b8c1317" />



### Fix

I've updated the example to use percentage units instead of absolute units. Here's a screen recording with my fix:

<img width="460" height="315" alt="Screen recording with my changes" src="https://github.com/user-attachments/assets/64cfb7d5-d529-4936-a45d-31358010e0d3" />
