### PR TITLE
Remove reference to closed bug 1385832

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -28,8 +28,6 @@ let gettingSpace = browser.storage.<storageType>.getBytesInUse(
 
 Where `<storageType>` is one of the storage types — {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, or {{WebExtAPIRef("storage.managed", "managed")}}.
 
-In Firefox, `<storageType>` can't be {{WebExtAPIRef("storage.local")}}, because of [bug 1385832](https://bugzil.la/1385832).
-
 ### Parameters
 
 - `keys`


### PR DESCRIPTION
### Description

Remove reference to closed [bug 1385832](https://bugzil.la/1385832) from `storagearea.getbytesinuse` documentation.

### Related issues and pull requests

Fixes #41552

