### PR TITLE
Remove font-family: emoji references, add font-variant-emoji note

### DIFF
--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -81,20 +81,6 @@ font-family: ui-rounded;
 font-family: math;
 font-family: fangsong;
 
-/* Generic family names using the generic() function */
-font-family: generic(serif);
-font-family: generic(sans-serif);
-font-family: generic(monospace);
-font-family: generic(cursive);
-font-family: generic(fantasy);
-font-family: generic(system-ui);
-font-family: generic(ui-serif);
-font-family: generic(ui-sans-serif);
-font-family: generic(ui-monospace);
-font-family: generic(ui-rounded);
-font-family: generic(math);
-font-family: generic(fangsong);
-
 /* Global values */
 font-family: inherit;
 font-family: initial;
@@ -121,7 +107,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     See also [Valid family names](#valid_family_names).
 
 - `<generic-name>`
-  - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names can be specified as keywords (which must not be quoted) or using the `generic()` function. A generic font family should be the last item in the list of font family names. The following keywords are defined:
+  - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names are keywords and must not be quoted. A generic font family should be the last item in the list of font family names. The following keywords are defined:
     - `serif`
       - : Glyphs have finishing strokes, flared or tapering ends, or have actual serifed endings.
 

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -78,7 +78,6 @@ font-family: ui-serif;
 font-family: ui-sans-serif;
 font-family: ui-monospace;
 font-family: ui-rounded;
-font-family: emoji;
 font-family: math;
 font-family: fangsong;
 
@@ -146,10 +145,11 @@ font-family: "Gill Sans Extrabold", sans-serif;
       - : The default user interface font that has rounded features.
     - `math`
       - : This is for the particular stylistic concerns of representing mathematics: superscript and subscript, brackets that cross several lines, nesting expressions, and double struck glyphs with distinct meanings.
-    - `emoji`
-      - : Fonts that are specifically designed to render emoji.
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
+
+> [!NOTE]
+> `font-family: emoji` is not a standard or supported value. To control emoji presentation, use the {{CSSxRef("font-variant-emoji")}} property instead.
 
 ## Formal definition
 
@@ -184,10 +184,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
   font-family: fantasy;
 }
 
-.emoji {
-  font-family: emoji;
-}
-
 .math {
   font-family: math;
 }
@@ -209,8 +205,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
 <div class="fantasy">This is an example of a fantasy font.</div>
 
 <div class="math">This is an example of a math font.</div>
-
-<div class="emoji">This is an example of an emoji font.</div>
 
 <div class="fangsong">This is an example of a fangsong font.</div>
 ```

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -81,6 +81,20 @@ font-family: ui-rounded;
 font-family: math;
 font-family: fangsong;
 
+/* Generic family names using the generic() function */
+font-family: generic(serif);
+font-family: generic(sans-serif);
+font-family: generic(monospace);
+font-family: generic(cursive);
+font-family: generic(fantasy);
+font-family: generic(system-ui);
+font-family: generic(ui-serif);
+font-family: generic(ui-sans-serif);
+font-family: generic(ui-monospace);
+font-family: generic(ui-rounded);
+font-family: generic(math);
+font-family: generic(fangsong);
+
 /* Global values */
 font-family: inherit;
 font-family: initial;
@@ -107,7 +121,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     See also [Valid family names](#valid_family_names).
 
 - `<generic-name>`
-  - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names are keywords and must not be quoted. A generic font family should be the last item in the list of font family names. The following keywords are defined:
+  - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names can be specified as keywords (which must not be quoted) or using the `generic()` function. A generic font family should be the last item in the list of font family names. The following keywords are defined:
     - `serif`
       - : Glyphs have finishing strokes, flared or tapering ends, or have actual serifed endings.
 
@@ -148,8 +162,19 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
 
-> [!NOTE]
-> `font-family: emoji` is not a standard or supported value. To control emoji presentation, use the {{CSSxRef("font-variant-emoji")}} property instead.
+  Generic family names can also be specified using the `generic()` function:
+  - `generic(serif)`
+  - `generic(sans-serif)`
+  - `generic(monospace)`
+  - `generic(cursive)`
+  - `generic(fantasy)`
+  - `generic(system-ui)`
+  - `generic(ui-serif)`
+  - `generic(ui-sans-serif)`
+  - `generic(ui-monospace)`
+  - `generic(ui-rounded)`
+  - `generic(math)`
+  - `generic(fangsong)`
 
 ## Formal definition
 
@@ -191,6 +216,35 @@ font-family: "Gill Sans Extrabold", sans-serif;
 .fangsong {
   font-family: fangsong;
 }
+
+/* Using generic() function syntax */
+.generic-serif {
+  font-family: Times, "Times New Roman", Georgia, generic(serif);
+}
+
+.generic-sans-serif {
+  font-family: Verdana, Arial, Helvetica, generic(sans-serif);
+}
+
+.generic-monospace {
+  font-family: "Lucida Console", Courier, generic(monospace);
+}
+
+.generic-cursive {
+  font-family: generic(cursive);
+}
+
+.generic-fantasy {
+  font-family: generic(fantasy);
+}
+
+.generic-math {
+  font-family: generic(math);
+}
+
+.generic-fangsong {
+  font-family: generic(fangsong);
+}
 ```
 
 ```html hidden
@@ -207,6 +261,24 @@ font-family: "Gill Sans Extrabold", sans-serif;
 <div class="math">This is an example of a math font.</div>
 
 <div class="fangsong">This is an example of a fangsong font.</div>
+
+<div class="generic-serif">This is an example using generic(serif).</div>
+
+<div class="generic-sans-serif">
+  This is an example using generic(sans-serif).
+</div>
+
+<div class="generic-monospace">
+  This is an example using generic(monospace).
+</div>
+
+<div class="generic-cursive">This is an example using generic(cursive).</div>
+
+<div class="generic-fantasy">This is an example using generic(fantasy).</div>
+
+<div class="generic-math">This is an example using generic(math).</div>
+
+<div class="generic-fangsong">This is an example using generic(fangsong).</div>
 ```
 
 {{EmbedLiveSample("Some_common_font_families", 600, 220)}}
