### PR TITLE
polish 'Understanding WebAssembly text format'

### DIFF
--- a/files/en-us/webassembly/guides/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/guides/understanding_the_text_format/index.md
@@ -444,7 +444,7 @@ The code below shows how we first import two memory instances, using the same ap
 To show how you can create memory within the WebAssembly module, we've created a third memory instance named `$mem2` in the module and _exported_ it.
 
 > [!NOTE]
-> If you’re using [wabt](https://github.com/WebAssembly/wabt) (e.g. `wat2wasm`), you may need to pass `--enable-multi-memory` because multi-memory support is still optional.
+> If you're using [wabt](https://github.com/WebAssembly/wabt) (e.g., `wat2wasm`), you may need to pass `--enable-multi-memory` because multi-memory support is still optional.
 
 ```wat
 (module

--- a/files/en-us/webassembly/guides/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/guides/understanding_the_text_format/index.md
@@ -5,16 +5,16 @@ page-type: guide
 sidebar: webassemblysidebar
 ---
 
-To enable WebAssembly to be read and edited by humans, there is a textual representation of the Wasm binary format. This is an intermediate form designed to be exposed in text editors, browser developer tools, etc. This article explains how that text format works, in terms of the raw syntax, and how it is related to the underlying bytecode it represents — and the wrapper objects representing Wasm in JavaScript.
+To enable WebAssembly to be read and edited by humans, there is a textual representation of the Wasm binary format. This is an intermediate form designed to be displayed in text editors, browser developer tools, and other similar environments. This article explains how the text format works in terms of its raw syntax, and how it relates to the underlying bytecode it represents and the wrapper objects that represent Wasm in JavaScript.
 
 > [!NOTE]
-> This is potentially overkill if you are a web developer who just wants to load a Wasm module into a page and use it in your code (see [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Guides/Using_the_JavaScript_API)), but it is more useful if for example, you want to write Wasm modules to optimize the performance of your JavaScript library, or build your own WebAssembly compiler.
+> This is potentially overkill if you are a web developer who wants to load a Wasm module into a page and use it in your code (see [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Guides/Using_the_JavaScript_API)). It is more useful if, for example, you want to write Wasm modules to optimize the performance of your JavaScript library or build your own WebAssembly compiler.
 
 ## S-expressions
 
-In both the binary and textual formats, the fundamental unit of code in WebAssembly is a module. In the text format, a module is represented as one big S-expression. S-expressions are a very old and very simple textual format for representing trees, and thus we can think of a module as a tree of nodes that describe the module's structure and its code. Unlike the Abstract Syntax Tree of a programming language, though, WebAssembly's tree is pretty flat, mostly consisting of lists of instructions.
+In both the binary and textual formats, the fundamental unit of code in WebAssembly is a module. In the text format, a module is represented as one big S-expression. S-expressions are an old, simplistic textual format for representing trees; we can therefore think of a module as a tree of nodes that describe the module's structure and its code. Unlike the Abstract Syntax Tree of a programming language, though, WebAssembly's tree is fairly flat, mostly consisting of lists of instructions.
 
-First, let's see what an S-expression looks like. Each node in the tree goes inside a pair of parentheses — `( ... )`. The first label inside the parenthesis tells you what type of node it is, and after that there is a space-separated list of either attributes or child nodes. So that means the WebAssembly S-expression:
+First, let's see what an S-expression looks like. Each node in the tree goes inside a pair of parentheses — `( ... )`. The first label inside the parentheses tells you what type of node it is, and after that, there is a space-separated list of either attributes or child nodes. So that means the WebAssembly S-expression:
 
 ```wat
 (module (memory 1) (func))
@@ -30,9 +30,9 @@ Let's start with the simplest, shortest possible Wasm module.
 (module)
 ```
 
-This module is totally empty, but is still a valid module.
+This module is empty, but it is still a valid module.
 
-If we convert our module to binary now (see [Converting WebAssembly text format to Wasm](/en-US/docs/WebAssembly/Guides/Text_format_to_Wasm)), we'll see just the 8 byte module header described in the [binary format](https://webassembly.github.io/spec/core/binary/modules.html#binary-module):
+If we convert our module to binary now (see [Converting WebAssembly text format to Wasm](/en-US/docs/WebAssembly/Guides/Text_format_to_Wasm)), we'll see just the 8-byte module header described in the [binary format](https://webassembly.github.io/spec/core/binary/modules.html#binary-module):
 
 ```plain
 0000000: 0061 736d              ; WASM_BINARY_MAGIC
@@ -43,7 +43,7 @@ If we convert our module to binary now (see [Converting WebAssembly text format 
 
 Ok, that's not very interesting, let's add some executable code to this module.
 
-All code in a webassembly module is grouped into functions, which have the following pseudocode structure:
+All code in a WebAssembly module is grouped into functions, which have the following pseudocode structure:
 
 ```wat
 ( func <signature> <locals> <body> )
@@ -53,7 +53,7 @@ All code in a webassembly module is grouped into functions, which have the follo
 - The **locals** are like vars in JavaScript, but with explicit types declared.
 - The **body** is just a linear list of low-level instructions.
 
-So this is similar to functions in other languages, even if it looks different because it is an S-expression.
+This is similar to functions in other languages, although it looks somewhat different.
 
 ## Signatures and parameters
 
@@ -93,7 +93,7 @@ The `local.get`/`local.set` commands refer to the item to be got/set by its nume
 
 The instruction `local.get 0` would get the i32 parameter, `local.get 1` would get the f32 parameter, and `local.get 2` would get the f64 local.
 
-There is another issue here — using numeric indices to refer to items can be confusing and annoying, so the text format allows you to name parameters, locals, and most other items by including a name prefixed by a dollar symbol (`$`) just before the type declaration.
+There is another issue here — using numeric indices to refer to items can be confusing and annoying. To mitigate this, you can name parameters, locals, and most other items by including a name prefixed by a dollar symbol (`$`) just before the type declaration.
 
 Thus, you could rewrite our previous signature like so:
 
@@ -105,11 +105,11 @@ And then could write `local.get $p1` instead of `local.get 0`, etc. (Note that w
 
 ## Stack machines
 
-Before we can write a function body, we have to talk about one more thing: **stack machines**. Although the browser compiles it to something more efficient, Wasm execution is defined in terms of a stack machine where the basic idea is that every type of instruction pushes and/or pops a certain number of `i32`/`i64`/`f32`/`f64` values to/from a stack.
+Before we write a function body, there is one more important concept to discuss: **stack machines**. Although the browser compiles it to something more efficient, Wasm execution is defined in terms of a stack machine where the basic idea is that every type of instruction pushes and/or pops a certain number of `i32`/`i64`/`f32`/`f64` values to/from a stack.
 
-For example, `local.get` is defined to push the value of the local it read onto the stack, and `i32.add` pops two `i32` values (it implicitly grabs the previous two values pushed onto the stack), computes their sum (modulo 2^32) and pushes the resulting i32 value.
+For example, `local.get` is defined to push the value of the local it reads onto the stack, and `i32.add` pops two `i32` values (it implicitly grabs the previous two values pushed onto the stack), computes their sum (modulo 2^32), and pushes the resulting i32 value.
 
-When a function is called, it starts with an empty stack which is gradually filled up and emptied as the body's instructions are executed. So for example, after executing the following function:
+When a function is called, it starts with an empty stack, which is gradually filled up and emptied as the body's instructions are executed. So, for example, after executing the following function:
 
 ```wat
 (func (param $p i32)
@@ -125,7 +125,7 @@ The WebAssembly validation rules ensure the stack matches exactly: if you declar
 
 ## Our first function body
 
-As mentioned before, the function body is a list of instructions that are followed as the function is called. Putting this together with what we have already learned, we can finally define a module containing our own simple function:
+The function body is a list of instructions that are followed as the function is called. Putting this together with what we have already learned, we can finally define a module containing our own basic function:
 
 ```wat
 (module
@@ -135,9 +135,9 @@ As mentioned before, the function body is a list of instructions that are follow
     i32.add))
 ```
 
-This function gets two parameters, adds them together, and returns the result.
+This function takes two parameters, adds them together, and returns the result.
 
-There are a lot more things that can be put inside function bodies, but we will start off simple for now, and you'll see a lot more examples as you go along. For a full list of the available opcodes, consult the [webassembly.org Semantics reference](https://webassembly.github.io/spec/core/exec/index.html).
+More things can be put inside function bodies, but we will start with a basic function for now. You'll see several more examples as you go along. For a full list of the available opcodes, consult the [webassembly.org Semantics reference](https://webassembly.github.io/spec/core/exec/index.html).
 
 ### Calling the function
 
@@ -155,7 +155,7 @@ Now we need to add an export declaration — this looks like so:
 (export "add" (func $add))
 ```
 
-Here, `add` is the name the function will be identified by in JavaScript whereas `$add` picks out which WebAssembly function inside the Module is being exported.
+Here, `add` is the name the function will be identified by in JavaScript, whereas `$add` picks out which WebAssembly function inside the Module is being exported.
 
 So our final module (for now) looks like this:
 
@@ -184,11 +184,11 @@ WebAssembly.instantiateStreaming(fetch("add.wasm")).then((obj) => {
 
 ## Exploring fundamentals
 
-Now we've covered the real basics, let's move on to look at some more advanced features.
+Now we've covered the basics, let's look at some more advanced features.
 
 ### Calling functions from other functions in the same module
 
-The `call` instruction calls a single function, given its index or name. For example, the following module contains two functions — one just returns the value 42, the other returns the result of calling the first plus one:
+The `call` instruction calls a single function, given its index or name. For example, the following module contains two functions — one returns the value `42`, the other returns the result of calling the first plus one:
 
 ```wat
 (module
@@ -201,9 +201,9 @@ The `call` instruction calls a single function, given its index or name. For exa
 ```
 
 > [!NOTE]
-> `i32.const` just defines a 32-bit integer and pushes it onto the stack. You could swap out the `i32` for any of the other available types, and change the value of the const to whatever you like (here we've set the value to `42`).
+> `i32.const` defines a 32-bit integer and pushes it onto the stack. You can swap out the `i32` for any of the other available types, and change the value of the const to whatever you like (here we've set the value to `42`).
 
-In this example you'll notice an `(export "getAnswerPlus1")` section, declared just after the `func` statement in the second function — this is a shorthand way of declaring that we want to export this function, and defining the name we want to export it as.
+In this example, you'll notice an `(export "getAnswerPlus1")` section, declared just after the `func` statement in the second function — this is a shorthand way of declaring that we want to export this function, and defining the name we want to export it as.
 
 This is functionally equivalent to including a separate function statement outside the function, elsewhere in the module in the same manner as we did before, e.g.:
 
@@ -221,7 +221,7 @@ WebAssembly.instantiateStreaming(fetch("call.wasm")).then((obj) => {
 
 ### Importing functions from JavaScript
 
-We have already seen JavaScript calling WebAssembly functions, but what about WebAssembly calling JavaScript functions? WebAssembly doesn't actually have any built-in knowledge of JavaScript, but it does have a general way to import functions that can accept either JavaScript or Wasm functions. Let's look at an example:
+We have already seen JavaScript calling WebAssembly functions, but what about WebAssembly calling JavaScript functions? WebAssembly doesn't have any built-in knowledge of JavaScript, but it does have a general way to import functions that can accept either JavaScript or Wasm functions. Let's look at an example:
 
 ```wat
 (module
@@ -231,15 +231,15 @@ We have already seen JavaScript calling WebAssembly functions, but what about We
     call $log))
 ```
 
-WebAssembly has a two-level namespace so the import statement here is saying that we're asking to import the `log` function from the `console` module. You can also see that the exported `logIt` function calls the imported function using the `call` instruction we introduced above.
+WebAssembly has a two-level namespace, so the import statement here imports the `log` function from the `console` module. You can also see that the exported `logIt` function calls the imported function using the `call` instruction we introduced above.
 
 Imported functions are just like normal functions: they have a signature that WebAssembly validation checks statically, and they are given an index and can be named and called.
 
 JavaScript functions have no notion of signature, so any JavaScript function can be passed, regardless of the import's declared signature. Once a module declares an import, the caller of [`WebAssembly.instantiate()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/instantiate_static) must pass in an import object that has the corresponding properties.
 
-For the above, we need an object (let's call it `importObject`) such that `importObject.console.log` is a JavaScript function.
+The above import requires an object (let's call it `importObject`) such that `importObject.console.log` is a JavaScript function.
 
-This would look like the following:
+This would look like the following in JavaScript:
 
 ```js
 const importObject = {
@@ -262,7 +262,7 @@ WebAssembly.instantiateStreaming(fetch("logger.wasm"), importObject).then(
 
 ### Declaring globals in WebAssembly
 
-WebAssembly has the ability to create global variable instances, accessible from both JavaScript and importable/exportable across one or more [`WebAssembly.Module`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Module) instances. This is very useful, as it allows dynamic linking of multiple modules.
+WebAssembly can create global variable instances, accessible from both JavaScript and importable/exportable across one or more [`WebAssembly.Module`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Module) instances. This is very useful, as it allows dynamic linking of multiple modules.
 
 In WebAssembly text format, it looks something like this (see [global.wat](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/global.wat) in our GitHub repo; also see [global.html](https://mdn.github.io/webassembly-examples/js-api-examples/global.html) for a live JavaScript example):
 
@@ -287,9 +287,9 @@ const global = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
 
 ### WebAssembly Memory
 
-The examples above show how to work with numbers in assembly code, adding them to the [stack](#stack_machines), perform operations on them, and then logging the result by calling a method in JavaScript.
+The examples above show how to work with numbers in assembly code, adding them to the [stack](#stack_machines), performing operations on them, and then logging the result by calling a method in JavaScript.
 
-For working with strings and other more complex data types we use `memory`, which can be created in either the WebAssembly or JavaScript, and shared between environments (more recent versions of WebAssembly can also use [Reference types](#reference_types)).
+For working with strings and other more complex data types, we use `memory`, which can be created in either WebAssembly or JavaScript, and shared between environments (more recent versions of WebAssembly can also use [Reference types](#reference_types)).
 
 In WebAssembly, `memory` is just a large contiguous, mutable array of raw bytes that can grow over time (see [linear memory](https://webassembly.github.io/spec/core/intro/overview.html?highlight=linear+memory) in the specification). WebAssembly contains [memory instructions](/en-US/docs/WebAssembly/Reference/Memory) like [`i32.load`](/en-US/docs/WebAssembly/Reference/Memory/Load) and [`i32.store`](/en-US/docs/WebAssembly/Reference/Memory/Store) for reading and writing bytes between the stack and any location in a memory.
 
@@ -299,24 +299,24 @@ JavaScript can create WebAssembly linear memory instances via the [`WebAssembly.
 Memory instances can also grow, for example via the [`Memory.grow()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/grow) method in JavaScript or [`memory.grow`](/en-US/docs/WebAssembly/Reference/Memory/Grow) in the WebAssembly.
 Since `ArrayBuffer` objects can't change size, the current `ArrayBuffer` is detached and a new `ArrayBuffer` is created to point to the newer, bigger memory.
 
-Note that when you create the memory you need to define the initial size, and you can optionally specify the maximum size to which the memory can grow.
-WebAssembly will attempt to reserve the maximum size (if specified), and if it is able to do so, it can grow the buffer more efficiently in future. Even if it can't allocate the maximum size now, it may still be able to grow later.
+Note that when you create the memory, you need to define the initial size, and you can optionally specify the maximum size to which the memory can grow.
+WebAssembly will attempt to reserve the maximum size (if specified), and if it is able to do so, it can grow the buffer more efficiently in the future. Even if it can't allocate the maximum size now, it may still be able to grow later.
 The method will only fail if it cannot allocate the _initial_ size.
 
 > [!NOTE]
-> Originally WebAssembly only allowed one memory per module instance.
+> Originally, WebAssembly only allowed one memory per module instance.
 > You can now have [multiple_memories](#multiple_memories) when supported by the browser.
 > Code that doesn't use multiple memories does not need to change!
 
 To demonstrate some of this behavior, let's consider the case where we want to work with a string in our WebAssembly code.
 A string is just a sequence of bytes somewhere inside this linear memory.
-Assuming we've written a suitable string of bytes to WebAssembly memory, we can pass that string to JavaScript by sharing the memory, the offset of the string within the memory, and some way of indicating the length.
+Assuming we've written a suitable string of bytes to WebAssembly memory, we can pass that string to JavaScript by sharing the memory, the offset of the string within the memory, and an indication of its length.
 
-Firstly let's create some memory and share it between the WebAssembly and JavaScript.
+Firstly, let's create some memory and share it between the WebAssembly and JavaScript.
 WebAssembly gives us a lot of flexibility here: we can either create a [`Memory`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory) object in JavaScript and have the WebAssembly module import the memory, or we can have the WebAssembly module create the memory and export it to JavaScript.
 
-For this example we'll create the memory in JavaScript then import it into WebAssembly.
-First we create a `Memory` object with 1 page, and add it to our `importObject` under the key `js.mem`.
+For this example, we'll create the memory in JavaScript then import it into WebAssembly.
+First, we create a `Memory` object with 1 page, and add it to our `importObject` under the key `js.mem`.
 We then instantiate our web assembly module, in this case "the_wasm_to_import.wasm", using the [`WebAssembly.instantiateStreaming()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static) method and passing the import object:
 
 ```js
@@ -334,7 +334,7 @@ WebAssembly.instantiateStreaming(
 });
 ```
 
-Within our WebAssembly file we import this memory. Using the WebAssembly text format, the `import` statement is written as follows:
+Within our WebAssembly file, we import this memory. Using the WebAssembly text format, the `import` statement is written as follows:
 
 ```wat
 (import "js" "mem" (memory 1))
@@ -344,13 +344,13 @@ The memory must be imported using the same two-level key specified in the `impor
 The `1` indicates that the imported memory must have at least 1 page of memory (WebAssembly currently defines a page to be 64KB).
 
 > [!NOTE]
-> As this is the first memory imported into the WebAssembly module it has a memory index of "0".
-> You could reference this particular memory using the index in [memory instructions](/en-US/docs/WebAssembly/Reference/Memory), but since 0 is the default index, in single-memory applications you don't need to.
+> As this is the first memory imported into the WebAssembly module, it has a memory index of `0`.
+> You could reference this particular memory using the index in [memory instructions](/en-US/docs/WebAssembly/Reference/Memory), but since `0` is the default index, in single-memory applications you don't need to.
 
 Now that we have a shared memory instance, the next step is to write a string of data into it.
 We'll then pass information about where the string is located and its length to the JavaScript (we could alternatively encode the string's length in the string itself, but passing a length is easier for us to implement).
 
-First let's add a string of data to our memory, in this case "Hi".
+First, let's add a string of data to our memory, in this case, "Hi".
 Since we own the entire linear memory, we can just write the string contents into global memory using a `data` section.
 Data sections allow a string of bytes to be written at a given offset at instantiation time and are similar to the `.data` sections in native executable formats.
 Here we're writing the data to the default memory (which we do not need to specify) at offset 0:
@@ -366,10 +366,10 @@ Here we're writing the data to the default memory (which we do not need to speci
 
 > [!NOTE]
 > The double semicolon syntax (`;;`) above is used to indicate comments in WebAssembly files.
-> In this case we're just using them to indicate placeholders for other code.
+> In this case, we're just using them to indicate placeholders for other code.
 
-To share this data with JavaScript we'll define two functions.
-First we import a function from the JavaScript, which we will use to log the string to the console.
+To share this data with JavaScript, we'll define two functions.
+First, we import a function from JavaScript, which we will use to log the string to the console.
 This will need to be mapped to `console.log` in the `importObject` used to instantiate the WebAssembly module.
 The function is named `$log` in the WebAssembly and takes `i32` parameters for the string offset and length in the memory.
 
@@ -391,7 +391,7 @@ Our final WebAssembly module (in text format) looks like this.
 )
 ```
 
-On the JavaScript-side we need to define the logging function, pass it to the WebAssembly, and then call the exported `writeHi()` method.
+On the JavaScript side, we need to define the logging function, pass it to the WebAssembly, and then call the exported `writeHi()` method.
 The complete code is shown below:
 
 ```js
@@ -418,7 +418,7 @@ WebAssembly.instantiateStreaming(fetch("logger2.wasm"), importObject).then(
 ```
 
 Note that the logging function `consoleLogString()` is passed to the `importObject` in the property `console.log`, and imported by the WebAssembly module.
-The function creates a view on the string in the shared memory using an `Uint8Array` at the passed offset and with the given length.
+The function creates a view on the string in the shared memory using a `Uint8Array` at the passed offset and with the given length.
 The bytes are then decoded from UTF-8 into a string using the [TextDecoder API](/en-US/docs/Web/API/TextDecoder) (we specify `utf8` here, but many other encodings are supported).
 The string is then logged to console with `console.log()`.
 
@@ -431,20 +431,20 @@ When you run the code, the console will show the text "Hi".
 #### Multiple memories
 
 More recent implementations allow you to use multiple memory objects in your WebAssembly and JavaScript, in a way that is compatible with code that is written for implementations that only support a single memory.
-Multiple memories can be useful for separating data that should be treated differently to other application data, such as public vs private data, data that needs to be persisted, and data that needs to be shared between threads.
+Multiple memories can be useful for separating data that should be treated differently from other application data, such as public vs private data, data that needs to be persisted, and data that needs to be shared between threads.
 It may also be useful for very large applications that need to scale beyond the Wasm 32-bit address space, and for other purposes.
 
-Memories that are made available to the WebAssembly code, either declared directly or imported, are given a zero-indexed sequentially allocated memory index number. All the [memory instructions](/en-US/docs/WebAssembly/Reference/Memory), such as [`load`](/en-US/docs/WebAssembly/Reference/Memory/Load) or [`store`](/en-US/docs/WebAssembly/Reference/Memory/Store), can reference any particular memory via its index so you can control which memory you're working with.
+Memories that are made available to the WebAssembly code, either declared directly or imported, are given a zero-indexed, sequentially allocated memory index number. All the [memory instructions](/en-US/docs/WebAssembly/Reference/Memory), such as [`load`](/en-US/docs/WebAssembly/Reference/Memory/Load) or [`store`](/en-US/docs/WebAssembly/Reference/Memory/Store), can reference any particular memory via its index so you can control which memory you're working with.
 
 The memory instructions have a default index of 0, the index of the first memory added to the WebAssembly instance.
 As a result, if you only add one memory, your code doesn't have to specify the index.
 
-To show how this works in more detail, we'll extend the previous example to write strings to three different memories and log the results.
+To explain this in more detail, we'll extend the previous example to write strings to three different memories and log the results.
 The code below shows how we first import two memory instances, using the same approach as in the previous example.
 To show how you can create memory within the WebAssembly module, we've created a third memory instance named `$mem2` in the module and _exported_ it.
 
 > [!NOTE]
-> If you're using [wabt](https://github.com/WebAssembly/wabt) (e.g., `wat2wasm`), you may need to pass `--enable-multi-memory` because multi-memory support is still optional.
+> If you're using [wabt](https://github.com/WebAssembly/wabt) (e.g., `wat2wasm`) to convert text format to Wasm, you may need to pass `--enable-multi-memory` because multi-memory support is still optional.
 
 ```wat
 (module
@@ -475,9 +475,9 @@ Here we write a string that indicates each memory type.
 ```
 
 Note that the `(memory 0)` is the default, and hence optional.
-To demonstrate this we write the text `" (Default)"` without specifying the memory index, and this should be appended after `"Memory 0 data"` when the memory contents are logged.
+To demonstrate this, we write the text `" (Default)"` without specifying the memory index, and this should be appended after `"Memory 0 data"` when the memory contents are logged.
 
-The WebAssembly logging code is almost exactly the same as the previous example, except that along with the string offset and length, we need to pass the index of the memory that contains the string.
+The WebAssembly logging code is similar to the previous example, except that we need to pass the index of the memory that contains the string along with the string offset and length.
 We also log all three memory instances.
 
 The complete module is shown below:
@@ -587,23 +587,23 @@ You can find the full source on GitHub as [multi-memory.html](https://github.com
 
 ### WebAssembly tables
 
-To finish this tour of the WebAssembly text format, let's look at the most intricate, and often confusing, part of WebAssembly: **tables**. Tables are basically resizable arrays of references that can be accessed by index from WebAssembly code.
+To finish this tour of the WebAssembly text format, let's look at the most intricate and often confusing part of WebAssembly: **tables**. Tables are basically resizable arrays of references that can be accessed by index from WebAssembly code.
 
-To see why tables are needed, we need to first observe that the `call` instruction we saw earlier (see [Calling functions from other functions in the same module](#calling_functions_from_other_functions_in_the_same_module)) takes a static function index and thus can only ever call one function — but what if the callee is a runtime value?
+To see why tables are needed, we need to observe that the `call` instruction we saw earlier (see [Calling functions from other functions in the same module](#calling_functions_from_other_functions_in_the_same_module)) takes a static function index and thus can only ever call one function — but what if the callee is a runtime value?
 
 - In JavaScript, we see this all the time: functions are first-class values.
 - In C/C++, we see this with function pointers.
 - In C++, we see this with virtual functions.
 
-WebAssembly needed a type of call instruction to achieve this, so we gave it `call_indirect`, which takes a dynamic function operand. The problem is that the only types we have to give operands in WebAssembly are (currently) `i32`/`i64`/`f32`/`f64`.
+WebAssembly needed a type of call instruction to achieve this, so we gave it `call_indirect`, which takes a dynamic function operand. The problem is that the only types we can give operands in WebAssembly are (currently) `i32`/`i64`/`f32`/`f64`.
 
-WebAssembly could add an `anyfunc` type ("any" because the type could hold functions of any signature), but unfortunately this `anyfunc` type couldn't be stored in linear memory for security reasons. Linear memory exposes the raw contents of stored values as bytes and this would allow Wasm content to arbitrarily observe and corrupt raw function addresses, which is something that cannot be allowed on the web.
+WebAssembly could add an `anyfunc` type ("any" because the type could hold functions of any signature), but unfortunately, this `anyfunc` type couldn't be stored in linear memory for security reasons. Linear memory exposes the raw contents of stored values as bytes, therefore, Wasm content could arbitrarily observe and corrupt raw function addresses, which is something that cannot be allowed on the web.
 
 The solution was to store function references in a table and pass around table indices instead, which are just i32 values. `call_indirect`'s operand can therefore be an i32 index value.
 
 #### Defining a table in Wasm
 
-So how do we place Wasm functions in our table? Just like `data` sections can be used to initialize regions of linear memory with bytes, `elem` sections can be used to initialize regions of tables with functions:
+So, how do we place Wasm functions in our table? Just like `data` sections can be used to initialize regions of linear memory with bytes, `elem` sections can be used to initialize regions of tables with functions:
 
 ```wat
 (module
@@ -617,9 +617,9 @@ So how do we place Wasm functions in our table? Just like `data` sections can be
 )
 ```
 
-- In `(table 2 funcref)`, the 2 is the initial size of the table (meaning it will store two references) and `funcref` declares that the element type of these references are function reference.
-- The functions (`func`) sections are just like any other declared Wasm functions. These are the functions we are going to refer to in our table (for example's sake, each one just returns a constant value). Note that the order the sections are declared in doesn't matter here — you can declare your functions anywhere and still refer to them in your `elem` section.
-- The `elem` section can list any subset of the functions in a module, in any order, allowing duplicates. This is a list of the functions that are to be referenced by the table, in the order they are to be referenced.
+- In `(table 2 funcref)`, the `2` is the initial size of the table (meaning it will store two references) and `funcref` declares that the element type of these references are function reference.
+- The functions (`func`) sections are just like any other declared Wasm functions. These are the functions we will refer to in our table (for example's sake, each one returns a constant value). Note that the order the sections are declared in doesn't matter here — you can declare your functions anywhere and still refer to them in your `elem` section.
+- The `elem` section can list any subset of the functions in a module, in any order, allowing duplicates. This is a list of the functions to be referenced by the table, in the order they are to be referenced.
 - The `(i32.const 0)` value inside the `elem` section is an offset — this needs to be declared at the start of the section, and specifies at what index in the table function references start to be populated. Here we've specified 0, and a size of 2 (see above), so we can fill in two references at indexes 0 and 1. If we wanted to start writing our references at offset 1, we'd have to write `(i32.const 1)`, and the table size would have to be 3.
 
 > [!NOTE]
@@ -664,17 +664,17 @@ You could also declare the `call_indirect` parameter explicitly during the comma
 (call_indirect (type $return_i32) (local.get $i))
 ```
 
-In a higher level, more expressive language like JavaScript, you could imagine doing the same thing with an array (or probably more likely, object) containing functions. The pseudocode would look something like `tbl[i]()`.
+In a higher-level, more expressive language like JavaScript, you could imagine doing the same thing with an array (or probably more likely, an object) containing functions. The pseudocode would look something like `tbl[i]()`.
 
-So, back to the typechecking. Since WebAssembly is type checked, and the `funcref` can be potentially any function signature, we have to supply the presumed signature of the callee at the callsite, hence we include the `$return_i32` type, to tell the program a function returning an `i32` is expected. If the callee doesn't have a matching signature (say an `f32` is returned instead), a [`WebAssembly.RuntimeError`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/RuntimeError) is thrown.
+So, back to the typechecking. Since WebAssembly is type-checked, and the `funcref` can potentially have any function signature, we have to supply the presumed signature of the callee at the callsite. We therefore include the `$return_i32` type to specify that a function returning an `i32` is expected. If the callee doesn't have a matching signature (say an `f32` is returned instead), a [`WebAssembly.RuntimeError`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/RuntimeError) is thrown.
 
-So what links the `call_indirect` to the table we are calling? The answer is that there is only one table allowed right now per module instance, and that is what `call_indirect` is implicitly calling. In the future, when multiple tables are allowed, we would also need to specify a table identifier of some kind, along the lines of
+So what links the `call_indirect` to the table we are calling? The answer is that there is currently only one table allowed per module instance, and that is what `call_indirect` is implicitly calling. In the future, when multiple tables are allowed, we would also need to specify a table identifier of some kind, along the lines of
 
 ```wat
 call_indirect $my_spicy_table (type $i32_to_void)
 ```
 
-The full module all together looks like this, and can be found in our [wasm-table.wat](https://github.com/mdn/webassembly-examples/blob/main/understanding-text-format/wasm-table.wat) example file:
+The full module looks like this, and can be found in our [wasm-table.wat](https://github.com/mdn/webassembly-examples/blob/main/understanding-text-format/wasm-table.wat) example file:
 
 ```wat
 (module
@@ -711,7 +711,7 @@ WebAssembly.instantiateStreaming(fetch("wasm-table.wasm")).then((obj) => {
 
 Because JavaScript has full access to function references, the Table object can be mutated from JavaScript using the [`grow()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table/grow), [`get()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table/get) and [`set()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table/set) methods. And WebAssembly code is itself able to manipulate tables using instructions added as part of [Reference types](#reference_types), such as `table.get` and `table.set`.
 
-Because tables are mutable, they can be used to implement sophisticated load-time and run-time [dynamic linking schemes](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). When a program is dynamically linked, multiple instances share the same memory and table. This is symmetric to a native application where multiple compiled `.dll`s share a single process's address space.
+Because tables are mutable, they can be used to implement sophisticated load-time and run-time [dynamic linking schemes](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). When a program is dynamically linked, multiple instances share the same memory and table. This is similar to a native application where multiple compiled `.dll`s share a single process's address space.
 
 To see this in action, we'll create a single import object containing a Memory object and a Table object, and pass this same import object to multiple [`instantiate()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/instantiate_static) calls.
 
@@ -787,14 +787,14 @@ Each of the modules that is being compiled can import the same memory and table 
 
 ## Bulk memory operations
 
-Bulk memory operations are a newer addition to the language — seven new built-in operations are provided for bulk memory operations such as copying and initializing, to allow WebAssembly to model native functions such as `memcpy` and `memmove` in a more efficient, performant way.
+Bulk memory operations are a newer addition to the language. Seven new built-in operations are provided for bulk memory operations, such as copying and initializing, to allow WebAssembly to model native functions like `memcpy` and `memmove` in a more efficient, performant way.
 
 > [!NOTE]
 > See [`webassembly.bulk-memory-operations` in the home page](/en-US/docs/WebAssembly#webassembly.bulk-memory-operations) for browser compatibility information.
 
 The new operations are:
 
-- `data.drop`: Discard the data in an data segment.
+- `data.drop`: Discard the data in a data segment.
 - `elem.drop`: Discard the data in an element segment.
 - `memory.copy`: Copy from one region of linear memory to another.
 - `memory.fill`: Fill a region of linear memory with a given byte value.
@@ -818,14 +818,14 @@ WebAssembly currently has four available _number types_:
 
 ### Vector types
 
-- `v128`: 128 bit vector of packed integer, floating-point data, or a single 128 bit type.
+- `v128`: 128-bit vector of packed integer, floating-point data, or a single 128-bit type.
 
 ### Reference types
 
 The [reference types proposal](https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md) provides two main features:
 
-- A new type, `externref`, which can hold _any_ JavaScript value, for example strings, DOM references, objects, etc. `externref` is opaque from the point of view of WebAssembly — a Wasm module can't access and manipulate these values and instead can only receive them and pass them back out. But this is very useful for allowing Wasm modules to call JavaScript functions, DOM APIs, etc., and generally to pave the way for easier interoperability with the host environment. `externref` can be used for value types and table elements.
-- A number of new instructions that allow Wasm modules to directly manipulate [WebAssembly tables](#webassembly_tables), rather than having to do it via the JavaScript API.
+- A new type, `externref`, which can hold _any_ JavaScript value, for example, strings, DOM references, objects, etc. `externref` is opaque from the point of view of WebAssembly — a Wasm module can't access and manipulate these values and instead can only receive them and pass them back out. This is still very useful for allowing Wasm modules to call JavaScript functions, DOM APIs, etc., and generally to pave the way for easier interoperability with the host environment. `externref` can be used for value types and table elements.
+- Several new instructions that allow Wasm modules to directly manipulate [WebAssembly tables](#webassembly_tables), rather than having to do it via the JavaScript API.
 
 > [!NOTE]
 > The [wasm-bindgen](https://rustwasm.github.io/docs/wasm-bindgen/) documentation contains some useful information on how to take advantage of `externref` from Rust.
@@ -859,9 +859,9 @@ But this will pave the way for more useful instruction types, and other things b
 
 ## WebAssembly threads
 
-WebAssembly Threads allow WebAssembly Memory objects to be shared across multiple WebAssembly instances running in separate Web Workers, in the same fashion as [`SharedArrayBuffer`s](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) in JavaScript. This allows very fast communication between Workers, and significant performance gains in web applications.
+WebAssembly Threads allow WebAssembly Memory objects to be shared across multiple WebAssembly instances running in separate Web Workers, in the same fashion as [`SharedArrayBuffer`s](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) in JavaScript. This enables fast communication between Workers and significant performance gains in web applications.
 
-The threads proposal has two parts, shared memories and atomic memory accesses.
+The threads proposal has two parts: shared memories and atomic memory accesses.
 
 > [!NOTE]
 > See [`webassembly.threads-and-atomics` in the home page](/en-US/docs/WebAssembly#webassembly.threads-and-atomics) for browser compatibility information.
@@ -899,7 +899,7 @@ Unlike unshared memories, shared memories must specify a "maximum" size, in both
 
 ### Atomic memory accesses
 
-A number of new Wasm instructions have been added that can be used to implement higher level features like mutexes, condition variables, etc. You can [find them listed here](https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md#atomic-memory-accesses).
+Several new Wasm instructions have been added that can be used to implement higher-level features like mutexes, condition variables, etc. You can [find them listed here](https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md#atomic-memory-accesses).
 
 > [!NOTE]
 > The [Emscripten Pthreads support page](https://emscripten.org/docs/porting/pthreads.html) shows how to take advantage of this new functionality from Emscripten.


### PR DESCRIPTION
### Description

- fix typos and minor grammatical errors
- update the example code by correcting the size of the string in memory and adding a helpful comment (I used [multi-memory.wat](https://github.com/mdn/webassembly-examples/blob/main/understanding-text-format/multi-memory.wat) as  a base)
- add a helpful note for the reader who is trying to follow along

### Motivation

I was reading the article and noticed a few places that could be clarified and corrected to make the article easier to follow.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
