### PR TITLE
improve HOL blocking and related protocol glossary entries

### DIFF
--- a/files/en-us/glossary/head_of_line_blocking/index.md
+++ b/files/en-us/glossary/head_of_line_blocking/index.md
@@ -8,9 +8,11 @@ sidebar: glossarysidebar
 
 In computer networking, **head-of-line blocking** (_HOL blocking_) refers to a performance bottleneck that occurs when a queue of {{glossary("packet", "packets")}} is held up by the first packet in the queue, even though other packets in the queue could be processed.
 
-In HTTP/1.1, requests on a single {{glossary("TCP")}} connection are usually sent sequentially;
-HTTP/1.1 also defines an optional feature called _HTTP pipelining_ that allows multiple requests to be sent without waiting for earlier responses.
-Even with pipelining, however, responses must be sent in the same order the server received the requests, so the connection remains first-in, first-out and HOL blocking can still occur.
+In HTTP/1.1, requests on a single {{glossary("TCP")}} connection are usually sent sequentially.
+Since there's usually a limitation on the number of TCP connections for each client to a server, doing a new request over one of these connections has to wait for the previous request on the same connection to be completed before the client can make a new request, which cause HOL blocking problems.
+
+HTTP/1.1 defines an optional feature called _HTTP pipelining_ that allows multiple requests to be sent without waiting for earlier responses, which try to work around this.
+However the responses still must be sent in the same order the server received the requests, so the connection remains first-in, first-out and HOL blocking can still occur.
 Network conditions such as congestion, packet loss (and the resulting TCP retransmissions), or {{glossary("TCP slow start")}} can also delay transmission and cause later responses to be blocked by earlier ones.
 
 {{glossary("HTTP 2", "HTTP/2")}} reduces application-level HOL blocking by introducing request and response _multiplexing_.

