### PR TITLE
Add DOMMatrixReadOnly static method documentation

### DIFF
--- a/files/en-us/web/api/dommatrix/invertself/index.md
+++ b/files/en-us/web/api/dommatrix/invertself/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMMatrix.invertSelf
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`invertSelf()`** method of the {{domxref("DOMMatrix")}} interface inverts the original matrix. If the matrix cannot be inverted, the new matrix's components are all set to `NaN` and its {{domxref("DOMMatrixReadonly.is2D", "is2D")}} property is set to `false`.
+The **`invertSelf()`** method of the {{domxref("DOMMatrix")}} interface inverts the original matrix. If the matrix cannot be inverted, the new matrix's components are all set to `NaN` and its {{domxref("DOMMatrixReadOnly.is2D", "is2D")}} property is set to `false`.
 
 To invert a matrix without mutating it, see {{domxref("DOMMatrixReadOnly.inverse()")}}
 

--- a/files/en-us/web/api/dommatrix/rotateaxisangleself/index.md
+++ b/files/en-us/web/api/dommatrix/rotateaxisangleself/index.md
@@ -25,9 +25,9 @@ rotateAxisAngleSelf(rotX, rotY, rotZ, angle)
 ### Parameters
 
 - `rotX`
-  - : A number; the x-coordinate of the vector denoting the axis of rotation. If non-zero, {{domxref("DOMMatrixReadonly.is2D", "is2D")}} is false.
+  - : A number; the x-coordinate of the vector denoting the axis of rotation. If non-zero, {{domxref("DOMMatrixReadOnly.is2D", "is2D")}} is false.
 - `rotY` {{optional_inline}}
-  - : A number; the y-coordinate of the vector denoting the axis of rotation. If undefined, the `rotX` value is used. If non-zero, {{domxref("DOMMatrixReadonly.is2D", "is2D")}} is false.
+  - : A number; the y-coordinate of the vector denoting the axis of rotation. If undefined, the `rotX` value is used. If non-zero, {{domxref("DOMMatrixReadOnly.is2D", "is2D")}} is false.
 - `rotZ` {{optional_inline}}
   - : A number; the z-coordinate of the vector denoting the axis of rotation. If undefined, the `rotX` value is used.
 - `angle` {{optional_inline}}

--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMMatrixReadOnly.DOMMatrixReadOnly
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMMatrixReadOnly`** constructor creates a new {{domxref("DOMMatrixReadOnly")}} object which represents a 4x4 matrix, suitable for 2D and 3D operations.
+The **`DOMMatrixReadOnly()`** constructor creates a new {{domxref("DOMMatrixReadOnly")}} object which represents a 4x4 matrix, suitable for 2D and 3D operations.
 
 ## Syntax
 

--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
@@ -8,26 +8,57 @@ browser-compat: api.DOMMatrixReadOnly.DOMMatrixReadOnly
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`DOMMatrixReadOnly`** constructor creates a new
-{{domxref("DOMMatrixReadOnly")}} object which represents 4x4 matrices, suitable for 2D
-and 3D operations.
+The **`DOMMatrixReadOnly`** constructor creates a new {{domxref("DOMMatrixReadOnly")}} object which represents a 4x4 matrix, suitable for 2D and 3D operations.
 
 ## Syntax
 
 ```js-nolint
 DOMMatrixReadOnly()
