### PR TITLE
Fix "the grid or row" with "the column or row"

### DIFF
--- a/files/en-us/web/css/position-area_value/index.md
+++ b/files/en-us/web/css/position-area_value/index.md
@@ -129,7 +129,7 @@ For example, `top span-left` spans the top-center and top-left grid cells.
 If only a single physical keyword is specified in the `position-area` value, the other value is implied as follows:
 
 - `left`, `right`, `top`, or `bottom`
-  - : The other value defaults to [`span-all`](#span-all_2), causing the element to span all three tiles of the grid or row it was initially placed in. For example, `left` is equivalent to `left span-all`.
+  - : The other value defaults to [`span-all`](#span-all_2), causing the element to span all three tiles of the column or row it was initially placed in. For example, `left` is equivalent to `left span-all`.
 
 - `center`, `span-left`, `span-right`, `span-top`, or `span-bottom`
   - : The other value defaults to `center`. For example, `span-left` is equivalent to `center span-left` and `center` is equivalent to `center center`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix "the grid or row" with "the column or row"

### Motivation

Perhaps this wants to say "column or row", directions which a grid spans.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
