### PR TITLE
FF144 Relnote: beforescriptexecute and afterscriptexecute removal

### DIFF
--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -63,7 +63,9 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
 - The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).
 
-<!-- #### Removals -->
+#### Removals
+
+- The [`afterscriptexecute` event](/en-US/docs/Web/API/Document/afterscriptexecute_event) and [`beforescriptexecute` event](/en-US/docs/Web/API/Document/beforescriptexecute_event) of the `Document` interface, and the [`afterscriptexecute` event](/en-US/docs/Web/API/Element/afterscriptexecute_event) and [`beforescriptexecute` event](/en-US/docs/Web/API/Element/beforescriptexecute_event) of the `Element` interface have been removed. ([Firefox bug 1584269](https://bugzil.la/1584269)).
 
 <!-- ### WebAssembly -->
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -65,7 +65,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Removals
 
-- The [`afterscriptexecute` event](/en-US/docs/Web/API/Document/afterscriptexecute_event) and [`beforescriptexecute` event](/en-US/docs/Web/API/Document/beforescriptexecute_event) of the `Document` interface, and the [`afterscriptexecute` event](/en-US/docs/Web/API/Element/afterscriptexecute_event) and [`beforescriptexecute` event](/en-US/docs/Web/API/Element/beforescriptexecute_event) of the `Element` interface have been removed. ([Firefox bug 1584269](https://bugzil.la/1584269)).
+- The following deprecated and non-standard events have been removed: [`afterscriptexecute` event](/en-US/docs/Web/API/Document/afterscriptexecute_event) and [`beforescriptexecute` event](/en-US/docs/Web/API/Document/beforescriptexecute_event) of the `Document` interface, and the [`afterscriptexecute` event](/en-US/docs/Web/API/Element/afterscriptexecute_event) and [`beforescriptexecute` event](/en-US/docs/Web/API/Element/beforescriptexecute_event) of the `Element` interface. ([Firefox bug 1584269](https://bugzil.la/1584269)).
 
 <!-- ### WebAssembly -->
 


### PR DESCRIPTION
FF144 removed support for [`afterscriptexecute` event in `Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document/afterscriptexecute_event), [`afterscriptexecute` event in `Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element/afterscriptexecute_event), [`beforescriptexecute` event in `Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document/beforescriptexecute_event), [`beforescriptexecute` event in `Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforescriptexecute_event) in https://bugzilla.mozilla.org/show_bug.cgi?id=1584269.

This adds a release note.

Related docs work can be tracked in #41141
