### PR TITLE
docs(learn_web_development): add link to first example in event bubbling section.

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
@@ -303,7 +303,8 @@ By default almost all event handlers are registered in the bubbling phase, and t
 
 In the last section, we looked at a problem caused by event bubbling and how to fix it. Event bubbling isn't just annoying, though: it can be very useful. In particular, it enables **event delegation**. In this practice, when we want some code to run when the user interacts with any one of a large number of child elements, we set the event listener on their parent and have events that happen on them bubble up to their parent rather than having to set the event listener on every child individually.
 
-Let's go back to our first example, where we set the background color of the whole page when the user clicked a button. Suppose that instead, the page is divided into 16 tiles, and we want to set each tile to a random color when the user clicks that tile.
+Let's go back to our [first example](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Events#an_example_handling_a_click_event),
+where we set the background color of the whole page when the user clicked a button. Suppose that instead, the page is divided into 16 tiles, and we want to set each tile to a random color when the user clicks that tile.
 
 Here's the HTML:
 

--- a/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
+++ b/files/en-us/learn_web_development/core/scripting/event_bubbling/index.md
@@ -303,7 +303,7 @@ By default almost all event handlers are registered in the bubbling phase, and t
 
 In the last section, we looked at a problem caused by event bubbling and how to fix it. Event bubbling isn't just annoying, though: it can be very useful. In particular, it enables **event delegation**. In this practice, when we want some code to run when the user interacts with any one of a large number of child elements, we set the event listener on their parent and have events that happen on them bubble up to their parent rather than having to set the event listener on every child individually.
 
-Let's go back to our [first example](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Events#an_example_handling_a_click_event),
+Let's go back to our [first example](/en-US/docs/Learn_web_development/Core/Scripting/Events#an_example_handling_a_click_event),
 where we set the background color of the whole page when the user clicked a button. Suppose that instead, the page is divided into 16 tiles, and we want to set each tile to a random color when the user clicks that tile.
 
 Here's the HTML:


### PR DESCRIPTION
 Add link to first example in event bubbling section

### Description
- Linked the phrase "first example" to the relevant documentation page for better context and navigation.
- This change improves the readability and usability of the event bubbling guide.

### Motivation

The paragraph in the Event delegation section referred to “our first example” without providing a link, causing confusion for readers who land directly on the page.
This update resolves that by adding a cross-reference to the “An example: handling a click event” section in the Events article, ensuring users can easily access the example being discussed.

### Additional details

Added link:
https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Events#an_example_handling_a_click_event

File updated:
files/en-us/learn_web_development/core/scripting/event_bubbling/index.md

This update maintains consistency with MDN’s documentation linking practices.

### Related issues and pull requests

Fixes #41587

