### PR TITLE
Fix auto ID for 3d specific CSS properties heading

### DIFF
--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -62,7 +62,7 @@ img {
 
 {{EmbedLiveSample('Skewing_and_translating') }}
 
-## 3D specific CSS properties
+## 3D specific CSS properties {#3d_specific_css_properties}
 
 Performing CSS transformations in 3D space is a bit more complex. You have to start by configuring the 3D space by giving it a perspective, then you have to configure how your 2D elements will behave in that space.
 


### PR DESCRIPTION
Added a custom ID to the 3d specific CSS properties heading to fix the issue with auto-generated ID stripping the leading number
Related to mdn/fred#1007