### PR TITLE
Editorial updates to ToggleEvent and ToggleEvent.source pages

### DIFF
--- a/files/en-us/web/api/popover_api/index.md
+++ b/files/en-us/web/api/popover_api/index.md
@@ -57,7 +57,7 @@ See [Using the popover API](/en-US/docs/Web/API/Popover_API/Using) for a detaile
 ## Interfaces
 
 - {{domxref("ToggleEvent")}}
-  - : Represents an event notifying the user when a popover element's state toggles between showing and hidden. It is the event object for the {{domxref("HTMLElement.beforetoggle_event", "beforetoggle")}} and {{domxref("HTMLElement.toggle_event", "toggle")}} events, which fire on popovers when their state changes.
+  - : Represents an event that fires when a popover element is toggled between being shown and hidden. It is the event object for the {{domxref("HTMLElement.beforetoggle_event", "beforetoggle")}} and {{domxref("HTMLElement.toggle_event", "toggle")}} events, which fire on popovers when their state changes.
 
 ## Extensions to other interfaces
 

--- a/files/en-us/web/api/toggleevent/index.md
+++ b/files/en-us/web/api/toggleevent/index.md
@@ -12,7 +12,7 @@ The **`ToggleEvent`** interface represents an event that fires when a popover el
 This is the event object for the {{domxref("HTMLElement.beforetoggle_event", "beforetoggle")}} and {{domxref("HTMLElement.toggle_event", "toggle")}} events, which fire on elements as follows:
 
 - The `beforetoggle` event fires before [popover](/en-US/docs/Web/API/Popover_API) or {{htmlelement("dialog")}} elements are shown or hidden.
-- The `toggle` event fires after [popover](/en-US/docs/Web/API/Popover_API), {{htmlelement("dialog")}}, or {{htmlelement("details")}} elements are shown or hidden.
+- The `toggle` event fires after popover, `<dialog>`, or {{htmlelement("details")}} elements are shown or hidden.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/toggleevent/index.md
+++ b/files/en-us/web/api/toggleevent/index.md
@@ -7,19 +7,19 @@ browser-compat: api.ToggleEvent
 
 {{APIRef("Popover API")}}
 
-The **`ToggleEvent`** interface represents an event notifying the user an Element's state has changed.
+The **`ToggleEvent`** interface represents an event that fires when a popover element is toggled between being shown and hidden.
 
-This is the event object for the `HTMLElement` {{domxref("HTMLElement.beforetoggle_event", "beforetoggle")}} and {{domxref("HTMLElement.toggle_event", "toggle")}} events, which fire on some elements just before and just after they transition between showing and hidden, respectively.
+This is the event object for the {{domxref("HTMLElement.beforetoggle_event", "beforetoggle")}} and {{domxref("HTMLElement.toggle_event", "toggle")}} events, which fire on elements as follows:
 
-- `beforetoggle` fires on [popovers](/en-US/docs/Web/API/Popover_API) and {{htmlelement("dialog")}} elements.
-- `toggle` fires on [popovers](/en-US/docs/Web/API/Popover_API), {{htmlelement("dialog")}} elements, and {{htmlelement("details")}} elements.
+- The `beforetoggle` event fires before [popover](/en-US/docs/Web/API/Popover_API) or {{htmlelement("dialog")}} elements are shown or hidden.
+- The `toggle` event fires after [popover](/en-US/docs/Web/API/Popover_API), {{htmlelement("dialog")}}, or {{htmlelement("details")}} elements are shown or hidden.
 
 {{InheritanceDiagram}}
 
 ## Constructor
 
 - {{DOMxRef("ToggleEvent.ToggleEvent", "ToggleEvent()")}}
-  - : Creates an `ToggleEvent` object.
+  - : Creates a `ToggleEvent` object.
 
 ## Instance properties
 

