### PR TITLE
Link to definition of default "XSS-safe" elements and attributes

### DIFF
--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -50,7 +50,7 @@ The **`setHTML()`** method provides an XSS-safe method to parse and sanitize a s
 It then removes any HTML entities that aren't allowed by the sanitizer configuration, and further removes any XSS-unsafe elements or attributes — whether or not they are allowed by the sanitizer configuration.
 
 If no sanitizer configuration is specified in the `options.sanitizer` parameter, `setHTML()` is used with the default {{domxref("Sanitizer")}} configuration.
-This configuration allows all elements and attributes that are considered XSS-safe, thereby disallowing entities that are considered unsafe.
+This configuration allows all elements and attributes that are [considered XSS-safe](https://wicg.github.io/sanitizer-api/#built-in-safe-default-configuration), thereby disallowing entities that are considered unsafe.
 A custom sanitizer or sanitizer configuration can be specified to choose which elements, attributes, and comments are allowed or removed.
 Note that even if unsafe options are allowed by the sanitizer configuration, they will still be removed when using this method (which implicitly calls {{domxref('Sanitizer.removeUnsafe()')}}).
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Link to the specification to define what "XSS-safe" means.

"XSS-safe" is not well-defined within MDN so let's link to the spec.

### Motivation

The current description of the default sanitizer's behavior is ultimately not meaningful.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

I don't know if "XSS-safe" is a well-defined term within the spec, but if it is then the definition should be linked in MDN (or translated to it)

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes whatwg/sanitizer-api#123" -->
<!-- 👉 Highlight related pull requests using "Relates to whatwg/sanitizer-api#123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** whatwg/sanitizer-api#123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
