### PR TITLE
fix incorrect aria-label usage for required labels

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
@@ -158,7 +158,7 @@ Add a `required` attribute to your input, as shown below.
 
 ```html live-sample___the-required-attribute
 <form>
-  <label for="choose">Would you prefer a banana or cherry? (*)</label>
+  <label for="choose">Would you prefer a banana or cherry? *</label>
   <input id="choose" name="i-like" required />
   <button>Submit</button>
 </form>
@@ -220,7 +220,7 @@ Update your HTML to add a [`pattern`](/en-US/docs/Web/HTML/Reference/Attributes/
 
 ```html live-sample___validate-regular-expression
 <form>
-  <label for="choose">Would you prefer a banana or a cherry? (*)</label>
+  <label for="choose">Would you prefer a banana or a cherry? *</label>
   <input id="choose" name="i-like" required pattern="[Bb]anana|[Cc]herry" />
   <button>Submit</button>
 </form>
@@ -279,7 +279,7 @@ Now delete the contents of the `<body>` element, and replace it with the followi
 ```html live-sample___constraining-values
 <form>
   <div>
-    <label for="choose">Would you prefer a banana or a cherry? (*)</label>
+    <label for="choose">Would you prefer a banana or a cherry? *</label>
     <input
       type="text"
       id="choose"
@@ -335,7 +335,7 @@ First, some HTML:
 <form>
   <p>Please complete all required (*) fields.</p>
   <fieldset>
-    <legend>Do you have a driver's license? (*)</legend>
+    <legend>Do you have a driver's license? *</legend>
     <input type="radio" required name="driver" id="r1" value="yes" />
     <label for="r1">Yes</label>
     <input type="radio" required name="driver" id="r2" value="no" />
@@ -346,7 +346,7 @@ First, some HTML:
     <input type="number" min="12" max="120" step="1" id="n1" name="age" />
   </p>
   <p>
-    <label for="t1">What's your favorite fruit? (*)</label>
+    <label for="t1">What's your favorite fruit? *</label>
     <input
       type="text"
       id="t1"
@@ -597,7 +597,7 @@ First, the HTML. Again, feel free to build this along with us:
 <form novalidate>
   <p>
     <label for="mail">
-      <span>Please enter an email address (*):</span>
+      <span>Please enter an email address *:</span>
       <input type="email" id="mail" name="mail" required minlength="8" />
       <span class="error" aria-live="polite"></span>
     </label>
@@ -729,7 +729,7 @@ Here is the live result (press the **Play** button to run the example in MDN Pla
 <form novalidate>
   <p>
     <label for="mail">
-      <span>Please enter an email address (*):</span>
+      <span>Please enter an email address *:</span>
       <input type="email" id="mail" name="mail" required minlength="8" />
       <span class="error" aria-live="polite"></span>
     </label>

--- a/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
@@ -158,13 +158,14 @@ Add a `required` attribute to your input, as shown below.
 
 ```html live-sample___the-required-attribute
 <form>
-  <label for="choose">Would you prefer a banana or cherry? (required)</label>
+  <label for="choose">Would you prefer a banana or cherry? (*)</label>
   <input id="choose" name="i-like" required />
   <button>Submit</button>
 </form>
 ```
 
-We added "(required)" to the {{htmlelement("label")}} to inform the user that the {{htmlelement("input")}} is required. Indicating to the user when form fields are required is not only good user experience, it is required by WCAG [accessibility](/en-US/docs/Learn_web_development/Core/Accessibility) guidelines.
+> [!NOTE]
+> A common practice is to put an asterisk (or some other marking) after the labels of required form controls, so they stand out to sighted users. Indicating to the user when form fields are required is not only good user experience, it is required by WCAG [accessibility](/en-US/docs/Learn_web_development/Core/Accessibility) guidelines.
 
 We include CSS styles that are applied based on whether the element is required, valid, and invalid:
 
@@ -219,7 +220,7 @@ Update your HTML to add a [`pattern`](/en-US/docs/Web/HTML/Reference/Attributes/
 
 ```html live-sample___validate-regular-expression
 <form>
-  <label for="choose">Would you prefer a banana or a cherry?</label>
+  <label for="choose">Would you prefer a banana or a cherry? (*)</label>
   <input id="choose" name="i-like" required pattern="[Bb]anana|[Cc]herry" />
   <button>Submit</button>
 </form>
