### PR TITLE
Add DOMQuad static method documentation

### DIFF
--- a/files/en-us/web/api/domquad/domquad/index.md
+++ b/files/en-us/web/api/domquad/domquad/index.md
@@ -8,13 +8,9 @@ browser-compat: api.DOMQuad.DOMQuad
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMQuad()`** constructor
-creates and returns a new {{domxref("DOMQuad")}} object, given the values for some or
-all of its properties.
+The **`DOMQuad()`** constructor creates and returns a new {{domxref("DOMQuad")}} object, given the values for some or all of its properties.
 
-You can also create a `DOMQuad` by calling the
-{{domxref("DOMQuad.fromRect_static", "DOMQuad.fromRect()")}} or {{domxref("DOMQuad.fromQuad_static", "DOMQuad.fromQuad()")}} static function. That function accepts any object with the required parameters, including a `DOMQuad`, {{domxref("DOMPoint")}} or
-{{domxref("DOMPointReadOnly")}}.
+You can also create a `DOMQuad` by calling the {{domxref("DOMQuad.fromRect_static", "DOMQuad.fromRect()")}} or {{domxref("DOMQuad.fromQuad_static", "DOMQuad.fromQuad()")}} static function. These functions accept any object with the required parameters, including a {{domxref("DOMRect")}}, {{domxref("DOMRectReadOnly")}}, or another `DOMQuad`.
 
 ## Syntax
 
@@ -28,14 +24,8 @@ new DOMQuad(p1, p2, p3, p4)
 
 ### Parameters
 
-- `p1` {{optional_inline}}
-  - : The `p1` {{domxref("DOMPoint")}} for the new `DOMQuad`.
-- `p2` {{optional_inline}}
-  - : The `p2` {{domxref("DOMPoint")}} for the new `DOMQuad`.
-- `p3` {{optional_inline}}
-  - : The `p3` {{domxref("DOMPoint")}} for the new `DOMQuad`.
-- `p4` {{optional_inline}}
-  - : The `p4` {{domxref("DOMPoint")}} for the new `DOMQuad`.
+- {{domxref("DOMQuad/p1", "p1")}} {{optional_inline}}, {{domxref("DOMQuad/p2", "p2")}} {{optional_inline}}, {{domxref("DOMQuad/p3", "p3")}} {{optional_inline}}, {{domxref("DOMQuad/p4", "p4")}} {{optional_inline}}
+  - : Each a {{domxref("DOMPoint")}} or an object with the same properties representing one corner of the quad.
 
 ## Examples
 

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -20,15 +20,9 @@ DOMQuad.fromQuad(quad)
 ### Parameters
 
 - `quad` {{optional_inline}}
-  - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. The object can contain the following properties:
-    - `p1` {{optional_inline}}
-      - : A {{domxref("DOMPoint")}} or an object with the same properties representing one corner of the quad.
-    - `p2` {{optional_inline}}
-      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
-    - `p3` {{optional_inline}}
-      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
-    - `p4` {{optional_inline}}
-      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
+  - : A {{domxref("DOMQuad")}} or an object with the same properties. All properties default to `(0, 0, 0, 1)`. The properties are:
+    - {{domxref("DOMQuad/p1", "p1")}} {{optional_inline}}, {{domxref("DOMQuad/p2", "p2")}} {{optional_inline}}, {{domxref("DOMQuad/p3", "p3")}} {{optional_inline}}, {{domxref("DOMQuad/p4", "p4")}} {{optional_inline}}
+      - : Each a {{domxref("DOMPoint")}} or an object with the same properties representing one corner of the quad.
 
     This object should usually be another {{domxref("DOMQuad")}} instance, or an existing object retrieved from some data storage. If you are creating this object from scratch, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor, which accepts the four points separately, avoiding creating the intermediate object.
 
@@ -68,5 +62,4 @@ console.log(newQuad.p2.x, newQuad.p2.y); // 50 0
 
 - {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor
 - {{domxref("DOMPoint")}}
-- {{domxref("DOMQuad.p1", "p1")}}, {{domxref("DOMQuad.p2", "p2")}}, {{domxref("DOMQuad.p3", "p3")}}, {{domxref("DOMQuad.p4", "p4")}}
 - {{domxref("DOMRect")}}

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -1,0 +1,104 @@
+---
+title: "DOMQuad: fromQuad() static method"
+short-title: fromQuad()
+slug: Web/API/DOMQuad/fromQuad_static
+page-type: web-api-static-method
+browser-compat: api.DOMQuad.fromQuad_static
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`fromQuad()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object or a set of quadrilateral coordinates based on the provided input.
+
+## Syntax
+
+```js-nolint
+DOMQuad.fromQuad()
+DOMQuad.fromQuad(quad)
+```
+
+### Parameters
+
+- `quad` {{optional_inline}}
+  - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. The object can contain the following properties:
+    - `p1` {{optional_inline}}
+      - : An object representing one corner of the quad.
+    - `p2` {{optional_inline}}
+      - : An object representing one corner of the quad.
+    - `p3` {{optional_inline}}
+      - : An object representing one corner of the quad.
+    - `p4` {{optional_inline}}
+      - : An object representing one corner of the quad.
+
+### Return value
+
+A {{domxref("DOMQuad")}} object.
+
+## Examples
+
+### Creating a quad from point objects
+
+This example creates a `DOMQuad` from four point objects.
+
+```js
+const quad = DOMQuad.fromQuad({
+  p1: { x: 10, y: 10 },
+  p2: { x: 100, y: 10 },
+  p3: { x: 100, y: 100 },
+  p4: { x: 10, y: 100 },
+});
+
+console.log(quad.p1); // DOMPoint {x: 10, y: 10, z: 0, w: 1}
+console.log(quad.p2); // DOMPoint {x: 100, y: 10, z: 0, w: 1}
+console.log(quad.p3); // DOMPoint {x: 100, y: 100, z: 0, w: 1}
+console.log(quad.p4); // DOMPoint {x: 10, y: 100, z: 0, w: 1}
+```
+
+### Creating a quad from an existing DOMQuad
+
+This example shows how to create a new `DOMQuad` from an existing one.
+
+```js
+const originalQuad = new DOMQuad(
+  { x: 0, y: 0 },
+  { x: 50, y: 0 },
+  { x: 50, y: 50 },
+  { x: 0, y: 50 },
+);
+
+const newQuad = DOMQuad.fromQuad(originalQuad);
+
+console.log(newQuad.p1.x, newQuad.p1.y); // 0 0
+console.log(newQuad.p2.x, newQuad.p2.y); // 50 0
+```
+
+### Creating a 3D quad
+
+This example creates a quad with 3D coordinates by specifying the z values.
+
+```js
+const quad3D = DOMQuad.fromQuad({
+  p1: { x: 0, y: 0, z: 10 },
+  p2: { x: 100, y: 0, z: 10 },
+  p3: { x: 100, y: 100, z: 20 },
+  p4: { x: 0, y: 100, z: 20 },
+});
+
+console.log(quad3D.p1.z); // 10
+console.log(quad3D.p3.z); // 20
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor
+- {{domxref("DOMPoint")}}
+- {{domxref("DOMQuad.p1", "p1")}}, {{domxref("DOMQuad.p2", "p2")}}, {{domxref("DOMQuad.p3", "p3")}}, {{domxref("DOMQuad.p4", "p4")}}
+- {{domxref("DOMRect")}}

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.fromQuad_static
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`fromQuad()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object or a set of quadrilateral coordinates based on the provided input.
+The **`fromQuad()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object based on the provided set of coordinates in the shape of another `DOMQuad` object.
 
 ## Syntax
 

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -20,7 +20,7 @@ DOMQuad.fromQuad(quad)
 ### Parameters
 
 - `quad` {{optional_inline}}
-  - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. This object should usually be another {{domxref("DOMQuad")}} instance. To manually construct the point properties, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor. The object can contain the following properties:
+  - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. The object can contain the following properties:
     - `p1` {{optional_inline}}
       - : A {{domxref("DOMPoint")}} representing one corner of the quad.
     - `p2` {{optional_inline}}

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -22,7 +22,7 @@ DOMQuad.fromQuad(quad)
 - `quad` {{optional_inline}}
   - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. The object can contain the following properties:
     - `p1` {{optional_inline}}
-      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
+      - : A {{domxref("DOMPoint")}} or an object with the same properties representing one corner of the quad.
     - `p2` {{optional_inline}}
       - : A {{domxref("DOMPoint")}} representing one corner of the quad.
     - `p3` {{optional_inline}}

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -20,39 +20,21 @@ DOMQuad.fromQuad(quad)
 ### Parameters
 
 - `quad` {{optional_inline}}
-  - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. The object can contain the following properties:
+  - : An object specifying the coordinates for the four corners of the quadrilateral. If not specified, all corners default to `(0, 0, 0, 1)`. This object should usually be another {{domxref("DOMQuad")}} instance. To manually construct the point properties, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor. The object can contain the following properties:
     - `p1` {{optional_inline}}
-      - : An object representing one corner of the quad.
+      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
     - `p2` {{optional_inline}}
-      - : An object representing one corner of the quad.
+      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
     - `p3` {{optional_inline}}
-      - : An object representing one corner of the quad.
+      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
     - `p4` {{optional_inline}}
-      - : An object representing one corner of the quad.
+      - : A {{domxref("DOMPoint")}} representing one corner of the quad.
 
 ### Return value
 
 A {{domxref("DOMQuad")}} object.
 
 ## Examples
-
-### Creating a quad from point objects
-
-This example creates a `DOMQuad` from four point objects.
-
-```js
-const quad = DOMQuad.fromQuad({
-  p1: { x: 10, y: 10 },
-  p2: { x: 100, y: 10 },
-  p3: { x: 100, y: 100 },
-  p4: { x: 10, y: 100 },
-});
-
-console.log(quad.p1); // DOMPoint {x: 10, y: 10, z: 0, w: 1}
-console.log(quad.p2); // DOMPoint {x: 100, y: 10, z: 0, w: 1}
-console.log(quad.p3); // DOMPoint {x: 100, y: 100, z: 0, w: 1}
-console.log(quad.p4); // DOMPoint {x: 10, y: 100, z: 0, w: 1}
-```
 
 ### Creating a quad from an existing DOMQuad
 
@@ -70,22 +52,6 @@ const newQuad = DOMQuad.fromQuad(originalQuad);
 
 console.log(newQuad.p1.x, newQuad.p1.y); // 0 0
 console.log(newQuad.p2.x, newQuad.p2.y); // 50 0
-```
-
-### Creating a 3D quad
-
-This example creates a quad with 3D coordinates by specifying the z values.
-
-```js
-const quad3D = DOMQuad.fromQuad({
-  p1: { x: 0, y: 0, z: 10 },
-  p2: { x: 100, y: 0, z: 10 },
-  p3: { x: 100, y: 100, z: 20 },
-  p4: { x: 0, y: 100, z: 20 },
-});
-
-console.log(quad3D.p1.z); // 10
-console.log(quad3D.p3.z); // 20
 ```
 
 ## Specifications

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -30,7 +30,7 @@ DOMQuad.fromQuad(quad)
     - `p4` {{optional_inline}}
       - : A {{domxref("DOMPoint")}} representing one corner of the quad.
 
