### PR TITLE
Enhance 'Jank' definition with glossary references

### DIFF
--- a/files/en-us/glossary/jank/index.md
+++ b/files/en-us/glossary/jank/index.md
@@ -5,4 +5,9 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Jank** refers to sluggishness in a user interface, usually caused by executing long tasks on the main thread, blocking rendering, or expending too much processor power on background processes.
+**Jank** refers to sluggishness in a user interface, usually caused by executing long tasks on the {{glossary("main thread")}}, blocking rendering, or expending too much processor power on background processes.
+
+## See also
+
+- {{glossary("Render blocking")}}
+- [Critical path rendering](/en-US/docs/Web/Performance/Guides/Critical_rendering_path) guide


### PR DESCRIPTION
Added glossary links for 'main thread' and 'Render blocking'.