### PR TITLE
HTMLScriptElement.textContent/innerText - docs for TrustedTypes

### DIFF
--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -71,7 +71,7 @@ The suffix "Unsafe" in the method name indicates that it does not enforce remova
 While it can do so if used with an appropriate sanitizer, it doesn't have to use an effective sanitizer, or any sanitizer at all!
 The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are injected into the DOM without first being sanitized.
 
-You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -83,7 +83,7 @@ In Edge only, calling `document.write()` more than once in an {{HTMLElement("ifr
 The method is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are injected into the DOM without first being sanitized.
 While the method may block {{HTMLElement("script")}} elements from executing when they are injected in some browsers (see [Intervening against document.write()](https://developer.chrome.com/blog/removing-document-write/) for Chrome), it is susceptible to many other ways that attackers can craft HTML to run malicious JavaScript.
 
-You can mitigate these issues by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You can mitigate these issues by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 ## Examples

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -54,7 +54,7 @@ The additional information in {{domxref("document.write()")}} also applies to th
 The method is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are injected into the DOM without first being sanitized.
 While the method may block {{HTMLElement("script")}} elements from executing when they are injected in some browsers (see [Intervening against document.write()](https://developer.chrome.com/blog/removing-document-write/) for Chrome), it is susceptible to many other ways that attackers can craft HTML to run malicious JavaScript.
 
-You can mitigate these issues by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You can mitigate these issues by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
 
 ## Examples

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -61,7 +61,7 @@ const name = "<img src='x' onerror='alert(1)'>";
 el.innerHTML = name; // shows the alert
 ```
 
-You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup before it is injected.
 
 > [!NOTE]

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -96,7 +96,7 @@ In this example we'll replace an element's DOM by assigning HTML to the element'
 To mitigate the risk of XSS, we'll first create a `TrustedHTML` object from the string containing the HTML, and then assign that object to `innerHTML`.
 
 Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
+This acts as a transparent replacement for the Trusted Types JavaScript API:
 
 ```js
 if (typeof trustedTypes === "undefined")

--- a/files/en-us/web/api/element/insertadjacenthtml/index.md
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.md
@@ -120,7 +120,7 @@ code {
 #### JavaScript
 
 Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
+This acts as a transparent replacement for the Trusted Types JavaScript API:
 
 ```js
 if (typeof trustedTypes === "undefined")

--- a/files/en-us/web/api/element/outerhtml/index.md
+++ b/files/en-us/web/api/element/outerhtml/index.md
@@ -126,7 +126,7 @@ In this example we'll replace an element in the DOM by assigning HTML to the ele
 To mitigate the risk of XSS, we'll first create a `TrustedHTML` object from the string containing the HTML, and then assign that object to `outerHTML`.
 
 Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
+This acts as a transparent replacement for the Trusted Types JavaScript API:
 
 ```js
 if (typeof trustedTypes === "undefined")

--- a/files/en-us/web/api/element/outerhtml/index.md
+++ b/files/en-us/web/api/element/outerhtml/index.md
@@ -93,7 +93,7 @@ const name = "<img src='x' onerror='alert(1)'>";
 element.outerHTML = name; // shows the alert
 ```
 
-You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup before it is injected.
 
 ## Examples

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -129,7 +129,7 @@ target.setHTMLUnsafe(input, { sanitizer: configLessSafe });
 
 To mitigate the risk of XSS, we'll first create a `TrustedHTML` object from the string containing the HTML, and then pass that object to `setHTMLUnsafe()`.
 Since trusted types are not yet supported on all browsers, we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
+This acts as a transparent replacement for the Trusted Types JavaScript API:
 
 ```js
 if (typeof trustedTypes === "undefined")

--- a/files/en-us/web/api/htmlelement/innertext/index.md
+++ b/files/en-us/web/api/htmlelement/innertext/index.md
@@ -8,6 +8,13 @@ browser-compat: api.HTMLElement.innerText
 
 {{APIRef("HTML DOM")}}
 
+> [!WARNING]
+> This property represents the text content of a script element, which may be executable depending on the script type.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks.
+>
+> You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
+> See [Security considerations](#security_considerations) for more information.
+
 The **`innerText`** property of the {{domxref("HTMLElement")}} interface represents the rendered text content of a node and its descendants.
 
 As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied it to the clipboard.
@@ -24,8 +31,7 @@ A string representing the rendered text content of an element.
 If the element itself is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the {{domxref("Node.textContent")}} property.
 
 > [!WARNING]
-> Setting `innerText` on a node removes _all_ of the node's children
-> and replaces them with a single text node with the given string value.
+> Setting `innerText` on a node removes _all_ of the node's children and replaces them with a single text node with the given string value.
 
 ## Examples
 
@@ -53,9 +59,9 @@ Note how `innerText` is aware of things like {{htmlElement("br")}} elements, and
   <span style="display:none">HIDDEN TEXT</span>
 </p>
 <h3>Result of textContent:</h3>
-<textarea id="textContentOutput" rows="6" cols="30" readonly>…</textarea>
+<textarea id="textContentOutput" rows="18" cols="40" readonly>…</textarea>
 <h3>Result of innerText:</h3>
-<textarea id="innerTextOutput" rows="6" cols="30" readonly>…</textarea>
+<textarea id="innerTextOutput" rows="6" cols="40" readonly>…</textarea>
 ```
 
 ### JavaScript
@@ -71,7 +77,7 @@ innerTextOutput.value = source.innerText;
 
 ### Result
 
-{{EmbedLiveSample("Examples", 700, 450)}}
+{{EmbedLiveSample("Examples", 700, 650)}}
 
 ## Specifications
 
@@ -83,5 +89,6 @@ innerTextOutput.value = source.innerText;
 
 ## See also
 
+- {{domxref("HTMLScriptElement.innerText")}}
 - {{domxref("HTMLElement.outerText")}}
 - {{domxref("Element.innerHTML")}}

--- a/files/en-us/web/api/htmlelement/innertext/index.md
+++ b/files/en-us/web/api/htmlelement/innertext/index.md
@@ -8,13 +8,6 @@ browser-compat: api.HTMLElement.innerText
 
 {{APIRef("HTML DOM")}}
 
-> [!WARNING]
-> This property represents the text content of a script element, which may be executable depending on the script type.
-> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks.
->
-> You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
-> See [Security considerations](#security_considerations) for more information.
-
 The **`innerText`** property of the {{domxref("HTMLElement")}} interface represents the rendered text content of a node and its descendants.
 
 As a getter, it approximates the text the user would get if they highlighted the contents of the element with the cursor and then copied it to the clipboard.

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -51,7 +51,6 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLScriptElement.text")}}
   - : A property that represents the inline text content of the {{HTMLElement("script")}} element.
     The property accepts either a {{domxref("TrustedScript")}} object or a string.
-    It returns a string that joins the contents of all {{domxref("Text")}} nodes inside the {{HTMLElement("script")}} element (ignoring other nodes like comments) in tree order.
     It acts the same way as the [textContent](#textcontent) property.
 - {{domxref("HTMLScriptElement.textContent")}}
   - : A property that represents the inline text content of the {{HTMLElement("script")}} element.

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -36,6 +36,9 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : A string; an obsolete way of registering event handlers on elements in an HTML document.
 - {{domxref("HTMLScriptElement.fetchPriority")}}
   - : An optional string representing a hint given to the browser on how it should prioritize fetching of an external script relative to other external scripts. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default). It reflects the `fetchpriority` attribute of the {{HTMLElement("script")}} element.
+- {{domxref("HTMLScriptElement.innerText")}}
+  - : A property that represents the inline text content of the {{HTMLElement("script")}} element as though it were rendered text.
+    The property accepts either a {{domxref("TrustedScript")}} object or a string.
 - {{domxref("HTMLScriptElement.integrity")}}
   - : A string that contains inline metadata that a browser can use to verify that a fetched resource has been delivered without unexpected manipulation. It reflects the `integrity` attribute of the {{HTMLElement("script")}} element.
 - {{domxref("HTMLScriptElement.noModule")}}

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -11,6 +11,9 @@ HTML {{HTMLElement("script")}} elements expose the **`HTMLScriptElement`** inter
 
 JavaScript files should be served with the `text/javascript` [MIME type](/en-US/docs/Web/HTTP/Guides/MIME_types), but browsers are lenient and block them only if the script is served with an image type (`image/*`), video type (`video/*`), audio type (`audio/*`), or `text/csv`. If the script is blocked, its element receives an {{domxref("HTMLElement/error_event", "error")}} event; otherwise, it receives a {{domxref("Window/load_event", "load")}} event.
 
+> [!NOTE]
+> When inserted using the {{domxref("Document.write()")}} method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using {{domxref("Element.innerHTML")}} or {{domxref("Element.outerHTML")}}, they do not execute at all.
+
 {{InheritanceDiagram}}
 
 ## Instance properties
@@ -40,15 +43,20 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLScriptElement.referrerPolicy")}}
   - : A string that reflects the [`referrerPolicy`](/en-US/docs/Web/HTML/Reference/Elements/script#referrerpolicy) HTML attribute indicating which referrer to use when fetching the script, and fetches done by that script.
 - {{domxref("HTMLScriptElement.src")}}
-  - : A string representing the URL of an external script; this can be used as an alternative to embedding a script directly within a document. It reflects the `src` attribute of the {{HTMLElement("script")}} element.
+  - : A string representing the URL of an external script; this can be used as an alternative to embedding a script directly within a document.
+    It reflects the `src` attribute of the {{HTMLElement("script")}} element.
 - {{domxref("HTMLScriptElement.text")}}
-  - : A string that joins and returns the contents of all {{domxref("Text")}} nodes inside the {{HTMLElement("script")}} element (ignoring other nodes like comments) in tree order. On setting, it acts the same way as the {{domxref("Node.textContent")}} property.
-
-    > [!NOTE]
-    > When inserted using the {{domxref("Document.write()")}} method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using {{domxref("Element.innerHTML")}} or {{domxref("Element.outerHTML")}}, they do not execute at all.
-
+  - : A property that represents the inline text content of the {{HTMLElement("script")}} element.
+    The property accepts either a {{domxref("TrustedScript")}} object or a string.
+    It returns a string that joins the contents of all {{domxref("Text")}} nodes inside the {{HTMLElement("script")}} element (ignoring other nodes like comments) in tree order.
+    It acts the same way as the [textContent](#textcontent) property.
+- {{domxref("HTMLScriptElement.textContent")}}
+  - : A property that represents the inline text content of the {{HTMLElement("script")}} element.
+    The property is redefined from {{domxref("Node/textContent","Node")}} to support {{domxref("TrustedScript")}} as an input.
+    On this element it behaves exactly like the [text](#text) property.
 - {{domxref("HTMLScriptElement.type")}}
-  - : A string representing the type of the script. It reflects the `type` attribute of the {{HTMLElement("script")}} element.
+  - : A string representing the type of the script.
+    It reflects the `type` attribute of the {{HTMLElement("script")}} element.
 
 ## Static methods
 

--- a/files/en-us/web/api/htmlscriptelement/innertext/index.md
+++ b/files/en-us/web/api/htmlscriptelement/innertext/index.md
@@ -1,9 +1,9 @@
 ---
-title: "HTMLScriptElement: text property"
-short-title: text
-slug: Web/API/HTMLScriptElement/text
+title: "HTMLScriptElement: innerText property"
+short-title: innerText
+slug: Web/API/HTMLScriptElement/innerText
 page-type: web-api-instance-property
-browser-compat: api.HTMLScriptElement.text
+browser-compat: api.HTMLScriptElement.innerText
 ---
 
 {{APIRef("HTML DOM")}}
@@ -15,42 +15,49 @@ browser-compat: api.HTMLScriptElement.text
 > You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 > See [Security considerations](#security_considerations) for more information.
 
-The **`text`** property of the {{domxref("HTMLScriptElement")}} interface represents the inline text content of the script element.
-It acts the same way as the {{domxref("HTMLScriptElement.textContent","textContent")}} property.
+The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element as though it were rendered text.
+
+The rendered string is [slightly different](#text_vs_textcontent_vs_innertext) to the raw string returned by {{domxref("HTMLScriptElement.text", "text")}} and {{domxref("HTMLScriptElement.textContent", "textContent")}} but the differences should not change script execution.
+
+The `innerText` property is also defined on {{domxref("HTMLElement.innerText","HTMLElement")}} and can hence be used with other elements.
+When used with other elements it does not expect or enforce the assignment of a {{domxref("TrustedScript")}}.
 
 ## Value
 
-Getting the property returns a string containing the element's text.
+Getting the property returns a string representing the rendered text content of an element.
+If the element is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the {{domxref("HTMLScriptElement.textContent","textContent")}} property.
 
 Setting the property accepts either a {{domxref("TrustedScript")}} object or a string.
 
 ## Description
 
-The **`text`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.
+The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element as though it were rendered text.
+
+When the property is set, the input is normalized the same way as any other element's `innerText` — whitespace is collapsed and `\n` is converted into line breaks.
+This produces the textual representation a user would obtain if a `<script>` element had visible rendering and they were to select its contents and copy them to the clipboard.
 
 For an executable script {{domxref('HTMLScriptElement/type','type')}}, such as a module or classic script, this text is inline executable code.
 For other types it might represent an import map, speculation rules, or some other kind of data block.
 
-Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `text` property is ignored.
+Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `innerText` property is ignored.
 
 ### `text` vs `textContent` vs `innerText`
 
-The `text` and {{domxref("HTMLScriptElement.textContent", "textContent")}} properties of `HTMLScriptElement` are equivalent: both can be set with a string or a `TrustedScript` type and both return a string representing the content of the script element.
+The {{domxref("HTMLScriptElement.text", "text")}} and {{domxref("HTMLScriptElement.textContent", "textContent")}} properties of `HTMLScriptElement` are equivalent: both can be set with a `TrustedScript` object or string, and both return a string representing the content of the script element exactly as it was written to the element.
 The main difference is that `textContent` is also defined on {{domxref("Node.textContent", "Node")}} and can be used with other elements to set their content with a string.
 
 {{domxref("HTMLScriptElement.innerText", "innerText")}} will generally set and execute the text in the same way as the other methods, but may return a slightly different value.
-The reason for this is that this property is designed for getting the rendered text of a string of HTML markup.
-When setting the value the text is treated as a text node, which normalizes the string as if it were visible text (collapsing spaces and converting `\n` to line breaks).
+The reason for this is that `innerText` is normalized when it is saved, collapsing spaces and converting `\n` to line breaks.
 This does not change the execution of the text, but it does alter the text that is stored and returned.
 
 ### Security considerations
 
-The `text` property is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
+The `innerText` property is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
 For example, the following example assumes the `scriptElement` is an executable `<script>` element, and that `untrustedCode` was provided by a user:
 
 ```js
 const untrustedCode = "alert('Potentially evil code!');";
-scriptElement.text = untrustedCode; // shows the alert
+scriptElement.innerText = untrustedCode; // shows the alert
 ```
 
 You can mitigate these issues by always assigning {{domxref("TrustedScript")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
@@ -64,7 +71,7 @@ If that is not possible, you might allow or block the use of certain functions w
 
 ### Using TrustedScript
 
-To mitigate the risk of XSS, we should always assign `TrustedScript` instances to the `text` property.
+To mitigate the risk of XSS, we should always assign `TrustedScript` instances to the `innerText` property.
 
 Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
 This acts as a transparent replacement for the trusted types JavaScript API:
@@ -110,26 +117,42 @@ const untrustedScriptOne = "const num = 10;\nconsole.log(num)";
 const trustedScript = policy.createScript(untrustedScriptOne);
 
 // Inject the TrustedScript (which contains a trusted string)
-el.text = trustedScript;
+el.innerText = trustedScript;
 ```
 
-### Comparing `text` and `textContent`
+### Comparing `innerText` to `textContent`
 
-In this example we'll set the value of a script element by assigning a string of code to the element's `text` property and `textContent` properties, and read the result back to show that the results are equivalent.
+This example compares `innerText` with {{domxref("HTMLScriptElement.textContent")}}.
+The result should be that `innerText` squashes any whitespace.
 
-Note that in this case we're not using the policy to create trusted scripts (for brevity we'll assume that the provided strings are trusted).
+#### HTML
+
+```html
+<h3>Source element:</h3>
+<script id="source">
+const num = 10;       console.log(num);
+const x = 5;
+</script>
+<h3>Result of textContent:</h3>
+<textarea id="textContentOutput" rows="6" cols="40" readonly>…</textarea>
+<h3>Result of innerText:</h3>
+<textarea id="innerTextOutput" rows="6" cols="40" readonly>…</textarea>
+```
+
+#### JavaScript
 
 ```js
-// Set the text property
-el.text = "const num = 10;\nconsole.log(num)";
-console.log(el.text); // Output: "const num = 10;\nconsole.log(num);"
-console.log(el.textContent); // Output: "const num = 10;\nconsole.log(num);"
+const source = document.getElementById("source");
+const textContentOutput = document.getElementById("textContentOutput");
+const innerTextOutput = document.getElementById("innerTextOutput");
 
-// Set the textContent property
-el.textContent = "console.log(10);";
-console.log(el.text); // Output: "console.log(10);"
-console.log(el.textContent); // Output: "console.log(10);"
+textContentOutput.value = source.textContent;
+innerTextOutput.value = source.innerText;
 ```
+
+#### Result
+
+{{EmbedLiveSample("Examples", 700, 450)}}
 
 ## Specifications
 
@@ -141,5 +164,4 @@ console.log(el.textContent); // Output: "console.log(10);"
 
 ## See also
 
-- {{domxref("HTMLScriptElement.textContent")}}
-- {{domxref("HTMLScriptElement.innerText")}}
+- {{domxref("HTMLElement.innerText")}}

--- a/files/en-us/web/api/htmlscriptelement/innertext/index.md
+++ b/files/en-us/web/api/htmlscriptelement/innertext/index.md
@@ -15,144 +15,39 @@ browser-compat: api.HTMLScriptElement.innerText
 > You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 > See [Security considerations](#security_considerations) for more information.
 
-The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element as though it were rendered text.
-
-The rendered string is [slightly different](#text_vs_textcontent_vs_innertext) to the raw string returned by {{domxref("HTMLScriptElement.text", "text")}} and {{domxref("HTMLScriptElement.textContent", "textContent")}} but the differences should not change script execution.
-
-The `innerText` property is also defined on {{domxref("HTMLElement.innerText","HTMLElement")}} and can hence be used with other elements.
-When used with other elements it does not expect or enforce the assignment of a {{domxref("TrustedScript")}}.
+The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content of the {{HTMLElement("script")}} element.
+It behaves in the same way as the {{domxref("HTMLScriptElement.textContent","textContent")}} and {{domxref("HTMLScriptElement.text","text")}} properties.
 
 ## Value
 
-Getting the property returns a string representing the rendered text content of an element.
-If the element is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the {{domxref("HTMLScriptElement.textContent","textContent")}} property.
+Getting the property returns a string containing the scripts's text.
 
 Setting the property accepts either a {{domxref("TrustedScript")}} object or a string.
 
+### Exceptions
+
+- `TypeError`
+  - : Thrown if the property is set to a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
+
 ## Description
 
-The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element as though it were rendered text.
-
-When the property is set, the input is normalized the same way as any other element's `innerText` — whitespace is collapsed and `\n` is converted into line breaks.
-This produces the textual representation a user would obtain if a `<script>` element had visible rendering and they were to select its contents and copy them to the clipboard.
+The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.
 
 For an executable script {{domxref('HTMLScriptElement/type','type')}}, such as a module or classic script, this text is inline executable code.
 For other types it might represent an import map, speculation rules, or some other kind of data block.
 
 Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `innerText` property is ignored.
 
-### `text` vs `textContent` vs `innerText`
-
-The {{domxref("HTMLScriptElement.text", "text")}} and {{domxref("HTMLScriptElement.textContent", "textContent")}} properties of `HTMLScriptElement` are equivalent: both can be set with a `TrustedScript` object or string, and both return a string representing the content of the script element exactly as it was written to the element.
-The main difference is that `textContent` is also defined on {{domxref("Node.textContent", "Node")}} and can be used with other elements to set their content with a string.
-
-{{domxref("HTMLScriptElement.innerText", "innerText")}} will generally set and execute the text in the same way as the other methods, but may return a slightly different value.
-The reason for this is that `innerText` is normalized when it is saved, collapsing spaces and converting `\n` to line breaks.
-This does not change the execution of the text, but it does alter the text that is stored and returned.
+The `innerText` property is also defined on {{domxref("HTMLElement.innerText","HTMLElement")}} and can hence be used with other elements.
+When used with other elements, the property does not expect or enforce the assignment of a {{domxref("TrustedScript")}}.
 
 ### Security considerations
 
-The `innerText` property is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
-For example, the following example assumes the `scriptElement` is an executable `<script>` element, and that `untrustedCode` was provided by a user:
-
-```js
-const untrustedCode = "alert('Potentially evil code!');";
-scriptElement.innerText = untrustedCode; // shows the alert
-```
-
-You can mitigate these issues by always assigning {{domxref("TrustedScript")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
-This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) or reject the text before it is injected.
-
-The behavior of the transformation function will depend on the specific use case that requires a user provided script.
-If possible you should lock the allowed scripts to exactly the code that you trust to run.
-If that is not possible, you might allow or block the use of certain functions within the provided string.
+See [security considerations](/en-US/docs/Web/API/HTMLScriptElement/textContent#security_considerations) in {{domxref("HTMLScriptElement.textContent")}} (the considerations are the same for `text`, `textContent` and `innerText` properties).
 
 ## Examples
 
-### Using TrustedScript
-
-To mitigate the risk of XSS, we should always assign `TrustedScript` instances to the `innerText` property.
-
-Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
-
-```js
-if (typeof trustedTypes === "undefined")
-  trustedTypes = { createPolicy: (n, rules) => rules };
-```
-
-Next we create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createScript", "createScript()")}} method for transforming input strings into {{domxref("TrustedScript")}} instances.
-For the purpose of this example we'll allow just exactly the script that we need.
-
-```js
-const policy = trustedTypes.createPolicy("inline-script-policy", {
-  createScript(input) {
-    // Here specify what scripts are safe to allow
-    if (input === "const num = 10;\nconsole.log(num)") {
-      return input; // allow this exact script
-    }
-    throw new TypeError(`Untrusted script blocked: ${input}`);
-  },
-});
-```
-
-Next we'll create the script element to which we will assign the value and get a handle to the element.
-
-```html
-<script id="el" type="text/javascript"></script>
-```
-
-```js
-// Get the script element we're injecting the code into
-const el = document.getElementById("el");
-```
-
-Then we use the `policy` object to create a `trustedScript` object from the potentially unsafe input string, and assign the result to the element:
-
-```js
-// The potentially malicious string
-const untrustedScriptOne = "const num = 10;\nconsole.log(num)";
-
-// Create a TrustedScript instance using the policy
-const trustedScript = policy.createScript(untrustedScriptOne);
-
-// Inject the TrustedScript (which contains a trusted string)
-el.innerText = trustedScript;
-```
-
-### Comparing `innerText` to `textContent`
-
-This example compares `innerText` with {{domxref("HTMLScriptElement.textContent")}}.
-The result should be that `innerText` squashes any whitespace.
-
-#### HTML
-
-```html
-<h3>Source element:</h3>
-<script id="source">
-const num = 10;       console.log(num);
-const x = 5;
-</script>
-<h3>Result of textContent:</h3>
-<textarea id="textContentOutput" rows="6" cols="40" readonly>…</textarea>
-<h3>Result of innerText:</h3>
-<textarea id="innerTextOutput" rows="6" cols="40" readonly>…</textarea>
-```
-
-#### JavaScript
-
-```js
-const source = document.getElementById("source");
-const textContentOutput = document.getElementById("textContentOutput");
-const innerTextOutput = document.getElementById("innerTextOutput");
-
-textContentOutput.value = source.textContent;
-innerTextOutput.value = source.innerText;
-```
-
-#### Result
-
-{{EmbedLiveSample("Examples", 700, 450)}}
+See the [Examples](/en-US/docs/Web/API/HTMLScriptElement/textContent#examples) in {{domxref("HTMLScriptElement.textContent")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlscriptelement/innertext/index.md
+++ b/files/en-us/web/api/htmlscriptelement/innertext/index.md
@@ -33,7 +33,7 @@ Setting the property accepts either a {{domxref("TrustedScript")}} object or a s
 
 The **`innerText`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.
 
-For an executable script {{domxref('HTMLScriptElement/type','type')}}, such as a module or classic script, this text is inline executable code.
+For an executable script (that is, a script whose {{domxref('HTMLScriptElement/type','type')}} indicates that it is a module or classic script), this text is inline executable code.
 For other types it might represent an import map, speculation rules, or some other kind of data block.
 
 Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `innerText` property is ignored.

--- a/files/en-us/web/api/htmlscriptelement/innertext/index.md
+++ b/files/en-us/web/api/htmlscriptelement/innertext/index.md
@@ -47,7 +47,7 @@ See [security considerations](/en-US/docs/Web/API/HTMLScriptElement/textContent#
 
 ## Examples
 
-See the [Examples](/en-US/docs/Web/API/HTMLScriptElement/textContent#examples) in {{domxref("HTMLScriptElement.textContent")}}.
+See the [examples](/en-US/docs/Web/API/HTMLScriptElement/textContent#examples) in {{domxref("HTMLScriptElement.textContent")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlscriptelement/text/index.md
+++ b/files/en-us/web/api/htmlscriptelement/text/index.md
@@ -44,7 +44,7 @@ See [security considerations](/en-US/docs/Web/API/HTMLScriptElement/textContent#
 
 ## Examples
 
-See the [Examples](/en-US/docs/Web/API/HTMLScriptElement/textContent#examples) in {{domxref("HTMLScriptElement.textContent")}}.
+See the [examples](/en-US/docs/Web/API/HTMLScriptElement/textContent#examples) in {{domxref("HTMLScriptElement.textContent")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlscriptelement/text/index.md
+++ b/files/en-us/web/api/htmlscriptelement/text/index.md
@@ -33,7 +33,7 @@ Setting the property accepts either a {{domxref("TrustedScript")}} object or a s
 
 The **`text`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.
 
-For an executable script {{domxref('HTMLScriptElement/type','type')}}, such as a module or classic script, this text is inline executable code.
+For an executable script (that is, a script whose {{domxref('HTMLScriptElement/type','type')}} indicates that it is a module or classic script), this text is inline executable code.
 For other types it might represent an import map, speculation rules, or some other kind of data block.
 
 Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `text` property is ignored.

--- a/files/en-us/web/api/htmlscriptelement/text/index.md
+++ b/files/en-us/web/api/htmlscriptelement/text/index.md
@@ -15,14 +15,19 @@ browser-compat: api.HTMLScriptElement.text
 > You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 > See [Security considerations](#security_considerations) for more information.
 
-The **`text`** property of the {{domxref("HTMLScriptElement")}} interface represents the inline text content of the script element.
-It acts the same way as the {{domxref("HTMLScriptElement.textContent","textContent")}} property.
+The **`text`** property of the {{domxref("HTMLScriptElement")}} interface represents the inline text content of the {{HTMLElement("script")}} element.
+It behaves in the same way as the {{domxref("HTMLScriptElement.textContent","textContent")}} and {{domxref("HTMLScriptElement.innerText","innerText")}} property.
 
 ## Value
 
-Getting the property returns a string containing the element's text.
+Getting the property returns a string containing the script's text.
 
 Setting the property accepts either a {{domxref("TrustedScript")}} object or a string.
+
+### Exceptions
+
+- `TypeError`
+  - : Thrown if the property is set to a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
 
 ## Description
 
@@ -33,103 +38,13 @@ For other types it might represent an import map, speculation rules, or some oth
 
 Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `text` property is ignored.
 
-### `text` vs `textContent` vs `innerText`
-
-The `text` and {{domxref("HTMLScriptElement.textContent", "textContent")}} properties of `HTMLScriptElement` are equivalent: both can be set with a string or a `TrustedScript` type and both return a string representing the content of the script element.
-The main difference is that `textContent` is also defined on {{domxref("Node.textContent", "Node")}} and can be used with other elements to set their content with a string.
-
-{{domxref("HTMLScriptElement.innerText", "innerText")}} will generally set and execute the text in the same way as the other methods, but may return a slightly different value.
-The reason for this is that this property is designed for getting the rendered text of a string of HTML markup.
-When setting the value the text is treated as a text node, which normalizes the string as if it were visible text (collapsing spaces and converting `\n` to line breaks).
-This does not change the execution of the text, but it does alter the text that is stored and returned.
-
 ### Security considerations
 
-The `text` property is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
-For example, the following example assumes the `scriptElement` is an executable `<script>` element, and that `untrustedCode` was provided by a user:
-
-```js
-const untrustedCode = "alert('Potentially evil code!');";
-scriptElement.text = untrustedCode; // shows the alert
-```
-
-You can mitigate these issues by always assigning {{domxref("TrustedScript")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
-This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) or reject the text before it is injected.
-
-The behavior of the transformation function will depend on the specific use case that requires a user provided script.
-If possible you should lock the allowed scripts to exactly the code that you trust to run.
-If that is not possible, you might allow or block the use of certain functions within the provided string.
+See [security considerations](/en-US/docs/Web/API/HTMLScriptElement/textContent#security_considerations) in {{domxref("HTMLScriptElement.textContent")}} (the considerations are the same for `text`, `textContent` and `innerText` properties).
 
 ## Examples
 
-### Using TrustedScript
-
-To mitigate the risk of XSS, we should always assign `TrustedScript` instances to the `text` property.
-
-Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
-
-```js
-if (typeof trustedTypes === "undefined")
-  trustedTypes = { createPolicy: (n, rules) => rules };
-```
-
-Next we create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createScript", "createScript()")}} method for transforming input strings into {{domxref("TrustedScript")}} instances.
-For the purpose of this example we'll allow just exactly the script that we need.
-
-```js
-const policy = trustedTypes.createPolicy("inline-script-policy", {
-  createScript(input) {
-    // Here specify what scripts are safe to allow
-    if (input === "const num = 10;\nconsole.log(num)") {
-      return input; // allow this exact script
-    }
-    throw new TypeError(`Untrusted script blocked: ${input}`);
-  },
-});
-```
-
-Next we'll create the script element to which we will assign the value and get a handle to the element.
-
-```html
-<script id="el" type="text/javascript"></script>
-```
-
-```js
-// Get the script element we're injecting the code into
-const el = document.getElementById("el");
-```
-
-Then we use the `policy` object to create a `trustedScript` object from the potentially unsafe input string, and assign the result to the element:
-
-```js
-// The potentially malicious string
-const untrustedScriptOne = "const num = 10;\nconsole.log(num)";
-
-// Create a TrustedScript instance using the policy
-const trustedScript = policy.createScript(untrustedScriptOne);
-
-// Inject the TrustedScript (which contains a trusted string)
-el.text = trustedScript;
-```
-
-### Comparing `text` and `textContent`
-
-In this example we'll set the value of a script element by assigning a string of code to the element's `text` property and `textContent` properties, and read the result back to show that the results are equivalent.
-
-Note that in this case we're not using the policy to create trusted scripts (for brevity we'll assume that the provided strings are trusted).
-
-```js
-// Set the text property
-el.text = "const num = 10;\nconsole.log(num)";
-console.log(el.text); // Output: "const num = 10;\nconsole.log(num);"
-console.log(el.textContent); // Output: "const num = 10;\nconsole.log(num);"
-
-// Set the textContent property
-el.textContent = "console.log(10);";
-console.log(el.text); // Output: "console.log(10);"
-console.log(el.textContent); // Output: "console.log(10);"
-```
+See the [Examples](/en-US/docs/Web/API/HTMLScriptElement/textContent#examples) in {{domxref("HTMLScriptElement.textContent")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlscriptelement/textcontent/index.md
+++ b/files/en-us/web/api/htmlscriptelement/textcontent/index.md
@@ -24,6 +24,11 @@ Getting the property returns a string containing the script's text.
 
 Setting the property accepts either a {{domxref("TrustedScript")}} object or a string.
 
+### Exceptions
+
+- `TypeError`
+  - : Thrown if the property is set to a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
+
 ## Description
 
 The **`textContent`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.

--- a/files/en-us/web/api/htmlscriptelement/textcontent/index.md
+++ b/files/en-us/web/api/htmlscriptelement/textcontent/index.md
@@ -15,15 +15,12 @@ browser-compat: api.HTMLScriptElement.textContent
 > You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 > See [Security considerations](#security_considerations) for more information.
 
-The **`textContent`** property of the {{domxref("HTMLScriptElement")}} interface represents the inline text content of the script element.
-It acts the same way as the {{domxref("HTMLScriptElement.text","text")}} property.
-
-The `textContent` property is also defined on {{domxref("Node.textContent","Node")}} and can hence be used with other elements.
-When used with other elements it does not expect or enforce the assignment of a {{domxref("TrustedScript")}}.
+The **`textContent`** property of the {{domxref("HTMLScriptElement")}} interface represents the inline text content of the {{HTMLElement("script")}} element.
+It behaves in the same way as the {{domxref("HTMLScriptElement.text","text")}} and {{domxref("HTMLScriptElement.innerText","innerText")}} properties.
 
 ## Value
 
-Getting the property returns a string containing the element's text.
+Getting the property returns a string containing the script's text.
 
 Setting the property accepts either a {{domxref("TrustedScript")}} object or a string.
 
@@ -36,19 +33,12 @@ For other types it might represent an import map, speculation rules, or some oth
 
 Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `textContent` property is ignored.
 
-### `text` vs `textContent` vs `innerText`
-
-The `text` and {{domxref("HTMLScriptElement.textContent", "textContent")}} properties of `HTMLScriptElement` are equivalent: both can be set with a `TrustedScript`object or string, and both return a string representing the content of the script element exactly as it was written to the element.
-The main difference is that `textContent` is also defined on {{domxref("Node.textContent", "Node")}}, and can be used with other elements to set their content with a string.
-
-{{domxref("HTMLScriptElement.innerText", "innerText")}} will generally set and execute the text in the same way as the other methods, but may return a slightly different value.
-The reason for this is that `innerText` is designed for getting the rendered text of a string of HTML markup.
-When setting the value the text is treated as a text node, which normalizes the string as though the `<script>` element could contain visible text (collapsing spaces and converting `\n` to line breaks).
-This does not change the execution of the text, but it does alter the text that is stored and returned.
+The `textContent` property is also defined on {{domxref("Node.textContent","Node")}} and can hence be used with other nodes (and elements).
+When used with other elements it does not expect or enforce the assignment of a {{domxref("TrustedScript")}}.
 
 ### Security considerations
 
-The `textContent` property is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
+The `textContent` property — and identical `text` and `innerText` properties — are a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
 For example, the following example assumes the `scriptElement` is an executable `<script>` element, and that `untrustedCode` was provided by a user:
 
 ```js
@@ -116,6 +106,32 @@ const trustedScript = policy.createScript(untrustedScriptOne);
 el.textContent = trustedScript;
 ```
 
+### Comparing `textContent`, `text` and `innerText`
+
+This example demonstrates that assigning a script to each of the text properties, such as `textContent`, results in the same value being read from all of the text properties.
+
+Note that in this case we're not using the policy to create trusted scripts (for brevity we'll assume that the provided strings are trusted).
+
+```js
+// Set the textContent property
+el.textContent = "console.log(10);";
+console.log(`textContent: ${el.textContent}`); // "textContent: console.log(10);"
+console.log(`text: ${el.text}`); // "text: console.log(10);"
+console.log(`innerText: ${el.innerText}`); // "innerText: console.log(10);"
+
+// Set the text property
+el.text = "const num = 10;\nconsole.log(num)";
+console.log(`textContent: ${el.textContent}`); // textContent: const num = 10; console.log(num)"
+console.log(`text: ${el.text}`); // "text: const num = 10; console.log(num)"
+console.log(`innerText: ${el.innerText}`); // "innerText: const num = 10; console.log(num)"
+
+// Set the innerText property
+el.innerText = "const num = 10;alert('Help')";
+console.log(`textContent: ${el.textContent}`); // textContent: const num = 10;alert('Help')"
+console.log(`text: ${el.text}`); // "text: const num = 10;alert('Help')"
+console.log(`innerText: ${el.innerText}`); // "innerText: const num = 10;alert('Help')"
+```
+
 ## Specifications
 
 {{Specifications}}
@@ -126,5 +142,5 @@ el.textContent = trustedScript;
 
 ## See also
 
-- {{domxref("HTMLElement.innerText")}}
-- {{domxref("Element.innerHTML")}}
+- {{domxref("HTMLScriptElement.text","text")}}
+- {{domxref("HTMLScriptElement.innerText","innerText")}}

--- a/files/en-us/web/api/htmlscriptelement/textcontent/index.md
+++ b/files/en-us/web/api/htmlscriptelement/textcontent/index.md
@@ -33,7 +33,7 @@ Setting the property accepts either a {{domxref("TrustedScript")}} object or a s
 
 The **`textContent`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.
 
-For an executable script {{domxref('HTMLScriptElement/type','type')}}, such as a module or classic script, this text is inline executable code.
+For an executable script (that is, a script whose {{domxref('HTMLScriptElement/type','type')}} indicates that it is a module or classic script), this text is inline executable code.
 For other types it might represent an import map, speculation rules, or some other kind of data block.
 
 Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `textContent` property is ignored.
@@ -51,7 +51,7 @@ const untrustedCode = "alert('Potentially evil code!');";
 scriptElement.textContent = untrustedCode; // shows the alert
 ```
 
-You can mitigate these issues by always assigning {{domxref("TrustedScript")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+You can mitigate these issues by always assigning {{domxref("TrustedScript")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) or reject the text before it is injected.
 
 The behavior of the transformation function will depend on the specific use case that requires a user provided script.

--- a/files/en-us/web/api/htmlscriptelement/textcontent/index.md
+++ b/files/en-us/web/api/htmlscriptelement/textcontent/index.md
@@ -65,7 +65,7 @@ If that is not possible, you might allow or block the use of certain functions w
 To mitigate the risk of XSS, we should always assign `TrustedScript` instances to the `textContent` property.
 
 Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
+This acts as a transparent replacement for the Trusted Types JavaScript API:
 
 ```js
 if (typeof trustedTypes === "undefined")

--- a/files/en-us/web/api/htmlscriptelement/textcontent/index.md
+++ b/files/en-us/web/api/htmlscriptelement/textcontent/index.md
@@ -120,21 +120,39 @@ Note that in this case we're not using the policy to create trusted scripts (for
 ```js
 // Set the textContent property
 el.textContent = "console.log(10);";
-console.log(`textContent: ${el.textContent}`); // "textContent: console.log(10);"
-console.log(`text: ${el.text}`); // "text: console.log(10);"
-console.log(`innerText: ${el.innerText}`); // "innerText: console.log(10);"
+
+console.log(`textContent: ${el.textContent}`);
+// "textContent: console.log(10);"
+
+console.log(`text: ${el.text}`);
+// "text: console.log(10);"
+
+console.log(`innerText: ${el.innerText}`);
+// "innerText: console.log(10);"
 
 // Set the text property
 el.text = "const num = 10;\nconsole.log(num)";
-console.log(`textContent: ${el.textContent}`); // textContent: const num = 10; console.log(num)"
-console.log(`text: ${el.text}`); // "text: const num = 10; console.log(num)"
-console.log(`innerText: ${el.innerText}`); // "innerText: const num = 10; console.log(num)"
+
+console.log(`textContent: ${el.textContent}`);
+// textContent: const num = 10; console.log(num)"
+
+console.log(`text: ${el.text}`);
+// "text: const num = 10; console.log(num)"
+
+console.log(`innerText: ${el.innerText}`);
+// "innerText: const num = 10; console.log(num)"
 
 // Set the innerText property
 el.innerText = "const num = 10;alert('Help')";
-console.log(`textContent: ${el.textContent}`); // textContent: const num = 10;alert('Help')"
-console.log(`text: ${el.text}`); // "text: const num = 10;alert('Help')"
-console.log(`innerText: ${el.innerText}`); // "innerText: const num = 10;alert('Help')"
+
+console.log(`textContent: ${el.textContent}`);
+// textContent: const num = 10;alert('Help')"
+
+console.log(`text: ${el.text}`);
+// "text: const num = 10;alert('Help')"
+
+console.log(`innerText: ${el.innerText}`);
+// "innerText: const num = 10;alert('Help')"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlscriptelement/textcontent/index.md
+++ b/files/en-us/web/api/htmlscriptelement/textcontent/index.md
@@ -1,0 +1,82 @@
+---
+title: "HTMLScriptElement: textContent property"
+short-title: textContent
+slug: Web/API/HTMLScriptElement/textContent
+page-type: web-api-instance-property
+browser-compat: api.HTMLScriptElement.textContent
+---
+
+{{APIRef("DOM")}}
+
+> [!WARNING]
+> This property represents the text content of a script element, which may be executable depending on the script type.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks.
+>
+> You can mitigate this risk by always assigning {{domxref("TrustedScript")}} objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
+> See [Security considerations](#security_considerations) for more information.
+
+The **`textContent`** property of the {{domxref("HTMLScriptElement")}} interface represents the inline text content of the script element.
+It acts the same way as the {{domxref("HTMLScriptElement.text","text")}} property.
+
+The `textContent` property is also defined on {{domxref("Node.textContent","Node")}} and can hence be used with other elements.
+When used with other elements it does not expect or enforce the assignment of a {{domxref("TrustedScript")}}.
+It is also different in that a {{domxref("HTMLScriptElement")}} is not expected to contain other elements, and will parse input as plain text rather than as HTML markup.
+
+## Value
+
+Getting the property returns a string containing the element's text.
+
+Setting the property accepts either a {{domxref("TrustedScript")}} object or a string.
+
+## Description
+
+The **`textContent`** property of the {{domxref("HTMLScriptElement")}} interface represents the text content inside the {{HTMLElement("script")}} element.
+
+For an executable script {{domxref('HTMLScriptElement/type','type')}}, such as a module or classic script, this text is inline executable code.
+For other types it might represent an import map, speculation rules, or some other kind of data block.
+
+Note that if the {{domxref('HTMLScriptElement/src','src')}} property is set the content of the `textContent` property is ignored.
+
+### `text` vs `textContent` vs `innerText`
+
+The `text` and {{domxref("HTMLScriptElement.textContent", "textContent")}} properties of `HTMLScriptElement` are equivalent: both can be set with a string or a `TrustedScript` type and both return a string representing the content of the script element.
+The main difference is that {{domxref("Node.textContent", "textContent")}} is also defined on {{domxref("Node")}} and can be used with other elements to set their content with a string.
+
+{{domxref("HTMLScriptElement.innerText", "innerText")}} will generally set and execute the text in the same way as the other methods, but may return a slightly different value.
+The reason for this is that this property is designed for getting the rendered text of a string of HTML markup.
+When setting the value the text is treated as a text node, which normalizes the string as if it were visible text (collapsing spaces and converting `\n` to line breaks).
+This does not change the execution of the text, but it does alter the text that is stored and returned.
+
+### Security considerations
+
+The `textContent` property is a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe strings provided by a user are executed.
+For example, the following example assumes the `scriptElement` is an executable `<script>` element, and that `untrustedCode` was provided by a user:
+
+```js
+const untrustedCode = "alert('Potentially evil code!');";
+scriptElement.textContent = untrustedCode; // shows the alert
+```
+
+You can mitigate these issues by always assigning {{domxref("TrustedScript")}} objects instead of strings, and [enforcing trusted type](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) or reject the text before it is injected.
+
+The behavior of the transformation function will depend on the specific use case that requires a user provided script.
+If possible you should lock the allowed scripts to exactly the code that you trust to run.
+If that is not possible, you might allow or block the use of certain functions within the provided string.
+
+## Examples
+
+See [Examples](/en-US/docs/Web/API/HTMLScriptElement/text) in {{domxref("HTMLScriptElement")}} (the behaviour is the same).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLElement.innerText")}}
+- {{domxref("Element.innerHTML")}}

--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -8,52 +8,33 @@ browser-compat: api.Node.textContent
 
 {{APIRef("DOM")}}
 
-The **`textContent`** property of the {{domxref("Node")}}
-interface represents the text content of the node and its descendants.
+The **`textContent`** property of the {{domxref("Node")}} interface represents the text content of the node and its descendants.
 
 > [!NOTE]
-> `textContent` and {{domxref("HTMLElement.innerText")}} are easily confused,
-> but the two properties are [different in important ways](#differences_from_innertext).
+> `textContent` and {{domxref("HTMLElement.innerText")}} are easily confused, but the two properties are [different in important ways](#differences_from_innertext).
 
 ## Value
 
 A string, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). Its value depends on the situation:
 
-- If the node is a {{domxref("document")}} or a {{glossary("doctype")}},
-  `textContent` returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+- If the node is a {{domxref("document")}} or a {{glossary("doctype")}}, `textContent` returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
   > [!NOTE]
-  > To get _all_ of the text and [CDATA data](/en-US/docs/Web/API/CDATASection) for the whole
-  > document, use `document.documentElement.textContent`.
+  > To get _all_ of the text and [CDATA data](/en-US/docs/Web/API/CDATASection) for the whole document, use `document.documentElement.textContent`.
 
-- If the node is a [CDATA section](/en-US/docs/Web/API/CDATASection),
-  a comment, a [processing instruction](/en-US/docs/Web/API/ProcessingInstruction),
-  or a [text node](/en-US/docs/Web/API/Text),
-  `textContent` returns, or sets, the text inside the node,
-  i.e., the {{domxref("Node.nodeValue")}}.
-- For other node types, `textContent` returns the concatenation of the
-  `textContent` of every child node, excluding comments and processing
-  instructions. (This is an empty string if the node has no children.)
+- If the node is a [CDATA section](/en-US/docs/Web/API/CDATASection), a comment, a [processing instruction](/en-US/docs/Web/API/ProcessingInstruction), or a [text node](/en-US/docs/Web/API/Text), `textContent` returns, or sets, the text inside the node, i.e., the {{domxref("Node.nodeValue")}}.
+- For other node types, `textContent` returns the concatenation of the `textContent` of every child node, excluding comments and processing instructions. (This is an empty string if the node has no children.)
 
 > [!WARNING]
-> Setting `textContent` on a node removes _all_ of the node's children
-> and replaces them with a single text node with the given string value.
+> Setting `textContent` on a node removes _all_ of the node's children and replaces them with a single text node with the given string value.
 
 ### Differences from innerText
 
-Don't get confused by the differences between `Node.textContent` and
-{{domxref("HTMLElement.innerText")}}. Although the names seem similar, there are
-important differences:
+Don't get confused by the differences between `Node.textContent` and {{domxref("HTMLElement.innerText")}}. Although the names seem similar, there are important differences:
 
-- `textContent` gets the content of _all_ elements, including
-  {{HTMLElement("script")}} and {{HTMLElement("style")}} elements. In contrast,
-  `innerText` only shows "human-readable" elements.
-- `textContent` returns every element in the node. In contrast,
-  `innerText` is aware of styling and won't return the text of "hidden"
-  elements.
-  - Moreover, since `innerText` takes CSS styles into account,
-    reading the value of `innerText` triggers a
-    {{glossary("reflow")}} to ensure up-to-date computed styles. (Reflows can
+- `textContent` gets the content of _all_ elements, including {{HTMLElement("script")}} and {{HTMLElement("style")}} elements. In contrast, `innerText` only shows "human-readable" elements.
+- `textContent` returns every element in the node. In contrast, `innerText` is aware of styling and won't return the text of "hidden" elements.
+  - Moreover, since `innerText` takes CSS styles into account, reading the value of `innerText` triggers a {{glossary("reflow")}} to ensure up-to-date computed styles. (Reflows can
     be computationally expensive, and thus should be avoided when possible.)
 
 ### Differences from innerHTML
@@ -93,5 +74,6 @@ document.getElementById("divA").textContent = "This text is different!";
 
 ## See also
 
+- {{domxref("HTMLScriptElement.textContent")}} and {{domxref("HTMLScriptElement.text")}}
 - {{domxref("HTMLElement.innerText")}}
 - {{domxref("Element.innerHTML")}}

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -127,7 +127,7 @@ shadow.setHTMLUnsafe(input, { sanitizer: configLessSafe });
 
 To mitigate the risk of XSS, we'll first create a `TrustedHTML` object from the string containing the HTML, and then pass that object to `setHTMLUnsafe()`.
 Since trusted types are not yet supported on all browsers, we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
-This acts as a transparent replacement for the trusted types JavaScript API:
+This acts as a transparent replacement for the Trusted Types JavaScript API:
 
 ```js
 if (typeof trustedTypes === "undefined")


### PR DESCRIPTION
This updates the TrustedType documentation for `HTMLScriptElement.textContent` so that it includes boilerplate and security considerations.

These was inherited from node but is now in IDL - see https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts

Note that this essentially copies [`HTMLScriptElement.text`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/text) which was updated in #41128. The only minor difference is the note about the fact it is also defined on Node and so can be used with other elements.

Project tracking in #37518
