### PR TITLE
Fix Transfer-Encoding example with correct length

### DIFF
--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -86,7 +86,7 @@ Transfer-Encoding: chunked
 
 7\r\n
 Mozilla\r\n
-11\r\n
+17\r\n
 Developer Network\r\n
 0\r\n
 \r\n


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Fixes the example where the length of the "Developer Network" chunk was incorrectly set to 11 instead of 17.

### Motivation
I was using the example to test my own HTTP server, only to realize that the chunk length was incorrect in the example.

### Additional details
None

### Related issues and pull requests
None
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
