### PR TITLE
Update "See also" for at-rule functions

### DIFF
--- a/files/en-us/web/css/@import/layer_function/index.md
+++ b/files/en-us/web/css/@import/layer_function/index.md
@@ -32,4 +32,5 @@ The `framework.themes.dark` is the layer into which the CSS file would be import
 ## See also
 
 - {{CSSxRef("@import")}}
+- [CSS at-rule functions](/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions)
 - [CSS cascading and inheritance](/en-US/docs/Web/CSS/CSS_cascade) module

--- a/files/en-us/web/css/css_syntax/at-rule_functions/index.md
+++ b/files/en-us/web/css/css_syntax/at-rule_functions/index.md
@@ -57,4 +57,5 @@ The {{CSSxRef("@container")}} at-rule is used to specify styles for a containmen
 
 ## See also
 
+- [CSS at-rules](/en-US/docs/Web/CSS/CSS_syntax/At-rule)
 - [CSS syntax](/en-US/docs/Web/CSS/CSS_syntax) module


### PR DESCRIPTION
### Description

- The `layer()` function page is missing a "See also" link to the page describing [at-rule functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_syntax/At-rule_functions).
- The at-rule functions page is missing a "See also" link to the [at-rules](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_syntax/At-rule) page.