### PR TITLE
Specify default offset of Range objects

### DIFF
--- a/files/en-us/web/api/document/createrange/index.md
+++ b/files/en-us/web/api/document/createrange/index.md
@@ -9,7 +9,8 @@ browser-compat: api.Document.createRange
 {{APIRef("DOM")}}
 
 The **`Document.createRange()`** method returns a new
-{{domxref("Range")}} object.
+{{domxref("Range")}} object whose start and end is offset 0 of the {{domxref("Document")}}
+object on which it was called.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/createrange/index.md
+++ b/files/en-us/web/api/document/createrange/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Document.createRange
 {{APIRef("DOM")}}
 
 The **`Document.createRange()`** method returns a new
-{{domxref("Range")}} object whose start and end is offset 0 of the {{domxref("Document")}}
+{{domxref("Range")}} object whose start and end are offset 0 of the {{domxref("Document")}}
 object on which it was called.
 
 ## Syntax

--- a/files/en-us/web/api/range/range/index.md
+++ b/files/en-us/web/api/range/range/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Range.Range
 {{ APIRef("DOM") }}
 
 The **`Range()`** constructor returns a newly created
-{{domxref("Range")}} object whose start and end is the global {{domxref("Document")}}
+{{domxref("Range")}} object whose start and end is offset 0 of the the global {{domxref("Window/document", "document")}}
 object.
 
 ## Syntax

--- a/files/en-us/web/api/range/range/index.md
+++ b/files/en-us/web/api/range/range/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Range.Range
 {{ APIRef("DOM") }}
 
 The **`Range()`** constructor returns a newly created
-{{domxref("Range")}} object whose start and end is offset 0 of the the global {{domxref("Window/document", "document")}}
+{{domxref("Range")}} object whose start and end are offset 0 of the the global {{domxref("Window/document", "document")}}
 object.
 
 ## Syntax


### PR DESCRIPTION
### Description

Specify default offset of Range objects.

### Motivation

Current wording is ambiguous — "start and end is the global document object" could also reasonably mean that `startOffset = 0` and `endOffset = document.childNodes.length`, whereas in fact both start and end are `0`.