### PR TITLE
Add “release notes” to Firefox release notes title

### DIFF
--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 10 for developers
+title: Firefox 10 release notes for developers
 short-title: Firefox 10
 slug: Mozilla/Firefox/Releases/10
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 100 for developers
+title: Firefox 100 release notes for developers
 short-title: Firefox 100
 slug: Mozilla/Firefox/Releases/100
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 101 for developers
+title: Firefox 101 release notes for developers
 short-title: Firefox 101
 slug: Mozilla/Firefox/Releases/101
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 102 for developers
+title: Firefox 102 release notes for developers
 short-title: Firefox 102
 slug: Mozilla/Firefox/Releases/102
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 103 for developers
+title: Firefox 103 release notes for developers
 short-title: Firefox 103
 slug: Mozilla/Firefox/Releases/103
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 104 for developers
+title: Firefox 104 release notes for developers
 short-title: Firefox 104
 slug: Mozilla/Firefox/Releases/104
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 105 for developers
+title: Firefox 105 release notes for developers
 short-title: Firefox 105
 slug: Mozilla/Firefox/Releases/105
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 106 for developers
+title: Firefox 106 release notes for developers
 short-title: Firefox 106
 slug: Mozilla/Firefox/Releases/106
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 107 for developers
+title: Firefox 107 release notes for developers
 short-title: Firefox 107
 slug: Mozilla/Firefox/Releases/107
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 108 for developers
+title: Firefox 108 release notes for developers
 short-title: Firefox 108
 slug: Mozilla/Firefox/Releases/108
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 109 for developers
+title: Firefox 109 release notes for developers
 short-title: Firefox 109
 slug: Mozilla/Firefox/Releases/109
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/11/index.md
+++ b/files/en-us/mozilla/firefox/releases/11/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 11 for developers
+title: Firefox 11 release notes for developers
 short-title: Firefox 11
 slug: Mozilla/Firefox/Releases/11
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 110 for developers
+title: Firefox 110 release notes for developers
 short-title: Firefox 110
 slug: Mozilla/Firefox/Releases/110
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 111 for developers
+title: Firefox 111 release notes for developers
 short-title: Firefox 111
 slug: Mozilla/Firefox/Releases/111
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 112 for developers
+title: Firefox 112 release notes for developers
 short-title: Firefox 112
 slug: Mozilla/Firefox/Releases/112
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 113 for developers
+title: Firefox 113 release notes for developers
 short-title: Firefox 113
 slug: Mozilla/Firefox/Releases/113
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 114 for developers
+title: Firefox 114 release notes for developers
 short-title: Firefox 114
 slug: Mozilla/Firefox/Releases/114
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 115 for developers
+title: Firefox 115 release notes for developers
 short-title: Firefox 115
 slug: Mozilla/Firefox/Releases/115
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 116 for developers
+title: Firefox 116 release notes for developers
 short-title: Firefox 116
 slug: Mozilla/Firefox/Releases/116
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 117 for developers
+title: Firefox 117 release notes for developers
 short-title: Firefox 117
 slug: Mozilla/Firefox/Releases/117
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 118 for developers
+title: Firefox 118 release notes for developers
 short-title: Firefox 118
 slug: Mozilla/Firefox/Releases/118
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 119 for developers
+title: Firefox 119 release notes for developers
 short-title: Firefox 119
 slug: Mozilla/Firefox/Releases/119
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 12 for developers
+title: Firefox 12 release notes for developers
 short-title: Firefox 12
 slug: Mozilla/Firefox/Releases/12
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 120 for developers
+title: Firefox 120 release notes for developers
 short-title: Firefox 120
 slug: Mozilla/Firefox/Releases/120
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 121 for developers
+title: Firefox 121 release notes for developers
 short-title: Firefox 121
 slug: Mozilla/Firefox/Releases/121
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 122 for developers
+title: Firefox 122 release notes for developers
 short-title: Firefox 122
 slug: Mozilla/Firefox/Releases/122
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 123 for developers
+title: Firefox 123 release notes for developers
 short-title: Firefox 123
 slug: Mozilla/Firefox/Releases/123
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 124 for developers
+title: Firefox 124 release notes for developers
 short-title: Firefox 124
 slug: Mozilla/Firefox/Releases/124
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 125 for developers
+title: Firefox 125 release notes for developers
 short-title: Firefox 125
 slug: Mozilla/Firefox/Releases/125
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 126 for developers
+title: Firefox 126 release notes for developers
 short-title: Firefox 126
 slug: Mozilla/Firefox/Releases/126
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 127 for developers
+title: Firefox 127 release notes for developers
 short-title: Firefox 127
 slug: Mozilla/Firefox/Releases/127
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 128 for developers
+title: Firefox 128 release notes for developers
 short-title: Firefox 128
 slug: Mozilla/Firefox/Releases/128
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 129 for developers
+title: Firefox 129 release notes for developers
 short-title: Firefox 129
 slug: Mozilla/Firefox/Releases/129
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/13/index.md
+++ b/files/en-us/mozilla/firefox/releases/13/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 13 for developers
+title: Firefox 13 release notes for developers
 short-title: Firefox 13
 slug: Mozilla/Firefox/Releases/13
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/130/index.md
+++ b/files/en-us/mozilla/firefox/releases/130/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 130 for developers
+title: Firefox 130 release notes for developers
 short-title: Firefox 130
 slug: Mozilla/Firefox/Releases/130
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/131/index.md
+++ b/files/en-us/mozilla/firefox/releases/131/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 131 for developers
+title: Firefox 131 release notes for developers
 short-title: Firefox 131
 slug: Mozilla/Firefox/Releases/131
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/132/index.md
+++ b/files/en-us/mozilla/firefox/releases/132/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 132 for developers
+title: Firefox 132 release notes for developers
 short-title: Firefox 132
 slug: Mozilla/Firefox/Releases/132
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/133/index.md
+++ b/files/en-us/mozilla/firefox/releases/133/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 133 for developers
+title: Firefox 133 release notes for developers
 short-title: Firefox 133
 slug: Mozilla/Firefox/Releases/133
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/134/index.md
+++ b/files/en-us/mozilla/firefox/releases/134/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 134 for developers
+title: Firefox 134 release notes for developers
 short-title: Firefox 134
 slug: Mozilla/Firefox/Releases/134
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 135 for developers
+title: Firefox 135 release notes for developers
 short-title: Firefox 135
 slug: Mozilla/Firefox/Releases/135
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/136/index.md
+++ b/files/en-us/mozilla/firefox/releases/136/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 136 for developers
+title: Firefox 136 release notes for developers
 short-title: Firefox 136
 slug: Mozilla/Firefox/Releases/136
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/137/index.md
+++ b/files/en-us/mozilla/firefox/releases/137/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 137 for developers
+title: Firefox 137 release notes for developers
 short-title: Firefox 137
 slug: Mozilla/Firefox/Releases/137
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/138/index.md
+++ b/files/en-us/mozilla/firefox/releases/138/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 138 for developers
+title: Firefox 138 release notes for developers
 short-title: Firefox 138
 slug: Mozilla/Firefox/Releases/138
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/139/index.md
+++ b/files/en-us/mozilla/firefox/releases/139/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 139 for developers
+title: Firefox 139 release notes for developers
 short-title: Firefox 139
 slug: Mozilla/Firefox/Releases/139
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/14/index.md
+++ b/files/en-us/mozilla/firefox/releases/14/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 14 for developers
+title: Firefox 14 release notes for developers
 short-title: Firefox 14
 slug: Mozilla/Firefox/Releases/14
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 140 for developers
+title: Firefox 140 release notes for developers
 short-title: Firefox 140
 slug: Mozilla/Firefox/Releases/140
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 141 for developers
+title: Firefox 141 release notes for developers
 short-title: Firefox 141
 slug: Mozilla/Firefox/Releases/141
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 142 for developers
+title: Firefox 142 release notes for developers
 short-title: Firefox 142
 slug: Mozilla/Firefox/Releases/142
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 143 for developers
+title: Firefox 143 release notes for developers
 short-title: Firefox 143
 slug: Mozilla/Firefox/Releases/143
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/144/index.md
+++ b/files/en-us/mozilla/firefox/releases/144/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 144 for developers
+title: Firefox 144 release notes for developers (Stable)
 short-title: Firefox 144 (Stable)
 slug: Mozilla/Firefox/Releases/144
 page-type: firefox-release-notes-active

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 145 for developers
+title: Firefox 145 release notes for developers (Beta)
 short-title: Firefox 145 (Beta)
 slug: Mozilla/Firefox/Releases/145
 page-type: firefox-release-notes-active

