### PR TITLE
FF145 Relnote: CSSStyleProperties returned by style and getComputedStyle()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -67,6 +67,8 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("ToggleEvent/source", "source")}} property of the {{domxref("ToggleEvent")}} interface is now supported.
   If a [popover](/en-US/docs/Web/API/Popover_API) is triggered to open or close by an HTML element such as a {{htmlelement("button")}}, the event's `source` property will contain the element that triggered the popover.
   ([Firefox bug 1968987](https://bugzil.la/1968987)).
+- A {{domxref("CSSStyleProperties")}} instance is now returned for the `style` property on {{domxref("HTMLElement.style", "HTMLElement")}}, {{domxref("MathMLElement.style", "MathMLElement")}}, {{domxref("SVGElement.style", "SVGElement")}}, and {{domxref("CSSStyleRule.style", "CSSStyleRule")}}, and the {{domxref("Window.getComputedStyle()")}} method. Previously a {{domxref("CSSStyleDeclaration")}} instance was returned.
+  ([Firefox bug 1989925](https://bugzil.la/1989925))
 
 <!-- #### DOM -->
 


### PR DESCRIPTION
FF145 supports returning a `CSSStyleProperties` for element style blocks rather than a `CSSStyleDeclaration` in https://bugzilla.mozilla.org/show_bug.cgi?id=1989925 (`CSSStyleProperties` itself was added in FF144).
This adds a release note.

Related docs work can be tracked in #41514
