### PR TITLE
Add CSS and HTML additional tutorials links to learnsidebar

### DIFF
--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -70,6 +70,11 @@ sidebar:
       - /Learn_web_development/Core/Structuring_content/Forms_challenge
       - /Learn_web_development/Core/Structuring_content/Debugging_HTML
       - /Learn_web_development/Core/Structuring_content/Test_your_skills
+      - title: Additional_tutorials
+        details: closed
+        children:
+          - /Learn_web_development/Core/Structuring_content/Including_vector_graphics_in_HTML
+          - /Learn_web_development/Core/Structuring_content/General_embedding_technologies
   - link: /Learn_web_development/Core/Styling_basics
     title: CSS_styling_basics
     details: closed
@@ -101,6 +106,13 @@ sidebar:
       - /Learn_web_development/Core/Styling_basics/Tables
       - /Learn_web_development/Core/Styling_basics/Debugging_CSS
       - /Learn_web_development/Core/Styling_basics/Test_your_skills
+      - title: Additional_tutorials
+        details: closed
+        children:
+          - /Learn_web_development/Core/Styling_basics/Advanced_styling_effects
+          - /Learn_web_development/Core/Styling_basics/Cascade_layers
+          - /Learn_web_development/Core/Styling_basics/Handling_different_text_directions
+          - /Learn_web_development/Core/Styling_basics/Organizing
   - link: /Learn_web_development/Core/Text_styling
     title: CSS_text_styling
     details: closed


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

There are still [several Learn articles](https://github.com/mdn/content/issues/39393#issuecomment-2851420219) not linked from the learnsidebar. The ones we want to keep should really be linked in some way. This PR adds an "Additional tutorials" subsection at the end of the basic HTML and CSS modules to contain the additional tutorials.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
