### PR TITLE
Add a page for JavaScript prototype pollution attack

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -95,7 +95,7 @@ cases:
           an attacker to override the object's prototype, which can lead to
           <a href="https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md">
             object injection attacks
-          </a>. Like the accidental keys issue, this can also be mitigated by using
+          </a> or <a href="/en-US/docs/Web/Security/Attacks/Prototype_pollution">prototype pollution attacks</a>. Like the accidental keys issue, this can also be mitigated by using
           a <code>null</code>-prototype object.
         </p>
       </td>

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -12,7 +12,7 @@ The **`Object`** type represents one of [JavaScript's data types](/en-US/docs/We
 
 Nearly all [objects](/en-US/docs/Web/JavaScript/Guide/Data_structures#objects) in JavaScript are instances of `Object`; a typical object inherits properties (including methods) from `Object.prototype`, although these properties may be shadowed (a.k.a. overridden). The only objects that don't inherit from `Object.prototype` are those with [`null` prototype](#null-prototype_objects), or descended from other `null` prototype objects.
 
-Changes to the `Object.prototype` object are seen by **all** objects through prototype chaining, unless the properties and methods subject to those changes are overridden further along the prototype chain. This provides a very powerful although potentially dangerous mechanism to override or extend object behavior. To make it more secure, `Object.prototype` is the only object in the core JavaScript language that has [immutable prototype](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf#description) — the prototype of `Object.prototype` is always `null` and not changeable.
+Changes to the `Object.prototype` object are seen by **all** objects through prototype chaining, unless the properties and methods subject to those changes are overridden further along the prototype chain. This provides a very powerful although [potentially dangerous mechanism](/en-US/docs/Web/Security/Attacks/Prototype_pollution) to override or extend object behavior. To make it more secure, `Object.prototype` is the only object in the core JavaScript language that has [immutable prototype](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf#description) — the prototype of `Object.prototype` is always `null` and not changeable.
 
 ### Object prototype properties
 
@@ -126,7 +126,7 @@ getAge("toString"); // undefined
 
 In such case, the addition of any method should be done cautiously, as they can be confused with the other key-value pairs stored as data.
 
-Making your object not inherit from `Object.prototype` also prevents prototype pollution attacks. If a malicious script adds a property to `Object.prototype`, it will be accessible on every object in your program, except objects that have null prototype.
+Making your object not inherit from `Object.prototype` also prevents [prototype pollution attacks](/en-US/docs/Web/Security/Attacks/Prototype_pollution). If a malicious script adds a property to `Object.prototype`, it will be accessible on every object in your program, except objects that have null prototype.
 
 ```js
 const user = {};
@@ -325,3 +325,4 @@ You can read more about prototypes in [Inheritance and the prototype chain](/en-
 ## See also
 
 - [Object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer)
+- [Prototype pollution attack](/en-US/docs/Web/Security/Attacks/Prototype_pollution)

--- a/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
@@ -15,7 +15,7 @@ sidebar: jsref
 > Changing the `[[Prototype]]` of an object is, by the nature of how modern JavaScript engines optimize property accesses, currently a very slow operation in every browser and JavaScript engine. In addition, the effects of altering inheritance are subtle and far-flung, and are not limited to the time spent in the `obj.__proto__ = ...` statement, but may extend to **_any_** code that has access to any object whose `[[Prototype]]` has been altered. You can read more in [JavaScript engine fundamentals: optimizing prototypes](https://mathiasbynens.be/notes/prototypes).
 
 > [!NOTE]
-> The use of `__proto__` is controversial and discouraged. Its existence and exact behavior have only been standardized as a legacy feature to ensure web compatibility, while it presents several security issues and footguns. For better support, prefer {{jsxref("Object.getPrototypeOf()")}}/{{jsxref("Reflect.getPrototypeOf()")}} and {{jsxref("Object.setPrototypeOf()")}}/{{jsxref("Reflect.setPrototypeOf()")}} instead.
+> The use of `__proto__` is controversial and discouraged. Its existence and exact behavior have only been standardized as a legacy feature to ensure web compatibility, while it presents several [security issues](/en-US/docs/Web/Security/Attacks/Prototype_pollution) and footguns. For better support, prefer {{jsxref("Object.getPrototypeOf()")}}/{{jsxref("Reflect.getPrototypeOf()")}} and {{jsxref("Object.setPrototypeOf()")}}/{{jsxref("Reflect.setPrototypeOf()")}} instead.
 
 The **`__proto__`** accessor property of {{jsxref("Object")}} instances exposes the [`[[Prototype]]`](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain) (either an object or {{jsxref("Operators/null", "null")}}) of this object.
 
@@ -123,3 +123,4 @@ obj.myName(); // myName
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Object.getPrototypeOf()")}}
 - {{jsxref("Object.setPrototypeOf()")}}
+- [Prototype pollution attack](/en-US/docs/Web/Security/Attacks/Prototype_pollution)

--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -60,7 +60,7 @@ The specified object.
 
 If the `obj` parameter is not an object (e.g., number, string, etc.), this method does nothing — without coercing it to an object or attempting to set its prototype — and directly returns `obj` as a primitive value. If `prototype` is the same value as the prototype of `obj`, then `obj` is directly returned, without causing a `TypeError` even when `obj` has immutable prototype.
 
-For security concerns, there are certain built-in objects that are designed to have an _immutable prototype_. This prevents prototype pollution attacks, especially [proxy-related ones](https://github.com/tc39/ecma262/issues/272). The core language only specifies `Object.prototype` as an immutable prototype exotic object, whose prototype is always `null`. In browsers, [`window`](/en-US/docs/Web/API/Window) and [`location`](/en-US/docs/Web/API/Window/location) are two other very common examples.
+For security concerns, there are certain built-in objects that are designed to have an _immutable prototype_. This prevents [prototype pollution attacks](/en-US/docs/Web/Security/Attacks/Prototype_pollution), especially [proxy-related ones](https://github.com/tc39/ecma262/issues/272). The core language only specifies `Object.prototype` as an immutable prototype exotic object, whose prototype is always `null`. In browsers, [`window`](/en-US/docs/Web/API/Window) and [`location`](/en-US/docs/Web/API/Window/location) are two other very common examples.
 
 ```js
 Object.isExtensible(Object.prototype); // true; you can add more properties

--- a/files/en-us/web/security/attacks/index.md
+++ b/files/en-us/web/security/attacks/index.md
@@ -21,6 +21,8 @@ This page links to pages explaining how some common attacks work, and how they c
   - : In a Manipulator in the Middle (MITM) attack, the attacker inserts themselves between the user's browser and the server, and can see and potentially modify any of the traffic exchanged over HTTP.
 - [Phishing](/en-US/docs/Web/Security/Attacks/Phishing)
   - : Phishing is a {{glossary("social engineering")}} attack in which the attacker steals a user's {{glossary("credential", "credentials")}} by tricking them into believing they are signing into the target site, when in reality they are interacting with a fake site controlled by the attacker.
+- [Prototype pollution](/en-US/docs/Web/Security/Attacks/Prototype_pollution)
+  - : JavaScript prototype pollution is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on objects in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
 - [Server Side Request Forgery (SSRF)](/en-US/docs/Web/Security/Attacks/SSRF)
   - : Server‑Side Request Forgery (SSRF) is a vulnerability that allows an attacker to make HTTP (or other network) requests to arbitrary destinations. SSRF makes these requests originate from within a server itself, which typically has broader access than an external client.
 - [Subdomain takeover](/en-US/docs/Web/Security/Attacks/Subdomain_takeover)

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -16,30 +16,36 @@ If you try to access a property or call a method on an object, and that property
 That's why you can do this:
 
 ```js
-const myArray = new Array(1, 2, 3);
+const mySet = new Set([1, 2, 3]);
 // prototype chain:
-// myArray -> Array -> Object -> null
+// mySet -> Set -> Object -> null
 
-myArray.length;
+mySet.size;
 // 3
-// length is defined on the prototype of `myArray`, which is `Array.prototype`
+// size is defined on the prototype of `mySet`, which is `Set.prototype`
 
-myArray.toString();
-// "1,2,3"
-// toString() is defined on the prototype of `Array.prototype`,
-// which is `Object.prototype`
+mySet.propertyIsEnumerable("size");
+// false
+// propertyIsEnumerable() is defined on the prototype
+// of `Set.prototype`, which is `Object.prototype`
 ```
 
 Unlike many other languages, JavaScript allows you to add inherited properties and methods at runtime by modifying an object's prototypes:
 
 ```js
-const myArray = new Array(1, 2, 3);
+const mySet = new Set([1, 2, 3]);
 
 // modify the Object prototype at runtime
-Object.prototype.extra = "new property!";
+Object.prototype.extra = "new property from the Object prototype!";
 
-myArray.extra;
-// "new property!"
+// modify the Set prototype at runtime
+Set.prototype.other = "new property from the Set prototype!";
+
+mySet.extra;
+// "new property from the Object prototype!"
+
+mySet.other;
+// "new property from the Set prototype!"
 ```
 
 In a prototype pollution attack, the attacker is able to change the object's prototype to make the object behave in unexpected or dangerous ways.

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -5,18 +5,22 @@ page-type: guide
 sidebar: security
 ---
 
-**Prototype pollution** is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on every object in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
+**Prototype pollution** is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on objects in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
 
 To understand how JavaScript prototypes work, read the following MDN articles:
 
 - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
 - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
 
-A key attack vector is the special [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application.
+In a nutshell, every object in JavaScript has a `prototype` property which is an object itself and that prototype has its own prototype, too. This is called the JavaScript prototype chain. The chain ends when we reach an object that has `null` for its own prototype. The power of the prototype chain is that it allows an object to inherit properties and methods from its parent. However, a bad practice that JavaScript allows, is that the prototypes of objects can be changed during runtime which makes it possible to install properties at unintended places with malicious values. This even includes the built-in default objects, like the {{jsxref("Object")}} object, which is likely in the prototype chain of the majority of objects in your codebase and therefore makes this attack especially dangerous.
+
+A key attack vector is the special [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application. The `__proto__` property is often used, but you can also reach `Object.prototype` via `yourObject.constructor.prototype`.
 
 Not all prototype pollution involves adding properties to `Object.prototype`, though. Other prototypes can also be polluted, like overriding {{jsxref("Promise.prototype.then")}}, which would be called for every `await` operation, and more.
 
-To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request.
+## Example scenarios
+
+To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request, which could lead to unintended side-affects on the server-side.
 
 ```js
 Object.prototype.body = "a=1";
@@ -31,52 +35,27 @@ fetch("https://example.com", {
 console.log({}.method); // "POST"
 ```
 
-## Example scenarios
+Another dangerous pollution attack target is the {{domxref("HTMLIframeElement.srcdoc")}} property which specifies the content of an {{HTMLElement("iframe")}} element. By overriding its value, it could potentially be possible to execute arbitrary code.
+
+```js
+Object.prototype.srcdoc = ["<script>alert(1)<\/script>"];
+```
+
+Any configuration objects, like `fetch()`'s {{domxref("RequestInit")}} object in the code example above, or the instantiation of `<iframes>`, or configuration of sanitizers ({{domxref("SanitizerConfig")}} objects) are some of the most sensitive objects and are often targets of prototype pollution attacks.
+
+### Vulnerable sources
 
 In order to pollute objects, the attacker needs a way to add arbitrary properties to prototype objects. This may happen as a consequence of [XSS](/en-US/docs/Web/Security/Attacks/XSS), in which the attacker gains direct access to the page's JavaScript execution environment. However, this can also happen without code injection, such as by constructing a payload that contains the `__proto__` property key will later get merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., turning it into an assignment operation and therefore triggering the setter.
 
-### Pollution via URL query strings
-
-In a [very common prototype pollution vulnerability](https://github.com/BlackFan/client-side-prototype-pollution), the attacker pollutes query strings in the URL:
-
-```http
-https://example.org/?__proto__={"test":"polluted"}
-```
-
-If you parse the query strings into key-value pairs and treat `__proto__` like an arbitrary string, you risk that `__proto__` will later be merged into a target object like this:
-
-```js
-const result = { ...defaultValues, ...query };
-```
-
-which you may expect to result in the following object structure for `result`:
-
-```js
-{
-  existingProperty: "hello",
-  __proto__: {
-      test: "polluted"
-  }
-}
-```
-
-However, this is not what is happening! Instead, this adds `test` to the object's prototype, which is {{jsxref("Object.prototype")}}. Now all objects in the JavaScript runtime will inherit the `test` property and we have successfully polluted the prototype. The `test` property is likely not meaningful in this case, but other property names might become a problem for your code or for any code in your imported libraries as it could override existing properties or functions.
-
-```js
-result.test; // "polluted"
-{}.test; // "polluted"
-"".test; // "polluted"
-[].test; // "polluted"
-// ...
-```
+In a [very common prototype pollution vulnerability](https://github.com/BlackFan/client-side-prototype-pollution), the attacker pollutes query strings in the URL, or alternatively pollution could happen via JSON input, because {{jsxref("JSON.parse()")}} also includes strings like `__proto__`.
 
 ## Defenses against prototype pollution
 
 There are a few options to mitigating prototype pollution vulnerabilities. This section presents them.
 
-### Create a JavaScript object without a prototype
+### Create JavaScript objects without a prototype
 
-The {{jsxref("Object.create()", "Object.create(null)")}} function allows you to create a new empty object without a prototype. Because of this, there won't be any prototype pollution issues:
+The {{jsxref("Object.create()", "Object.create(null)")}} function allows you to create a new empty object without a prototype. For your most sensitive objects, you could prevent prototype pollution attacks this way. However, note that creating objects without a prototype is not the default, so whenever instantiating an object, you need to remember to use {{jsxref("Object.create()", "Object.create(null)")}}.
 
 ```js
 let obj = Object.create(null);
@@ -85,13 +64,9 @@ obj.constructor; // undefined
 obj["__proto__"]["a"] = 1; // TypeError: Cannot set properties of undefined
 ```
 
-### Use `Map` and `Set` instead
-
-Instead of using JavaScript objects, use {{jsxref("Map")}} or {{jsxref("Set")}} objects. These are more modern data structures not vulnerable to prototype pollution issues.
-
 ### Freezing the prototype
 
-The static method {{jsxref("Object.freeze()")}} prevents extensions and makes existing properties non-writable and non-configurable. Freezing an object is the highest integrity level that JavaScript provides. Alternatively, {{jsxref("Object.seal()")}} is available, which allows existing properties changed, as long as they are writable.
+The static method {{jsxref("Object.freeze()")}} prevents extensions and makes existing properties non-writable and non-configurable. Freezing an object is the highest integrity level that JavaScript provides. Alternatively, {{jsxref("Object.seal()")}} is available, which allows existing properties changed, as long as they are writable, or {{jsxref("Object.preventExtensions()")}} which prevents new properties from being added to an object.
 
 You can also freeze the prototype of the built-in base {{jsxref("Object")}}. However, note that in your code or in the code of your dependencies you may want to add to the built-in {{jsxref("Object")}} prototype or other built-in objects (for example, to provide a {{glossary("Polyfill")}} implementation). Given assignment on frozen objects fails silently, it may be difficult to debug.
 
@@ -119,6 +94,21 @@ config.headers.Authorization = "hacked_token"; // fails thanks to deepFreeze
 
 The `deepFreeze` approach is not handling circular references by default, so to create true immutable objects, you may want to look into using a library like [Immer](https://immerjs.github.io/immer/). You could also consider the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) shim for [Hardened JavaScript](https://hardenedjs.org) to freeze every built-in object.
 
+### Use `Map` and `Set` instead
+
+Instead of using JavaScript objects, use {{jsxref("Map")}} or {{jsxref("Set")}} objects. These are more modern data structures not vulnerable to prototype pollution issues. See the `Map` documentation for a [comparison between Maps and Objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#objects_vs._maps). The {{jsxref("Map.prototype.get()")}} method will always only return the property that have been set directly on the `Map`.
+
+```js
+// Assume Object got polluted somehow
+Object.prototype.admin = true;
+
+let config = new Map();
+config.set("admin", false);
+
+config.admin; // true
+config.get("admin"); // false
+```
+
 ### JSON schema validation
 
 JSON schema validators, such as [ajv](https://ajv.js.org), ensure that the JSON data structure contains the appropriate properties with the appropriate types. To mitigate the prototype pollution attack, reject unneeded properties by setting `additionalProperties` to `false` in the schema.
@@ -129,12 +119,12 @@ If you are in a Node.js environment, you can disable `Object.prototype.__proto__
 
 ## Defense summary checklist
 
-- Create empty objects with `Object.create(null)`.
-- Use `Map` and `Set` objects instead.
+- Create your own objects with `Object.create(null)`.
 - Consider freezing your own objects, for example with a library like [Immer](https://immerjs.github.io/immer/).
 - Consider freezing built-in objects, for example by using the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) shim.
+- Use `Map` and `Set` objects instead.
 - Validate your object structure with a schema.
-- Use `--disable-proto` in Node.js.
+- Use `--disable-proto` in Node.js to disable `Object.prototype.__proto__`.
 
 ## See also
 

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -1,0 +1,135 @@
+---
+title: Prototype pollution
+slug: Web/Security/Attacks/Prototype_pollution
+page-type: guide
+sidebar: security
+---
+
+**JavaScript prototype pollution** is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on every object in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
+
+To understand how prototypes can be polluted, the following MDN articles are useful resources to get an understanding of how JavaScript prototypes work:
+
+- [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
+- [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
+
+The key thing to understand is the special meaning of the {{jsxref("Object.**proto**")}} property as well as the built-in global {{jsxref("Object.prototype")}} and how adding a property to `Object.prototype`, will make that property accessible on ("polluted to") every object in your application.
+
+For example, the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request.
+
+```js
+Object.prototype.body = "a=1";
+Object.prototype.method = "POST";
+
+fetch("https://example.com", {
+  mode: "cors",
+});
+// Promise {status: "pending", body: "a=1", method: "POST"}
+
+// Any new object initialization is now modified to contain additional default properties
+new Object(); // {body: "a=1", method: "POST"}
+```
+
+## Example scenarios
+
+In order to pollute objects, the attacker needs a way in to add arbitrary properties to prototype objects.
+
+### Pollution via URL query strings
+
+In a very common prototype pollution vulnerability, the attacker pollutes query strings in the URL. A few examples:
+
+```http
+https://example.org/?__proto__[test]=polluted
+https://example.com/?__proto__.test=polluted
+https://example.com/#__proto__[test]=polluted
+https://example.com/#__proto__.test=polluted
+```
+
+See also [Client-Side Prototype Pollution](https://github.com/BlackFan/client-side-prototype-pollution) for libraries vulnerable due to {{domxref("document.location")}} parsing and the various URL payloads used.
+
+If you parse the query strings into key-value pairs and treat `__proto__` like an arbitrary string, you risk that `__proto__` will later be merged into a target object like this:
+
+```js
+targetObject.__proto__.test = "polluted";
+```
+
+which you may expect to result in the following object structure for `targetObject`:
+
+```js
+{
+  existingProperty: "hello",
+  __proto__: {
+      test: "polluted"
+  }
+}
+```
+
+However, this is not what is happening! Instead, this adds `test` to the object's prototype, which is {{jsxref("Object.prototype")}}. Now all objects in the JavaScript runtime will inherit the `test` property and we have successfully polluted the prototype. The `test` property is likely not meaningful in this case, but other property names might become a problem for your code or for any code in your imported libraries.
+
+## Defenses against prototype pollution
+
+There are a few options to mitigating prototype pollution vulnerabilities. This section presents them.
+
+### Create a JavaScript object without a prototype
+
+The {{jsxref("Object.create()", "Object.create(null)")}} function allows you to create a new empty object without a prototype. Because of this, there won't be any prototype pollution issues:
+
+```js
+let obj = Object.create(null);
+obj.__proto__; // undefined
+obj.constructor; // undefined
+obj["__proto__"]["a"] = 1; // TypeError: Cannot set properties of undefined
+```
+
+### Use `Map` and `Set` instead
+
+Instead of using JavaScript objects, use {{jsxref("Map")}} or {{jsxref("Set")}} objects. These are more modern data structures not vulnerable to prototype pollution issues.
+
+### Freezing the prototype
+
+The static method {{jsxref("Object.freeze()")}} prevents extensions and makes existing properties non-writable and non-configurable. Freezing an object is the highest integrity level that JavaScript provides. Alternatively, {{jsxref("Object.seal()")}} is available, which allows existing properties changed, as long as they are writable.
+
+You can also freeze the prototype of the built-in base {{jsxref("Object")}}. However, note that in your code or in the code of your dependencies you may want to add to the built-in {{jsxref("Object")}} prototype or other built-in objects (for example, to provide a {{glossary("Polyfill")}} implementation). Given assignment on frozen objects fails silently, it may be difficult to debug.
+
+```js
+Object.freeze(Object.prototype);
+let obj = {};
+obj["__proto__"]["a"] = 1; // fails silently in non-strict mode
+obj.a; // undefined
+```
+
+You can enable JavaScript's [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) to see errors when trying to define properties on objects that are not extensible.
+
+Another caveat to note with {{jsxref("Object.freeze()")}} is that it doesn't provide a deep freeze by default. If you want true immutability, you need to recursively freeze every property ([example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#deep_freezing)).
+
+```js
+const config = deepFreeze({
+  url: "https://api.example.org",
+  headers: {
+    Authorization: "some_token",
+  },
+});
+
+config.headers.Authorization = "hacked_token"; // fails thanks to deepFreeze
+```
+
+The `deepFreeze` approach is not handling circular references by default, so to create true immutable objects, you may want to look into using a library like [Immer](https://immerjs.github.io/immer/).
+
+### JSON schema validation
+
+JSON schema validators, such as [ajv](https://ajv.js.org), ensure that the JSON data structure contains the appropriate properties with the appropriate types. To mitigate the prototype pollution attack, reject unneeded properties by setting `additionalProperties` to `false` in the schema.
+
+### Node.js flag `--disable-proto`
+
+If you are in a Node.js environment, you can disable `Object.prototype.__proto__` with the ``--disable-proto=MODE` option where `MODE` is either `delete` (the property is removed entirely), or `throw` (accesses to the property throws an exception with the code `ERR_PROTO_ACCESS`).
+
+## Defense summary checklist
+
+- Create empty objects with `Object.create(null)`.
+- Use `Map` and `Set` objects instead.
+- Freeze your objects and consider freezing built-in objects, or use a library like [Immer](https://immerjs.github.io/immer/).
+- Validate your object structure with a schema.
+- Use `--disable-proto` in Node.js.
+
+## See also
+
+- [OWASP: Prototype pollution prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html#other-resources)

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -120,20 +120,21 @@ console.log(merged.test); // "value"
 
 ### Exploitation targets
 
-To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object.prototype` object with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request, which could lead to unintended side effects on the server-side.
+To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request with no content to send to the server, but because we polluted the `Object.prototype` object with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request and the request body now contains instructions for the server, for example to transfer an arbitrary amount of money to an arbitrary address:
 
 ```js
 // Attacker indirectly causes the following pollution
-Object.prototype.body = "a=1";
+Object.prototype.body = "action=transfer&amount=1337&to=1337-1337-1337-1337";
 Object.prototype.method = "POST";
 
 fetch("https://example.com", {
   mode: "cors",
 });
-// Promise {status: "pending", body: "a=1", method: "POST"}
+// Promise {status: "pending", body: "action=transfer&amount=1337&to=1337-1337-1337-1337", method: "POST"}
 
 // Any new object initialization is now modified to contain additional default properties
 console.log({}.method); // "POST"
+console.log({}.body); // "action=transfer&amount=1337&to=1337-1337-1337-1337"
 ```
 
 Another dangerous pollution attack target is the {{domxref("HTMLIframeElement.srcdoc")}} property which specifies the content of an {{HTMLElement("iframe")}} element. By overriding its value, it could potentially be possible to execute arbitrary code.
@@ -312,3 +313,5 @@ Runtime defenses:
 ## See also
 
 - [OWASP: Prototype pollution prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html#other-resources)
+- [Client-side prototype pollution](https://github.com/BlackFan/client-side-prototype-pollution)
+- [Server-side prototype pollution](https://github.com/KTH-LangSec/server-side-prototype-pollution)

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -12,7 +12,49 @@ To understand how JavaScript prototypes work, read the following MDN articles:
 - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
 - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
 
-In a nutshell, every object in JavaScript has a `prototype` property which is an object itself and that prototype has its own prototype, too. This is called the JavaScript prototype chain. The chain ends when we reach an object that has `null` for its own prototype. The power of the prototype chain is that it allows an object to inherit properties and methods from its parent. However, a bad practice that JavaScript allows, is that the prototypes of objects can be changed during runtime which makes it possible to install properties at unintended places with malicious values. This even includes the built-in default objects, like the {{jsxref("Object")}} object, which is likely in the prototype chain of the majority of objects in your codebase and therefore makes this attack especially dangerous.
+## Prototypes in JavaScript
+
+JavaScript implements {{glossary("inheritance")}} using _prototypes_. Each object has a reference to a prototype, which is itself an object, and which itself has a prototype, and so on, until we get to the fundamental prototype, which is called `Object.prototype`, whose own prototype is `null`.
+
+If you try to access a property or call a method on an object, and that property or method isn't defined on the object, then the JavaScript runtime looks in the object's prototype for the property or method, and then in the object's prototype's prototype, and so on, until it finds the method or property, or reaches an object whose prototype is `null`.
+
+That's why you can do this:
+
+```js
+const myArray = new Array(1,2,3);
+// prototype chain:
+// myArray -> Array -> Object -> null
+
+myArray.length 
+// 3
+// length is defined on the prototype of `myArray`, which is `Array.prototype`
+
+myArray.toString();
+// "1,2,3" 
+// toString() is defined on the prototype of `Array.prototype`,
+// which is `Object.prototype`
+```
+
+Unlike many other languages, JavaScript allows you to add inherited properties and methods at runtime by modifying an object's prototypes:
+
+```js
+const myArray = new Array(1,2,3); 
+
+// modify the Object prototype at runtime
+Object.prototype.extra = "new property!" 
+
+myArray.extra;
+// "new property!"
+```
+
+In a prototype pollution attack, the attacker is able to change the object's prototype to make the object behave in unexpected or dangerous ways.
+
+> [!NOTE]
+> To learn much more about prototypes, see:
+>
+> - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
+> - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
+
 
 A key attack vector is the special [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application. The `__proto__` property is often used, but you can also reach `Object.prototype` via `yourObject.constructor.prototype`.
 

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -12,7 +12,7 @@ To understand how prototypes can be polluted, the following MDN articles are use
 - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
 - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
 
-The key thing to understand is the special meaning of the {{jsxref("Object.**proto**")}} property as well as the built-in global {{jsxref("Object.prototype")}} and how adding a property to `Object.prototype`, will make that property accessible on ("polluted to") every object in your application.
+The key thing to understand is the special meaning of the [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application.
 
 For example, the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request.
 
@@ -26,7 +26,7 @@ fetch("https://example.com", {
 // Promise {status: "pending", body: "a=1", method: "POST"}
 
 // Any new object initialization is now modified to contain additional default properties
-new Object(); // {body: "a=1", method: "POST"}
+console.log({}.method); // "POST"
 ```
 
 ## Example scenarios

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -117,7 +117,7 @@ const config = deepFreeze({
 config.headers.Authorization = "hacked_token"; // fails thanks to deepFreeze
 ```
 
-The `deepFreeze` approach is not handling circular references by default, so to create true immutable objects, you may want to look into using a library like [Immer](https://immerjs.github.io/immer/). You could also consider the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) shim for [Hardened JavaScript](https://hardenedjs.org) which is a [draft proposal for ECMAScript](https://github.com/tc39/proposal-ses) to freeze every built-in object.
+The `deepFreeze` approach is not handling circular references by default, so to create true immutable objects, you may want to look into using a library like [Immer](https://immerjs.github.io/immer/). You could also consider the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) shim for [Hardened JavaScript](https://hardenedjs.org) to freeze every built-in object.
 
 ### JSON schema validation
 

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -18,7 +18,7 @@ That's why you can do this:
 ```js
 const mySet = new Set([1, 2, 3]);
 // prototype chain:
-// mySet -> Set -> Object -> null
+// mySet -> Set.prototype -> Object.prototype -> null
 
 mySet.size;
 // 3
@@ -32,7 +32,7 @@ mySet.propertyIsEnumerable("size");
 
 Unlike many other languages, JavaScript allows you to add inherited properties and methods at runtime by modifying an object's prototypes:
 
-```js
+```js example-bad
 const mySet = new Set([1, 2, 3]);
 
 // modify the Object prototype at runtime
@@ -57,15 +57,19 @@ In a prototype pollution attack, the attacker is able to change the object's pro
 > - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
 > - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
 
-A key attack vector is [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property and the [prototype setter syntax in object initializers](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#prototype_setter). These `__proto__` properties are often used for this attack, but you can also reach the prototype via `yourObject.constructor.prototype`.
+## Anatomy of prototype pollution
 
-A common pollution target is `Object.prototype` as it will make properties accessible on ("polluted to") every object in your application. However, not all prototype pollution involves adding properties to `Object.prototype`. Other prototypes can also be polluted, like overriding {{jsxref("Promise.prototype.then")}}, which would be called for every `await` operation, and more.
+Prototype pollution involves two phases:
 
-## Example scenarios
+1. **Pollution**: The attacker is able to add or modify properties on an object's prototype.
+2. **Exploitation**: Original application code accesses the polluted properties, leading to unexpected behavior.
+
+### Exploitation targets
 
 To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request, which could lead to unintended side-affects on the server-side.
 
 ```js
+// Attacker indirectly causes the following pollution
 Object.prototype.body = "a=1";
 Object.prototype.method = "POST";
 
@@ -81,41 +85,118 @@ console.log({}.method); // "POST"
 Another dangerous pollution attack target is the {{domxref("HTMLIframeElement.srcdoc")}} property which specifies the content of an {{HTMLElement("iframe")}} element. By overriding its value, it could potentially be possible to execute arbitrary code.
 
 ```js
-Object.prototype.srcdoc = ["<script>alert(1)<\/script>"];
+Object.prototype.srcdoc = "<script>alert(1)<\/script>";
 ```
 
-Any configuration objects, like `fetch()`'s {{domxref("RequestInit")}} object in the code example above, or the instantiation of `<iframes>`, or configuration of sanitizers ({{domxref("SanitizerConfig")}} objects) are some of the most sensitive objects and are often targets of prototype pollution attacks.
+Configuration objects, like `fetch()`'s {{domxref("RequestInit")}} object in the code example above, or the instantiation of `<iframes>`, or configuration of sanitizers ({{domxref("SanitizerConfig")}} objects), are some of the most sensitive objects and are often targets of prototype pollution attacks. Data objects can also be polluted:
 
-### Vulnerable sources
+```js
+function accessDashboard(user) {
+  if (!user.isAdmin) {
+    return new Response("Access denied", { status: 403 });
+  }
+  // show admin page
+}
+```
 
-In order to pollute objects, the attacker needs a way to add arbitrary properties to prototype objects. This may happen as a consequence of [XSS](/en-US/docs/Web/Security/Attacks/XSS), in which the attacker gains direct access to the page's JavaScript execution environment. However, this can also happen without code injection, such as by constructing a payload that contains the `__proto__` property key will later get merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., turning it into an assignment operation and therefore triggering the setter.
+If `Object.prototype.isAdmin` is set to `true`, then all users will be treated as admins, leading to a complete bypass of the access control.
 
-In a [very common prototype pollution vulnerability](https://github.com/BlackFan/client-side-prototype-pollution), the attacker pollutes query strings in the URL. Alternatively, pollution could happen via JSON input, because {{jsxref("JSON.parse()")}} also includes strings like `__proto__`.
+### Pollution sources
+
+In order to pollute objects, the attacker needs a way to add arbitrary properties to prototype objects. This may happen as a consequence of [XSS](/en-US/docs/Web/Security/Attacks/XSS), in which the attacker gains direct access to the page's JavaScript execution environment. However, attackers with this level of access can do damage much more directly, so prototype pollution is usually discussed as a _data-only_ attack, where the attacker constructs a payload that is processed by the application code, leading to pollution.
+
+A key attack vector is [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, which allows accessing the prototype object of an arbitrary object. You can also reach the prototype via `yourObject.constructor.prototype`. The key code pattern that is a pollution source is dynamic property modification of the following kind:
+
+```js
+obj[key1][key2] = value;
+```
+
+In this case, if `obj` is an ordinary object, `key1` is `"__proto__"`, and `key2` is some property name such as `"test"`, then the code adds a property called `test` to `Object.prototype`, which is the prototype of all ordinary objects. Even if the [`"__proto__"` setter is disabled](#node.js_flag_--disable-proto), the `constructor.prototype` access pattern can still be used to reach the prototype, which is also `Object.prototype` for ordinary objects:
+
+```js
+obj[key1][key2][key3] = value;
+```
+
+...where `key1` is `"constructor"`, `key2` is `"prototype"`, and `key3` is some property name such as `"test"`.
+
+To put this line into more context, `key1`, `key2`, and `key3` may be attacker-controlled values. For example, imagine an API endpoint that takes a list of student names, and a list of fields to query for each student, and returns an object mapping each student name to their fields:
+
+```js
+function getGrades(request) {
+  const grades = {};
+  const studentNames = new URL(request.url).searchParams.getAll("students");
+  const fields = new URL(request.url).searchParams.getAll("fields");
+  for (const name of studentNames) {
+    const student = database.lookup(name);
+    for (const field of fields) {
+      grades[name][field] = student[field];
+    }
+  }
+  return grades;
+}
+```
+
+Now, if the attacker calls this API with the URL `https://example.com/api?students=__proto__&fields=age`, the code will add a property called `age` to `Object.prototype`, with the value being whatever the `age` property of the `__proto__` student is. It may be `undefined`, but if the attacker can add a student called `__proto__` to the database (e.g., via a separate API call), they can control the value of the `age` property.
+
+Many libraries that do [custom parsing of the URL query strings](https://github.com/BlackFan/client-side-prototype-pollution) are particularly vulnerable, because they allow specifying deep object structures via the query string, and then use dynamic property modification to build the object, such as `?__proto__[test]=test` or `?__proto__.test=test`. Libraries in general are more vulnerable than application code, because they cannot allowlist valid keys, and they often need to use dynamic property modification to be generic.
+
+Note that in [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON), the `__proto__` property is just a normal property name, so parsing JSON payloads like `{"__proto__": {"test": "value"}}` just creates an object with a property called `__proto__`, and is not immediately problematic. However, if later in the code, the object is merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., then the implicit property assignment operation will triggering the setter. Usually, this does not actually modify `Object.prototype` because there's only one level of spreading, but it does change the prototype of the target object.
+
+```js
+// Just an object with a property called `__proto__`
+const options = JSON.parse('{"__proto__": {"test": "value"}}');
+const optionsDefaults = { mode: "cors" };
+const merged = { ...optionsDefaults, ...options };
+// In the process of spreading `options`, we indirectly executed
+// merged.__proto__ = { test: "value" }, causing `merged` to have
+// a different prototype
+console.log(merged.test); // "value"
+```
 
 ## Defenses against prototype pollution
 
-There are a few options to mitigating prototype pollution vulnerabilities. Generally, the more you can avoid prototype modifications and the more you can lock the object's prototypes, the better your protection against prototype pollution will be. This following section presents some strategies which you can use depending on your situation.
+Defenses against prototype pollution go along two lines: avoiding prototype modifications, and avoiding accessing potentially polluted properties. Generally, the more you can avoid prototype modifications and the more you can lock the object's prototypes, the better your protection against prototype pollution will be. This following section presents some strategies which you can use depending on your situation.
 
 ### Create JavaScript objects without a prototype
 
-If you need to work with an object (for example, because an API like `fetch()` requires you to use an object), consider creating an object without a prototype. The {{jsxref("Object.create()", "Object.create(null)")}} function let's you do this. Note that creating objects without a prototype is not the default, so whenever instantiating an object, you need to remember to use {{jsxref("Object.create()", "Object.create(null)")}} instead of the regular object initializer (`const myObj = { }`).
+If you need to pass an object as options (for example, because an API like `fetch()` requires you to use an object), consider creating an [object without a prototype](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects), which avoids reading potentially polluted properties. The {{jsxref("Object.create()", "Object.create(null)")}} function let's you do this, as well as the `{ __proto__: null }` syntax. Note that creating objects without a prototype is not the default, so whenever instantiating an object, you need to remember to explicitly create a null-prototype object instead of the regular object initializer (`const myObj = { }`).
 
 ```js
-let obj = Object.create(null);
-obj.__proto__; // undefined
-obj.constructor; // undefined
-obj["__proto__"]["a"] = 1; // TypeError: Cannot set properties of undefined
+Object.prototype.method = "POST";
+
+// Still sends a GET request, because the object has no prototype
+fetch("https://example.com", {
+  __proto__: null,
+  mode: "cors",
+});
 ```
+
+> [!NOTE]
+> The `{ __proto__: null }` [prototype setter](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#prototype_setter) syntax in object initializers is fully secure, unlike the `obj.__proto__` accessor property.
+
+This approach also avoids pollution because the `__proto__` and `constructor` properties are not present on the object, so dynamic property modification cannot reach the prototype.
 
 ### Avoid lookups on the prototype
 
 In code where you access the object's properties, make sure you know that the property exists on the object itself. You can make use of the {{jsxref("Object.hasOwn()")}} check when you are accessing or traversing keys on objects.
 
-```js
-Object.hasOwn(options, "method");
+Instead of:
+
+```js example-bad
+if (!user.isAdmin) {
+  return new Response("Access denied", { status: 403 });
+}
 ```
 
-When iterating, the [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loop traverses the prototype. If possible replace such loops with [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) and {{jsxref("Object.keys()")}} to only visit own keys.
+Consider:
+
+```js
+if (!Object.hasOwn(user, "isAdmin") || !user.isAdmin) {
+  return new Response("Access denied", { status: 403 });
+}
+```
+
+When iterating, the [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loop traverses the prototype. If possible, replace such loops with [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) and {{jsxref("Object.keys()")}} to only visit own keys.
 
 ```js
 // Looks up the prototype
@@ -129,85 +210,83 @@ for (const key of Object.keys(payload)) {
 }
 ```
 
-In functions, explicitly set default parameters instead of leaving them undefined. This way, the default parameter values can be used instead of a potential lookup on the prototype chain.
+In functions, explicitly set default parameters instead of leaving them undefined. This way, the default parameter values can be used instead of a potential lookup on the prototype chain. Instead of this:
 
-```js
-function fetchMyResource(options = { method: "GET" }) {
-  fetch("https://example.com", options);
+```js example-bad
+function doDangerousAction(options = {}) {
+  if (!options.enableDangerousAction) {
+    return;
+  }
 }
 ```
 
-### Freeze the prototype
+Consider this:
 
-If you work with third party or built-in objects, consider using the static method {{jsxref("Object.freeze()")}} which prevents extensions and makes existing properties non-writable and non-configurable. Freezing an object is the highest integrity level that JavaScript provides. Alternatively, {{jsxref("Object.seal()")}} is available, which allows existing properties changed, as long as they are writable, or {{jsxref("Object.preventExtensions()")}} which prevents new properties from being added to an object.
+```js
+function doDangerousAction(options = { enableDangerousAction: false }) {
+  if (!options.enableDangerousAction) {
+    return;
+  }
+}
+```
 
-You can also freeze the prototype of the built-in base {{jsxref("Object")}}. However, note that in your code or in the code of your dependencies you may want to add to the built-in {{jsxref("Object")}} prototype or other built-in objects (for example, to provide a {{glossary("Polyfill")}} implementation). Given assignment on frozen objects fails silently, it may be difficult to debug.
+### Lock down built-in objects
+
+High-sensitivity environments may implement a defense known as _realm lockdown_ which prevents any modifications to built-in objects. One example is the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) shim for [Hardened JavaScript](https://hardenedjs.org). This is implemented based on the {{jsxref("Object.freeze()")}} function, which prevents extensions and makes existing properties non-writable and non-configurable. Freezing an object is the highest integrity level that JavaScript provides. Alternatively, {{jsxref("Object.seal()")}} allows existing properties changed, as long as they are writable, while {{jsxref("Object.preventExtensions()")}} prevents new properties from being added to an object.
 
 ```js
 Object.freeze(Object.prototype);
-let obj = {};
-obj["__proto__"]["a"] = 1; // fails silently in non-strict mode
+const obj = {};
+const key1 = "__proto__";
+const key2 = "a";
+obj[key1][key2] = 1; // fails silently in non-strict mode
 obj.a; // undefined
 ```
 
-You can enable JavaScript's [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) to see errors when trying to define properties on objects that are not extensible.
+However, note that legitimate prototype modifications may happen, usually to provide a {{glossary("Polyfill")}} implementation. In [non-strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), attempts to modify a frozen object fail silently, while in strict mode, they throw a `TypeError`. To allow polyfills, the polyfill code needs to run before the freeze.
 
-Another caveat to note with {{jsxref("Object.freeze()")}} is that it doesn't provide a deep freeze by default. If you want true immutability, you need to recursively freeze every property ([example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#deep_freezing)).
-
-```js
-const config = deepFreeze({
-  url: "https://api.example.org",
-  headers: {
-    Authorization: "some_token",
-  },
-});
-
-config.headers.Authorization = "hacked_token"; // fails thanks to deepFreeze
-```
-
-The `deepFreeze` approach is not handling circular references by default, so to create true immutable objects, you may want to look into using a library like [Immer](https://immerjs.github.io/immer/). You could also consider the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) shim for [Hardened JavaScript](https://hardenedjs.org) to freeze every built-in object.
+Another caveat with {{jsxref("Object.freeze()")}} is that it doesn't provide a deep freeze by default. If you want true immutability, you need to recursively freeze every property ([example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#deep_freezing)). Use a library like SES so you don't miss any built-in objects.
 
 ### Use `Map` and `Set` instead
 
-Evaluate if instead of using JavaScript objects, a {{jsxref("Map")}} or {{jsxref("Set")}} object could be used. These are more modern data structures not vulnerable to prototype pollution issues. See the `Map` documentation for a [comparison between Maps and Objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#objects_vs._maps). The {{jsxref("Map.prototype.get()")}} method will always only return the property that have been set directly on the `Map`.
+When JavaScript objects are used as ad-hoc key-value pairs, consider using a {{jsxref("Map")}} or {{jsxref("Set")}} object instead. These are more modern data structures that are not vulnerable to prototype pollution issues. See the `Map` documentation for a [comparison between Maps and Objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#objects_vs._maps). The {{jsxref("Map.prototype.get()")}} method will always only return entries within the `Map`.
 
 ```js
 // Assume Object got polluted somehow
 Object.prototype.admin = true;
 
-let config = new Map();
+const config = new Map();
 config.set("admin", false);
 
 config.admin; // true
 config.get("admin"); // false
 ```
 
-### Validate keys with JSON schema validation
+### Validate user input
 
-If you work with more complex and potentially unfrozen objects with a prototype, consider using JSON schema validators, such as [ajv](https://ajv.js.org), to ensure that the JSON data structure contains the appropriate properties with the appropriate types. To mitigate the prototype pollution attack, reject unneeded properties by setting `additionalProperties` to `false` in the schema.
+Always validate user input with validators, such as [ajv](https://ajv.js.org) and [Zod](https://zod.dev/), to ensure that the input data structure contains the appropriate properties with the appropriate types. To mitigate the prototype pollution attack, reject unneeded properties by setting `additionalProperties` to `false` in the schema. Using a schema also allows setting default values for missing properties, which avoids prototype lookups.
 
 You should avoid dynamic property modification (of the form `obj[key] = value`) unless you are able to validate the `key` values. If you are in this situation, you could rule out `__proto__`, `constructor`, `prototype` as keys in your validation.
 
 ### Node.js flag `--disable-proto`
 
-If you are in a Node.js environment, you can disable `Object.prototype.__proto__` with the `--disable-proto=MODE` option where `MODE` is either `delete` (the property is removed entirely), or `throw` (accesses to the property throws an exception with the code `ERR_PROTO_ACCESS`).
+If you are in a Node.js environment, you can disable `Object.prototype.__proto__` with the `--disable-proto=MODE` option where `MODE` is either `delete` (the property is removed entirely), or `throw` (accesses to the property throws an exception with the code `ERR_PROTO_ACCESS`). Use `delete Object.prototype.__proto__` in non-Node environments for the same effect.
 
-This doesn't protect you from prototype pollution generally, but it does remove one entry point to it. Use `delete Object.prototype.__proto__` in non-Node environments for the same effect.
+This doesn't protect you from prototype pollution generally (because `constructor.prototype` is still available), but it does remove one entry point to it.
 
 ## Defense summary checklist
 
-For objects you create and fully control:
+When creating objects:
 
 - Evaluate if an object is needed or if a {{jsxref("Map")}} or {{jsxref("Set")}} would be the better choice.
-- If you are forced to create an object, use `Object.create(null)`, especially for sensitive objects like `FetchInit` or `SanitizerConfig`.
-- If you can't create an object with `Object.create(null)`, consider freezing your object, or making it immutable using a library like [Immer](https://immerjs.github.io/immer/).
-- If you need to create complex and unfrozen objects with a prototype, consider validating your object structure with a JSON schema validator and reject unneeded properties by setting `additionalProperties` to `false`.
+- When passing objects to other functions, such as `FetchInit` or `SanitizerConfig`, either ensure that all keys are defined or use [null-prototype objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects).
+- When creating objects that will be dynamically modified later (e.g., via `obj[key] = value`), also create them as null-prototype objects.
 
-For code that accesses or traverses objects:
+When accepting user input, either via URL query strings, JSON payloads, or function parameters:
 
-- Use the {{jsxref("Object.hasOwn()")}} check.
+- Always validate user input with a schema validator. Reject unrecognized properties and set default values for missing properties.
+- Function that receive objects as parameters should either make sure all expected keys are defined on the object itself, or first check if the key exists on the object itself (e.g., via {{jsxref("Object.hasOwn()")}}) before accessing it.
 - Prefer [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) and {{jsxref("Object.keys()")}} over [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loops.
-- In functions, explicitly set default parameters for objects.
 
 For built-in and third party objects:
 

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -105,17 +105,16 @@ Now, if the attacker calls this API with the URL `https://example.com/api?names=
 
 Many libraries that do [custom parsing of the URL query strings](https://github.com/BlackFan/client-side-prototype-pollution) are particularly vulnerable, because they allow specifying deep object structures via the query string, and then use dynamic property modification to build the object, such as `?__proto__[test]=test` or `?__proto__.test=test`. Libraries in general are more vulnerable than application code, because they cannot allowlist valid keys, and they often need to use dynamic property modification to be generic.
 
-Note that in [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON), the `__proto__` property is just a normal property name, so parsing JSON payloads like `{"__proto__": {"test": "value"}}` just creates an object with a property called `__proto__`, and is not immediately problematic. However, if later in the code, the object is merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., then the implicit property assignment operation will trigger the setter. Usually, this does not actually modify `Object.prototype` because there's only one level of dynamic property access, but it does change the prototype of the target object.
+Note that in [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON), the `__proto__` property is just a normal property name, so parsing JSON payloads like `{"__proto__": {"test": "value"}}` just creates an object with a property called `__proto__`, and is not immediately problematic. However, if later in the code, the object is merged into another object via {{jsxref("Object.assign()")}}, [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., then the implicit property assignment operation will trigger the setter. Usually, this does not actually modify `Object.prototype` because there's only one level of dynamic property access, but it does change the prototype of the target object. Note that [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) is not susceptible to this type of attack, because spreading does not trigger setters.
 
 ```js
 // Just an object with a property called `__proto__`
 const options = JSON.parse('{"__proto__": {"test": "value"}}');
-const optionsDefaults = { mode: "cors" };
-const merged = { ...optionsDefaults, ...options };
-// In the process of spreading `options`, we indirectly executed
-// merged.__proto__ = { test: "value" }, causing `merged` to have
+const withDefaults = Object.assign({ mode: "cors" }, options);
+// In the process of merging `options`, we indirectly executed
+// withDefaults.__proto__ = { test: "value" }, causing `withDefaults` to have
 // a different prototype
-console.log(merged.test); // "value"
+console.log(withDefaults.test); // "value"
 ```
 
 ### Exploitation targets

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -7,11 +7,6 @@ sidebar: security
 
 **Prototype pollution** is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on objects in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
 
-To understand how JavaScript prototypes work, read the following MDN articles:
-
-- [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
-- [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
-
 ## Prototypes in JavaScript
 
 JavaScript implements {{glossary("inheritance")}} using _prototypes_. Each object has a reference to a prototype, which is itself an object, and which itself has a prototype, and so on, until we get to the fundamental prototype, which is called `Object.prototype`, whose own prototype is `null`.
@@ -21,16 +16,16 @@ If you try to access a property or call a method on an object, and that property
 That's why you can do this:
 
 ```js
-const myArray = new Array(1,2,3);
+const myArray = new Array(1, 2, 3);
 // prototype chain:
 // myArray -> Array -> Object -> null
 
-myArray.length 
+myArray.length;
 // 3
 // length is defined on the prototype of `myArray`, which is `Array.prototype`
 
 myArray.toString();
-// "1,2,3" 
+// "1,2,3"
 // toString() is defined on the prototype of `Array.prototype`,
 // which is `Object.prototype`
 ```
@@ -38,10 +33,10 @@ myArray.toString();
 Unlike many other languages, JavaScript allows you to add inherited properties and methods at runtime by modifying an object's prototypes:
 
 ```js
-const myArray = new Array(1,2,3); 
+const myArray = new Array(1, 2, 3);
 
 // modify the Object prototype at runtime
-Object.prototype.extra = "new property!" 
+Object.prototype.extra = "new property!";
 
 myArray.extra;
 // "new property!"
@@ -52,13 +47,13 @@ In a prototype pollution attack, the attacker is able to change the object's pro
 > [!NOTE]
 > To learn much more about prototypes, see:
 >
+> - [Object prototypes](/en-US/docs/Learn_web_development/Extensions/Advanced_JavaScript_objects/Object_prototypes)
 > - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
 > - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
 
+A key attack vector is [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property and the [prototype setter syntax in object initializers](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#prototype_setter). These `__proto__` properties are often used for this attack, but you can also reach the prototype via `yourObject.constructor.prototype`.
 
-A key attack vector is the special [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application. The `__proto__` property is often used, but you can also reach `Object.prototype` via `yourObject.constructor.prototype`.
-
-Not all prototype pollution involves adding properties to `Object.prototype`, though. Other prototypes can also be polluted, like overriding {{jsxref("Promise.prototype.then")}}, which would be called for every `await` operation, and more.
+A common pollution target is `Object.prototype` as it will make properties accessible on ("polluted to") every object in your application. However, not all prototype pollution involves adding properties to `Object.prototype`. Other prototypes can also be polluted, like overriding {{jsxref("Promise.prototype.then")}}, which would be called for every `await` operation, and more.
 
 ## Example scenarios
 

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -103,7 +103,7 @@ Now, if the attacker calls this API with the URL `https://example.com/api?studen
 
 Many libraries that do [custom parsing of the URL query strings](https://github.com/BlackFan/client-side-prototype-pollution) are particularly vulnerable, because they allow specifying deep object structures via the query string, and then use dynamic property modification to build the object, such as `?__proto__[test]=test` or `?__proto__.test=test`. Libraries in general are more vulnerable than application code, because they cannot allowlist valid keys, and they often need to use dynamic property modification to be generic.
 
-Note that in [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON), the `__proto__` property is just a normal property name, so parsing JSON payloads like `{"__proto__": {"test": "value"}}` just creates an object with a property called `__proto__`, and is not immediately problematic. However, if later in the code, the object is merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., then the implicit property assignment operation will triggering the setter. Usually, this does not actually modify `Object.prototype` because there's only one level of spreading, but it does change the prototype of the target object.
+Note that in [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON), the `__proto__` property is just a normal property name, so parsing JSON payloads like `{"__proto__": {"test": "value"}}` just creates an object with a property called `__proto__`, and is not immediately problematic. However, if later in the code, the object is merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., then the implicit property assignment operation will trigger the setter. Usually, this does not actually modify `Object.prototype` because there's only one level of spreading, but it does change the prototype of the target object.
 
 ```js
 // Just an object with a property called `__proto__`
@@ -118,7 +118,7 @@ console.log(merged.test); // "value"
 
 ### Exploitation targets
 
-To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request, which could lead to unintended side-affects on the server-side.
+To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request, which could lead to unintended side effects on the server-side.
 
 ```js
 // Attacker indirectly causes the following pollution

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -1,20 +1,20 @@
 ---
-title: Prototype pollution
+title: JavaScript prototype pollution
 slug: Web/Security/Attacks/Prototype_pollution
 page-type: guide
 sidebar: security
 ---
 
-**JavaScript prototype pollution** is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on every object in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
+**Prototype pollution** is a vulnerability where an attacker can add or modify properties on an object's prototype. This means malicious values can unexpectedly appear on every object in your application, often leading to logic errors or additional attacks like [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
 
-To understand how prototypes can be polluted, the following MDN articles are useful resources to get an understanding of how JavaScript prototypes work:
+To understand how JavaScript prototypes work, read the following MDN articles:
 
 - [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain)
 - [Working with objects](/en-US/docs/Web/JavaScript/Guide/Working_with_objects)
 
-The key thing to understand is the special meaning of the [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application.
+A key attack vector is the special [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) property, and how adding a property to `Object.prototype` will make that property accessible on ("polluted to") every object in your application.
 
-Not all prototype pollution involves adding properties to `Object.prototype`, though. Other prototypes can also be polluted, like when overriding {{jsxref("Promise.prototype.then")}} which would be called for every `await` operation, and more.
+Not all prototype pollution involves adding properties to `Object.prototype`, though. Other prototypes can also be polluted, like overriding {{jsxref("Promise.prototype.then")}}, which would be called for every `await` operation, and more.
 
 To see the effect of prototype pollution, we can look at the how the following {{domxref("fetch()")}} call can be changed completely. By default, it is a {{HTTPMethod("GET")}} request, but because we polluted the `Object` object's prototype with two new default properties, the `fetch()` call is now transformed into a {{HTTPMethod("POST")}} request.
 
@@ -33,7 +33,7 @@ console.log({}.method); // "POST"
 
 ## Example scenarios
 
-In order to pollute objects, the attacker needs a way in to add arbitrary properties to prototype objects. Typically, happens in form of some payload that contains the `__proto__` property key will later get merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc, turning it into an assignment operation and therefore triggering the setter.
+In order to pollute objects, the attacker needs a way to add arbitrary properties to prototype objects. This may happen as a consequence of [XSS](/en-US/docs/Web/Security/Attacks/XSS), in which the attacker gains direct access to the page's JavaScript execution environment. However, this can also happen without code injection, such as by constructing a payload that contains the `__proto__` property key will later get merged into another object via [spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), [`for...in` loops](/en-US/docs/Web/JavaScript/Reference/Statements/for...in), etc., turning it into an assignment operation and therefore triggering the setter.
 
 ### Pollution via URL query strings
 

--- a/files/en-us/web/security/attacks/prototype_pollution/index.md
+++ b/files/en-us/web/security/attacks/prototype_pollution/index.md
@@ -37,13 +37,11 @@ In order to pollute objects, the attacker needs a way to add arbitrary propertie
 
 ### Pollution via URL query strings
 
-In a very common prototype pollution vulnerability, the attacker pollutes query strings in the URL:
+In a [very common prototype pollution vulnerability](https://github.com/BlackFan/client-side-prototype-pollution), the attacker pollutes query strings in the URL:
 
 ```http
 https://example.org/?__proto__={"test":"polluted"}
 ```
-
-See also [Client-Side Prototype Pollution](https://github.com/BlackFan/client-side-prototype-pollution) for libraries vulnerable due to {{domxref("document.location")}} parsing and the various URL payloads used.
 
 If you parse the query strings into key-value pairs and treat `__proto__` like an arbitrary string, you risk that `__proto__` will later be merged into a target object like this:
 


### PR DESCRIPTION
### Description

This PR adds a new page to our list of "attacks", this one is on JavaScript Prototype Pollution.

Generally, I'm not sure if I covered everything that needs to appear here. I think I'm somewhat happy about the defenses part, but explaining how to actually get into to polluting objects might need some more words?

Also, I think this needs integration into JS docs (at a minimum some linkage).

### Motivation

Developing a series of guides about common attacks on websites, explaining for each attack: how it works, the impact, and how to defend against it.

### Additional details

Would love some feedback from @wbamberg, @aaronshim and maybe @Josh-Cena.

### Related issues and pull requests

None, I think.