### PR TITLE
Fix CryptoKey examples

### DIFF
--- a/files/en-us/web/api/cryptokey/algorithm/index.md
+++ b/files/en-us/web/api/cryptokey/algorithm/index.md
@@ -38,8 +38,11 @@ function importSecretKey(rawKey) {
   ]);
 }
 
-const key = importSecretKey(rawKey);
-console.log(`This key is to be used with the ${key.algorithm} algorithm.`);
+importSecretKey(rawKey).then((key) =>
+  console.log(
+    `This key is to be used with the ${key.algorithm.name} algorithm.`,
+  ),
+);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cryptokey/usages/index.md
+++ b/files/en-us/web/api/cryptokey/usages/index.md
@@ -38,9 +38,10 @@ function importSecretKey(rawKey) {
   ]);
 }
 
-const key = importSecretKey(rawKey);
-console.log(
-  `The following usages are reported for this key: ${key.usages.toString()}`,
+importSecretKey(rawKey).then((key) =>
+  console.log(
+    `The following usages are reported for this key: ${key.usages.toString()}`,
+  ),
 );
 ```
 


### PR DESCRIPTION
### Description

Fixes the CryptoKey examples for the usages and algorithm properties as the importSecretKey function returns a promise.
Additionally changed the string passed to console.log for algorithm to use the name property as otherwise it would attempt to turn the object returned by algorithm into a string.
I went for .then instead of await so that the example would work anywhere and to avoid top level await.

### Motivation

Making the examples runnable.