-DOMMatrixReadOnly(init)
+DOMMatrixReadOnly(initString)
+DOMMatrixReadOnly(initArray)
 ```
 
 ### Parameters
 
-- `init` {{optional_inline}}
-  - : Either a string containing a sequence of numbers or an array of numbers
-    specifying the matrix you want to create.
+- `initString` {{optional_inline}}
+  - : A string representing a 2D or 3D matrix in CSS {{cssxref("transform-function/matrix", "matrix()")}} or {{cssxref("transform-function/matrix3d", "matrix3d()")}} format.
+- `initArray` {{optional_inline}}
+  - : An array containing either 6 or 16 numbers in column-major order. Other array lengths throw a {{jsxref("TypeError")}}.
+    - A 6-element array is interpreted as the matrix components `[m11, m12, m21, m22, m41, m42]`, creating a 2D matrix.
+    - A 16-element array is interpreted as the matrix components `[m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44]`, creating a 3D matrix.
 
-    In case an array of numbers is passed, the behavior depends on the length of the array:
-    - for a 6-element array of components in the form `[a, b, c, d, e, f]`, a 2D read-only matrix is created, initialized with the provided components.
-    - for a 16-element array of components (in the column-major order) in the form `[m11, m12, m13, …, m42, m43, m44]`, a 3D read-only matrix is created, initialized with the provided components.
+    If this argument is omitted, an identity matrix is created, i.e., equivalent to `[1, 0, 0, 1, 0, 0]`.
+
+    If this argument is provided as a {{jsxref("Float32Array")}} or {{jsxref("Float64Array")}}, consider using the more performant static methods {{domxref("DOMMatrixReadOnly.fromFloat32Array_static", "DOMMatrixReadOnly.fromFloat32Array()")}} or {{domxref("DOMMatrixReadOnly.fromFloat64Array_static", "DOMMatrixReadOnly.fromFloat64Array()")}} instead.
+
+### Return value
+
+A new {{domxref("DOMMatrixReadOnly")}} object.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the argument is not a string or an array with a length other than 6 or 16.
+- {{jsxref("SyntaxError")}}
+  - : Thrown if the string argument is not in a valid CSS {{cssxref("transform-function/matrix", "matrix()")}} or {{cssxref("transform-function/matrix3d", "matrix3d()")}} format.
+
+## Examples
+
+### Creating a DOMMatrixReadOnly from a string
+
+```js
+const matrixFromString = new DOMMatrixReadOnly("matrix(1, 0, 0, 1, 10, 20)");
+console.log(matrixFromString.toJSON());
+// Output: {a: 1, b: 0, c: 0, d: 1, e: 10, f: 20}
+```
+
+### Creating a DOMMatrixReadOnly from an array
+
+```js
+const matrixFromArray = new DOMMatrixReadOnly([1, 0, 0, 1, 10, 20]);
+console.log(matrixFromArray.toJSON());
+// Output: {a: 1, b: 0, c: 0, d: 1, e: 10, f: 20}
+```
 
 ## Specifications
 
@@ -36,3 +67,9 @@ DOMMatrixReadOnly(init)
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("DOMMatrixReadOnly.fromFloat32Array_static", "DOMMatrixReadOnly.fromFloat32Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromFloat64Array_static", "DOMMatrixReadOnly.fromFloat64Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromMatrix_static", "DOMMatrixReadOnly.fromMatrix()")}}

--- a/files/en-us/web/api/dommatrixreadonly/fromfloat32array_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/fromfloat32array_static/index.md
@@ -25,7 +25,12 @@ DOMMatrixReadOnly.fromFloat32Array(array)
 
 ### Return value
 
-A {{domxref("DOMMatrixReadonly")}} object.
+A {{domxref("DOMMatrixReadOnly")}} object.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the length of the `array` parameter is not 6 or 16.
 
 ## Examples
 
@@ -71,5 +76,8 @@ console.log(matrix3D.m41, matrix3D.m42, matrix3D.m43);
 
 ## See also
 
+- {{domxref("DOMMatrixReadOnly/DOMMatrixReadOnly", "DOMMatrixReadOnly()")}}
 - {{domxref("DOMMatrixReadOnly.toFloat32Array()")}}
 - {{domxref("DOMMatrixReadOnly.toFloat64Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromFloat64Array_static", "DOMMatrixReadOnly.fromFloat64Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromMatrix_static", "DOMMatrixReadOnly.fromMatrix()")}}

--- a/files/en-us/web/api/dommatrixreadonly/fromfloat32array_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/fromfloat32array_static/index.md
@@ -1,0 +1,75 @@
+---
+title: "DOMMatrixReadOnly: fromFloat32Array() static method"
+short-title: fromFloat32Array()
+slug: Web/API/DOMMatrixReadOnly/fromFloat32Array_static
+page-type: web-api-static-method
+browser-compat: api.DOMMatrixReadOnly.fromFloat32Array_static
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`fromFloat32Array()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new mutable {{domxref("DOMMatrix")}} object given an array of single-precision (32-bit) floating-point values.
+
+If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix.
+
+## Syntax
+
+```js-nolint
+DOMMatrixReadOnly.fromFloat32Array(array)
+```
+
+### Parameters
+
+- `array`
+  - : A {{jsxref("Float32Array")}}.
+
+### Return value
+
+A {{domxref("DOMMatrix")}} object.
+
+## Examples
+
+### Creating a 2D matrix from a Float32Array
+
+This example creates a 2D matrix from a 6-element `Float32Array`.
+
+```js
+const float32Array = new Float32Array([1, 0, 0, 1, 10, 20]);
+const matrix2D = DOMMatrixReadOnly.fromFloat32Array(float32Array);
+
+console.log(matrix2D.toString());
+// Output: matrix(1, 0, 0, 1, 10, 20)
+
+console.log(matrix2D.is2D);
+// Output: true
+```
+
+### Creating a 3D matrix from a Float32Array
+
+This example creates a 3D matrix from a 16-element `Float32Array`.
+
+```js
+const float32Array = new Float32Array([
+  1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1,
+]);
+const matrix3D = DOMMatrixReadOnly.fromFloat32Array(float32Array);
+
+console.log(matrix3D.is2D);
+// Output: false
+
+console.log(matrix3D.m41, matrix3D.m42, matrix3D.m43);
+// Output: 10 20 30
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMMatrixReadOnly.toFloat32Array()")}}
+- {{domxref("DOMMatrixReadOnly.toFloat64Array()")}}

--- a/files/en-us/web/api/dommatrixreadonly/fromfloat32array_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/fromfloat32array_static/index.md
@@ -8,9 +8,9 @@ browser-compat: api.DOMMatrixReadOnly.fromFloat32Array_static
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`fromFloat32Array()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new mutable {{domxref("DOMMatrix")}} object given an array of single-precision (32-bit) floating-point values.
+The **`fromFloat32Array()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new {{domxref("DOMMatrixReadOnly")}} object given an array of single-precision (32-bit) floating-point values.
 
-If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix.
+If the array has 6 values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 
 ## Syntax
 
@@ -21,11 +21,11 @@ DOMMatrixReadOnly.fromFloat32Array(array)
 ### Parameters
 
 - `array`
-  - : A {{jsxref("Float32Array")}}.
+  - : A {{jsxref("Float32Array")}} with 6 or 16 elements in column-major order.
 
 ### Return value
 
-A {{domxref("DOMMatrix")}} object.
+A {{domxref("DOMMatrixReadonly")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/dommatrixreadonly/fromfloat64array_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/fromfloat64array_static/index.md
@@ -25,7 +25,12 @@ DOMMatrixReadOnly.fromFloat64Array(array)
 
 ### Return value
 
-A {{domxref("DOMMatrixReadonly")}} object.
+A {{domxref("DOMMatrixReadOnly")}} object.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the length of the `array` parameter is not 6 or 16.
 
 ## Examples
 
@@ -34,17 +39,17 @@ A {{domxref("DOMMatrixReadonly")}} object.
 This example creates a 2D matrix from a 6-element `Float64Array`.
 
 ```js
