### PR TITLE
Remove unnecessary useCapture parameter from addEventListener (1)

### DIFF
--- a/files/en-us/games/techniques/audio_for_web_games/index.md
+++ b/files/en-us/games/techniques/audio_for_web_games/index.md
@@ -96,26 +96,18 @@ const buttons = document.getElementsByTagName("button");
 let stopTime = 0;
 
 for (const button of buttons) {
-  button.addEventListener(
-    "click",
-    () => {
-      myAudio.currentTime = button.dataset.start;
-      stopTime = Number(button.dataset.stop);
-      myAudio.play();
-    },
-    false,
-  );
+  button.addEventListener("click", () => {
+    myAudio.currentTime = button.dataset.start;
+    stopTime = Number(button.dataset.stop);
+    myAudio.play();
+  });
 }
 
-myAudio.addEventListener(
-  "timeupdate",
-  () => {
-    if (myAudio.currentTime > stopTime) {
-      myAudio.pause();
-    }
-  },
-  false,
-);
+myAudio.addEventListener("timeupdate", () => {
+  if (myAudio.currentTime > stopTime) {
+    myAudio.pause();
+  }
+});
 ```
 
 {{EmbedLiveSample("audio-sprite", "", 200)}}

--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
@@ -19,8 +19,8 @@ It's also easier to test control-independent features like gameplay on desktop i
 Let's think about implementing pure JavaScript keyboard/mouse controls in the game first, to see how it would work. First, we'd need an event listener to listen for the pressed keys:
 
 ```js
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 ```
 
 Whenever any key is pressed down, we're executing the `keyDownHandler` function, and when press finishes we're executing the `keyUpHandler` function, so we know when it's no longer pressed. To do that, we'll hold the information on whether the keys we are interested in are pressed or not:

--- a/files/en-us/games/techniques/control_mechanisms/other/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/other/index.md
@@ -30,13 +30,9 @@ if (this.cursors.right.isDown) {
 It works out of the box. The cursors are the four directional arrow keys on the keyboard, and these have exactly the same key codes as the arrow keys on the remote. How do you know the codes for the other remote keys? You can check them by printing the responses out in the console:
 
 ```js
-window.addEventListener(
-  "keydown",
-  (event) => {
-    console.log(event.keyCode);
-  },
-  true,
-);
+window.addEventListener("keydown", (event) => {
+  console.log(event.keyCode);
+});
 ```
 
 Every key pressed on the remote will show its key code in the console. You can also check this handy cheat sheet seen below if you're working with Panasonic TVs running Firefox OS:
@@ -46,23 +42,19 @@ Every key pressed on the remote will show its key code in the console. You can a
 You can add moving between states, starting a new game, controlling the ship and blowing stuff up, pausing and restarting the game. All that is needed is checking for key presses:
 
 ```js
