### PR TITLE
Fix - Added missing demo choices for font-variant-numeric (#41231)

### DIFF
--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -8,10 +8,30 @@ sidebar: cssref
 
 The **`font-variant-numeric`** [CSS](/en-US/docs/Web/CSS) property controls the usage of alternate glyphs for numbers, fractions, and ordinal markers.
 
-{{InteractiveExample("CSS Demo: font-variant-numeric")}}
+{{InteractiveExample("CSS Demo: font-variant-numeric", "taller")}}
 
 ```css interactive-example-choice
 font-variant-numeric: normal;
+```
+
+```css interactive-example-choice
+font-variant-numeric: ordinal;
+```
+
+```css interactive-example-choice
+font-variant-numeric: diagonal-fractions;
+```
+
+```css interactive-example-choice
+font-variant-numeric: lining-nums;
+```
+
+```css interactive-example-choice
+font-variant-numeric: oldstyle-nums;
+```
+
+```css interactive-example-choice
+font-variant-numeric: proportional-nums;
 ```
 
 ```css interactive-example-choice
@@ -19,11 +39,11 @@ font-variant-numeric: slashed-zero;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: tabular-nums;
+font-variant-numeric: stacked-fractions;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: oldstyle-nums;
+font-variant-numeric: tabular-nums;
 ```
 
 ```html interactive-example


### PR DESCRIPTION
### Description

Added missing interactive demo choices for the `font-variant-numeric` CSS property and improved the demo layout by adding the "taller" keyword to reduce scrolling.

### Motivation

The interactive demo was missing several important `font-variant-numeric` values and had excessive scrolling that made it difficult to use. This change adds all the missing demo choices and reorganizes them in a logical order (normal/ordinal first, then alphabetical) while using the "taller" keyword to improve the user experience by reducing scrolling.

### Additional details

- Added "taller" keyword to the InteractiveExample macro to make the demo container taller
- Reorganized demo choices with `normal` and `ordinal` at the top (most commonly used)
- Arranged remaining choices in alphabetical order for easier navigation
- All `font-variant-numeric` values are now represented in the interactive demo

### Related issues and pull requests

Fixes #41231