### PR TITLE
Expand markdown guidelines to allow reference links

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -20,7 +20,7 @@ The GFM specification defines two basic types of links:
 - [inline links](https://github.github.com/gfm/#inline-link), in which the destination is given immediately after the link text.
 - [reference links](https://github.github.com/gfm/#reference-link), in which the destination is defined elsewhere in the document.
 
-On MDN we prefer to use inline links because they are easier to read and maintain without loosing context. This is the preferable way to write links on MDN:
+On MDN we prefer to use inline links because they are easier to read and maintain without loosing context. This is the preferred way to write links on MDN:
 
 ```md
 [Macarons](https://en.wikipedia.org/wiki/Macaron) are delicious but tricky to make.

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -20,20 +20,25 @@ The GFM specification defines two basic types of links:
 - [inline links](https://github.github.com/gfm/#inline-link), in which the destination is given immediately after the link text.
 - [reference links](https://github.github.com/gfm/#reference-link), in which the destination is defined elsewhere in the document.
 
-On MDN we allow only inline links.
-This is the correct way to write GFM links on MDN:
+On MDN we prefer to use inline links because they are easier to read and maintain without loosing context. This is the preferable way to write links on MDN:
 
-```md example-good
+```md
 [Macarons](https://en.wikipedia.org/wiki/Macaron) are delicious but tricky to make.
 ```
 
-This is an incorrect way to write links on MDN:
+In certain situations, however, reference links are more appropriate for their compactness. For example, they are particularly useful in tables:
 
-```md example-bad
-[Macarons][macaron] are delicious but tricky to make.
+```md
+| Name                 | Features                          |
+| -------------------- | --------------------------------- |
+| [Macarons][macarons] | are delicious but tricky to make. |
+| [Biscotti][biscotti] | are crisp and easier to make.     |
 
-[macaron]: https://en.wikipedia.org/wiki/Macaron
+[macarons]: https://en.wikipedia.org/wiki/Macaron
+[biscotti]: https://en.wikipedia.org/wiki/Biscotti
 ```
+
+In rare cases when it's necessary to use reference links, please make sure they immediately follow the context where they are used.
 
 ## Example code blocks
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -26,13 +26,14 @@ On MDN we prefer to use inline links because they are easier to read and maintai
 [Macarons](https://en.wikipedia.org/wiki/Macaron) are delicious but tricky to make.
 ```
 
-In certain situations, however, reference links are more appropriate for their compactness. For example, they are particularly useful in tables:
+In certain situations, however, reference links are more appropriate for their compactness.
+For example, shrinking wide tables can make them easier to review and edit.
 
 ```md
-| Name                 | Features                          |
-| -------------------- | --------------------------------- |
-| [Macarons][macarons] | are delicious but tricky to make. |
-| [Biscotti][biscotti] | are crisp and easier to make.     |
+| Name                 | Features                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| [Macarons][macarons] | Delicious but tricky to make. Add more class to a tea party than almost any other confectionary. |
+| [Biscotti][biscotti] | Crisp and easier to make.                                                                        |
 
 [macarons]: https://en.wikipedia.org/wiki/Macaron
 [biscotti]: https://en.wikipedia.org/wiki/Biscotti


### PR DESCRIPTION
### Description

Expands markdown guidelines to allow reference links when it makes sense. For example, in tables.

### Motivation

To be flexible and allow better readability in complex tables.