### PR TITLE
Editorial review: Add GPUAdapterInfo.isFallbackAdapter...

### DIFF
--- a/files/en-us/web/api/gpuadapter/index.md
+++ b/files/en-us/web/api/gpuadapter/index.md
@@ -17,12 +17,15 @@ A `GPUAdapter` object is requested using the {{domxref("GPU.requestAdapter()")}}
 
 - {{domxref("GPUAdapter.features", "features")}} {{ReadOnlyInline}}
   - : A {{domxref("GPUSupportedFeatures")}} object that describes additional functionality supported by the adapter.
-- {{domxref("GPUAdapter.isFallbackAdapter", "isFallbackAdapter")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
-  - : A boolean value. Returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not.
 - {{domxref("GPUAdapter.info", "info")}} {{ReadOnlyInline}}
   - : A {{domxref("GPUAdapterInfo")}} object containing identifying information about the adapter.
 - {{domxref("GPUAdapter.limits", "limits")}} {{ReadOnlyInline}}
   - : A {{domxref("GPUSupportedLimits")}} object that describes the limits supported by the adapter.
+
+### Deprecated properties
+
+- {{domxref("GPUAdapter.isFallbackAdapter", "isFallbackAdapter")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
+  - : A boolean value. Returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not. This property has been removed from the web platform: use {{domxref("GPUAdapterInfo.isFallbackAdapter")}} instead.
 
 ## Instance methods
 

--- a/files/en-us/web/api/gpuadapter/index.md
+++ b/files/en-us/web/api/gpuadapter/index.md
@@ -25,7 +25,7 @@ A `GPUAdapter` object is requested using the {{domxref("GPU.requestAdapter()")}}
 ### Deprecated properties
 
 - {{domxref("GPUAdapter.isFallbackAdapter", "isFallbackAdapter")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
-  - : A boolean value. Returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not. This property has been removed from the web platform: use {{domxref("GPUAdapterInfo.isFallbackAdapter")}} instead.
+  - : A boolean value. Returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not. This property has been removed from the web platform. Use {{domxref("GPUAdapterInfo.isFallbackAdapter")}} instead.
 
 ## Instance methods
 

--- a/files/en-us/web/api/gpuadapter/isfallbackadapter/index.md
+++ b/files/en-us/web/api/gpuadapter/isfallbackadapter/index.md
@@ -14,6 +14,8 @@ browser-compat: api.GPUAdapter.isFallbackAdapter
 The **`isFallbackAdapter`** read-only property of the
 {{domxref("GPUAdapter")}} interface returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not.
 
+This property has been removed from the web platform: use {{domxref("GPUAdapterInfo.isFallbackAdapter")}} instead.
+
 ## Value
 
 A boolean.
@@ -31,8 +33,8 @@ async function init() {
     throw Error("Couldn't request WebGPU adapter.");
   }
 
-  const fallback = adapter.isFallbackAdapter;
-  console.log(fallback);
+  const isFallback = adapter.isFallbackAdapter;
+  console.log(isFallback);
 
   // …
 }

--- a/files/en-us/web/api/gpuadapter/isfallbackadapter/index.md
+++ b/files/en-us/web/api/gpuadapter/isfallbackadapter/index.md
@@ -14,7 +14,7 @@ browser-compat: api.GPUAdapter.isFallbackAdapter
 The **`isFallbackAdapter`** read-only property of the
 {{domxref("GPUAdapter")}} interface returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not.
 
-This property has been removed from the web platform: use {{domxref("GPUAdapterInfo.isFallbackAdapter")}} instead.
+This property has been removed from the web platform. Use {{domxref("GPUAdapterInfo.isFallbackAdapter")}} instead.
 
 ## Value
 

--- a/files/en-us/web/api/gpuadapterinfo/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/index.md
@@ -23,12 +23,14 @@ This object allows developers to access specific details about the user's GPU so
   - : A human-readable string describing the adapter. Returns an empty string if it is not available.
 - {{domxref("GPUAdapterInfo.device", "device")}} {{ReadOnlyInline}}
   - : A vendor-specific identifier for the adapter. Returns an empty string if it is not available.
-- {{domxref("GPUAdapterInfo.vendor", "vendor")}} {{ReadOnlyInline}}
-  - : The name of the adapter vendor. Returns an empty string if it is not available.
+- {{domxref("GPUAdapterInfo.isFallbackAdapter", "isFallbackAdapter")}} {{ReadOnlyInline}}
+  - : A boolean value. Returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not.
 - {{domxref("GPUAdapterInfo.subgroupMaxSize", "subgroupMaxSize")}} {{ReadOnlyInline}}
   - : The maximum supported [subgroup size](https://gpuweb.github.io/gpuweb/wgsl/#subgroup-size) for the {{domxref("GPUAdapter")}}.
 - {{domxref("GPUAdapterInfo.subgroupMinSize", "subgroupMinSize")}} {{ReadOnlyInline}}
   - : The minimum supported [subgroup size](https://gpuweb.github.io/gpuweb/wgsl/#subgroup-size) for the {{domxref("GPUAdapter")}}.
+- {{domxref("GPUAdapterInfo.vendor", "vendor")}} {{ReadOnlyInline}}
+  - : The name of the adapter vendor. Returns an empty string if it is not available.
 
 ## Examples
 

--- a/files/en-us/web/api/gpuadapterinfo/isfallbackadapter/index.md
+++ b/files/en-us/web/api/gpuadapterinfo/isfallbackadapter/index.md
@@ -1,0 +1,48 @@
+---
+title: "GPUAdapterInfo: isFallbackAdapter property"
+short-title: isFallbackAdapter
+slug: Web/API/GPUAdapterInfo/isFallbackAdapter
+page-type: web-api-instance-property
+browser-compat: api.GPUAdapterInfo.isFallbackAdapter
+---
+
+{{APIRef("WebGPU API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+
+The **`isFallbackAdapter`** read-only property of the
+{{domxref("GPUAdapterInfo")}} interface returns `true` if the adapter is a [fallback adapter](/en-US/docs/Web/API/GPU/requestAdapter#fallback_adapters), and `false` if not.
+
+## Value
+
+A boolean.
+
+## Examples
+
+```js
+async function init() {
+  if (!navigator.gpu) {
+    throw Error("WebGPU not supported.");
+  }
+
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) {
+    throw Error("Couldn't request WebGPU adapter.");
+  }
+
+  const isFallback = adapter.info.isFallbackAdapter;
+  console.log(isFallback);
+
+  // …
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The [WebGPU API](/en-US/docs/Web/API/WebGPU_API)


### PR DESCRIPTION
…and update GPUAdapter.isFallbackAdapter

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In Chrome 140, `GPUAdapter.isFallbackAdapter` was removed, replaced by `GPUAdapterInfo.isFallbackAdapter`. See https://developer.chrome.com/blog/new-in-webgpu-140#remove_gpuadapter_isfallbackadapter_attribute.

This PR adds a page for `GPUAdapterInfo.isFallbackAdapter`, and marks `GPUAdapter.isFallbackAdapter` more clearly as deprecated/removed, with a note on what to use instead.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
