### PR TITLE
Docs: Fixed a small typo in the Accelerometer API

### DIFF
--- a/files/en-us/web/api/accelerometer/index.md
+++ b/files/en-us/web/api/accelerometer/index.md
@@ -35,11 +35,11 @@ _In addition to the properties listed below, `Accelerometer` inherits properties
 
 ## Instance methods
 
-_`Accelerometer` doesn't have own methods. However, it inherits methods from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
+_`Accelerometer` doesn't have its own methods. However, it inherits methods from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 
 ## Events
 
-_`Accelerometer` doesn't have own events. However, it inherits events from its parent interface, {{domxref('Sensor')}}._
+_`Accelerometer` doesn't have its own events. However, it inherits events from its parent interface, {{domxref('Sensor')}}._
 
 ## Example
 


### PR DESCRIPTION
### Description

Hi, I found some typos in [this page](https://developer.mozilla.org/en-US/docs/Web/API/Accelerometer) that I fixed.

- `doesn't have own methods` → `doesn't have its own methods`
- `doesn't have own events` → `doesn't have its own events`

### Motivation

Making the docs great and free from mistakes.

### Additional details

None

### Related issues and pull requests

None