@@ -251,5 +323,6 @@ font-family:
 
 - {{cssxref("font-style")}}
 - {{cssxref("font-weight")}}
+- {{cssxref("font-variant-emoji")}}
 - SVG {{SVGAttr("font-family")}} attribute
 - [Learn: Fundamental text and font styling](/en-US/docs/Learn_web_development/Core/Text_styling/Fundamentals)

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -162,20 +162,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
 
-  Generic family names can also be specified using the `generic()` function:
-  - `generic(serif)`
-  - `generic(sans-serif)`
-  - `generic(monospace)`
-  - `generic(cursive)`
-  - `generic(fantasy)`
-  - `generic(system-ui)`
-  - `generic(ui-serif)`
-  - `generic(ui-sans-serif)`
-  - `generic(ui-monospace)`
-  - `generic(ui-rounded)`
-  - `generic(math)`
-  - `generic(fangsong)`
-
 ## Formal definition
 
 {{cssinfo}}
@@ -216,35 +202,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
 .fangsong {
   font-family: fangsong;
 }
-
-/* Using generic() function syntax */
-.generic-serif {
-  font-family: Times, "Times New Roman", Georgia, generic(serif);
-}
-
-.generic-sans-serif {
-  font-family: Verdana, Arial, Helvetica, generic(sans-serif);
-}
-
-.generic-monospace {
-  font-family: "Lucida Console", Courier, generic(monospace);
-}
-
-.generic-cursive {
-  font-family: generic(cursive);
-}
-
-.generic-fantasy {
-  font-family: generic(fantasy);
-}
-
-.generic-math {
-  font-family: generic(math);
-}
-
-.generic-fangsong {
-  font-family: generic(fangsong);
-}
 ```
 
 ```html hidden
@@ -261,24 +218,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
 <div class="math">This is an example of a math font.</div>
 
 <div class="fangsong">This is an example of a fangsong font.</div>
-
-<div class="generic-serif">This is an example using generic(serif).</div>
-
-<div class="generic-sans-serif">
-  This is an example using generic(sans-serif).
-</div>
-
-<div class="generic-monospace">
-  This is an example using generic(monospace).
-</div>
-
-<div class="generic-cursive">This is an example using generic(cursive).</div>
-
-<div class="generic-fantasy">This is an example using generic(fantasy).</div>
-
-<div class="generic-math">This is an example using generic(math).</div>
-
-<div class="generic-fangsong">This is an example using generic(fangsong).</div>
 ```
 
 {{EmbedLiveSample("Some_common_font_families", 600, 220)}}

--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -8,30 +8,10 @@ sidebar: cssref
 
 The **`font-variant-numeric`** [CSS](/en-US/docs/Web/CSS) property controls the usage of alternate glyphs for numbers, fractions, and ordinal markers.
 
-{{InteractiveExample("CSS Demo: font-variant-numeric", "taller")}}
+{{InteractiveExample("CSS Demo: font-variant-numeric")}}
 
 ```css interactive-example-choice
 font-variant-numeric: normal;
