### PR TITLE
Document that ::-moz-meter-bar now needs appearance: none to work properly.

### DIFF
--- a/files/en-us/web/css/_doublecolon_-moz-meter-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-meter-bar/index.md
@@ -15,6 +15,9 @@ The **`::-moz-meter-bar`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/do
 ## Syntax
 
 ```css
+meter {
+  appearance: none;
+}
 ::-moz-meter-bar {
   /* ... */
 }
@@ -39,6 +42,10 @@ meter {
   height: 20px;
   width: 200px;
   vertical-align: -0.4rem;
+}
+
+.styled {
+  appearance: none;
 }
 
 .styled::-moz-meter-bar {

--- a/files/en-us/web/css/_doublecolon_-moz-meter-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-meter-bar/index.md
@@ -12,6 +12,9 @@ sidebar: cssref
 
 The **`::-moz-meter-bar`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Glossary/Pseudo-element) represents the meter gauge in a {{HTMLElement("meter")}} element. It is used for selecting and applying styles to the gauge inside a meter element.
 
+> [!NOTE]
+> By default, the `<meter>` element uses native styling. To apply your own styles, first set `appearance: none` on the `<meter>` element, and then style using `::-moz-meter-bar`.
+
 ## Syntax
 
 ```css


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1991270#c3 for details.