### PR TITLE
Generic syntax

### DIFF
--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -78,7 +78,6 @@ font-family: ui-serif;
 font-family: ui-sans-serif;
 font-family: ui-monospace;
 font-family: ui-rounded;
-font-family: emoji;
 font-family: math;
 font-family: fangsong;
 
@@ -146,10 +145,11 @@ font-family: "Gill Sans Extrabold", sans-serif;
       - : The default user interface font that has rounded features.
     - `math`
       - : This is for the particular stylistic concerns of representing mathematics: superscript and subscript, brackets that cross several lines, nesting expressions, and double struck glyphs with distinct meanings.
-    - `emoji`
-      - : Fonts that are specifically designed to render emoji.
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
+
+> [!NOTE]
+> `font-family: emoji` is not a standard or supported value. To control emoji presentation, use the {{CSSxRef("font-variant-emoji")}} property instead.
 
 ## Formal definition
 
@@ -184,10 +184,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
   font-family: fantasy;
 }
 
-.emoji {
-  font-family: emoji;
-}
-
 .math {
   font-family: math;
 }
@@ -209,8 +205,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
 <div class="fantasy">This is an example of a fantasy font.</div>
 
 <div class="math">This is an example of a math font.</div>
-
-<div class="emoji">This is an example of an emoji font.</div>
 
 <div class="fangsong">This is an example of a fangsong font.</div>
 ```

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -81,6 +81,20 @@ font-family: ui-rounded;
 font-family: math;
 font-family: fangsong;
 
+/* Generic family names using the generic() function */
+font-family: generic(serif);
+font-family: generic(sans-serif);
+font-family: generic(monospace);
+font-family: generic(cursive);
+font-family: generic(fantasy);
+font-family: generic(system-ui);
+font-family: generic(ui-serif);
+font-family: generic(ui-sans-serif);
+font-family: generic(ui-monospace);
+font-family: generic(ui-rounded);
+font-family: generic(math);
+font-family: generic(fangsong);
+
 /* Global values */
 font-family: inherit;
 font-family: initial;
@@ -107,7 +121,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     See also [Valid family names](#valid_family_names).
 
 - `<generic-name>`
-  - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names are keywords and must not be quoted. A generic font family should be the last item in the list of font family names. The following keywords are defined:
+  - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names can be specified as keywords (which must not be quoted) or using the `generic()` function. A generic font family should be the last item in the list of font family names. The following keywords are defined:
     - `serif`
       - : Glyphs have finishing strokes, flared or tapering ends, or have actual serifed endings.
 
@@ -148,8 +162,19 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
 
-> [!NOTE]
-> `font-family: emoji` is not a standard or supported value. To control emoji presentation, use the {{CSSxRef("font-variant-emoji")}} property instead.
+  Generic family names can also be specified using the `generic()` function:
+  - `generic(serif)`
+  - `generic(sans-serif)`
+  - `generic(monospace)`
+  - `generic(cursive)`
+  - `generic(fantasy)`
+  - `generic(system-ui)`
+  - `generic(ui-serif)`
+  - `generic(ui-sans-serif)`
+  - `generic(ui-monospace)`
+  - `generic(ui-rounded)`
+  - `generic(math)`
+  - `generic(fangsong)`
 
 ## Formal definition
 
@@ -191,6 +216,35 @@ font-family: "Gill Sans Extrabold", sans-serif;
 .fangsong {
   font-family: fangsong;
 }
+
+/* Using generic() function syntax */
+.generic-serif {
+  font-family: Times, "Times New Roman", Georgia, generic(serif);
+}
+
+.generic-sans-serif {
+  font-family: Verdana, Arial, Helvetica, generic(sans-serif);
+}
+
+.generic-monospace {
+  font-family: "Lucida Console", Courier, generic(monospace);
+}
+
+.generic-cursive {
+  font-family: generic(cursive);
+}
+
+.generic-fantasy {
+  font-family: generic(fantasy);
+}
+
+.generic-math {
+  font-family: generic(math);
+}
+
+.generic-fangsong {
+  font-family: generic(fangsong);
+}
 ```
 
 ```html hidden
@@ -207,6 +261,24 @@ font-family: "Gill Sans Extrabold", sans-serif;
 <div class="math">This is an example of a math font.</div>
 
 <div class="fangsong">This is an example of a fangsong font.</div>
+
+<div class="generic-serif">This is an example using generic(serif).</div>
+
+<div class="generic-sans-serif">
+  This is an example using generic(sans-serif).
+</div>
+
+<div class="generic-monospace">
+  This is an example using generic(monospace).
+</div>
+
+<div class="generic-cursive">This is an example using generic(cursive).</div>
+
+<div class="generic-fantasy">This is an example using generic(fantasy).</div>
+
+<div class="generic-math">This is an example using generic(math).</div>
+
+<div class="generic-fangsong">This is an example using generic(fangsong).</div>
 ```
 
 {{EmbedLiveSample("Some_common_font_families", 600, 220)}}
