### PR TITLE
Fix wording in :not() examples documentation

### DIFF
--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -68,7 +68,7 @@ There are several unusual effects and outcomes when using `:not()` that you shou
 
 ### Using :not() with valid selectors
 
-This example shows some a few examples of using `:not()`.
+This example shows a few ways of using `:not()`.
 
 #### HTML
 


### PR DESCRIPTION
### Description

This PR corrects a small grammatical issue and improves clarity in the `:not()` documentation.

#### [Original sentence](https://developer.mozilla.org/en-US/docs/Web/CSS/:not#using_not_with_valid_selectors)

"This example shows some a few examples of using `:not()`."

#### Corrected sentence

"This example shows a few ways of using `:not()`."

This change removes the duplicated quantifier ("some a few") and avoids repeating the word "example", making the sentence easier to read.

### Motivation

To fix a typo and improve the readability of the documentation for readers.

### Additional details

The issue was found on:
https://developer.mozilla.org/en-US/docs/Web/CSS/:not