### PR TITLE
Intl.DurationFormat Example Code: fix space error

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/format/index.md
@@ -79,7 +79,7 @@ new Intl.DurationFormat("en", { style: "short" }).format(duration);
 
 // With style set to "short" and locale set to "pt"
 new Intl.DurationFormat("pt", { style: "narrow" }).format(duration);
-// "1h 46min 40s"
+// "1 h 46 min 40 s"
 
 // With style set to "digital" and locale set to "en"
 new Intl.DurationFormat("en", { style: "digital" }).format(duration);

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/index.md
@@ -59,7 +59,7 @@ new Intl.DurationFormat("en", { style: "short" }).format(duration);
 
 // With style set to "narrow" and locale "pt"
 new Intl.DurationFormat("pt", { style: "narrow" }).format(duration);
-// "1h 46 min 40s"
+// "1 h 46 min 40 s"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/index.md
@@ -59,7 +59,7 @@ new Intl.DurationFormat("en", { style: "short" }).format(duration);
 
 // With style set to "narrow" and locale "pt"
 new Intl.DurationFormat("pt", { style: "narrow" }).format(duration);
-// "1h 46min 40s"
+// "1h 46 min 40s"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->


The spacing in the output of the example code in the [original text](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat) does not match the actual output when the code is executed.


**output of the example code from original MDN document : `"1h 46min 40s"`**
<img width="702" height="111" alt="image" src="https://github.com/user-attachments/assets/9f5b5ca6-d8fe-4e6a-bd21-05a9d6ea1bff" />

**actual output when code is excuted : `"1 h 46 min 40 s"`**
<img width="621" height="257" alt="image" src="https://github.com/user-attachments/assets/ac733ee5-d196-4b37-8222-ad84b90e3e26" />





### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
