### PR TITLE
Fix typo in chemical formula example

### DIFF
--- a/files/en-us/web/html/reference/elements/sub/index.md
+++ b/files/en-us/web/html/reference/elements/sub/index.md
@@ -76,7 +76,7 @@ In mathematics, families of variables related to the same concept (such as dista
 
 ### Chemical formulas
 
-When writing a chemical formula, such as H<sub>2</sub>0, the number of atoms of a given element within the described molecule is represented using a subscripted number; in the case of water, the subscripted "2" indicates that there are two atoms of hydrogen in the molecule.
+When writing a chemical formula, such as H<sub>2</sub>O, the number of atoms of a given element within the described molecule is represented using a subscripted number; in the case of water, the subscripted "2" indicates that there are two atoms of hydrogen in the molecule.
 
 Another example:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Fixing a tiny typo: `H2O` not `H20`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I was just going through the element docs and it caught my eye.
