### PR TITLE
Docs: Clarify <progress> element attributes

### DIFF
--- a/files/en-us/web/media/guides/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -81,7 +81,7 @@ In addition to adding the `<track>` elements, we have also added a new button to
   <button id="play-pause" type="button" data-state="play">Play/Pause</button>
   <button id="stop" type="button" data-state="stop">Stop</button>
   <div class="progress">
-    <progress id="progress" value="0" min="0">
+    <progress id="progress" value="0">
       <span id="progress-bar"></span>
     </progress>
   </div>

--- a/files/en-us/web/media/guides/audio_and_video_delivery/cross_browser_video_player/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/cross_browser_video_player/index.md
@@ -73,7 +73,7 @@ Once again the HTML is quite straightforward, using an unordered list with `list
   <li><button id="play-pause" type="button">Play/Pause</button></li>
   <li><button id="stop" type="button">Stop</button></li>
   <li class="progress">
-    <progress id="progress" value="0" min="0"></progress>
+    <progress id="progress" value="0"></progress>
   </li>
   <li><button id="mute" type="button">Mute/Unmute</button></li>
   <li><button id="vol-inc" type="button">Vol+</button></li>
@@ -194,7 +194,7 @@ This function makes use of the Media API's `volume` attribute, which holds the c
 
 ### Progress
 
-When the {{ htmlelement("progress") }} element was defined above in the HTML, only two attributes were set, `value` and `min`, both being given a value of 0. The function of these attributes is self-explanatory, with `min` indicating the minimum allowed value of the `progress` element and `value` indicating its current value. It also needs to have a maximum value set so that it can display its range correctly, and this can be done via the `max` attribute, which needs to be set to the maximum playing time of the video. This is obtained from the video's `duration` attribute, which again is part of the Media API.
+When the {{ htmlelement("progress") }} element was defined above in the HTML, only the `value` attribute was set to 0. This attribute indicates the current value of the progress element. It also needs to have a maximum value set so that it can display its range correctly, and this can be done via the `max` attribute, which needs to be set to the maximum playing time of the video. This is obtained from the video's `duration` attribute, which again is part of the Media API.
 
 Ideally, the correct value of the video's `duration` attribute is available when the `loadedmetadata` event is raised, which occurs when the video's metadata has been loaded:
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -44,7 +44,7 @@ The markup for the custom controls now looks as follows:
   <button id="play-pause" type="button" data-state="play">Play/Pause</button>
   <button id="stop" type="button" data-state="stop">Stop</button>
   <div class="progress">
-    <progress id="progress" value="0" min="0">
+    <progress id="progress" value="0">
       <span id="progress-bar"></span>
     </progress>
   </div>


### PR DESCRIPTION
### Description

Clarify the <progress> element attributes, delete the `min` attribute which is not allowed for the <progress> element.

### Motivation

In the [`<progress>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress) MDN Web, have this note:

> [!NOTE] 
> Note: Unlike the [`<meter>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meter) element, the minimum value is always 0, and the min attribute is not allowed for the \<progress\> element.

so I delete the `min` attribute in `<progress>` and the description in these pages.

### Additional details

[\<progress\> - HTML | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress)

### Related issues and pull requests