@@ -278,7 +279,7 @@ Now delete the contents of the `<body>` element, and replace it with the followi
 ```html live-sample___constraining-values
 <form>
   <div>
-    <label for="choose">Would you prefer a banana or a cherry?</label>
+    <label for="choose">Would you prefer a banana or a cherry? (*)</label>
     <input
       type="text"
       id="choose"
@@ -332,27 +333,20 @@ First, some HTML:
 
 ```html
 <form>
+  <p>Please complete all required (*) fields.</p>
   <fieldset>
-    <legend>
-      Do you have a driver's license?<span aria-label="required">*</span>
-    </legend>
-    <input type="radio" required name="driver" id="r1" value="yes" /><label
-      for="r1"
-      >Yes</label
-    >
-    <input type="radio" required name="driver" id="r2" value="no" /><label
-      for="r2"
-      >No</label
-    >
+    <legend>Do you have a driver's license? (*)</legend>
+    <input type="radio" required name="driver" id="r1" value="yes" />
+    <label for="r1">Yes</label>
+    <input type="radio" required name="driver" id="r2" value="no" />
+    <label for="r2">No</label>
   </fieldset>
   <p>
     <label for="n1">How old are you?</label>
     <input type="number" min="12" max="120" step="1" id="n1" name="age" />
   </p>
   <p>
-    <label for="t1"
-      >What's your favorite fruit?<span aria-label="required">*</span></label
-    >
+    <label for="t1">What's your favorite fruit? (*)</label>
     <input
       type="text"
       id="t1"
@@ -603,7 +597,7 @@ First, the HTML. Again, feel free to build this along with us:
 <form novalidate>
   <p>
     <label for="mail">
-      <span>Please enter an email address:</span>
+      <span>Please enter an email address (*):</span>
       <input type="email" id="mail" name="mail" required minlength="8" />
       <span class="error" aria-live="polite"></span>
     </label>
