### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/learn_web_development/howto/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn_web_development/howto/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -58,7 +58,7 @@ For VS Code, try out the following free extensions:
 
 ### Using Node.js
 
-The Node.js [`http-server`](https://www.npmjs.com/package/http-server) module is an easiest way to host HTML files in any directory.
+The Node.js [`http-server`](https://www.npmjs.com/package/http-server) module is an easy way to host HTML files in any directory.
 
 To use the module:
 


### PR DESCRIPTION
This was a typo in the following article:
https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server

There are three ways to correcting this:
1. "The Node.js http-server module is the easiest way to host HTML files in any directory."
2. "The Node.js http-server module is an easy way to host HTML files in any directory."
3. "The Node.js http-server module is one of the easiest ways to host HTML files in any directory."

I've opted for the second change, to adopt the least authoritative tone on the topic. Three works as well, but these are just my opinions.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Fixed typo in the following article: https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server

It was in the `Using Node.js` subsection, under the `Running a simple local HTTP server` section.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Additional details
Article edited: https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->