### PR TITLE
firefox datetime-local time-picker

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -49,6 +49,20 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/R
 - `layout.forms.reveal-password-button.enabled`
   - : Set to `true` to enable.
 
+### Time picker for datetime-local input field
+
+HTML datetime-local input elements ([`<input type="datetime-local">`](/en-US/docs/Web/HTML/Reference/Elements/input/datetime-local)) now includes a time picker ([Firefox bug 1726108](https://bugzil.la/1726108)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 144           | No                  |
+| Developer Edition | 144           | No                  |
+| Beta              | 144           | No                  |
+| Release           | 144           | No                  |
+
+- `layout.forms.reveal-password-button.enabled`
+  - : Set to `true` to enable.
+
 ## CSS
 
 ### Hex boxes to display stray control characters

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -60,7 +60,7 @@ HTML datetime-local input elements ([`<input type="datetime-local">`](/en-US/doc
 | Beta              | 144           | No                  |
 | Release           | 144           | No                  |
 
-- `layout.forms.reveal-password-button.enabled`
+- `dom.forms.datetime.timepicker`
   - : Set to `true` to enable.
 
 ## CSS

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -113,3 +113,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 These features are shipping in Firefox 144 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+- **datetime-local time picker:** `dom.forms.datetime.timepicker`.
+
+  HTML datetime-local input elements ([`<input type="datetime-local">`](/en-US/docs/Web/HTML/Reference/Elements/input/datetime-local)) now includes a time picker ([Firefox bug 1726108](https://bugzil.la/1726108)).


### PR DESCRIPTION
### Description

- Added experimental release note for `datetime-local` time-picker and flag details
- Added 144 experimental release  for `datetime-local` time-picker

### Motivation

- Working on [MDN issue #41140](https://github.com/mdn/content/issues/41140)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/28051)