### PR TITLE
Add MediaTrackConstraints extensions spec URL

### DIFF
--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -2,7 +2,9 @@
 title: MediaTrackConstraints
 slug: Web/API/MediaTrackConstraints
 page-type: web-api-interface
-spec-urls: https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
+spec-urls:
+  - https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
+  - https://w3c.github.io/mediacapture-screen-share/#extensions-to-mediatrackconstraintset
 ---
 
 {{APIRef("Media Capture and Streams")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Adds another spec URL to the `MediaTrackConstraints` page.

### Motivation

The dictionary is extended in the Screen Capture spec.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Noticed as part of triaging https://github.com/mdn/browser-compat-data/issues/27993.
