### PR TITLE
FF144 Relnote: moveBefore supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -56,7 +56,9 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
-<!-- #### DOM -->
+#### DOM
+
+- The `moveBefore()` method is now supported on the {{domxref("Element.moveBefore()","Element")}}, {{domxref("DocumentFragment.moveBefore()","DocumentFragment")}} and {{domxref("Document.moveBefore()","Document")}} interfaces. This allows moving of an immediate child element of the object, before another of its child elements. Unlike with {{domxref("Node.insertBefore()")}}, moved elements retain their state. ([Firefox bug 1983688](https://bugzil.la/1983688)).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
FF144 adds support for the `moveBefore()` method on Element, Document, DocumentFragment. This adds a release note.

Related docs can be tracked in https://github.com/mdn/content/issues/41144