-window.addEventListener(
-  "keydown",
-  (event) => {
-    switch (event.keyCode) {
-      case 8: {
-        // Pause the game
-        break;
-      }
-      case 588: {
-        // Detonate bomb
-        break;
-      }
-      // …
+window.addEventListener("keydown", (event) => {
+  switch (event.keyCode) {
+    case 8: {
+      // Pause the game
+      break;
     }
-  },
-  true,
-);
+    case 588: {
+      // Detonate bomb
+      break;
+    }
+    // …
+  }
+});
 ```
 
 You can see it in action by watching [this video](https://www.youtube.com/watch?v=Bh11sP0bcTY).

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -152,8 +152,8 @@ for (let c = 0; c < brickColumnCount; c++) {
   }
 }
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -175,8 +175,8 @@ for (let c = 0; c < brickColumnCount; c++) {
   }
 }
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -147,9 +147,9 @@ for (let c = 0; c < brickColumnCount; c++) {
   }
 }
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
-document.addEventListener("mousemove", mouseMoveHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
+document.addEventListener("mousemove", mouseMoveHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -114,8 +114,8 @@ let leftPressed = false;
 
 let interval = 0;
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -16,7 +16,7 @@ The game itself is actually finished, so let's work on polishing it up. We have 
 Listening for mouse movement is even easier than listening for key presses: all we need is the listener for the {{domxref("Element/mousemove_event", "mousemove")}} event. Add the following line in the same place as the other event listeners, just below the `keyup event`:
 
 ```js
-document.addEventListener("mousemove", mouseMoveHandler, false);
+document.addEventListener("mousemove", mouseMoveHandler);
 ```
 
 ## Anchoring the paddle movement to the mouse movement
@@ -91,9 +91,9 @@ for (let c = 0; c < brickColumnCount; c++) {
   }
 }
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
-document.addEventListener("mousemove", mouseMoveHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
+document.addEventListener("mousemove", mouseMoveHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -52,8 +52,8 @@ let leftPressed = false;
 The default value for both is `false` because at the beginning the control buttons are not pressed. To listen for key presses, we will set up two event listeners. Add the following lines just above the `setInterval()` line at the bottom of your JavaScript:
 
 ```js
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 ```
 
 When the `keydown` event is fired on any of the keys on your keyboard (when they are pressed), the `keyDownHandler()` function will be executed. The same pattern is true for the second listener: `keyup` events will fire the `keyUpHandler()` function (when the keys stop being pressed). Add these to your code now, below the `addEventListener()` lines:
@@ -144,8 +144,8 @@ let paddleX = (canvas.width - paddleWidth) / 2;
 let rightPressed = false;
 let leftPressed = false;
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -143,8 +143,8 @@ for (let c = 0; c < brickColumnCount; c++) {
   }
 }
 
-document.addEventListener("keydown", keyDownHandler, false);
-document.addEventListener("keyup", keyUpHandler, false);
+document.addEventListener("keydown", keyDownHandler);
+document.addEventListener("keyup", keyUpHandler);
 
 function keyDownHandler(e) {
   if (e.key === "Right" || e.key === "ArrowRight") {

--- a/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -306,7 +306,7 @@ That way we can check which key is pressed at the given frame and apply the defi
 Probably the most interesting part of the game is its usage of the **Device Orientation API** for control on mobile devices. Thanks to this you can play the game by tilting the device in the direction you want the ball to roll. Here's the code from the `create()` function responsible for this:
 
 ```js
-window.addEventListener("deviceorientation", this.handleOrientation, true);
+window.addEventListener("deviceorientation", this.handleOrientation);
 ```
 
 We're adding an event listener to the `"deviceorientation"` event and binding the `handleOrientation` function which looks like this:

--- a/files/en-us/learn_web_development/extensions/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_build_custom_form_controls/index.md
@@ -1236,13 +1236,9 @@ selectList.forEach((select) => {
     });
   });
 
-  select.addEventListener(
-    "click",
-    (event) => {
-      toggleOptList(select);
-    },
-    false,
-  );
+  select.addEventListener("click", (event) => {
+    toggleOptList(select);
+  });
 
   select.addEventListener("focus", (event) => {
     activeSelect(select, selectList);

--- a/files/en-us/learn_web_development/extensions/forms/user_input_methods/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/user_input_methods/index.md
@@ -34,8 +34,8 @@ Most users will use a keyboard to enter data into your form controls. Some will 
 If you want to add additional keyboard support, such as validating a form control when a specific key is hit, you can use event listeners to capture and react to keyboard events. For example, if you want to add controls when any key gets pressed, you need to add an event listener on the window object:
 
 ```js
-window.addEventListener("keydown", handleKeyDown, true);
-window.addEventListener("keyup", handleKeyUp, true);
+window.addEventListener("keydown", handleKeyDown);
+window.addEventListener("keyup", handleKeyUp);
 ```
 
 `handleKeyDown` and `handleKeyUp` are functions defining the control logic to be executed when the `keydown` and `keyup` events are fired.
@@ -56,10 +56,10 @@ To provide additional support for touchscreen devices, it's a good practice to t
 If you want to use touch events, you need to add event listeners and specify handler functions, which will be called when the event gets fired:
 
 ```js
-element.addEventListener("touchstart", handleStart, false);
-element.addEventListener("touchcancel", handleCancel, false);
-element.addEventListener("touchend", handleEnd, false);
-element.addEventListener("touchmove", handleMove, false);
+element.addEventListener("touchstart", handleStart);
+element.addEventListener("touchcancel", handleCancel);
+element.addEventListener("touchend", handleEnd);
+element.addEventListener("touchmove", handleMove);
 ```
 
 where `element` is the DOM element you want to register the touch events on.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
@@ -11,7 +11,7 @@ Opens print preview for the active tab.
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). An extension can detect when print preview has been closed by listening to the [afterprint](/en-US/docs/Web/API/Window/afterprint_event) event:
 
 ```js
-window.addEventListener("afterprint", resumeFunction, false);
+window.addEventListener("afterprint", resumeFunction);
 ```
 
 ## Syntax

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/cloneinto/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/cloneinto/index.md
@@ -61,13 +61,9 @@ Scripts running in the page can access the object:
 
 ```js
 // page script
-button.addEventListener(
-  "click",
-  () => {
-    console.log(window.addonScriptObject.greeting); // "hello from your extension"
-  },
-  false,
-);
+button.addEventListener("click", () => {
+  console.log(window.addonScriptObject.greeting); // "hello from your extension"
+});
 ```
 
 Of course, you don't have to assign the clone to the window itself; you can assign it to some other object in the target scope:
@@ -113,13 +109,9 @@ window.addonScriptObject = cloneInto(addonScriptObject, window, {
 ```js
 // page script
 const test = document.getElementById("test");
-test.addEventListener(
-  "click",
-  () => {
-    window.addonScriptObject.greetMe();
-  },
-  false,
-);
+test.addEventListener("click", () => {
+  window.addonScriptObject.greetMe();
+});
 ```
 
 ### Cloning objects that contain DOM elements
@@ -139,13 +131,9 @@ window.addonScriptObject = cloneInto(addonScriptObject, window, {
 ```js
 // page script
 const test = document.getElementById("test");
-test.addEventListener(
-  "click",
-  () => {
-    console.log(window.addonScriptObject.body.innerHTML);
-  },
-  false,
-);
+test.addEventListener("click", () => {
+  console.log(window.addonScriptObject.body.innerHTML);
+});
 ```
 
 Access to these objects in the target scope is subject to the normal [script security checks](https://firefox-source-docs.mozilla.org/dom/scriptSecurity/index.html).

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/exportfunction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/exportfunction/index.md
@@ -63,15 +63,11 @@ exportFunction(changeMyName, window, {
 // less-privileged scope: for example, a page script
 const user = { name: "Jim" };
 const test = document.getElementById("test");
-test.addEventListener(
-  "click",
-  () => {
-    console.log(user.name); // "Jim"
-    window.changeMyName(user);
-    console.log(user.name); // "Bill"
-  },
-  false,
-);
+test.addEventListener("click", () => {
+  console.log(user.name); // "Jim"
+  window.changeMyName(user);
+  console.log(user.name); // "Bill"
+});
 ```
 
 This behavior is subject to the normal rules of Xrays. For example, an expando property added to a DOM node isn't visible in the original object.
@@ -99,13 +95,9 @@ const user = {
   },
 };
 const test = document.getElementById("test");
