### PR TITLE
fix: Add perms to calling workflow

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   # Label pull requests.
   pull-requests: write
+  contents: read
+  issues: write
 
 concurrency:
   group: pr-rebase-needed-${{ github.event.pull_request.number || github.ref_name }}


### PR DESCRIPTION
### Description

Adding permissions to add or remove labels from PRs. I think the fix should be here and not in the called workflow at https://github.com/mdn/workflows/blob/main/.github/workflows/pr-rebase-needed.yml

### Motivation

This workflow is passing when no action needed and failing when it needs to add or remove a label: https://github.com/mdn/content/actions/workflows/pr-rebase-needed.yml

