### PR TITLE
Fix grammar in nodeType documentation

### DIFF
--- a/files/en-us/web/api/node/nodetype/index.md
+++ b/files/en-us/web/api/node/nodetype/index.md
@@ -9,8 +9,8 @@ browser-compat: api.Node.nodeType
 {{APIRef("DOM")}}
 
 The read-only **`nodeType`** property of a {{domxref("Node")}} interface is an integer
-that identifies what the node is. It distinguishes different kind of nodes from each other,
-such as {{domxref("Element", "elements")}}, {{domxref("Text", "text")}} and {{domxref("Comment", "comments")}}.
+that identifies what the node is. It distinguishes different kinds of nodes from each other,
+such as {{domxref("Element", "elements")}}, {{domxref("Text", "text")}}, and {{domxref("Comment", "comments")}}.
 
 ## Value
 


### PR DESCRIPTION
Fixed two typos in the nodeType documentation

### Description

I fixed a plurality typo and added an Oxford comma (consistent with the rest of the page and other pages).

### Motivation

I came across these typos while reading the documentation, and it didn't seem quite right to me.

### Additional details

For precedent of the Oxford comma being used, search for ", and" in the rest of the nodeType page. You could also search for ", and" in the files/en-us/web/html/index.md path in this repo.