-test.addEventListener(
-  "click",
-  () => {
-    window.logUser(user);
-  },
-  false,
-);
+test.addEventListener("click", () => {
+  window.logUser(user);
+});
 ```
 
 See [Xray vision](https://firefox-source-docs.mozilla.org/dom/scriptSecurity/xray_vision.html) in the Firefox Source Tree documentation for more information.
@@ -130,13 +122,9 @@ function getUser() {
   return "Bill";
 }
 const test = document.getElementById("test");
-test.addEventListener(
-  "click",
-  () => {
-    window.logUser(getUser);
-  },
-  false,
-);
+test.addEventListener("click", () => {
+  window.logUser(getUser);
+});
 ```
 
 ### Cross-origin checking

--- a/files/en-us/web/accessibility/aria/reference/roles/switch_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/switch_role/index.md
@@ -111,7 +111,7 @@ This JavaScript code defines and applies a function to handle click events on sw
 
 ```js
 document.querySelectorAll(".switch").forEach((theSwitch) => {
-  theSwitch.addEventListener("click", handleClickEvent, false);
+  theSwitch.addEventListener("click", handleClickEvent);
 });
 
 function handleClickEvent(evt) {

--- a/files/en-us/web/css/_colon_-moz-drag-over/index.md
+++ b/files/en-us/web/css/_colon_-moz-drag-over/index.md
@@ -42,14 +42,10 @@ For more information, see [Drag operations: Specifying drop targets](/en-US/docs
 ```js
 const target = document.getElementById("drop-target");
 /* dragenter event fired on the drop target */
