### PR TITLE
[Experiment] Provide complete minimal reference for SVGAElement interface

### DIFF
--- a/files/en-us/web/api/svgaelement/download/index.md
+++ b/files/en-us/web/api/svgaelement/download/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.download
 
 {{APIRef("SVG")}}
 
-The **`download`** property of the {{domxref("SVGAElement")}} returns a string indicating that the browser should treat the linked URL as a download.
+The **`download`** property of the {{domxref("SVGAElement")}} interface returns a string indicating that the browser should treat the linked URL as a download.
 
 This property can be set, to change the URL's `download` value. It reflects the value of the [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download) attribute.
 

--- a/files/en-us/web/api/svgaelement/download/index.md
+++ b/files/en-us/web/api/svgaelement/download/index.md
@@ -1,0 +1,32 @@
+---
+title: "SVGAElement: download property"
+short-title: download
+slug: Web/API/SVGAElement/download
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.download
+---
+
+{{APIRef("SVG")}}
+
+The **`download`** property of the {{domxref("SVGAElement")}} returns a string indicating that the browser should treat the linked URL as a download.
+
+This property can be set, to change the URL's `download` value. It reflects the value of the [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download) attribute.
+
+> [!NOTE]
+> This value might not be used for download. This value cannot be used to determine whether the download will occur.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download) attribute

--- a/files/en-us/web/api/svgaelement/hash/index.md
+++ b/files/en-us/web/api/svgaelement/hash/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.hash
 
 {{APIRef("SVG")}}
 
-The **`hash`** property of the {{domxref("SVGAElement")}} returns a string representing the fragment identifier, including the leading hash mark (`#`), if any, in the referenced URL.
+The **`hash`** property of the {{domxref("SVGAElement")}} interface returns a string representing the fragment identifier, including the leading hash mark (`#`), if any, in the referenced URL.
 
 This property can be set, to change the URL's fragment (ignores leading `#`).
 