--- a/files/en-us/glossary/head_of_line_blocking/index.md
+++ b/files/en-us/glossary/head_of_line_blocking/index.md
@@ -15,7 +15,7 @@ Network conditions such as congestion, packet loss (and the resulting TCP retran
 
 {{glossary("HTTP 2", "HTTP/2")}} reduces application-level HOL blocking by introducing request and response _multiplexing_.
 With this feature multiple requests and responses can be interleaved over a single TCP connection using independently numbered streams, and stream prioritization helps the server decide which streams to send first.
-Packet loss at the transport layer can still cause HOL blocking across streams because HTTP/2 runs over TCP  — a lost TCP segment can stall all streams carried on that connection until the lost data is retransmitted.
+Packet loss at the transport layer can still cause HOL blocking across streams because HTTP/2 runs over TCP — a lost TCP segment can stall all streams carried on that connection until the lost data is retransmitted.
 
 {{glossary("HTTP 3", "HTTP/3")}} eliminates the transport-layer head-of-line blocking by using {{glossary("QUIC")}} over {{glossary("UDP")}} and thus HOL problem on HTTP no longer exists.
 QUIC provides multiple independent streams with per-stream loss recovery, so packet loss affects only the stream where it occurs rather than the entire connection. This removes the TCP-level HOL problem.

--- a/files/en-us/glossary/head_of_line_blocking/index.md
+++ b/files/en-us/glossary/head_of_line_blocking/index.md
@@ -6,23 +6,24 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-In computer networking, **head-of-line blocking** (_HOL blocking_) refers to a performance bottleneck that occurs when a queue of packets is held up by the first packet in the queue, even though other packets in the queue could be processed.
+In computer networking, **head-of-line blocking** (_HOL blocking_) refers to a performance bottleneck that occurs when a queue of {{glossary("packet", "packets")}} is held up by the first packet in the queue, even though other packets in the queue could be processed.
 
-In HTTP/1.1, HOL blocking occurs when a client sends multiple requests to a {{glossary("server")}} over a particular TCP connection, and a response on that connection is delayed for any reason — such as network congestion, {{glossary("TCP slow start")}}, or, problems in transit.
-HTTP/1.1 requests are sent sequentially per TCP connection, so a delay in receiving a response blocks the next request-response exchange.
+In HTTP/1.1, requests on a single {{glossary("TCP")}} connection are usually sent sequentially;
+HTTP/1.1 also defines an optional feature called _HTTP pipelining_ that allows multiple requests to be sent without waiting for earlier responses.
+Even with pipelining, however, responses must be sent in the same order the server received the requests, so the connection remains first-in, first-out and HOL blocking can still occur.
+Network conditions such as congestion, packet loss (and the resulting TCP retransmissions), or {{glossary("TCP slow start")}} can also delay transmission and cause later responses to be blocked by earlier ones.
 
-A mechanism called _HTTP pipelining_ tried to work around this, where multiple requests were sent off by a client without waiting for any responses.
-Pipelining proved tricky to implement in reality, so this mechanism is rarely used, if ever, and most browsers no longer support it.
+{{glossary("HTTP 2", "HTTP/2")}} reduces application-level HOL blocking by introducing request and response _multiplexing_:
+multiple requests and responses can be interleaved over a single TCP connection using independently numbered streams, and stream prioritization helps the server decide which streams to send first.
+Because HTTP/2 runs over TCP, though, packet loss at the transport layer can still cause HOL blocking across streams — a lost TCP segment can stall all streams carried on that connection until the lost data is retransmitted.
 
-HTTP/2 addresses the HOL blocking problems in HTTP/1.1 through request _multiplexing_.
-Multiplexing allows a single TCP connection to interleave requests and responses in numbered streams.
-A client can send many requests over a single connection without waiting for earlier responses.
-Note that while HOL blocking has been fixed in HTTP/2, it is still a problem at the transport ({{glossary("TCP")}}) layer level.
+{{glossary("HTTP 3", "HTTP/3")}} eliminates the transport-layer head-of-line blocking by using {{glossary("QUIC")}} over {{glossary("UDP")}} and thus HOL problem on HTTP no longer exists.
+QUIC provides multiple independent streams with per-stream loss recovery, so packet loss affects only the stream where it occurs rather than the entire connection. This removes the TCP-level HOL problem.
 
 ## See also
 
 - Related glossary terms
-  - {{glossary("HTTP")}}, {{glossary("HTTP 2", "HTTP/2")}}
-  - {{glossary("TCP")}}
+  - {{glossary("HTTP")}}, {{glossary("HTTP 2", "HTTP/2")}}, {{glossary("HTTP 3", "HTTP/3")}}
+  - {{glossary("TCP")}}, {{glossary("QUIC")}}, {{glossary("UDP")}}
 - [Populating the page: how browsers work](/en-US/docs/Web/Performance/Guides/How_browsers_work)
 - [Head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking) on Wikipedia

--- a/files/en-us/glossary/head_of_line_blocking/index.md
+++ b/files/en-us/glossary/head_of_line_blocking/index.md
@@ -8,8 +8,8 @@ sidebar: glossarysidebar
 
 In computer networking, **head-of-line blocking** (_HOL blocking_) refers to a performance bottleneck that occurs when a queue of {{glossary("packet", "packets")}} is held up by the first packet in the queue, even though other packets in the queue could be processed.
 
-In HTTP/1.1, requests on a single {{glossary("TCP")}} connection are usually sent sequentially.
-Since there's usually a limitation on the number of TCP connections for each client to a server, doing a new request over one of these connections has to wait for the previous request on the same connection to be completed before the client can make a new request, which cause HOL blocking problems.
+In HTTP/1.1, requests on a single {{glossary("TCP")}} connection are usually sent sequentially — a new request can't be made on the connection while waiting for a response to the previous request.
+This can lead to HOL blocking problems even if there are several TCP connections between the client and server.
 
 HTTP/1.1 defines an optional feature called _HTTP pipelining_ that allows multiple requests to be sent without waiting for earlier responses, which try to work around this.
 However the responses still must be sent in the same order the server received the requests, so the connection remains first-in, first-out and HOL blocking can still occur.

--- a/files/en-us/glossary/head_of_line_blocking/index.md
+++ b/files/en-us/glossary/head_of_line_blocking/index.md
@@ -11,8 +11,8 @@ In computer networking, **head-of-line blocking** (_HOL blocking_) refers to a p
 In HTTP/1.1, requests on a single {{glossary("TCP")}} connection are usually sent sequentially — a new request can't be made on the connection while waiting for a response to the previous request.
 This can lead to HOL blocking problems even if there are several TCP connections between the client and server.
 
-HTTP/1.1 defines an optional feature called _HTTP pipelining_ that allows multiple requests to be sent without waiting for earlier responses, which try to work around this.
-However the responses still must be sent in the same order the server received the requests, so the connection remains first-in, first-out and HOL blocking can still occur.
+HTTP/1.1 defines an optional feature called _HTTP pipelining_ that unsuccessfully attempted to work around HOL blocking, by allowing requests to be sent without waiting for earlier responses.
+Unfortunately the design of HTTP/1.1 means that responses must be returned in the same order as the requests were received, so HOL blocking can still occur if a request takes a long time to complete.
 Network conditions such as congestion, packet loss (and the resulting TCP retransmissions), or {{glossary("TCP slow start")}} can also delay transmission and cause later responses to be blocked by earlier ones.
 
 {{glossary("HTTP 2", "HTTP/2")}} reduces application-level HOL blocking by introducing request and response _multiplexing_.

--- a/files/en-us/glossary/head_of_line_blocking/index.md
+++ b/files/en-us/glossary/head_of_line_blocking/index.md
@@ -13,9 +13,9 @@ HTTP/1.1 also defines an optional feature called _HTTP pipelining_ that allows m
 Even with pipelining, however, responses must be sent in the same order the server received the requests, so the connection remains first-in, first-out and HOL blocking can still occur.
 Network conditions such as congestion, packet loss (and the resulting TCP retransmissions), or {{glossary("TCP slow start")}} can also delay transmission and cause later responses to be blocked by earlier ones.
 
-{{glossary("HTTP 2", "HTTP/2")}} reduces application-level HOL blocking by introducing request and response _multiplexing_:
-multiple requests and responses can be interleaved over a single TCP connection using independently numbered streams, and stream prioritization helps the server decide which streams to send first.
-Because HTTP/2 runs over TCP, though, packet loss at the transport layer can still cause HOL blocking across streams — a lost TCP segment can stall all streams carried on that connection until the lost data is retransmitted.
+{{glossary("HTTP 2", "HTTP/2")}} reduces application-level HOL blocking by introducing request and response _multiplexing_.
+With this feature multiple requests and responses can be interleaved over a single TCP connection using independently numbered streams, and stream prioritization helps the server decide which streams to send first.
+Packet loss at the transport layer can still cause HOL blocking across streams because HTTP/2 runs over TCP  — a lost TCP segment can stall all streams carried on that connection until the lost data is retransmitted.
 
 {{glossary("HTTP 3", "HTTP/3")}} eliminates the transport-layer head-of-line blocking by using {{glossary("QUIC")}} over {{glossary("UDP")}} and thus HOL problem on HTTP no longer exists.
 QUIC provides multiple independent streams with per-stream loss recovery, so packet loss affects only the stream where it occurs rather than the entire connection. This removes the TCP-level HOL problem.

--- a/files/en-us/glossary/http_2/index.md
+++ b/files/en-us/glossary/http_2/index.md
@@ -22,6 +22,6 @@ As a result, all existing applications can be delivered over the protocol withou
 - [HTTP](/en-US/docs/Web/HTTP) on MDN
 - Related glossary terms:
   - {{glossary("HTTP")}}
-  - {{glossary("Latency")}}, {{glossary("head of line blocking", "head-of-line blocking")}}
+  - {{glossary("Latency")}}, {{glossary("head of line blocking", "Head-of-line blocking")}}
 - {{RFC("7540", "Server Push", "8.2")}}
 - [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) on Wikipedia

--- a/files/en-us/glossary/http_2/index.md
+++ b/files/en-us/glossary/http_2/index.md
@@ -7,7 +7,7 @@ sidebar: glossarysidebar
 
 **HTTP/2** is a major revision of the [HTTP network protocol](/en-US/docs/Web/HTTP).
 
-The primary goals for HTTP/2 are to reduce {{glossary("latency")}} and {{glossary("head of line blocking", "head-of-line blocking")}} by enabling full request and response multiplexing and support for request prioritization, minimize protocol overhead via efficient compression of HTTP header fields (HPACK).
+The primary goals for HTTP/2 are to reduce {{glossary("latency")}} and {{glossary("head of line blocking", "head-of-line blocking")}}, by enabling full request and response multiplexing and support for request prioritization, and to minimize protocol overhead via efficient compression of HTTP header fields (HPACK).
 
 HTTP/2 also introduced a mechanism called Server Push, which allowed a server to send resources to a client in anticipation that the client would need them very soon.
 Server Push proved tricky to implement in practice, and has been removed from most major browser engines.

--- a/files/en-us/glossary/http_2/index.md
+++ b/files/en-us/glossary/http_2/index.md
@@ -7,7 +7,7 @@ sidebar: glossarysidebar
 
 **HTTP/2** is a major revision of the [HTTP network protocol](/en-US/docs/Web/HTTP).
 
-The primary goals for HTTP/2 are to reduce {{glossary("latency")}} and {{glossary("head of line blocking", "head-of-line blocking")}} by enabling full request and response multiplexing, minimize protocol overhead via efficient compression of HTTP header fields (HPACK), and support for request prioritization.
+The primary goals for HTTP/2 are to reduce {{glossary("latency")}} and {{glossary("head of line blocking", "head-of-line blocking")}} by enabling full request and response multiplexing and support for request prioritization, minimize protocol overhead via efficient compression of HTTP header fields (HPACK).
 
 HTTP/2 also introduced a mechanism called Server Push, which allowed a server to send resources to a client in anticipation that the client would need them very soon.
 Server Push proved tricky to implement in practice, and has been removed from most major browser engines.
@@ -19,9 +19,9 @@ As a result, all existing applications can be delivered over the protocol withou
 
 ## See also
 
-- [HTTP on MDN](/en-US/docs/Web/HTTP)
+- [HTTP](/en-US/docs/Web/HTTP) on MDN
 - Related glossary terms:
   - {{glossary("HTTP")}}
-  - {{glossary("Latency")}}
+  - {{glossary("Latency")}}, {{glossary("head of line blocking", "head-of-line blocking")}}
 - {{RFC("7540", "Server Push", "8.2")}}
 - [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) on Wikipedia

--- a/files/en-us/glossary/http_3/index.md
+++ b/files/en-us/glossary/http_3/index.md
@@ -7,7 +7,8 @@ sidebar: glossarysidebar
 
 **HTTP/3** is a major revision of the [HTTP network protocol](/en-US/docs/Web/HTTP), succeeding {{glossary("HTTP 2", "HTTP/2")}}.
 
-The most notable difference in HTTP/3 is that it uses a protocol named {{glossary("QUIC")}} over {{glossary("UDP")}} instead of {{glossary("TCP")}}, which help to eliminate the {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP and lower {{glossary("latency")}} for HTTP connections.
+The most notable difference in HTTP/3 is that it uses a protocol named {{glossary("QUIC")}} over {{glossary("UDP")}} instead of {{glossary("TCP")}}.
+This reduces {{glossary("latency")}} and eliminates the {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP.
 
 ## See also
 

--- a/files/en-us/glossary/http_3/index.md
+++ b/files/en-us/glossary/http_3/index.md
@@ -7,13 +7,13 @@ sidebar: glossarysidebar
 
 **HTTP/3** is a major revision of the [HTTP network protocol](/en-US/docs/Web/HTTP), succeeding {{glossary("HTTP 2", "HTTP/2")}}.
 
-The most notable difference in HTTP/3 is that it uses a protocol named QUIC over {{glossary("UDP")}} instead of {{glossary("TCP")}}.
+The most notable difference in HTTP/3 is that it uses a protocol named {{glossary("QUIC")}} over {{glossary("UDP")}} instead of {{glossary("TCP")}}, which help to eliminate the {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP and lower {{glossary("latency")}} for HTTP connections.
 
 ## See also
 
-- [HTTP documentation](/en-US/docs/Web/HTTP)
+- [HTTP](/en-US/docs/Web/HTTP) on MDN
 - [HTTP/3](https://en.wikipedia.org/wiki/HTTP/3) on Wikipedia
 - Related glossary terms:
-  - {{glossary("HTTP")}}
-  - {{glossary("HTTP 2")}}
-  - {{glossary("Latency")}}
+  - {{glossary("HTTP")}}, {{glossary("HTTP 2")}}
+  - {{glossary("TCP")}}, {{glossary("QUIC")}}, {{glossary("UDP")}}
+  - {{glossary("Latency")}}, {{glossary("head of line blocking", "Head-of-line blocking")}}

--- a/files/en-us/glossary/quic/index.md
+++ b/files/en-us/glossary/quic/index.md
@@ -5,15 +5,21 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**QUIC** is a multiplexed transport protocol implemented on UDP. It is used instead of {{Glossary("TCP")}} as the transport layer in HTTP/3.
+**QUIC** is a multiplexed transport protocol implemented on {{glossary("UDP")}}. It is used instead of {{Glossary("TCP")}} as the transport layer in {{glossary("HTTP 3", "HTTP/3")}}.
 
-QUIC was designed to provide quicker setup and lower latency for HTTP connections. In particular:
+QUIC was designed to provide quicker setup and lower {{glossary("latency")}} for {{glossary("HTTP")}} connections. In particular:
 
 - In TCP, the initial TCP handshake is optionally followed by a TLS handshake, which must complete before data can be transmitted. Since TLS is almost ubiquitous now, QUIC integrates the TLS handshake into the initial QUIC handshake, reducing the number of messages that must be exchanged during setup.
 
 - HTTP/2 is a multiplexed protocol, allowing multiple simultaneous HTTP transactions. However, the transactions are multiplexed over a single TCP connection, meaning that packet loss and subsequent retransmissions at the TCP layer can block all transactions. QUIC avoids this by running over UDP and implementing packet loss detection and retransmission separately for each stream, meaning that packet loss only blocks the particular stream whose packets were lost.
 
+In addition, QUIC help to resolve the {{glossary("HTTP 2", "HTTP/2")}} transport-layer {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP/3, since it now runs over UDP instead of TCP, and thus HOL problem on HTTP no longer exists. 
+
 ## See also
 
+- Related glossary terms
+  - {{glossary("HTTP")}}, {{glossary("HTTP 2", "HTTP/2")}}, {{glossary("HTTP 3", "HTTP/3")}}
+  - {{glossary("TCP")}}, {{glossary("UDP")}}
+  - {{glossary("Latency")}}, {{glossary("head of line blocking", "Head-of-line blocking")}}
 - {{rfc("9000", "the QUIC specification")}}
 - {{rfc("9114", "the HTTP/3 specification")}}

--- a/files/en-us/glossary/quic/index.md
+++ b/files/en-us/glossary/quic/index.md
@@ -13,8 +13,6 @@ QUIC was designed to provide quicker setup and lower {{glossary("latency")}} for
 
 - HTTP/2 is a multiplexed protocol, allowing multiple simultaneous HTTP transactions. However, the transactions are multiplexed over a single TCP connection, meaning that packet loss and subsequent retransmissions at the TCP layer can block all transactions. QUIC avoids this by running over UDP and implementing packet loss detection and retransmission separately for each stream, meaning that packet loss only blocks the particular stream whose packets were lost.
 
-In addition, QUIC help to resolve the {{glossary("HTTP 2", "HTTP/2")}} transport-layer {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP/3, since it now runs over UDP instead of TCP, and thus HOL problem on HTTP no longer exists.
-
 ## See also
 
 - Related glossary terms

--- a/files/en-us/glossary/quic/index.md
+++ b/files/en-us/glossary/quic/index.md
@@ -13,7 +13,7 @@ QUIC was designed to provide quicker setup and lower {{glossary("latency")}} for
 
 - HTTP/2 is a multiplexed protocol, allowing multiple simultaneous HTTP transactions. However, the transactions are multiplexed over a single TCP connection, meaning that packet loss and subsequent retransmissions at the TCP layer can block all transactions. QUIC avoids this by running over UDP and implementing packet loss detection and retransmission separately for each stream, meaning that packet loss only blocks the particular stream whose packets were lost.
 
-In addition, QUIC help to resolve the {{glossary("HTTP 2", "HTTP/2")}} transport-layer {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP/3, since it now runs over UDP instead of TCP, and thus HOL problem on HTTP no longer exists. 
+In addition, QUIC help to resolve the {{glossary("HTTP 2", "HTTP/2")}} transport-layer {{glossary("head of line blocking", "head-of-line blocking")}} problem in HTTP/3, since it now runs over UDP instead of TCP, and thus HOL problem on HTTP no longer exists.
 
 ## See also
 


### PR DESCRIPTION
### Motivations

1. current content base contains entries kind of isolated and linked to each other as expected
2. several typos and more importantly, some are technically incorrect

### Details

1. revise the glossary entries for HOL blocking problem, QUIC, HTTP/2 and HTTP/3
3. fix a technical issue at HOL blocking L12, where http/1.1 requests can be sent either pipelined or non-pipelined