-```
-
-```css interactive-example-choice
-font-variant-numeric: ordinal;
-```
-
-```css interactive-example-choice
-font-variant-numeric: diagonal-fractions;
-```
-
-```css interactive-example-choice
-font-variant-numeric: lining-nums;
-```
-
-```css interactive-example-choice
-font-variant-numeric: oldstyle-nums;
-```
-
-```css interactive-example-choice
-font-variant-numeric: proportional-nums;
 ```
 
 ```css interactive-example-choice
@@ -39,11 +19,11 @@ font-variant-numeric: slashed-zero;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: stacked-fractions;
+font-variant-numeric: tabular-nums;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: tabular-nums;
+font-variant-numeric: oldstyle-nums;
 ```
 
 ```html interactive-example

--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -8,10 +8,30 @@ sidebar: cssref
 
 The **`font-variant-numeric`** [CSS](/en-US/docs/Web/CSS) property controls the usage of alternate glyphs for numbers, fractions, and ordinal markers.
 
-{{InteractiveExample("CSS Demo: font-variant-numeric")}}
+{{InteractiveExample("CSS Demo: font-variant-numeric", "taller")}}
 
 ```css interactive-example-choice
 font-variant-numeric: normal;
+```
+
+```css interactive-example-choice
+font-variant-numeric: ordinal;
+```
+
+```css interactive-example-choice
+font-variant-numeric: diagonal-fractions;
+```
+
+```css interactive-example-choice
+font-variant-numeric: lining-nums;
+```
+
+```css interactive-example-choice
+font-variant-numeric: oldstyle-nums;
+```
+
+```css interactive-example-choice
+font-variant-numeric: proportional-nums;
 ```
 
 ```css interactive-example-choice
@@ -19,11 +39,11 @@ font-variant-numeric: slashed-zero;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: tabular-nums;
+font-variant-numeric: stacked-fractions;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: oldstyle-nums;
+font-variant-numeric: tabular-nums;
 ```
 
 ```html interactive-example

--- a/files/en-us/web/css/generic-family/index.md
+++ b/files/en-us/web/css/generic-family/index.md
@@ -47,15 +47,12 @@ The `<generic-family>` {{glossary("enumerated")}} type is specified using one of
 - `math`
   - : Fonts for displaying mathematical expressions, for example superscript and subscript, brackets that cross several lines, nesting expressions, and double-struck glyphs with distinct meanings.
 
-- `emoji`
-  - : Fonts that are specifically designed to render emoji.
-
 - `fangsong`
   - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
 
 ## Formal syntax
 
-{{CSSSyntaxRaw(`<generic-family> = serif | sans-serif | monospace | cursive | fantasy | system-ui | ui-serif | ui-sans-serif | ui-monospace | ui-rounded | emoji | math | fangsong`)}}
+{{CSSSyntaxRaw(`<generic-family> = serif | sans-serif | monospace | cursive | fantasy | system-ui | ui-serif | ui-sans-serif | ui-monospace | ui-rounded | math | fangsong`)}}
 
 ## Examples
 


### PR DESCRIPTION
### Description
Remove incorrect `font-family: emoji` references from the CSS font-family documentation and add a note directing users to the correct `font-variant-emoji` property.

### Motivation
The documentation incorrectly suggested that `font-family: emoji` is a standard or supported value, when it's not supported by any browsers. This was misleading developers who might try to use this non-existent syntax. The correct approach for emoji presentation is to use the `font-variant-emoji` property instead.

### Additional details
- Removed `font-family: emoji` from syntax examples and generic family descriptions
- Removed `.emoji` CSS class and corresponding HTML example
- Added note with proper GFM syntax directing users to `font-variant-emoji` property
- `font-variant-emoji` has limited browser support (Chrome 131+, Edge 131+, Firefox 141+, but not Safari)

### Related issues and pull requests

Fixes #41093