### PR TITLE
Revert "ci(pr-review-companion): use PR number from event payload 

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -32,10 +32,8 @@ jobs:
   review:
     environment: review
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number
+    if: github.event.workflow_run.conclusion == 'success'
     env:
-      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-      PREFIX: pr${{ github.event.workflow_run.pull_requests[0].number }}
       STATUS_PATH: repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.pull_requests[0].head.sha }}
       STATUS_CONTEXT: pr-review-companion
       STATUS_TARGET: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -52,10 +50,14 @@ jobs:
       - name: Check for artifacts
         id: check
         if: hashFiles('build/') != ''
-        run: echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
+          PR_NUMBER=`cat build/NR | tr -dc '0-9'`
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "PREFIX=pr$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Mark status as pending
-        if: steps.check.outputs.HAS_ARTIFACT
+        if: steps.check.outputs.HAS_ARTIFACT && github.event.workflow_run.pull_requests[0].number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -82,7 +84,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: "build"
-          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
+          destination: "${{ vars.GCP_BUCKET_NAME }}/${{ steps.check.outputs.PREFIX }}"
           resumable: false
           headers: |-
             cache-control: no-store
@@ -114,6 +116,8 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
+          PREFIX: ${{ steps.check.outputs.PREFIX }}
+          PR_NUMBER: ${{ steps.check.outputs.PR_NUMBER }}
         working-directory: content
         run: |
           echo "Pull request:"
@@ -130,7 +134,7 @@ jobs:
             $BUILD_OUT_ROOT
 
       - name: Mark status as success
-        if: steps.check.outputs.HAS_ARTIFACT && success()
+        if: steps.check.outputs.HAS_ARTIFACT && success() && github.event.workflow_run.pull_requests[0].number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -141,7 +145,7 @@ jobs:
             -f target_url="$STATUS_TARGET"
 
       - name: Mark status as failure
-        if: steps.check.outputs.HAS_ARTIFACT && failure()
+        if: steps.check.outputs.HAS_ARTIFACT && failure() && github.event.workflow_run.pull_requests[0].number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -145,6 +145,9 @@ jobs:
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT
 
+          # Save the PR number into the build
+          echo ${{ github.event.number }} > ${BUILD_OUT_ROOT}/NR
+
           # Download the raw diff blob and store that inside the build
           # directory.
           # The purpose of this is for the PR Review Companion to later


### PR DESCRIPTION
### Description

This reverts commit 260db2823bce0512bbf883a79e446f6ed0cbfbac.

### Motivation

The `pr-review-companion` is being skipped, probably due to `github.event.workflow_run.pull_requests[0].number` not being set.

### Additional details

First skipped run: https://github.com/mdn/content/actions/runs/18234985659 using 260db2823bce0512bbf883a79e446f6ed0cbfbac (Oct 4, 12:12am GMT+2)

### Related issues and pull requests

Reverts #41013.