### PR TITLE
New pages: SVG text-overflow and white-space

### DIFF
--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -236,6 +236,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 - {{SVGAttr("targetY")}}
 - {{SVGAttr("text-anchor")}}
 - {{SVGAttr("text-decoration")}}
+- {{SVGAttr("text-overflow")}}
 - {{SVGAttr("text-rendering")}}
 - {{SVGAttr("textLength")}}
 - {{SVGAttr("to")}}
@@ -257,6 +258,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 
 ### W
 
+- {{SVGAttr("white-space")}}
 - {{SVGAttr("width")}}
 - {{SVGAttr("word-spacing")}}
 - {{SVGAttr("writing-mode")}}
@@ -381,6 +383,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 - {{SVGAttr("stroke-width")}}
 - {{SVGAttr("text-anchor")}}
 - {{SVGAttr("text-decoration")}}
+- {{SVGAttr("text-overflow")}}
 - {{SVGAttr("text-rendering")}}
 - {{SVGAttr("transform")}}
 - {{SVGAttr("transform-origin")}}
@@ -388,6 +391,7 @@ Below is a list of all of the attributes available in SVG along with links to re
 - {{SVGAttr("vector-effect")}}
 - {{SVGAttr("visibility")}}
 - {{SVGAttr("width")}}
+- {{SVGAttr("white-space")}}
 - {{SVGAttr("word-spacing")}}
 - {{SVGAttr("writing-mode")}}
 - {{SVGAttr("x")}}

--- a/files/en-us/web/svg/reference/attribute/text-overflow/index.md
+++ b/files/en-us/web/svg/reference/attribute/text-overflow/index.md
@@ -6,9 +6,9 @@ browser-compat: svg.global_attributes.text-overflow
 sidebar: svgref
 ---
 
-The SVG **`text-overflow`** attribute specifies how text content block elements render when text overflows line boxes as, for example, can happen when the {{SVGAttr("white-space")}} attribute or {{CSSxref("white-space", "CSS property")}} has the value `nowrap`. The property does not apply to pre-formatted text or text-on-a-path.
+The SVG **`text-overflow`** attribute specifies how text content block elements render when text overflows line boxes. This can happen, for example, when the {{SVGAttr("white-space")}} attribute or {{CSSxref("white-space", "CSS property")}} has the value `nowrap`. The property does not apply to pre-formatted text or text situated on a path.
 
-In SVG `text-overflow` has an effect if there is a validly specified wrapping area, regardless of the computed value of the {{CSSxref("overflow")}} property on the text content block element. The effect is purely visual: clipped text is not removed from the DOM, and any ellipsis, if presented, does not itself become part of the DOM. For all the DOM methods, it is as if `text-overflow` was not applied, and as if the wrapping area did not constrain the text.
+In SVG, `text-overflow` has an effect if there is a validly specified wrapping area, regardless of the computed value of the {{CSSxref("overflow")}} property on the text content block element. The effect is purely visual: clipped text is not removed from the DOM, and any ellipsis, if presented, does not itself become part of the DOM. For all the DOM methods, it is as if `text-overflow` was not applied, and as if the wrapping area did not constrain the text.
 
 > [!NOTE]
 > As a presentation attribute, `text-overflow` also has a CSS property counterpart: {{cssxref("text-overflow")}}. When both are specified, the CSS property takes priority.

--- a/files/en-us/web/svg/reference/attribute/text-overflow/index.md
+++ b/files/en-us/web/svg/reference/attribute/text-overflow/index.md
@@ -1,0 +1,52 @@
+---
+title: text-overflow
+slug: Web/SVG/Reference/Attribute/text-overflow
+page-type: svg-attribute
+browser-compat: svg.global_attributes.text-overflow
+sidebar: svgref
+---
+
+The SVG **`text-overflow`** attribute specifies how text content block elements render when text overflows line boxes as, for example, can happen when the {{SVGAttr("white-space")}} attribute or {{CSSxref("white-space", "CSS property")}} has the value `nowrap`. The property does not apply to pre-formatted text or text-on-a-path.
+
+In SVG `text-overflow` has an effect if there is a validly specified wrapping area, regardless of the computed value of the {{CSSxref("overflow")}} property on the text content block element. The effect is purely visual: clipped text is not removed from the DOM, and any ellipsis, if presented, does not itself become part of the DOM. For all the DOM methods, it is as if `text-overflow` was not applied, and as if the wrapping area did not constrain the text.
+
+> [!NOTE]
+> As a presentation attribute, `text-overflow` also has a CSS property counterpart: {{cssxref("text-overflow")}}. When both are specified, the CSS property takes priority.
+
+## Usage notes
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Value</th>
+      <td><code>clip</code> | <code>ellipses</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Default value</th>
+      <td><code>clip</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Animatable</th>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+- `clip`
+  - : Any text that overflows the wrapping area is clipped. Characters may be partially rendered. This is the default value.
+- `ellipsis`
+  - : If the text to be rendered overflows the wrapping area, the text is clipped and an ellipsis is rendered such that it fits within the given area.
+
+For more information, refer to the [CSS `text-overflow`](/en-US/docs/Web/CSS/text-overflow#values) property.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- CSS {{cssxref("text-overflow")}} property

--- a/files/en-us/web/svg/reference/attribute/white-space/index.md
+++ b/files/en-us/web/svg/reference/attribute/white-space/index.md
@@ -1,0 +1,46 @@
+---
+title: white-space
+slug: Web/SVG/Reference/Attribute/white-space
+page-type: svg-attribute
+browser-compat: svg.global_attributes.white-space
+sidebar: svgref
+---
+
+The **`white-space`** SVG attribute specifies how {{Glossary("whitespace", "white space")}} within text should be handled; whether and how white space inside the element is collapsed and whether lines may wrap at unforced soft wrap opportunities.
+
+> [!NOTE]
+> As a presentation attribute, `white-space` also has a CSS property counterpart: {{cssxref("white-space")}}. When both are specified, the CSS property takes priority.
+
+## Usage notes
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Value</th>
+      <td><code>normal</code> | <code>pre</code> | <code>nowrap</code> | <code>pre-wrap</code> | <code>break-space</code> | <code>pre-line</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Default value</th>
+      <td><code>normal</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Animatable</th>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+For a description of the values, please refer to the [CSS `white-space`](/en-US/docs/Web/CSS/white-space#values) property.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{SVGAttr("xml:space")}} attribute
+- CSS {{cssxref("white-space")}} property

--- a/files/en-us/web/svg/reference/attribute/white-space/index.md
+++ b/files/en-us/web/svg/reference/attribute/white-space/index.md
@@ -6,7 +6,7 @@ browser-compat: svg.global_attributes.white-space
 sidebar: svgref
 ---
 
-The **`white-space`** SVG attribute specifies how {{Glossary("whitespace", "white space")}} within text should be handled; whether and how white space inside the element is collapsed and whether lines may wrap at unforced soft wrap opportunities.
+The **`white-space`** SVG attribute specifies how {{Glossary("whitespace", "white space")}} within text should be handled. This includes whether and how white space inside the element is collapsed and whether lines may wrap at unforced soft wrap opportunities.
 
 > [!NOTE]
 > As a presentation attribute, `white-space` also has a CSS property counterpart: {{cssxref("white-space")}}. When both are specified, the CSS property takes priority.


### PR DESCRIPTION
These are missing baseline widely available pages.

I could not find a valid use case so no examples are provided. For example, text overflow does not apply to pre-formatted text or text-on-a-path so it doesn't apply to `<text>` or `<textpath>`. 
 
 part of https://github.com/openwebdocs/project/issues/230