### PR TITLE
Editorial review: Add information on echoCancellation constraint all and remote-only values

### DIFF
--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -22,7 +22,9 @@ None.
 
 ### Return value
 
-A `MediaTrackCapabilities` object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties. It is required to return identical information as returned by calling `getCapabilities()` on the first {{domxref("MediaStreamTrack")}} of the same `kind` as this device (video or audio) in the `MediaStream` returned by `getUserMedia({ deviceId: deviceInfo.deviceId })`. See {{domxref("MediaStreamTrack.getCapabilities()")}} for a list of commonly supported properties and their types.
+A `MediaTrackCapabilities` object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties. It is required to return identical information as returned by calling `getCapabilities()` on the first {{domxref("MediaStreamTrack")}} of the same `kind` as this device (video or audio) in the `MediaStream` returned by `getUserMedia({ deviceId: deviceInfo.deviceId })`.
+
+See {{domxref("MediaStreamTrack.getCapabilities()")}} for a list of commonly supported properties and their types.
 
 > [!NOTE]
 > If the user has not granted permission to access the input device an empty object will be returned.

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -25,7 +25,7 @@ A boolean, a string, or a [`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/Me
 
 If the browser supports specific echo cancellation types, the value can be set as one of the following strings:
 
-- `all`
+- `"all"`
   - : All user system-generated audio captured by the user's microphone is removed. This is useful for example in situations where you want to avoid capturing privacy-sensitive audio such as screen reader output and system notifications.
 - `remote-only`
   - : Only user system-generated audio captured by the user's microphone from remote sources (as represented by {{domxref("MediaStreamtrack")}}s sourced from an {{domxref("RTCPeerConnection")}}) is removed. This is useful when you want to remove echo from communication with remote peers but still share local audio, such as in the case of a music lesson where the teacher wants to hear their student(s) playing along to an audio track but still communicate clearly with them.

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -27,7 +27,7 @@ If the browser supports specific echo cancellation types, the value can be set a
 
 - `"all"`
   - : All user system-generated audio captured by the user's microphone is removed. This is useful for example in situations where you want to avoid capturing privacy-sensitive audio such as screen reader output and system notifications.
-- `remote-only`
+- `"remote-only"`
   - : Only user system-generated audio captured by the user's microphone from remote sources (as represented by {{domxref("MediaStreamtrack")}}s sourced from an {{domxref("RTCPeerConnection")}}) is removed. This is useful when you want to remove echo from communication with remote peers but still share local audio, such as in the case of a music lesson where the teacher wants to hear their student(s) playing along to an audio track but still communicate clearly with them.
 - `true`
   - : The browser decides what audio will be removed from the signals recorded by the microphone. It must attempt to cancel at least as much as `remote-only` and should attempt to cancel as much as `all`.

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -10,7 +10,7 @@ browser-compat: api.MediaStreamTrack.applyConstraints.echoCancellation_constrain
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`echoCancellation`** property is a
-[`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) describing the requested or mandatory constraints placed
+[`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constrainbooleanofdomstring) describing the requested or mandatory constraints placed
 upon the value of the {{domxref("MediaTrackSettings.echoCancellation", "echoCancellation")}} constrainable property.
 
 If needed, you can determine whether or not this constraint is supported by checking
@@ -18,18 +18,26 @@ the value of {{domxref("MediaTrackSupportedConstraints.echoCancellation")}} as r
 by a call to {{domxref("MediaDevices.getSupportedConstraints()")}}. However, typically
 this is unnecessary since browsers will ignore any constraints they're unfamiliar with.
 
-Because {{Glossary("RTP")}} doesn't include this information, tracks associated with a
-[WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("RTCPeerConnection")}}
-will never include this property.
-
 ## Value
 
-If this value is a simple `true` or `false`, the user agent will
-attempt to obtain media with echo cancellation enabled or disabled as specified, if
-possible, but will not fail if this can't be done. If, instead, the value is given as an
-object with an `exact` field, that field's Boolean value indicates a required
-setting for the echo cancellation feature; if it can't be met, then the request will
-result in an error.
+A string or a [`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constrainbooleanofdomstring) object.
+
+If the browser supports specific echo cancellation types, the value can be set as one of the following strings:
+
+- `all`
+  - : All user system-generated audio captured by the user's microphone is removed. This is useful for example in situations where you want to avoid capturing privacy-sensitive audio such as screen reader output and system notifications.
+- `remote-only`
+  - : Only user system-generated audio captured by the user's microphone from remote sources (as represented by {{domxref("MediaStreamtrack")}}s sourced from an {{domxref("RTCPeerConnection")}}) is removed. This is useful when you want to remove echo from communication with remote peers but still share local audio, such as in the case of a music lesson where the teacher wants to hear their student(s) playing along to an audio track but still communicate clearly with them.
+- `true`
+  - : The browser decides what audio will be removed from the signals recorded by the microphone. It must attempt to cancel at least as much as `remote-only` and should attempt to cancel as much as `all`.
+- `false`
+  - : No audio is removed; no echo cancellation will take place.
+
+If the browser doesn't support specific echo cancellation types, the value can be `true` or `false`.
+
+If set as one of the above values, the user agent will attempt to obtain media with echo cancellation enabled or disabled as specified, if possible, but will not fail if this can't be done.
+
+If the value is given as an object with an `exact` field, that field's value indicates a required setting for the echo cancellation feature; if it can't be met, then the request will result in an error.
 
 ## Examples
 

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -20,7 +20,8 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 
 ## Value
 
