### PR TITLE
Bug-1976509 cookie.set method rejects invalid cookies

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -62,7 +62,7 @@ If there is more than one cookie with the same name for a URL, the cookie with t
 If the requested cookie is invalid or the call otherwise fails, the promise is rejected with an error message.
 
 > [!NOTE]
-> Before Firefox 145 , invalid cookies were created.
+> Before Firefox 145, invalid cookies were created.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -6,11 +6,9 @@ browser-compat: webextensions.api.cookies.set
 sidebar: addonsidebar
 ---
 
-The **`set()`** method of the {{WebExtAPIRef("cookies")}} API sets a cookie containing the specified cookie data. This method is equivalent to issuing an HTTP `Set-Cookie` header during a request to a given URL.
+Sets a cookie. This method is equivalent to issuing an HTTP `Set-Cookie` header during a request to a URL.
 
 To use this method, an extension must have the `"cookies"` permission and relevant host permissions. See [`cookie` permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#permissions) for more details.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 ## Syntax
 
@@ -54,14 +52,17 @@ let setting = browser.cookies.set(
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with a {{WebExtAPIRef('cookies.Cookie')}} object containing details about the cookie that's been set.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with a {{WebExtAPIRef('cookies.Cookie')}} object containing details about the set cookie.
 
 If there is more than one cookie with the same name for a URL, the cookie with the longest path is returned. For cookies with the same path length, the cookie with the earliest creation time is returned.
 
 > [!NOTE]
 > Before Firefox 133, when there was more than one cookie with the same name, Firefox returned the cookie with the earliest creation time.
 
-If the call fails, the promise is rejected with an error message.
+If the requested cookie is invalid or the call otherwise fails, the promise is rejected with an error message.
+
+> [!NOTE]
+> Before Firefox 145 , invalid cookies were created.
 
 ## Examples
 

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -74,6 +74,8 @@ Firefox 145 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- Cookies created with {{WebExtAPIRef("cookies.set()")}} are now validated, and invalid cookies are rejected. This change was implemented in Nightly only from Firefox 142. ([Firefox bug 1976509](https://bugzil.la/1976509))
+
 <!-- ### Removals -->
 
 <!-- ### Other -->


### PR DESCRIPTION
### Description

Addresses the dev-docs-needed requirements of [Bug 1976509](https://bugzilla.mozilla.org/show_bug.cgi?id=1976509) Reject invalid cookies in the webExt cookie API with:
- a release note describing the change
- an update to the cookies.set method documentation
