### PR TITLE
FF144 Relnote+Doc: Cross origin iframe requires user interaction for top navigation

### DIFF
--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -61,7 +61,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### Media, WebRTC, and Web Audio
 
 - Cross-origin {{htmlelement("iframe")}}s now require either user interaction ({{glossary("sticky activation")}}) or explicit permission to redirect the top-level page using `window.top.location`.
-  See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#window.top_navigation) for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
+  See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#top_navigation_in_cross-origin_frames) for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
 - {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
 - The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).
 - The {{domxref("MediaDevices/getUserMedia","getUserMedia()")}} and {{domxref("MediaDevices/getDisplayMedia","getDisplayMedia()")}} methods of the {{domxref("MediaDevices")}} interface now support the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint.

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -60,7 +60,8 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
-- Cross-origin {{htmlelement("iframe")}}s require either user interaction or explicit permission in order to redirect to another page using `window.top.location`. See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#window.top_navigation) in the `<iframe>` topic for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
+- Framebusting Intervention: Cross-origin {{htmlelement("iframe")}}s require either user interaction or explicit permission in order to redirect the top level page using `window.top.location`, aligning behavior with Chrome and Safari.
+  See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#window.top_navigation) for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
 - {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
 - The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).
 - The {{domxref("MediaDevices/getUserMedia","getUserMedia()")}} and {{domxref("MediaDevices/getDisplayMedia","getDisplayMedia()")}} methods of the {{domxref("MediaDevices")}} interface now support the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint.

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -60,6 +60,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
+- Cross-origin {{htmlelement("iframe")}}s require either user interaction or explicit permission in order to redirect to another page using `window.top.location`. See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#window.top_navigation) in the `<iframe>` topic for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
 - {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
 - The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).
 - The {{domxref("MediaDevices/getUserMedia","getUserMedia()")}} and {{domxref("MediaDevices/getDisplayMedia","getDisplayMedia()")}} methods of the {{domxref("MediaDevices")}} interface now support the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint.

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -60,7 +60,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
-- Framebusting Intervention: Cross-origin {{htmlelement("iframe")}}s require either user interaction or explicit permission in order to redirect the top level page using `window.top.location`, aligning behavior with Chrome and Safari.
+- Cross-origin {{htmlelement("iframe")}}s now require either user interaction ({{glossary("sticky activation")}}) or explicit permission to redirect the top-level page using `window.top.location`.
   See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#window.top_navigation) for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
 - {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
 - The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -61,7 +61,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### Media, WebRTC, and Web Audio
 
 - Cross-origin {{htmlelement("iframe")}}s now require either user interaction ({{glossary("sticky activation")}}) or explicit permission to redirect the top-level page using `window.top.location`.
-  See [`Window.top` navigation](/en-US/docs/Web/HTML/Reference/Elements/iframe#top_navigation_in_cross-origin_frames) for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
+  See [Top navigation in cross-origin frames](/en-US/docs/Web/HTML/Reference/Elements/iframe#top_navigation_in_cross-origin_frames) for more information. ([Firefox bug 1419501](https://bugzil.la/1419501)).
 - {{domxref("RTCDataChannel")}} instances are now [transferrable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), and hence can be passed to [workers](/en-US/docs/Web/API/Worker). ([Firefox bug 1209163](https://bugzil.la/1209163)).
 - The [`closing` event](/en-US/docs/Web/API/RTCDataChannel/closing_event) and the `onclosing()` event handler are now supported on the {{domxref("RTCDataChannel")}} interface. ([Firefox bug 1611953](https://bugzil.la/1611953)).
 - The {{domxref("MediaDevices/getUserMedia","getUserMedia()")}} and {{domxref("MediaDevices/getDisplayMedia","getDisplayMedia()")}} methods of the {{domxref("MediaDevices")}} interface now support the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints#resizemode) constraint.

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -192,8 +192,8 @@ Cross-origin communication can be achieved using {{domxref("Window.postMessage()
 
 ### `Window.top` navigation
 
-Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the page to a new location.
-This is referred to as a "top-navigation".
+Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the top level page to a new location.
+This is referred to as a "top-navigation" or "framebusting".
 
 A cross-origin frame is only allowed to redirect the page using `top` if the frame has {{glossary("Sticky activation")}}.
 If a top-navigation is blocked the browser may prompt for user permission to redirect, or it may simply report the error in the developer console.

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -186,7 +186,21 @@ With the DOM {{domxref("HTMLIFrameElement")}} object, scripts can access the {{d
 
 From the inside of a frame, a script can get a reference to its parent window with {{domxref("window.parent")}}.
 
-Script access to a frame's content is subject to the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy). Scripts cannot access most properties in other `window` objects if the script was loaded from a different origin, including scripts inside a frame accessing the frame's parent. Cross-origin communication can be achieved using {{domxref("Window.postMessage()")}}.
+Script access to a frame's content is subject to the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
+Scripts cannot access most properties in other `window` objects if the script was loaded from a different origin, including scripts inside a frame accessing the frame's parent.
+Cross-origin communication can be achieved using {{domxref("Window.postMessage()")}}.
+
+### `Window.top` navigation
+
+Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the page to a new location.
+This is referred to as a "top-navigation".
+
+A cross-origin frame is only allowed to redirect the page using `top` if the frame has {{glossary("Sticky activation")}}.
+If a top-navigation is blocked the browser may prompt for user permission to redirect, or it may simply report the error in the developer console.
+What this means is that you won't be able to load a cross-origin frame and immediately redirect to a new page — the user must first (or previously) have interacted with the frame or granted permission to redirect.
+
+A sandboxed frame will block all top-navigations unless the values [`allow-top-navigation`](#allow-top-navigation) or [`allow-top-navigation-by-user-activation`](#allow-top-navigation-by-user-activation) are set.
+Note that top-navigation permissions are inherited, so a nested frame will only be allowed to perform top-navigation if its parents are able to.
 
 ## Positioning and scaling
 

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -199,8 +199,8 @@ A cross-origin frame is only allowed to redirect the page using `top` if the fra
 If a top-navigation is blocked the browser may prompt for user permission to redirect, or it may simply report the error in the developer console.
 What this means is that you won't be able to load a cross-origin frame and immediately redirect to a new page — the user must first (or previously) have interacted with the frame or granted permission to redirect.
 
-A sandboxed frame will block all top-navigations unless the values [`allow-top-navigation`](#allow-top-navigation) or [`allow-top-navigation-by-user-activation`](#allow-top-navigation-by-user-activation) are set.
-Note that top-navigation permissions are inherited, so a nested frame will only be allowed to perform top-navigation if its parents are able to.
+A sandboxed frame blocks all top navigation unless the `sandbox` attribute values are set to [`allow-top-navigation`](#allow-top-navigation) or [`allow-top-navigation-by-user-activation`](#allow-top-navigation-by-user-activation).
+Note that top-navigation permissions are inherited, so a nested frame can perform a top navigation only if its parent frames are also allowed to.
 
 ## Positioning and scaling
 

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -195,9 +195,10 @@ Cross-origin communication can be achieved using {{domxref("Window.postMessage()
 Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the top-level page to a new location.
 This behavior is referred to as "top navigation".
 
-A cross-origin frame is only allowed to redirect the page using `top` if the frame has {{glossary("Sticky activation")}}.
-If a top-navigation is blocked the browser may prompt for user permission to redirect, or it may simply report the error in the developer console.
-What this means is that you won't be able to load a cross-origin frame and immediately redirect to a new page — the user must first (or previously) have interacted with the frame or granted permission to redirect.
+A cross-origin frame is allowed to redirect the top-level page using `top` only if the frame has {{glossary("sticky activation")}}.
+If a top navigation is blocked, browsers may either prompt for user permission to redirect or report the error in the developer console (or both).
+This restriction by browsers is called a _framebusting intervention_.
+What this means is that a cross-origin frame can't immediately redirect the top-level page — the user must have previously interacted with the frame or granted permission to redirect.
 
 A sandboxed frame blocks all top navigation unless the `sandbox` attribute values are set to [`allow-top-navigation`](#allow-top-navigation) or [`allow-top-navigation-by-user-activation`](#allow-top-navigation-by-user-activation).
 Note that top-navigation permissions are inherited, so a nested frame can perform a top navigation only if its parent frames are also allowed to.

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -190,7 +190,7 @@ Script access to a frame's content is subject to the [same-origin policy](/en-US
 Scripts cannot access most properties in other `window` objects if the script was loaded from a different origin, including scripts inside a frame accessing the frame's parent.
 Cross-origin communication can be achieved using {{domxref("Window.postMessage()")}}.
 
-### `Window.top` navigation
+### Top navigation in cross-origin frames
 
 Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the top level page to a new location.
 This is referred to as a "top-navigation" or "framebusting".

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -192,8 +192,8 @@ Cross-origin communication can be achieved using {{domxref("Window.postMessage()
 
 ### Top navigation in cross-origin frames
 
-Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the top level page to a new location.
-This is referred to as a "top-navigation" or "framebusting".
+Scripts running in a same-origin frame can access the {{domxref("Window.top")}} property and set {{domxref("Window.location","window.top.location")}} to redirect the top-level page to a new location.
+This behavior is referred to as "top navigation".
 
 A cross-origin frame is only allowed to redirect the page using `top` if the frame has {{glossary("Sticky activation")}}.
 If a top-navigation is blocked the browser may prompt for user permission to redirect, or it may simply report the error in the developer console.

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -196,8 +196,8 @@ Scripts running in a same-origin frame can access the {{domxref("Window.top")}} 
 This behavior is referred to as "top navigation".
 
 A cross-origin frame is allowed to redirect the top-level page using `top` only if the frame has {{glossary("sticky activation")}}.
-If a top navigation is blocked, browsers may either prompt for user permission to redirect or report the error in the developer console (or both).
-This restriction by browsers is called a _framebusting intervention_.
+If top navigation is blocked, browsers may either prompt for user permission to redirect or report the error in the developer console (or both).
+This restriction by browsers is called _framebusting intervention_.
 What this means is that a cross-origin frame can't immediately redirect the top-level page — the user must have previously interacted with the frame or granted permission to redirect.
 
 A sandboxed frame blocks all top navigation unless the `sandbox` attribute values are set to [`allow-top-navigation`](#allow-top-navigation) or [`allow-top-navigation-by-user-activation`](#allow-top-navigation-by-user-activation).


### PR DESCRIPTION
FF144 aligns with Chrome and Safari such that a cross origin iframe now requires sticky activation in order to redirect the top level page via `window.top.location` (in https://bugzilla.mozilla.org/show_bug.cgi?id=1419501).

This PR adds a release note and also a section in the iframe docs explaining the expected behavior as it is now. 

Related docs work can be tracked in https://github.com/mdn/content/issues/41138