### PR TITLE
Fix typo in HTTP glossary: change 'schema' to 'scheme'

### DIFF
--- a/files/en-us/glossary/http/index.md
+++ b/files/en-us/glossary/http/index.md
@@ -7,7 +7,7 @@ sidebar: glossarysidebar
 
 The HyperText Transfer Protocol (**HTTP**) is the underlying network {{glossary("protocol")}} that enables transfer of hypermedia documents on the {{glossary("World Wide Web","Web")}}, typically between a browser and a server so that humans can read them. The current version of the HTTP specification is called {{glossary("HTTP_2", "HTTP/2")}}.
 
-As part of a {{glossary("URI")}}, the "http" within "http\://example.com/" is called a "scheme". Resources using the "http" schema are typically transported over unencrypted connections using the HTTP protocol. The "https" scheme (as in "https\://developer.mozilla.org") indicates that a resource is transported using the HTTP protocol, but over a secure {{glossary("TLS")}} channel.
+As part of a {{glossary("URI")}}, the "http" within "http\://example.com/" is called a "scheme". Resources using the "http" scheme are typically transported over unencrypted connections using the HTTP protocol. The "https" scheme (as in "https\://developer.mozilla.org") indicates that a resource is transported using the HTTP protocol, but over a secure {{glossary("TLS")}} channel.
 
 HTTP is textual (all communication is done in plain text) and stateless (no communication is aware of previous communications). This property makes it ideal for humans to read documents (websites) on the world wide web. However, HTTP can also be used as a basis for {{glossary("REST")}} web services from server to server or {{domxref("Window/fetch", "fetch()")}} requests within websites to make them more dynamic.
 

