### PR TITLE
ScreenOrientation lock() and unlock() fixes

### DIFF
--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -68,7 +68,7 @@ The promise may be rejected with the following exceptions:
   - : Thrown if the user agent does not support locking the screen orientation of the specific orientation.
 
 - `AbortError` {{domxref("DOMException")}}
-  - : Thrown if there is any other `lock()` method invoking.
+  - : Thrown if there is any other `lock()` method invoking or if {{domxref("ScreenOrientation/unlock","unlock()")}} is called while the lock promise is pending.
 
 ## Examples
 

--- a/files/en-us/web/api/screenorientation/unlock/index.md
+++ b/files/en-us/web/api/screenorientation/unlock/index.md
@@ -26,11 +26,8 @@ None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
-The method may throw with the following exceptions:
-
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the document is not fully active.
-
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the document's visibility state is hidden or if the document is forbidden to use the feature (for example, by omitting the keyword `allow-orientation-lock` of the `sandbox` attribute of the `iframe` element).
 

--- a/files/en-us/web/api/screenorientation/unlock/index.md
+++ b/files/en-us/web/api/screenorientation/unlock/index.md
@@ -8,9 +8,7 @@ browser-compat: api.ScreenOrientation.unlock
 
 {{APIRef("Screen Orientation")}}
 
-The **`unlock()`** method of the
-{{domxref("ScreenOrientation")}} interface unlocks the orientation of the containing
-document from its default orientation.
+The **`unlock()`** method of the {{domxref("ScreenOrientation")}} interface unlocks the orientation of the containing document, effectively locking it to the default screen orientation.
 
 ## Syntax
 
@@ -28,16 +26,13 @@ None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
-The promise may be rejected with the following exceptions:
+The method may throw with the following exceptions:
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the document is not fully active.
 
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the document's visibility state is hidden or if the document is forbidden to use the feature (for example, by omitting the keyword `allow-orientation-lock` of the `sandbox` attribute of the `iframe` element).
-
-- `AbortError` {{domxref("DOMException")}}
-  - : Thrown if there is any other `lock()` method invoking.
 
 ## Specifications
 


### PR DESCRIPTION
This adds some fixes to [`ScreenOrientation.lock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) and [`ScreenOrientation.unlock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock).

Fixes #40363

Related docs work can be tracked in #41142