### PR TITLE
fix: encodings table corrections

### DIFF
--- a/files/en-us/web/api/encoding_api/encodings/index.md
+++ b/files/en-us/web/api/encoding_api/encodings/index.md
@@ -319,7 +319,6 @@ The following table lists all encoding labels that user agents must support, alo
         <a href="https://en.wikipedia.org/wiki/GB_18030">gb18030</a>
       </td>
     </tr>
-    
     <tr>
       <td>
         <code>"big5"</code>, <code>"big5-hkscs"</code>, <code>"cn-big5"</code>,
@@ -347,11 +346,11 @@ The following table lists all encoding labels that user agents must support, alo
     <tr>
       <td>
         <code>"csshiftjis"</code>, <code>"ms_kanji"</code>,
-        <code>"shift_jis"</code>, <code>"shift_jis"</code>, <code>"sjis"</code>,
+        <code>"shift-jis"</code>, <code>"shift_jis"</code>, <code>"sjis"</code>,
         <code>"windows-31j"</code>, <code>"x-sjis"</code>
       </td>
       <td>
-        <a href="https://en.wikipedia.org/wiki/Shift_JIS">shift-jis</a>
+        <a href="https://en.wikipedia.org/wiki/Shift_JIS">shift_jis</a>
       </td>
     </tr>
     <tr>
@@ -366,7 +365,6 @@ The following table lists all encoding labels that user agents must support, alo
         <a href="https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR">euc-kr</a>
       </td>
     </tr>
-    
     <tr>
       <td><code>"utf-16be"</code></td>
       <td>
@@ -382,10 +380,6 @@ The following table lists all encoding labels that user agents must support, alo
     <tr>
       <td><code>"x-user-defined"</code></td>
       <td><code>"x-user-defined"</code></td>
-    </tr>
-    <tr>
-      <td><code>"iso-2022-cn"</code>, <code>"iso-2022-cn-ext"</code></td>
-      <td><code>"replacement"</code></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/api/encoding_api/encodings/index.md
+++ b/files/en-us/web/api/encoding_api/encodings/index.md
@@ -124,7 +124,7 @@ The following table lists all encoding labels that user agents must support, alo
         <code>"logical"</code>
       </td>
       <td>
-        <a href="https://en.wikipedia.org/wiki/ISO-8859-8-I">iso-8859-8i</a>
+        <a href="https://en.wikipedia.org/wiki/ISO-8859-8-I">iso-8859-8-i</a>
       </td>
     </tr>
     <tr>
@@ -319,12 +319,7 @@ The following table lists all encoding labels that user agents must support, alo
         <a href="https://en.wikipedia.org/wiki/GB_18030">gb18030</a>
       </td>
     </tr>
-    <tr>
-      <td><code>"hz-gb-2312"</code></td>
-      <td>
-        <a href="https://en.wikipedia.org/wiki/HZ_(character_encoding)">hz-gb-2312</a>
-      </td>
-    </tr>
+    
     <tr>
       <td>
         <code>"big5"</code>, <code>"big5-hkscs"</code>, <code>"cn-big5"</code>,
@@ -352,7 +347,7 @@ The following table lists all encoding labels that user agents must support, alo
     <tr>
       <td>
         <code>"csshiftjis"</code>, <code>"ms_kanji"</code>,
-        <code>"shift-jis"</code>, <code>"shift_jis"</code>, <code>"sjis"</code>,
+        <code>"shift_jis"</code>, <code>"shift_jis"</code>, <code>"sjis"</code>,
         <code>"windows-31j"</code>, <code>"x-sjis"</code>
       </td>
       <td>
@@ -377,11 +372,7 @@ The following table lists all encoding labels that user agents must support, alo
         <a href="https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-KR">iso-2022-kr</a>
       </td>
     </tr>
-    <tr>
-      <td><code>"utf-16be"</code></td>
-      <td>
-        <a href="https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes">utf-16be</a>
-      </td>
+    
     </tr>
     <tr>
       <td><code>"utf-16"</code>, <code>"utf-16le"</code></td>

--- a/files/en-us/web/api/encoding_api/encodings/index.md
+++ b/files/en-us/web/api/encoding_api/encodings/index.md
@@ -366,13 +366,12 @@ The following table lists all encoding labels that user agents must support, alo
         <a href="https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR">euc-kr</a>
       </td>
     </tr>
-    <tr>
-      <td><code>"csiso2022kr"</code>, <code>"iso-2022-kr"</code></td>
-      <td>
-        <a href="https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-KR">iso-2022-kr</a>
-      </td>
-    </tr>
     
+    <tr>
+      <td><code>"utf-16be"</code></td>
+      <td>
+        <a href="https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes">utf-16be</a>
+      </td>
     </tr>
     <tr>
       <td><code>"utf-16"</code>, <code>"utf-16le"</code></td>


### PR DESCRIPTION
Fix #41461 

Hello, 
In the file ---> /en-us/web/api/encoding_api/encodings/index.md

Changes made : 
1. Updated the encoding text to iso-8859-8-i for the row iso-8859-8-i.
2. Updated the encoding text to shift_jis for the shift_jis row.
3. Removed the entire row for both iso-2022-kr and hz-gb-2312.

Thank you 🤗 .