### PR TITLE
Issue-41421 scripting API host permission requirements clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -10,7 +10,7 @@ Use this function to register one or more content scripts.
 
 It accepts one parameter, which is an object with similar properties to the objects given in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) manifest key (but note that `content_scripts` is an array of objects, while the argument to `register()` is one object).
 
-The extension must have the appropriate [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the patterns in `contentScriptOptions`, or the 
+The extension must have the appropriate [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the patterns in `contentScriptOptions`, or the
 API call is rejected.
 
 ## Syntax

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -10,7 +10,8 @@ Use this function to register one or more content scripts.
 
 It accepts one parameter, which is an object with similar properties to the objects given in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) manifest key (but note that `content_scripts` is an array of objects, while the argument to `register()` is one object).
 
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+The extension must have the appropriate [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the patterns in `contentScriptOptions`, or the 
+API call is rejected.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -11,9 +11,8 @@ Registers one or more content scripts.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To call this API, you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
 
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -13,7 +13,6 @@ Registers one or more content scripts.
 
 To call this API, you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
 
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
@@ -11,9 +11,7 @@ Updates registered content scripts. If there are errors during script parsing an
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+To call this API, you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Provide clarification regarding the need for host permissions in `scripting.registercontentscripts`, `scripting.updatecontentscripts`, and `contentscripts.register`.

### Related issues and pull requests

Fixes #41421