@@ -735,7 +729,7 @@ Here is the live result (press the **Play** button to run the example in MDN Pla
 <form novalidate>
   <p>
     <label for="mail">
-      <span>Please enter an email address:</span>
+      <span>Please enter an email address (*):</span>
       <input type="email" id="mail" name="mail" required minlength="8" />
       <span class="error" aria-live="polite"></span>
     </label>

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
@@ -14,10 +14,7 @@ This the example for a basic payment form for the article [How to structure an H
 ```html-nolint
 <form method="post">
   <h1>Payment form</h1>
-  <p>
-    Required fields are followed by
-    <strong><span aria-label="required">*</span></strong>.
-  </p>
+  <p>Please complete all required (*) fields.</p>
   <section>
     <h2>Contact information</h2>
     <fieldset>
@@ -44,24 +41,15 @@ This the example for a basic payment form for the article [How to structure an H
       </ul>
     </fieldset>
     <p>
-      <label for="name">
-        <span>Name: </span>
-        <strong><span aria-label="required">*</span></strong>
-      </label>
+      <label for="name">Name (*):</label>
       <input type="text" id="name" name="username" required />
     </p>
     <p>
-      <label for="mail">
-        <span>Email: </span>
-        <strong><span aria-label="required">*</span></strong>
-      </label>
+      <label for="mail"><span>Email (*):</span></label>
       <input type="email" id="mail" name="user-mail" required />
     </p>
     <p>
-      <label for="pwd">
-        <span>Password: </span>
-        <strong><span aria-label="required">*</span></strong>
-      </label>
+      <label for="pwd">Password (*):</label>
       <input type="password" id="pwd" name="password" required />
     </p>
   </section>
@@ -78,21 +66,15 @@ This the example for a basic payment form for the article [How to structure an H
       </select>
     </p>
     <p>
-      <label for="number">
-        <span>Card number:</span>
-        <strong><span aria-label="required">*</span></strong>
-      </label>
+      <label for="number">Card number (*):</label>
       <input type="tel" id="number" name="card-number" />
     </p>
     <p>
-      <label for="expiration">
-        <span>Expiration date:</span>
-        <strong><span aria-label="required">*</span></strong>
-      </label>
+      <label for="expiration">Expiration date (*):</label>
       <input
         type="text"
         id="expiration"
-        required="true"
+        required
         placeholder="MM/YY"
         pattern="^(0[1-9]|1[0-2])\/([0-9]{2})$" />
     </p>

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/example/index.md
@@ -41,15 +41,15 @@ This the example for a basic payment form for the article [How to structure an H
       </ul>
     </fieldset>
     <p>
-      <label for="name">Name (*):</label>
+      <label for="name">Name *:</label>
       <input type="text" id="name" name="username" required />
     </p>
     <p>
-      <label for="mail"><span>Email (*):</span></label>
+      <label for="mail"><span>Email *:</span></label>
       <input type="email" id="mail" name="user-mail" required />
     </p>
     <p>
-      <label for="pwd">Password (*):</label>
+      <label for="pwd">Password *:</label>
       <input type="password" id="pwd" name="password" required />
     </p>
   </section>
@@ -66,11 +66,11 @@ This the example for a basic payment form for the article [How to structure an H
       </select>
     </p>
     <p>
-      <label for="number">Card number (*):</label>
+      <label for="number">Card number *:</label>
       <input type="tel" id="number" name="card-number" />
     </p>
     <p>
-      <label for="expiration">Expiration date (*):</label>
+      <label for="expiration">Expiration date *:</label>
       <input
         type="text"
         id="expiration"

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -135,7 +135,7 @@ Let's consider this example:
 <!--<div>
   <label for="username">Name:</label>
   <input id="username" type="text" name="username" required />
-  <label for="username">(*)</label>
+  <label for="username">*</label>
 </div>-->
 
 <!-- would be better done like this: -->
@@ -143,13 +143,13 @@ Let's consider this example:
   <label for="username">
     <span>Name:</span>
     <input id="username" type="text" name="username" required />
-    <span>(*)</span>
+    <span>*</span>
   </label>
 </div>-->
 
 <!-- But this is probably best: -->
 <div>
-  <label for="username">Name (*):</label>
+  <label for="username">Name *:</label>
   <input id="username" type="text" name="username" required />
 </div>
 ```
@@ -216,15 +216,15 @@ Let's put these ideas into practice and build a slightly more involved form — 
        </ul>
      </fieldset>
      <p>
-       <label for="name">Name (*):</label>
+       <label for="name">Name *:</label>
        <input type="text" id="name" name="username" required />
      </p>
      <p>
-       <label for="mail">Email (*):</label>
+       <label for="mail">Email *:</label>
        <input type="email" id="mail" name="user-mail" required />
      </p>
      <p>
-       <label for="pwd">Password (*):</label>
+       <label for="pwd">Password *:</label>
        <input type="password" id="pwd" name="password" required />
      </p>
    </section>
@@ -253,11 +253,11 @@ Let's put these ideas into practice and build a slightly more involved form — 
        </select>
      </p>
      <p>
-       <label for="number">Card number (*):</label>
+       <label for="number">Card number *:</label>
        <input type="tel" id="number" name="card-number" required />
      </p>
      <p>
-       <label for="expiration">Expiration date (*):</label>
+       <label for="expiration">Expiration date *:</label>
        <input
          type="text"
          id="expiration"

--- a/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -129,13 +129,13 @@ Strictly speaking, you can put multiple labels on a single widget, but this is n
 Let's consider this example:
 
 ```html
-<p>Required fields are followed by <span aria-label="required">*</span>.</p>
+<p>Please complete all required (*) fields.</p>
 
 <!-- So this: -->
 <!--<div>
   <label for="username">Name:</label>
   <input id="username" type="text" name="username" required />
-  <label for="username"><span aria-label="required">*</span></label>
+  <label for="username">(*)</label>
 </div>-->
 
 <!-- would be better done like this: -->
@@ -143,32 +143,20 @@ Let's consider this example:
   <label for="username">
     <span>Name:</span>
     <input id="username" type="text" name="username" required />
-    <span aria-label="required">*</span>
+    <span>(*)</span>
   </label>
 </div>-->
 
 <!-- But this is probably best: -->
 <div>
-  <label for="username">Name: <span aria-label="required">*</span></label>
+  <label for="username">Name (*):</label>
   <input id="username" type="text" name="username" required />
 </div>
 ```
 
 {{EmbedLiveSample("Multiple_labels", 120, 120)}}
 
-The paragraph at the top states a rule for required elements. The rule must be included _before_ it is used so that sighted users and users of assistive technologies such as screen readers can learn what it means before they encounter a required element. While this helps inform users what an asterisk means, it can not be relied upon. A screen reader will speak an asterisk as "_star_" when encountered. When hovered by a sighted mouse user, "_required_" should appear, which is achieved by use of the `title` attribute. Titles being read aloud depends on the screen reader's settings, so it is more reliable to also include the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) attribute, which is always read by screen readers.
-
-The above variants increase in effectiveness as you go through them:
-
-- In the first example, the label is not read out at all with the input — you just get "edit text blank", plus the actual labels are read out separately. The multiple `<label>` elements confuse the screen reader.
-- In the second example, things are a bit clearer — the label read out along with the input is "name star name edit text required", and the labels are still read out separately. Things are still a bit confusing, but it's a bit better this time because the `<input>` has a label associated with it.
-- The third example is best — the actual label is read out all together, and the label read out with the input is "name required edit text".
-
-> [!NOTE]
-> You might get slightly different results, depending on your screen reader. This was tested in VoiceOver (and NVDA behaves similarly). We'd love to hear about your experiences too.
-
-> [!NOTE]
-> You can find this example on GitHub as [required-labels.html](https://github.com/mdn/learning-area/blob/main/html/forms/html-form-structure/required-labels.html) ([see it live also](https://mdn.github.io/learning-area/html/forms/html-form-structure/required-labels.html)). Don't test the example with 2 or 3 of the versions uncommented — screen readers will definitely get confused if you have multiple labels AND multiple inputs with the same ID!
+The paragraph at the top states a rule for required elements. The rule must be included _before_ it is used so that sighted users and users of assistive technologies (AT) such as screen readers can learn what it means before they encounter a required element.
 
 ## Common HTML structures used with forms
 
@@ -196,10 +184,7 @@ Let's put these ideas into practice and build a slightly more involved form — 
 
    ```html-nolint
    <h1>Payment form</h1>
-   <p>
-     Required fields are followed by
-     <strong><span aria-label="required">*</span></strong>.
-   </p>
+   <p>Please complete all required (*) fields.</p>
    ```
 
 4. Next, we'll add a larger section of code into the form, below our previous entry. Here you'll see that we are wrapping the contact information fields inside a distinct {{htmlelement("section")}} element. Moreover, we have a set of three radio buttons, each of which we are putting inside its own list ({{htmlelement("li")}}) element. We also have two standard text {{htmlelement("input")}}s and their associated {{htmlelement("label")}} elements, each contained inside a {{htmlelement("p")}}, and a password input for entering a password. Add this code to your form:
@@ -231,24 +216,15 @@ Let's put these ideas into practice and build a slightly more involved form — 
        </ul>
      </fieldset>
      <p>
-       <label for="name">
-         <span>Name: </span>
-         <strong><span aria-label="required">*</span></strong>
-       </label>
+       <label for="name">Name (*):</label>
        <input type="text" id="name" name="username" required />
      </p>
      <p>
-       <label for="mail">
-         <span>Email: </span>
-         <strong><span aria-label="required">*</span></strong>
-       </label>
+       <label for="mail">Email (*):</label>
        <input type="email" id="mail" name="user-mail" required />
      </p>
      <p>
-       <label for="pwd">
-         <span>Password: </span>
-         <strong><span aria-label="required">*</span></strong>
-       </label>
+       <label for="pwd">Password (*):</label>
        <input type="password" id="pwd" name="password" required />
      </p>
    </section>
@@ -277,17 +253,11 @@ Let's put these ideas into practice and build a slightly more involved form — 
        </select>
      </p>
      <p>
-       <label for="number">
-         <span>Card number:</span>
-         <strong><span aria-label="required">*</span></strong>
-       </label>
+       <label for="number">Card number (*):</label>
        <input type="tel" id="number" name="card-number" required />
      </p>
      <p>
-       <label for="expiration">
-         <span>Expiration date:</span>
-         <strong><span aria-label="required">*</span></strong>
-       </label>
+       <label for="expiration">Expiration date (*):</label>
        <input
          type="text"
          id="expiration"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

https://github.com/mdn/content/issues/41245 explains why the `<span aria-label=required>*</span>` pattern in forms is bad. This PR aims to remove it from the places I could find it and replace it with a simpler, more effective pattern.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/41245

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