--- a/files/en-us/web/api/toggleevent/source/index.md
+++ b/files/en-us/web/api/toggleevent/source/index.md
@@ -18,25 +18,24 @@ An {{domxref("Element")}} object instance, or `null` if the popover was not acti
 
 A {{htmlelement("button")}} element can be set as a popover control by specifying the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) of the popover element in its [`commandfor`](/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) or [`popovertarget`](/en-US/docs/Web/HTML/Reference/Elements/button#popovertarget) attribute (if the button is specified using `<input type="button">`, only the `popovertarget` attribute works).
 
-When the [`toggle`](/en-US/docs/Web/API/HTMLElement/toggle_event) event fires on the popover, the `ToggleEvent` event object's `source` property will then contain a reference to the popover control button that initiated the toggle. This is useful for running different code in response to the `toggle` event depending on which control initiated it (see an [example](#basic_source_usage)).
+When the [`toggle`](/en-US/docs/Web/API/HTMLElement/toggle_event) event fires on the popover, the `ToggleEvent` event object's `source` property will then contain a reference to the popover control button that initiated the toggle. This is useful for running different code in response to the `toggle` event depending on which popover control initiated it (see an [example](#basic_source_usage)).
 
-Before the `source` property was available, developers would have to reimplement the `command` attribute functionality from scratch to provide a similar identifier and then monitor it with JavaScript to know which button invoked the popover.
+Before the `source` property existed, you had to manually reimplement the `command` attribute functionality in JavaScript to provide a similar identifier and then monitor it to identify which button invoked the popover.
 In addition, there was a danger of such JavaScript tasks blocking the showing or hiding of the popover.
 The `toggle` event is asynchronous, and therefore avoids this problem.
 
-If the popover was not activated by a control button — for example, if the popover is being controlled using a JavaScript method such as {{domxref("HTMLElement.togglePopover()")}} — the `source` property returns `null`.
+If the popover element is not activated by a control button — for example, if it's controlled using a JavaScript method such as {{domxref("HTMLElement.togglePopover()")}} — the `source` property is `null`.
 
 ## Examples
 
 ### Basic `source` usage
 
-This demo shows how to use the `source` property to perform a different action depending on which control button was used to close a popover.
+This demo shows how to use the `source` property to perform different actions based on the control button that closes the popover element.
 
 #### HTML
 
 Our markup contains a `<button>`, a {{htmlelement("p")}}, and a {{htmlelement("div")}} element. The `<div>` is designated as an [`auto` popover](/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss), and the button is designated as a control for showing the popover using the [`commandfor`](/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) and [`command`](/en-US/docs/Web/HTML/Reference/Elements/button#command) attributes.
-
-The popover contains a heading asking the user if they would like a cookie, and two buttons allowing them to select an answer of "yes" or "no". Each one of these buttons is designated as a control for hiding the popover.
+The popover contains a heading asking the user if they would like a cookie, and two buttons labeled **Yes** and **No** allowing them to select an answer. Each of these buttons is designated as a control for hiding the popover.
 
 ```html live-sample___toggleevent-source
 <button commandfor="popover" command="show-popover">
@@ -68,7 +67,7 @@ html {
 
 #### JavaScript
 
-In our script, we start off by grabbing references to the "yes" and "no" buttons, the popover, and the output `<p>`.
+In our script, we start off by grabbing references to the `"yes"` and `"no"` buttons, the popover, and the output `<p>`.
 
 ```js live-sample___toggleevent-source
 const yesBtn = document.getElementById("yes");
@@ -77,7 +76,7 @@ const popover = document.getElementById("popover");
 const output = document.getElementById("output");
 ```
 
-We then add some feature detection to detect whether the HTML `command` attribute is supported, and whether the `source` property is supported. If either are not supported, we output an appropriate message to the output `<p>`. If both are supported, we add a [`toggle`](/en-US/docs/Web/API/HTMLElement/toggle_event) event listener to the popover. When fired, it checks if the "yes" or the "no" button was used to toggle (hide) the popover; an appropriate message is printed to the output `<p>` in each case.
+We've added feature detection for the HTML `command` attribute and the `source` property. If either is not supported in the browser, we print a message in the `<p>` element. If both are supported, we add a [`toggle`](/en-US/docs/Web/API/HTMLElement/toggle_event) event listener to the popover element. When the event fires, the code checks if the `"yes"` or `"no"` button was used to toggle (hide) the popover element; an appropriate message is printed to the output `<p>` in each case.
 
 ```js live-sample___toggleevent-source
 if (yesBtn.command === undefined) {


### PR DESCRIPTION
### Motivation

I came across the [ToggleEvent](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent) and [ToggleEvent.source](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/source) pages while reviewing [#41653](https://github.com/mdn/content/pull/41653) and noticed few opportunities where the text could be improved and made clearer.

I'll leave inline comments to explain some of the specific changes.