--- a/files/en-us/learn_web_development/extensions/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/apache_configuration_htaccess/index.md
@@ -317,7 +317,7 @@ These directives will rewrite `www.example.com` to `example.com`.
 
 You should not duplicate content in multiple origins (with and without www). This can cause SEO problems (duplicate content), and therefore, you should choose one of the alternatives and redirect the other one. You should also use [Canonical URLs](https://www.semrush.com/blog/canonical-url-guide/) to indicate which URL should search engines crawl (if they support the feature).
 
-Set `%{ENV:PROTO}` variable, to allow rewrites to redirect with the appropriate schema automatically (`http` or `https`).
+Set `%{ENV:PROTO}` variable, to allow rewrites to redirect with the appropriate scheme automatically (`http` or `https`).
 
 The rule assumes by default that both HTTP and HTTPS environments are available for redirection.
 
@@ -340,7 +340,7 @@ These rules will insert `www.` at the beginning of a URL. It's important to note
 
 This can cause SEO problems (duplicate content), and therefore, you should choose one of the alternatives and redirect the other one. For search engines that support them, you should use [Canonical URLs](https://www.semrush.com/blog/canonical-url-guide/) to indicate which URL should search engines crawl.
 
-Set the `%{ENV:PROTO}` variable, to allow rewrites to redirect with the appropriate schema automatically (`http` or `https`).
+Set the `%{ENV:PROTO}` variable, to allow rewrites to redirect with the appropriate scheme automatically (`http` or `https`).
 
 The rule assumes by default that both HTTP and HTTPS environments are available for redirection. If your TLS certificate cannot handle one of the domains used during redirection, you should turn the condition on.
 

--- a/files/en-us/learn_web_development/howto/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn_web_development/howto/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -40,7 +40,7 @@ Some examples won't run if you open them as local files. This can be due to a va
 
 - **They feature asynchronous requests**. Some browsers (including Chrome) will not run async requests (see [Learn: Making network requests with JavaScript](/en-US/docs/Learn_web_development/Core/Scripting/Network_requests)) if you just run the example from a local file. This is because of security restrictions (for more on web security, read [Website security](/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security)).
 - **They feature a server-side language**. Server-side languages (such as PHP or Python) require a special server to interpret the code and deliver the results.
-- **They include other files**. Browsers commonly treat requests to load resources using the `file://` schema as cross-origin requests.
+- **They include other files**. Browsers commonly treat requests to load resources using the `file://` scheme as cross-origin requests.
   So if you load a local file that includes other local files, this may trigger a {{Glossary("CORS")}} error.
 
 ## Running a simple local HTTP server

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -60,7 +60,7 @@ This article provides information about the changes in Firefox 136 that affect d
 
 - Firefox now handles WebSocket port conflicts for the RemoteAgent more efficiently. If the port specified via the `--remote-debugging-port` command line argument cannot be acquired within 5 seconds, such as when another Firefox process is already using it, Firefox will now shut down instead of hanging ([Firefox bug 1927721](https://bugzil.la/1927721)).
 
-- Navigations using the HTTP schema, triggered by the `WebDriver:Navigate` command in Marionette or `browsingContext.navigate` in WebDriver BiDi, will no longer be automatically upgraded to HTTPS. These requests will now remain on HTTP as intended ([Firefox bug 1943551](https://bugzil.la/1943551)).
+- Navigations using the HTTP scheme, triggered by the `WebDriver:Navigate` command in Marionette or `browsingContext.navigate` in WebDriver BiDi, will no longer be automatically upgraded to HTTPS. These requests will now remain on HTTP as intended ([Firefox bug 1943551](https://bugzil.la/1943551)).
 
 #### WebDriver BiDi
 

--- a/files/en-us/web/api/webotp_api/index.md
+++ b/files/en-us/web/api/webotp_api/index.md
@@ -66,7 +66,7 @@ Your verification code is 123456.
   - Followed by the OTP, preceded by a pound sign (`#`).
 
 > [!NOTE]
-> The provided domain value must not include a URL schema, port, or other URL features not shown above.
+> The provided domain value must not include a URL scheme, port, or other URL features not shown above.
 
 If the `get()` method is invoked by a third-party site embedded in an {{htmlelement("iframe")}}, the SMS structure should be:
 

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -51,7 +51,7 @@ new WebSocket(url, protocols)
 
 The examples below show how you might connect to a `WebSocket`.
 
-The code below shows how we can connect to a socket using an URL with the `wss` schema:
+The code below shows how we can connect to a socket using an URL with the `wss` scheme:
 
 ```js
 const wssWebSocket = new WebSocket("wss://websocket.example.org");
@@ -63,7 +63,7 @@ wssWebSocket.close();
 ```
 
 The code for connecting to an HTTPS URL is nearly the same.
-Under the hood the browser resolves this to a "WSS" connection, so the {{domxref("WebSocket.url")}} will have the schema "wss:".
+Under the hood the browser resolves this to a "WSS" connection, so the {{domxref("WebSocket.url")}} will have the scheme "wss:".
 
 ```js
 const httpsWebSocket = new WebSocket("https://websocket.example.org");

--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -33,7 +33,7 @@ For example, `about:blank` is often used as a URL of new, empty popup windows in
 
 ### File origins
 
-Modern browsers usually treat the origin of files loaded using the `file:///` schema as _opaque origins_.
+Modern browsers usually treat the origin of files loaded using the `file:///` scheme as _opaque origins_.
 What this means is that if a file includes other files from the same folder (say), they are not assumed to come from the same origin, and may trigger {{Glossary("CORS")}} errors.
 
 Note that the [URL specification](https://url.spec.whatwg.org/#origin) states that the origin of files is implementation-dependent, and some browsers may treat files in the same directory or subdirectory as same-origin even though this has [security implications](https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/#CVE-2019-11730).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Fixed a typo in the HTTP glossary entry where "schema" was incorrectly used instead of "scheme" when referring to URI schemes.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Corrects technical terminology and ensures consistency within the glossary entry. In URI terminology, "http" and "https" are called "schemes," not "schemas."


### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

- The change is a single word correction from "schema" to "scheme" in line 10 of the HTTP glossary entry
- This maintains consistency with the rest of the paragraph which correctly uses "scheme"
- Reference: [RFC 3986 - URI Generic Syntax](https://tools.ietf.org/html/rfc3986#section-3.1) defines the correct terminology

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes #41300

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->