### PR TITLE
FF144 Relnote: ScreenOrientation.lock() and unlock()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -56,6 +56,8 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The [`lock()`](/en-US/docs/Web/API/ScreenOrientation/lock) and [`unlock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock) methods of the {{domxref("ScreenOrientation")}} interface are now supported for Android and for Windows tablets. ([Firefox bug 1983483](https://bugzil.la/1983483))
+
 <!-- #### DOM -->
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -56,7 +56,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
-- The [`lock()`](/en-US/docs/Web/API/ScreenOrientation/lock) and [`unlock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock) methods of the {{domxref("ScreenOrientation")}} interface are now supported for Android and for Windows tablets. ([Firefox bug 1983483](https://bugzil.la/1983483))
+- The [`lock()`](/en-US/docs/Web/API/ScreenOrientation/lock) and [`unlock()`](/en-US/docs/Web/API/ScreenOrientation/unlock) methods of the {{domxref("ScreenOrientation")}} interface are now supported for Android and for Windows tablets. ([Firefox bug 1983483](https://bugzil.la/1983483))
 
 <!-- #### DOM -->
 


### PR DESCRIPTION
FF144 supports [`ScreenOrientation.lock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) and [`ScreenOrientation.unlock()`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock) in https://bugzilla.mozilla.org/show_bug.cgi?id=1983483

This adds a release note.

Related docs work can be tracked in #41142