-     This object should usually be another {{domxref("DOMQuad")}} instance, or an existing object retrieved from some data storage. If you are creating this object from scratch, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor, which accepts the four points separately, avoiding creating the intermediate object.
+    This object should usually be another {{domxref("DOMQuad")}} instance, or an existing object retrieved from some data storage. If you are creating this object from scratch, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor, which accepts the four points separately, avoiding creating the intermediate object.
 
 ### Return value
 

--- a/files/en-us/web/api/domquad/fromquad_static/index.md
+++ b/files/en-us/web/api/domquad/fromquad_static/index.md
@@ -30,6 +30,8 @@ DOMQuad.fromQuad(quad)
     - `p4` {{optional_inline}}
       - : A {{domxref("DOMPoint")}} representing one corner of the quad.
 
+     This object should usually be another {{domxref("DOMQuad")}} instance, or an existing object retrieved from some data storage. If you are creating this object from scratch, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor, which accepts the four points separately, avoiding creating the intermediate object.
+
 ### Return value
 
 A {{domxref("DOMQuad")}} object.

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -32,20 +32,6 @@ A {{domxref("DOMQuad")}} object.
 
 ## Examples
 
-### Creating a quad from a rectangle
-
-This example creates a `DOMQuad` from a rectangle object with position and dimensions.
-
-```js
-const rect = { x: 10, y: 20, width: 100, height: 50 };
-const quad = DOMQuad.fromRect(rect);
-
-console.log(quad.p1); // DOMPoint {x: 10, y: 20, z: 0, w: 1}
-console.log(quad.p2); // DOMPoint {x: 110, y: 20, z: 0, w: 1}
-console.log(quad.p3); // DOMPoint {x: 110, y: 70, z: 0, w: 1}
-console.log(quad.p4); // DOMPoint {x: 10, y: 70, z: 0, w: 1}
-```
-
 ### Creating a quad from DOMRect
 
 This example shows how to create a `DOMQuad` from a {{domxref("DOMRect")}} object.

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -32,6 +32,20 @@ A {{domxref("DOMQuad")}} object.
 
 ## Examples
 
