### PR TITLE
ci(pr-review-companion): print workflow_run payload

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -38,6 +38,11 @@ jobs:
       STATUS_CONTEXT: pr-review-companion
       STATUS_TARGET: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - name: Show workflow_run payload
+        env:
+          PAYLOAD: ${{ toJson(github.event.workflow_run) }}
+        run: echo "$PAYLOAD" | jq .
+
       - name: Download artifact
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Print `github.event.workflow_run` in the `pr-review-companion` workflow to understand when and what is set.

### Motivation

It seems that `github.event.workflow_run.pull_requests` is not set on PRs from forks.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/content/pull/41415.
