### PR TITLE
Dispel ambiguity in `Using classes`

### DIFF
--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -637,7 +637,7 @@ There are a few things that have immediately come to attention. First is that in
 
 After the parent class is done with modifying `this`, the derived class can do its own logic. Here we added a private field called `#alpha`, and also provided a pair of getter/setters to interact with them.
 
-A derived class inherits all methods from its parent. For example, although `ColorWithAlpha` doesn't declare a `get red()` accessor itself, you can still access `red` because this behavior is specified by the parent class:
+A derived class inherits all methods from its parent. For example, consider the get red() accessor we added to the Color in the [Accessor fields](#accessor_fields) section, even though we haven't declared one in the ColorWithAlpha, we can still access red because this behavior is specified by the parent class:
 
 ```js
 const color = new ColorWithAlpha(255, 0, 0, 0.5);

--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -637,7 +637,7 @@ There are a few things that have immediately come to attention. First is that in
 
 After the parent class is done with modifying `this`, the derived class can do its own logic. Here we added a private field called `#alpha`, and also provided a pair of getter/setters to interact with them.
 
-A derived class inherits all methods from its parent. For example, consider the get red() accessor we added to the Color in the [Accessor fields](#accessor_fields) section, even though we haven't declared one in the ColorWithAlpha, we can still access red because this behavior is specified by the parent class:
+A derived class inherits all methods from its parent. For example, consider the `get red()` accessor we added to the `Color` in the [Accessor fields](#accessor_fields) section—even though we haven't declared one in `ColorWithAlpha`, we can still access `red` because this behavior is specified by the parent class:
 
 ```js
 const color = new ColorWithAlpha(255, 0, 0, 0.5);


### PR DESCRIPTION
### Description

make it clear that we are refering to the `accessor fields` section's example, instead of the example just above the current sentence.

### Motivation

see #41188 for motivation

### Additional details

### Related issues and pull requests

Fixes #41188 and hopefully, mdn/translated-content#29023