### PR TITLE
Every filter primitive accepts common attributes

### DIFF
--- a/files/en-us/web/svg/reference/element/feblend/index.md
+++ b/files/en-us/web/svg/reference/element/feblend/index.md
@@ -19,6 +19,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("in")}}
 - {{SVGAttr("in2")}}
 - {{SVGAttr("mode")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fecolormatrix/index.md
+++ b/files/en-us/web/svg/reference/element/fecolormatrix/index.md
@@ -70,6 +70,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("in")}}: Values include `SourceGraphic`, `SourceAlpha`, `BackgroundImage`, `BackgroundAlpha`, `FillPaint`, `StrokePaint`, or a reference to another filter primitive.
 - {{SVGAttr("type")}}: Values include `matrix`, `saturate`, `hueRotate`, and `luminanceToAlpha`.
 - {{SVGAttr("values")}}: The value for the matrix type set in the `type` attribute.
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fecolormatrix/index.md
+++ b/files/en-us/web/svg/reference/element/fecolormatrix/index.md
@@ -67,9 +67,9 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 
 ## Attributes
 
-- {{SVGAttr("in")}}: Values include `SourceGraphic`, `SourceAlpha`, `BackgroundImage`, `BackgroundAlpha`, `FillPaint`, `StrokePaint`, or a reference to another filter primitive.
-- {{SVGAttr("type")}}: Values include `matrix`, `saturate`, `hueRotate`, and `luminanceToAlpha`.
-- {{SVGAttr("values")}}: The value for the matrix type set in the `type` attribute.
+- {{SVGAttr("in")}}
+- {{SVGAttr("type")}}: Values include `matrix`, `saturate`, `hueRotate`, and `luminanceToAlpha`
+- {{SVGAttr("values")}}: The value for the matrix type set in the `type` attribute
 - [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface

--- a/files/en-us/web/svg/reference/element/fecomponenttransfer/index.md
+++ b/files/en-us/web/svg/reference/element/fecomponenttransfer/index.md
@@ -19,6 +19,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 ## Attributes
 
 - {{SVGAttr("in")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fecomposite/index.md
+++ b/files/en-us/web/svg/reference/element/fecomposite/index.md
@@ -130,6 +130,7 @@ The table below shows each of these operations using an image of the MDN logo co
 - {{SVGAttr("in2")}}: Second input for the given filter primitive (works the same as the `in` attribute).
 - {{SVGAttr("operator")}}: `over` | `in` | `out` | `atop` | `xor` | `lighter` | `arithmetic`
 - {{SVGAttr("k1")}}, {{SVGAttr("k2")}}, {{SVGAttr("k3")}}, {{SVGAttr("k4")}}: Values used for calculating the result pixel in `arithmetic` {{SVGAttr("operator")}} filter primitives.
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/feconvolvematrix/index.md
+++ b/files/en-us/web/svg/reference/element/feconvolvematrix/index.md
@@ -64,6 +64,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("edgeMode")}}
 - {{SVGAttr("kernelUnitLength")}}
 - {{SVGAttr("preserveAlpha")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fediffuselighting/index.md
+++ b/files/en-us/web/svg/reference/element/fediffuselighting/index.md
@@ -22,6 +22,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("surfaceScale")}}
 - {{SVGAttr("diffuseConstant")}}
 - {{SVGAttr("kernelUnitLength")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fedisplacementmap/index.md
+++ b/files/en-us/web/svg/reference/element/fedisplacementmap/index.md
@@ -27,6 +27,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("scale")}}
 - {{SVGAttr("xChannelSelector")}}
 - {{SVGAttr("yChannelSelector")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fedistantlight/index.md
+++ b/files/en-us/web/svg/reference/element/fedistantlight/index.md
@@ -6,9 +6,7 @@ browser-compat: svg.elements.feDistantLight
 sidebar: svgref
 ---
 
-The **`<feDistantLight>`** [SVG](/en-US/docs/Web/SVG) filter primitive defines a distant light source that can be used within a lighting filter primitive: {{SVGElement("feDiffuseLighting")}} or {{SVGElement("feSpecularLighting")}}.
-
-Like other filter primitives, it handles color components in the `linearRGB` {{glossary("color space")}} by default. You can use {{svgattr("color-interpolation-filters")}} to use `sRGB` instead.
+The **`<feDistantLight>`** [SVG](/en-US/docs/Web/SVG) element defines a distant light source that can be used within a lighting filter primitive: {{SVGElement("feDiffuseLighting")}} or {{SVGElement("feSpecularLighting")}}.
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/fedropshadow/index.md
+++ b/files/en-us/web/svg/reference/element/fedropshadow/index.md
@@ -19,15 +19,14 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 
 ## Attributes
 
-- {{SVGAttr("dx")}}
-  - : This attribute defines the x offset of the drop shadow.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
-- {{SVGAttr("dy")}}
-  - : This attribute defines the y offset of the drop shadow.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Guides/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
-- {{SVGAttr("stdDeviation")}}
-  - : This attribute defines the standard deviation for the blur operation in the drop shadow.
-    _Value type_: [**\<number-optional-number>**](/en-US/docs/Web/SVG/Guides/Content_type#number-optional-number); _Default value_: `2`; _Animatable_: **yes**
+- {{SVGAttr("dx")}}: This attribute defines the x offset of the drop shadow.
+  _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
+- {{SVGAttr("dy")}}: This attribute defines the y offset of the drop shadow.
+  _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
+- {{SVGAttr("in")}}
+- {{SVGAttr("stdDeviation")}}: This attribute defines the standard deviation for the blur operation in the drop shadow.
+  _Value type_: [**\<number-optional-number>**](/en-US/docs/Web/SVG/Content_type#number-optional-number); _Default value_: `2`; _Animatable_: **yes**
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/feflood/index.md
+++ b/files/en-us/web/svg/reference/element/feflood/index.md
@@ -16,6 +16,7 @@ The **`<feFlood>`** [SVG](/en-US/docs/Web/SVG) filter primitive fills the filter
 
 - {{SVGAttr("flood-color")}}
 - {{SVGAttr("flood-opacity")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fegaussianblur/index.md
+++ b/files/en-us/web/svg/reference/element/fegaussianblur/index.md
@@ -19,6 +19,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("in")}}
 - {{SVGAttr("stdDeviation")}}
 - {{SVGAttr("edgeMode")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/feimage/index.md
+++ b/files/en-us/web/svg/reference/element/feimage/index.md
@@ -17,7 +17,9 @@ The **`<feImage>`** [SVG](/en-US/docs/Web/SVG) filter primitive fetches image da
 - {{SVGAttr("crossorigin")}}
 - {{SVGAttr("fetchpriority")}} {{experimental_inline}}
 - {{SVGAttr("preserveAspectRatio")}}
+- {{SVGAttr("href")}}
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/femerge/index.md
+++ b/files/en-us/web/svg/reference/element/femerge/index.md
@@ -14,6 +14,14 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 
 {{svginfo}}
 
+## Attributes
+
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
+
+## DOM Interface
+
+This element implements the {{domxref("SVGFEMergeElement")}} interface.
+
 ## Example
 
 ### SVG
@@ -43,10 +51,6 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 ### Result
 
 {{EmbedLiveSample('Example', 200, 200)}}
-
-## DOM Interface
-
-This element implements the {{domxref("SVGFEMergeElement")}} interface.
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/femergenode/index.md
+++ b/files/en-us/web/svg/reference/element/femergenode/index.md
@@ -12,6 +12,14 @@ The **`<feMergeNode>`** [SVG](/en-US/docs/Web/SVG) takes the result of another f
 
 {{svginfo}}
 
+## Attributes
+
+- {{SVGAttr("in")}}
+
+## DOM Interface
+
+This element implements the [`SVGFEMergeNodeElement`](/en-US/docs/Web/API/SVGFEMergeNodeElement) interface.
+
 ## Example
 
 ```html
@@ -44,14 +52,6 @@ The **`<feMergeNode>`** [SVG](/en-US/docs/Web/SVG) takes the result of another f
 ### Result
 
 {{EmbedLiveSample('Example', 200, 200)}}
-
-## Attributes
-
-- {{ SVGAttr("in") }}
-
-## DOM Interface
-
-This element implements the [`SVGFEMergeNodeElement`](/en-US/docs/Web/API/SVGFEMergeNodeElement) interface.
 
 ## Specifications
 

--- a/files/en-us/web/svg/reference/element/femorphology/index.md
+++ b/files/en-us/web/svg/reference/element/femorphology/index.md
@@ -19,6 +19,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("in")}}
 - {{SVGAttr("operator")}}
 - {{SVGAttr("radius")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/feoffset/index.md
+++ b/files/en-us/web/svg/reference/element/feoffset/index.md
@@ -17,6 +17,7 @@ The **`<feOffset>`** [SVG](/en-US/docs/Web/SVG) filter primitive enables offsett
 - {{SVGAttr("in")}}
 - {{SVGAttr("dx")}}
 - {{SVGAttr("dy")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fepointlight/index.md
+++ b/files/en-us/web/svg/reference/element/fepointlight/index.md
@@ -6,9 +6,7 @@ browser-compat: svg.elements.fePointLight
 sidebar: svgref
 ---
 
-The **`<fePointLight>`** [SVG](/en-US/docs/Web/SVG) filter primitive defines a light source which allows to create a point light effect. It that can be used within a lighting filter primitive: {{SVGElement("feDiffuseLighting")}} or {{SVGElement("feSpecularLighting")}}.
-
-Like other filter primitives, it handles color components in the `linearRGB` {{glossary("color space")}} by default. You can use {{svgattr("color-interpolation-filters")}} to use `sRGB` instead.
+The **`<fePointLight>`** [SVG](/en-US/docs/Web/SVG) element defines a light source which allows to create a point light effect. It can be used within a lighting filter primitive: {{SVGElement("feDiffuseLighting")}} or {{SVGElement("feSpecularLighting")}}.
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/fespecularlighting/index.md
+++ b/files/en-us/web/svg/reference/element/fespecularlighting/index.md
@@ -23,6 +23,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("specularConstant")}}
 - {{SVGAttr("specularExponent")}}
 - {{SVGAttr("kernelUnitLength")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/fespotlight/index.md
+++ b/files/en-us/web/svg/reference/element/fespotlight/index.md
@@ -6,10 +6,8 @@ browser-compat: svg.elements.feSpotLight
 sidebar: svgref
 ---
 
-The **`<feSpotLight>`** [SVG](/en-US/docs/Web/SVG) filter primitive defines a light source that can be used to create a spotlight effect.
+The **`<feSpotLight>`** [SVG](/en-US/docs/Web/SVG) element defines a light source that can be used to create a spotlight effect.
 It is used within a lighting filter primitive: {{SVGElement("feDiffuseLighting")}} or {{SVGElement("feSpecularLighting")}}.
-
-Like other filter primitives, it handles color components in the `linearRGB` {{glossary("color space")}} by default. You can use {{svgattr("color-interpolation-filters")}} to use `sRGB` instead.
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/fetile/index.md
+++ b/files/en-us/web/svg/reference/element/fetile/index.md
@@ -15,6 +15,7 @@ The **`<feTile>`** [SVG](/en-US/docs/Web/SVG) filter primitive allows to fill a 
 ## Attributes
 
 - {{SVGAttr("in")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/feturbulence/index.md
+++ b/files/en-us/web/svg/reference/element/feturbulence/index.md
@@ -21,6 +21,7 @@ Like other filter primitives, it handles color components in the `linearRGB` {{g
 - {{SVGAttr("seed")}}
 - {{SVGAttr("stitchTiles")}}
 - {{SVGAttr("type")}}
+- [Filter primitive attributes](/en-US/docs/Web/SVG/Reference/Attribute#filter_primitive_attributes_presentation_attributes): {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}, {{SVGAttr("result")}}
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/filter/index.md
+++ b/files/en-us/web/svg/reference/element/filter/index.md
@@ -22,13 +22,18 @@ The **`<filter>`** [SVG](/en-US/docs/Web/SVG) element defines a custom filter ef
 - {{SVGAttr("primitiveUnits")}}
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
+> [!NOTE]
+> For `<filter>`, the `x` and `y` attributes default to `-10%`, and the `width` and `height` attributes default to `120%`. This is because many filter effects, such as {{svgelement("feGaussianBlur")}}, extend beyond the bounds of the element being filtered. The default sizing ensures that the filter effect is not clipped.
+
 ## DOM Interface
 
 This element implements the {{domxref("SVGFilterElement")}} interface.
 
-## Example
+## Examples
 
-### SVG
+### Adding a blur effect
+
+#### SVG
 
 ```html
 <svg width="230" height="120" xmlns="http://www.w3.org/2000/svg">
@@ -42,7 +47,7 @@ This element implements the {{domxref("SVGFilterElement")}} interface.
 </svg>
 ```
 
-### Result
+#### Result
 
 {{EmbedLiveSample("Example",235,150)}}
 


### PR DESCRIPTION
In preparation for https://github.com/mdn/content/issues/24169, we should document that filter primitives accept more attributes than what's listed here. We are still missing the global attributes, but that's a separate topic.

Also the three light source elements are not filter primitives, so removed words indicating that they are.