### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/interfacedata-updater.yml
+++ b/.github/workflows/interfacedata-updater.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: mdn-content
           ref: main
+          persist-credentials: false
 
       - name: Setup node.js
         uses: actions/setup-node@v4
@@ -32,6 +33,7 @@ jobs:
           repository: w3c/webref
           path: webref
           ref: "@webref/idl@latest"
+          persist-credentials: false
 
       - name: Extract data from webref
         working-directory: mdn-content

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout BASE
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: check
@@ -59,6 +61,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
+          persist-credentials: false
 
       - name: Get changed content from HEAD
         if: steps.check.outputs.HAS_FILES == 'true'

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -97,6 +97,7 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         with:
           path: content
+          persist-credentials: false
 
       - name: Setup (mdn/content)
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
