### PR TITLE
FF145 Relnote/Expr: Atomics.waitAsync()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -342,20 +342,7 @@ The {{CSSXRef(":heading")}} pseudo-class allows you to style all [heading elemen
 
 ## JavaScript
 
-### Atomics.waitAsync()
-
-The {{jsxref("Atomics.waitAsync()")}} static method waits asynchronously on a shared memory location and returns an object representing the result of the operation.
-It is non-blocking and usable on the main thread. ([Firefox bug 1467846](https://bugzil.la/1467846)).
-
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 140           | No                  |
-| Developer Edition | 140           | No                  |
-| Beta              | 140           | No                  |
-| Release           | 140           | No                  |
-
-- `javascript.options.atomics_wait_async`
-  - : Set to `true` to enable.
+**No experimental features in this release cycle.**
 
 ## APIs
 

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -46,8 +46,8 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### JavaScript
 
-- Firefox now supports the {{jsxref("Atomics.waitAsync()")}} static method, which waits asynchronously on a shared memory location and returns an object representing the result of the operation.
-  It is non-blocking and usable on the main thread.
+- Firefox now supports the {{jsxref("Atomics.waitAsync()")}} static method, which allows synchronization of threads based upon the value in a shared memory location.
+  The method waits asynchronously on the value and returns an object representing the result of the operation. It is non-blocking and usable on the main thread.
   ([Firefox bug 1884148](https://bugzil.la/1884148)).
 
 <!-- #### Removals -->

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -44,9 +44,11 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### JavaScript -->
+### JavaScript
 
-<!-- No notable changes. -->
+- Firefox now supports the {{jsxref("Atomics.waitAsync()")}} static method, which waits asynchronously on a shared memory location and returns an object representing the result of the operation.
+  It is non-blocking and usable on the main thread.
+  ([Firefox bug 1884148](https://bugzil.la/1884148)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
FF145 ships [`Atomics.waitAsync()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync) in https://bugzilla.mozilla.org/show_bug.cgi?id=1884148

This adds a release note and removes the experimental features note.

Related docs work can be tracked in #41498
