### PR TITLE
Fix inheritance of Crypto interface

### DIFF
--- a/files/en-us/web/api/crypto/index.md
+++ b/files/en-us/web/api/crypto/index.md
@@ -14,14 +14,10 @@ The `Crypto` is available in windows using the {{domxref("Window.crypto")}} prop
 
 ## Instance properties
 
-_This interface implements properties defined on {{domxref("Crypto/getRandomValues", "RandomSource")}}._
-
 - {{domxref("Crypto.subtle")}} {{ReadOnlyInline}} {{SecureContext_inline}}
   - : Returns a {{domxref("SubtleCrypto")}} object providing access to common cryptographic primitives, like hashing, signing, encryption, or decryption.
 
 ## Instance methods
-
-_This interface implements methods defined on {{domxref("Crypto/getRandomValues", "RandomSource")}}._
 
 - {{domxref("Crypto.getRandomValues()")}}
   - : Fills the passed {{ jsxref("TypedArray") }} with cryptographically sound random values.


### PR DESCRIPTION
### Description

Removes mention of the RandomSource interface.

The last mention of the RandomSource interface I was able to find is in the [Last Call Working Draft of the Specification](https://www.w3.org/TR/2014/WD-WebCryptoAPI-20140325/) which is from 25 March 2014, and it wasn't included in the [Candidate Recommendation Snapshot](https://www.w3.org/TR/2014/CR-WebCryptoAPI-20141211/) from 11 December 2014 or any future versions of the specification.

### Motivation

Keeping the documentation up to date.
