### PR TITLE
Fix command event type

### DIFF
--- a/files/en-us/web/api/commandevent/commandevent/index.md
+++ b/files/en-us/web/api/commandevent/commandevent/index.md
@@ -21,7 +21,7 @@ new CommandEvent(type, options)
 
 - `type`
   - : A string with the name of the event.
-    It is case-sensitive and browsers set it to `beforeinput` or `input`.
+    It is case-sensitive and browsers set it to `command`.
 - `options` {{optional_inline}}
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `source` {{optional_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The CommandEvent has a type of `command`, not `input`/`beforeinput`. Likely a copypaste mistake.

### Motivation

Corrects the type.

### Additional details

Step 5.5 of https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command doesn't say anything about a type of `input`/`beforeinput`.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
