### PR TITLE
Docs: Clarify that inert cannot be reverted by descendants

### DIFF
--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -10,9 +10,7 @@ browser-compat: api.HTMLElement.inert
 
 The {{domxref("HTMLElement")}} property **`inert`** reflects the value of the element's [`inert`](/en-US/docs/Web/HTML/Reference/Global_attributes/inert) attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
 
-A key characteristic of the `inert` attribute is that its effect is inherited by all of an element's descendants. Once a parent element is marked as `inert`, none of its children can reverse this state. For example, explicitly setting `inert="false"` on a child element will have no effect, and the element will remain non-interactive.
-
-Note that if the `inert` attribute is unspecified, the element itself may still inherit inertness from its parent. However, that inherited inertness is not reflected by this property's value.
+Note that if the `inert` attribute is unspecified, the element itself may still inherit inertness from its parent. However, that inherited inertness is not reflected by this property's value. Explicitly setting the property to `false` cannot revert inertness inherited from the parent.
 
 ## Value
 

--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -10,6 +10,8 @@ browser-compat: api.HTMLElement.inert
 
 The {{domxref("HTMLElement")}} property **`inert`** reflects the value of the element's [`inert`](/en-US/docs/Web/HTML/Reference/Global_attributes/inert) attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
 
+A key characteristic of the `inert` attribute is that its effect is inherited by all of an element's descendants. Once a parent element is marked as `inert`, none of its children can reverse this state. For example, explicitly setting `inert="false"` on a child element will have no effect, and the element will remain non-interactive.
+
 Note that if the `inert` attribute is unspecified, the element itself may still inherit inertness from its parent. However, that inherited inertness is not reflected by this property's value.
 
 ## Value

--- a/files/en-us/web/html/reference/global_attributes/inert/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inert/index.md
@@ -7,7 +7,12 @@ browser-compat: html.global_attributes.inert
 sidebar: htmlsidebar
 ---
 
-The **`inert`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a Boolean attribute indicating that the element and all of its flat tree descendants become _inert_. Modal {{htmlelement("dialog")}}s generated with [`showModal()`](/en-US/docs/Web/API/HTMLDialogElement/showModal) escape inertness, meaning that they don't inherit inertness from their ancestors, but can only be made inert by having the `inert` attribute explicitly set on themselves.
+The **`inert`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a Boolean attribute indicating that the element and all of its flat tree descendants become _inert_. The `inert` attribute can be added to sections of content that should not be interactive. When an element is inert, it along with all of the element's descendants, including normally interactive elements such as links, buttons, and form controls are disabled because they cannot receive focus or be clicked. The `inert` attribute can also be added to elements that should be offscreen or hidden. An inert element, along with its descendants, gets removed from the tab order and accessibility tree.
+
+Modal {{htmlelement("dialog")}}s generated with [`showModal()`](/en-US/docs/Web/API/HTMLDialogElement/showModal) escape inertness, meaning that they don't inherit inertness from their ancestors, but can only be made inert by having the `inert` attribute explicitly set on themselves. No other element can escape inertness.
+
+> [!NOTE]
+> While `inert` is a global attribute and can be applied to any element, it is generally used for sections of content. To make individual controls "inert", consider using the [`disabled`](/en-US/docs/Web/HTML/Reference/Attributes/disabled) attribute, along with CSS [`:disabled`](/en-US/docs/Web/CSS/:disabled) styles, instead.
 
 Specifically, `inert` does the following:
 
@@ -17,19 +22,6 @@ Specifically, `inert` does the following:
 - Prevents users from selecting text within the element — akin to using the CSS property {{cssxref("user-select")}} to disable text selection.
 - Prevents users from editing any contents of the element that are otherwise editable.
 - Hides the element and its content from assistive technologies by excluding them from the accessibility tree.
-
-```html
-<div inert>
-  <!-- content -->
-</div>
-```
-
-The `inert` attribute can be added to sections of content that should not be interactive. When an element is inert, it along with all of the element's descendants, including normally interactive elements such as links, buttons, and form controls are disabled because they cannot receive focus or be clicked.
-
-The `inert` attribute can also be added to elements that should be offscreen or hidden. An inert element, along with its descendants, gets removed from the tab order and accessibility tree.
-
-> [!NOTE]
-> While `inert` is a global attribute and can be applied to any element, it is generally used for sections of content. To make individual controls "inert", consider using the [`disabled`](/en-US/docs/Web/HTML/Reference/Attributes/disabled) attribute, along with CSS [`:disabled`](/en-US/docs/Web/CSS/:disabled) styles, instead.
 
 ## Accessibility concerns
 


### PR DESCRIPTION
### Description

This PR adds a clarifying paragraph to the documentation for the `inert` attribute. It explicitly states that inertness is inherited by all descendants and cannot be reversed by a child element, a key piece of information that was previously missing.

### Motivation

This change makes the behavior of the `inert` attribute clearer for developers, preventing potential confusion, especially for those familiar with CSS properties like `visibility` that allow for descendant overrides.

### Related issues and pull requests

Fixes #40295
