### PR TITLE
Bug 1886894 Clear sessionStorage in browsingData remove options

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -34,7 +34,7 @@ Values of this type are objects. They contain these properties:
 - `indexedDB` {{optional_inline}}
   - : `boolean`. IndexedDB data.
 - `localStorage` {{optional_inline}}
-  - : `boolean`. Local and session storage data.
+  - : `boolean`. Local storage ([`localStorage`](/en-US/docs/Web/API/Window/localStorage)) and session storage ([`sessionStorage`](/en-US/docs/Web/API/Window/sessionStorage)) data.
 - `passwords` {{optional_inline}}
   - : `boolean`. Saved passwords for autocomplete.
 - `pluginData` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -8,16 +8,16 @@ sidebar: addonsidebar
 
 The **`browsingData.DataTypeSet`** type describes a set of data types.
 
-It contains a number of boolean properties. The name of each property is the name of a particular type of browsing data: "downloads", "history" and so on. All properties are optional.
+It contains a number of boolean properties. The name of each property is the name of a particular type of browsing data: "downloads", "history", and so on. All properties are optional.
 
 This type is used:
 
-- in {{WebExtAPIRef("browsingData.remove()")}} to describe which data types to remove
-- in {{WebExtAPIRef("browsingData.settings()")}} to describe which data types are currently selected in the browser's "Clear History" feature.
+- in {{WebExtAPIRef("browsingData.remove()")}} to describe which data types to remove.
+- in {{WebExtAPIRef("browsingData.settings()")}} to describe which data types are selected in the browser's "Clear History" feature.
 
 ## Type
 
-Values of this type are objects. They contain the following properties:
+Values of this type are objects. They contain these properties:
 
 - `cache` {{optional_inline}}
   - : `boolean`. The browser's cache.
@@ -28,15 +28,15 @@ Values of this type are objects. They contain the following properties:
 - `fileSystems` {{optional_inline}}
   - : `boolean`. Website's file systems.
 - `formData` {{optional_inline}}
-  - : `boolean`. Saved form data, for autocomplete.
+  - : `boolean`. Saved form data for autocomplete.
 - `history` {{optional_inline}}
   - : `boolean`. The user's browsing history.
 - `indexedDB` {{optional_inline}}
   - : `boolean`. IndexedDB data.
 - `localStorage` {{optional_inline}}
-  - : `boolean`. Local storage data.
+  - : `boolean`. Local and session storage data.
 - `passwords` {{optional_inline}}
-  - : `boolean`. Saved passwords, for autocomplete.
+  - : `boolean`. Saved passwords for autocomplete.
 - `pluginData` {{optional_inline}}
   - : `boolean`. Stored data associated with plugins.
 - `serverBoundCertificates` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -24,7 +24,7 @@ You can use the {{WebExtAPIRef("browsingData.remove()")}} function to remove any
 All the `browsingData.remove[X]()` functions take a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which you can use to control two further aspects of data removal:
 
 - how far back in time to remove data
-- whether to remove data only from normal web pages, or also from hosted web apps and add-ons. Note that this option is not yet supported in Firefox.
+- whether to remove data only from normal web pages, or also from add-ons. Note that this option is not yet supported in Firefox.
 
 Finally, this API gives you a {{WebExtAPIRef("browsingData.settings()")}} function that gives you the current value of the settings for the browser's built-in "Clear History" feature.
 
