### PR TITLE
docs(Fx145): -webkit-fill-available value supported

### DIFF
--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -140,7 +140,7 @@ For each of the properties below, use the standard equivalents.
 
 - `-webkit-fill-available`
   - : Used with sizing properties like {{CSSxRef("width")}} and {{CSSxRef("height")}}, to allow elements to take up all available space within their parent container.
-    The flexbox `stretch` value (see {{CSSxRef("align-items")}} and {{CSSxRef("justify-items")}}) provides a standard replacement.
+    The `stretch` value provides a standard replacement, but `-webkit-fill-available` is supported as an alias by browsers for backwards-compatibility reasons.
 
 ## Pseudo-classes
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -136,6 +136,12 @@ For each of the properties below, use the standard equivalents.
 - `-webkit-padding-end`: Use {{CSSxRef("padding-inline-end")}}.
 - `-webkit-padding-start`: Use {{CSSxRef("padding-inline-start")}}.
 
+## -webkit-prefixed property values
+
+- `-webkit-fill-available`
+  - : Used with sizing properties like {{CSSxRef("width")}} and {{CSSxRef("height")}}, to allow elements to take up all available space within their parent container.
+    The flexbox `stretch` value (see {{CSSxRef("align-items")}} and {{CSSxRef("justify-items")}}) provides a standard replacement.
+
 ## Pseudo-classes
 
 > [!NOTE]


### PR DESCRIPTION
### Description

The CSS `-webkit-fill-available` keyword is enabled in Fx by default in 145. It can be used like:

```css
height: -webkit-fill-available;
width: -webkit-fill-available;
```

It's been added back to Fx for backwards-compatibility reasons. I previously removed it from content in:

- [x] https://github.com/mdn/content/pull/38914

I'm not adding much content here about it (examples, etc.) to avoid propagating it.

## Related issues and pull requests

- [ ] Parent https://github.com/mdn/content/issues/41502