@@ -251,5 +323,6 @@ font-family:
 
 - {{cssxref("font-style")}}
 - {{cssxref("font-weight")}}
+- {{cssxref("font-variant-emoji")}}
 - SVG {{SVGAttr("font-family")}} attribute
 - [Learn: Fundamental text and font styling](/en-US/docs/Learn_web_development/Core/Text_styling/Fundamentals)

--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -161,6 +161,12 @@ font-family: "Gill Sans Extrabold", sans-serif;
       - : This is for the particular stylistic concerns of representing mathematics: superscript and subscript, brackets that cross several lines, nesting expressions, and double struck glyphs with distinct meanings.
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
+    - `kai`
+      - : A calligraphic style of Chinese characters with notable handwriting features. This style is commonly used in official documents and textbooks, particularly in Taiwan where most official documents are set in Kai.
+    - `khmer-mul`
+      - : The âksâr mul style in the Khmer script, often used for decorative purposes such as headings or titles. This style is characterized by its intricate and ornamental design.
+    - `nastaliq`
+      - : The standard way of writing Urdu and Kashmiri, and often a preferred style for Persian and other language texts, especially in literary genres such as poetry. Features include a sloping baseline for joined letters and complex shaping and positioning for base letters and diacritics.
 
   Generic family names can also be specified using the `generic()` function:
   - `generic(serif)`
@@ -175,6 +181,9 @@ font-family: "Gill Sans Extrabold", sans-serif;
   - `generic(ui-rounded)`
   - `generic(math)`
   - `generic(fangsong)`
+  - `generic(kai)`
+  - `generic(khmer-mul)`
+  - `generic(nastaliq)`
 
 ## Formal definition
 
@@ -245,6 +254,18 @@ font-family: "Gill Sans Extrabold", sans-serif;
 .generic-fangsong {
   font-family: generic(fangsong);
 }
+
+.generic-kai {
+  font-family: generic(kai);
+}
+
+.generic-khmer-mul {
+  font-family: generic(khmer-mul);
+}
+
+.generic-nastaliq {
+  font-family: generic(nastaliq);
+}
 ```
 
 ```html hidden
@@ -279,6 +300,14 @@ font-family: "Gill Sans Extrabold", sans-serif;
 <div class="generic-math">This is an example using generic(math).</div>
 
 <div class="generic-fangsong">This is an example using generic(fangsong).</div>
+
+<div class="generic-kai">This is an example using generic(kai).</div>
+
+<div class="generic-khmer-mul">
+  This is an example using generic(khmer-mul).
+</div>
+
+<div class="generic-nastaliq">This is an example using generic(nastaliq).</div>
 ```
 
 {{EmbedLiveSample("Some_common_font_families", 600, 220)}}

--- a/files/en-us/web/css/font-variant-numeric/index.md
+++ b/files/en-us/web/css/font-variant-numeric/index.md
@@ -8,10 +8,30 @@ sidebar: cssref
 
 The **`font-variant-numeric`** [CSS](/en-US/docs/Web/CSS) property controls the usage of alternate glyphs for numbers, fractions, and ordinal markers.
 
-{{InteractiveExample("CSS Demo: font-variant-numeric")}}
+{{InteractiveExample("CSS Demo: font-variant-numeric", "taller")}}
 
 ```css interactive-example-choice
 font-variant-numeric: normal;
+```
+
+```css interactive-example-choice
+font-variant-numeric: ordinal;
+```
+
+```css interactive-example-choice
+font-variant-numeric: diagonal-fractions;
+```
+
+```css interactive-example-choice
+font-variant-numeric: lining-nums;
+```
+
+```css interactive-example-choice
+font-variant-numeric: oldstyle-nums;
+```
+
+```css interactive-example-choice
+font-variant-numeric: proportional-nums;
 ```
 
 ```css interactive-example-choice
@@ -19,11 +39,11 @@ font-variant-numeric: slashed-zero;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: tabular-nums;
+font-variant-numeric: stacked-fractions;
 ```
 
 ```css interactive-example-choice
-font-variant-numeric: oldstyle-nums;
+font-variant-numeric: tabular-nums;
 ```
 
 ```html interactive-example


### PR DESCRIPTION
### Description

Add missing script-specific generic font families (kai, khmer-mul, nastaliq) to font-family documentation and remove broken references to the deleted font-variant-numeric page.

### Motivation

The font-family documentation was missing three script-specific generic families that are part of the CSS Fonts Module Level 4 specification. Additionally, several CSS font-related pages contained broken links to the deleted font-variant-numeric page, causing build errors.

### Additional details

- Added kai, khmer-mul, and nastaliq as generic family names with descriptions
- Updated generic() function examples to include the new script-specific families
- Removed broken links to font-variant-numeric from multiple font-variant pages
- Updated CSS fonts index to remove font-variant-numeric type references

### Related issues and pull requests

Fixes #41281