+### Creating a quad from a rectangle
+
+This example creates a `DOMQuad` from a rectangle object with position and dimensions.
+
+```js
+const rect = { x: 10, y: 20, width: 100, height: 50 };
+const quad = DOMQuad.fromRect(rect);
+
+console.log(quad.p1); // DOMPoint {x: 10, y: 20, z: 0, w: 1}
+console.log(quad.p2); // DOMPoint {x: 110, y: 20, z: 0, w: 1}
+console.log(quad.p3); // DOMPoint {x: 110, y: 70, z: 0, w: 1}
+console.log(quad.p4); // DOMPoint {x: 10, y: 70, z: 0, w: 1}
+```
+
 ### Creating a quad from DOMRect
 
 This example shows how to create a `DOMQuad` from a {{domxref("DOMRect")}} object.

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -20,7 +20,7 @@ DOMQuad.fromRect(rect)
 ### Parameters
 
 - `rect` {{optional_inline}}
-  - : An object specifying the coordinates of a rectangle. All properties default to `0`. This object should usually be a {{domxref("DOMRect")}} or {{domxref("DOMRectReadOnly")}} instance. To manually construct the rectangle properties, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor. The properties are:
+  - : A {{domxref("DOMRect")}}, {{domxref("DOMRectReadOnly")}}, or an object with the same properties. All properties default to `0`. The properties are:
     - `x`: The x coordinate of the rectangle's origin (top-left corner).
     - `y`: The y coordinate of the rectangle's origin (top-left corner).
     - `width`: The width of the rectangle.

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.fromRect_static
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`fromRect()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object based on the provided set of coordinates in the shape of a `DOMRect` object.
+The **`fromRect()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object based on the provided set of coordinates in the shape of a {{domxref("DOMRect")}} object.
 
 ## Syntax
 
