### PR TITLE
Sticky/transient activation - clarify causes

### DIFF
--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -5,17 +5,24 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Sticky activation** (or "sticky user activation") is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction.
+**Sticky activation** (or "sticky user activation") is a window state that indicates a user has meaningfully and directly interacted with the window since page load.
+Once active, the state lasts for the duration of the session.
 
-A page is considered "user activated" if a user is currently interacting with the page or has completed a touch, pointer, or keyboard interaction since page load. With sticky user activation, if activation is set it is not reset for the duration of the session (unlike {{Glossary("Transient activation")}}).
+The state is enabled following any user interaction that results in the browser generating a `mousedown` or `pointerdown` event for a mouse, a `pointerup` event for any other kind of pointer, a `touchend` event, or a `keydown` event (other than for the escape or browser shortcut keys) when the window has focus.
+The window is not user activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
 
-See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _sticky activation_.
+Sticky activation is used to control access to certain features, blocking them if the user hasn't interacted with the page.
+For example, it can be used to ensure that controlled features in cross-origin frames don't run code on page load.
+See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for more information.
 
-See the {{domxref("UserActivation.hasBeenActive")}} property to programmatically access the current window's sticky activation state.
+The {{domxref("UserActivation.hasBeenActive")}} property can be used to programmatically check the current window's sticky activation state.
+
+> [!NOTE]
+> See {{Glossary("Transient activation")}} for a user activation state that expires after a timeout, and may also be "consumed" by some APIs.
 
 ## See also
 
-- [HTML Living Standard > Sticky activation](https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation)
 - Related glossary terms:
   - {{Glossary("Transient activation")}}
 - {{domxref("UserActivation.hasBeenActive")}}
