### PR TITLE
docs(css): update the container-type property note

### DIFF
--- a/files/en-us/web/css/container-name/index.md
+++ b/files/en-us/web/css/container-name/index.md
@@ -10,9 +10,6 @@ The **container-name** [CSS](/en-US/docs/Web/CSS) property specifies a list of q
 A container query will apply styles to elements based on the [size](/en-US/docs/Web/CSS/CSS_containment/Container_size_and_style_queries#container_size_queries) or [scroll-state](/en-US/docs/Web/CSS/CSS_conditional_rules/Container_scroll-state_queries) of the nearest ancestor with a containment context.
 When a containment context is given a name, it can be specifically targeted using the {{Cssxref("@container")}} at-rule instead of the nearest ancestor with containment.
 
-> [!NOTE]
-> When using the {{cssxref("container-type")}} and `container-name` properties, the `style` and `layout` values of the {{cssxref("contain")}} property are automatically applied.
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -11,9 +11,6 @@ An element can be established as a query container using the **`container-type`*
 - [Size](/en-US/docs/Web/CSS/CSS_containment/Container_size_and_style_queries): Enable selectively applying CSS rules to a container's children based on a general size or inline size condition such as a maximum or minimum dimension, aspect ratio, or orientation.
 - [Scroll-state](/en-US/docs/Web/CSS/CSS_conditional_rules/Container_scroll-state_queries): Enable selectively applying CSS rules to a container's children based on a scroll-state condition such as whether the container is a scroll container that is partially scrolled or whether the container is a [snap target](/en-US/docs/Glossary/Scroll_snap#snap_target) that is going to be snapped to its scroll snap container.
 
-> [!NOTE]
-> When using the `container-type` and {{cssxref("container-name")}} properties, the `style` and `size` values of the {{cssxref("contain")}} property are automatically applied. In older browser versions, `contain: layout` was also applied, which created separate stacking contexts. See [browser compatibility](#browser_compatibility) for more details.
-
 ## Syntax
 
 ```css
@@ -40,9 +37,7 @@ The `container-type` property can take a single value from the list below, or tw
 
 - `inline-size`
   - : Establishes a query container for dimensional queries on the [inline axis](/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values#block_and_inline_dimensions) of the container.
-    Applies style, and inline-size containment to the element.
-
-    Inline size containment is applied to the element. The inline size of the element can be [computed in isolation](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment#size_containment), ignoring the child elements (see [Using CSS containment](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment)).
+    Applies [style](/en-US/docs/Web/CSS/contain#style) and [inline-size](/en-US/docs/Web/CSS/contain#inline-size) containment to the element. The inline size of the element can be [computed in isolation](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment#size_containment), ignoring the child elements (see [Using CSS containment](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment)).
 
 - `normal`
   - : Default value. The element is not a query container for any container size queries, but remains a query container for [container style queries](/en-US/docs/Web/CSS/@container#container_style_queries).
@@ -52,9 +47,7 @@ The `container-type` property can take a single value from the list below, or tw
 
 - `size`
   - : Establishes a query container for container size queries in both the [inline and block](/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values#block_and_inline_dimensions) dimensions.
-    Applies style containment, and size containment to the container.
-
-    Size containment is applied to the element in both the inline and block directions. The size of the element can be computed in isolation, ignoring the child elements.
+    Applies [style](/en-US/docs/Web/CSS/contain#style) and [size](/en-US/docs/Web/CSS/contain#size) containment to the element. Size containment is applied to the element in both the inline and block directions. The size of the element can be computed in isolation, ignoring the child elements.
 
 ## Formal definition
 

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -12,7 +12,9 @@ An element can be established as a query container using the **`container-type`*
 - [Scroll-state](/en-US/docs/Web/CSS/CSS_conditional_rules/Container_scroll-state_queries): Enable selectively applying CSS rules to a container's children based on a scroll-state condition such as whether the container is a scroll container that is partially scrolled or whether the container is a [snap target](/en-US/docs/Glossary/Scroll_snap#snap_target) that is going to be snapped to its scroll snap container.
 
 > [!NOTE]
-> When using the `container-type` and {{cssxref("container-name")}} properties, the `style` and `layout` values of the {{cssxref("contain")}} property are automatically applied.
+> Previously, setting `container-type` automatically applied both `contain: style` and `contain: layout`.
+>
+> In recent browser versions (starting with Chromium 129 and Firefox 133), `container-type` **no longer** applies `contain: layout` automatically. Only `contain: style` is applied. This change prevents unintended side effects, such as the creation of unexpected stacking contexts.
 
 ## Syntax
 

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -42,7 +42,7 @@ The `container-type` property can take a single value from the list below, or tw
 
 - `inline-size`
   - : Establishes a query container for dimensional queries on the [inline axis](/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values#block_and_inline_dimensions) of the container.
-    Applies layout, style, and inline-size containment to the element.
+    Applies style, and inline-size containment to the element.
 
     Inline size containment is applied to the element. The inline size of the element can be [computed in isolation](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment#size_containment), ignoring the child elements (see [Using CSS containment](/en-US/docs/Web/CSS/CSS_containment/Using_CSS_containment)).
 
@@ -54,7 +54,7 @@ The `container-type` property can take a single value from the list below, or tw
 
 - `size`
   - : Establishes a query container for container size queries in both the [inline and block](/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values#block_and_inline_dimensions) dimensions.
-    Applies layout containment, style containment, and size containment to the container.
+    Applies style containment, and size containment to the container.
 
     Size containment is applied to the element in both the inline and block directions. The size of the element can be computed in isolation, ignoring the child elements.
 

--- a/files/en-us/web/css/container-type/index.md
+++ b/files/en-us/web/css/container-type/index.md
@@ -12,9 +12,7 @@ An element can be established as a query container using the **`container-type`*
 - [Scroll-state](/en-US/docs/Web/CSS/CSS_conditional_rules/Container_scroll-state_queries): Enable selectively applying CSS rules to a container's children based on a scroll-state condition such as whether the container is a scroll container that is partially scrolled or whether the container is a [snap target](/en-US/docs/Glossary/Scroll_snap#snap_target) that is going to be snapped to its scroll snap container.
 
 > [!NOTE]
-> Previously, setting `container-type` automatically applied both `contain: style` and `contain: layout`.
->
-> In recent browser versions (starting with Chromium 129 and Firefox 133), `container-type` **no longer** applies `contain: layout` automatically. Only `contain: style` is applied. This change prevents unintended side effects, such as the creation of unexpected stacking contexts.
+> When using the `container-type` and {{cssxref("container-name")}} properties, the `style` and `size` values of the {{cssxref("contain")}} property are automatically applied. In older browser versions, `contain: layout` was also applied, which created separate stacking contexts. See [browser compatibility](#browser_compatibility) for more details.
 
 ## Syntax
 


### PR DESCRIPTION
### Description
Update the note on the [container-type](https://developer.mozilla.org/en-US/docs/Web/CSS/container-type) page, where it says that applying `container-type` automatically applies `container: layout`, but this is no longer the case in recent browser versions. More information is available in the related issue.

### Motivation
Avoid reading outdated information.

### Related issues and pull requests
Fixes #41375