-target.addEventListener(
-  "dragenter",
-  (event) => {
-    // prevent default to allow drop
-    event.preventDefault();
-  },
-  false,
-);
+target.addEventListener("dragenter", (event) => {
+  // prevent default to allow drop
+  event.preventDefault();
+});
 ```
 
 ### CSS

--- a/files/en-us/web/css/_doublecolon_before/index.md
+++ b/files/en-us/web/css/_doublecolon_before/index.md
@@ -178,15 +178,11 @@ li.done::before {
 
 ```js
 const list = document.querySelector("ul");
-list.addEventListener(
-  "click",
-  (ev) => {
-    if (ev.target.tagName === "LI") {
-      ev.target.classList.toggle("done");
-    }
-  },
-  false,
-);
+list.addEventListener("click", (ev) => {
+  if (ev.target.tagName === "LI") {
+    ev.target.classList.toggle("done");
+  }
+});
 ```
 
 Here is the above code example running live. Note that there are no icons used, and the check-mark is actually the `::before` that has been styled in CSS. Go ahead and get some stuff done.

--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -331,9 +331,9 @@ We'll use JavaScript code to listen for all three possible animation events. Thi
 
 ```js
 const element = document.getElementById("watch-me");
-element.addEventListener("animationstart", listener, false);
-element.addEventListener("animationend", listener, false);
-element.addEventListener("animationiteration", listener, false);
+element.addEventListener("animationstart", listener);
+element.addEventListener("animationend", listener);
+element.addEventListener("animationiteration", listener);
 
 element.className = "slide-in";
 ```

--- a/files/en-us/web/css/css_colors/color_values/index.md
+++ b/files/en-us/web/css/css_colors/color_values/index.md
@@ -110,21 +110,13 @@ const output = document.querySelector("output");
 
 box.style.borderColor = colorPicker.value;
 
-colorPicker.addEventListener(
-  "input",
-  (event) => {
-    box.style.borderColor = event.target.value;
-  },
-  false,
-);
+colorPicker.addEventListener("input", (event) => {
+  box.style.borderColor = event.target.value;
+});
 
-colorPicker.addEventListener(
-  "change",
-  (event) => {
-    output.innerText = `${colorPicker.value}`;
-  },
-  false,
-);
+colorPicker.addEventListener("change", (event) => {
+  output.innerText = `${colorPicker.value}`;
+});
 ```
 
 The {{domxref("Element/input_event", "input")}} event is sent every time the value of the element changes; that is, every time the user adjusts the color in the color picker. Each time this event arrives, we set the box's border color to match the color picker's current value.

--- a/files/en-us/web/css/css_filter_effects/index.md
+++ b/files/en-us/web/css/css_filter_effects/index.md
@@ -159,24 +159,16 @@ const controls = document.querySelectorAll("input");
 const output = document.querySelector("output");
 
 for (control of controls) {
-  control.addEventListener(
-    "change",
-    () => {
-      /* do function */
-      changeCSS();
-    },
-    false,
-  );
+  control.addEventListener("change", () => {
+    /* do function */
+    changeCSS();
+  });
 }