@@ -21,10 +21,14 @@ DOMQuad.fromRect(rect)
 
 - `rect` {{optional_inline}}
   - : A {{domxref("DOMRect")}}, {{domxref("DOMRectReadOnly")}}, or an object with the same properties. All properties default to `0`. The properties are:
-    - `x`: The x coordinate of the rectangle's origin (top-left corner).
-    - `y`: The y coordinate of the rectangle's origin (top-left corner).
-    - `width`: The width of the rectangle.
-    - `height`: The height of the rectangle.
+    - {{domxref("DOMRect/x", "x")}} {{optional_inline}}
+      - : The x coordinate of the rectangle's origin (top-left corner).
+    - {{domxref("DOMRect/y", "y")}} {{optional_inline}}
+      - : The y coordinate of the rectangle's origin (top-left corner).
+    - {{domxref("DOMRect/width", "width")}} {{optional_inline}}
+      - : The width of the rectangle.
+    - {{domxref("DOMRect/height", "height")}} {{optional_inline}}
+      - : The height of the rectangle.
 
 ### Return value
 
@@ -32,13 +36,12 @@ A {{domxref("DOMQuad")}} object.
 
 ## Examples
 
-### Creating a quad from a rectangle
+### Creating a rectangular quad
 
-This example creates a `DOMQuad` from a rectangle object with position and dimensions.
+This example creates a `DOMQuad` from scratch that happens to be rectangular. Using `fromRect()` is more convenient than using the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor.
 
 ```js
-const rect = { x: 10, y: 20, width: 100, height: 50 };
-const quad = DOMQuad.fromRect(rect);
+const quad = DOMQuad.fromRect({ x: 10, y: 20, width: 100, height: 50 });
 
 console.log(quad.p1); // DOMPoint {x: 10, y: 20, z: 0, w: 1}
 console.log(quad.p2); // DOMPoint {x: 110, y: 20, z: 0, w: 1}

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -1,0 +1,75 @@
+---
+title: "DOMQuad: fromRect() static method"
+short-title: fromRect()
+slug: Web/API/DOMQuad/fromRect_static
+page-type: web-api-static-method
+browser-compat: api.DOMQuad.fromRect_static
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`fromRect()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object based on the passed set of coordinates.
+
+## Syntax
+
+```js-nolint
+DOMQuad.fromRect()
+DOMQuad.fromRect(rect)
+```
+
+### Parameters
+
+- `rect` {{optional_inline}}
+  - : An object specifying the coordinates of a rectangle. All properties default to `0`. The properties are:
+    - `x`: The x coordinate of the rectangle's origin.
+    - `y`: The y coordinate of the rectangle's origin.
+    - `width`: The width of the rectangle.
+    - `height`: The height of the rectangle.
+
+### Return value
+
+A {{domxref("DOMQuad")}} object.
+
+## Examples
+
+### Creating a quad from a rectangle
+
+This example creates a `DOMQuad` from a rectangle object with position and dimensions.
+
+```js
+const rect = { x: 10, y: 20, width: 100, height: 50 };
+const quad = DOMQuad.fromRect(rect);
+
+console.log(quad.p1); // DOMPoint {x: 10, y: 20, z: 0, w: 1}
+console.log(quad.p2); // DOMPoint {x: 110, y: 20, z: 0, w: 1}
+console.log(quad.p3); // DOMPoint {x: 110, y: 70, z: 0, w: 1}
+console.log(quad.p4); // DOMPoint {x: 10, y: 70, z: 0, w: 1}
+```
+
+### Creating a quad from DOMRect
+
+This example shows how to create a `DOMQuad` from a {{domxref("DOMRect")}} object.
+
+```js
+const domRect = new DOMRect(50, 60, 200, 100);
+const quad = DOMQuad.fromRect(domRect);
+
+console.log(quad.p1); // DOMPoint {x: 50, y: 60, z: 0, w: 1}
+console.log(quad.p2); // DOMPoint {x: 250, y: 60, z: 0, w: 1}
+console.log(quad.p3); // DOMPoint {x: 250, y: 160, z: 0, w: 1}
+console.log(quad.p4); // DOMPoint {x: 50, y: 160, z: 0, w: 1}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor
+- {{domxref("DOMRect")}}
+- {{domxref("DOMPoint")}}

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -20,9 +20,9 @@ DOMQuad.fromRect(rect)
 ### Parameters
 
 - `rect` {{optional_inline}}
-  - : An object specifying the coordinates of a rectangle. All properties default to `0`. The properties are:
-    - `x`: The x coordinate of the rectangle's origin.
-    - `y`: The y coordinate of the rectangle's origin.
+  - : An object specifying the coordinates of a rectangle. All properties default to `0`. This object should usually be a {{domxref("DOMRect")}} or {{domxref("DOMRectReadOnly")}} instance. To manually construct the rectangle properties, you should use the {{domxref("DOMQuad.DOMQuad", "DOMQuad()")}} constructor. The properties are:
+    - `x`: The x coordinate of the rectangle's origin (top-left corner).
+    - `y`: The y coordinate of the rectangle's origin (top-left corner).
     - `width`: The width of the rectangle.
     - `height`: The height of the rectangle.
 

--- a/files/en-us/web/api/domquad/fromrect_static/index.md
+++ b/files/en-us/web/api/domquad/fromrect_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMQuad.fromRect_static
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`fromRect()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object based on the passed set of coordinates.
+The **`fromRect()`** static method of the {{domxref("DOMQuad")}} interface returns a new `DOMQuad` object based on the provided set of coordinates in the shape of a `DOMRect` object.
 
 ## Syntax
 

--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -34,10 +34,10 @@ A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbit
 
 ## Static methods
 
-- {{domxref("DOMQuad.fromRect_static", "DOMQuad.fromRect()")}}
-  - : Returns a new `DOMQuad` object based on the passed set of coordinates.
 - {{domxref("DOMQuad.fromQuad_static", "DOMQuad.fromQuad()")}}
-  - : Returns a new `DOMQuad` object or a set of quadrilateral coordinates based on the provided input.
+  - : Returns a new `DOMQuad` object based on the provided set of coordinates in the shape of another `DOMQuad` object.
+- {{domxref("DOMQuad.fromRect_static", "DOMQuad.fromRect()")}}
+  - : Returns a new `DOMQuad` object based on the provided set of coordinates in the shape of a {{domxref("DOMRect")}} object.
 
 ## Specifications
 


### PR DESCRIPTION
- Add documentation for DOMQuad.fromQuad()
- Add documentation for DOMQuad.fromRect()

These static methods allow creating DOMQuad objects from quadrilateral coordinates or rectangle coordinates.

Part of https://github.com/openwebdocs/project/issues/230