### PR TITLE
[Experiment]: Add CSS layout additional tutorials links to learnsidebar

### DIFF
--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -128,6 +128,13 @@ sidebar:
       - /Learn_web_development/Core/CSS_layout/Test_your_skills/Responsive_design
       - /Learn_web_development/Core/CSS_layout/Fundamental_Layout_Comprehension
       - /Learn_web_development/Core/CSS_layout/Test_your_skills
+      - title: Additional_tutorials
+        details: closed
+        children:
+          - /Learn_web_development/Core/CSS_layout/Multiple-column_Layout
+          - /Learn_web_development/Core/CSS_layout/Practical_positioning_examples
+          - /Learn_web_development/Core/CSS_layout/Legacy_Layout_Methods
+          - /Learn_web_development/Core/CSS_layout/Supporting_Older_Browsers
   - link: /Learn_web_development/Core/Scripting
     title: Dynamic_scripting_with_JavaScript
     details: closed
@@ -394,6 +401,7 @@ l10n:
     About: About
     Resources_for_educators: Resources for educators
     Changelog: Changelog
+    Additional_tutorials: Additional tutorials
   pt-BR:
     CSS_layout: Esquemas CSS
     Asynchronous_JavaScript: Asynchronous JavaScript


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

There are still [several Learn articles](https://github.com/mdn/content/issues/39393#issuecomment-2851420219) not linked from the learnsidebar. The ones we want to keep should really be linked in some way. This PR provides an experimental suggestion of what we could do in each case — an "Additional tutorials" subsection at the end of each module sidebar subsection.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
