### PR TITLE
FF144 Idempotency-Key docs

### DIFF
--- a/files/en-us/web/http/reference/headers/idempotency-key/index.md
+++ b/files/en-us/web/http/reference/headers/idempotency-key/index.md
@@ -112,13 +112,6 @@ Content-Language: en
 }
 ```
 
-<!-- ## Browser integration -->
-<!-- Firefox has a (non-standard) integration that automatically applies keys.
-This is discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1991641#c6
-Since this might not survive in the shipped release it is undocumented now.
-This hidden comment remains so that the possible differences are known at that point by the editor.
--->
-
 ## Examples
 
 ### A POST with a key
@@ -162,3 +155,11 @@ Content-Language: en
 ## Browser compatibility
 
 {{Compat}}
+
+<!-- ## Browser integration -->
+<!-- Firefox has a (non-standard) integration that automatically applies keys to POST requests (but not PATCH).
+This is discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1991641#c6
+Since this might not survive in the shipped release it is undocumented now - there is a BCD key
+This hidden comment is here as a reminder when there is an update to browser status w.r.t this header.
+-->
+

--- a/files/en-us/web/http/reference/headers/idempotency-key/index.md
+++ b/files/en-us/web/http/reference/headers/idempotency-key/index.md
@@ -44,12 +44,12 @@ What this means is that you can send a message with these methods any number of 
 For example, if you send the same `PUT` message multiple times it will update the same resource on the server each time, with the same value.
 
 The {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} methods are non-idempotent, which means that the server state may change each time the message is received.
-Unlike a `PUT` message, if you send the same `POST` message multiple times it may create a new record each time.
+Unlike a `PUT` message, if you send the same `POST` request multiple times, the server may create a new resource for each successful request.
 Similarly, a `PATCH` reflects a change with respect to a particular state, and that state is changed each time the patch is applied.
 
 Idempotence is important in cases where a client does not receive a response, because it means the client can safely resend the request without having to worry about possible side effects.
 
-The HTTP `Idempotency-Key` header allows a client to make `POST` and `PATCH` requests idempotent by giving them a unique identifier (key).
+The HTTP `Idempotency-Key` header allows a client to make `POST` and `PATCH` requests idempotent by giving them a unique identifier (a key).
 The client can then resend the same request multiple times, and the server can know that it should only perform the action once.
 
 ### Client responsibilities
@@ -62,7 +62,7 @@ A unique key must be used for each new request that is sent, and the same key sh
 
 Servers that support the `Idempotency-Key` header are expected to document and publish their support, including the endpoints that require the header, and any requirements on the key (such as length, computation method, and expiry).
 
-Note that the server may choose to expire received keys over time; the key expiry behavior must be defined and documented.
+Note that the server may choose to expire received keys over time; the key expiry behavior must be defined and documented so that clients can make conforming requests.
 
 #### Idempotency fingerprint
 
@@ -96,7 +96,7 @@ A server should provide error responses in the following cases:
 In the case of a `409 Conflict` response, clients will need to wait before retrying.
 For all the other errors clients will need to amend the requests before resending.
 
-The specification does not mandate the format of the error response payload, but indicates it should contain a link to site-specific documentation explaining the error.
+The specification does not mandate a format for the error response payload, but errors should contain a link to implementation-specific documentation explaining the error.
 The JSON payload format outlined in {{rfc(9457, "Problem Details for HTTP APIs")}} is one option.
 For example, the following response might be used for a missing key:
 
@@ -104,6 +104,7 @@ For example, the following response might be used for a missing key:
 HTTP/1.1 400 Bad Request
 Content-Type: application/problem+json
 Content-Language: en
+
 {
     "type": "https://developer.example.com/idempotency/docs",
     "title": "Idempotency-Key is missing",
@@ -138,9 +139,9 @@ Idempotency-Key: 9c7d2b4a0e1f6c835a2d1b0f4e3c5a7d
 }
 ```
 
-If no response is received the client can safely resend exactly the same request again; if the server didn't get the request it will act on it, if it has already had the request is will not make the post, but it will respond as though it had.
+If no response is received, the client can safely resend exactly the same request again; if the server didn't get the request it will act on it, if it has already had the request is will not make the post, but it will respond as though it had.
 
