### PR TITLE
[htmlsidebar]: Replace manual HTML guides list with `listSubPages`

### DIFF
--- a/files/en-us/web/html/guides/cheatsheet/index.md
+++ b/files/en-us/web/html/guides/cheatsheet/index.md
@@ -1,6 +1,6 @@
 ---
 title: HTML cheatsheet for syntax and common tasks
-short-title: HTML cheatsheet
+short-title: Cheatsheet
 slug: Web/HTML/Guides/Cheatsheet
 page-type: guide
 sidebar: htmlsidebar

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -3,19 +3,11 @@
 sidebar:
   - type: section
     link: /Web/HTML
-  - type: section
+  - type: listSubPages
+    path: /Web/HTML/Guides
     link: /Web/HTML/Guides
     title: Guides
-  - /Web/HTML/Guides/Content_categories
-  - /Web/HTML/Guides/Comments
-  - /Web/HTML/Guides/Date_and_time_formats
-  - /Web/HTML/Guides/Constraint_validation
-  - /Web/HTML/Guides/Viewport_meta_element
-  - /Web/HTML/Guides/Responsive_images
-  - /Web/HTML/Guides/Microdata
-  - /Web/HTML/Guides/Microformats
-  - /Web/HTML/Guides/Quirks_mode_and_standards_mode
-  - /Web/HTML/Guides/Cheatsheet
+    details: closed
   - type: section
     link: /Web/HTML/How_to
   - /Web/HTML/How_to/Define_terms_with_HTML


### PR DESCRIPTION

### Description

With https://github.com/mdn/rari/issues/201 fixed and the items in the sidebar now automatically sorted based on `short-title` as well, we can replace the manually curated list for `HTML/Guides` in the sidebar file with `listSubPages`.

Also added a tiny tweak to the `short-title` in the cheatsheet so it surfaces to the top in the sidebar.

### Additional details

| With this fix | Presently on prod |
| --- | --- | 
| <kbd><img width="332" height="584" alt="html sidebar with listSubPages" src="https://github.com/user-attachments/assets/6dbb148b-e66a-42c2-8a57-a74b30917de8" /></kbd> | <kbd><img width="281" height="489" alt="html sidebar using manual listing" src="https://github.com/user-attachments/assets/18b6424b-1d76-4f49-ac8c-b2374ac3f2d8" /></kbd> |




