### PR TITLE
Editorial review: Document using GPUBuffer directly as a binding resource

### DIFF
--- a/files/en-us/web/api/gpudevice/createbindgroup/index.md
+++ b/files/en-us/web/api/gpudevice/createbindgroup/index.md
@@ -27,10 +27,11 @@ createBindGroup(descriptor)
           - : A number representing a unique identifier for this resource binding, which matches the `binding` value of a corresponding {{domxref("GPUBindGroupLayout")}} entry. In addition, it matches the `n` index value of the corresponding [`@binding(n)`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-binding) attribute in the shader ({{domxref("GPUShaderModule")}}) used in the related pipeline.
         - `resource`
           - : The resource to bind. This can be one of the following:
-            - `GPUBufferBinding` (which wraps a {{domxref("GPUBuffer")}}; see [GPUBufferBinding objects](#gpubufferbinding_objects) for a definition)
+            - `GPUBufferBinding`: Wraps a {{domxref("GPUBuffer")}}; see [GPUBufferBinding objects](#gpubufferbinding_objects) for a definition.
+            - {{domxref("GPUBuffer")}}: Can be used directly rather than being wrapped in a `GPUBufferBinding`, provided the default [`offset`](#offset) and [`size`](#size) values are being used.
             - {{domxref("GPUExternalTexture")}}
+            - {{domxref("GPUTextureView")}}: Can be used in place of a `GPUExternalTexture` provided it is compatible (a 2D format with a single subresource, that is, [`dimension: "2d"`](/en-US/docs/Web/API/GPUTexture/createView#dimension)).
             - {{domxref("GPUSampler")}}
-            - {{domxref("GPUTextureView")}}; can be used in place of a `GPUExternalTexture` provided it is compatible (a 2D format with a single subresource, that is, [`dimension: "2d"`](/en-US/docs/Web/API/GPUTexture/createView#dimension)).
     - `label` {{optional_inline}}
       - : A string providing a label that can be used to identify the object, for example in {{domxref("GPUError")}} messages or console warnings.
     - `layout`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 138 adds the ability for a `GPUBuffer` to be passed directly into a [`GPUDevice.createBindGroup()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createBindGroup) call as a binding resource in place of a `GPUBufferBinding` object, provided the default `size` and `offset` values are being used.

See https://developer.chrome.com/blog/new-in-webgpu-138#shorthand_for_using_buffer_as_a_binding_resource.

This PR documents the new feature.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
