### PR TITLE
fix broken text-fragment for example.com

### DIFF
--- a/files/en-us/web/uri/reference/fragment/text_fragments/index.md
+++ b/files/en-us/web/uri/reference/fragment/text_fragments/index.md
@@ -76,7 +76,7 @@ Supporting browsers will scroll to and highlight the first text fragment in the 
 
 ### Text fragment with textStart
 
-- [https://example.com/#:~:text=for](https://example.com/#:~:text=for) scrolls to and highlights the first instance of the text `for` in the document.
+- [https://example.com/#:~:text=use](https://example.com/#:~:text=use) scrolls to and highlights the first instance of the text `use` in the document.
 - [https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=human](/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=human) scrolls to and highlights the first instance of the text `human` in the document.
 - [https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=linked%20URL](/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=linked%20URL) scrolls to and highlights the first instance of the text `linked URL` in the document.
 
@@ -87,7 +87,7 @@ Supporting browsers will scroll to and highlight the first text fragment in the 
 
 ### Examples with prefix- and/or -suffix
 
-- [https://example.com/#:~:text=asking-,for](https://example.com/#:~:text=asking-,for) scrolls to and highlights the second instance of the text `for` in the document.
+- [https://example.com/#:~:text=avoid-,use](https://example.com/#:~:text=avoid-,use) scrolls to and highlights the second instance of the text `use` in the document.
 - [https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=sent-,referrer](/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=sent-,referrer) scrolls to and highlights the first instance of the text `referrer` that has the text `sent` directly before it. This is the 5th instance of `referrer` in the document; without the prefix, the first instance would be highlighted.
 - [https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=linked%20URL,-'s%20format](/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=linked%20URL,-'s%20format) scrolls to and highlights the first instance of the text `linked URL` that has the text `'s format` directly following it. This is the 5th instance of `linked URL` in the document; without the suffix, the first instance would be highlighted.
 - [https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=downgrade:-,The%20Referer,be%20sent,-to%20origins](/en-US/docs/Web/HTML/Reference/Elements/a#:~:text=downgrade:-,The%20Referer,be%20sent,-to%20origins) scrolls to and highlights the instance of the text `The Referer ... be sent` that is prefixed by `downgrade:` and suffixed by `to origins`. This illustrates a more complex example where the prefix/suffix are used to home in on the specific text instance you want to link to. Try removing the prefix, for example, and seeing what is matched.


### PR DESCRIPTION


### Description

[example.{com,org,net}](https://example.com) have recently had their first update [in over 10 years](https://web.archive.org/web/20140228235225/http://example.com/). The wording on the page has changed: the phrase `asking for` no longer exists, which broke one of the examples for [text fragments](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments).

### Motivation

it's broken. which is a bit ironic given [the warning a few lines above](https://github.com/k-yle/content/blob/8109821f5642d9200b376a0f974f9176af22997b/files/en-us/web/uri/reference/fragment/text_fragments/index.md?plain=1#L33) 😆

### Additional details

&shy;-

### Related issues and pull requests

&shy;-
