### PR TITLE
setHTML clarify default options

### DIFF
--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -50,6 +50,7 @@ The **`setHTML()`** method provides an XSS-safe method to parse and sanitize a s
 It then removes any HTML entities that aren't allowed by the sanitizer configuration, and further removes any XSS-unsafe elements or attributes — whether or not they are allowed by the sanitizer configuration.
 
 If no sanitizer configuration is specified in the `options.sanitizer` parameter, `setHTML()` is used with the default {{domxref("Sanitizer")}} configuration.
+**For details on the default configuration, see the [`Sanitizer()`](/en-US/docs/Web/API/Sanitizer/Sanitizer) constructor's documentation.**
 This configuration allows all elements and attributes that are considered XSS-safe, thereby disallowing entities that are considered unsafe.
 A custom sanitizer or sanitizer configuration can be specified to choose which elements, attributes, and comments are allowed or removed.
 Note that even if unsafe options are allowed by the sanitizer configuration, they will still be removed when using this method (which implicitly calls {{domxref('Sanitizer.removeUnsafe()')}}).

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -29,6 +29,7 @@ setHTML(input, options)
       - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed, or the string `"default"` for the default configuration.
         Note that generally a `Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to be reused.
         If not specified, the default sanitizer configuration is used.
+        The default configuration only allows known elements and attributes that are considered XSS-safe; notably, {{HTMLElement("script")}}, {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("object")}}, {{SVGElement("use")}}, event handler attributes, and data attributes are all not in the allowlist.
 
 ### Return value
 
@@ -50,8 +51,7 @@ The **`setHTML()`** method provides an XSS-safe method to parse and sanitize a s
 It then removes any HTML entities that aren't allowed by the sanitizer configuration, and further removes any XSS-unsafe elements or attributes — whether or not they are allowed by the sanitizer configuration.
 
 If no sanitizer configuration is specified in the `options.sanitizer` parameter, `setHTML()` is used with the default {{domxref("Sanitizer")}} configuration.
-**For details on the default configuration, see the [`Sanitizer()`](/en-US/docs/Web/API/Sanitizer/Sanitizer) constructor's documentation.**
-This configuration allows all elements and attributes that are considered XSS-safe, thereby disallowing entities that are considered unsafe.
+This configuration allows all elements and attributes that are considered XSS-safe, thereby disallowing entities that are considered unsafe; see the [`Sanitizer()`](/en-US/docs/Web/API/Sanitizer/Sanitizer) constructor for more information.
 A custom sanitizer or sanitizer configuration can be specified to choose which elements, attributes, and comments are allowed or removed.
 Note that even if unsafe options are allowed by the sanitizer configuration, they will still be removed when using this method (which implicitly calls {{domxref('Sanitizer.removeUnsafe()')}}).
 

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -251,7 +251,7 @@ We also define the handler for the reload button.
 const unsanitizedString = `
   <div>
     <p>This is a paragraph. <button onclick="alert('You clicked the button!')">Click me</button></p>
-    <script src="path/to/a/module.js" type="module"><script>
+    <script src="path/to/a/module.js" type="module"></script>
   </div>
 `;
 

--- a/files/en-us/web/api/shadowroot/sethtml/index.md
+++ b/files/en-us/web/api/shadowroot/sethtml/index.md
@@ -24,9 +24,10 @@ setHTML(input, options)
 - `options` {{optional_inline}}
   - : An options object with the following optional parameters:
     - `sanitizer`
-      - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed, or the string `"default"` for the default sanitizer configuration.
-        Note that generally a `"Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to reused.
+      - : A {{domxref("Sanitizer")}} or {{domxref("SanitizerConfig")}} object which defines what elements of the input will be allowed or removed, or the string `"default"` for the default configuration.
+        Note that generally a `Sanitizer` is expected to be more efficient than a `SanitizerConfig` if the configuration is to be reused.
         If not specified, the default sanitizer configuration is used.
+        The default configuration only allows known elements and attributes that are considered XSS-safe; notably, {{HTMLElement("script")}}, {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("object")}}, {{SVGElement("use")}}, event handler attributes, and data attributes are all not in the allowlist.
 
 ### Return value
 
@@ -47,7 +48,7 @@ The **`setHTML()`** method provides an XSS-safe method to parse and sanitize a s
 `setHTML()` removes any HTML entities that aren't allowed by the sanitizer configuration, and further removes any XSS-unsafe elements or attributes — whether or not they are allowed by the sanitizer configuration.
 
 If no sanitizer configuration is specified in the `options.sanitizer` parameter, `setHTML()` is used with the default {{domxref("Sanitizer")}} configuration.
-This configuration allows all elements and attributes that are considered XSS-safe, thereby disallowing entities that are considered unsafe.
+This configuration allows all elements and attributes that are considered XSS-safe, thereby disallowing entities that are considered unsafe; see the [`Sanitizer()`](/en-US/docs/Web/API/Sanitizer/Sanitizer) constructor for more information.
 A custom sanitizer or sanitizer configuration can be specified to choose which elements, attributes, and comments are allowed or removed.
 Note that even if unsafe options are allowed by the sanitizer configuration, they will still be removed when using this method (which implicitly calls {{domxref('Sanitizer.removeUnsafe()')}}).
 
@@ -165,7 +166,7 @@ We also get variable `shadow`, which is our handle to the shadow root.
 const unsanitizedString = `
   <div>
     <p>Paragraph to inject into shadow DOM. <button onclick="alert('You clicked the button!')">Click me</button></p>
-    <script src="path/to/a/module.js" type="module"><script>
+    <script src="path/to/a/module.js" type="module"></script>
   </div>
 `;
 

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -270,7 +270,7 @@ We also get variable `shadow`, which is our handle to the shadow root.
 const unsanitizedString = `
   <div>
     <p>Paragraph to inject into shadow DOM. <button onclick="alert('You clicked the button!')">Click me</button></p>
-    <script src="path/to/a/module.js" type="module"><script>
+    <script src="path/to/a/module.js" type="module"></script>
   </div>
 `;
 


### PR DESCRIPTION
### Description

Hi! This PR adds a clarifying sentence to the `setHTML()` documentation. It now links directly to the `Sanitizer()` constructor page so users can easily find out what the "default sanitizer configuration" includes.

### Motivation

This change was motivated by issue #41655. A user was (correctly!) a bit confused about what "default sanitizer configuration" meant. This PR makes the docs more helpful by directly linking to the answer.

### Additional details

N/A

### Related issues and pull requests

Fixes #41655