--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 146 for developers
+title: Firefox 146 release notes for developers (Nightly)
 short-title: Firefox 146 (Nightly)
 slug: Mozilla/Firefox/Releases/146
 page-type: firefox-release-notes-active

--- a/files/en-us/mozilla/firefox/releases/15/index.md
+++ b/files/en-us/mozilla/firefox/releases/15/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 15 for developers
+title: Firefox 15 release notes for developers
 short-title: Firefox 15
 slug: Mozilla/Firefox/Releases/15
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/16/index.md
+++ b/files/en-us/mozilla/firefox/releases/16/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 16 for developers
+title: Firefox 16 release notes for developers
 short-title: Firefox 16
 slug: Mozilla/Firefox/Releases/16
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/17/index.md
+++ b/files/en-us/mozilla/firefox/releases/17/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 17 for developers
+title: Firefox 17 release notes for developers
 short-title: Firefox 17
 slug: Mozilla/Firefox/Releases/17
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 18 for developers
+title: Firefox 18 release notes for developers
 short-title: Firefox 18
 slug: Mozilla/Firefox/Releases/18
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/19/index.md
+++ b/files/en-us/mozilla/firefox/releases/19/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 19 for developers
+title: Firefox 19 release notes for developers
 short-title: Firefox 19
 slug: Mozilla/Firefox/Releases/19
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/2/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 2 for developers
+title: Firefox 2 release notes for developers
 short-title: Firefox 2
 slug: Mozilla/Firefox/Releases/2
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 20 for developers
+title: Firefox 20 release notes for developers
 short-title: Firefox 20
 slug: Mozilla/Firefox/Releases/20
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/21/index.md
+++ b/files/en-us/mozilla/firefox/releases/21/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 21 for developers
+title: Firefox 21 release notes for developers
 short-title: Firefox 21
 slug: Mozilla/Firefox/Releases/21
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/22/index.md
+++ b/files/en-us/mozilla/firefox/releases/22/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 22 for developers
+title: Firefox 22 release notes for developers
 short-title: Firefox 22
 slug: Mozilla/Firefox/Releases/22
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/23/index.md
+++ b/files/en-us/mozilla/firefox/releases/23/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 23 for developers
+title: Firefox 23 release notes for developers
 short-title: Firefox 23
 slug: Mozilla/Firefox/Releases/23
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/24/index.md
+++ b/files/en-us/mozilla/firefox/releases/24/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 24 for developers
+title: Firefox 24 release notes for developers
 short-title: Firefox 24
 slug: Mozilla/Firefox/Releases/24
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/25/index.md
+++ b/files/en-us/mozilla/firefox/releases/25/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 25 for developers
+title: Firefox 25 release notes for developers
 short-title: Firefox 25
 slug: Mozilla/Firefox/Releases/25
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/26/index.md
+++ b/files/en-us/mozilla/firefox/releases/26/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 26 for developers
+title: Firefox 26 release notes for developers
 short-title: Firefox 26
 slug: Mozilla/Firefox/Releases/26
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/27/index.md
+++ b/files/en-us/mozilla/firefox/releases/27/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 27 for developers
+title: Firefox 27 release notes for developers
 short-title: Firefox 27
 slug: Mozilla/Firefox/Releases/27
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/28/index.md
+++ b/files/en-us/mozilla/firefox/releases/28/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 28 for developers
+title: Firefox 28 release notes for developers
 short-title: Firefox 28
 slug: Mozilla/Firefox/Releases/28
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/29/index.md
+++ b/files/en-us/mozilla/firefox/releases/29/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 29 for developers
+title: Firefox 29 release notes for developers
 short-title: Firefox 29
 slug: Mozilla/Firefox/Releases/29
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/3/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 3 for developers
+title: Firefox 3 release notes for developers
 short-title: Firefox 3
 slug: Mozilla/Firefox/Releases/3
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 30 for developers
+title: Firefox 30 release notes for developers
 short-title: Firefox 30
 slug: Mozilla/Firefox/Releases/30
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/31/index.md
+++ b/files/en-us/mozilla/firefox/releases/31/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 31 for developers
+title: Firefox 31 release notes for developers
 short-title: Firefox 31
 slug: Mozilla/Firefox/Releases/31
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/32/index.md
+++ b/files/en-us/mozilla/firefox/releases/32/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 32 for developers
+title: Firefox 32 release notes for developers
 short-title: Firefox 32
 slug: Mozilla/Firefox/Releases/32
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/33/index.md
+++ b/files/en-us/mozilla/firefox/releases/33/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 33 for developers
+title: Firefox 33 release notes for developers
 short-title: Firefox 33
 slug: Mozilla/Firefox/Releases/33
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/34/index.md
+++ b/files/en-us/mozilla/firefox/releases/34/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 34 for developers
+title: Firefox 34 release notes for developers
 short-title: Firefox 34
 slug: Mozilla/Firefox/Releases/34
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/35/index.md
+++ b/files/en-us/mozilla/firefox/releases/35/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 35 for developers
+title: Firefox 35 release notes for developers
 short-title: Firefox 35
 slug: Mozilla/Firefox/Releases/35
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 36 for developers
+title: Firefox 36 release notes for developers
 short-title: Firefox 36
 slug: Mozilla/Firefox/Releases/36
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/37/index.md
+++ b/files/en-us/mozilla/firefox/releases/37/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 37 for developers
+title: Firefox 37 release notes for developers
 short-title: Firefox 37
 slug: Mozilla/Firefox/Releases/37
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 38 for developers
+title: Firefox 38 release notes for developers
 short-title: Firefox 38
 slug: Mozilla/Firefox/Releases/38
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 39 for developers
+title: Firefox 39 release notes for developers
 short-title: Firefox 39
 slug: Mozilla/Firefox/Releases/39
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 4 for developers
+title: Firefox 4 release notes for developers
 short-title: Firefox 4
 slug: Mozilla/Firefox/Releases/4
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/40/index.md
+++ b/files/en-us/mozilla/firefox/releases/40/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 40 for developers
+title: Firefox 40 release notes for developers
 short-title: Firefox 40
 slug: Mozilla/Firefox/Releases/40
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/41/index.md
+++ b/files/en-us/mozilla/firefox/releases/41/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 41 for developers
+title: Firefox 41 release notes for developers
 short-title: Firefox 41
 slug: Mozilla/Firefox/Releases/41
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/42/index.md
+++ b/files/en-us/mozilla/firefox/releases/42/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 42 for developers
+title: Firefox 42 release notes for developers
 short-title: Firefox 42
 slug: Mozilla/Firefox/Releases/42
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/43/index.md
+++ b/files/en-us/mozilla/firefox/releases/43/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 43 for developers
+title: Firefox 43 release notes for developers
 short-title: Firefox 43
 slug: Mozilla/Firefox/Releases/43
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/44/index.md
+++ b/files/en-us/mozilla/firefox/releases/44/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 44 for developers
+title: Firefox 44 release notes for developers
 short-title: Firefox 44
 slug: Mozilla/Firefox/Releases/44
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/45/index.md
+++ b/files/en-us/mozilla/firefox/releases/45/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 45 for developers
+title: Firefox 45 release notes for developers
 short-title: Firefox 45
 slug: Mozilla/Firefox/Releases/45
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/46/index.md
+++ b/files/en-us/mozilla/firefox/releases/46/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 46 for developers
+title: Firefox 46 release notes for developers
 short-title: Firefox 46
 slug: Mozilla/Firefox/Releases/46
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/47/index.md
+++ b/files/en-us/mozilla/firefox/releases/47/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 47 for developers
+title: Firefox 47 release notes for developers
 short-title: Firefox 47
 slug: Mozilla/Firefox/Releases/47
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/48/index.md
+++ b/files/en-us/mozilla/firefox/releases/48/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 48 for developers
+title: Firefox 48 release notes for developers
 short-title: Firefox 48
 slug: Mozilla/Firefox/Releases/48
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/49/index.md
+++ b/files/en-us/mozilla/firefox/releases/49/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 49 for developers
+title: Firefox 49 release notes for developers
 short-title: Firefox 49
 slug: Mozilla/Firefox/Releases/49
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/5/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 5 for developers
+title: Firefox 5 release notes for developers
 short-title: Firefox 5
 slug: Mozilla/Firefox/Releases/5
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/50/index.md
+++ b/files/en-us/mozilla/firefox/releases/50/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 50 for developers
+title: Firefox 50 release notes for developers
 short-title: Firefox 50
 slug: Mozilla/Firefox/Releases/50
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/51/index.md
+++ b/files/en-us/mozilla/firefox/releases/51/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 51 for developers
+title: Firefox 51 release notes for developers
 short-title: Firefox 51
 slug: Mozilla/Firefox/Releases/51
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/52/index.md
+++ b/files/en-us/mozilla/firefox/releases/52/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 52 for developers
+title: Firefox 52 release notes for developers
 short-title: Firefox 52
 slug: Mozilla/Firefox/Releases/52
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/53/index.md
+++ b/files/en-us/mozilla/firefox/releases/53/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 53 for developers
+title: Firefox 53 release notes for developers
 short-title: Firefox 53
 slug: Mozilla/Firefox/Releases/53
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/54/index.md
+++ b/files/en-us/mozilla/firefox/releases/54/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 54 for developers
+title: Firefox 54 release notes for developers
 short-title: Firefox 54
 slug: Mozilla/Firefox/Releases/54
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/55/index.md
+++ b/files/en-us/mozilla/firefox/releases/55/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 55 for developers
+title: Firefox 55 release notes for developers
 short-title: Firefox 55
 slug: Mozilla/Firefox/Releases/55
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/56/index.md
+++ b/files/en-us/mozilla/firefox/releases/56/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 56 for developers
+title: Firefox 56 release notes for developers
 short-title: Firefox 56
 slug: Mozilla/Firefox/Releases/56
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/58/index.md
+++ b/files/en-us/mozilla/firefox/releases/58/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 58 for developers
+title: Firefox 58 release notes for developers
 short-title: Firefox 58
 slug: Mozilla/Firefox/Releases/58
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/59/index.md
+++ b/files/en-us/mozilla/firefox/releases/59/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 59 for developers
+title: Firefox 59 release notes for developers
 short-title: Firefox 59
 slug: Mozilla/Firefox/Releases/59
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 6 for developers
+title: Firefox 6 release notes for developers
 short-title: Firefox 6
 slug: Mozilla/Firefox/Releases/6
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/60/index.md
+++ b/files/en-us/mozilla/firefox/releases/60/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 60 for developers
+title: Firefox 60 release notes for developers
 short-title: Firefox 60
 slug: Mozilla/Firefox/Releases/60
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/61/index.md
+++ b/files/en-us/mozilla/firefox/releases/61/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 61 for developers
+title: Firefox 61 release notes for developers
 short-title: Firefox 61
 slug: Mozilla/Firefox/Releases/61
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/62/index.md
+++ b/files/en-us/mozilla/firefox/releases/62/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 62 for developers
+title: Firefox 62 release notes for developers
 short-title: Firefox 62
 slug: Mozilla/Firefox/Releases/62
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/63/index.md
+++ b/files/en-us/mozilla/firefox/releases/63/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 63 for developers
+title: Firefox 63 release notes for developers
 short-title: Firefox 63
 slug: Mozilla/Firefox/Releases/63
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/64/index.md
+++ b/files/en-us/mozilla/firefox/releases/64/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 64 for developers
+title: Firefox 64 release notes for developers
 short-title: Firefox 64
 slug: Mozilla/Firefox/Releases/64
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/65/index.md
+++ b/files/en-us/mozilla/firefox/releases/65/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 65 for developers
+title: Firefox 65 release notes for developers
 short-title: Firefox 65
 slug: Mozilla/Firefox/Releases/65
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/66/index.md
+++ b/files/en-us/mozilla/firefox/releases/66/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 66 for developers
+title: Firefox 66 release notes for developers
 short-title: Firefox 66
 slug: Mozilla/Firefox/Releases/66
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/67/index.md
+++ b/files/en-us/mozilla/firefox/releases/67/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 67 for developers
+title: Firefox 67 release notes for developers
 short-title: Firefox 67
 slug: Mozilla/Firefox/Releases/67
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/68/index.md
+++ b/files/en-us/mozilla/firefox/releases/68/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 68 for developers
+title: Firefox 68 release notes for developers
 short-title: Firefox 68
 slug: Mozilla/Firefox/Releases/68
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/69/index.md
+++ b/files/en-us/mozilla/firefox/releases/69/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 69 for developers
+title: Firefox 69 release notes for developers
 short-title: Firefox 69
 slug: Mozilla/Firefox/Releases/69
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/7/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 7 for developers
+title: Firefox 7 release notes for developers
 short-title: Firefox 7
 slug: Mozilla/Firefox/Releases/7
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/70/index.md
+++ b/files/en-us/mozilla/firefox/releases/70/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 70 for developers
+title: Firefox 70 release notes for developers
 short-title: Firefox 70
 slug: Mozilla/Firefox/Releases/70
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/71/index.md
+++ b/files/en-us/mozilla/firefox/releases/71/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 71 for Developers
+title: Firefox 71 release notes for developers
 short-title: Firefox 71
 slug: Mozilla/Firefox/Releases/71
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/72/index.md
+++ b/files/en-us/mozilla/firefox/releases/72/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 72 for Developers
+title: Firefox 72 release notes for developers
 short-title: Firefox 72
 slug: Mozilla/Firefox/Releases/72
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/73/index.md
+++ b/files/en-us/mozilla/firefox/releases/73/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 73 for developers
+title: Firefox 73 release notes for developers
 short-title: Firefox 73
 slug: Mozilla/Firefox/Releases/73
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/74/index.md
+++ b/files/en-us/mozilla/firefox/releases/74/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 74 for developers
+title: Firefox 74 release notes for developers
 short-title: Firefox 74
 slug: Mozilla/Firefox/Releases/74
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/75/index.md
+++ b/files/en-us/mozilla/firefox/releases/75/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 75 for developers
+title: Firefox 75 release notes for developers
 short-title: Firefox 75
 slug: Mozilla/Firefox/Releases/75
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/76/index.md
+++ b/files/en-us/mozilla/firefox/releases/76/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 76 for developers
+title: Firefox 76 release notes for developers
 short-title: Firefox 76
 slug: Mozilla/Firefox/Releases/76
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/77/index.md
+++ b/files/en-us/mozilla/firefox/releases/77/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 77 for developers
+title: Firefox 77 release notes for developers
 short-title: Firefox 77
 slug: Mozilla/Firefox/Releases/77
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/78/index.md
+++ b/files/en-us/mozilla/firefox/releases/78/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 78 for developers
+title: Firefox 78 release notes for developers
 short-title: Firefox 78
 slug: Mozilla/Firefox/Releases/78
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/79/index.md
+++ b/files/en-us/mozilla/firefox/releases/79/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 79 for developers
+title: Firefox 79 release notes for developers
 short-title: Firefox 79
 slug: Mozilla/Firefox/Releases/79
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/8/index.md
+++ b/files/en-us/mozilla/firefox/releases/8/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 8 for developers
+title: Firefox 8 release notes for developers
 short-title: Firefox 8
 slug: Mozilla/Firefox/Releases/8
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/80/index.md
+++ b/files/en-us/mozilla/firefox/releases/80/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 80 for developers
+title: Firefox 80 release notes for developers
 short-title: Firefox 80
 slug: Mozilla/Firefox/Releases/80
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/81/index.md
+++ b/files/en-us/mozilla/firefox/releases/81/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 81 for developers
+title: Firefox 81 release notes for developers
 short-title: Firefox 81
 slug: Mozilla/Firefox/Releases/81
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/82/index.md
+++ b/files/en-us/mozilla/firefox/releases/82/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 82 for developers
+title: Firefox 82 release notes for developers
 short-title: Firefox 82
 slug: Mozilla/Firefox/Releases/82
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/83/index.md
+++ b/files/en-us/mozilla/firefox/releases/83/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 83 for developers
+title: Firefox 83 release notes for developers
 short-title: Firefox 83
 slug: Mozilla/Firefox/Releases/83
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/84/index.md
+++ b/files/en-us/mozilla/firefox/releases/84/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 84 for developers
+title: Firefox 84 release notes for developers
 short-title: Firefox 84
 slug: Mozilla/Firefox/Releases/84
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/85/index.md
+++ b/files/en-us/mozilla/firefox/releases/85/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 85 for developers
+title: Firefox 85 release notes for developers
 short-title: Firefox 85
 slug: Mozilla/Firefox/Releases/85
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/86/index.md
+++ b/files/en-us/mozilla/firefox/releases/86/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 86 for developers
+title: Firefox 86 release notes for developers
 short-title: Firefox 86
 slug: Mozilla/Firefox/Releases/86
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/87/index.md
+++ b/files/en-us/mozilla/firefox/releases/87/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 87 for developers
+title: Firefox 87 release notes for developers
 short-title: Firefox 87
 slug: Mozilla/Firefox/Releases/87
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/88/index.md
+++ b/files/en-us/mozilla/firefox/releases/88/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 88 for developers
+title: Firefox 88 release notes for developers
 short-title: Firefox 88
 slug: Mozilla/Firefox/Releases/88
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/89/index.md
+++ b/files/en-us/mozilla/firefox/releases/89/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 89 for developers
+title: Firefox 89 release notes for developers
 short-title: Firefox 89
 slug: Mozilla/Firefox/Releases/89
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/9/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 9 for developers
+title: Firefox 9 release notes for developers
 short-title: Firefox 9
 slug: Mozilla/Firefox/Releases/9
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/90/index.md
+++ b/files/en-us/mozilla/firefox/releases/90/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 90 for developers
+title: Firefox 90 release notes for developers
 short-title: Firefox 90
 slug: Mozilla/Firefox/Releases/90
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/91/index.md
+++ b/files/en-us/mozilla/firefox/releases/91/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 91 for developers
+title: Firefox 91 release notes for developers
 short-title: Firefox 91
 slug: Mozilla/Firefox/Releases/91
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/92/index.md
+++ b/files/en-us/mozilla/firefox/releases/92/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 92 for developers
+title: Firefox 92 release notes for developers
 short-title: Firefox 92
 slug: Mozilla/Firefox/Releases/92
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/93/index.md
+++ b/files/en-us/mozilla/firefox/releases/93/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 93 for developers
+title: Firefox 93 release notes for developers
 short-title: Firefox 93
 slug: Mozilla/Firefox/Releases/93
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 94 for developers
+title: Firefox 94 release notes for developers
 short-title: Firefox 94
 slug: Mozilla/Firefox/Releases/94
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 95 for developers
+title: Firefox 95 release notes for developers
 short-title: Firefox 95
 slug: Mozilla/Firefox/Releases/95
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 96 for developers
+title: Firefox 96 release notes for developers
 short-title: Firefox 96
 slug: Mozilla/Firefox/Releases/96
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 97 for developers
+title: Firefox 97 release notes for developers
 short-title: Firefox 97
 slug: Mozilla/Firefox/Releases/97
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 98 for developers
+title: Firefox 98 release notes for developers
 short-title: Firefox 98
 slug: Mozilla/Firefox/Releases/98
 page-type: firefox-release-notes

--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -1,5 +1,5 @@
 ---
-title: Firefox 99 for developers
+title: Firefox 99 release notes for developers
 short-title: Firefox 99
 slug: Mozilla/Firefox/Releases/99
 page-type: firefox-release-notes


### PR DESCRIPTION
### Description

```diff
- Firefox N for developers
+ Firefox N release notes for developers (Stable|Beta|Nightly)
```

### Motivation

To remove confusion with [Firefox Developer Edition](https://www.firefox.com/en-US/channel/desktop/developer/) and feature Stable, Beta, and Nightly tags in the title.