### PR TITLE
'bt2020' color primaries

### DIFF
--- a/files/en-us/web/api/videocolorspace/primaries/index.md
+++ b/files/en-us/web/api/videocolorspace/primaries/index.md
@@ -20,6 +20,9 @@ A string containing one of the following values:
   - : Color primaries used by BT.601 PAL.
 - `"smpte170m"`
   - : Color primaries used by BT.601 NTSC.
+- `"bt2020"`
+  - : Color primaries used by BT.2020 and BT.2100.
+
 
 ## Examples
 

--- a/files/en-us/web/api/videocolorspace/primaries/index.md
+++ b/files/en-us/web/api/videocolorspace/primaries/index.md
@@ -23,7 +23,6 @@ A string containing one of the following values:
 - `"bt2020"`
   - : Color primaries used by BT.2020 and BT.2100.
 
-
 ## Examples
 
 In the following example, `colorSpace` is a `VideoColorSpace` object returned from {{domxref("VideoFrame")}}. The value of `primaries` is printed to the console.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->


### Description

Add bt2020 color primaries

### Motivation
Webcodecs support bt2020

### Additional details

(https://w3c.github.io/webcodecs/#dom-videocolorprimaries-bt2020)
