### PR TITLE
Tweak operator precedence example

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -221,11 +221,11 @@ console.log(C() || B() && A());
 Only `C()` is evaluated, despite `&&` having higher precedence. This does not mean that `||` has higher precedence in this case — it's exactly _because_ `(B() && A())` has higher precedence that causes it to be neglected as a whole. If it's re-arranged as:
 
 ```js-nolint
-console.log(A() && C() || B());
+console.log(A() && B() || C());
 // Logs:
 // called A
-// called B
-// false
+// called C
+// true
 ```
 
 Then the short-circuiting effect of `&&` would only prevent `C()` from being evaluated, but because `A() && C()` as a whole is `false`, `B()` would still be evaluated.

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -228,7 +228,7 @@ console.log(A() && B() || C());
 // true
 ```
 
-Then the short-circuiting effect of `&&` would only prevent `C()` from being evaluated, but because `A() && C()` as a whole is `false`, `B()` would still be evaluated.
+Then the short-circuiting effect of `&&` would only prevent `B()` from being evaluated, but because `A() && B()` as a whole is `false`, `C()` would still be evaluated.
 
 However, note that short-circuiting does not change the final evaluation outcome. It only affects the evaluation of _operands_, not how _operators_ are grouped — if evaluation of operands doesn't have side effects (for example, logging to the console, assigning to variables, throwing an error), short-circuiting would not be observable at all.
 


### PR DESCRIPTION
## Description
This PR updates a confusing code example used to explain JavaScript's logical operator short-circuiting. The previous "re-arranged" example has been replaced with a clearer one that more accurately demonstrates the concept.

## Motivation
The previous example was confusing for learners because the "re-arranged" expression resulted in a different boolean outcome, which obscured the core concept of short-circuiting. The new example (A() && B() || C()) directly and clearly illustrates how the && operator short-circuits without this confusion, improving the article's educational value.

## Additional details
N/A

## Related issues and pull requests
Fixes #41243