-The client resends the request too quickly it might get an error response like this.
+If the client resends the request too quickly, it might get an error response like this.
 Note that only the HTTP status code is mandated, the rest of the information is defined by the server.
 
 ```http

--- a/files/en-us/web/http/reference/headers/idempotency-key/index.md
+++ b/files/en-us/web/http/reference/headers/idempotency-key/index.md
@@ -8,7 +8,7 @@ spec-urls: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-h
 sidebar: http
 ---
 
-The HTTP **Idempotency-Key** {{glossary("request header")}} can be used to make {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} requests {{glossary("idempotent")}}.
+The HTTP **`Idempotency-Key`** {{glossary("request header")}} can be used to make {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} requests {{glossary("idempotent")}}.
 
 This allows clients to resend unacknowledged requests without having to be concerned that the request has already have been received and acted on by the server.
 
@@ -75,7 +75,7 @@ If idempotency fingerprinting is supported, the server can send an error respons
 
 #### Request processing
 
-On receiving a `POST` or `PATCH` request with an **Idempotency-Key** on an endpoint that requires it, the server should check whether it already has received a response with that key.
+On receiving a `POST` or `PATCH` request with an `Idempotency-Key` on an endpoint that requires it, the server should check whether it already has received a request with that key.
 
 - If it hasn't, the server should perform the operation and respond, and then store the key.
 - If it has, it should not perform the operation, but should respond as though it had.
@@ -83,7 +83,7 @@ On receiving a `POST` or `PATCH` request with an **Idempotency-Key** on an endpo
 Servers that are using an idempotency fingerprint would also generate and store a fingerprint for each new request.
 This would be used to respond with an error if a subsequent key and fingerprint did not match.
 
-If a request is received without an **Idempotency-Key** on an endpoint that requires it, the server should respond with an error.
+If a request is received without an `Idempotency-Key` on an endpoint that requires it, the server should respond with an error.
 
 #### Server error responses
 
@@ -141,6 +141,7 @@ Note that only the HTTP status code is mandated, the rest of the information is 
 HTTP/1.1 409 Conflict
 Content-Type: application/problem+json
 Content-Language: en
+
 {
     "type": "https://example.com/idempotency/docs",
     "title": "Server processing previous request.",

--- a/files/en-us/web/http/reference/headers/idempotency-key/index.md
+++ b/files/en-us/web/http/reference/headers/idempotency-key/index.md
@@ -162,4 +162,3 @@ This is discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1991641#c6
 Since this might not survive in the shipped release it is undocumented now - there is a BCD key
 This hidden comment is here as a reminder when there is an update to browser status w.r.t this header.
 -->
-

--- a/files/en-us/web/http/reference/headers/idempotency-key/index.md
+++ b/files/en-us/web/http/reference/headers/idempotency-key/index.md
@@ -1,0 +1,163 @@
+---
+title: Idempotency-Key header
+short-title: Idempotency-Key
+slug: Web/HTTP/Reference/Headers/Idempotency-Key
+page-type: http-header
+browser-compat: http.headers.Idempotency-Key
+spec-urls: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/
+sidebar: http
+---
+
+The HTTP **Idempotency-Key** {{glossary("request header")}} can be used to make {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} requests {{glossary("idempotent")}}.
+
+This allows clients to resend unacknowledged requests without having to be concerned that the request has already have been received and acted on by the server.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Request header")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```http
+Idempotency-Key: <key>
+```
+
+## Directives
+
+- `<key>`
+  - : The unique key for a particular request.
+    The format is defined by the server.
+
+## Description
+
+The HTTP methods {{HTTPMethod("GET")}}, {{HTTPMethod("HEAD")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("DELETE")}}, and {{HTTPMethod("OPTIONS")}} are idempotent.
+What this means is that you can send a message with these methods any number of times and the state of the server either won't be changed, or will be changed in the same way every time it gets the message.
+For example, if you send the same `PUT` message multiple times it will update the same resource on the server each time, with the same value.
+
+The {{HTTPMethod("POST")}} and {{HTTPMethod("PATCH")}} methods are non-idempotent, which means that the server state may change each time the message is received.
+Unlike a `PUT` message, if you send the same `POST` message multiple times it may create a new record each time.
+Similarly, a `PATCH` reflects a change with respect to a particular state, and that state is changed each time the patch is applied.
+
+Idempotence is important in cases where a client does not receive a response, because it means the client can safely resend the request without having to worry about possible side effects.
+
+The HTTP `Idempotency-Key` header allows a client to make `POST` and `PATCH` requests idempotent by giving them a unique identifier (key).
+The client can then resend the same request multiple times, and the server can know that it should only perform the action once.
+
+### Client responsibilities
+
+Client JavaScript should attach the `Idempotency-Key` header in fetch requests for endpoints that require it, with a key that conforms to the requirements published by the server.
+
+A unique key must be used for each new request that is sent, and the same key should be used if that request is resent.
+
+### Server responsibilities
+
+Servers that support the `Idempotency-Key` header are expected to document and publish their support, including the endpoints that require the header, and any requirements on the key (such as length, computation method, and expiry).
+
+Note that the server may choose to expire received keys over time; the key expiry behavior must be defined and documented.
+
+#### Idempotency fingerprint
+
+A unique key is expected to be used in each request.
+
+In order to protect against clients reusing keys for new requests, a server may create and store an "idempotency fingerprint" of the request along with the key.
+This is a hash of all or part of a request that can be compared to other requests with the same key.
+
+If idempotency fingerprinting is supported, the server can send an error response the same key has a different fingerprint.
+
+#### Request processing
+
+On receiving a `POST` or `PATCH` request with an **Idempotency-Key** on an endpoint that requires it, the server should check whether it already has received a response with that key.
+
+- If it hasn't, the server should perform the operation and respond, and then store the key.
+- If it has, it should not perform the operation, but should respond as though it had.
+
+Servers that are using an idempotency fingerprint would also generate and store a fingerprint for each new request.
+This would be used to respond with an error if a subsequent key and fingerprint did not match.
+
+If a request is received without an **Idempotency-Key** on an endpoint that requires it, the server should respond with an error.
+
+#### Server error responses
+
+A server should provide error responses in the following cases:
+
+- {{HTTPStatus("400", "400 Bad Request")}}: The header is omitted for an endpoint that is documented as requiring it.
+- {{HTTPStatus("409", "409 Conflict")}}: A request with the same key is currently/still being processed.
+- {{HTTPStatus("422", "422 Unprocessable Content")}}: The key is already being used for a different request payload (if idempotency fingerprinting is supported).
+
+In the case of a `409 Conflict` response, clients will need to wait before retrying.
+For all the other errors clients will need to amend the requests before resending.
+
+The specification does not mandate the format of the error response payload, but indicates it should contain a link to site-specific documentation explaining the error.
+The JSON payload format outlined in {{rfc(9457, "Problem Details for HTTP APIs")}} is one option.
+For example, the following response might be used for a missing key:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+Content-Language: en
+{
+    "type": "https://developer.example.com/idempotency/docs",
+    "title": "Idempotency-Key is missing",
+    "detail": "This operation is idempotent and requires correct usage of Idempotency Key.",
+}
+```
+
+<!-- ## Browser integration -->
+<!-- Firefox has a (non-standard) integration that automatically applies keys.
+This is discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1991641#c6
+Since this might not survive in the shipped release it is undocumented now.
+This hidden comment remains so that the possible differences are known at that point by the editor.
+-->
+
+## Examples
+
+### A POST with a key
+
+The following message shows POST request to create a new user.
+The key `9c7d2b4a0e1f6c835a2d1b0f4e3c5a7d` is a unique value that matches the requirements published by the host (example.com doesn't support this header, so we've just made up a value).
+
+```http
+POST /api/users HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Idempotency-Key: 9c7d2b4a0e1f6c835a2d1b0f4e3c5a7d
+
+{
+  "user_id": "12345",
+  "name": "Sharma Chow",
+  "email": "sharmac@example.com"
+}
+```
+
+If no response is received the client can safely resend exactly the same request again; if the server didn't get the request it will act on it, if it has already had the request is will not make the post, but it will respond as though it had.
+
+The client resends the request too quickly it might get an error response like this.
+Note that only the HTTP status code is mandated, the rest of the information is defined by the server.
+
+```http
+HTTP/1.1 409 Conflict
+Content-Type: application/problem+json
+Content-Language: en
+{
+    "type": "https://example.com/idempotency/docs",
+    "title": "Server processing previous request.",
+    "detail": "A request with the same key is currently/still being processed.",
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/http/reference/headers/index.md
+++ b/files/en-us/web/http/reference/headers/index.md
@@ -484,6 +484,8 @@ See the [Topics API](/en-US/docs/Web/API/Topics_API) documentation for more info
   - : A client can send the [`Accept-Signature`](https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#name-the-accept-signature-header) header field to indicate intention to take advantage of any available signatures and to indicate what kinds of signatures it supports.
 - {{HTTPHeader("Early-Data")}} {{experimental_inline}}
   - : Indicates that the request has been conveyed in TLS early data.
+- {{HTTPHeader("Idempotency-Key")}} {{experimental_inline}}
+  - : Provides a unique key for `POST` and `PATCH` requests, allowing them to be made idempotent.
 - {{HTTPHeader("Set-Login")}} {{experimental_inline}}
   - : Response header sent by a federated identity provider (IdP) to set its login status, meaning whether any users are logged into the IdP on the current browser or not.
     This is stored by the browser and used by the [FedCM API](/en-US/docs/Web/API/FedCM_API).


### PR DESCRIPTION
FF135 adds support for the `Idempotency-Key` header behind a preference - I'm working on this because there was an abortive attempt to ship in 145.

This allows a client to make a POST or PATCH request idempotent, so that if the client doesn't receive a response it can safely resend the request without having to worry about whether the server already acted on it and the response was just lost.

The key is sent in each new requests to indicate that a POST/PATCH is a particular unique command. If the server gets the same request with the same key it doesn't act on it after the first time, but responds as though it had. The key and error response format is defined by the server.

Related docs work can be tracked in #41497
