### PR TITLE
fix typo: sync against apple naming convention

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/html_forms_in_legacy_browsers/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/html_forms_in_legacy_browsers/index.md
@@ -44,13 +44,13 @@ All HTML input types are useable in all browsers, even ancient ones, because the
     <tr>
       <td>
         <img
-          alt="Screen shot of the color input on Chrome for Mac OSX"
+          alt="Screen shot of the color input on Chrome for macOS"
           src="color-fallback-chrome.png"
         />
       </td>
       <td>
         <img
-          alt="Screen shot of the color input on Firefox for Mac OSX"
+          alt="Screen shot of the color input on Firefox for macOS"
           src="color-fallback-firefox.png"
         />
       </td>

--- a/files/en-us/learn_web_development/extensions/testing/testing_strategies/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/testing_strategies/index.md
@@ -192,7 +192,7 @@ An emulator might be as simple as testing a device condition. For example, if yo
 More often than not though, you'll have to install some kind of emulator. The most common devices/browsers you'll want to test are as follows:
 
 - The official [Android Studio IDE](https://developer.android.com/studio/) for developing Android apps is a bit heavy weight for just testing websites on Google Chrome or the old Stock Android browser, but it does come with a Robust [emulator](https://developer.android.com/studio/run/emulator.html). If you want something a bit more lightweight, [Andy](https://www.andyroid.net/) is a reasonable option that runs on both Windows and Mac.
-- Apple provides an app called [Simulator](https://help.apple.com/simulator/mac/current/) that runs on top of the [XCode](https://developer.apple.com/xcode/) development environment, and emulates iPad/iPhone/Apple Watch/Apple TV. This includes the native iOS Safari browser. This unfortunately only runs on a Mac.
+- Apple provides an app called [Simulator](https://help.apple.com/simulator/mac/current/) that runs on top of the [Xcode](https://developer.apple.com/xcode/) development environment, and emulates iPad/iPhone/Apple Watch/Apple TV. This includes the native iOS Safari browser. This unfortunately only runs on a Mac.
 
 You can often find simulators for other mobile device environments too, for example:
 

--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -27,7 +27,7 @@ Firefox 18 was released on January 8, 2013. This article lists key changes that 
 
 - `navigator.mozPay` has been landed. ([Firefox bug 767818](https://bugzil.la/767818))
 - `window.devicePixelRatio` has been landed. ([Firefox bug 564815](https://bugzil.la/564815))
-- The macOS X backend for `window.navigator.battery` has been implemented. ([Firefox bug 696045](https://bugzil.la/696045))
+- The OS X backend for `window.navigator.battery` has been implemented. ([Firefox bug 696045](https://bugzil.la/696045))
 - `MozBlobBuilder` is removed. Developers need to use {{domxref("Blob")}} constructor for creating a `Blob` object. ([Firefox bug 744907](https://bugzil.la/744907))
 - The {{domxref("document.visibilitychange_event", "visibilitychange")}} event and the [Page Visibility API](/en-US/docs/Web/API/Page_Visibility_API) has been unprefixed ([Firefox bug 812086](https://bugzil.la/812086)).
 - {{domxref("TextDecoder")}} and {{domxref("TextEncoder")}} have been added. Note that the implementation and spec of these evolved and have been changed in Firefox 19 ([Firefox bug 764234](https://bugzil.la/764234)).

--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Document.activeElement
 
 The **`activeElement`** read-only property of the {{domxref("Document")}} interface returns the {{domxref("Element")}} within the DOM that is receiving keyboard events such as {{domxref("Element/keydown_event", "keydown")}} and {{domxref("Element/keyup_event", "keyup")}}. This is usually analogous to the focused element.
 
-Which elements are focusable varies depending on the platform and the browser's current configuration. For example, on Safari, following the behavior of macOS, elements that aren't text input elements are not focusable by default, unless the "Full Keyboard Access" setting is enabled in System Preferences.
+Which elements are focusable varies depending on the platform and the browser's current configuration. For example, on Safari, following the behavior of macOS, elements that aren't text input elements are not focusable by default, unless the "Full Keyboard Access" setting is enabled in System Settings.
 
 Typically a user can press the <kbd>Tab</kbd> key to move the focus around the page among focusable elements, and use keyboard gestures such as <kbd>Space</kbd> or <kbd>Enter</kbd> to simulate clicks on the focused element.
 

--- a/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
@@ -24,7 +24,7 @@ If you're looking to follow the steps listed here, but don't have any media to e
 
 When working with MSE, the following tools are a must have:
 
-1. [ffmpeg](https://ffmpeg.org/) — A command-line utility for transcoding your media into the required formats. You can download a version for your system at the [Download FFmpeg page](https://ffmpeg.org/download.html). Extract the executable from the archive file and add it's location to your PATH statement. OSX users can also use [homebrew](https://brew.sh/) to install ffmpeg.
+1. [ffmpeg](https://ffmpeg.org/) — A command-line utility for transcoding your media into the required formats. You can download a version for your system at the [Download FFmpeg page](https://ffmpeg.org/download.html). Extract the executable from the archive file and add it's location to your PATH statement. macOS users can also use [homebrew](https://brew.sh/) to install ffmpeg.
 2. [Bento4](https://github.com/axiomatic-systems/Bento4) — A set of command-line utilities for getting asset metadata and creating content for DASH. To install, you'll need to build/compile the application yourself from the provided project files/source files, depending on your OS and preferences. See the [Building instructions](https://github.com/axiomatic-systems/Bento4#building) for more details, or download the [prebuilt file](https://www.bento4.com/downloads/). Put the contents of the `bin` directory in the same place as ffmpeg.
 3. python2 — Bento4 uses it.
 

--- a/files/en-us/web/css/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-motion/index.md
@@ -31,7 +31,7 @@ For Firefox, the `reduce` request is honoured if:
 - In Plasma/KDE: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to right to "Instant".
 - In Windows 10: Settings > Ease of Access > Display > Show animations in Windows.
 - In Windows 11: Settings > Accessibility > Visual Effects > Animation Effects
-- In macOS: System Preferences > Accessibility > Display > Reduce motion.
+- In macOS: System Settings > Accessibility > Display > Reduce motion.
 - In iOS: Settings > Accessibility > Motion.
 - In Android 9+: Settings > Accessibility > Remove animations.
 - In Firefox `about:config`: Add a number preference called `ui.prefersReducedMotion` and set its value to either `0` for full animation or to `1` to indicate a preference for reduced motion. Changes to this preference take effect immediately.

--- a/files/en-us/web/css/@media/prefers-reduced-transparency/index.md
+++ b/files/en-us/web/css/@media/prefers-reduced-transparency/index.md
@@ -25,7 +25,7 @@ Various operating systems provide a preference for reducing transparency, and us
 They may also rely on less explicit signals on platforms which don't offer a specific setting.
 
 - In Windows 10/11: Settings > Personalization > Colors > Transparency effects.
-- In macOS: System Preferences > Accessibility > Display > Reduce transparency.
+- In macOS: System Settings > Accessibility > Display > Reduce transparency.
 - In iOS: Settings > Accessibility > Display & Text Size > Reduce Transparency.
 
 ## Examples

--- a/files/en-us/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/index.md
@@ -244,7 +244,7 @@ New formats and protocols are being rolled out to facilitate adaptive streaming.
 The main formats used for adaptive streaming are [HLS](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Live_streaming_web_audio_and_video#hls) and [MPEG-DASH](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Live_streaming_web_audio_and_video#mpeg-dash). MSE has been designed with DASH in mind. MSE defines byte streams according to [ISOBMFF](https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/isobmff-byte-stream-format.html) and [M2TS](https://en.wikipedia.org/wiki/M2ts) (both supported in DASH, the latter supported in HLS). Generally speaking, if you are interested in standards, are looking for flexibility, or wish to support most modern browsers, you are probably better off with DASH.
 
 > [!NOTE]
-> Currently Safari does not support DASH although dash.js will work on newer versions of Safari scheduled for release with OSX Yosemite.
+> Currently Safari does not support DASH although dash.js will work on newer versions of Safari scheduled for release with OS X Yosemite.
 
 DASH also provides a number of profiles including onDemand profiles that require no preprocessing and splitting up of media files. There are also a number of cloud based services that will convert your media to both HLS and DASH.
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
@@ -210,7 +210,7 @@ it might be wise to provide a fallback:
 
 ## HLS Encoding
 
-HTTP Live Streaming (HLS) is an HTTP-based media streaming protocol implemented by Apple. It's incorporated into iOS and OSX platforms and works well on [mobile and desktop Safari and most Android devices](https://caniuse.com/?search=hls).
+HTTP Live Streaming (HLS) is an HTTP-based media streaming protocol implemented by Apple. It's incorporated into iOS and macOS platforms and works well on [mobile and desktop Safari and most Android devices](https://caniuse.com/?search=hls).
 
 Media is usually encoded as MPEG-4 (H.264 video and AAC audio) and packaged into an MPEG-2 Transport Stream, which is then broken into segments and saved as one or more `.ts` media files. Apple provides tools to convert media files to the appropriate format.
 

--- a/files/en-us/webassembly/guides/concepts/index.md
+++ b/files/en-us/webassembly/guides/concepts/index.md
@@ -90,7 +90,7 @@ The Emscripten tool is able to take just about any C/C++ source code and compile
 
 In a nutshell, the process works as follows:
 
-1. Emscripten first feeds the C/C++ into clang+LLVM — a mature open-source C/C++ compiler toolchain, shipped as part of XCode on OSX for example.
+1. Emscripten first feeds the C/C++ into clang+LLVM — a mature open-source C/C++ compiler toolchain, shipped as part of Xcode on macOS for example.
 2. Emscripten transforms the compiled result of clang+LLVM into a Wasm binary.
 3. By itself, WebAssembly cannot currently directly access the DOM; it can only call JavaScript, passing in integer and floating point primitive data types. Thus, to access any Web API, WebAssembly needs to call out to JavaScript, which then makes the Web API call. Emscripten therefore creates the HTML and JavaScript glue code needed to achieve this.
 


### PR DESCRIPTION
1/ System Preferences renamed to System Settings in Ventura
2/ unified OSX, OS X, Mac OS and macOS names accordingly
3/ XCode -> Xcode

notes that:

1/ FF relnotes are kept untouched (since the last occurrence of Mac OS or related strings in these files are FF48, at the time it was OS X 10.12)
2/ [one occurrence](https://github.com/mdn/content/blob/74e7902b0875b6378d77df6d2d925a2d09d19f5d/files/en-us/web/http/reference/headers/user-agent/firefox/index.md) is kept there based on what the description above said: 

```md
## macOS

Here, _x.y_ is the version of macOS (for instance, macOS 10.15). Starting in Firefox 87, Firefox caps the reported macOS version number to 10.15, so macOS 11.0 Big Sur and later will be reported as "10.15" in the User-Agent string. ARM-based Macs will be reported as "Intel" in the User-Agent string.

| Mac OS X version                    | Gecko user agent string                                                            |
| ----------------------------------- | ---------------------------------------------------------------------------------- |
| Mac OS X on x86, x86_64, or aarch64 | Mozilla/5.0 (Macintosh; Intel Mac OS X _x.y_; rv:10.0) Gecko/20100101 Firefox/10.0 |
| Mac OS X on PowerPC                 | Mozilla/5.0 (Macintosh; PPC Mac OS X _x.y_; rv:10.0) Gecko/20100101 Firefox/10.0   |
```
