### PR TITLE
ci(workflows): disable automatic setup-node caching

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile

--- a/.github/workflows/interfacedata-updater.yml
+++ b/.github/workflows/interfacedata-updater.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: "mdn-content/.nvmrc"
+          package-manager-cache: false
 
       - name: Checkout webref
         uses: actions/checkout@v5

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -104,6 +104,7 @@ jobs:
         if: steps.check.outputs.HAS_ARTIFACT
         with:
           node-version-file: "content/.nvmrc"
+          package-manager-cache: false
 
       - name: Install (mdn/content)
         if: steps.check.outputs.HAS_ARTIFACT

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile


### PR DESCRIPTION
### Description

Sets `package-manager-cache: false` to all `actions/setup-node` workflow steps that don't already have caching configured via either `package-manager-cache` or `cache`.

### Motivation

The new default behavior introduced in [`actions/setup-node v5.0.0`](https://github.com/actions/setup-node/releases/tag/v5.0.0) is not safe.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
