### PR TITLE
Update spec URL for Cookie Store API

### DIFF
--- a/files/en-us/web/api/cookie_store_api/index.md
+++ b/files/en-us/web/api/cookie_store_api/index.md
@@ -5,7 +5,6 @@ page-type: web-api-overview
 browser-compat:
   - api.CookieStore
   - api.CookieStoreManager
-spec-urls: https://wicg.github.io/cookie-store/
 ---
 
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}

--- a/files/en-us/web/api/cookie_store_api/index.md
+++ b/files/en-us/web/api/cookie_store_api/index.md
@@ -5,6 +5,7 @@ page-type: web-api-overview
 browser-compat:
   - api.CookieStore
   - api.CookieStoreManager
+spec-urls: https://cookiestore.spec.whatwg.org/
 ---
 
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}{{AvailableInWorkers("window_and_service")}}


### PR DESCRIPTION
### Description

There's a `spec-urls` key in the front matter that I don't think we need now.

### Motivation

Fixes #41288