### PR TITLE
Lint: quote non-generic font-family values (2)

### DIFF
--- a/files/en-us/web/css/animation-range-end/index.md
+++ b/files/en-us/web/css/animation-range-end/index.md
@@ -110,7 +110,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/animation-range-start/index.md
+++ b/files/en-us/web/css/animation-range-start/index.md
@@ -110,7 +110,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/animation-range/index.md
+++ b/files/en-us/web/css/animation-range/index.md
@@ -164,7 +164,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/animation-timeline/index.md
+++ b/files/en-us/web/css/animation-timeline/index.md
@@ -297,7 +297,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {
@@ -406,7 +406,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/border-radius/index.md
+++ b/files/en-us/web/css/border-radius/index.md
@@ -347,7 +347,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/break-after/index.md
+++ b/files/en-us/web/css/break-after/index.md
@@ -220,7 +220,7 @@ By default, the subheadings and paragraphs were laid out rather messily because 
 
 ```css
 html {
-  font-family: helvetica, arial, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/break-before/index.md
+++ b/files/en-us/web/css/break-before/index.md
@@ -220,7 +220,7 @@ By default, the subheadings and paragraphs were laid out rather messily because 
 
 ```css
 html {
-  font-family: helvetica, arial, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/break-inside/index.md
+++ b/files/en-us/web/css/break-inside/index.md
@@ -168,7 +168,7 @@ By default, it is possible for you to get a break between the image and its capt
 
 ```css
 html {
-  font-family: helvetica, arial, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 body {

--- a/files/en-us/web/css/calc-size/index.md
+++ b/files/en-us/web/css/calc-size/index.md
@@ -203,7 +203,7 @@ The HTML contains a single {{htmlelement("section")}} element that contains some
 }
 
 section {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   border: 1px solid black;
 }
 
@@ -275,7 +275,7 @@ The HTML contains a single {{htmlelement("section")}} element with [`tabindex="0
 }
 
 section {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 175px;
   border-radius: 5px;
   background: #eeeeee;
@@ -379,7 +379,7 @@ body {
 
 section {
   margin-top: 20px;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   background: #eeeeee;
   border: 2px solid #cccccc;
   padding: 0 20px;
@@ -505,7 +505,7 @@ body {
 form {
   margin-top: 20px;
   padding: 20px;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   background: #eeeeee;
   border: 2px solid #cccccc;
 }

--- a/files/en-us/web/css/corner-block-end-shape/index.md
+++ b/files/en-us/web/css/corner-block-end-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-block-start-shape/index.md
+++ b/files/en-us/web/css/corner-block-start-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-bottom-left-shape/index.md
+++ b/files/en-us/web/css/corner-bottom-left-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-bottom-right-shape/index.md
+++ b/files/en-us/web/css/corner-bottom-right-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-bottom-shape/index.md
+++ b/files/en-us/web/css/corner-bottom-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-end-end-shape/index.md
+++ b/files/en-us/web/css/corner-end-end-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-end-start-shape/index.md
+++ b/files/en-us/web/css/corner-end-start-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-inline-end-shape/index.md
+++ b/files/en-us/web/css/corner-inline-end-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-inline-start-shape/index.md
+++ b/files/en-us/web/css/corner-inline-start-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-left-shape/index.md
+++ b/files/en-us/web/css/corner-left-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-right-shape/index.md
+++ b/files/en-us/web/css/corner-right-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-shape-value/index.md
+++ b/files/en-us/web/css/corner-shape-value/index.md
@@ -89,7 +89,7 @@ The `corner-shape` property defines the shape of the box's corners while the reg
 
 ```css hidden live-sample___value-comparison
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 body {

--- a/files/en-us/web/css/corner-shape/index.md
+++ b/files/en-us/web/css/corner-shape/index.md
@@ -156,7 +156,7 @@ We give the box a fixed {{cssxref("height")}}, a {{cssxref("box-shadow")}}, a `b
 
 ```css hidden live-sample___basic-corner-shape
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }
@@ -245,7 +245,7 @@ html {
 }
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   height: inherit;
   margin: 0;
   display: flex;
@@ -361,7 +361,7 @@ We apply a {{cssxref("box-shadow")}} to the `<section>`. We also give the `<sect
 
 ```css hidden live-sample___corner-shape-select
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 body {
@@ -490,7 +490,7 @@ We apply a {{cssxref("box-shadow")}} to the `<section>` element. Additional basi
 
 ```css hidden live-sample___superellipse-slider
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 body {

--- a/files/en-us/web/css/corner-start-end-shape/index.md
+++ b/files/en-us/web/css/corner-start-end-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-start-start-shape/index.md
+++ b/files/en-us/web/css/corner-start-start-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-top-left-shape/index.md
+++ b/files/en-us/web/css/corner-top-left-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-top-right-shape/index.md
+++ b/files/en-us/web/css/corner-top-right-shape/index.md
@@ -65,7 +65,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/corner-top-shape/index.md
+++ b/files/en-us/web/css/corner-top-shape/index.md
@@ -79,7 +79,7 @@ We give the box some basic styles, which we've hidden for brevity. We also apply
 
 ```css hidden live-sample___basic-usage
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 240px;
   margin: 20px auto;
 }

--- a/files/en-us/web/css/css_borders_and_box_decorations/index.md
+++ b/files/en-us/web/css/css_borders_and_box_decorations/index.md
@@ -82,7 +82,7 @@ body:has(input:checked) div {
 
 @layer pageSetUp {
   html {
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: "Helvetica", "Arial", sans-serif;
   }
   body {
     max-width: 600px;

--- a/files/en-us/web/css/css_cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/css_cascade/shorthand_properties/index.md
@@ -91,14 +91,14 @@ font-style: italic;
 font-weight: bold;
 font-size: 0.8em;
 line-height: 1.2;
-font-family: Arial, sans-serif;
+font-family: "Arial", sans-serif;
 ```
 
 These 5 statements can be shortened to the following:
 
 ```css
 font:
-  italic bold 0.8em/1.2 Arial,
+  italic bold 0.8em/1.2 "Arial",
   sans-serif;
 ```
 

--- a/files/en-us/web/css/css_colors/color_format_converter/index.md
+++ b/files/en-us/web/css/css_colors/color_format_converter/index.md
@@ -163,7 +163,7 @@ dialog {
   border-radius: 5px;
   box-shadow: 3px 3px 10px rgb(0 0 0 / 0.2);
   background-color: white;
-  font-family: segue, arial, helvetica, sans-serif;
+  font-family: "Segue", "Helvetica", "Arial", sans-serif;
   margin-top: 5vh;
   width: 550px;
 }

--- a/files/en-us/web/css/css_conditional_rules/container_scroll-state_queries/index.md
+++ b/files/en-us/web/css/css_conditional_rules/container_scroll-state_queries/index.md
@@ -238,7 +238,7 @@ The `.back-to-top` link is given a {{cssxref("position")}} value of `fixed`, pla
 }
 
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   height: 100%;
 }
 
@@ -487,7 +487,7 @@ The `<section>` elements are designated as snap targets by setting a non-`none` 
 
 ```css live-sample___snapped
 section {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   width: 150px;
   height: 150px;
   margin: 50px auto;
@@ -758,7 +758,7 @@ Each `<header>` has a {{cssxref("position")}} value of `sticky` and a {{cssxref(
 }
 
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   height: 100%;
 }
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -93,7 +93,7 @@ div::before {
   font-size: min(6vh, 2rem);
   justify-content: center;
   display: flex;
-  font-family: comic-sans, papyrus, sans-serif;
+  font-family: "Comic Sans", "Papyrus", sans-serif;
 }
 ```
 

--- a/files/en-us/web/css/css_overflow/css_carousels/index.md
+++ b/files/en-us/web/css/css_overflow/css_carousels/index.md
@@ -81,7 +81,7 @@ The unordered list is made to fill the full width of the viewport with a width {
 
 body {
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {
@@ -394,7 +394,7 @@ This example uses [CSS multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_lay
 
 body {
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/css_positioned_layout/stacking_context/stacking_context_example_1/index.md
+++ b/files/en-us/web/css/css_positioned_layout/stacking_context/stacking_context_example_1/index.md
@@ -60,7 +60,7 @@ In terms of stacking contexts, DIV #1 and DIV #3 are assimilated into the root e
 
 ```css
 .bold {
-  font-family: Arial;
+  font-family: "Arial";
   font-size: 12px;
   font-weight: bold;
 }

--- a/files/en-us/web/css/css_positioned_layout/understanding_z-index/index.md
+++ b/files/en-us/web/css/css_positioned_layout/understanding_z-index/index.md
@@ -45,7 +45,7 @@ div {
   line-height: 100px;
   font-size: 40px;
   text-align: center;
-  font-family: arial, helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 #div1 {

--- a/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
+++ b/files/en-us/web/css/css_scroll_snap/using_scroll_snap_events/index.md
@@ -144,7 +144,7 @@ h2 {
 }
 
 section {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   border-radius: 5px;
   background: #eeeeee;
   box-shadow:
@@ -283,7 +283,7 @@ body {
 }
 
 section {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   border-radius: 5px;
   background: #eeeeee;
   box-shadow:

--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -358,8 +358,8 @@ Use the sliders in the example below to modify the translation, rotation, scale,
   margin-bottom: 4px;
   accent-color: blue; /* or any color */
   font-family:
-    "Inter", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    "Inter", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
 #allTransformFieldset > legend {

--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -358,7 +358,7 @@ Use the sliders in the example below to modify the translation, rotation, scale,
   margin-bottom: 4px;
   accent-color: blue; /* or any color */
   font-family:
-    Inter, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Inter", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
     "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 

--- a/files/en-us/web/css/dashed-ident/index.md
+++ b/files/en-us/web/css/dashed-ident/index.md
@@ -65,7 +65,7 @@ When `<dashed-ident>` is used with the [@font-palette-values](/en-US/docs/Web/CS
 
 ```css
 @font-palette-values --my-palette {
-  font-family: Bixa;
+  font-family: "Bixa";
   base-palette: 1;
   override-colors: 0 red;
 }

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -425,7 +425,7 @@ We have included {{cssxref("padding")}} and {{cssxref("background-color")}} on t
 
 ```css
 html {
-  font-family: helvetica, arial, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   letter-spacing: 1px;
   padding-top: 10px;
 }

--- a/files/en-us/web/css/flex-basis/index.md
+++ b/files/en-us/web/css/flex-basis/index.md
@@ -130,7 +130,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
 
 ```css
 .container {
-  font-family: arial, sans-serif;
+  font-family: "Arial", sans-serif;
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -259,7 +259,7 @@ body * {
   padding: 1rem;
   user-select: none;
   box-sizing: border-box;
-  font-family: Consolas, Arial, sans-serif;
+  font-family: "Consolas", "Arial", sans-serif;
 }
 ```
 

--- a/files/en-us/web/css/text-wrap-mode/index.md
+++ b/files/en-us/web/css/text-wrap-mode/index.md
@@ -100,7 +100,7 @@ The default setting is to wrap the content so the `text-wrap-mode` property is n
 
 ```css
 .box {
-  font-family: Arial, sans-serif;
+  font-family: "Arial", sans-serif;
   font-weight: bold;
   font-size: 64px;
   box-sizing: border-box;
@@ -129,7 +129,7 @@ In this example the content will **not** flow over to the next line so that it f
 
 ```css
 .box {
-  font-family: Arial, sans-serif;
+  font-family: "Arial", sans-serif;
   font-weight: bold;
   font-size: 64px;
   box-sizing: border-box;

--- a/files/en-us/web/css/transition-behavior/index.md
+++ b/files/en-us/web/css/transition-behavior/index.md
@@ -101,7 +101,7 @@ The HTML contains a {{htmlelement("div")}} element declared as a popover using t
 
 ```css hidden
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 [popover] {

--- a/files/en-us/web/css/view-timeline-axis/index.md
+++ b/files/en-us/web/css/view-timeline-axis/index.md
@@ -123,7 +123,7 @@ Also worth noting is that the subject element has an `animation-duration` applie
 }
 
 p {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 p {

--- a/files/en-us/web/css/view-timeline-inset/index.md
+++ b/files/en-us/web/css/view-timeline-inset/index.md
@@ -119,7 +119,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/view-timeline-name/index.md
+++ b/files/en-us/web/css/view-timeline-name/index.md
@@ -109,7 +109,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/view-timeline/index.md
+++ b/files/en-us/web/css/view-timeline/index.md
@@ -134,7 +134,7 @@ The `subject` element and its containing `content` element are styled minimally,
 
 p,
 h1 {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
 }
 
 h1 {

--- a/files/en-us/web/css/view-transition-name/index.md
+++ b/files/en-us/web/css/view-transition-name/index.md
@@ -256,7 +256,7 @@ We use [flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout) to lay out the `<l
 }
 
 html {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica", "Arial", sans-serif;
   height: 100%;
 }
 

--- a/files/en-us/web/css/word-spacing/index.md
+++ b/files/en-us/web/css/word-spacing/index.md
@@ -39,13 +39,13 @@ word-spacing: -0.4ch;
 ```css interactive-example
 @font-face {
   src: url("/shared-assets/fonts/variable-fonts/AmstelvarAlpha-VF.ttf");
-  font-family: Amstelvar;
+  font-family: "Amstelvar";
   font-style: normal;
 }
 
 section {
   font-size: 1.2em;
-  font-family: Amstelvar, serif;
+  font-family: "Amstelvar", serif;
 }
 ```
 


### PR DESCRIPTION
After https://github.com/mdn/content/pull/40228, we are a lot more explicit on some CSS stylistic decisions. In particular, we now require all non-generic font family names to be quoted, no exceptions—not even `"Arial"`. In addition, I noticed that the weird `Arial, Helvetica, sans-serif` combination is used a lot—which is pointless because every computer that supports Helvetica is also going to support Arial, so I reordered these two.