### PR TITLE
Editorial review: Document size requirement changes for GPUBuffers mapped at creation

### DIFF
--- a/files/en-us/web/api/gpudevice/createbuffer/index.md
+++ b/files/en-us/web/api/gpudevice/createbuffer/index.md
@@ -29,7 +29,7 @@ createBuffer(descriptor)
         Note that it is valid to set `mappedAtCreation: true` so you can set the buffer's initial data, even if the `GPUBufferUsage.MAP_READ` or `GPUBufferUsage.MAP_WRITE` usage flags are not set.
 
     - `size`
-      - : A number representing the size of the buffer, in bytes. If `mappedAtCreation` is set to `true`, this should be a multiple of `4`.
+      - : A number representing the size of the buffer, in bytes. If `mappedAtCreation` is set to `true`, this must be a multiple of `4`.
     - `usage`
       - : The {{glossary("Bitwise flags", "bitwise flags")}} representing the allowed usages for the `GPUBuffer`. The possible values are in the [`GPUBuffer.usage` value table](/en-US/docs/Web/API/GPUBuffer/usage#value).
 

--- a/files/en-us/web/api/gpudevice/createbuffer/index.md
+++ b/files/en-us/web/api/gpudevice/createbuffer/index.md
@@ -29,7 +29,7 @@ createBuffer(descriptor)
         Note that it is valid to set `mappedAtCreation: true` so you can set the buffer's initial data, even if the `GPUBufferUsage.MAP_READ` or `GPUBufferUsage.MAP_WRITE` usage flags are not set.
 
     - `size`
-      - : A number representing the size of the buffer, in bytes.
+      - : A number representing the size of the buffer, in bytes. If `mappedAtCreation` is set to `true`, this should be a multiple of `4`.
     - `usage`
       - : The {{glossary("Bitwise flags", "bitwise flags")}} representing the allowed usages for the `GPUBuffer`. The possible values are in the [`GPUBuffer.usage` value table](/en-US/docs/Web/API/GPUBuffer/usage#value).
 
@@ -39,6 +39,11 @@ createBuffer(descriptor)
 
 A {{domxref("GPUBuffer")}} object instance.
 
+### Exceptions
+
+- `RangeError` {{domxref("DOMException")}}
+  - : Thrown if `mappedAtCreation` is set to `true`, and the specified `size` is not a multiple of `4`.
+
 ### Validation
 
 The following criteria must be met when calling **`createBuffer()`**, otherwise a {{domxref("GPUValidationError")}} is generated and an invalid {{domxref("GPUBuffer")}} object is returned:
@@ -46,7 +51,7 @@ The following criteria must be met when calling **`createBuffer()`**, otherwise 
 - A valid `usage` is specified.
 - `GPUBufferUsage.MAP_READ` is specified, and no additional flags are specified other than `GPUBufferUsage.COPY_DST`.
 - `GPUBufferUsage.MAP_WRITE` is specified, and no additional flags are specified other than `GPUBufferUsage.COPY_SRC`.
-- `mappedAtCreation: true` is specified, and the specified `size` is a multiple of 4.
+- `mappedAtCreation: true` is specified, and the specified `size` is a multiple of `4`.
 
 > [!NOTE]
 > If the buffer allocation fails without any specific side-effects, a {{domxref("GPUOutOfMemoryError")}} object is generated.

--- a/files/en-us/web/api/gpudevice/createbuffer/index.md
+++ b/files/en-us/web/api/gpudevice/createbuffer/index.md
@@ -51,7 +51,6 @@ The following criteria must be met when calling **`createBuffer()`**, otherwise 
 - A valid `usage` is specified.
 - `GPUBufferUsage.MAP_READ` is specified, and no additional flags are specified other than `GPUBufferUsage.COPY_DST`.
 - `GPUBufferUsage.MAP_WRITE` is specified, and no additional flags are specified other than `GPUBufferUsage.COPY_SRC`.
-- `mappedAtCreation: true` is specified, and the specified `size` is a multiple of `4`.
 
 > [!NOTE]
 > If the buffer allocation fails without any specific side-effects, a {{domxref("GPUOutOfMemoryError")}} object is generated.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In Chrome 138, the size requirements for `GPUBuffer`s mapped at creation have changed. During a [`GPUDevice.createBuffer()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createBuffer) call, if `mappedAtCreation` is set `true` and `size` is not a multiple of `4`, a `RangeError` exception is thrown.

See https://developer.chrome.com/blog/new-in-webgpu-138#size_requirement_changes_for_buffers_mapped_at_creation.

This PR adds a mention of the change. cc @beaufortfrancois.

Question — if the `RangeError` is thrown, will an invalid `GPUBuffer` object still be returned? If not, should I remove the corresponding entry from the validation section?

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
