### PR TITLE
Add example to 'inert' attribute

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/inert/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inert/index.md
@@ -29,6 +29,23 @@ Use careful consideration for accessibility when applying the `inert` attribute.
 
 While providing visual and non-visual cues about content inertness, also remember that the visual viewport may contain only sections of content. Users may be zoomed in to a small section of content, or users may not be able to view the content at all. Inert sections not being obviously inert can lead to frustration and bad user experience.
 
+## Examples
+
+In this example, the second {{htmlelement("div")}} and all of its descendants are made inert via the `inert` attribute: 
+
+```html
+<div>
+  <label for="button1">Button 1</label>
+  <button id="button1">I am not inert</button>
+</div>
+<div inert>
+  <label for="button2">Button 2</label>
+  <button id="button2">I am inert</button>
+</div>
+```
+
+{{ EmbedLiveSample('Examples', 560, 200) }}
+
 ## Specifications
 
 {{Specifications}}
@@ -40,6 +57,4 @@ While providing visual and non-visual cues about content inertness, also remembe
 ## See also
 
 - HTML {{HTMLElement("dialog")}} element
-- {{domxref("HTMLElement.inert")}} HTML DOM property
-- [Introducing inert](https://web.dev/articles/inert)
-- [The "inert" attribute is finally coming to the web](https://www.stefanjudis.com/blog/the-inert-attribute-is-finally-coming-to-the-web/)
+- {{domxref("HTMLElement.inert")}} DOM property

--- a/files/en-us/web/html/reference/global_attributes/inert/index.md
+++ b/files/en-us/web/html/reference/global_attributes/inert/index.md
@@ -31,7 +31,7 @@ While providing visual and non-visual cues about content inertness, also remembe
 
 ## Examples
 
-In this example, the second {{htmlelement("div")}} and all of its descendants are made inert via the `inert` attribute: 
+In this example, the second {{htmlelement("div")}} and all of its descendants are made inert via the `inert` attribute:
 
 ```html
 <div>


### PR DESCRIPTION
Added example of using the 'inert' attribute in HTML. 
Remove links to external articles
