### PR TITLE
fix typo

### DIFF
--- a/files/en-us/web/svg/reference/element/clippath/index.md
+++ b/files/en-us/web/svg/reference/element/clippath/index.md
@@ -89,7 +89,7 @@ By default, {{cssxref("pointer-events")}} are not dispatched on clipped regions.
 
 {{Compat}}
 
-## Related
+## See also
 
 - {{SVGElement("mask")}}
 - CSS {{cssxref("clip-path")}} property


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/clipPath
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/svg/reference/element/clippath/index.md
* Last commit: https://github.com/mdn/content/commit/ac806e34aba086be141689c64dc4dd73636fbd62