### PR TITLE
update cookie block errors

### DIFF
--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedall/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedall/index.md
@@ -19,12 +19,12 @@ CookieBlockedAll=Request to access cookies or storage on "X" was blocked because
 
 The permission can be changed or removed by:
 
-- Going to _Preferences > Privacy & Security > Enhanced Tracking Protection_
+- Going to _Settings > Privacy & Security > Enhanced Tracking Protection_.
 - In the _Custom_ Content Blocking section, selecting a value other than _All Cookies_ for the _Cookies_ item
 
 If the resource that is being blocked doesn't need authentication, you can fix the warning message by adding a `crossorigin="anonymous"` attribute to your element.
 
 ## See also
 
-- [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)
+- [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-deskto) on [support.mozilla.org](https://support.mozilla.org/)
 - [The `crossorigin` attribute](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin)

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedall/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedall/index.md
@@ -19,12 +19,12 @@ CookieBlockedAll=Request to access cookies or storage on "X" was blocked because
 
 The permission can be changed or removed by:
 
-- Going to _Preferences > Content Blocking_
+- Going to _Preferences > Privacy & Security > Enhanced Tracking Protection_
 - In the _Custom_ Content Blocking section, selecting a value other than _All Cookies_ for the _Cookies_ item
 
 If the resource that is being blocked doesn't need authentication, you can fix the warning message by adding a `crossorigin="anonymous"` attribute to your element.
 
 ## See also
 
-- [Content blocking](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)
+- [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)
 - [The `crossorigin` attribute](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin)

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedbypermission/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedbypermission/index.md
@@ -19,8 +19,8 @@ CookieBlockedByPermission=Request to access cookies or storage on "X" was blocke
 
 The permission can be changed or removed by:
 
-- Going to _Preferences > Privacy & Security > Cookies and Site Data_
-- Clicking on the _Manage exceptions_ button and updating the listed exceptions
+- Going to _Preferences > Privacy & Security > Cookies and Site Data_.
+- Clicking on the _Manage exceptions_ button and updating the listed exceptions.
 
 ## See also
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedbypermission/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedbypermission/index.md
@@ -19,7 +19,7 @@ CookieBlockedByPermission=Request to access cookies or storage on "X" was blocke
 
 The permission can be changed or removed by:
 
-- Going to _Preferences > Privacy & Security > Cookies and Site Data_.
+- Going to _Settings > Privacy & Security > Cookies and Site Data_.
 - Clicking on the _Manage exceptions_ button and updating the listed exceptions.
 
 ## See also

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedbypermission/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedbypermission/index.md
@@ -19,9 +19,9 @@ CookieBlockedByPermission=Request to access cookies or storage on "X" was blocke
 
 The permission can be changed or removed by:
 
-- Going to _Preferences > Content Blocking > Cookies and Site Data_
-- Clicking on the _Manage Permissions_ button and updating the listed exceptions
+- Going to _Preferences > Privacy & Security > Cookies and Site Data_
+- Clicking on the _Manage exceptions_ button and updating the listed exceptions
 
 ## See also
 
-- [Content blocking](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)
+- [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -17,10 +17,7 @@ CookieBlockedForeign=Request to access cookies or storage on "X" was blocked bec
 
 ## What can be done
 
-The permission can be changed or removed by:
-
-- Going to _Settings > Privacy & Security > Enhanced Tracking Protection_ and either
-- Adding an exception with the _Manage Exceptions_… button.
+The permission can be changed or removed by going to _Settings > Privacy & Security > Enhanced Tracking Protection_ and adding an exception with the _Manage Exceptions_… button.
 
 If the resource that is being blocked doesn't need authentication, you can fix the warning message by adding a `crossorigin="anonymous"` attribute to the relevant element.
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -20,8 +20,8 @@ CookieBlockedForeign=Request to access cookies or storage on "X" was blocked bec
 The permission can be changed or removed by either:
 
 - Going to _Preferences > Privacy & Security > Enhanced Tracking Protection_ and either
-  - adding an exception with the _Manage Exceptions_… button
-  - choosing the _Custom_ Content Blocking and unchecking the _Tracker_ checkbox
+  - adding an exception with the _Manage Exceptions_… button.
+  - choosing the _Custom_ Content Blocking and unchecking the _Tracker_ checkbox.
 
 If the resource that is being blocked doesn't need authentication, you can fix the warning message by adding a `crossorigin="anonymous"` attribute to the relevant element.
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -17,11 +17,10 @@ CookieBlockedForeign=Request to access cookies or storage on "X" was blocked bec
 
 ## What can be done
 
-The permission can be changed or removed by either:
+The permission can be changed or removed by:
 
 - Going to _Settings > Privacy & Security > Enhanced Tracking Protection_ and either
-  - adding an exception with the _Manage Exceptions_… button.
-  - choosing the _Custom_ Content Blocking and unchecking the _Tracker_ checkbox.
+- Adding an exception with the _Manage Exceptions_… button.
 
 If the resource that is being blocked doesn't need authentication, you can fix the warning message by adding a `crossorigin="anonymous"` attribute to the relevant element.
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -19,7 +19,7 @@ CookieBlockedForeign=Request to access cookies or storage on "X" was blocked bec
 
 The permission can be changed or removed by either:
 
-- Going to _Preferences > Privacy & Security > Enhanced Tracking Protection_ and either
+- Going to _Settings > Privacy & Security > Enhanced Tracking Protection_ and either
   - adding an exception with the _Manage Exceptions_… button.
   - choosing the _Custom_ Content Blocking and unchecking the _Tracker_ checkbox.
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -17,15 +17,15 @@ CookieBlockedForeign=Request to access cookies or storage on "X" was blocked bec
 
 ## What can be done
 
-The permission can be changed or removed by:
+The permission can be changed or removed by either:
 
-- Going to _Preferences > Content Blocking_ and either
-- adding an exception with the _Manage Exceptions_… button
-- choosing the _Custom_ Content Blocking and unchecking the _Cookies_ checkbox
+- Going to _Preferences > Privacy & Security > Enhanced Tracking Protection_ and either
+  - adding an exception with the _Manage Exceptions_… button
+  - choosing the _Custom_ Content Blocking and unchecking the _Tracker_ checkbox
 
 If the resource that is being blocked doesn't need authentication, you can fix the warning message by adding a `crossorigin="anonymous"` attribute to the relevant element.
 
 ## See also
 
-- [Content blocking](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)
+- [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/content-blocking) on [support.mozilla.org](https://support.mozilla.org/)
 - [The `crossorigin` attribute](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin)


### PR DESCRIPTION
several content are outdated since:

Content blocking was redesigned in [Firefox version](https://support.mozilla.org/en-US/kb/find-what-version-firefox-you-are-using) 70 and is now Enhanced Tracking Protection. Please see the [Enhanced Tracking Protection in Firefox for desktop](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop) article.

and the cookie & site data tab is redesigned as well