### PR TITLE
Technical review: Add details and example for null bindGroupLayouts entries

### DIFF
--- a/files/en-us/web/api/gpudevice/createpipelinelayout/index.md
+++ b/files/en-us/web/api/gpudevice/createpipelinelayout/index.md
@@ -22,7 +22,9 @@ createPipelineLayout(descriptor)
 - `descriptor`
   - : An object containing the following properties:
     - `bindGroupLayouts`
-      - : An array of {{domxref("GPUBindGroupLayout")}} objects (which are in turn created via calls to {{domxref("GPUDevice.createBindGroupLayout()")}}). Each one corresponds to a [`@group`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-binding) attribute in the shader code contained in the {{domxref("GPUShaderModule")}} used in a related pipeline.
+      - : An array of values representing the bind group layouts for a pipeline. Each value can be:
+        - A {{domxref("GPUBindGroupLayout")}} object, created via a call to {{domxref("GPUDevice.createBindGroupLayout()")}}. Each object corresponds to a [`@group`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-binding) attribute in the shader code contained in the {{domxref("GPUShaderModule")}} used in a related pipeline.
+        - `null`, which represents an empty bind group layout. `null` values are ignored when creating a pipeline layout.
     - `label` {{optional_inline}}
       - : A string providing a label that can be used to identify the object, for example in {{domxref("GPUError")}} messages or console warnings.
 
@@ -77,6 +79,21 @@ const pipelineLayout = device.createPipelineLayout({
 });
 
 // …
+```
+
+### Specifying an empty bind group layout
+
+In this snippet, we create three bind group layouts, with bind group layout 1 representing fragment data and bind group layout 2 representing vertex data. If we want to create a pipeline that uses only bind group layouts 0 and 2, we can pass `null` for bind group layout 1 and then render without a fragment shader.
+
+```js
+const bgl0 = myDevice.createBindGroupLayout({ entries: myGlobalEntries });
+const bgl1 = myDevice.createBindGroupLayout({ entries: myFragmentEntries });
+const bgl2 = myDevice.createBindGroupLayout({ entries: myVertexEntries });
+
+// pipeline layout can be used to render without a fragment shader
+const myPipelineLayout = myDevice.createPipelineLayout({
+  bindGroupLayouts: [bgl0, null, bgl2],
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/gpudevice/createpipelinelayout/index.md
+++ b/files/en-us/web/api/gpudevice/createpipelinelayout/index.md
@@ -86,12 +86,12 @@ const pipelineLayout = device.createPipelineLayout({
 In this snippet, we create three bind group layouts, with bind group layout 1 representing fragment data and bind group layout 2 representing vertex data. If we want to create a pipeline that uses only bind group layouts 0 and 2, we can pass `null` for bind group layout 1 and then render without a fragment shader.
 
 ```js
-const bgl0 = myDevice.createBindGroupLayout({ entries: myGlobalEntries });
-const bgl1 = myDevice.createBindGroupLayout({ entries: myFragmentEntries });
-const bgl2 = myDevice.createBindGroupLayout({ entries: myVertexEntries });
+const bgl0 = device.createBindGroupLayout({ entries: myGlobalEntries });
+const bgl1 = device.createBindGroupLayout({ entries: myFragmentEntries });
+const bgl2 = device.createBindGroupLayout({ entries: myVertexEntries });
 
 // pipeline layout can be used to render without a fragment shader
-const myPipelineLayout = myDevice.createPipelineLayout({
+const pipelineLayout = device.createPipelineLayout({
   bindGroupLayouts: [bgl0, null, bgl2],
 });
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As of Chrome 135, [`GPUDevice.createPipelineLayout`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createPipelineLayout) supports `null` entries in the `bindGroupLayouts` array. See https://developer.chrome.com/blog/new-in-webgpu-135#allow_creating_pipeline_layout_with_null_bind_group_layout for details.

This PR adds details for this feature, plus a quick example snippet.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