@@ -35,7 +35,7 @@ To use this API you must have the "browsingData" [API permission](/en-US/docs/Mo
 - {{WebExtAPIRef("browsingData.DataTypeSet")}}
   - : Object used to specify the type of data to remove: for example, history, downloads, passwords, and so on.
 - {{WebExtAPIRef("browsingData.RemovalOptions")}}
-  - : Object used to specify how far back in time to remove data, and whether to remove data added through normal web browsing, by hosted apps, or by add-ons.
+  - : Object used to specify how far back in time to remove data, and whether to remove data added through normal web browsing or by add-ons.
 
 ## Methods
 
@@ -52,7 +52,7 @@ To use this API you must have the "browsingData" [API permission](/en-US/docs/Mo
 - {{WebExtAPIRef("browsingData.removeHistory()")}}
   - : Clears the browser's history.
 - {{WebExtAPIRef("browsingData.removeLocalStorage()")}}
-  - : Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) created by websites.
+  - : Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) and [session storage](/en-US/docs/Web/API/Window/sessionStorage) created by websites.
 - {{WebExtAPIRef("browsingData.removePasswords()")}}
   - : Clears saved passwords.
 - {{WebExtAPIRef("browsingData.removePluginData()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -6,17 +6,14 @@ browser-compat: webextensions.api.browsingData.RemovalOptions
 sidebar: addonsidebar
 ---
 
-The **`browsingData.RemovalOptions`** type contains options to control certain aspects of browsing data removal.
+The **`browsingData.RemovalOptions`** type contains options to control browsing data removal.
 
 ## Type
 
-Values of this type are objects. They contain the following properties:
+Values of this type are objects. They contain these properties:
 
 - `cookieStoreId` {{optional_inline}}
   - : `string`. This property only applies to cookies and indexedDB items. The removal is limited to items belonging to a specific [cookie store](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore) as specified by the ID. See [Work with contextual identities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) for more information.
-
-    > [!NOTE]
-    > On Firefox Nightly removal of localStorage items by `cookieStoreId` is also supported.
 
 - `excludeOrigin` {{optional_inline}}
   - : `array` of `string`. List of origins to exclude from the removal process. Can't be used together with `origins`. Only supported for cookies, storage, and cache. Cookies are excluded for the entire registrable domain.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -13,7 +13,7 @@ The **`browsingData.RemovalOptions`** type contains options to control browsing 
 Values of this type are objects. They contain these properties:
 
 - `cookieStoreId` {{optional_inline}}
-  - : `string`. This property only applies to cookies and indexedDB items. The removal is limited to items belonging to a specific [cookie store](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore) as specified by the ID. See [Work with contextual identities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) for more information.
+  - : `string`. This property only applies to cookies, indexedDB, and local storage ([`localStorage`](/en-US/docs/Web/API/Window/localStorage)) items. The removal is limited to items belonging to a specific [cookie store](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore) as specified by the ID. See [Work with contextual identities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) for more information.
 
 - `excludeOrigin` {{optional_inline}}
   - : `array` of `string`. List of origins to exclude from the removal process. Can't be used together with `origins`. Only supported for cookies, storage, and cache. Cookies are excluded for the entire registrable domain.
@@ -27,13 +27,13 @@ Values of this type are objects. They contain these properties:
   - : `array` of `string`. List of origins to remove data for. Can't be used together with `excludeOrigins`. Only supported for cookies, storage, and cache. Cookies are cleared for the entire registrable domain.
 
 - `originTypes` {{optional_inline}}
-  - : `object`. Used to control whether to remove data only from normal web pages, or also from hosted web apps and extensions. If this option is omitted, only data from normal web pages (`unprotectedWeb`) is removed. Before removing data from web apps or extensions, be very careful to ensure that this is really what the user wants.
+  - : `object`. Used to control whether to remove data only from normal web pages, or also from extensions. If this option is omitted, only data from normal web pages (`unprotectedWeb`) is removed. Before removing data from web apps or extensions, be very careful to ensure that this is really what the user wants.
 
     This object may contain any of the following properties:
     - `unprotectedWeb` {{optional_inline}}
       - : `boolean`. If present and `true`, remove data from normal web pages.
     - `protectedWeb` {{optional_inline}}
-      - : `boolean`. If present and `true`, remove data from websites that have been installed as hosted apps.
+      - : `boolean`. If present and `true`, remove data from websites that have been installed as hosted apps. (This option is redundant, as hosted web apps are no longer supported.)
     - `extension` {{optional_inline}}
       - : `boolean`. If present and `true`, remove data from extensions.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -10,7 +10,7 @@ Removes the specified browsing data.
 
 The browsing data to be removed is specified in the `dataTypes` option, which is a {{WebExtAPIRef("browsingData.DataTypeSet")}} object.
 
-You can use the `removalOptions` option, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to control how far back in time to remove data and whether to remove data only from normal web pages or to remove data from hosted apps and extensions as well.
+You can use the `removalOptions` option, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to control how far back in time to remove data and whether to remove data only from normal web pages or to remove data from extensions as well.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ let removing = browser.browsingData.remove(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to control how far back in time to remove data, and whether to remove data from hosted web apps and extensions, or just normal web pages.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to control how far back in time to remove data, and whether to remove data from extensions, or just normal web pages.
 - `dataTypes`
   - : `object`. A {{WebExtAPIRef("browsingData.DataTypeSet")}} object, describing the types of data to remove (e.g., history, downloads, etc.).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -12,8 +12,6 @@ The browsing data to be removed is specified in the `dataTypes` option, which is
 
 You can use the `removalOptions` option, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to control how far back in time to remove data and whether to remove data only from normal web pages or to remove data from hosted apps and extensions as well.
 
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
-
 ## Syntax
 
 ```js-nolint
@@ -26,13 +24,13 @@ let removing = browser.browsingData.remove(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to control how far back in time to remove data, and whether to remove data from hosted web apps and extensions, or just normal web pages.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to control how far back in time to remove data, and whether to remove data from hosted web apps and extensions, or just normal web pages.
 - `dataTypes`
-  - : `object`. A {{WebExtAPIRef("browsingData.DataTypeSet")}} object, describing the types of data to remove (e.g., history, downloads, …).
+  - : `object`. A {{WebExtAPIRef("browsingData.DataTypeSet")}} object, describing the types of data to remove (e.g., history, downloads, etc.).
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal finishes. If an error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -10,10 +10,8 @@ Clears the browser's cookies.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only cookies created after a given time
-- control whether to clear cookies only set from normal web pages or to clear cookies set from hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear cookies created after a given time.
+- control whether to clear cookies set from web pages or web pages and extensions.
 
 ## Syntax
 
@@ -26,11 +24,11 @@ let removing = browser.browsingData.removeCookies(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only cookies created after a given time, and whether to clear cookies only set from normal web pages or to clear cookies set from hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear cookies created after a given time, and control whether to clear cookies set from web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -10,10 +10,8 @@ Clears the browser's download history. Note that this does not delete the downlo
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear records of items downloaded after a given time
-- control whether to clear only records of items downloaded from normal web pages or to clear records from hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear records of items downloaded after a given time.
+- control whether to clear records of items downloaded from web pages or web pages and extensions.
 
 ## Syntax
 
@@ -26,11 +24,11 @@ let removing = browser.browsingData.removeDownloads(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only records created after a given time, and whether to clear only records of items downloaded from normal web pages or to clear records from hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only records created after a given time, and control whether to clear records of items downloaded from web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -10,10 +10,8 @@ Clears data that the browser has saved for autofilling forms.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only form data entered after a given time
-- control whether to clear only form data entered in normal web pages or to clear data entered in hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear form data entered after a given time.
+- control whether to clear form data entered in web pages or web pages and extensions.
 
 ## Syntax
 
@@ -26,11 +24,11 @@ let removing = browser.browsingData.removeFormData(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only form data entered after a given time, and whether to clear only form data entered in normal web pages or to clear data entered in hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only form data entered after a given time, and controi whether to clear form data entered in web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -11,7 +11,7 @@ Clears the record of web pages that the user has visited (browsing history).
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
 - clear records of web pages visited after a given time.
-- control whether to clear records of web pages or web pages and extensions.
+- control whether to clear records of web pages, or web pages and extensions.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -10,10 +10,8 @@ Clears the record of web pages that the user has visited (browsing history).
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only records of web pages visited after a given time
-- control whether to clear only records of normal web pages or to clear records of hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear records of web pages visited after a given time.
+- control whether to clear records of web pages or web pages and extensions.
 
 ## Syntax
 
@@ -26,11 +24,11 @@ let removing = browser.browsingData.removeHistory(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only records of web pages visited after a given time, and whether to clear only records of normal web pages or to clear records of hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to clear records of web pages visited after a given time, and control whether to clear records of web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -6,14 +6,12 @@ browser-compat: webextensions.api.browsingData.removeLocalStorage
 sidebar: addonsidebar
 ---
 
-Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) created by websites.
+Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) created by websites and [session storage](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/session) created by extensions.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only local storage objects created after a given time
-- control whether to clear only local storage objects created by normal web pages or to clear objects created by hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear only local and session storage objects created after a given time.
+- control whether to clear only local storage objects created by normal web pages or to clear objects (including objects in session storage) created by hosted apps and extensions as well.
 
 ## Syntax
 
@@ -26,7 +24,7 @@ let removing = browser.browsingData.removeLocalStorage(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only local storage objects created by normal web pages or to clear objects created by hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear local and session storage objects created by normal web pages or to clear objects created by hosted apps and extensions.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -6,12 +6,12 @@ browser-compat: webextensions.api.browsingData.removeLocalStorage
 sidebar: addonsidebar
 ---
 
-Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) created by websites and [session storage](/en-US/docs/Web/API/Window/sessionStorage) created by extensions.
+Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) and [session storage](/en-US/docs/Web/API/Window/sessionStorage) created by websites and extensions.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only local and session storage objects created after a given time.
-- control whether to clear only localStorage and sessionStorage objects created by normal web pages or to clear objects created by extensions as well.
+- clear local and session storage objects created after a given time.
+- control whether to clear localStorage and sessionStorage objects created by web pages or web pages extensions.
 
 ## Syntax
 
@@ -24,11 +24,11 @@ let removing = browser.browsingData.removeLocalStorage(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear local and session storage objects created by normal web pages or to clear objects created by extensions.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to clear local and session storage objects stored after a given time, and control whether to clear local and session storage objects created by web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -6,12 +6,12 @@ browser-compat: webextensions.api.browsingData.removeLocalStorage
 sidebar: addonsidebar
 ---
 
-Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) created by websites and [session storage](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/session) created by extensions.
+Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) created by websites and [session storage](/en-US/docs/Web/API/Window/sessionStorage) created by extensions.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
 - clear only local and session storage objects created after a given time.
-- control whether to clear only local storage objects created by normal web pages or to clear objects (including objects in session storage) created by hosted apps and extensions as well.
+- control whether to clear only localStorage and sessionStorage objects created by normal web pages or to clear objects created by extensions as well.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ let removing = browser.browsingData.removeLocalStorage(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear local and session storage objects created by normal web pages or to clear objects created by hosted apps and extensions.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear local and session storage objects created by normal web pages or to clear objects created by extensions.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -10,8 +10,8 @@ Clears any [local storage](/en-US/docs/Web/API/Window/localStorage) and [session
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear local and session storage objects created after a given time.
-- control whether to clear localStorage and sessionStorage objects created by web pages or web pages extensions.
+- clear local and session storage values created after a given time.
+- control whether to clear localStorage and sessionStorage values created by web pages or web pages extensions.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ let removing = browser.browsingData.removeLocalStorage(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to clear local and session storage objects stored after a given time, and control whether to clear local and session storage objects created by web pages or web pages and extensions.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to clear localStorage and sessionStorage values stored after a given time, and control whether to clear localStorage and sessionStorage objects created by web pages, or web pages and extensions.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -10,10 +10,8 @@ Clears saved passwords.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only passwords that were saved after a given time
-- control whether to clear passwords that were saved on normal web pages or to clear passwords that were saved on hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear passwords that were saved after a given time.
+- control whether to clear passwords that were saved on web pages or web pages and extensions.
 
 ## Syntax
 
@@ -26,11 +24,11 @@ let removing = browser.browsingData.removePasswords(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only passwords that were saved after a given time, and whether to clear passwords that were saved on normal web pages or to clear passwords that were saved on hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to clear passwords that were saved after a given time, and control whether to clear passwords that were saved on web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -10,10 +10,8 @@ Clears data stored by browser plugins.
 
 You can use the `removalOptions` parameter, which is a {{WebExtAPIRef("browsingData.RemovalOptions")}} object, to:
 
-- clear only plugin data stored after a given time
-- control whether to clear only data stored by plugins running in normal web pages or to clear data stored by plugins running in hosted apps and extensions as well.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+- clear plugin data stored after a given time.
+- control whether to clear data stored by plugins running in web pages or web pages and extensions.
 
 ## Syntax
 
@@ -26,11 +24,11 @@ let removing = browser.browsingData.removePluginData(
 ### Parameters
 
 - `removalOptions`
-  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which may be used to clear only plugin data stored after a given time, and whether to clear only data stored by plugins running in normal web pages or to clear data stored by plugins running in hosted apps and extensions as well.
+  - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object, which can be used to clear plugin data stored after a given time, and control whether to clear data stored by plugins running in web pages or web pages and extensions.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments when the removal has finished. If any error occurs, the promise will be rejected with an error message.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with no arguments when the removal has finished. If any error occurs, the promise is rejected with an error message.
 
 ## Examples
 

--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -74,7 +74,7 @@ Firefox 146 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
-- {{WebExtAPIRef("browsingData.removeLocalStorage")}} and {{WebExtAPIRef("browsingData.remove")}} (when `localStorage` is set in {{WebExtAPIRef("browsingData.DataTypeSet")}}) now delete objects from [sessionStorage](/en-US/docs/Web/API/Window/sessionStorage). ([Firefox bug 1886894](https://bugzil.la/1886894))
+- {{WebExtAPIRef("browsingData.removeLocalStorage")}} and {{WebExtAPIRef("browsingData.remove")}} (when `localStorage` is set in {{WebExtAPIRef("browsingData.DataTypeSet")}}) now delete objects from [`sessionStorage`](/en-US/docs/Web/API/Window/sessionStorage). ([Firefox bug 1886894](https://bugzil.la/1886894))
 
 <!-- ### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -74,6 +74,8 @@ Firefox 146 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- {{WebExtAPIRef("browsingData.removeLocalStorage")}} and {{WebExtAPIRef("browsingData.remove")}} (when `localStorage` is set in {{WebExtAPIRef("browsingData.DataTypeSet")}}) now delete objects from session storage. This provides parity with the Firefox browser **Clear cookies and site data** options, and the Chrome API. ([Firefox bug 1886894](https://bugzil.la/1886894))
+
 <!-- ### Removals -->
 
 <!-- ### Other -->

--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -74,7 +74,7 @@ Firefox 146 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
-- {{WebExtAPIRef("browsingData.removeLocalStorage")}} and {{WebExtAPIRef("browsingData.remove")}} (when `localStorage` is set in {{WebExtAPIRef("browsingData.DataTypeSet")}}) now delete objects from session storage. This provides parity with the Firefox browser **Clear cookies and site data** options, and the Chrome API. ([Firefox bug 1886894](https://bugzil.la/1886894))
+- {{WebExtAPIRef("browsingData.removeLocalStorage")}} and {{WebExtAPIRef("browsingData.remove")}} (when `localStorage` is set in {{WebExtAPIRef("browsingData.DataTypeSet")}}) now delete objects from [sessionStorage](/en-US/docs/Web/API/Window/sessionStorage). ([Firefox bug 1886894](https://bugzil.la/1886894))
 
 <!-- ### Removals -->
 


### PR DESCRIPTION
### Description

This PR addresses the dev-docs needed requirements of [Bug 1886894](https://bugzilla.mozilla.org/show_bug.cgi?id=1886894) Clear sessionStorage in browsingData.remove() for parity with "Clear Cookies and Site Data". It includes: 

- a release note
- update to the `browsingData.removeLocalStorage`, `browsingData.remove`, and `browsingData.DataTypeSet` documentation.

### Related issues and pull requests

Related BCD changes in PR https://github.com/mdn/browser-compat-data/pull/28261.