### PR TITLE
Make CSS module titles uniform

### DIFF
--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -64,7 +64,7 @@ By allowing authors to provide their own fonts, `@font-face` makes it possible t
 > [!NOTE]
 > Fallback strategies for loading fonts on older browsers are described in the [`src` descriptor page](/en-US/docs/Web/CSS/@font-face/src#specifying_fallbacks_for_older_browsers).
 
-The `@font-face` at-rule may be used not only at the top level of a CSS, but also inside any [CSS conditional-group at-rule](/en-US/docs/Web/CSS/CSS_conditional_rules#at-rules).
+The `@font-face` at-rule may be used not only at the top level of a CSS, but also inside any [CSS conditional-group at-rule](/en-US/docs/Web/CSS/CSS_conditional_rules#at-rules_and_descriptors).
 
 ### Font MIME Types
 

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -62,7 +62,7 @@ As the `@import` at-rule is declared after the styles it is invalid and hence ig
 /* more styles */
 ```
 
-The `@import` rule is not a [nested statement](/en-US/docs/Web/CSS/CSS_syntax/Syntax#nested_statements). Therefore, it cannot be used inside [conditional group at-rules](/en-US/docs/Web/CSS/CSS_conditional_rules#at-rules).
+The `@import` rule is not a [nested statement](/en-US/docs/Web/CSS/CSS_syntax/Syntax#nested_statements). Therefore, it cannot be used inside [conditional group at-rules](/en-US/docs/Web/CSS/CSS_conditional_rules#at-rules_and_descriptors).
 
 So that {{glossary("user agent", "user agents")}} can avoid retrieving resources for unsupported media types, authors may specify media-dependent import conditions. These conditional imports specify comma-separated [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) after the URL. In the absence of any media query, the import is not conditional on the media used. Specifying `all` for the `list-of-media-queries` has the same effect.
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -246,7 +246,7 @@ Click "Play" in the example above to see or edit the code for the animation in t
 
 The CSS animations module level 2 also introduces the `animation-trigger`, `animation-trigger-exit-range`, `animation-trigger-exit-range-end`, `animation-trigger-exit-range-start`, `animation-trigger-range`, `animation-trigger-range-end`, `animation-trigger-range-start`, `animation-trigger-timeline`, and `animation-trigger-type` properties. Currently, no browsers support these features.
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@keyframes")}}
 

--- a/files/en-us/web/css/css_cascade/index.md
+++ b/files/en-us/web/css/css_cascade/index.md
@@ -24,7 +24,7 @@ The opposite also occurs. Sometimes there are no declarations defining the value
 
 - {{cssxref("all")}}
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@import")}}
 - {{cssxref("@layer")}}
@@ -45,7 +45,7 @@ The opposite also occurs. Sometimes there are no declarations defining the value
 - {{DOMXRef("CSSLayerStatementRule")}}
 - {{DOMXRef("CSSRule")}}
 
-### Glossary and definitions
+### Glossary terms and definitions
 
 - [Actual value](/en-US/docs/Web/CSS/CSS_cascade/Value_processing#actual_value)
 - [Anonymous layer](/en-US/docs/Learn_web_development/Core/Styling_basics/Cascade_layers#the_layer_block_at-rule_for_named_and_anonymous_layers)

--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -66,9 +66,9 @@ The CSS color modules also introduce the {{CSSXref("color_value/device-cmyk", "d
 
 ### Glossary terms and keywords
 
-- {{glossary("color space")}}
+- {{glossary("Color space")}}
 - [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
-- {{glossary("interpolation")}}
+- {{glossary("Interpolation")}}
 - {{glossary("RGB")}}
 - [`transparent`](/en-US/docs/Web/CSS/named-color#transparent)
 

--- a/files/en-us/web/css/css_conditional_rules/index.md
+++ b/files/en-us/web/css/css_conditional_rules/index.md
@@ -29,7 +29,7 @@ There are plans to further extend possible queries by adding the generalized con
 - {{cssxref("container-name")}}
 - {{cssxref("container-type")}}
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@container")}}
 - {{cssxref("@media")}}

--- a/files/en-us/web/css/css_custom_functions_and_mixins/index.md
+++ b/files/en-us/web/css/css_custom_functions_and_mixins/index.md
@@ -19,25 +19,20 @@ CSS custom functions and mixins can be assigned optional data types for their ar
 
 ## Reference
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@function")}}
+  - {{cssxref("@function#result", "result")}}
 
 The CSS custom functions and mixins module also introduces the `@mixin`, `@apply`, `@contents`, and `@env` at-rules. Currently, no browsers support these features.
 
-### Descriptors
-
-- {{cssxref("@function#result", "result")}}
-
 ### Data types and values
 
-- {{cssxref("&lt;dashed-function>")}} data type
+- {{cssxref("dashed-function")}}
 
 ### Functions
 
-- [`type()`](/en-US/docs/Web/CSS/type)
-
-The CSS custom functions and mixins module also introduces scoped {{cssxref("env()")}} variables. Currently, no browsers support this feature.
+- {{cssxref("type")}}
 
 ### Interfaces
 

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -29,7 +29,7 @@ The **CSS display** module defines how the CSS formatting box tree is generated 
 - {{CSSxRef("&lt;display-internal&gt;")}}
 - {{CSSxRef("&lt;display-legacy&gt;")}}
 
-### Glossary and terms
+### Glossary terms and definitions
 
 - {{glossary("block/css", "Block")}}
 - [Block formatting context (BFC)](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context)
@@ -62,7 +62,7 @@ The **CSS display** module defines how the CSS formatting box tree is generated 
 - {{cssxref("overflow")}}
 - {{cssxref("transition-behavior")}}
 
-### Glossary and terms
+### Glossary terms and definitions
 
 - {{glossary("Flex")}}
 - {{glossary("Grid")}}

--- a/files/en-us/web/css/css_fragmentation/index.md
+++ b/files/en-us/web/css/css_fragmentation/index.md
@@ -23,7 +23,7 @@ When content is physically printed or displayed as a print preview, there are pa
 - {{cssxref("orphans")}}
 - {{cssxref("widows")}}
 
-### Glossary terms and definitions
+### Glossary terms
 
 - {{glossary("Fragmentainer")}}
 

--- a/files/en-us/web/css/css_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/index.md
@@ -21,47 +21,44 @@ When designing reusable HTML components, you may also use [container queries](/e
 
 ## Reference
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@import")}}
 - {{cssxref("@media")}}
-
-### Descriptors
-
-- {{cssxref("@media/any-hover", "any-hover")}}
-- {{cssxref("@media/any-pointer", "any-pointer")}}
-- {{cssxref("@media/aspect-ratio", "aspect-ratio")}}
-- {{cssxref("@media/color", "color")}}
-- {{cssxref("@media/color-gamut", "color-gamut")}}
-- {{cssxref("@media/color-index", "color-index")}}
-- {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}}
-- {{cssxref("@media/device-height", "device-height")}}
-- {{cssxref("@media/device-width", "device-width")}}
-- {{cssxref("@media/display-mode", "display-mode")}}
-- {{cssxref("@media/dynamic-range", "dynamic-range")}}
-- {{cssxref("@media/forced-colors", "forced-colors")}}
-- {{cssxref("@media/grid", "grid")}}
-- {{cssxref("@media/height", "height")}}
-- {{cssxref("@media/horizontal-viewport-segments", "horizontal-viewport-segments")}}
-- {{cssxref("@media/hover", "hover")}}
-- {{cssxref("@media/inverted-colors", "inverted-colors")}}
-- {{cssxref("@media/monochrome", "monochrome")}}
-- {{cssxref("@media/orientation", "orientation")}}
-- {{cssxref("@media/overflow-block", "overflow-block")}}
-- {{cssxref("@media/overflow-inline", "overflow-inline")}}
-- {{cssxref("@media/pointer", "pointer")}}
-- {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}
-- {{cssxref("@media/prefers-contrast", "prefers-contrast")}}
-- {{cssxref("@media/prefers-reduced-data", "prefers-reduced-data")}}
-- {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}
-- {{cssxref("@media/prefers-reduced-transparency", "prefers-reduced-transparency")}}
-- {{cssxref("@media/resolution", "resolution")}}
-- {{cssxref("@media/scan", "scan")}}
-- {{cssxref("@media/scripting", "scripting")}}
-- {{cssxref("@media/update", "update")}}
-- {{cssxref("@media/vertical-viewport-segments", "vertical-viewport-segments")}}
-- {{cssxref("@media/video-dynamic-range", "video-dynamic-range")}}
-- {{cssxref("@media/width", "width")}}
+  - {{cssxref("@media/any-hover", "any-hover")}}
+  - {{cssxref("@media/any-pointer", "any-pointer")}}
+  - {{cssxref("@media/aspect-ratio", "aspect-ratio")}}
+  - {{cssxref("@media/color", "color")}}
+  - {{cssxref("@media/color-gamut", "color-gamut")}}
+  - {{cssxref("@media/color-index", "color-index")}}
+  - {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}}
+  - {{cssxref("@media/device-height", "device-height")}}
+  - {{cssxref("@media/device-width", "device-width")}}
+  - {{cssxref("@media/display-mode", "display-mode")}}
+  - {{cssxref("@media/dynamic-range", "dynamic-range")}}
+  - {{cssxref("@media/forced-colors", "forced-colors")}}
+  - {{cssxref("@media/grid", "grid")}}
+  - {{cssxref("@media/height", "height")}}
+  - {{cssxref("@media/horizontal-viewport-segments", "horizontal-viewport-segments")}}
+  - {{cssxref("@media/hover", "hover")}}
+  - {{cssxref("@media/inverted-colors", "inverted-colors")}}
+  - {{cssxref("@media/monochrome", "monochrome")}}
+  - {{cssxref("@media/orientation", "orientation")}}
+  - {{cssxref("@media/overflow-block", "overflow-block")}}
+  - {{cssxref("@media/overflow-inline", "overflow-inline")}}
+  - {{cssxref("@media/pointer", "pointer")}}
+  - {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}
+  - {{cssxref("@media/prefers-contrast", "prefers-contrast")}}
+  - {{cssxref("@media/prefers-reduced-data", "prefers-reduced-data")}}
+  - {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}
+  - {{cssxref("@media/prefers-reduced-transparency", "prefers-reduced-transparency")}}
+  - {{cssxref("@media/resolution", "resolution")}}
+  - {{cssxref("@media/scan", "scan")}}
+  - {{cssxref("@media/scripting", "scripting")}}
+  - {{cssxref("@media/update", "update")}}
+  - {{cssxref("@media/vertical-viewport-segments", "vertical-viewport-segments")}}
+  - {{cssxref("@media/video-dynamic-range", "video-dynamic-range")}}
+  - {{cssxref("@media/width", "width")}}
 
 The CSS media queries level 5 module also introduces the `environment-blending`, `nav-controls`, and `video-color-gamut` `@media` descriptors. Currently, no browsers support these features.
 

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -16,7 +16,7 @@ The `@namespace` rule is used for declaring a default namespace and for binding 
 
 ## Reference
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@namespace")}}
 

--- a/files/en-us/web/css/css_paged_media/index.md
+++ b/files/en-us/web/css/css_paged_media/index.md
@@ -18,7 +18,7 @@ The process of paginating content into generated pages and controlling breaks in
 
 - {{cssxref("page")}}
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@page")}}
   - {{cssxref("@page/page-orientation", "page-orientation")}} descriptor

--- a/files/en-us/web/css/css_positioned_layout/index.md
+++ b/files/en-us/web/css/css_positioned_layout/index.md
@@ -36,7 +36,7 @@ Like all CSS modules, this module impacts and is impacted by other modules. This
 
 - {{cssxref("::backdrop")}}
 
-### Glossary and terms
+### Glossary terms and definitions
 
 - [Block direction](/en-US/docs/Glossary/Flow_relative_values#block_direction)
 - [Containing block](/en-US/docs/Web/CSS/CSS_display/Containing_block)

--- a/files/en-us/web/css/css_properties_and_values_api/index.md
+++ b/files/en-us/web/css/css_properties_and_values_api/index.md
@@ -63,7 +63,7 @@ The value of `--stop-color` is set to `cornflowerblue` at first, but when you ho
 
 ## Reference
 
-### At-rules
+### At-rules and descriptors
 
 - {{cssxref("@property")}}
   - [syntax](/en-US/docs/Web/CSS/@property#descriptors) descriptor

--- a/files/en-us/web/css/css_round_display/index.md
+++ b/files/en-us/web/css/css_round_display/index.md
@@ -14,7 +14,7 @@ The **CSS round display** module defines CSS extensions to support a round displ
 
 The CSS round display module introduces the `border-boundary` and `shape-inside` properties. Currently, no browsers support these features.
 
-### Descriptors
+### At-rules and descriptors
 
 - {{cssxref("@media/shape", "shape")}} ({{cssxref("@media")}} feature)
 

--- a/files/en-us/web/css/css_ruby_layout/index.md
+++ b/files/en-us/web/css/css_ruby_layout/index.md
@@ -27,9 +27,9 @@ The CSS ruby layout module adds the following values to the {{cssxref("display")
 - `ruby-base-container`
 - `ruby-text-container`
 
-### Glossary and keywords
+### Glossary terms
 
-- {{Glossary("ruby")}}
+- {{Glossary("Ruby")}}
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_scroll-driven_animations/index.md
+++ b/files/en-us/web/css/css_scroll-driven_animations/index.md
@@ -55,7 +55,7 @@ Modify timeline scope:
 
 - {{cssxref("timeline-scope")}}
 
-### At-rules
+### At-rules and descriptors
 
 CSS scroll-driven animations adds the ability to include `<timeline-range-name>`s in {{cssxref("@keyframes")}} blocks, to place keyframes at specific positions inside named timeline ranges.
 

--- a/files/en-us/web/css/css_scroll_anchoring/index.md
+++ b/files/en-us/web/css/css_scroll_anchoring/index.md
@@ -18,7 +18,7 @@ For scroll containers that are [snapped](/en-US/docs/Glossary/Scroll_snap) to an
 
 - {{cssxref("overflow-anchor")}}
 
-## Glossary and definitions
+## Glossary terms
 
 - {{glossary("Scroll container")}}
 - {{glossary("Scroll snap")}}

--- a/files/en-us/web/css/css_syntax/index.md
+++ b/files/en-us/web/css/css_syntax/index.md
@@ -10,14 +10,14 @@ The **CSS syntax** module describes, in general terms, the structure and syntax 
 
 This module doesn't define any properties, [data types](/en-US/docs/Web/CSS/CSS_values_and_units/CSS_data_types), [functions](/en-US/docs/Web/CSS/CSS_values_and_units/CSS_value_functions), or [at-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule). Rather, it elaborates on how all of these features should be defined and how user agents should parse CSS.
 
-## At-rules
+## Reference
+
+### At-rules and descriptors
 
 - none
 
 > [!NOTE]
 > The module explicitly states that {{cssxref("@charset")}} is not an actual at-rule, but rather an unrecognized legacy rule that should be omitted when a stylesheet is grammar-checked. The only valid `@charset` usage is at the very beginning of a stylesheet, where it is interpreted as a special byte sequence stripped before processing the content.
-
-## Reference
 
 ### Key concepts
 
@@ -27,15 +27,15 @@ This module doesn't define any properties, [data types](/en-US/docs/Web/CSS/CSS_
 - [CSS declaration](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration)
 - [CSS declaration block](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block)
 - [CSS function](/en-US/docs/Web/CSS/CSS_values_and_units/CSS_value_functions)
-- [invalid](/en-US/docs/Web/CSS/CSS_syntax/Error_handling)
-- [style rule](/en-US/docs/Web/API/CSSStyleRule)
+- [Invalid](/en-US/docs/Web/CSS/CSS_syntax/Error_handling)
+- [Style rule](/en-US/docs/Web/API/CSSStyleRule)
 
 ### Glossary terms
 
-- {{glossary("CSS_Descriptor", "CSS descriptor")}}
-- {{glossary("parse")}}
-- {{glossary("stylesheet")}}
-- {{glossary("whitespace")}}
+- {{glossary("CSS descriptor")}}
+- {{glossary("Parse")}}
+- {{glossary("Stylesheet")}}
+- {{glossary("Whitespace")}}
 
 ## Guides
 

--- a/files/en-us/web/css/cssom_view/index.md
+++ b/files/en-us/web/css/cssom_view/index.md
@@ -27,7 +27,7 @@ The **CSSOM view** module lets you manipulate the visual view of a document, inc
 - {{domxref("MediaQueryList")}} events
   - {{domxref("MediaQueryList/change_event", "change")}}
 
-### Glossary
+### Glossary terms
 
 - {{glossary("Viewport")}}
 - {{glossary("Layout viewport")}}
@@ -49,7 +49,7 @@ For the JavaScript API defined by this module, see the [CSSOM view API](/en-US/d
 - {{cssxref("zoom")}}
 - {{htmlelement("meta")}}
 
-### Glossary terms and definitions
+### Glossary terms
 
 - {{glossary("CSSOM", "CSS object model (CSSOM)")}}
 - {{glossary("CSS pixel")}}


### PR DESCRIPTION
1. If only glossary terms, the header is "Glossary terms", otherwise "Glossary terms and definitions" or  "Glossary terms, definitions, and keywords" 
2. All at-rules and all descriptors now merged as "At-rules and descriptors"
3. All glossary terms and definitions start with an uppercase. Keywords don't