### PR TITLE
Deprecate onunload event in body element documentation

### DIFF
--- a/files/en-us/web/html/reference/elements/body/index.md
+++ b/files/en-us/web/html/reference/elements/body/index.md
@@ -61,7 +61,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   - : Function to call when the storage area has changed.
 - [`onunhandledrejection`](/en-US/docs/Web/API/Window/unhandledrejection_event)
   - : Function to call when a JavaScript {{jsxref("Promise")}} that has no rejection handler is rejected.
-- [`onunload`](/en-US/docs/Web/API/Window/unload_event)
+- [`onunload`](/en-US/docs/Web/API/Window/unload_event) {{deprecated_inline}}
   - : Function to call when the document is going away.
 
 ### Deprecated attributes


### PR DESCRIPTION
Mark the 'onunload' event as deprecated.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/body#onunload leads to https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event which is deprecated.

### Motivation

Deprecated event should be marked as such.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
