### PR TITLE
Clarify wording and accompanying CSS

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
@@ -506,8 +506,7 @@ body {
 
 All of the above fully applies to block boxes. Some of the properties can apply to inline boxes too, such as those created by a `<span>` element.
 
-In the example below, we have a `<span>` inside a paragraph. We have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width and height are ignored. The top and bottom margin, padding, and border are respected but don't change the relationship of other content to our inline box. The padding and border overlap other words in the paragraph. The left and right padding, margins, and borders move other content away from the box.
-
+In the example below, we have a `<span>` inside a paragraph. We have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width, height, and vertical margins do not affect the `<span>`. The vertical padding and border alter the size of the inline box but don't affect the position of the surrounding content. Instead, the vertical padding and border overlap other words in the paragraph. Only the horizontal padding, margins, and borders move other content away from the box.
 ```html live-sample___inline-box-model
 <p>
   I am a paragraph and this is a <span>span</span> inside that paragraph. A span
@@ -524,12 +523,13 @@ p {
   width: 200px;
 }
 span {
-  margin: 20px;
-  padding: 20px;
+  margin: 20px 40px;
+  padding: 10px 20px;
   width: 80px;
   height: 150px;
   background-color: lightblue;
-  border: 2px solid blue;
+  border: solid blue;
+  border-width: 7px 1px;
 }
 ```
 

--- a/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
@@ -506,7 +506,7 @@ body {
 
 All of the above fully applies to block boxes. Some of the properties can apply to inline boxes too, such as those created by a `<span>` element.
 
-In the example below, we have a `<span>` inside a paragraph. We have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width, height, and vertical margins do not affect the `<span>`. The vertical padding and border alter the size of the inline box but don't affect the position of the surrounding content. Instead, the vertical padding and border overlap other words in the paragraph. Only the horizontal padding, margins, and borders move other content away from the box.
+In the example below, we have a `<span>` inside a paragraph. We have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width, height, and vertical margins do not affect the `<span>`. The vertical padding and border alter the size of the inline box but don't affect the position of the surrounding content. Instead, the vertical padding and border overlap other words in the paragraph. Only the horizontal padding, margins, and borders affect the position of the text surrounding the `<span>`.
 
 ```html live-sample___inline-box-model
 <p>

--- a/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
@@ -524,7 +524,7 @@ p {
   width: 200px;
 }
 span {
-  margin: 20px 40px;
+  margin: 20px 30px;
   padding: 10px 20px;
   width: 80px;
   height: 150px;

--- a/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/box_model/index.md
@@ -507,6 +507,7 @@ body {
 All of the above fully applies to block boxes. Some of the properties can apply to inline boxes too, such as those created by a `<span>` element.
 
 In the example below, we have a `<span>` inside a paragraph. We have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width, height, and vertical margins do not affect the `<span>`. The vertical padding and border alter the size of the inline box but don't affect the position of the surrounding content. Instead, the vertical padding and border overlap other words in the paragraph. Only the horizontal padding, margins, and borders move other content away from the box.
+
 ```html live-sample___inline-box-model
 <p>
   I am a paragraph and this is a <span>span</span> inside that paragraph. A span


### PR DESCRIPTION
Clarify that vertical margins do not affect span. Update accompanying CSS example, so that users can more easily alter vertical and horizontal margins, padding, and border in the playground.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Clarified wording and accompanying CSS example in the section "The box model and inline boxes".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I was confused myself when trying to learn about inline boxes from this section. The original wording said that the top and bottom margins are "respected", which is misleading since they do not affect the span.
I also updated the accompanying playground CSS so that users can more easily adjust the vertical properties independently from the horizontal properties to see how they affect the inline box.

### Additional details
The top and bottom margins do not affect the span, and this is also noted here:
https://developer.mozilla.org/en-US/docs/Web/CSS/margin#description


<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->


### Related issues and pull requests
Fixes #41447

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
