### PR TITLE
DocParser.parseFromString() - update for trusted types

### DIFF
--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -26,7 +26,7 @@ Note that {{domxref("XMLHttpRequest")}} can parse XML and HTML directly from a U
 ## Instance methods
 
 - {{domxref("DOMParser.parseFromString()")}}
-  - : Parses an input {{domxref("TrustedHTML")}} instance or string as HTML or XML and returns an {{domxref("Document")}}.
+  - : Parses an input {{domxref("TrustedHTML")}} instance or string as HTML or XML and returns a {{domxref("Document")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -7,26 +7,16 @@ browser-compat: api.DOMParser
 
 {{APIRef("DOM")}}
 
-The **`DOMParser`** interface provides
-the ability to parse {{Glossary("XML")}} or {{Glossary("HTML")}} source code from a
-string into a DOM {{domxref("Document")}}.
+The **`DOMParser`** interface provides the ability to parse {{Glossary("XML")}} or {{Glossary("HTML")}} source code from a string into a DOM {{domxref("Document")}}.
 
-You can perform the opposite operation—converting a DOM tree into XML or HTML
-source—using the {{domxref("XMLSerializer")}} interface.
+You can perform the opposite operation—converting a DOM tree into XML or HTML source—using the {{domxref("XMLSerializer")}} interface.
 
-In the case of an HTML document, you can also replace portions of the DOM with new DOM
-trees built from HTML by setting the value of the {{domxref("Element.innerHTML")}} and
-{{domxref("Element.outerHTML", "outerHTML")}} properties. These properties can also be
-read to fetch HTML fragments corresponding to the corresponding DOM subtree.
+In the case of an HTML document, you can also replace portions of the DOM with new DOM trees built from HTML by setting the value of the {{domxref("Element.innerHTML")}} and {{domxref("Element.outerHTML", "outerHTML")}} properties. These properties can also be read to fetch HTML fragments corresponding to the corresponding DOM subtree.
 
-Note that {{domxref("XMLHttpRequest")}} can parse XML and HTML directly
-from a URL-addressable resource, returning a `Document` in its
-{{domxref("XMLHttpRequest.response", "response")}} property.
+Note that {{domxref("XMLHttpRequest")}} can parse XML and HTML directly from a URL-addressable resource, returning a `Document` in its {{domxref("XMLHttpRequest.response", "response")}} property.
 
 > [!NOTE]
-> Be aware that [block-level elements](/en-US/docs/Glossary/Block-level_content)
-> like `<p>` will be automatically closed if another
-> block-level element is nested inside and therefore parsed before the closing `</p>` tag.
+> Be aware that [block-level elements](/en-US/docs/Glossary/Block-level_content) like `<p>` will be automatically closed if another block-level element is nested inside and therefore parsed before the closing `</p>` tag.
 
 ## Constructor
 
@@ -36,7 +26,7 @@ from a URL-addressable resource, returning a `Document` in its
 ## Instance methods
 
 - {{domxref("DOMParser.parseFromString()")}}
-  - : Parses a string using either the HTML parser or the XML parser, returning an {{domxref("HTMLDocument")}} or {{domxref("XMLDocument")}}.
+  - : Parses an input {{domxref("TrustedHTML")}} instance or string as HTML or XML and returns an {{domxref("Document")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -76,7 +76,7 @@ Disallowed `mimeType` values cause a [`TypeError`](/en-US/docs/Web/JavaScript/Re
 
 This method parses its input into a separate in-memory DOM, disabling any {{htmlelement("script")}} elements and stopping event handlers from running.
 While the returned document is effectively inert, event handlers and scripts in its DOM will be able to run if they are inserted into the visible DOM.
-The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe input is first parsed into a `Document` without being santizied, and then injected into the visible/active DOM were code is able to run.
+The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe input is first parsed into a `Document` without being sanitizied, and then injected into the visible/active DOM where code is able to run.
 
 You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -8,62 +8,150 @@ browser-compat: api.DOMParser.parseFromString
 
 {{APIRef("DOMParser")}}
 
-The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface parses a string containing either HTML or XML, returning an {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}.
+> [!WARNING]
+> This method parses its input as HTML, writing the result into the DOM.
+> APIs like this are known as [injection sinks](/en-US/docs/Web/API/Trusted_Types_API#concepts_and_usage), and are potentially a vector for [cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, if the input originally came from an attacker.
+>
+> You can mitigate this risk by always passing `TrustedHTML` objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
+> See [Security considerations](#security_considerations) for more information.
+
+The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface parses an input containing either HTML or XML, returning an {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}.
 
 > [!NOTE]
-> The [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) static method provides an ergonomic alternative for parsing HTML strings into a {{domxref("Document")}}.
+> The [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) static method provides an ergonomic alternative for parsing HTML markup into a {{domxref("Document")}}.
 
 ## Syntax
 
 ```js-nolint
-parseFromString(string, mimeType)
+parseFromString(input, mimeType)
 ```
 
 ### Parameters
 
-- `string`
-  - : The string to be parsed. It must contain either an
-    {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("XHTML")}}, or
-    {{Glossary("svg")}} document.
+- `input`
+  - : A {{domxref("TrustedHTML")}} or string instance defining HTML to be parsed.
+    The markup must contain either an {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("XHTML")}}, or {{Glossary("svg")}} document.
 - `mimeType`
-  - : A string. This string determines whether the XML parser or the HTML parser is used to parse the string. Valid values are:
+
+  - : A string that specifies whether the XML parser or the HTML parser is used to parse the string.
+
+    Allowed values are:
+
     - `text/html`
     - `text/xml`
     - `application/xml`
     - `application/xhtml+xml`
     - `image/svg+xml`
 
-    A value of `text/html` will invoke the HTML parser, and the method will return an {{domxref("HTMLDocument")}}. Any {{HTMLElement("script")}} element gets marked non-executable, and the contents of {{HTMLElement("noscript")}} are parsed as markup.
-
-    The other valid values (`text/xml`, `application/xml`, `application/xhtml+xml`, and `image/svg+xml`) are functionally equivalent. They all invoke the XML parser, and the method will return a {{domxref("XMLDocument")}}.
-
-    Any other value is invalid and will cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) to be thrown.
-
 ### Return value
 
-An {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}, depending on the
-`mimeType` argument.
+A {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}, depending on the `mimeType` argument.
+
+> ![NOTE]
+> You can treat the returned object as a {{domxref("Document")}} with the {{domxref("Document/contentType","contentType")}} matching the `mimeType`.
+
+### Exceptions
+
+- [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
+  - : This is thrown when:
+    - `mimeType` is passed a value that is not one of the [allowed value](#mimetype).
+    - `input` is passed a string value when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
+
+## Description
+
+The **`parseFromString()`** method parses an input containing either HTML or XML, returning a {{domxref("Document")}} with the {{domxref("Document/contentType","contentType")}} matching the `mimeType`.
+This `Document` contains a complete in-memory DOM that is separate from the main document in the associated page.
+
+If the `mimeType` is `text/html` the input is parsed as HTML and {{htmlelement("script")}} elements are marked as non-executable, events are not fired, and event handlers aren't called to run inline scripts.
+While the document can download resources specified in {{htmlelement("iframe")}} and {{htmlelement("img")}} elements, it is essentially inert.
+This is ueful because you can parse HTML inputs that include {{glossary("Shadow tree","declarative shadow roots")}}, and perform operations on the document without affecting the visible page.
+For example, you can use this to sanitize the input tree, and inject parts of the input into the visible DOM when needed.
+
+For the other allowed values (`text/xml`, `application/xml`, `application/xhtml+xml`, and `image/svg+xml`) the input is parsed as XML.
+This is useful if you want to import XML files, validate their structure, and extract data.
+If the input doesn't represent well-formed XML, the returned document will contain a `<parsererror>` node describing the nature of the parsing error.
+
+Disallowed `mimeType` values cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) is thrown.
+
+### Security considerations
+
+This method parses its input into a separate in-memory DOM, disabling any {{htmlelement("script")}} elements and stopping event handlers from running.
+While the returned document is effectively inert, event handlers and scripts in its DOM will be able. run if they are inserted into the visible DOM.
+The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe input is first parsed into a `Document` without being santizied, and then injected into the visible/active DOM were code is able to run.
+
+You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
+This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup (such as {{htmlelement("script")}} elements and event handler attributes), before it is injected.
+
+Using `TrustedHTML` makes it possible to audit and check that sanitization code is effective in just a few places, rather than scattered across all your injection sinks.
+You should not need to pass a sanitizer to the method when using `TrustedHTML`.
+
+Note that even if you sanitize the input of elements and attributes that can execute code, you still need to be careful when taking any user input.
+For example, you page might use data in an XML to fetch files that it then executes.
 
 ## Examples
 
+### Parsing an input using Trusted Types
+
+In this example we'll safely parse a potentially harmful HTML input and then inject it into the DOM of the visible page.
+
+To mitigate the risk of XSS, we'll create a `TrustedHTML` object from the string containing the HTML.
+Trusted types are not yet supported on all browsers, so first we define the [trusted types tinyfill](/en-US/docs/Web/API/Trusted_Types_API#trusted_types_tinyfill).
+This acts as a transparent replacement for the trusted types JavaScript API:
+
+```js
+if (typeof trustedTypes === "undefined")
+  trustedTypes = { createPolicy: (n, rules) => rules };
+```
+
+Next we create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createHTML", "createHTML()")}} for transforming an input string into {{domxref("TrustedHTML")}} instances.
+Commonly implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the input as shown below:
+
+```js
+const policy = trustedTypes.createPolicy("my-policy", {
+  createHTML: (input) => DOMPurify.sanitize(input),
+});
+```
+
+Then we use this `policy` object to create a `TrustedHTML` object from the potentially unsafe input string and parse it into a `Document`.
+Note that the resulting `Document` will represent a complete HTML document with a root `<html>`, `<head>` and `<body>`, even though the input does not have these elements:
+
+```js
+// The potentially malicious string
+const untrustedString = "<p>I might be XSS</p><img src='x' onerror='alert(1)'>";
+
+// Create a TrustedHTML instance using the policy
+const trustedHTML = policy.createHTML(untrustedString);
+
+// Parse the TrustedHTML (which contains a trusted string)
+const safeDocument = parser.parseFromString(trustedHTML, "text/html");
+```
+
+The `safeDocument` now contains a DOM that is sanitized of harmful elements according to our policy.
+Below we use {{domxref("Element.replaceWith()")}} to replace the `body` of the visible DOM with the body of our document: scripts in the new body will run, as will code when event handlers are triggered.
+
+```js
+document.body.replaceWith(safeDocument.body);
+```
+
 ### Parsing XML, SVG, and HTML
 
-Note that a MIME type of `text/html` will invoke the HTML parser, and any other valid MIME type will invoke the XML parser. The `application/xml` and `image/svg+xml` MIME types in the example below are functionally identical — the latter does not include any SVG-specific parsing rules. Distinguishing between the two serves only to clarify the code's intent.
+The code below shows how you use the method to parse each of the content types.
+While you should use trusted types in real code, here they are omitted for brevity.
 
 ```js
 const parser = new DOMParser();
 
 const xmlString = "<warning>Beware of the tiger</warning>";
 const doc1 = parser.parseFromString(xmlString, "application/xml");
-// XMLDocument
+console.log(doc1.contentType); // "application/xml"
 
 const svgString = '<circle cx="50" cy="50" r="50"/>';
 const doc2 = parser.parseFromString(svgString, "image/svg+xml");
-// XMLDocument
+console.log(doc2.contentType); // "image/svg+xml"
 
 const htmlString = "<strong>Beware of the leopard</strong>";
 const doc3 = parser.parseFromString(htmlString, "text/html");
-// HTMLDocument
+console.log(doc\32.contentType); // "text/html"
 
 console.log(doc1.documentElement.textContent);
 // "Beware of the tiger"
@@ -74,6 +162,8 @@ console.log(doc2.firstChild.tagName);
 console.log(doc3.body.firstChild.textContent);
 // "Beware of the leopard"
 ```
+
+Note that `application/xml` and `image/svg+xml` MIME types above are functionally identical — the latter does not include any SVG-specific parsing rules.
 
 ### Error handling
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -75,7 +75,7 @@ Disallowed `mimeType` values cause a [`TypeError`](/en-US/docs/Web/JavaScript/Re
 ### Security considerations
 
 This method parses its input into a separate in-memory DOM, disabling any {{htmlelement("script")}} elements and stopping event handlers from running.
-While the returned document is effectively inert, event handlers and scripts in its DOM will be able. run if they are inserted into the visible DOM.
+While the returned document is effectively inert, event handlers and scripts in its DOM will be able to run if they are inserted into the visible DOM.
 The method is therefore a possible vector for [Cross-site-scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks, where potentially unsafe input is first parsed into a `Document` without being santizied, and then injected into the visible/active DOM were code is able to run.
 
 You should mitigate this risk by always passing {{domxref("TrustedHTML")}} objects instead of strings, and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -35,7 +35,6 @@ parseFromString(input, mimeType)
   - : A string that specifies whether the XML parser or the HTML parser is used to parse the string.
 
     Allowed values are:
-
     - `text/html`
     - `text/xml`
     - `application/xml`

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -85,7 +85,7 @@ Using `TrustedHTML` makes it possible to audit and check that sanitization code 
 You should not need to pass a sanitizer to the method when using `TrustedHTML`.
 
 Note that even if you sanitize the input of elements and attributes that can execute code, you still need to be careful when taking any user input.
-For example, you page might use data in an XML to fetch files that it then executes.
+For example, your page might use data in an XML document to fetch files that it then executes.
 
 ## Examples
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -30,7 +30,7 @@ parseFromString(input, mimeType)
 
 - `input`
   - : A {{domxref("TrustedHTML")}} or string instance defining HTML to be parsed.
-    The markup must contain either an {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("XHTML")}}, or {{Glossary("svg")}} document.
+    The markup must contain either an {{Glossary("HTML")}}, {{Glossary("XML")}}, {{Glossary("XHTML")}}, or {{Glossary("svg")}} document.
 - `mimeType`
   - : A string that specifies whether the XML parser or the HTML parser is used to parse the string.
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -162,7 +162,7 @@ console.log(doc3.body.firstChild.textContent);
 // "Beware of the leopard"
 ```
 
-Note that `application/xml` and `image/svg+xml` MIME types above are functionally identical — the latter does not include any SVG-specific parsing rules.
+Note that the `application/xml` and `image/svg+xml` MIME types above are functionally identical — the latter does not include any SVG-specific parsing rules.
 
 ### Error handling
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -103,7 +103,7 @@ if (typeof trustedTypes === "undefined")
 ```
 
 Next we create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createHTML", "createHTML()")}} for transforming an input string into {{domxref("TrustedHTML")}} instances.
-Commonly implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the input as shown below:
+Commonly, implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the, input as shown below:
 
 ```js
 const policy = trustedTypes.createPolicy("my-policy", {

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -53,7 +53,7 @@ A {{domxref("Document")}} with {{domxref("Document/contentType","contentType")}}
 
 - [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
   - : This is thrown when:
-    - `mimeType` is passed a value that is not one of the [allowed value](#mimetype).
+    - `mimeType` is passed a value that is not one of the [allowed values](#mimetype).
     - `input` is passed a string value when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
 
 ## Description

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -70,7 +70,7 @@ For the other allowed values (`text/xml`, `application/xml`, `application/xhtml+
 This is useful if you want to import XML files, validate their structure, and extract data.
 If the input doesn't represent well-formed XML, the returned document will contain a `<parsererror>` node describing the nature of the parsing error.
 
-Disallowed `mimeType` values cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) is thrown.
+Disallowed `mimeType` values cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) to be thrown.
 
 ### Security considerations
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -30,7 +30,7 @@ parseFromString(input, mimeType)
 
 - `input`
   - : A {{domxref("TrustedHTML")}} or string instance defining HTML to be parsed.
-    The markup must contain either an {{Glossary("HTML")}}, {{Glossary("XML")}}, {{Glossary("XHTML")}}, or {{Glossary("svg")}} document.
+    The markup must contain either an {{Glossary("HTML")}}, {{Glossary("XML")}}, {{Glossary("XHTML")}}, or {{Glossary("SVG")}} document.
 - `mimeType`
   - : A string that specifies whether the XML parser or the HTML parser is used to parse the string.
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -15,7 +15,7 @@ browser-compat: api.DOMParser.parseFromString
 > You can mitigate this risk by always passing `TrustedHTML` objects instead of strings and [enforcing trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types).
 > See [Security considerations](#security_considerations) for more information.
 
-The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface parses an input containing either HTML or XML, returning an {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}.
+The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface parses an input containing either HTML or XML, returning a {{domxref("Document")}} with the type given in the {{domxref("Document/contentType","contentType")}} property.
 
 > [!NOTE]
 > The [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) static method provides an ergonomic alternative for parsing HTML markup into a {{domxref("Document")}}.
@@ -45,10 +45,11 @@ parseFromString(input, mimeType)
 
 ### Return value
 
-A {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}, depending on the `mimeType` argument.
+A {{domxref("Document")}} with {{domxref("Document/contentType","contentType")}} matching the given `mimeType`.
 
 > ![NOTE]
-> You can treat the returned object as a {{domxref("Document")}} with the {{domxref("Document/contentType","contentType")}} matching the `mimeType`.
+> The browser may actually return an {{domxref("HTMLDocument")}} or {{domxref("XMLDocument")}} object.
+> These derive from {{domxref("Document")}} and add no attributes: they are essentially equivalent.
 
 ### Exceptions
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -45,7 +45,7 @@ parseFromString(input, mimeType)
 
 A {{domxref("Document")}} with {{domxref("Document/contentType","contentType")}} matching the given `mimeType`.
 
-> ![NOTE]
+> [!NOTE]
 > The browser may actually return an {{domxref("HTMLDocument")}} or {{domxref("XMLDocument")}} object.
 > These derive from {{domxref("Document")}} and add no attributes: they are essentially equivalent.
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -32,7 +32,6 @@ parseFromString(input, mimeType)
   - : A {{domxref("TrustedHTML")}} or string instance defining HTML to be parsed.
     The markup must contain either an {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("XHTML")}}, or {{Glossary("svg")}} document.
 - `mimeType`
-
   - : A string that specifies whether the XML parser or the HTML parser is used to parse the string.
 
     Allowed values are:


### PR DESCRIPTION
This updates the TrustedType documentation for [`DocParser.parseFromString()`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString) so that it includes boilerplate and security considerations.

Quite a lot of additional info too.

Project tracking in #37518
