### PR TITLE
Alphabetizing roles that cannot be named

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-label/index.md
@@ -84,8 +84,9 @@ Used in almost all roles **except** roles that cannot be provided an accessible 
 
 The `aria-label` attribute is **NOT** supported in:
 
-- [`code`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
+
 - [`caption`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
+- [`code`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`definition`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`deletion`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`emphasis`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
@@ -96,8 +97,8 @@ The `aria-label` attribute is **NOT** supported in:
 - [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role) / [`none`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/none_role)
 - [`strong`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`subscript`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
-- [`superscript`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`suggestion`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/suggestion_role)
+- [`superscript`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`term`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/term_role)
 - [`time`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-label/index.md
@@ -84,7 +84,6 @@ Used in almost all roles **except** roles that cannot be provided an accessible 
 
 The `aria-label` attribute is **NOT** supported in:
 
-
 - [`caption`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`code`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)
 - [`definition`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles)


### PR DESCRIPTION
Closes https://github.com/mdn/content/issues/41214

Also matches the sorting of https://w3c.github.io/aria/#namefromprohibited
