### PR TITLE
fix(css): add warning messages to the livesamples

### DIFF
--- a/files/en-us/web/css/corner-shape/index.md
+++ b/files/en-us/web/css/corner-shape/index.md
@@ -175,7 +175,7 @@ div {
 
 @supports not (corner-shape: scoop) {
   body {
-    width: 100%;
+    all: unset !important;
   }
 
   body::before {
@@ -185,6 +185,7 @@ div {
     display: block;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 
   body > * {
@@ -259,8 +260,7 @@ div {
 
 @supports not (corner-shape: scoop notch) {
   body {
-    width: 100%;
-    background: initial !important;
+    all: unset !important;
   }
 
   body::before {
@@ -270,6 +270,7 @@ div {
     display: block;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 
   body > * {
@@ -397,7 +398,7 @@ section {
 
 @supports not (corner-shape: scoop) {
   body {
-    width: 100%;
+    all: unset !important;
   }
 
   body::before {
@@ -407,6 +408,7 @@ section {
     display: block;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 
   body > * {
@@ -521,7 +523,7 @@ section {
 
 @supports not (corner-shape: superellipse(0)) {
   body {
-    width: 100%;
+    all: unset !important;
   }
 
   body::before {
@@ -531,6 +533,7 @@ section {
     display: block;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 
   body > * {
@@ -610,7 +613,7 @@ div {
 
 @supports not (corner-shape: square) {
   body {
-    width: 100%;
+    all: unset !important;
   }
 
   body::before {
@@ -620,6 +623,7 @@ div {
     display: block;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 
   body > * {
@@ -634,7 +638,8 @@ div {
     corner-shape: square;
   }
 
-  /* To make the starting point apparent, let us keep the shape the same for a small duration. */
+  /* To make the starting point apparent, let us keep
+  the shape the same for a small duration. */
   20% {
     corner-shape: square;
   }

--- a/files/en-us/web/css/corner-shape/index.md
+++ b/files/en-us/web/css/corner-shape/index.md
@@ -172,6 +172,25 @@ div {
     rgb(255 255 255 / 0.5)
   );
 }
+
+@supports not (corner-shape: scoop) {
+  body {
+    width: 100%;
+  }
+
+  body::before {
+    content: "Your browser does not support the 'corner-shape' property.";
+    color: black;
+    background-color: #ffcd33;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body > * {
+    display: none;
+  }
+}
 ```
 
 ```css live-sample___basic-corner-shape
@@ -236,6 +255,26 @@ body {
 div {
   width: 240px;
   height: 180px;
+}
+
+@supports not (corner-shape: scoop notch) {
+  body {
+    width: 100%;
+    background: initial !important;
+  }
+
+  body::before {
+    content: "Your browser does not support the 'corner-shape' property.";
+    color: black;
+    background-color: #ffcd33;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body > * {
+    display: none;
+  }
 }
 ```
 
@@ -355,6 +394,25 @@ section {
     rgb(255 255 255 / 0.5)
   );
 }
+
+@supports not (corner-shape: scoop) {
+  body {
+    width: 100%;
+  }
+
+  body::before {
+    content: "Your browser does not support the 'corner-shape' property.";
+    color: black;
+    background-color: #ffcd33;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body > * {
+    display: none;
+  }
+}
 ```
 
 ```css live-sample___corner-shape-select
@@ -460,6 +518,25 @@ section {
     rgb(255 255 255 / 0.5)
   );
 }
+
+@supports not (corner-shape: superellipse(0)) {
+  body {
+    width: 100%;
+  }
+
+  body::before {
+    content: "Your browser does not support the 'corner-shape' property.";
+    color: black;
+    background-color: #ffcd33;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body > * {
+    display: none;
+  }
+}
 ```
 
 ```css live-sample___superellipse-slider
@@ -502,10 +579,8 @@ In this example, we demonstrate how the `corner-shape` property can be animated.
 
 #### HTML
 
-The markup for this example contains a single `<div>`, with [`tabindex="0"`](/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex) applied so it can be focused.
-
 ```html live-sample___corner-shape-animation
-<div tabindex="0"></div>
+<div></div>
 ```
 
 #### CSS
@@ -532,6 +607,25 @@ div {
   corner-shape: square;
   outline: none;
 }
+
+@supports not (corner-shape: square) {
+  body {
+    width: 100%;
+  }
+
+  body::before {
+    content: "Your browser does not support the 'corner-shape' property.";
+    color: black;
+    background-color: #ffcd33;
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  body > * {
+    display: none;
+  }
+}
 ```
 
 ```css live-sample___corner-shape-animation
@@ -540,14 +634,18 @@ div {
     corner-shape: square;
   }
 
+  /* To make the starting point apparent, let us keep the shape the same for a small duration. */
+  20% {
+    corner-shape: square;
+  }
+
   to {
     corner-shape: notch;
   }
 }
 
-html:hover div,
-div:focus {
-  animation: corner-pulse infinite alternate 2s linear;
+div {
+  animation: corner-pulse infinite alternate 4s linear;
 }
 ```
 
@@ -556,8 +654,6 @@ div:focus {
 The rendered result looks like this:
 
 {{EmbedLiveSample("corner-shape-animation", "100%", "270")}}
-
-Hover or focus the shape to see the animation.
 
 ## Specifications
 

--- a/files/en-us/web/css/corner-shape/index.md
+++ b/files/en-us/web/css/corner-shape/index.md
@@ -387,7 +387,7 @@ form div:nth-of-type(2) {
 section {
   width: 100%;
   height: 180px;
-  background-color: palegoldenrod;
+  background-color: gold;
   background-image: linear-gradient(
     to bottom,
     rgb(255 255 255 / 0),


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/41113

The PR does the following:
- Adds warnings to the live sample outputs if the `corner-shape` is not supported by the browsers. We have used the `@supports not (corner-shape: ...)` technique on other pages.
- Simplifies the last example. Many non-technical users may not know how to hover or focus on the div on touch devices. So to make the animation starting point prominent, we can simply extend the initial state for a while.

You'll have to test this on both Firefox and Chrome browsers.