### PR TITLE
Clarify highWaterMark description

### DIFF
--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -72,7 +72,7 @@ new ReadableStream(underlyingSource, queuingStrategy)
   - : An object that optionally defines a queuing strategy for the stream. This takes two
     parameters:
     - `highWaterMark`
-      - : A non-negative integer — this defines the total number of chunks that can be
+      - : A non-negative integer — this defines the total size of all chunks that can be
         contained in the internal queue before backpressure is applied.
     - `size(chunk)`
       - : A method containing a parameter `chunk` — this indicates the size to


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

The current text defines the `highWaterMark` property of the `queuingStrategy` argument object of `ReadableStream.constructor(underlyingSource, queuingStrategy)`, as a *"total number of chunks"* while it is specified as a *"total size of chunks"* in the WHATWG Stream specification.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I make this change because I am learning about streams and this material is incorrect.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://streams.spec.whatwg.org/#high-water-mark

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
