### PR TITLE
FF144 Relnote/Exp/Tweak PerformanceEventTiming.interactionId supported

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -447,20 +447,6 @@ The non-standard events [`beforescriptexecute`](/en-US/docs/Web/API/Document/bef
 - `dom.events.script_execute.enable`
   - : Set to `true` to enable.
 
-### PerformanceEventTiming.interactionId
-
-{{domxref("PerformanceEventTiming.interactionId")}} can be used to measure latency timing for events triggered by a particular user interaction. ([Firefox bug 1934683](https://bugzil.la/1934683)).
-
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 138           | No                  |
-| Developer Edition | 138           | No                  |
-| Beta              | 138           | No                  |
-| Release           | 138           | No                  |
-
-- `dom.performance.event_timing.enable_interactionid`
-  - : Set to `true` to enable.
-
 ### Notification actions and maxActions properties
 
 The {{domxref("Notification/actions","actions")}} read-only property and the [`maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static read-only property of the {{domxref("Notification")}} interface are supported in Nightly on desktop.

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -77,6 +77,8 @@ Firefox 144 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The [View Transition API](/en-US/docs/Web/API/View_Transition_API) is now supported for [SPAs (single-page applications)](/en-US/docs/Glossary/SPA). This provides a mechanism for easily creating animated transitions between different website views. ([Firefox bug 1985809](https://bugzil.la/1985809)).
 - The {{domxref("CSSStyleProperties")}} interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) is now implemented (this was renamed from a non-standard interface `CSS2Properties`). The new interface is present but not yet used. ([Firefox bug 1919582](https://bugzil.la/1919582)).
 
+- The {{domxref("PerformanceEventTiming.interactionId", "interactionId")}} property of the {{domxref("PerformanceEventTiming")}} interface is a unique identifier that associates related events belonging to a single user interaction. This can be used to calculate the {{glossary("Interaction to next paint")}} metric, which helps analyze responsiveness to user interaction over the lifetime of a page. ([Firefox bug 1956809](https://bugzil.la/1956809)).
+
 #### DOM
 
 - The `moveBefore()` method is now supported on the {{domxref("Element.moveBefore()","Element")}}, {{domxref("DocumentFragment.moveBefore()","DocumentFragment")}} and {{domxref("Document.moveBefore()","Document")}} interfaces. This allows moving of an immediate child element of the object, before another of its child elements. Unlike with {{domxref("Node.insertBefore()")}}, moved elements retain their state. ([Firefox bug 1983688](https://bugzil.la/1983688)).

--- a/files/en-us/web/api/performanceeventtiming/interactionid/index.md
+++ b/files/en-us/web/api/performanceeventtiming/interactionid/index.md
@@ -8,11 +8,16 @@ browser-compat: api.PerformanceEventTiming.interactionId
 
 {{APIRef("Performance API")}}
 
-The read-only **`interactionId`** property returns an ID that uniquely identifies a user interaction which triggered a series of associated events.
+The read-only **`interactionId`** property or the {{domxref("PerformanceEventTiming")}} interface returns an ID that uniquely identifies a user interaction which triggered a series of associated events.
+
+## Value
+
+A number. For event types where an interaction ID is not calculated the value is 0.
 
 ## Description
 
-When a user interacts with a web page, a user interaction (for example a click) usually triggers a sequence of events, such as `pointerdown`, `pointerup`, and `click` events. To measure the latency of this series of events, the events share the same `interactionId`.
+When a user interacts with a web page, a user interaction (for example a click) usually triggers a sequence of events, such as `pointerdown`, `pointerup`, and `click` events.
+To measure the latency of this series of events, the events share the same `interactionId`.
 
 An `interactionId` is only computed for the following event types belonging to a user interaction. It is `0` otherwise.
 
@@ -21,15 +26,14 @@ An `interactionId` is only computed for the following event types belonging to a
 | {{domxref("Element/pointerdown_event", "pointerdown")}}, {{domxref("Element/pointerup_event", "pointerup")}}, {{domxref("Element/click_event", "click")}} | click / tap / drag |
 | {{domxref("Element/keydown_event", "keydown")}}, {{domxref("Element/keyup_event", "keyup")}}                                                              | key press          |
 
-## Value
-
-A number.
+The `interactionId` is also needed to calculate the {{glossary("Interaction to next paint")}} metric, which helps analyze responsiveness to user interaction over the lifetime of a page.
 
 ## Examples
 
 ### Using interactionId
 
-The following example collects event duration for all events corresponding to an interaction. The `eventLatencies` map can then be used to find events with maximum duration for a user interaction, for example.
+The following example collects event duration for all events corresponding to an interaction.
+The `eventLatencies` map can then be used to find events with maximum duration for a user interaction, for example.
 
 ```js
 // The key is the interaction ID.


### PR DESCRIPTION
FF144 adds support for [`PerformanceEventTiming.interactionId`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming/interactionId). This adds to the release note, removes from the experimental features, and does minor tweak to the doc to match it to the API template.

Related docs work can be tracked in #41409