### PR TITLE
feat: add a note to suggest using CookieStore instead of document.cookie

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -68,6 +68,9 @@ You can also assign to this property a string of the form `"key=value"`, specify
 > [!NOTE]
 > The `document.cookie` property is an [accessor property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with native _setter_ and _getter_ functions, and consequently is _not_ a [data property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with a value: what you write is not the same as what you read, everything is always mediated by the JavaScript interpreter.
 
+> [!NOTE]
+> Using the synchronous `document.cookie` API can be a source of performance issues. The [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) can be used instead, as it provides an asynchronous way to handle cookies to avoid performance issues. See the [Cookie Store API introduction](/en-US/docs/Web/API/Cookie_Store_API) for more information.
+
 ## Examples
 
 ### Example 1: Simple usage

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -12,7 +12,7 @@ The {{domxref("Document")}} property `cookie` lets you read and write [cookies](
 It serves as a getter and setter for the actual values of the cookies.
 
 > [!NOTE]
-> The `document.cookie` can be a source of performance issues because it is synchronous API and may block the main thread when reading cookies across processes or performing I/O operations. Developers should consider using the asynchronous [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) to manage cookies when possible.
+> The `document.cookie` can be a source of performance issues because it is a synchronous API and block the main thread when reading cookies across processes or performing I/O operations. Developers should if possible use the asynchronous [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) to manage cookies.
 
 ## Value
 

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -12,7 +12,7 @@ The {{domxref("Document")}} property `cookie` lets you read and write [cookies](
 It serves as a getter and setter for the actual values of the cookies.
 
 > [!NOTE]
-> The `document.cookie` can be a source of performance issues because it is a synchronous API and block the main thread when reading cookies across processes or performing I/O operations. Developers should if possible use the asynchronous [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) to manage cookies.
+> The `document.cookie` can be a source of performance issues because it is a synchronous API and blocks the main thread when reading cookies across processes or performing I/O operations. Developers should if possible use the asynchronous [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) to manage cookies.
 
 ## Value
 

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -11,6 +11,9 @@ browser-compat: api.Document.cookie
 The {{domxref("Document")}} property `cookie` lets you read and write [cookies](/en-US/docs/Web/HTTP/Guides/Cookies) associated with the document.
 It serves as a getter and setter for the actual values of the cookies.
 
+> [!NOTE]
+> The `document.cookie` can be a source of performance issues because it is synchronous API and may block the main thread when reading cookies across processes or performing I/O operations. Developers should consider using the asynchronous [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) to manage cookies when possible.
+
 ## Value
 
 A string containing a semicolon-separated list of all cookies (i.e., `key=value` pairs).
@@ -67,9 +70,6 @@ You can also assign to this property a string of the form `"key=value"`, specify
 
 > [!NOTE]
 > The `document.cookie` property is an [accessor property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with native _setter_ and _getter_ functions, and consequently is _not_ a [data property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with a value: what you write is not the same as what you read, everything is always mediated by the JavaScript interpreter.
-
-> [!NOTE]
-> Using the synchronous `document.cookie` API can be a source of performance issues. The [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API) can be used instead, as it provides an asynchronous way to handle cookies to avoid performance issues. See the [Cookie Store API introduction](/en-US/docs/Web/API/Cookie_Store_API) for more information.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Add a note to suggest using asynchronous CookieStore API instead of synchronous document.cookie to avoid performance issues.

### Motivation

We met a source of jank of document.cookie in chromium-based app because document.cookie is synchronous API that will make renderer process main thread jank. So we contributed to whatwg document.cookie spec https://github.com/whatwg/html/pull/11668 and now want to contribute to mdn content to warn developer to use CookieStore instead of document.cookie.

### Additional details

[Asynchronous Access to HTTP Cookies chrome docs](https://developer.chrome.com/blog/asynchronous-access-to-http-cookies): describe performance issues like jank.
[CookieStore API in Chromium](https://issues.chromium.org/issues/40524203#comment5): facebook also met a  huge source of jank when using document.cookie.


### Related issues and pull requests

https://github.com/whatwg/html/issues/11658
https://github.com/whatwg/html/pull/11668