-document.querySelector("button").addEventListener(
-  "click",
-  () => {
-    setTimeout(() => {
-      changeCSS();
-    }, 50);
-  },
-  false,
-);
+document.querySelector("button").addEventListener("click", () => {
+  setTimeout(() => {
+    changeCSS();
+  }, 50);
+});
 
 function changeCSS() {
   let currentFilter = "filter: ";

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -306,14 +306,10 @@ Transitions are a great tool to make things look much smoother without having to
 ```js live-sample___js-transitions
 // Make the ball move to a certain position:
 const f = document.getElementById("foo");
-document.addEventListener(
-  "click",
-  (ev) => {
-    f.style.transform = `translateY(${ev.clientY - 25}px)`;
-    f.style.transform += `translateX(${ev.clientX - 25}px)`;
-  },
-  false,
-);
+document.addEventListener("click", (ev) => {
+  f.style.transform = `translateY(${ev.clientY - 25}px)`;
+  f.style.transform += `translateX(${ev.clientX - 25}px)`;
+});
 ```
 
 With CSS, you can smooth the styles applied through JavaScript. Add a transition to the element and any change will happen smoothly:
@@ -374,14 +370,14 @@ You can use the {{domxref("Element/transitionend_event", "transitionend")}} even
 As usual, you can use the {{domxref("EventTarget.addEventListener", "addEventListener()")}} method to monitor for this event:
 
 ```js
-el.addEventListener("transitionend", updateTransition, true);
+el.addEventListener("transitionend", updateTransition);
 ```
 
 You detect the beginning of a transition using {{domxref("Element/transitionrun_event", "transitionrun")}} (fires before any delay) and {{domxref("Element/transitionstart_event", "transitionstart")}} (fires after any delay), in the same kind of fashion:
 
 ```js
-el.addEventListener("transitionrun", signalStart, true);
-el.addEventListener("transitionstart", signalStart, true);
+el.addEventListener("transitionrun", signalStart);
+el.addEventListener("transitionstart", signalStart);
 ```
 
 > [!NOTE]

--- a/files/en-us/web/html/how_to/cors_enabled_image/index.md
+++ b/files/en-us/web/html/how_to/cors_enabled_image/index.md
@@ -67,7 +67,7 @@ function startDownload() {
 
   downloadedImg = new Image();
   downloadedImg.crossOrigin = "anonymous";
-  downloadedImg.addEventListener("load", imageReceived, false);
+  downloadedImg.addEventListener("load", imageReceived);
   downloadedImg.alt = imageDescription;
   downloadedImg.src = imageURL;
 }

--- a/files/en-us/web/html/reference/elements/input/color/index.md
+++ b/files/en-us/web/html/reference/elements/input/color/index.md
@@ -97,8 +97,8 @@ As is the case with other {{HTMLElement("input")}} types, there are two events t
 Here's an example that watches changes over time to the color value:
 
 ```js
-colorPicker.addEventListener("input", updateFirst, false);
-colorPicker.addEventListener("change", watchColorPicker, false);
+colorPicker.addEventListener("input", updateFirst);
+colorPicker.addEventListener("change", watchColorPicker);
 
 function watchColorPicker(event) {
   document.querySelectorAll("p").forEach((p) => {
@@ -157,8 +157,8 @@ The following code initializes the color input:
 const defaultColor = "#0000ff";
 const colorPicker = document.querySelector("#color-picker");
 colorPicker.value = defaultColor;
-colorPicker.addEventListener("input", updateFirst, false);
-colorPicker.addEventListener("change", updateAll, false);
+colorPicker.addEventListener("input", updateFirst);
+colorPicker.addEventListener("change", updateAll);
 colorPicker.select();
 ```
 

--- a/files/en-us/web/html/reference/elements/input/radio/index.md
+++ b/files/en-us/web/html/reference/elements/input/radio/index.md
@@ -133,19 +133,15 @@ Then we add some [JavaScript](/en-US/docs/Web/JavaScript) to set up an event lis
 const form = document.querySelector("form");
 const log = document.querySelector("#log");
 
-form.addEventListener(
-  "submit",
-  (event) => {
-    const data = new FormData(form);
-    let output = "";
-    for (const entry of data) {
-      output = `${output}${entry[0]}=${entry[1]}\r`;
-    }
-    log.innerText = output;
-    event.preventDefault();
-  },
-  false,
-);
+form.addEventListener("submit", (event) => {
+  const data = new FormData(form);
+  let output = "";
+  for (const entry of data) {
+    output = `${output}${entry[0]}=${entry[1]}\r`;
+  }
+  log.innerText = output;
+  event.preventDefault();
+});
 ```
 
 Try this example out and see how there's never more than one result for the `contact` group.

--- a/files/en-us/web/html/reference/elements/input/time/index.md
+++ b/files/en-us/web/html/reference/elements/input/time/index.md
@@ -89,13 +89,9 @@ The JavaScript code adds code to the time input to watch for the {{domxref("Elem
 const startTime = document.getElementById("startTime");
 const valueSpan = document.getElementById("value");
 
-startTime.addEventListener(
-  "input",
-  () => {
-    valueSpan.innerText = startTime.value;
-  },
-  false,
-);
+startTime.addEventListener("input", () => {
+  valueSpan.innerText = startTime.value;
+});
 ```
 
 {{EmbedLiveSample("Time_value_format", 600, 80)}}

--- a/files/en-us/web/javascript/guide/memory_management/index.md
+++ b/files/en-us/web/javascript/guide/memory_management/index.md
@@ -41,13 +41,9 @@ function f(a) {
 } // allocates a function (which is a callable object)
 
 // function expressions also allocate an object
-someElement.addEventListener(
-  "click",
-  () => {
-    someElement.style.backgroundColor = "blue";
-  },
-  false,
-);
+someElement.addEventListener("click", () => {
+  someElement.style.backgroundColor = "blue";
+});
 ```
 
 #### Allocation via function calls

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -493,15 +493,11 @@ If we change this so that the `<iframe>` in the document is listening to post me
 <!-- x.html -->
 <!doctype html>
 <script>
-  window.addEventListener(
-    "message",
-    (event) => {
-      document.querySelector("#text").textContent = "hello";
-      // this code will only run in browsers that track the incumbent settings object
-      console.log(event);
-    },
-    false,
-  );
+  window.addEventListener("message", (event) => {
+    document.querySelector("#text").textContent = "hello";
+    // this code will only run in browsers that track the incumbent settings object
+    console.log(event);
+  });
 </script>
 ```
 

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -451,7 +451,7 @@ const elements = document.getElementsByTagName("*");
 // Add bluify as a click listener so when the
 // element is clicked on, it turns blue
 for (const element of elements) {
-  element.addEventListener("click", bluify, false);
+  element.addEventListener("click", bluify);
 }
 ```
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/index.md
@@ -288,15 +288,11 @@ function checkKey(e) {
   }
 }
 
-myControl.addEventListener(
-  "click",
-  () => {
-    switchState();
-  },
-  false,
-);
+myControl.addEventListener("click", () => {
+  switchState();
+});
 
-window.addEventListener("keypress", checkKey, false);
+window.addEventListener("keypress", checkKey);
 ```
 
 {{EmbedLiveSample("customizing your media player", "", 200)}}
@@ -452,15 +448,11 @@ Another way to show the fallback content of a video, when none of the sources co
 const v = document.querySelector("video");
 const sources = v.querySelectorAll("source");
 const lastSource = sources[sources.length - 1];
-lastSource.addEventListener(
-  "error",
-  (ev) => {
-    const d = document.createElement("div");
-    d.innerHTML = v.innerHTML;
-    v.parentNode.replaceChild(d, v);
-  },
-  false,
-);
+lastSource.addEventListener("error", (ev) => {
+  const d = document.createElement("div");
+  d.innerHTML = v.innerHTML;
+  v.parentNode.replaceChild(d, v);
+});
 ```
 
 ## Audio/Video JavaScript libraries

--- a/files/en-us/web/media/guides/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
@@ -55,14 +55,10 @@ const v = document.getElementById("myVideo");
 const p = document.getElementById("pbr");
 const c = document.getElementById("currentPbr");
 
-p.addEventListener(
-  "input",
-  () => {
-    c.textContent = p.value;
-    v.playbackRate = p.value;
-  },
-  false,
-);
+p.addEventListener("input", () => {
+  c.textContent = p.value;
+  v.playbackRate = p.value;
+});
 ```
 
 Finally, we listen for the `input` event firing on the {{ htmlelement("input") }} element, allowing us to react to the playback rate control being changed.

--- a/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
@@ -62,15 +62,11 @@ const processor = {
     this.c1 = document.getElementById("my-canvas");
     this.ctx1 = this.c1.getContext("2d");
 
-    this.video.addEventListener(
-      "play",
-      () => {
-        this.width = this.video.width;
-        this.height = this.video.height;
-        this.timerCallback();
-      },
-      false,
-    );
+    this.video.addEventListener("play", () => {
+      this.width = this.video.width;
+      this.height = this.video.height;
+      this.timerCallback();
+    });
   },
 
   computeFrame() {

--- a/files/en-us/web/media/guides/autoplay/index.md
+++ b/files/en-us/web/media/guides/autoplay/index.md
@@ -135,7 +135,7 @@ Here we have a {{HTMLElement("video")}} element whose [`autoplay`](/en-US/docs/W
 
 ```js
 const video = document.getElementById("video");
-video.addEventListener("play", handleFirstPlay, false);
+video.addEventListener("play", handleFirstPlay);
 
 let hasPlayed = false;
 function handleFirstPlay(event) {

--- a/files/en-us/web/svg/guides/scripting/index.md
+++ b/files/en-us/web/svg/guides/scripting/index.md
@@ -29,7 +29,7 @@ function myRect(x, y, w, h, message) {
   this.rect.setAttributeNS(null, "height", h);
   document.documentElement.appendChild(this.rect);
 
-  this.rect.addEventListener("click", this, false);
+  this.rect.addEventListener("click", this);
 
   this.handleEvent = (evt) => {
     switch (evt.type) {

--- a/files/en-us/web/svg/reference/attribute/textlength/index.md
+++ b/files/en-us/web/svg/reference/attribute/textlength/index.md
@@ -138,17 +138,13 @@ const baseLength = Math.floor(textElement.textLength.baseVal.value);
 
 widthSlider.value = baseLength;
 
-widthSlider.addEventListener(
-  "input",
-  (event) => {
-    textElement.textLength.baseVal.newValueSpecifiedUnits(
-      SVGLength.SVG_LENGTHTYPE_PX,
-      widthSlider.valueAsNumber,
-    );
-    widthDisplay.innerText = widthSlider.value;
-  },
-  false,
-);
+widthSlider.addEventListener("input", (event) => {
+  textElement.textLength.baseVal.newValueSpecifiedUnits(
+    SVGLength.SVG_LENGTHTYPE_PX,
+    widthSlider.valueAsNumber,
+  );
+  widthDisplay.innerText = widthSlider.value;
+});
 
 widthSlider.dispatchEvent(new Event("input"));
 ```


### PR DESCRIPTION
There hasn't been a need to specify `useCapture=false` since IE, and almost all cases where we specify this parameter, we are setting it to `false`. Removing it helps makes our `addEventListener` syntax more uniform and more easily greppable (for example, when I was removing `load` handlers, I missed a few because those have `"load"` on a separate line). This also removes one level of indentation which is nice. In order to review it, you probably want to hide whitespace.