### PR TITLE
FF145 RTCEncodedVideoFrame/RTCEncodedAudioFrame constructors

### DIFF
--- a/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
@@ -10,7 +10,7 @@ browser-compat: api.RTCEncodedAudioFrame.getMetadata
 
 The **`getMetadata()`** method of the {{domxref("RTCEncodedAudioFrame")}} interface returns an object containing the metadata associated with the frame.
 
-This includes information about the frame, including the audio encoding used, the synchronization source and contributing sources, and the sequence number (for incoming frames).
+This includes information about the frame, such as the audio encoding used, the synchronization source and contributing sources, and the sequence number (for incoming frames).
 
 ## Syntax
 
@@ -27,26 +27,39 @@ None.
 An object with the following properties:
 
 - `audioLevel`
-  - : A number representing the audio level of this frame. The value is between 0 and 1 inclusive (linear), where 1.0 represents 0 dBov ([decibels relative to full scale (DBFS)](https://en.wikipedia.org/wiki/DBFS)), 0 represents silence, and 0.5 represents approximately 6 dB SPL change in the [sound pressure level](https://en.wikipedia.org/wiki/Sound_pressure#Sound_pressure_level) from 0 dBov. The value is converted from the -127 to 0 range specified in [RFC6464](https://www.rfc-editor.org/rfc/rfc6464) via the equation `10^(-rfc_level/20)`. If the RFC6464 header extension is not present in the received packets of the frame, `audioLevel` will be `undefined`.
-- `synchronizationSource`
-  - : A positive integer value indicating synchronization source ("ssrc") of the stream of RTP packets that are described by this frame.
-    A source might be something like a microphone, or a mixer application that combines multiple sources.
-    All packets from the same source share the same time source and sequence space, and so can be ordered relative to each other.
-    Note that two frames with the same value refer to the same source.
-- `payloadType`
-  - : A positive integer value in the range from 0 to 127 that describes the format of the RTP payload.
-    The mappings of values to formats is defined in RFC3550, and more specifically [Section 6: Payload Type Definitions](https://www.rfc-editor.org/rfc/rfc3551#section-6) of RFC3551.
+  - : A number representing the audio level of this frame.
+    The value is between 0 and 1 inclusive (linear), where 1.0 represents 0 dBov ([decibels relative to full scale (DBFS)](https://en.wikipedia.org/wiki/DBFS)), 0 represents silence, and 0.5 represents approximately 6 dB SPL change in the [sound pressure level](https://en.wikipedia.org/wiki/Sound_pressure#Sound_pressure_level) from 0 dBov.
+    The value is converted from the -127 to 0 range specified in [RFC6464](https://www.rfc-editor.org/rfc/rfc6464) via the equation `10^(-rfc_level/20)`.
+    If the RFC6464 header extension is not present in the received packets of the frame, `audioLevel` will be `undefined`.
+- `captureTime`
+  - : A {{domxref("DOMHighResTimeStamp")}} indicating the capture time of the frame relative to {{domxref("Performance.timeOrigin")}}.
 - `contributingSources`
   - : An {{jsxref("Array")}} of sources (ssrc) that have contributed to the frame.
     Consider the case of a conferencing application that combines audio from multiple users.
     The `synchronizationSource` would include the ssrc of the application, while `contributingSources` would include the ssrc values of all the individual audio sources.
+- `mimeType`
+  - : A string containing the {{glossary("MIME type")}} of the codec used, such as "audio/opus".
+- `payloadType`
+  - : A positive integer value in the range from 0 to 127 that describes the format of the RTP payload.
+    The mappings of values to formats is defined in {{rfc("3550")}}, and more specifically [Section 6: Payload Type Definitions](https://www.rfc-editor.org/rfc/rfc3551#section-6) of {{rfc("3551")}}.
+- `receiveTime`
+  - : A {{domxref("DOMHighResTimeStamp")}} indicating the timestamp of the last received packet of an incoming frame (from an {{domxref("RTCRtpReceiver")}}) used to produce this media frame, relative to {{domxref("Performance.timeOrigin")}}.
+- `rtpTimestamp`
+  - : A positive integer that that reflects the sampling instant of the first octet in the RTP data packet (see {{rfc("3550")}}).
 - `sequenceNumber`
   - : The sequence number of an incoming audio frame (not used for outgoing frames) that can be used for reconstructing the original send-order of frames.
     This is number between 0 and 32767.
     Note that while numbers are allocated sequentially when sent, they will overflow at 32767 and restart back at 0.
     Therefore to compare two frame sequence numbers, in order to determine whether one is assumed to be after another, you must use [serial number arithmetic](https://en.wikipedia.org/wiki/Serial_number_arithmetic). <!-- [RFC1982] -->
+- `synchronizationSource`
+  - : A positive integer value indicating synchronization source ("ssrc") of the stream of RTP packets that are described by this frame.
+    A source might be something like a microphone, or a mixer application that combines multiple sources.
+    All packets from the same source share the same time source and sequence space, and so can be ordered relative to each other.
+    Note that two frames with the same value refer to the same source.
 
 ## Examples
+
+### Getting frame metadata
 
 This example [WebRTC encoded transform](/en-US/docs/Web/API/WebRTC_API/Using_Encoded_Transforms) implementation shows how you might get the frame metadata in a `transform()` function and log it.
 
@@ -73,8 +86,13 @@ Note that there are no contributing sources because there is just one source, an
 
 ```json
 {
-  "payloadType": 109,
-  "synchronizationSource": 1876443470
+  "captureTime": 19745.400000000373,
+  "contributingSources": [],
+  "mimeType": "audio/opus",
+  "payloadType": 111,
+  "rtpTimestamp": 1786045165,
+  "synchronizationSource": 3365032712,
+  "audioLevel": 0.001584893192461114
 }
 ```
 

--- a/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
@@ -45,7 +45,7 @@ An object with the following properties:
 - `receiveTime`
   - : A {{domxref("DOMHighResTimeStamp")}} indicating the timestamp of the last received packet of an incoming frame (from an {{domxref("RTCRtpReceiver")}}) used to produce this media frame, relative to {{domxref("Performance.timeOrigin")}}.
 - `rtpTimestamp`
-  - : A positive integer that that reflects the sampling instant of the first octet in the RTP data packet (see {{rfc("3550")}}).
+  - : A positive integer that reflects the sampling instant of the first octet in the RTP data packet (see {{rfc("3550")}}).
 - `sequenceNumber`
   - : The sequence number of an incoming audio frame (not used for outgoing frames) that can be used for reconstructing the original send-order of frames.
     This is number between 0 and 32767.

--- a/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/getmetadata/index.md
@@ -52,7 +52,7 @@ An object with the following properties:
     Note that while numbers are allocated sequentially when sent, they will overflow at 32767 and restart back at 0.
     Therefore to compare two frame sequence numbers, in order to determine whether one is assumed to be after another, you must use [serial number arithmetic](https://en.wikipedia.org/wiki/Serial_number_arithmetic). <!-- [RFC1982] -->
 - `synchronizationSource`
-  - : A positive integer value indicating synchronization source ("ssrc") of the stream of RTP packets that are described by this frame.
+  - : A positive integer value indicating the synchronization source ("ssrc") of the stream of RTP packets that are described by this frame.
     A source might be something like a microphone, or a mixer application that combines multiple sources.
     All packets from the same source share the same time source and sequence space, and so can be ordered relative to each other.
     Note that two frames with the same value refer to the same source.

--- a/files/en-us/web/api/rtcencodedaudioframe/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/index.md
@@ -12,6 +12,11 @@ The **`RTCEncodedAudioFrame`** of the [WebRTC API](/en-US/docs/Web/API/WebRTC_AP
 The interface provides methods and properties to get metadata about the frame, allowing its format and order in the sequence of frames to be determined.
 The `data` property gives access to the encoded frame data as a buffer, which might be encrypted, or otherwise modified by a transform.
 
+## Constructor
+
+- {{domxref("RTCEncodedAudioFrame.RTCEncodedAudioFrame()","RTCEncodedAudioFrame()")}}
+  - : Copy constructor. Creates a new and independent `RTCEncodedAudioFrame` object from a frame, optionally overwriting some of the copied metadata.
+
 ## Instance properties
 
 - {{domxref("RTCEncodedAudioFrame.timestamp")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
@@ -25,6 +30,8 @@ The `data` property gives access to the encoded frame data as a buffer, which mi
   - : Returns the metadata associated with the frame.
 
 ## Examples
+
+### Transforming an encoded audio frame
 
 This code snippet shows a handler for the `rtctransform` event in a {{domxref("Worker")}} that implements a {{domxref("TransformStream")}}, and pipes encoded frames through it from the `event.transformer.readable` to `event.transformer.writable` (`event.transformer` is a {{domxref("RTCRtpScriptTransformer")}}, the worker-side counterpart of {{domxref("RTCRtpScriptTransform")}}).
 

--- a/files/en-us/web/api/rtcencodedaudioframe/rtcencodedaudioframe/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/rtcencodedaudioframe/index.md
@@ -1,0 +1,67 @@
+---
+title: "RTCEncodedAudioFrame: RTCEncodedAudioFrame() constructor"
+short-title: RTCEncodedAudioFrame()
+slug: Web/API/RTCEncodedAudioFrame/RTCEncodedAudioFrame
+page-type: web-api-constructor
+browser-compat: api.RTCEncodedAudioFrame.RTCEncodedAudioFrame
+---
+
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
+
+The **`RTCEncodedAudioFrame()`** constructor creates a new and fully independent {{domxref("RTCEncodedAudioFrame")}} object.
+
+The new object is a deep clone of the original object data and metadata, with any metadata specified in the options parameter overwriting the copied values.
+
+## Syntax
+
+```js-nolint
+
+new RTCEncodedAudioFrame(originalFrame);
+new RTCEncodedAudioFrame(originalFrame, options);
+```
+
+### Parameters
+
+- `originalFrame`
+  - : The frame to be copied.
+- `options` {{optional_inline}}
+  - : This is an object with the following property:
+    - `metadata` {{optional_inline}}
+      - : An object setting the frame metadata.
+        This is object has the same properties as the object returned by {{DOMxRef("RTCEncodedAudioFrame.getMetadata()")}}.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - The source buffer is detached.
+- {{jsxref("RangeError")}}
+  - The allocation is too large.
+
+## Examples
+
+### Cloning a frame with modified metadata
+
+This snippet shows how you might copy a frame and modify its metadata.
+In this case we just update the capture time.
+
+```js
+// Frame is an incoming RTCEncodedAudioFrame
+frame.getMetadata();
+
+const newFrame = new RTCEncodedAudioFrame(frame, {
+  metadata: {
+    captureTime: frame.metadata.captureTime + 3,
+  },
+});
+```
+
+This kind of modification might be useful if you need to create multiple outgoing frames from a single incoming frame, for example in order to relay media to another peer on the network.
+Generally you will not need to modify the metadata for a frame.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcencodedaudioframe/rtcencodedaudioframe/index.md
+++ b/files/en-us/web/api/rtcencodedaudioframe/rtcencodedaudioframe/index.md
@@ -28,7 +28,7 @@ new RTCEncodedAudioFrame(originalFrame, options);
   - : This is an object with the following property:
     - `metadata` {{optional_inline}}
       - : An object setting the frame metadata.
-        This is object has the same properties as the object returned by {{DOMxRef("RTCEncodedAudioFrame.getMetadata()")}}.
+        This is an object with the same properties as the object returned by {{DOMxRef("RTCEncodedAudioFrame.getMetadata()")}}.
 
 ### Exceptions
 
@@ -55,7 +55,7 @@ const newFrame = new RTCEncodedAudioFrame(frame, {
 });
 ```
 
-This kind of modification might be useful if you need to create multiple outgoing frames from a single incoming frame, for example in order to relay media to another peer on the network.
+This kind of modification might be useful if you need to create multiple outgoing frames from a single incoming frame; for example, in order to relay media to another peer on the network.
 Generally you will not need to modify the metadata for a frame.
 
 ## Specifications

--- a/files/en-us/web/api/rtcencodedvideoframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedvideoframe/getmetadata/index.md
@@ -48,7 +48,7 @@ An object with the following properties:
 - `receiveTime`
   - : A {{domxref("DOMHighResTimeStamp")}} indicating the timestamp of the last received packet of an incoming frame (from an {{domxref("RTCRtpReceiver")}}) used to produce this media frame, relative to {{domxref("Performance.timeOrigin")}}.
 - `rtpTimestamp`
-  - : A positive integer that that reflects the sampling instant of the first octet in the RTP data packet (see {{rfc("3550")}}).
+  - : A positive integer that reflects the sampling instant of the first octet in the RTP data packet (see {{rfc("3550")}}).
 - `spatialIndex`
   - : A positive integer indicating the spatial index of the frame.
     Some codecs allow generation of layers of frames with different layers of resolutions.

--- a/files/en-us/web/api/rtcencodedvideoframe/getmetadata/index.md
+++ b/files/en-us/web/api/rtcencodedvideoframe/getmetadata/index.md
@@ -10,7 +10,7 @@ browser-compat: api.RTCEncodedVideoFrame.getMetadata
 
 The **`getMetadata()`** method of the {{domxref("RTCEncodedVideoFrame")}} interface returns an object containing the metadata associated with the frame.
 
-This includes information about the frame, including its size, video encoding, other frames needed to construct a full image, timestamp, and other information.
+This includes information about the frame, such as its size, video encoding, other frames needed to construct a full image, timestamp, and other information.
 
 ## Syntax
 
@@ -26,42 +26,45 @@ None.
 
 An object with the following properties:
 
-- `frameId`
-  - : A positive integer value indicating the id of this frame.
+- `contributingSources`
+  - : An {{jsxref("Array")}} of sources (ssrc) that have contributed to the frame.
+    Consider the case of a conferencing application that combines the audio and video from multiple users.
+    The `synchronizationSource` would include the ssrc of the application, while `contributingSources` would include the ssrc values of all the individual video and audio sources.
 - `dependencies`
   - : An {{jsxref("Array")}} of positive integers indicating the frameIds of frames on which this frame depends.
     For a key frame this will be empty, as a key frame contains all the information it needs to construct the image.
     For a delta frame this will list all the frames needed to render this frame.
     The type of frame can be determined using {{domxref("RTCEncodedVideoFrame.type")}}.
-- `width`
-  - : A positive integer indicating the width of the frame.
-    The maximum value is 65535.
+- `frameId`
+  - : A positive integer value indicating the id of this frame.
 - `height`
   - : A positive integer indicating the height of the frame.
     The maximum value is 65535.
+- `mimeType`
+  - : A string containing the {{glossary("MIME type")}} of the codec used, such as "video/VP8".
+- `payloadType`
+  - : A positive integer value in the range from 0 to 127 that describes the format of the RTP payload.
+    The mappings of values to formats is defined in RFC3550.
+- `receiveTime`
+  - : A {{domxref("DOMHighResTimeStamp")}} indicating the timestamp of the last received packet of an incoming frame (from an {{domxref("RTCRtpReceiver")}}) used to produce this media frame, relative to {{domxref("Performance.timeOrigin")}}.
+- `rtpTimestamp`
+  - : A positive integer that that reflects the sampling instant of the first octet in the RTP data packet (see {{rfc("3550")}}).
 - `spatialIndex`
   - : A positive integer indicating the spatial index of the frame.
     Some codecs allow generation of layers of frames with different layers of resolutions.
-    Frames in higher layers can be selectively dropped in order to reduce bit rate when needed, while maintaining acceptable video quality.
-- `temporalIndex`
-  - : A positive integer indicating the temporal index of the frame.
-    Some codecs group frames in layers, based on whether dropping the a frame will prevent others from being decoded.
     Frames in higher layers can be selectively dropped in order to reduce bit rate when needed, while maintaining acceptable video quality.
 - `synchronizationSource`
   - : A positive integer value indicating synchronization source ("ssrc") of the stream of RTP packets that are described by this encoded video frame.
     A source might be something like a camera or microphone, or some kind of mixer app that combines multiple sources.
     All packets from the same source share the same time source and sequence space, and so can be ordered relative to each other.
     Note two frames with the same value refer to the same source (for more information see [`RTCInboundRtpStreamStats.ssrc`](/en-US/docs/Web/API/RTCInboundRtpStreamStats/ssrc)).
-- `payloadType`
-  - : A positive integer value in the range from 0 to 127 that describes the format of the RTP payload.
-    The mappings of values to formats is defined in RFC3550.
-- `contributingSources`
-  - : An {{jsxref("Array")}} of sources (ssrc) that have contributed to the frame.
-    Consider the case of a conferencing application that combines the audio and video from multiple users.
-    The `synchronizationSource` would include the ssrc of the application, while `contributingSources` would include the ssrc values of all the individual video and audio sources.
-- `timestamp`
-  - : The [media presentation timestamp (PTS)](https://en.wikipedia.org/wiki/Presentation_timestamp) in microseconds of raw frame, matching the timestamp for raw frames which correspond to this frame.
-    This is used to synchronize separate video, audio, subtitle and other streams belonging to the same presentation.
+- `temporalIndex`
+  - : A positive integer indicating the temporal index of the frame.
+    Some codecs group frames in layers, based on whether dropping the a frame will prevent others from being decoded.
+    Frames in higher layers can be selectively dropped in order to reduce bit rate when needed, while maintaining acceptable video quality.
+- `width`
+  - : A positive integer indicating the width of the frame.
+    The maximum value is 65535.
 
 ## Examples
 
@@ -91,14 +94,16 @@ Note that there are no contributing sources because there is just one source.
 ```json
 {
   "contributingSources": [],
-  "dependencies": [405],
-  "frameId": 406,
-  "height": 480,
-  "payloadType": 120,
+  "mimeType": "video/VP8",
+  "payloadType": 96,
+  "rtpTimestamp": 2503280194,
+  "synchronizationSource": 1736709460,
+  "dependencies": [],
+  "frameId": 1,
+  "height": 240,
   "spatialIndex": 0,
-  "synchronizationSource": 3956716931,
   "temporalIndex": 0,
-  "width": 640
+  "width": 320
 }
 ```
 

--- a/files/en-us/web/api/rtcencodedvideoframe/index.md
+++ b/files/en-us/web/api/rtcencodedvideoframe/index.md
@@ -9,6 +9,11 @@ browser-compat: api.RTCEncodedVideoFrame
 
 The **`RTCEncodedVideoFrame`** of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) represents an encoded video frame in the WebRTC receiver or sender pipeline, which may be modified using a [WebRTC Encoded Transform](/en-US/docs/Web/API/WebRTC_API/Using_Encoded_Transforms).
 
+## Constructor
+
+- {{domxref("RTCEncodedVideoFrame.RTCEncodedVideoFrame()","RTCEncodedVideoFrame()")}}
+  - : Copy constructor. Creates a new and independent `RTCEncodedVideoFrame` object from another frame, optionally overwriting some of the copied metadata.
+
 ## Instance properties
 
 - {{domxref("RTCEncodedVideoFrame.type")}} {{ReadOnlyInline}}
@@ -36,6 +41,8 @@ The {{domxref("RTCEncodedVideoFrame.type","type")}} property indicates whether t
 The {{domxref("RTCEncodedVideoFrame.data", "data")}} property provides access to the encoded image data for the frame, which can then be modified ("transformed") when frames are sent or received.
 
 ## Examples
+
+### Transforming an encoded video frame
 
 This code snippet shows a handler for the `rtctransform` event in a {{domxref("Worker")}} that implements a {{domxref("TransformStream")}}, and pipes encoded frames through it from the `event.transformer.readable` to `event.transformer.writable` (`event.transformer` is a {{domxref("RTCRtpScriptTransformer")}}, the worker-side counterpart of {{domxref("RTCRtpScriptTransform")}}).
 

--- a/files/en-us/web/api/rtcencodedvideoframe/rtcencodedvideoframe/index.md
+++ b/files/en-us/web/api/rtcencodedvideoframe/rtcencodedvideoframe/index.md
@@ -1,0 +1,67 @@
+---
+title: "RTCEncodedVideoFrame: RTCEncodedVideoFrame() constructor"
+short-title: RTCEncodedVideoFrame()
+slug: Web/API/RTCEncodedVideoFrame/RTCEncodedVideoFrame
+page-type: web-api-constructor
+browser-compat: api.RTCEncodedVideoFrame.RTCEncodedVideoFrame
+---
+
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
+
+The **`RTCEncodedVideoFrame()`** constructor creates a new and fully independent {{domxref("RTCEncodedVideoFrame")}} object.
+
+The new object is a deep clone of the original object data and metadata, with any metadata specified in the options parameter overwriting the copied values.
+
+## Syntax
+
+```js-nolint
+
+new RTCEncodedVideoFrame(originalFrame);
+new RTCEncodedVideoFrame(originalFrame, options);
+```
+
+### Parameters
+
+- `originalFrame`
+  - : The frame to be copied.
+- `options` {{optional_inline}}
+  - : This is an object with the following property:
+    - `metadata` {{optional_inline}}
+      - : An object setting the frame metadata.
+        This is object has the same properties as the object returned by {{DOMxRef("RTCEncodedVideoFrame.getMetadata()")}}.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - The source buffer is detached.
+- {{jsxref("RangeError")}}
+  - The allocation is too large.
+
+## Examples
+
+### Cloning a frame with modified metadata
+
+This snippet shows how you might copy a frame and modify its metadata.
+In this case we just update the capture time.
+
+```js
+// Frame is an incoming RTCEncodedVideoFrame
+frame.getMetadata();
+
+const newFrame = new RTCEncodedVideoFrame(frame, {
+  metadata: {
+    captureTime: frame.metadata.captureTime + 3,
+  },
+});
+```
+
+This kind of modification might be useful if you need to create multiple outgoing frames from a single incoming frame, for example in order to relay media to another peer on the network.
+Generally you will not need to modify the metadata for a frame.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcencodedvideoframe/rtcencodedvideoframe/index.md
+++ b/files/en-us/web/api/rtcencodedvideoframe/rtcencodedvideoframe/index.md
@@ -28,7 +28,7 @@ new RTCEncodedVideoFrame(originalFrame, options);
   - : This is an object with the following property:
     - `metadata` {{optional_inline}}
       - : An object setting the frame metadata.
-        This is object has the same properties as the object returned by {{DOMxRef("RTCEncodedVideoFrame.getMetadata()")}}.
+        This is an object with the same properties as the object returned by {{DOMxRef("RTCEncodedVideoFrame.getMetadata()")}}.
 
 ### Exceptions
 
@@ -55,7 +55,7 @@ const newFrame = new RTCEncodedVideoFrame(frame, {
 });
 ```
 
-This kind of modification might be useful if you need to create multiple outgoing frames from a single incoming frame, for example in order to relay media to another peer on the network.
+This kind of modification might be useful if you need to create multiple outgoing frames from a single incoming frame; for example, in order to relay media to another peer on the network.
 Generally you will not need to modify the metadata for a frame.
 
 ## Specifications


### PR DESCRIPTION
FF145 makes `RTCEncodedAudioFrame` and `RTCEncodeVideoFrame` be serializeable, which essentially means adding constructors.

This updates the `getMetadata()` for for both interfaces with the correct properties in returned object according to tests. It also creates constructor docs. These don't duplicate the properties but link to the getMetadata doc.


Related docs work can be tracked in #41508