### PR TITLE
relnote(Fx145): text-autospace CSS prop supported

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -336,20 +336,6 @@ The {{CSSXRef(":heading")}} pseudo-class allows you to style all [heading elemen
 - `layout.css.heading-selector.enabled`
   - : Set to `true` to enable.
 
-### `text-autospace` property
-
-The **`text-autospace`** CSS property allows you to specify the space applied between Chinese/Japanese/Korean (CJK) and non-CJK characters. Currently these values are only parsed and there is no effect on the output. ([Firefox bug 1869577](https://bugzil.la/1869577)).
-
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 143           | No                  |
-| Developer Edition | 143           | No                  |
-| Beta              | 143           | No                  |
-| Release           | 143           | No                  |
-
-- `layout.css.text-autospace.enabled`
-  - : Set to `true` to enable.
-
 ## SVG
 
 **No experimental features in this release cycle.**

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -32,7 +32,9 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### CSS -->
+### CSS
+
+- The {{cssxref("text-autospace")}} property is now supported, allowing automatic spacing adjustments between characters from different scripts ([Firefox bug 1981086](https://bugzil.la/1981086), [Firefox bug 1869577](https://bugzil.la/1869577)).
 
 <!-- No notable changes. -->
 


### PR DESCRIPTION
### Description

The CSS `text-autospace` property is enabled in Fx by default in 145.

Removing the experimental features note and adding to stable relnotes.

## Related issues and pull requests

- [x] Parent https://github.com/mdn/content/issues/41501

