### PR TITLE
Reference "origin" glossary entry in `X-Frame-Options` header reference

### DIFF
--- a/files/en-us/web/http/reference/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/reference/headers/x-frame-options/index.md
@@ -39,7 +39,7 @@ X-Frame-Options: SAMEORIGIN
 - `DENY`
   - : The page cannot be displayed in a frame, regardless of the site attempting to do so. Not only will the browser attempt to load the page in a frame fail when loaded from other sites, attempts to do so will fail when loaded from the same site.
 - `SAMEORIGIN`
-  - : The page can only be displayed if all ancestor frames are same {{glossary("origin")}} to the page itself. You can still use the page in a frame as long as the site including it in a frame is the same as the one serving the page.
+  - : The page can only be displayed if all ancestor frames have the same {{glossary("origin")}} as the page itself. You can still use the page in a frame as long as the site including it in a frame is the same as the one serving the page.
 - `ALLOW-FROM origin` {{deprecated_inline}}
   - : This is an obsolete directive. Modern browsers that encounter response headers with this directive will ignore the header completely. The {{HTTPHeader("Content-Security-Policy")}} HTTP header has a {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} directive which you should use instead.
 

--- a/files/en-us/web/http/reference/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/reference/headers/x-frame-options/index.md
@@ -39,7 +39,7 @@ X-Frame-Options: SAMEORIGIN
 - `DENY`
   - : The page cannot be displayed in a frame, regardless of the site attempting to do so. Not only will the browser attempt to load the page in a frame fail when loaded from other sites, attempts to do so will fail when loaded from the same site.
 - `SAMEORIGIN`
-  - : The page can only be displayed if all ancestor frames are same origin to the page itself. You can still use the page in a frame as long as the site including it in a frame is the same as the one serving the page.
+  - : The page can only be displayed if all ancestor frames are same {{glossary("origin")}} to the page itself. You can still use the page in a frame as long as the site including it in a frame is the same as the one serving the page.
 - `ALLOW-FROM origin` {{deprecated_inline}}
   - : This is an obsolete directive. Modern browsers that encounter response headers with this directive will ignore the header completely. The {{HTTPHeader("Content-Security-Policy")}} HTTP header has a {{HTTPHeader("Content-Security-Policy/frame-ancestors", "frame-ancestors")}} directive which you should use instead.
 


### PR DESCRIPTION
This is referenced in the `'self'` CSP directive (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#self), so figured it wouldn't hurt to have it here as well.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
