### PR TITLE
tab widget example - update color of focused tabpanel border

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/roles/tab_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/tab_role/index.md
@@ -170,8 +170,8 @@ There is some basic styling applied that restyles the buttons and changes the [`
 }
 
 [role="tabpanel"]:focus {
-  border-color: orange;
-  outline: 1px solid orange;
+  border-color: #356FB3;
+  outline: 1px solid #356FB3;
 }
 ```
 

--- a/files/en-us/web/accessibility/aria/reference/roles/tab_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/tab_role/index.md
@@ -170,8 +170,8 @@ There is some basic styling applied that restyles the buttons and changes the [`
 }
 
 [role="tabpanel"]:focus {
-  border-color: #356FB3;
-  outline: 1px solid #356FB3;
+  border-color: #356fb3;
+  outline: 1px solid #356fb3;
 }
 ```
 


### PR DESCRIPTION
Updated the focus style for when a tabpanel receives focus.  the previous color was orange, but that did not pass minimum non-text contrast.  i just arbitrarily picked the new color because it does pass contrast against the white background, and it had more than a 3:1 ratio compared to the non-focused border color, so it'd still generally be a noticeable change.
