### PR TITLE
Clipboard API / Security: fix read access checks

### DIFF
--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -59,7 +59,7 @@ The Clipboard API extends the following APIs, adding the listed features.
 
 The Clipboard API allows users to programmatically read and write text and other kinds of data to and from the system clipboard in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
 
-When reading from the clipboard, the specification requires that a user has recently interacted with the page ([transient user activation](/en-US/docs/Web/Security/User_activation)) and that the call is made as a result of the user interacting with a browser or OS "paste element" (such as choosing "Paste" on a native context menu). In practice, browsers often allow read operations that do not satisfy these requirements but place other requirements instead (such as a permission or per-operation prompt).
+When reading from the clipboard, the specification requires that a user has recently interacted with the page ([transient user activation](/en-US/docs/Web/Security/User_activation)) and that the call is made as a result of the user interacting with a browser or OS "paste element" (such as choosing "Paste" on a native context menu). In practice, browsers often allow read operations that do not satisfy these requirements, while placing other requirements instead (such as a permission or per-operation prompt).
 For writing to the clipboard the specification expects that the page has been granted the [Permissions API](/en-US/docs/Web/API/Permissions_API) `clipboard-write` permission, and the browser may also require [transient user activation](/en-US/docs/Web/Security/User_activation).
 Browsers may place additional restrictions over use of the methods to access the clipboard.
 

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -59,8 +59,7 @@ The Clipboard API extends the following APIs, adding the listed features.
 
 The Clipboard API allows users to programmatically read and write text and other kinds of data to and from the system clipboard in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
 
-The specification requires that a user has recently interacted with the page in order to read from the clipboard ([transient user activation](/en-US/docs/Web/Security/User_activation) is required).
-If the read operation is caused by user interaction with a browser or OS "paste element" (such as a context menu), the browser is expected to prompt the user for acknowledgement.
+When reading from the clipboard, the specification requires that a user has recently interacted with the page ([transient user activation](/en-US/docs/Web/Security/User_activation)) and that the call is made as a result of the user interacting with a browser or OS "paste element" (such as choosing "Paste" on a native context menu). In practice, browsers often allow read operations that do not satisfy these requirements but place other requirements instead (permission, user prompt).
 For writing to the clipboard the specification expects that the page has been granted the [Permissions API](/en-US/docs/Web/API/Permissions_API) `clipboard-write` permission, and the browser may also require [transient user activation](/en-US/docs/Web/Security/User_activation).
 Browsers may place additional restrictions over use of the methods to access the clipboard.
 
@@ -69,16 +68,15 @@ The differences are captured in the [Browser compatibility](#browser_compatibili
 
 Chromium browsers:
 
-- Reading requires the [Permissions API](/en-US/docs/Web/API/Permissions_API) `clipboard-read` permission be granted.
-  Transient activation is not required.
+- If a read isn't allowed by the spec and the document has focus, it triggers a request to use permission `clipboard-read`, and succeeds if the permission is granted (either because the user accepted the prompt, or because the permission was granted already).
 - Writing requires either the `clipboard-write` permission or transient activation.
   If the permission is granted, it persists, and further transient activation is not required.
 - The HTTP [Permissions-Policy](/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy) permissions `clipboard-read` and `clipboard-write` must be allowed for {{HTMLElement("iframe")}} elements that access the clipboard.
-- No persistent paste-prompt is displayed when a read operation is caused by a browser or OS "paste element".
 
 Firefox & Safari:
 
-- Reading and writing require transient activation.
+- If a read isn't allowed by the spec and the document has focus, it triggers a user prompt in the form of an ephemeral context menu with a single "Paste" option (which becomes enabled after 1 second) and succeeds if the user chooses the option.
+- Writing requires transient activation.
 - The paste-prompt is suppressed if reading same-origin clipboard content, but not cross-origin content.
 - The `clipboard-read` and `clipboard-write` permissions are not supported (and not planned to be supported) by Firefox or Safari.
 

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -59,7 +59,7 @@ The Clipboard API extends the following APIs, adding the listed features.
 
 The Clipboard API allows users to programmatically read and write text and other kinds of data to and from the system clipboard in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
 
-When reading from the clipboard, the specification requires that a user has recently interacted with the page ([transient user activation](/en-US/docs/Web/Security/User_activation)) and that the call is made as a result of the user interacting with a browser or OS "paste element" (such as choosing "Paste" on a native context menu). In practice, browsers often allow read operations that do not satisfy these requirements but place other requirements instead (permission, user prompt).
+When reading from the clipboard, the specification requires that a user has recently interacted with the page ([transient user activation](/en-US/docs/Web/Security/User_activation)) and that the call is made as a result of the user interacting with a browser or OS "paste element" (such as choosing "Paste" on a native context menu). In practice, browsers often allow read operations that do not satisfy these requirements but place other requirements instead (such as a permission or per-operation prompt).
 For writing to the clipboard the specification expects that the page has been granted the [Permissions API](/en-US/docs/Web/API/Permissions_API) `clipboard-write` permission, and the browser may also require [transient user activation](/en-US/docs/Web/Security/User_activation).
 Browsers may place additional restrictions over use of the methods to access the clipboard.
 
@@ -75,7 +75,7 @@ Chromium browsers:
 
 Firefox & Safari:
 
-- If a read isn't allowed by the spec and the document has focus, it triggers a user prompt in the form of an ephemeral context menu with a single "Paste" option (which becomes enabled after 1 second) and succeeds if the user chooses the option.
+- If a read isn't allowed by the spec but transient user activation is still met, it triggers a user prompt in the form of an ephemeral context menu with a single "Paste" option (which becomes enabled after 1 second) and succeeds if the user chooses the option.
 - Writing requires transient activation.
 - The paste-prompt is suppressed if reading same-origin clipboard content, but not cross-origin content.
 - The `clipboard-read` and `clipboard-write` permissions are not supported (and not planned to be supported) by Firefox or Safari.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The "Security considerations" section of the Clipboard API doesn't correctly describe the access checks that browsers perform when a website attempts a read operation. This PR proposes a (hopefully) more correct/precise explanation.

### Motivation

I was reading the section and I had a little heart attack. It seems to imply that Firefox lets websites read the clipboard on any click to the website content (more generally, any interaction that sets transient user activation but isn't made through a native "paste element"). I quickly verified this is not the case. It seems that this phrase:

> If the read operation is caused by user interaction with a browser or OS "paste element" (such as a context menu), the browser is expected to prompt the user for acknowledgement.

was meant to say the opposite, e.g. a "not" was lost. Logically, if the operation is caused by the user pressing "Paste" in a context menu, then the browser knows the user intends for the website to be able to read the clipboard; it is on reads that do NOT satisfy this requirement that we'd want the browser to prompt for acknowledgment. Indeed this is what Firefox and Safari do; read() succeeds if called as a result of e.g. a `paste` event, but triggers a prompt in other cases.

The text also states, for Chromium, that the `clipboard-read` permission is required for a read to succeed. This is incorrect; reads that result from interaction with a native "paste element" always succeed, regardless of permission status. The text also seems to imply that once the permission is granted, the website can read the clipboard at any time (there are no further requirements). This is also incorrect: in either browser, the document must have focus for a read to succeed.

I haven't been able to find the origins of the phrase I quoted above (but I haven't done that much research). The spec doesn't mention anything about prompts for reads, it just says [a read is allowed if transient user activation is set and the code is running as a result of an interaction with a paste element, and disallowed otherwise](https://w3c.github.io/clipboard-apis/#check-clipboard-read-permission). Maybe it comes from an earlier version of the spec?

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
