### PR TITLE
Use getter syntax for static observedAttributes

### DIFF
--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -72,7 +72,9 @@ Here's a minimal custom element that logs these lifecycle events:
 ```js
 // Create a class for the element
 class MyCustomElement extends HTMLElement {
-  static observedAttributes = ["color", "size"];
+  static get observedAttributes () {
+    return ["color", "size"];
+  }
 
   constructor() {
     // Always call super first in constructor
@@ -188,7 +190,7 @@ For example, this autonomous element will observe a `size` attribute, and log th
 ```js
 // Create a class for the element
 class MyCustomElement extends HTMLElement {
-  static observedAttributes = ["size"];
+  static get observedAttributes () { return ["size"] };
 
   constructor() {
     super();


### PR DESCRIPTION
So, after losing my marbles in a codepen:

https://codepen.io/paramagicdev/pen/xbZWabx?editors=1010

it turns out FF 144, Safari 17.6, and Chrome 141.0 do not support static class properties for `observedAttributes`.

I was trying to figure out why `attributeChangedCallback()` wasn't firing, and turns out its because the browser expect the getter and not a static property 🙃

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
