### PR TITLE
Fix 'pager' spelling in autocomplete attributes

### DIFF
--- a/files/en-us/web/html/reference/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/reference/attributes/autocomplete/index.md
@@ -127,7 +127,7 @@ The tokens that identify the type of recipient include:
   - : The contact type identified by subsequent tokens is for contacting the recipient regardless of location.
 - `fax`
   - : The recipient identified by subsequent tokens is for a fax machine.
-- `page`
+- `pager`
   - : The recipient identified by subsequent tokens is for a pager or beeper.
 
 ##### Digital contact tokens


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

There's a mismatch between MDN and the HTML living standard on the recipient token used for pagers and beepers in the autocomplete attribute. I fixed the spelling from "page" to "pager".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The HTML specification states:

> "pager", meaning the field describes a pager's or beeper's contact details

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-pager

<!-- ### Additional details -->

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
