### PR TITLE
Fix "Using relative colors" syntax example

### DIFF
--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -61,7 +61,7 @@ Let's look at relative color syntax in action. The below CSS is used to style tw
 }
 
 #two {
-  background-color: rgb(from red 150 g b / alpha);
+  background-color: rgb(from red 200 g b / alpha);
 }
 ```
 


### PR DESCRIPTION
### Description

Fixes the "General syntax" example on the "Using relative colors" page.

### Motivation

The example was not consistent with the following text.

### Additional details

Reported by @Mossop on Slack.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
