### PR TITLE
Note system-ui is not for large paragraphs

### DIFF
--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -137,7 +137,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `system-ui`
       - : Glyphs are taken from the default user interface font on a given platform. Because typographic traditions vary widely across the world, this generic is provided for typefaces that don't map cleanly into the other generics.
         > [!NOTE]
-        > The `system-ui` font family matches the operating system’s default UI font, making web apps look native. However, it is platform-dependent, may produce inconsistent or undesirable results in some languages/locales, and is not optimized for large paragraphs of text or articles. To ensure readability and optimization, use the `sans-serif` generic family instead. See the [CSS Fonts Module Level 4 spec](https://www.w3.org/TR/css-fonts-4/#system-ui-def).
+        > As the name implies, `system-ui` is intended for use with UI elements to provide a native app appearance, and not for large paragraphs of text. It may cause the displayed typeface to be undesirable for some end users—for example, the default Windows CJK font may render Latin scripts poorly, and the `lang` attribute might not affect the displayed font. Some operating systems do not allow customizing `system-ui`, while browsers generally allow customizing the `sans-serif` font family. For large paragraphs, use `sans-serif` instead.
     - `ui-serif`
       - : The default user interface serif font.
     - `ui-sans-serif`

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -136,6 +136,8 @@ font-family: "Gill Sans Extrabold", sans-serif;
 
     - `system-ui`
       - : Glyphs are taken from the default user interface font on a given platform. Because typographic traditions vary widely across the world, this generic is provided for typefaces that don't map cleanly into the other generics.
+        > [!NOTE]
+        > The `system-ui` font family matches the operating system’s default UI font, making web apps look native. However, it is platform-dependent, may produce inconsistent or undesirable results in some languages/locales, and is not optimized for large paragraphs of text or articles. To ensure readability and optimization, use the `sans-serif` generic family instead. See the [CSS Fonts Module Level 4 spec](https://www.w3.org/TR/css-fonts-4/#system-ui-def).
     - `ui-serif`
       - : The default user interface serif font.
     - `ui-sans-serif`

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -137,7 +137,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `system-ui`
       - : Glyphs are taken from the default user interface font on a given platform. Because typographic traditions vary widely across the world, this generic is provided for typefaces that don't map cleanly into the other generics.
         > [!NOTE]
-        > As the name implies, `system-ui` is intended for use with UI elements to provide a native app appearance, and not for large paragraphs of text. It may cause the displayed typeface to be undesirable for some end users—for example, the default Windows CJK font may render Latin scripts poorly, and the `lang` attribute might not affect the displayed font. Some operating systems do not allow customizing `system-ui`, while browsers generally allow customizing the `sans-serif` font family. For large paragraphs, use `sans-serif` instead.
+        > As the name implies, `system-ui` is intended to make UI elements look like native apps, and not for typesetting large paragraphs of text. It may cause the displayed typeface to be undesirable for some users—for example, the default Windows CJK font may render Latin scripts poorly, and the `lang` attribute may not affect the displayed font. Some operating systems do not allow customizing `system-ui`, while browsers generally allow customizing the `sans-serif` font family. For large paragraphs, use `sans-serif` or some other non-UI font family instead.
     - `ui-serif`
       - : The default user interface serif font.
     - `ui-sans-serif`

--- a/files/en-us/web/css/generic-family/index.md
+++ b/files/en-us/web/css/generic-family/index.md
@@ -31,6 +31,8 @@ The `<generic-family>` {{glossary("enumerated")}} type is specified using one of
 
 - `system-ui`
   - : Glyphs are taken from the default user interface font on a given platform. Because typographic traditions vary widely across the world, this generic family is provided for typefaces that don't map cleanly into the others.
+    > [!NOTE]
+    > As the name implies, `system-ui` is intended to make UI elements look like native apps, and not for typesetting large paragraphs of text. It may cause the displayed typeface to be undesirable for some users—for example, the default Windows CJK font may render Latin scripts poorly, and the `lang` attribute may not affect the displayed font. Some operating systems do not allow customizing `system-ui`, while browsers generally allow customizing the `sans-serif` font family. For large paragraphs, use `sans-serif` or some other non-UI font family instead.
 
 - `ui-serif`
   - : The default user interface serif font. See the definition of `serif` above.


### PR DESCRIPTION
### Description

#### Changes
- Add note on `system-ui` font family usage and limitations

### Additional details

#### Before

<img width="799" height="154" alt="image" src="https://github.com/user-attachments/assets/e00638e0-316d-4943-a53e-4e278354098a" />


#### After

<img width="770" height="320" alt="image" src="https://github.com/user-attachments/assets/8dcf2f59-665c-447c-92db-729138a3c2b9" />


### Related issues and pull requests

Fix #41244
