### PR TITLE
chore: migrate GitHub team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,37 +3,37 @@
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owners
-* @mdn/core-yari-content
+* @mdn/content-team
 
 # Default content owners
-/files/en-us/ @mdn/yari-content-mdn
+/files/en-us/ @mdn/web
 
 # MDN Firefox release notes
-/files/en-us/mozilla/ @mdn/core-yari-content
+/files/en-us/mozilla/ @mdn/content-team
 
 # Mozilla Add-ons
-/files/en-us/mozilla/add-ons/ @mdn/yari-content-mozilla-add-ons
+/files/en-us/mozilla/add-ons/ @mdn/add-ons
 
 # Accessibility
-/files/en-us/web/accessibility/ @mdn/yari-content-accessibility
+/files/en-us/web/accessibility/ @mdn/accessibility
 
 # Web API
-/files/en-us/web/api/ @mdn/yari-content-web-api
+/files/en-us/web/api/ @mdn/web-api
 
 # CSS
-/files/en-us/web/css/ @mdn/yari-content-css
+/files/en-us/web/css/ @mdn/css
 
 # HTML
-/files/en-us/web/html/ @mdn/yari-content-html
+/files/en-us/web/html/ @mdn/web
 
 # HTTP
-/files/en-us/web/http/ @mdn/yari-content-http
+/files/en-us/web/http/ @mdn/http
 
 # JavaScript
-/files/en-us/web/javascript/ @mdn/yari-content-javascript
+/files/en-us/web/javascript/ @mdn/javascript
 
 # MathML
-/files/en-us/web/mathml/ @mdn/content-mathml
+/files/en-us/web/mathml/ @mdn/mathml
 
 # Templates and sidebars (rari)
 /files/jsondata/L10n-Template.json @mdn/engineering
@@ -45,12 +45,12 @@
 # mdn/content GitHub configuration
 /.github/ @mdn/engineering
 # Issue templates in .github
-/.github/ISSUE_TEMPLATE/ff-project-issue.md @mdn/core-yari-content
+/.github/ISSUE_TEMPLATE/ff-project-issue.md @mdn/content-team
 
 # Root directory
 /* @mdn/engineering
 # Markdown files in root directory
-/*.md @mdn/core-yari-content
+/*.md @mdn/content-team
 # Filecheck
 /scripts @mdn/engineering
 

--- a/files/en-us/mdn/community/getting_started/index.md
+++ b/files/en-us/mdn/community/getting_started/index.md
@@ -46,7 +46,7 @@ We need your technical expertise, and we'll help polish your English in order to
 
 ## Choosing what to work on and getting started
 
-Once you've decided what sort of task you want to work on, it is time to head over to the [contributors task board](https://github.com/orgs/mdn/projects/25/views/1), pick an issue, and let us know by commenting on the issue and tagging the `@mdn/mdn-community-engagement` team.
+Once you've decided what sort of task you want to work on, it is time to head over to the [contributors task board](https://github.com/orgs/mdn/projects/25/views/1), pick an issue, and let us know by commenting on the issue and tagging the `@mdn/community` team.
 Someone from the team will respond with some comments, hints, or guidance.
 
 Make sure you're not working on something that's already in-progress - it can be frustrating to duplicate or lose work.


### PR DESCRIPTION
### Description

Migrates GitHub team references to their new names, e.g.:
- `@mdn/core-dev` → `@mdn/engineering`
- `@mdn/core-yari-content` → `@mdn/content-team`

### Motivation

Teams have been renamed for clarity.

### Additional details

All references have been automatically updated to use the new team names.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1001.