### PR TITLE
WebDriver conformance changes for Firefox 144

### DIFF
--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -98,7 +98,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Implemented the new `browsingContext.downloadWillBegin` event, which is emitted when a new download is initiated, either by clicking a link with the `download` attribute, or in response to a network request with a `Content-Disposition` header indicating a file attachment ([Firefox bug 1874365](https://bugzil.la/1874365)).
 
-- Implemented the new `emulation.setScreenOrientationOverride` command, which allows clients to emulate different screen orientations. This command is not limited to mobile devices, but also works for desktop applications ([Firefox bug 1974167](https://bugzilla.mozilla.org/show_bug.cgi?id=1974167)).
+- Implemented the new `emulation.setScreenOrientationOverride` command, which allows clients to emulate different screen orientations. This command is not limited to mobile devices, but also works for desktop applications ([Firefox bug 1974167](https://bugzil.la/1974167)).
 
 - Implemented the new `emulation.setTimezoneOverride` command, which allows clients to simulate a specific timezone setting ([Firefox bug 1978027](https://bugzilla.mozilla.org/show_bug.cgi?id=1978027)).
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -92,13 +92,25 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### WebDriver BiDi
 
-<!-- #### WebDriver BiDi -->
+- Implemented the new `browsingContext.downloadWillBegin` event, which is emitted when a new download is initiated, either by clicking a link with the `download` attribute, or in response to a network request with a `Content-Disposition` header indicating a file attachment ([Firefox bug 1874365](https://bugzilla.mozilla.org/show_bug.cgi?id=1874365)).
 
-<!-- #### Marionette -->
+- Implemented the new `emulation.setScreenOrientationOverride` command, which allows clients to emulate different screen orientations. This command is not limited to mobile devices, but also works for desktop applications ([Firefox bug 1974167](https://bugzilla.mozilla.org/show_bug.cgi?id=1974167)).
+
+- Implemented the new `emulation.setTimezoneOverride` command, which allows clients to simulate a specific timezone setting ([Firefox bug 1978027](https://bugzilla.mozilla.org/show_bug.cgi?id=1978027)).
+
+- Enhanced the `emulation.setLocaleOverride` command to also apply the specified settings to sandboxes previously created via WebDriver BiDi ([Firefox bug 1983807](https://bugzilla.mozilla.org/show_bug.cgi?id=1983807)).
+
+- Fixed a bug where the locale override set via `emulation.setLocaleOverride` was sometimes incorrectly shared between different browsing contexts within the same process ([Firefox bug 1980211](https://bugzilla.mozilla.org/show_bug.cgi?id=1980211)).
+
+- Enhanced the `browsingContext.navigate` command to avoid `NS_BINDING_ABORTED` errors caused by redirects or interruptions occurring after the navigation was already committed ([Firefox bug 1914407](https://bugzilla.mozilla.org/show_bug.cgi?id=1914407)).
+
+#### Marionette
+
+- Reverted the [`Scroll Into View` WebDriver algorithm](https://w3c.github.io/webdriver/#dfn-scrolls-into-view) as used by several WebDriver classic commands in Marionette to always use the `instant` scroll behavior. This undoes the change introduced in Firefox 97, which had switched the behavior to `auto`. The reversion addresses potential race conditions when scrolling elements that use `smooth` behavior ([Firefox bug 1986238](https://bugzilla.mozilla.org/show_bug.cgi?id=1986238)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -102,7 +102,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Implemented the new `emulation.setTimezoneOverride` command, which allows clients to simulate a specific timezone setting ([Firefox bug 1978027](https://bugzil.la/1978027)).
 
-- Enhanced the `emulation.setLocaleOverride` command to also apply the specified settings to sandboxes previously created via WebDriver BiDi ([Firefox bug 1983807](https://bugzilla.mozilla.org/show_bug.cgi?id=1983807)).
+- Enhanced the `emulation.setLocaleOverride` command to also apply the specified settings to sandboxes previously created via WebDriver BiDi ([Firefox bug 1983807](https://bugzil.la/1983807)).
 
 - Fixed a bug where the locale override set via `emulation.setLocaleOverride` was sometimes incorrectly shared between different browsing contexts within the same process ([Firefox bug 1980211](https://bugzilla.mozilla.org/show_bug.cgi?id=1980211)).
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -110,7 +110,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Marionette
 
-- Reverted the [`Scroll Into View` WebDriver algorithm](https://w3c.github.io/webdriver/#dfn-scrolls-into-view) as used by several WebDriver classic commands in Marionette to always use the `instant` scroll behavior. This undoes the change introduced in Firefox 97, which had switched the behavior to `auto`. The reversion addresses potential race conditions when scrolling elements that use `smooth` behavior ([Firefox bug 1986238](https://bugzilla.mozilla.org/show_bug.cgi?id=1986238)).
+- Reverted the [`Scroll Into View` WebDriver algorithm](https://w3c.github.io/webdriver/#dfn-scrolls-into-view) as used by several WebDriver classic commands in Marionette to always use the `instant` scroll behavior. This undoes the change introduced in Firefox 97, which had switched the behavior to `auto`. The reversion addresses potential race conditions when scrolling elements that use `smooth` behavior ([Firefox bug 1986238](https://bugzil.la/1986238)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -106,7 +106,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Fixed a bug where the locale override set via `emulation.setLocaleOverride` was sometimes incorrectly shared between different browsing contexts within the same process ([Firefox bug 1980211](https://bugzil.la/1980211)).
 
-- Enhanced the `browsingContext.navigate` command to avoid `NS_BINDING_ABORTED` errors caused by redirects or interruptions occurring after the navigation was already committed ([Firefox bug 1914407](https://bugzilla.mozilla.org/show_bug.cgi?id=1914407)).
+- Enhanced the `browsingContext.navigate` command to avoid `NS_BINDING_ABORTED` errors caused by redirects or interruptions occurring after the navigation was already committed ([Firefox bug 1914407](https://bugzil.la/1914407)).
 
 #### Marionette
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -104,7 +104,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Enhanced the `emulation.setLocaleOverride` command to also apply the specified settings to sandboxes previously created via WebDriver BiDi ([Firefox bug 1983807](https://bugzil.la/1983807)).
 
-- Fixed a bug where the locale override set via `emulation.setLocaleOverride` was sometimes incorrectly shared between different browsing contexts within the same process ([Firefox bug 1980211](https://bugzilla.mozilla.org/show_bug.cgi?id=1980211)).
+- Fixed a bug where the locale override set via `emulation.setLocaleOverride` was sometimes incorrectly shared between different browsing contexts within the same process ([Firefox bug 1980211](https://bugzil.la/1980211)).
 
 - Enhanced the `browsingContext.navigate` command to avoid `NS_BINDING_ABORTED` errors caused by redirects or interruptions occurring after the navigation was already committed ([Firefox bug 1914407](https://bugzilla.mozilla.org/show_bug.cgi?id=1914407)).
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -96,7 +96,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### WebDriver BiDi
 
-- Implemented the new `browsingContext.downloadWillBegin` event, which is emitted when a new download is initiated, either by clicking a link with the `download` attribute, or in response to a network request with a `Content-Disposition` header indicating a file attachment ([Firefox bug 1874365](https://bugzilla.mozilla.org/show_bug.cgi?id=1874365)).
+- Implemented the new `browsingContext.downloadWillBegin` event, which is emitted when a new download is initiated, either by clicking a link with the `download` attribute, or in response to a network request with a `Content-Disposition` header indicating a file attachment ([Firefox bug 1874365](https://bugzil.la/1874365)).
 
 - Implemented the new `emulation.setScreenOrientationOverride` command, which allows clients to emulate different screen orientations. This command is not limited to mobile devices, but also works for desktop applications ([Firefox bug 1974167](https://bugzilla.mozilla.org/show_bug.cgi?id=1974167)).
 

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -100,7 +100,7 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - Implemented the new `emulation.setScreenOrientationOverride` command, which allows clients to emulate different screen orientations. This command is not limited to mobile devices, but also works for desktop applications ([Firefox bug 1974167](https://bugzil.la/1974167)).
 
-- Implemented the new `emulation.setTimezoneOverride` command, which allows clients to simulate a specific timezone setting ([Firefox bug 1978027](https://bugzilla.mozilla.org/show_bug.cgi?id=1978027)).
+- Implemented the new `emulation.setTimezoneOverride` command, which allows clients to simulate a specific timezone setting ([Firefox bug 1978027](https://bugzil.la/1978027)).
 
 - Enhanced the `emulation.setLocaleOverride` command to also apply the specified settings to sandboxes previously created via WebDriver BiDi ([Firefox bug 1983807](https://bugzilla.mozilla.org/show_bug.cgi?id=1983807)).
 


### PR DESCRIPTION
Changes related to WebDriver for Firefox 144 based on this [bug list](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox143&query_format=advanced&o1=equals&f1=cf_status_firefox144&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=17713153).

@juliandescottes can you please review?