--- a/files/en-us/web/api/svgaelement/hash/index.md
+++ b/files/en-us/web/api/svgaelement/hash/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: hash property"
+short-title: hash
+slug: Web/API/SVGAElement/hash
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.hash
+---
+
+{{APIRef("SVG")}}
+
+The **`hash`** property of the {{domxref("SVGAElement")}} returns a string representing the fragment identifier, including the leading hash mark (`#`), if any, in the referenced URL.
+
+This property can be set, to change the URL's fragment (ignores leading `#`).
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/host/index.md
+++ b/files/en-us/web/api/svgaelement/host/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: host property"
+short-title: host
+slug: Web/API/SVGAElement/host
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.host
+---
+
+{{APIRef("SVG")}}
+
+The **`host`** property of the {{domxref("SVGAElement")}} returns a string representing the hostname and port (if it's not the default port) in the referenced URL.
+
+This property can be set, to change the URL's host and port.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/host/index.md
+++ b/files/en-us/web/api/svgaelement/host/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.host
 
 {{APIRef("SVG")}}
 
-The **`host`** property of the {{domxref("SVGAElement")}} returns a string representing the hostname and port (if it's not the default port) in the referenced URL.
+The **`host`** property of the {{domxref("SVGAElement")}} interface returns a string representing the hostname and port (if it's not the default port) in the referenced URL.
 
 This property can be set, to change the URL's host and port.
 

--- a/files/en-us/web/api/svgaelement/hostname/index.md
+++ b/files/en-us/web/api/svgaelement/hostname/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.hostname
 
 {{APIRef("SVG")}}
 
-The **`hostname`** property of the {{domxref("SVGAElement")}} returns a string representing the hostname in the referenced URL.
+The **`hostname`** property of the {{domxref("SVGAElement")}} interface returns a string representing the hostname in the referenced URL.
 
 This property can be set, to change the URL's hostname.
 

--- a/files/en-us/web/api/svgaelement/hostname/index.md
+++ b/files/en-us/web/api/svgaelement/hostname/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: hostname property"
+short-title: hostname
+slug: Web/API/SVGAElement/hostname
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.hostname
+---
+
+{{APIRef("SVG")}}
+
+The **`hostname`** property of the {{domxref("SVGAElement")}} returns a string representing the hostname in the referenced URL.
+
+This property can be set, to change the URL's hostname.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/hreflang/index.md
+++ b/files/en-us/web/api/svgaelement/hreflang/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.hreflang
 
 {{APIRef("SVG")}}
 
-The **`hreflang`** property of the {{domxref("SVGAElement")}} returns a string indicating the language of the linked resource.
+The **`hreflang`** property of the {{domxref("SVGAElement")}} interface returns a string indicating the language of the linked resource.
 
 This property can be set, to change the URL's `hreflang` value. It reflects the value of the [`hreflang`](/en-US/docs/Web/HTML/Reference/Elements/a#hreflang) attribute.
 

--- a/files/en-us/web/api/svgaelement/hreflang/index.md
+++ b/files/en-us/web/api/svgaelement/hreflang/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: hreflang property"
+short-title: hreflang
+slug: Web/API/SVGAElement/hreflang
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.hreflang
+---
+
+{{APIRef("SVG")}}
+
+The **`hreflang`** property of the {{domxref("SVGAElement")}} returns a string indicating the language of the linked resource.
+
+This property can be set, to change the URL's `hreflang` value. It reflects the value of the [`hreflang`](/en-US/docs/Web/HTML/Reference/Elements/a#hreflang) attribute.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`hreflang`](/en-US/docs/Web/HTML/Reference/Elements/a#hreflang) attribute

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -16,7 +16,7 @@ The **`SVGAElement`** interface provides access to the properties of an {{SVGEle
 _This interface also inherits properties from its parent, {{domxref("SVGGraphicsElement")}}._
 
 - {{domxref("SVGAElement.download")}}
-  - : See {{domxref("HTMLAnchorElement.download")}}.
+  - : A string indicating that the linked resource is intended to be downloaded rather than displayed in the browser.
 - {{domxref("SVGAElement.hash")}}
   - : A string representing the fragment identifier, including the leading hash mark (`#`), if any, in the referenced URL.
 - {{domxref("SVGAElement.host")}}
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} that reflects the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} {{deprecated_inline}} attribute.
 - {{domxref("SVGAElement.hreflang")}}
-  - : A string that reflects the `hreflang` attribute, indicating the language of the linked resource.
+  - : A string indicating the language of the linked resource.
 - {{domxref("SVGAElement.origin")}} {{ReadOnlyInline}}
   - : Returns a string containing the origin of the URL, that is its scheme, its domain and its port.
 - {{domxref("SVGAElement.pathname")}}
@@ -40,16 +40,16 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.protocol")}}
   - : A string representing the protocol component, including trailing colon (`:`), of the referenced URL.
 - {{domxref("SVGAElement.referrerPolicy")}}
-  - : See {{domxref("HTMLAnchorElement.referrerPolicy")}}.
+  - : A string specifying which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the [URL](/en-US/docs/Glossary/URL).
 - {{domxref("SVGAElement.rel")}}
   - : A string reflecting the `rel` SVG attribute, specifying the relationship of the link's target.
 - {{domxref("SVGAElement.relList")}}
   - : A {{domxref("DOMTokenList")}} reflecting the `rel` SVG attribute, as a list of tokens.
 - {{domxref("SVGAElement.search")}}
-  - : A string representing the search element, including leading question mark (`?`), if any, of the referenced URL.
+  - : A string representing the URL's query string, if any, including the leading question mark (`?`).
 - {{domxref("SVGAElement.target")}} {{ReadOnlyInline}}
   - : It corresponds to the {{SVGAttr("target")}} attribute of the given element.
-- {{domxref("SVGAElement.text")}} {{deprecated_inline}}
+- {{domxref("SVGAElement.text")}} {{deprecated_inline}} {{non-standard_inline}}
   - : A string that is a synonym for the {{domxref("Node.textContent")}} property.
 - {{domxref("SVGAElement.type")}}
   - : A string that reflects the `type` attribute, indicating the MIME type of the linked resource.

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -28,7 +28,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.hreflang")}}
   - : A string indicating the language of the linked resource.
 - {{domxref("SVGAElement.origin")}} {{ReadOnlyInline}}
-  - : Returns a string containing the origin of the URL, that is its scheme, its domain and its port.
+  - : Returns a string containing the origin of the URL — that is, its scheme, its domain and its port.
 - {{domxref("SVGAElement.pathname")}}
   - : A string containing an initial `/` followed by the path of the URL, not including the query string or fragment.
 - {{domxref("SVGAElement.password")}}

--- a/files/en-us/web/api/svgaelement/origin/index.md
+++ b/files/en-us/web/api/svgaelement/origin/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.origin
 
 {{APIRef("SVG")}}
 
-The **`origin`** readonly property of the {{domxref("SVGAElement")}} returns a string containing the origin of the URL, that is its scheme, its domain and its port.
+The **`origin`** readonly property of the {{domxref("SVGAElement")}} interface returns a string containing the origin of the URL — that is, its scheme, its domain and its port.
 
 ## Value
 

--- a/files/en-us/web/api/svgaelement/origin/index.md
+++ b/files/en-us/web/api/svgaelement/origin/index.md
@@ -1,0 +1,27 @@
+---
+title: "SVGAElement: origin property"
+short-title: origin
+slug: Web/API/SVGAElement/origin
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.origin
+---
+
+{{APIRef("SVG")}}
+
+The **`origin`** readonly property of the {{domxref("SVGAElement")}} returns a string containing the origin of the URL, that is its scheme, its domain and its port.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/password/index.md
+++ b/files/en-us/web/api/svgaelement/password/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.password
 
 {{APIRef("SVG")}}
 
-The **`password`** property of the {{domxref("SVGAElement")}} returns a string containing the password specified before the domain name.
+The **`password`** property of the {{domxref("SVGAElement")}} interface returns a string containing the password specified before the domain name.
 
 This property can be set, to change the URL's password.
 

--- a/files/en-us/web/api/svgaelement/password/index.md
+++ b/files/en-us/web/api/svgaelement/password/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: password property"
+short-title: password
+slug: Web/API/SVGAElement/password
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.password
+---
+
+{{APIRef("SVG")}}
+
+The **`password`** property of the {{domxref("SVGAElement")}} returns a string containing the password specified before the domain name.
+
+This property can be set, to change the URL's password.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/pathname/index.md
+++ b/files/en-us/web/api/svgaelement/pathname/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.pathname
 
 {{APIRef("SVG")}}
 
-The **`pathname`** property of the {{domxref("SVGAElement")}} returns a string containing an initial `/` followed by the path of the URL, not including the query string or fragment.
+The **`pathname`** property of the {{domxref("SVGAElement")}} interface returns a string containing an initial `/` followed by the path of the URL, not including the query string or fragment.
 
 This property can be set, to change the URL's pathname.
 

--- a/files/en-us/web/api/svgaelement/pathname/index.md
+++ b/files/en-us/web/api/svgaelement/pathname/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: pathname property"
+short-title: pathname
+slug: Web/API/SVGAElement/pathname
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.pathname
+---
+
+{{APIRef("SVG")}}
+
+The **`pathname`** property of the {{domxref("SVGAElement")}} returns a string containing an initial `/` followed by the path of the URL, not including the query string or fragment.
+
+This property can be set, to change the URL's pathname.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/ping/index.md
+++ b/files/en-us/web/api/svgaelement/ping/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: ping property"
+short-title: ping
+slug: Web/API/SVGAElement/ping
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.ping
+---
+
+{{APIRef("SVG")}}
+
+The **`ping`** property of the {{domxref("SVGAElement")}} returns a string that reflects the `ping` attribute, containing a space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking.
+
+This property can be set, to change the URL's `ping` value. It reflects the value of the [`ping`](/en-US/docs/Web/HTML/Reference/Elements/a#ping) attribute.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`ping`](/en-US/docs/Web/HTML/Reference/Elements/a#ping) attribute

--- a/files/en-us/web/api/svgaelement/ping/index.md
+++ b/files/en-us/web/api/svgaelement/ping/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.ping
 
 {{APIRef("SVG")}}
 
-The **`ping`** property of the {{domxref("SVGAElement")}} returns a string that reflects the `ping` attribute, containing a space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking.
+The **`ping`** property of the {{domxref("SVGAElement")}} interface returns a string that reflects the `ping` attribute, containing a space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking.
 
 This property can be set, to change the URL's `ping` value. It reflects the value of the [`ping`](/en-US/docs/Web/HTML/Reference/Elements/a#ping) attribute.
 

--- a/files/en-us/web/api/svgaelement/port/index.md
+++ b/files/en-us/web/api/svgaelement/port/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: port property"
+short-title: port
+slug: Web/API/SVGAElement/port
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.port
+---
+
+{{APIRef("SVG")}}
+
+The **`port`** property of the {{domxref("SVGAElement")}} returns a string representing the port component, if any, of the referenced URL.
+
+This property can be set, to change the URL's port.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/port/index.md
+++ b/files/en-us/web/api/svgaelement/port/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.port
 
 {{APIRef("SVG")}}
 
-The **`port`** property of the {{domxref("SVGAElement")}} returns a string representing the port component, if any, of the referenced URL.
+The **`port`** property of the {{domxref("SVGAElement")}} interface returns a string representing the port component, if any, of the referenced URL.
 
 This property can be set, to change the URL's port.
 

--- a/files/en-us/web/api/svgaelement/protocol/index.md
+++ b/files/en-us/web/api/svgaelement/protocol/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: protocol property"
+short-title: protocol
+slug: Web/API/SVGAElement/protocol
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.protocol
+---
+
+{{APIRef("SVG")}}
+
+The **`protocol`** property of the {{domxref("SVGAElement")}} returns a string representing the protocol component, including trailing colon (`:`), of the referenced URL.
+
+This property can be set, to change the URL's protocol.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/protocol/index.md
+++ b/files/en-us/web/api/svgaelement/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.protocol
 
 {{APIRef("SVG")}}
 
-The **`protocol`** property of the {{domxref("SVGAElement")}} returns a string representing the protocol component, including trailing colon (`:`), of the referenced URL.
+The **`protocol`** property of the {{domxref("SVGAElement")}} interface returns a string representing the protocol component, including trailing colon (`:`), of the referenced URL.
 
 This property can be set, to change the URL's protocol.
 

--- a/files/en-us/web/api/svgaelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/svgaelement/referrerpolicy/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.referrerpolicy
 
 {{APIRef("SVG")}}
 
-The **`referrerpolicy`** property of the {{domxref("SVGAElement")}} returns a string specifying which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the [URL](/en-US/docs/Glossary/URL)..
+The **`referrerpolicy`** property of the {{domxref("SVGAElement")}} interface returns a string specifying which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the [URL](/en-US/docs/Glossary/URL)..
 
 This property can be set, to change the URL's `referrerpolicy` value. It reflects the value of the [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy) attribute.
 

--- a/files/en-us/web/api/svgaelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/svgaelement/referrerpolicy/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: referrerpolicy property"
+short-title: referrerpolicy
+slug: Web/API/SVGAElement/referrerpolicy
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.referrerpolicy
+---
+
+{{APIRef("SVG")}}
+
+The **`referrerpolicy`** property of the {{domxref("SVGAElement")}} returns a string specifying which [referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referer) to send when fetching the [URL](/en-US/docs/Glossary/URL)..
+
+This property can be set, to change the URL's `referrerpolicy` value. It reflects the value of the [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy) attribute.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/a#referrerpolicy) attribute

--- a/files/en-us/web/api/svgaelement/search/index.md
+++ b/files/en-us/web/api/svgaelement/search/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: search property"
+short-title: search
+slug: Web/API/SVGAElement/search
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.search
+---
+
+{{APIRef("SVG")}}
+
+The **`search`** property of the {{domxref("SVGAElement")}} returns a string representing the URL's query string, if any, including the leading question mark (`?`).
+
+This property can be set, to change the URL's query component.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/search/index.md
+++ b/files/en-us/web/api/svgaelement/search/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.search
 
 {{APIRef("SVG")}}
 
-The **`search`** property of the {{domxref("SVGAElement")}} returns a string representing the URL's query string, if any, including the leading question mark (`?`).
+The **`search`** property of the {{domxref("SVGAElement")}} interface returns a string representing the URL's query string, if any, including the leading question mark (`?`).
 
 This property can be set, to change the URL's query component.
 

--- a/files/en-us/web/api/svgaelement/text/index.md
+++ b/files/en-us/web/api/svgaelement/text/index.md
@@ -1,0 +1,23 @@
+---
+title: "SVGAElement: text property"
+short-title: text
+slug: Web/API/SVGAElement/text
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.text
+---
+
+{{APIRef("SVG")}}
+
+The **`text`** property of the {{domxref("SVGAElement")}} returns a string that is a synonym for the {{domxref("Node.textContent")}} property.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svgaelement/text/index.md
+++ b/files/en-us/web/api/svgaelement/text/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.text
 
 {{APIRef("SVG")}}
 
-The **`text`** property of the {{domxref("SVGAElement")}} returns a string that is a synonym for the {{domxref("Node.textContent")}} property.
+The **`text`** property of the {{domxref("SVGAElement")}} interface returns a string that is a synonym for the {{domxref("Node.textContent")}} property.
 
 ## Value
 

--- a/files/en-us/web/api/svgaelement/type/index.md
+++ b/files/en-us/web/api/svgaelement/type/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.type
 
 {{APIRef("SVG")}}
 
-The **`type`** property of the {{domxref("SVGAElement")}} returns a string indicating the MIME type of the linked resource.
+The **`type`** property of the {{domxref("SVGAElement")}} interface returns a string indicating the MIME type of the linked resource.
 
 This property can be set, to change the URL's `type` value. It reflects the value of the [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type) attribute.
 

--- a/files/en-us/web/api/svgaelement/type/index.md
+++ b/files/en-us/web/api/svgaelement/type/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: type property"
+short-title: type
+slug: Web/API/SVGAElement/type
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.type
+---
+
+{{APIRef("SVG")}}
+
+The **`type`** property of the {{domxref("SVGAElement")}} returns a string indicating the MIME type of the linked resource.
+
+This property can be set, to change the URL's `type` value. It reflects the value of the [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type) attribute.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`type`](/en-US/docs/Web/HTML/Reference/Elements/a#type) attribute

--- a/files/en-us/web/api/svgaelement/username/index.md
+++ b/files/en-us/web/api/svgaelement/username/index.md
@@ -1,0 +1,29 @@
+---
+title: "SVGAElement: username property"
+short-title: username
+slug: Web/API/SVGAElement/username
+page-type: web-api-instance-property
+browser-compat: api.SVGAElement.username
+---
+
+{{APIRef("SVG")}}
+
+The **`username`** property of the {{domxref("SVGAElement")}} returns a string containing the username specified before the domain name.
+
+This property can be set, to change the URL's username.
+
+## Value
+
+A string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element

--- a/files/en-us/web/api/svgaelement/username/index.md
+++ b/files/en-us/web/api/svgaelement/username/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAElement.username
 
 {{APIRef("SVG")}}
 
-The **`username`** property of the {{domxref("SVGAElement")}} returns a string containing the username specified before the domain name.
+The **`username`** property of the {{domxref("SVGAElement")}} interface returns a string containing the username specified before the domain name.
 
 This property can be set, to change the URL's username.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR is part of an experiment conducted by Mozilla in which we are looking at trying to find efficient ways to fill in all the content gaps of features that have BCD but no content pages.

For this one, I've filled in minimal pages for all the members of the [`SVGAElement`](https://developer.mozilla.org/en-US/docs/Web/API/SVGAElement) interface. This includes:

- Frontmatter
- Description
- Value, Specifications, and Browser compatibility sections
- Minimal See also links where appropriate

It does not include examples or detailed usage information. The idea is that having this minimal documentation is better than nothing, and it might encourage contributors to fill in more details. Creating these 16 pages took me probably 45 minutes, and I did it manually as a test.

The questions we want to explore are:

1. Is this enough content to be useful?
2. Could we automate it to speed it up further?

Note that some pages do not have BCD, so this would need to be updated as well.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
