### PR TITLE
chore: add translation of `source_prefix` for l10n-zh

### DIFF
--- a/files/jsondata/L10n-Template.json
+++ b/files/jsondata/L10n-Template.json
@@ -429,6 +429,8 @@
   },
   "sources_prefix": {
     "de": "Quellen: ",
-    "en-US": "Sources: "
+    "en-US": "Sources: ",
+    "zh-CN": "来源：",
+    "zh-TW": "來源："
   }
 }


### PR DESCRIPTION
### Description

add translation of `source_prefix` for l10n-zh

### Additional details

reference doc (the csssyntax section): https://developer.mozilla.org/zh-CN/docs/Web/CSS/border-top

/cc @mdn/zh-content