+- [HTML Living Standard > Sticky activation](https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation)

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -23,14 +23,9 @@ See [Features gated by user activation](/en-US/docs/Web/Security/User_activation
 
 The {{domxref("UserActivation.hasBeenActive")}} property can be used to programmatically check the current window's sticky activation state.
 
-## Comparison between sticky and transient activation
-
-The difference between sticky and {{Glossary("transient activation")}} is that transient activation only lasts for a short while, and may in some cases be consumed (deactivated) when a protected feature is used.
-
-While the presence of sticky activation is primarily used to prevent features automatically being available on page load, transient activation is used to ensure that features are allowed only if directly triggered by a user.
-
 ## See also
 
+- [Comparison between transient and sticky activation](/en-US/docs/Web/Security/User_activation#comparison_between_transient_and_sticky_activation) in _Features gated by user activation_
 - Related glossary terms:
   - {{Glossary("Transient activation")}}
 - {{domxref("UserActivation.hasBeenActive")}}

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -8,7 +8,12 @@ sidebar: glossarysidebar
 **Sticky activation** (or "sticky user activation") is a window state that indicates a user has meaningfully and directly interacted with the window since page load.
 Once active, the state lasts for the duration of the session.
 
-The state is enabled following any user interaction that results in the browser generating a `mousedown` or `pointerdown` event for a mouse, a `pointerup` event for any other kind of pointer, a `touchend` event, or a `keydown` event (other than for the escape or browser shortcut keys) when the window has focus.
+The state is enabled following any user interaction, when the window has focus, that results in the browser generating one or more of the following:
+
+- A `mousedown` or `pointerdown` event for a mouse.
+- A `pointerup` event for any other kind of pointer.
+- A `touchend` event.
+- A `keydown` event, other than for the escape or browser shortcut keys.
 The window is not user activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
 
 Sticky activation is used to control access to certain features, blocking them if the user hasn't interacted with the page.

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -14,7 +14,7 @@ The state is enabled following any user interaction, when the window has focus, 
 - A `pointerup` event for any other kind of pointer.
 - A `touchend` event.
 - A `keydown` event, other than for the escape or browser shortcut keys.
-The window is not user activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
+The window is not user-activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
 
 Sticky activation is used to control access to certain features, blocking them if the user hasn't interacted with the page.
 For example, it can be used to ensure that controlled features in cross-origin frames don't run code on page load.

--- a/files/en-us/glossary/sticky_activation/index.md
+++ b/files/en-us/glossary/sticky_activation/index.md
@@ -14,7 +14,8 @@ The state is enabled following any user interaction, when the window has focus, 
 - A `pointerup` event for any other kind of pointer.
 - A `touchend` event.
 - A `keydown` event, other than for the escape or browser shortcut keys.
-The window is not user-activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
+
+The window is not user-activated by events that aren't necessarily caused by intentional interaction with the window, such as mouse move events or `wheel` events.
 
 Sticky activation is used to control access to certain features, blocking them if the user hasn't interacted with the page.
 For example, it can be used to ensure that controlled features in cross-origin frames don't run code on page load.
@@ -22,8 +23,11 @@ See [Features gated by user activation](/en-US/docs/Web/Security/User_activation
 
 The {{domxref("UserActivation.hasBeenActive")}} property can be used to programmatically check the current window's sticky activation state.
 
-> [!NOTE]
-> See {{Glossary("Transient activation")}} for a user activation state that expires after a timeout, and may also be "consumed" by some APIs.
+## Comparison between sticky and transient activation
+
+The difference between sticky and {{Glossary("transient activation")}} is that transient activation only lasts for a short while, and may in some cases be consumed (deactivated) when a protected feature is used.
+
+While the presence of sticky activation is primarily used to prevent features automatically being available on page load, transient activation is used to ensure that features are allowed only if directly triggered by a user.
 
 ## See also
 

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -7,9 +7,16 @@ sidebar: glossarysidebar
 
 **Transient activation** (or "transient user activation") is a window state that indicates a user has recently directly and meaningfully interacted with the window.
 
-The state is enabled following any user interaction that results in the browser generating a `mousedown` or `pointerdown` event for a mouse, a `pointerup` event for any other kind of pointer, a `touchend` event, or a `keydown` event (other than for the escape or browser shortcut keys) when the window has focus.
-The window is not user activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
-Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs.
+The state is enabled following any user interaction, when the window has focus, that results in the browser generating one or more of the following:
+
+- A `mousedown` or `pointerdown` event for a mouse.
+- A `pointerup` event for any other kind of pointer.
+- A `touchend` event.
+- A `keydown` event, other than for the escape or browser shortcut keys.
+
+The window is not user-activated by events that aren't necessarily caused by intentional interaction with the window, such as mouse move events or `wheel` events.
+
+Transient activation expires after a timeout (if not renewed by further interaction), and may also be consumed/deactivated after using some gated features (such as {{domxref("Window.open()")}}).
 
 Transient activation is commonly used as a mechanism for ensuring that a web API can only function if triggered by user interaction.
 For example, scripts cannot arbitrarily launch a popup that requires _transient activation_ ⁠— it must be triggered from a UI element's event handler.
@@ -17,8 +24,12 @@ See [Features gated by user activation](/en-US/docs/Web/Security/User_activation
 
 The {{domxref("UserActivation.isActive")}} property can be used to programmatically check the current window's transient activation state.
 
-> [!NOTE]
-> See {{Glossary("Sticky activation")}} for a user activation that persists for the duration of the session.
+
+## Comparison between transient and sticky activation
+
+The difference between transient and {{Glossary("sticky activation")}} is that sticky activation persists from the first meaningful interaction until the end of the session.
+
+While the presence of transient activation is used to ensure that features are only allowed if directly triggered by a user, sticky activation is primarily used to prevent features automatically being triggered on page load.
 
 ## See also
 

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -24,14 +24,9 @@ See [Features gated by user activation](/en-US/docs/Web/Security/User_activation
 
 The {{domxref("UserActivation.isActive")}} property can be used to programmatically check the current window's transient activation state.
 
-## Comparison between transient and sticky activation
-
-The difference between transient and {{Glossary("sticky activation")}} is that sticky activation persists from the first meaningful interaction until the end of the session.
-
-While the presence of transient activation is used to ensure that features are only allowed if directly triggered by a user, sticky activation is primarily used to prevent features automatically being triggered on page load.
-
 ## See also
 
+- [Comparison between transient and sticky activation](/en-US/docs/Web/Security/User_activation#comparison_between_transient_and_sticky_activation) in _Features gated by user activation_
 - Related glossary terms:
   - {{Glossary("Sticky activation")}}
 - {{domxref("UserActivation.isActive")}}

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -5,21 +5,24 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Transient activation** (or "transient user activation") is a window state that indicates a user has recently pressed a button, moved a mouse, used a menu, or performed some other user interaction.
+**Transient activation** (or "transient user activation") is a window state that indicates a user has recently directly and meaningfully interacted with the window.
 
-This state is sometimes used as a mechanism for ensuring that a web API can only function if triggered by user interaction.
-For example, scripts cannot arbitrarily launch a popup that requires _transient activation_ ⁠—it must be triggered from a UI element's event handler.
+The state is enabled following any user interaction that results in the browser generating a `mousedown` or `pointerdown` event for a mouse, a `pointerup` event for any other kind of pointer, a `touchend` event, or a `keydown` event (other than for the escape or browser shortcut keys) when the window has focus.
+The window is not user activated by events that don't indicate intentional interaction with the window, such as mouse move events or `wheel` events.
+Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs.
 
-See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for examples of APIs that require _transient activation_.
+Transient activation is commonly used as a mechanism for ensuring that a web API can only function if triggered by user interaction.
+For example, scripts cannot arbitrarily launch a popup that requires _transient activation_ ⁠— it must be triggered from a UI element's event handler.
+See [Features gated by user activation](/en-US/docs/Web/Security/User_activation) for information about APIs that require _transient activation_.
 
-See the {{domxref("UserActivation.isActive")}} property to programmatically access the current window's transient activation state.
+The {{domxref("UserActivation.isActive")}} property can be used to programmatically check the current window's transient activation state.
 
 > [!NOTE]
-> Transient activation expires after a timeout (if not renewed by further interaction), and may also be "consumed" by some APIs. See {{Glossary("Sticky activation")}} for a user activation that doesn't reset after it has been set initially.
+> See {{Glossary("Sticky activation")}} for a user activation that persists for the duration of the session.
 
 ## See also
 
-- [HTML Living Standard > Transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation)
 - Related glossary terms:
   - {{Glossary("Sticky activation")}}
 - {{domxref("UserActivation.isActive")}}
+- [HTML Living Standard > Transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation)

--- a/files/en-us/glossary/transient_activation/index.md
+++ b/files/en-us/glossary/transient_activation/index.md
@@ -24,7 +24,6 @@ See [Features gated by user activation](/en-US/docs/Web/Security/User_activation
 
 The {{domxref("UserActivation.isActive")}} property can be used to programmatically check the current window's transient activation state.
 
-
 ## Comparison between transient and sticky activation
 
 The difference between transient and {{Glossary("sticky activation")}} is that sticky activation persists from the first meaningful interaction until the end of the session.

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -10,7 +10,7 @@ Browsers limit access to sensitive APIs like popups, fullscreen, or vibration AP
 This page lists web platform features available only after user activation.
 
 A user activation either implies that the user is currently interacting with the page, or has completed an interaction since page load.
-Typically, this is a click on a button or some other user interaction with the UI.
+Typically, this is a click on a button or some other interaction with the UI.
 
 More precisely, an _activation triggering input event_ is an event which:
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -5,9 +5,12 @@ page-type: guide
 sidebar: security
 ---
 
-To ensure applications are unable to abuse APIs that can create a bad user experience when the behavior is not desired, some APIs can only be used when the user is in an "active interaction" state, meaning the user is currently interacting with the web page, or has interacted with the page at least once. Browsers limit access to sensitive APIs like popups, fullscreen, or vibration APIs to active user interactions to prevent malicious scripts from abusing these features. This page lists web platform features available only after user activation.
+To ensure applications are unable to abuse APIs that can create a bad user experience when the behavior is not desired, some APIs can only be used when the user is in an "active interaction" state, meaning the user is currently interacting with the web page, or has interacted with the page at least once.
+Browsers limit access to sensitive APIs like popups, fullscreen, or vibration APIs to active user interactions to prevent malicious scripts from abusing these features.
+This page lists web platform features available only after user activation.
 
-A user activation either implies that the user is currently interacting with the page, or has completed an interaction since page load. Typically, this is a click on a button or some other user interaction with the UI.
+A user activation either implies that the user is currently interacting with the page, or has completed an interaction since page load.
+Typically, this is a click on a button or some other user interaction with the UI.
 
 More precisely, an _activation triggering input event_ is an event which:
 
@@ -21,9 +24,17 @@ More precisely, an _activation triggering input event_ is an event which:
 
 If an activation has been triggered, the user agent differentiates between two types of user activation window states: sticky and transient.
 
+## Comparison between transient and sticky activation
+
+The difference between transient and sticky activation is that transient activation only lasts for a short while, and may in some cases be consumed (deactivated) when a protected feature is used, while sticky activation persists until the end of the session.
+
+Gating features on transient activation ensures that they are only available if directly triggered by a user.
+Sticky activation, by contrast, is primarily used to restrict features that should not automatically trigger on page load, such as popups
+
 ## Transient activation
 
-{{Glossary("Transient activation")}} is a window state that indicates a user has recently pressed a button, moved a mouse, used a menu, or performed some other user interaction. Transient activation expires after a timeout (if not renewed by further interaction) and may also be consumed by some APIs (like {{domxref("Window.open()")}}).
+{{Glossary("Transient activation")}} is a window state that indicates a user has recently pressed a button or performed some other user interaction.
+Transient activation expires after a timeout (if not renewed by further interaction) and may also be consumed by some APIs (like {{domxref("Window.open()")}}).
 
 APIs that require transient activation (list is not exhaustive):
 
@@ -65,7 +76,8 @@ APIs that require transient activation (list is not exhaustive):
 
 ## Sticky activation
 
-{{Glossary("Sticky activation")}} is a window state that indicates a user has pressed a button, moved a mouse, used a menu, or performed some other user interaction. It is not reset after it has been set initially (unlike transient activation).
+{{Glossary("Sticky activation")}} is a window state that indicates a user has at some time in the session pressed a button, used a menu, or performed some other user interaction.
+It is not reset after it has been set initially (unlike transient activation).
 
 APIs that require sticky activation (not exhaustive):
 
@@ -73,6 +85,8 @@ APIs that require sticky activation (not exhaustive):
 - {{domxref("Navigator.vibrate()")}}
 - {{domxref("VirtualKeyboard.show()")}}
 - Autoplay of [Media and Web Audio APIs](/en-US/docs/Web/Media/Guides/Autoplay) (in particular for [`AudioContexts`](/en-US/docs/Web/API/AudioContext)).
+
+.
 
 ## UserActivation API
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -29,7 +29,7 @@ If an activation has been triggered, the user agent differentiates between two t
 The difference between transient and sticky activation is that transient activation only lasts for a short while, and may in some cases be consumed (deactivated) when a protected feature is used, while sticky activation persists until the end of the session.
 
 Gating features on transient activation ensures that they are only available if directly triggered by a user.
-Sticky activation, by contrast, is primarily used to restrict features that should not automatically trigger on page load, such as popups
+Sticky activation, by contrast, is primarily used to restrict features that should not automatically trigger on page load, such as popups.
 
 ## Transient activation
 

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -86,8 +86,6 @@ APIs that require sticky activation (not exhaustive):
 - {{domxref("VirtualKeyboard.show()")}}
 - Autoplay of [Media and Web Audio APIs](/en-US/docs/Web/Media/Guides/Autoplay) (in particular for [`AudioContexts`](/en-US/docs/Web/API/AudioContext)).
 
-.
-
 ## UserActivation API
 
 To programmatically determine if a window has either sticky or transient user activation, the {{domxref("UserActivation")}} API provides two properties which are available using {{domxref("navigator.userActivation")}}:

--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -15,7 +15,7 @@ Typically, this is a click on a button or some other interaction with the UI.
 More precisely, an _activation triggering input event_ is an event which:
 
 - has the [`isTrusted`](/en-US/docs/Web/API/Event/isTrusted) attribute set to `true`, and
-- is an event of the following types:
+- is one of the following types:
   - [`keydown`](/en-US/docs/Web/API/Element/keydown_event) (except for the <kbd>Esc</kbd> key nor a shortcut key reserved by the user agent)
   - [`mousedown`](/en-US/docs/Web/API/Element/mousedown_event)
   - [`pointerdown`](/en-US/docs/Web/API/Element/pointerdown_event) (if `pointerType` is "mouse")


### PR DESCRIPTION
Fixes #41308

The linked issue points out that it isn't just any mouse movement that causes user activation. This makes it clear that it is "direct and meaningful interaction", and lists the specific events