### PR TITLE
<figcaption> sets the accessible name, not description

### DIFF
--- a/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
@@ -555,7 +555,7 @@ It is possible to render external images onto your canvas. These can be simple i
    - Parameters 6 and 7 define the coordinates at which you want to draw the top-left corner of the cut-out portion of the image, relative to the top-left corner of the canvas.
    - Parameters 8 and 9 define the width and height to draw the cut-out area of the image. In this case, we have specified the same dimensions as the original slice, but you could resize it by specifying different values.
 
-5. When the image is meaningfully updated, the {{glossary("accessible description")}} must also be updated.
+5. When the image is meaningfully updated, the description must also be updated.
 
    ```js live-sample___5-canvas-images
    canvas.setAttribute("aria-label", "Firefox Logo");

--- a/files/en-us/web/html/reference/elements/caption/index.md
+++ b/files/en-us/web/html/reference/elements/caption/index.md
@@ -6,7 +6,7 @@ browser-compat: html.elements.caption
 sidebar: htmlsidebar
 ---
 
-The **`<caption>`** [HTML](/en-US/docs/Web/HTML) element specifies the caption (or title) of a table, providing the table an {{glossary("accessible description")}}.
+The **`<caption>`** [HTML](/en-US/docs/Web/HTML) element specifies the caption (or title) of a table, providing the table an {{glossary("accessible name")}} or {{glossary("accessible description")}}.
 
 {{InteractiveExample("HTML Demo: &lt;caption&gt;", "tabbed-taller")}}
 

--- a/files/en-us/web/html/reference/elements/figcaption/index.md
+++ b/files/en-us/web/html/reference/elements/figcaption/index.md
@@ -6,7 +6,7 @@ browser-compat: html.elements.figcaption
 sidebar: htmlsidebar
 ---
 
-The **`<figcaption>`** [HTML](/en-US/docs/Web/HTML) element represents a caption or legend describing the rest of the contents of its parent {{HTMLElement("figure")}} element, providing the `<figure>` an {{glossary("accessible description")}}.
+The **`<figcaption>`** [HTML](/en-US/docs/Web/HTML) element represents a caption or legend describing the rest of the contents of its parent {{HTMLElement("figure")}} element, providing the `<figure>` an {{glossary("accessible name")}}.
 
 {{InteractiveExample("HTML Demo: &lt;figcaption&gt;", "tabbed-shorter")}}
 

--- a/files/en-us/web/html/reference/elements/table/index.md
+++ b/files/en-us/web/html/reference/elements/table/index.md
@@ -459,7 +459,7 @@ It's a common and advisable practice to provide a summary for the table's conten
 
 #### HTML
 
-A table summary is added by using a table [caption](#captions) ({{HTMLElement("caption")}} element) as the first child element of the `<table>`. The caption provides the {{glossary("accessible description")}} for the table.
+A table summary is added by using a table [caption](#captions) ({{HTMLElement("caption")}} element) as the first child element of the `<table>`. The caption provides the {{glossary("accessible name")}} or {{glossary("accessible description")}} for the table.
 
 Lastly, a table foot section ({{HTMLElement("tfoot")}} element) is added below the body, with a row that summarizes the "Balance" column by displaying a sum. The elements and attributes introduced earlier are applied.
 


### PR DESCRIPTION
Related to https://github.com/mdn/content/issues/41334

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Fix incorrect description of \<figcaption\> because it provides accessible name, not description

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To bring a little more clarity

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Reference:
- https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#naming_with_captions


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes https://github.com/mdn/content/issues/41334

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
