### PR TITLE
Fix: Update Firefox cap link for Access-Control-Max-Age header

### DIFF
--- a/files/en-us/web/http/reference/headers/access-control-max-age/index.md
+++ b/files/en-us/web/http/reference/headers/access-control-max-age/index.md
@@ -32,7 +32,7 @@ Access-Control-Max-Age: <delta-seconds>
 
 - `<delta-seconds>`
   - : Maximum number of seconds for which the results can be cached as an unsigned non-negative integer.
-    Firefox [caps this at 24 hours](https://searchfox.org/firefox-main/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1207) (86400 seconds).
+    Firefox [caps this at 24 hours](https://searchfox.org/firefox-main/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1393) (86400 seconds).
     Chromium (prior to v76) [caps at 10 minutes](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=52002151773d8cd9ffc5f557cd7cc880fddcae3e;l=36) (600 seconds).
     Chromium (starting in v76) [caps at 2 hours](https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa;l=31) (7200 seconds).
     The default value is 5 seconds.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

### Description

Updated the Firefox source link for the `Access-Control-Max-Age` header documentation.  
The previous link pointed to line `#1207` in `nsCORSListenerProxy.cpp`, which has since shifted to line `#1393`.

### Motivation

This allows readers following the link see the correct implementation of Firefox's 24-hour cap for `Access-Control-Max-Age`.  
Keeping source references up to date improves accuracy and prevents confusion for developers reading the docs.

### Additional details

- Updated link: [searchfox.org/firefox-main/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1393](https://searchfox.org/firefox-main/source/netwerk/protocol/http/nsCORSListenerProxy.cpp#1393)  
- Original line reference: `#1207`  
- Verified current line position in [Searchfox main branch](https://searchfox.org/firefox-main/source/netwerk/protocol/http/nsCORSListenerProxy.cpp)

### Related issues and pull requests

N/A
