### PR TITLE
fix(scripts/filecheck): declare as command

### DIFF
--- a/scripts/filecheck/index.js
+++ b/scripts/filecheck/index.js
@@ -35,7 +35,7 @@ function resolveFiles(files, cwd) {
 const argv = yargs(hideBin(process.argv))
   .scriptName("filecheck")
   .version("0.0.0")
-  .usage("$0 [options] [files...]")
+  .command("$0 [files...]", "Check image files")
   .option("cwd", {
     type: "string",
     describe: "Explicit current-working-directory",


### PR DESCRIPTION
### Description

Declares the `filecheck` script as a command.

### Motivation

The positional arguments were considered unknown.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