-A string or a [`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constrainbooleanofdomstring) object.
+A boolean, a string, or a [`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constrainbooleanofdomstring) object.
+
 
 If the browser supports specific echo cancellation types, the value can be set as one of the following strings:
 

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -23,7 +23,7 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 A boolean, a string, or a [`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constrainbooleanofdomstring) object.
 
 
-If the browser supports specific echo cancellation types, the value can be set as one of the following strings:
+If the browser supports specific echo cancellation types, the value can be set as one of the following:
 
 - `"all"`
   - : All user system-generated audio captured by the user's microphone is removed. This is useful for example in situations where you want to avoid capturing privacy-sensitive audio such as screen reader output and system notifications.

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -22,7 +22,6 @@ this is unnecessary since browsers will ignore any constraints they're unfamilia
 
 A boolean, a string, or a [`ConstrainBooleanOrDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constrainbooleanofdomstring) object.
 
-
 If the browser supports specific echo cancellation types, the value can be set as one of the following:
 
 - `"all"`

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -44,6 +44,10 @@ Its value may either be set to a Boolean (`true` or `false`) or an object contai
   - : A Boolean specifying an ideal value for the property.
     If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
 
+### ConstrainBooleanOrDOMString
+
+The `ConstrainBooleanOrDOMString` constraint type is used to specify a constraint for a property whose value is a Boolean or string value. It can take values as specified in the [`ConstrainBoolean`](#constrainboolean) and [`ConstrainDOMString`](#constraindomstring) sections.
+
 ### ConstrainDouble
 
 The `ConstrainDouble` constraint type is used to specify a constraint for a property whose value is a double-precision floating-point number.
@@ -110,7 +114,7 @@ For example, because {{Glossary("RTP")}} doesn't provide some of these values du
 - {{domxref("MediaTrackConstraints.channelCount", "channelCount")}}
   - : A [`ConstrainULong`](#constrainulong) specifying the channel count or range of channel counts which are acceptable and/or required.
 - {{domxref("MediaTrackConstraints.echoCancellation", "echoCancellation")}}
-  - : A [`ConstrainBoolean`](#constrainboolean) object specifying whether or not echo cancellation is preferred and/or required.
+  - : A [`ConstrainBooleanOrDOMString`](#constrainbooleanordomstring) object specifying whether or not echo cancellation is preferred and/or required, and if supported, what type.
 - {{domxref("MediaTrackConstraints.latency", "latency")}}
   - : A [`ConstrainDouble`](#constraindouble) specifying the latency or range of latencies which are acceptable and/or required.
 - {{domxref("MediaTrackConstraints.noiseSuppression", "noiseSuppression")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -20,48 +20,48 @@ To learn more about how constraints work, see [Capabilities, constraints, and se
 Some combination—but not necessarily all—of the following properties will exist on the object.
 
 - {{domxref("MediaTrackSupportedConstraints.autoGainControl", "autoGainControl")}}
-  - : A Boolean whose value is `true` if the [`autoGainControl`](/en-US/docs/Web/API/MediaTrackConstraints/autoGainControl) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`autoGainControl`](/en-US/docs/Web/API/MediaTrackConstraints/autoGainControl) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.width", "width")}}
-  - : A Boolean value whose value is `true` if the [`width`](/en-US/docs/Web/API/MediaTrackConstraints/width) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`width`](/en-US/docs/Web/API/MediaTrackConstraints/width) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.height", "height")}}
-  - : A Boolean value whose value is `true` if the [`height`](/en-US/docs/Web/API/MediaTrackConstraints/height) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`height`](/en-US/docs/Web/API/MediaTrackConstraints/height) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.aspectRatio", "aspectRatio")}}
-  - : A Boolean value whose value is `true` if the [`aspectRatio`](/en-US/docs/Web/API/MediaTrackConstraints/aspectRatio) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`aspectRatio`](/en-US/docs/Web/API/MediaTrackConstraints/aspectRatio) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.frameRate", "frameRate")}}
-  - : A Boolean value whose value is `true` if the [`frameRate`](/en-US/docs/Web/API/MediaTrackConstraints/frameRate) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`frameRate`](/en-US/docs/Web/API/MediaTrackConstraints/frameRate) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.facingMode", "facingMode")}}
-  - : A Boolean value whose value is `true` if the [`facingMode`](/en-US/docs/Web/API/MediaTrackConstraints/facingMode) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`facingMode`](/en-US/docs/Web/API/MediaTrackConstraints/facingMode) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.resizeMode", "resizeMode")}}
-  - : A Boolean value whose value is `true` if the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints/resizeMode) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`resizeMode`](/en-US/docs/Web/API/MediaTrackConstraints/resizeMode) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.volume", "volume")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
-  - : A Boolean value whose value is `true` if the [`volume`](/en-US/docs/Web/API/MediaTrackConstraints/volume) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`volume`](/en-US/docs/Web/API/MediaTrackConstraints/volume) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.sampleRate", "sampleRate")}}
-  - : A Boolean value whose value is `true` if the [`sampleRate`](/en-US/docs/Web/API/MediaTrackConstraints/sampleRate) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`sampleRate`](/en-US/docs/Web/API/MediaTrackConstraints/sampleRate) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.sampleSize", "sampleSize")}}
-  - : A Boolean value whose value is `true` if the [`sampleSize`](/en-US/docs/Web/API/MediaTrackConstraints/sampleSize) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`sampleSize`](/en-US/docs/Web/API/MediaTrackConstraints/sampleSize) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.echoCancellation", "echoCancellation")}}
-  - : A Boolean value whose value is `true` if the [`echoCancellation`](/en-US/docs/Web/API/MediaTrackConstraints/echoCancellation) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`echoCancellation`](/en-US/docs/Web/API/MediaTrackConstraints/echoCancellation) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.latency", "latency")}}
-  - : A Boolean value whose value is `true` if the [`latency`](/en-US/docs/Web/API/MediaTrackConstraints/latency) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`latency`](/en-US/docs/Web/API/MediaTrackConstraints/latency) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.noiseSuppression", "noiseSuppression")}}
-  - : A Boolean whose value is `true` if the [`noiseSuppression`](/en-US/docs/Web/API/MediaTrackConstraints/noiseSuppression) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`noiseSuppression`](/en-US/docs/Web/API/MediaTrackConstraints/noiseSuppression) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.suppressLocalAudioPlayback", "suppressLocalAudioPlayback")}}
-  - : A Boolean whose value is `true` if the [`suppressLocalAudioPlayback`](/en-US/docs/Web/API/MediaTrackConstraints/suppressLocalAudioPlayback) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`suppressLocalAudioPlayback`](/en-US/docs/Web/API/MediaTrackConstraints/suppressLocalAudioPlayback) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.channelCount", "channelCount")}}
-  - : A Boolean value whose value is `true` if the [`channelCount`](/en-US/docs/Web/API/MediaTrackConstraints/channelCount) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`channelCount`](/en-US/docs/Web/API/MediaTrackConstraints/channelCount) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.deviceId", "deviceId")}}
-  - : A Boolean value whose value is `true` if the [`deviceId`](/en-US/docs/Web/API/MediaTrackConstraints/deviceId) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`deviceId`](/en-US/docs/Web/API/MediaTrackConstraints/deviceId) constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.groupId", "groupId")}}
-  - : A Boolean value whose value is `true` if the [`groupId`](/en-US/docs/Web/API/MediaTrackConstraints/groupId) constraint is supported in the current environment.
+  - : A Boolean that is `true` if the [`groupId`](/en-US/docs/Web/API/MediaTrackConstraints/groupId) constraint is supported in the current environment.
 
 ### Instance properties specific to shared screen tracks
 
 For tracks containing video sources from the user's screen contents, the following additional properties are may be included in addition to those available for video tracks.
 
 - {{domxref("MediaTrackSupportedConstraints.displaySurface", "displaySurface")}}
-  - : A Boolean value which is `true` if the {{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}} constraint is supported in the current environment.
+  - : A Boolean that is `true` if the {{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}} constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.logicalSurface", "logicalSurface")}}
-  - : A Boolean value which is `true` if the {{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}} constraint is supported in the current environment.
+  - : A Boolean that is `true` if the {{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}} constraint is supported in the current environment.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 141 adds support for the new `all` and `remote-only` values of the [`MediaTrackConstraints/echoCancellation`](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/echoCancellation) constraint. See https://chromestatus.com/feature/5585747985563648.

This PR adds information to describe these new values.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
