### PR TITLE
FF145Relnote: ToggleEvent.source

### DIFF
--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -65,7 +65,7 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### APIs
 
 - The {{domxref("ToggleEvent/source", "source")}} property of the {{domxref("ToggleEvent")}} interface is now supported.
-  If a [popover](/en-US/docs/Web/API/Popover_API) was triggered open or closed by an HTML element, such as a {{htmlelement("button")}}, the corresponding event will include the element in this property.
+  If a [popover](/en-US/docs/Web/API/Popover_API) is triggered to open or close by an HTML element such as a {{htmlelement("button")}}, the event's `source` property will contain the element that triggered the popover.
   ([Firefox bug 1968987](https://bugzil.la/1968987)).
 
 <!-- #### DOM -->

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -64,6 +64,10 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The {{domxref("ToggleEvent/source", "source")}} property of the {{domxref("ToggleEvent")}} interface is now supported.
+  If a [popover](/en-US/docs/Web/API/Popover_API) was triggered open or closed by an HTML element, such as a {{htmlelement("button")}}, the corresponding event will include the element in this property.
+  ([Firefox bug 1968987](https://bugzil.la/1968987)).
+
 <!-- #### DOM -->
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF145 supports `ToggleEvent.source` in https://bugzilla.mozilla.org/show_bug.cgi?id=1968987.

This adds a release note.

Related docs can be tracked in #41543
