### PR TITLE
FF145 Relnote: RTCEncodedVideoFrame/AudioFrame constructor

### DIFF
--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -56,11 +56,13 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
 <!-- #### DOM -->
 
-<!-- #### Media, WebRTC, and Web Audio -->
+#### Media, WebRTC, and Web Audio
+
+- {{domxref("RTCEncodedVideoFrame")}} and {{domxref("RTCEncodedAudioFrame")}} are now {{glossary("Serializable object", "serializable objects")}}, and {{domxref("RTCEncodedAudioFrame/RTCEncodedAudioFrame", "RTCEncodedAudioFrame()")}} and {{domxref("RTCEncodedVideoFrame/RTCEncodedVideoFrame", "RTCEncodedVideoFrame()")}} copy constructors are supported. These changes allow frames to be cloned, and to be shared between workers and the main thread. ([Firefox bug 1868223](https://bugzil.la/1868223) and [Firefox bug 1975032](https://bugzil.la/1975032)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
FF145 makes `RTCEncodedAudioFrame` and `RTCEncodeVideoFrame` be serializeable and also adds copy constructors.

This creates a release note.

Related docs work can be tracked in #41508