### PR TITLE
fix(pr-test): enable writer toolbar

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -108,24 +108,14 @@ jobs:
           # information about the flaws when we analyze the built PR.
           BUILD_FLAW_LEVELS: "unsafe_html: error, *:warn"
 
-          # Because we build these pages in a way that you get a toolbar,
-          # so the flaws can be displayed, but we don't want any of the
-          # other toolbar features like "Fix fixable flaws" or "Quick-edit"
-          # we set this to disable that stuff.
-          REACT_APP_CRUD_MODE_READONLY: true
-
           BUILD_LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
           BUILD_LEGACY_LIVE_SAMPLES_BASE_URL: https://live-samples.mdn.allizom.net
-
-          # In these builds, we never care for or need the ability to sign in.
-          # This environment variable will disable that functionality entirely.
-          REACT_APP_DISABLE_AUTH: true
 
           # TODO: This should be implicit when `CI=true`
           BUILD_NO_PROGRESSBAR: true
 
-          # Playground
-          REACT_APP_PLAYGROUND_BASE_HOST: mdnyalp.dev
+          FRED_WRITER_MODE: true
+          FRED_PLAYGROUND_BASE_HOST: mdnyalp.dev
 
           # rari
           LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev


### PR DESCRIPTION
Relates to https://github.com/mdn/fred/issues/730

I forgot I already added a localServer flag to our context:

https://github.com/mdn/fred/blob/4d6c46696ae10507eecb19f1bc6c323be0bef82e/server.js#L51

and used it in the writer toolbar to ensure things which require a local server don't appear when we don't have one:

https://github.com/mdn/fred/blob/4d6c46696ae10507eecb19f1bc6c323be0bef82e/components/writer-toolbar/server.js#L21

So the only change we should need to make is enabling the toolbar in the workflow.

I'll open a PR in translated content after it's successful here.