### PR TITLE
Bug 1954524 data collection permissions key in manifest doc and RN

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -62,7 +62,7 @@ The `gecko` sub-key supports these properties:
     - `required`
       - : The data that the extension requires to be collected and transmitted for its operation. Must contain the value `none`, or one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`, `searchTerms`, `websiteActivity`, or `websiteContent`.
     - `optional` {{optional_inline}}
-      - : The data that the user can opt to provide. Can contain one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`, `searchTerms`, `websiteActivity`, or `websiteContent`.
+      - : The data that the user can opt to provide. Can contain one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`, `searchTerms`, `technicalAndInteraction`, `websiteActivity`, or `websiteContent`.
 
   - : For more information, see the Extension Workshop article [Firefox built-in consent for data collection and transmission](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/).
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -55,6 +55,8 @@ Firefox stores browser-specific settings in these sub-keys:
 
 The `gecko` sub-key supports these properties:
 
+- `data_collection_permissions`
+  - : The optional and required data types that the extension collects and transmits for storage and processing outside the extension. For more information, see the Extension Workshop article [Firefox built-in consent for data collection and transmission](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/).
 - `id`
   - : The extension ID. When provided, this property must contain 80 characters or less. See [Extensions and the Add-on ID](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/) to determine when to specify the ID.
 - `strict_min_version`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -60,11 +60,12 @@ The `gecko` sub-key supports these properties:
 - `data_collection_permissions`
   - : The optional and required data types that the extension collects and transmits for storage and processing outside the extension. These are represented by the properties:
     - `required`
-      - : The data that the extension requires to be collected and transmitted for its operation. Must contain the value `none`, or one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`,  `searchTerms`, `websiteActivity`, or `websiteContent`.
+      - : The data that the extension requires to be collected and transmitted for its operation. Must contain the value `none`, or one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`, `searchTerms`, `websiteActivity`, or `websiteContent`.
     - `optional` {{optional_inline}}
-      - : The data that the user can opt to provide. Can contain one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`,  `searchTerms`, `websiteActivity`, or `websiteContent`.
+      - : The data that the user can opt to provide. Can contain one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`, `searchTerms`, `websiteActivity`, or `websiteContent`.
 
   - : For more information, see the Extension Workshop article [Firefox built-in consent for data collection and transmission](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/).
+
 - `id`
   - : The extension ID. When provided, this property must contain 80 characters or less. See [Extensions and the Add-on ID](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/) to determine when to specify the ID.
 - `strict_min_version`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -15,12 +15,14 @@ sidebar: addonsidebar
     <tr>
       <th scope="row">Mandatory</th>
       <td>
-        Usually, no (but see also
+        Must be provided with details specified for <a href="#data_collection_permissions"><code>browser_specific_settings.gecko.data_collection_permissions</code></a> for new extension submitted to addons.mozilla.org from November 3, 2025.
+        <br/>
+        Otherwise, usually not required (but see also
         <a
           href="https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when-do-you-need-an-add-on-id"
           >When do you need an Add-on ID?</a
         >). Mandatory if the extension ID cannot be determined, see
-        <a href="#firefox_gecko_properties"
+        <a href="#id"
           ><code>browser_specific_settings.gecko.id</code></a
         >.
       </td>
@@ -56,7 +58,13 @@ Firefox stores browser-specific settings in these sub-keys:
 The `gecko` sub-key supports these properties:
 
 - `data_collection_permissions`
-  - : The optional and required data types that the extension collects and transmits for storage and processing outside the extension. For more information, see the Extension Workshop article [Firefox built-in consent for data collection and transmission](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/).
+  - : The optional and required data types that the extension collects and transmits for storage and processing outside the extension. These are represented by the properties:
+    - `required`
+      - : The data that the extension requires to be collected and transmitted for its operation. Must contain the value `none`, or one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`,  `searchTerms`, `websiteActivity`, or `websiteContent`.
+    - `optional` {{optional_inline}}
+      - : The data that the user can opt to provide. Can contain one or more of `authenticationInfo`, `bookmarksInfo`, `browsingActivity`, `financialAndPaymentInfo`, `healthInfo`, `locationInfo`, `personalCommunications`, `personallyIdentifyingInfo`,  `searchTerms`, `websiteActivity`, or `websiteContent`.
+
+  - : For more information, see the Extension Workshop article [Firefox built-in consent for data collection and transmission](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/).
 - `id`
   - : The extension ID. When provided, this property must contain 80 characters or less. See [Extensions and the Add-on ID](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/) to determine when to specify the ID.
 - `strict_min_version`

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -74,6 +74,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - Support added for `unspecified` in {{WebExtAPIRef("cookies.SameSiteStatus")}}. In addition, `unspecified` is now the default value for `sameSite` in {{WebExtAPIRef("cookies.set()")}}. ([Firefox bug 1550032](https://bugzil.la/1550032))
+- Added the `data_collection_permissions` property to the `gecko` sub-key of the manifest key [`browser_specific_settings`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) for Firefox for desktop. This property enables the Firefox built-in data collection consent feature. See the Extension Workshop article [Firefox built-in consent for data collection and transmission](http://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/). ([Firefox bug 1954524](https://bugzil.la/1954524))
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/140/index.md
+++ b/files/en-us/mozilla/firefox/releases/140/index.md
@@ -74,7 +74,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - Support added for `unspecified` in {{WebExtAPIRef("cookies.SameSiteStatus")}}. In addition, `unspecified` is now the default value for `sameSite` in {{WebExtAPIRef("cookies.set()")}}. ([Firefox bug 1550032](https://bugzil.la/1550032))
-- Added the `data_collection_permissions` property to the `gecko` sub-key of the manifest key [`browser_specific_settings`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) for Firefox for desktop. This property enables the Firefox built-in data collection consent feature. See the Extension Workshop article [Firefox built-in consent for data collection and transmission](http://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/). ([Firefox bug 1954524](https://bugzil.la/1954524))
+- Added the `data_collection_permissions` property to the `gecko` sub-key of the manifest key [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) for Firefox for desktop. This property enables the Firefox built-in data collection consent feature. See the Extension Workshop article [Firefox built-in consent for data collection and transmission](http://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/). ([Firefox bug 1954524](https://bugzil.la/1954524))
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -77,6 +77,7 @@ No notable changes.
 - The {{WebExtAPIRef("cookies")}} methods now accept and return milliseconds in the fractional part of `expirationDate`. ([Firefox bug 1972757](https://bugzil.la/1972757))
 - Adds the {{WebExtAPIRef("browserAction.onUserSettingsChanged")}} and {{WebExtAPIRef("action.onUserSettingsChanged")}} events that listen for changes in the user-specified settings that affect an extension's action. ([Firefox bug 1828220](https://bugzil.la/1828220))
 - Adds {{WebExtAPIRef("browserSettings.verticalTabs")}}, which enables extensions to control whether the browser displays the tab bar horizontally or vertically. ([Firefox bug 1946600](https://bugzil.la/1946600))
+- Enabled the Firefox built-in data collection consent feature for Firefox for Android. See the Extension Workshop article [Firefox built-in consent for data collection and transmission](http://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/). ([Firefox bug 1954524](https://bugzil.la/1954524))
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Documents the `data_collection_permissions` property of the `gecko` sub-key of the manifest key `browser_specific_settings` introduced by [Bug 1954524](https://bugzilla.mozilla.org/show_bug.cgi?id=1954524) Add support for data collection permissions in the manifest.

### Related issues and pull requests

BCD compatibility changes in PR https://github.com/mdn/browser-compat-data/pull/28276

Fixes #41555