-const float64Array = new Float64Array([1, 0, 0, 1, 100, 200]);
+const float64Array = new Float64Array([1, 0, 0, 1, 10, 20]);
 const matrix2D = DOMMatrixReadOnly.fromFloat64Array(float64Array);
 
 console.log(matrix2D.toString());
-// Output: matrix(1, 0, 0, 1, 100, 200)
+// Output: matrix(1, 0, 0, 1, 10, 20)
 
 console.log(matrix2D.is2D);
 // Output: true
 
 console.log(matrix2D.e, matrix2D.f);
-// Output: 100 200
+// Output: 10 20
 ```
 
 ### Creating a 3D matrix from a Float64Array
@@ -53,7 +58,7 @@ This example creates a 3D matrix from a 16-element `Float64Array`.
 
 ```js
 const float64Array = new Float64Array([
-  1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 50, 75, 100, 1,
+  1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1,
 ]);
 const matrix3D = DOMMatrixReadOnly.fromFloat64Array(float64Array);
 
@@ -61,7 +66,7 @@ console.log(matrix3D.is2D);
 // Output: false
 
 console.log(matrix3D.m41, matrix3D.m42, matrix3D.m43);
-// Output: 50 75 100
+// Output: 10 20 30
 ```
 
 ## Specifications
@@ -74,5 +79,8 @@ console.log(matrix3D.m41, matrix3D.m42, matrix3D.m43);
 
 ## See also
 
+- {{domxref("DOMMatrixReadOnly/DOMMatrixReadOnly", "DOMMatrixReadOnly()")}}
 - {{domxref("DOMMatrixReadOnly.toFloat32Array()")}}
 - {{domxref("DOMMatrixReadOnly.toFloat64Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromFloat32Array_static", "DOMMatrixReadOnly.fromFloat32Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromMatrix_static", "DOMMatrixReadOnly.fromMatrix()")}}

--- a/files/en-us/web/api/dommatrixreadonly/fromfloat64array_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/fromfloat64array_static/index.md
@@ -8,9 +8,9 @@ browser-compat: api.DOMMatrixReadOnly.fromFloat64Array_static
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`fromFloat64Array()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new mutable {{domxref("DOMMatrix")}} object given an array of double-precision (64-bit) floating-point values.
+The **`fromFloat64Array()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new {{domxref("DOMMatrixReadOnly")}} object given an array of double-precision (64-bit) floating-point values.
 
-If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix.
+If the array has 6 values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 
 ## Syntax
 
@@ -21,11 +21,11 @@ DOMMatrixReadOnly.fromFloat64Array(array)
 ### Parameters
 
 - `array`
-  - : A {{jsxref("Float64Array")}}.
+  - : A {{jsxref("Float64Array")}} with 6 or 16 elements in column-major order.
 
 ### Return value
 
-A {{domxref("DOMMatrix")}} object.
+A {{domxref("DOMMatrixReadonly")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/dommatrixreadonly/fromfloat64array_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/fromfloat64array_static/index.md
@@ -1,0 +1,78 @@
+---
+title: "DOMMatrixReadOnly: fromFloat64Array() static method"
+short-title: fromFloat64Array()
+slug: Web/API/DOMMatrixReadOnly/fromFloat64Array_static
+page-type: web-api-static-method
+browser-compat: api.DOMMatrixReadOnly.fromFloat64Array_static
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`fromFloat64Array()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new mutable {{domxref("DOMMatrix")}} object given an array of double-precision (64-bit) floating-point values.
+
+If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix.
+
+## Syntax
+
+```js-nolint
+DOMMatrixReadOnly.fromFloat64Array(array)
+```
+
+### Parameters
+
+- `array`
+  - : A {{jsxref("Float64Array")}}.
+
+### Return value
+
+A {{domxref("DOMMatrix")}} object.
+
+## Examples
+
+### Creating a 2D matrix from a Float64Array
+
+This example creates a 2D matrix from a 6-element `Float64Array`.
+
+```js
+const float64Array = new Float64Array([1, 0, 0, 1, 100, 200]);
+const matrix2D = DOMMatrixReadOnly.fromFloat64Array(float64Array);
+
+console.log(matrix2D.toString());
+// Output: matrix(1, 0, 0, 1, 100, 200)
+
+console.log(matrix2D.is2D);
+// Output: true
+
+console.log(matrix2D.e, matrix2D.f);
+// Output: 100 200
+```
+
+### Creating a 3D matrix from a Float64Array
+
+This example creates a 3D matrix from a 16-element `Float64Array`.
+
+```js
+const float64Array = new Float64Array([
+  1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 50, 75, 100, 1,
+]);
+const matrix3D = DOMMatrixReadOnly.fromFloat64Array(float64Array);
+
+console.log(matrix3D.is2D);
+// Output: false
+
+console.log(matrix3D.m41, matrix3D.m42, matrix3D.m43);
+// Output: 50 75 100
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMMatrixReadOnly.toFloat32Array()")}}
+- {{domxref("DOMMatrixReadOnly.toFloat64Array()")}}

--- a/files/en-us/web/api/dommatrixreadonly/frommatrix_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/frommatrix_static/index.md
@@ -1,0 +1,104 @@
+---
+title: "DOMMatrixReadOnly: fromMatrix() static method"
+short-title: fromMatrix()
+slug: Web/API/DOMMatrixReadOnly/fromMatrix_static
+page-type: web-api-static-method
+browser-compat: api.DOMMatrixReadOnly.fromMatrix_static
+---
+
+{{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
+
+The **`fromMatrix()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new mutable {{domxref("DOMMatrix")}} object given an existing matrix or an object which provides the values for its properties.
+
+## Syntax
+
+```js-nolint
+DOMMatrixReadOnly.fromMatrix()
+DOMMatrixReadOnly.fromMatrix(other)
+```
+
+### Parameters
+
+- `other` {{optional_inline}}
+  - : An existing matrix or an object providing the matrix values. If not specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
+
+    The object can contain any of the following properties:
+    - `m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`
+      - : Double-precision floating-point values representing each component of a 4×4 matrix, where `m11` through `m14` are the first column, `m21` through `m24` are the second column, and so forth.
+    - `a`, `b`, `c`, `d`, `e`, `f`
+      - : Double-precision floating-point values representing the components of a 4×4 matrix which are required in order to perform 2D rotations and translations. These are aliases for specific components of a 4×4 matrix: `a` = `m11`, `b` = `m12`, `c` = `m21`, `d` = `m22`, `e` = `m41`, `f` = `m42`.
+    - `is2D`
+      - : A Boolean flag whose value is `true` if the matrix was initialized as a 2D matrix. If `false`, the matrix is 3D.
+
+### Return value
+
+A {{domxref("DOMMatrix")}} object.
+
+## Examples
+
+### Creating a matrix from an object
+
+This example creates a `DOMMatrix` by providing matrix values in an object.
+
+```js
+const matrix = DOMMatrixReadOnly.fromMatrix({
+  a: 1,
+  b: 0,
+  c: 0,
+  d: 1,
+  e: 50,
+  f: 50,
+  is2D: true,
+});
+
+console.log(matrix.toString());
+// Output: matrix(1, 0, 0, 1, 50, 50)
+
+console.log(matrix.is2D);
+// Output: true
+```
+
+### Creating a matrix from an existing matrix
+
+This example creates a new `DOMMatrix` from an existing `DOMMatrixReadOnly`.
+
+```js
+const readOnlyMatrix = new DOMMatrixReadOnly([1, 0, 0, 1, 100, 100]);
+const mutableMatrix = DOMMatrixReadOnly.fromMatrix(readOnlyMatrix);
+
+console.log(mutableMatrix.toString());
+// Output: matrix(1, 0, 0, 1, 100, 100)
+
+// The returned matrix is mutable
+mutableMatrix.translateSelf(50, 25);
+
+console.log(mutableMatrix.toString());
+// Output: matrix(1, 0, 0, 1, 150, 125)
+```
+
+### Creating a default identity matrix
+
+This example shows how calling `fromMatrix()` with no arguments creates an identity matrix.
+
+```js
+const identityMatrix = DOMMatrixReadOnly.fromMatrix();
+
+console.log(identityMatrix.toString());
+// Output: matrix(1, 0, 0, 1, 0, 0)
+
+console.log(identityMatrix.isIdentity);
+// Output: true
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly()")}} constructor
+- {{domxref("DOMMatrix.DOMMatrix", "DOMMatrix()")}} constructor

--- a/files/en-us/web/api/dommatrixreadonly/frommatrix_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/frommatrix_static/index.md
@@ -20,27 +20,31 @@ DOMMatrixReadOnly.fromMatrix(other)
 ### Parameters
 
 - `other` {{optional_inline}}
-  - : An existing matrix or an object providing the matrix values. If not specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
-
-    This should usually be another {{domxref("DOMMatrix")}} or {{domxref("DOMMatrixReadOnly")}} instance. To manually construct the matrix properties, you should use the {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly()")}} constructor.
-
-    The object can contain any of the following properties:
-    - `m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`
-      - : Double-precision floating-point values representing each component of a 4×4 matrix, where `m11` through `m14` are the first column, `m21` through `m24` are the second column, and so forth.
-    - `a`, `b`, `c`, `d`, `e`, `f`
-      - : Double-precision floating-point values representing the components of a 4×4 matrix which are required in order to perform 2D rotations and translations. These are aliases for specific components of a 4×4 matrix: `a` = `m11`, `b` = `m12`, `c` = `m21`, `d` = `m22`, `e` = `m41`, `f` = `m42`.
+  - : A {{domxref("DOMMatrix")}}, {{domxref("DOMMatrixReadOnly")}}, or an object with the same properties. All properties default to `0`. The properties are:
     - `is2D`
-      - : A Boolean flag whose value is `true` if the matrix was initialized as a 2D matrix. If `false`, the matrix is 3D.
+      - : A boolean. `true` if the matrix should be created as a 2D matrix. Defaults to `false` if at least one of `m13`, `m14`, `m23`, `m24`, `m31`, `m32`, `m34`, or `m43` is non-zero, or at least one of `m33` or `m44` is not 1; otherwise, defaults to `true`.
+    - `m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`
+      - : Numbers representing each component of a 4×4 matrix, where `m11` through `m14` are the first column, `m21` through `m24` are the second column, and so forth. `m11`, `m22`, `m33`, and `m44` default to `1`, and all other components default to `0`.
+
+        If `is2D` is explicitly set to `true`, `m13`, `m14`, `m23`, `m24`, `m31`, `m32`, `m34`, or `m43` must either be omitted or set to `0`, and `m33` and `m44` must either be omitted or set to `1`.
+
+    - `a`, `b`, `c`, `d`, `e`, `f`
+      - : Aliases for `m11`, `m12`, `m21`, `m22`, `m41`, and `m42`, respectively, for convenience when initializing 2D matrices. If these aliases are provided with the `m` counterparts, their values must be equal.
 
 ### Return value
 
-A {{domxref("DOMMatrixReadonly")}} object.
+A {{domxref("DOMMatrixReadOnly")}} object.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the provided object's properties are inconsistent (for example, if both `a` and `m11` are provided but have different values).
 
 ## Examples
 
 ### Creating a matrix from an object
 
-This example creates a `DOMMatrixReadonly` by providing matrix values in an object.
+This example creates a `DOMMatrixReadOnly` by providing matrix values in an object.
 
 ```js
 const matrix = DOMMatrixReadOnly.fromMatrix({
@@ -65,17 +69,11 @@ console.log(matrix.is2D);
 This example creates a new `DOMMatrixReadOnly` from an existing `DOMMatrixReadOnly`.
 
 ```js
-const readOnlyMatrix = new DOMMatrixReadOnly([1, 0, 0, 1, 100, 100]);
-const mutableMatrix = DOMMatrixReadOnly.fromMatrix(readOnlyMatrix);
+const matrix1 = new DOMMatrixReadOnly([1, 0, 0, 1, 100, 100]);
+const matrix2 = DOMMatrixReadOnly.fromMatrix(matrix1);
 
-console.log(mutableMatrix.toString());
+console.log(matrix2.toString());
 // Output: matrix(1, 0, 0, 1, 100, 100)
-
-// The returned matrix is mutable
-mutableMatrix.translateSelf(50, 25);
-
-console.log(mutableMatrix.toString());
-// Output: matrix(1, 0, 0, 1, 150, 125)
 ```
 
 ### Creating a default identity matrix
@@ -103,4 +101,5 @@ console.log(identityMatrix.isIdentity);
 ## See also
 
 - {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly()")}} constructor
-- {{domxref("DOMMatrix.DOMMatrix", "DOMMatrix()")}} constructor
+- {{domxref("DOMMatrixReadOnly.fromFloat32Array_static", "DOMMatrixReadOnly.fromFloat32Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromFloat64Array_static", "DOMMatrixReadOnly.fromFloat64Array()")}}

--- a/files/en-us/web/api/dommatrixreadonly/frommatrix_static/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/frommatrix_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DOMMatrixReadOnly.fromMatrix_static
 
 {{APIRef("Geometry Interfaces")}}{{AvailableInWorkers}}
 
-The **`fromMatrix()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new mutable {{domxref("DOMMatrix")}} object given an existing matrix or an object which provides the values for its properties.
+The **`fromMatrix()`** static method of the {{domxref("DOMMatrixReadOnly")}} interface creates a new {{domxref("DOMMatrixReadOnly")}} object given an existing matrix or an object which provides the values for its properties.
 
 ## Syntax
 
@@ -22,6 +22,8 @@ DOMMatrixReadOnly.fromMatrix(other)
 - `other` {{optional_inline}}
   - : An existing matrix or an object providing the matrix values. If not specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
 
+    This should usually be another {{domxref("DOMMatrix")}} or {{domxref("DOMMatrixReadOnly")}} instance. To manually construct the matrix properties, you should use the {{domxref("DOMMatrixReadOnly.DOMMatrixReadOnly", "DOMMatrixReadOnly()")}} constructor.
+
     The object can contain any of the following properties:
     - `m11`, `m12`, `m13`, `m14`, `m21`, `m22`, `m23`, `m24`, `m31`, `m32`, `m33`, `m34`, `m41`, `m42`, `m43`, `m44`
       - : Double-precision floating-point values representing each component of a 4×4 matrix, where `m11` through `m14` are the first column, `m21` through `m24` are the second column, and so forth.
@@ -32,13 +34,13 @@ DOMMatrixReadOnly.fromMatrix(other)
 
 ### Return value
 
-A {{domxref("DOMMatrix")}} object.
+A {{domxref("DOMMatrixReadonly")}} object.
 
 ## Examples
 
 ### Creating a matrix from an object
 
-This example creates a `DOMMatrix` by providing matrix values in an object.
+This example creates a `DOMMatrixReadonly` by providing matrix values in an object.
 
 ```js
 const matrix = DOMMatrixReadOnly.fromMatrix({
@@ -60,7 +62,7 @@ console.log(matrix.is2D);
 
 ### Creating a matrix from an existing matrix
 
-This example creates a new `DOMMatrix` from an existing `DOMMatrixReadOnly`.
+This example creates a new `DOMMatrixReadOnly` from an existing `DOMMatrixReadOnly`.
 
 ```js
 const readOnlyMatrix = new DOMMatrixReadOnly([1, 0, 0, 1, 100, 100]);

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -82,11 +82,11 @@ _This interface doesn't inherit any methods. None of the following methods alter
 ## Static methods
 
 - {{domxref("DOMMatrixReadOnly.fromFloat32Array_static", "fromFloat32Array()")}}
-  - : Creates a new `DOMMatrixReadonly` object given an array of single-precision (32-bit) floating-point values. If the array has 6 values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
+  - : Creates a new `DOMMatrixReadOnly` object given a {{jsxref("Float32Array")}} of 6 or 16 single-precision (32-bit) floating-point values.
 - {{domxref("DOMMatrixReadOnly.fromFloat64Array_static", "fromFloat64Array()")}}
-  - : Creates a new `DOMMatrixReadonly` object given an array of double-precision (64-bit) floating-point values. If the array has 6 values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
+  - : Creates a new `DOMMatrixReadOnly` object given a {{jsxref("Float64Array")}} of 6 or 16 double-precision (64-bit) floating-point values.
 - {{domxref("DOMMatrixReadOnly.fromMatrix_static", "fromMatrix()")}}
-  - : Creates a new `DOMMatrixReadonly` object given an existing matrix or an object which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
+  - : Creates a new `DOMMatrixReadOnly` object given an existing matrix or an object which provides the values for its properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -82,11 +82,11 @@ _This interface doesn't inherit any methods. None of the following methods alter
 ## Static methods
 
 - {{domxref("DOMMatrixReadOnly.fromFloat32Array_static", "fromFloat32Array()")}}
-  - : Creates a new mutable `DOMMatrix` object given an array of single-precision (32-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
+  - : Creates a new `DOMMatrixReadonly` object given an array of single-precision (32-bit) floating-point values. If the array has 6 values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrixReadOnly.fromFloat64Array_static", "fromFloat64Array()")}}
-  - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
+  - : Creates a new `DOMMatrixReadonly` object given an array of double-precision (64-bit) floating-point values. If the array has 6 values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrixReadOnly.fromMatrix_static", "fromMatrix()")}}
-  - : Creates a new mutable `DOMMatrix` object given an existing matrix or an object which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
+  - : Creates a new `DOMMatrixReadonly` object given an existing matrix or an object which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
 
 ## Specifications
 

--- a/files/en-us/web/api/dompointreadonly/matrixtransform/index.md
+++ b/files/en-us/web/api/dompointreadonly/matrixtransform/index.md
@@ -10,7 +10,7 @@ browser-compat: api.DOMPointReadOnly.matrixTransform
 
 The **`matrixTransform()`** method of the {{domxref("DOMPointReadOnly")}} interface applies a matrix transform specified as an object to the DOMPointReadOnly object, creating and returning a new `DOMPointReadOnly` object. Neither the matrix nor the point are altered.
 
-If the matrix passed as a parameter is 2D (the {{domxref("DOMMatrixReadonly.is2D", "is2D")}} is `true`) then this is a 2D transformation and the point's `z` coordinate will be `0` and point's `w` perspective will be `1`. Otherwise this is a 3D transformation.
+If the matrix passed as a parameter is 2D (the {{domxref("DOMMatrixReadOnly.is2D", "is2D")}} is `true`) then this is a 2D transformation and the point's `z` coordinate will be `0` and point's `w` perspective will be `1`. Otherwise this is a 3D transformation.
 
 You can also create a new `DOMPoint` with a point and matrix with the {{domxref("DOMMatrixReadOnly.transformPoint()")}} method.
 


### PR DESCRIPTION
- Add documentation for DOMMatrixReadOnly.fromFloat32Array()
- Add documentation for DOMMatrixReadOnly.fromFloat64Array()
- Add documentation for DOMMatrixReadOnly.fromMatrix()

Part of https://github.com/openwebdocs/project/issues/230

