### PR TITLE
docs: clarify responseStart behavior for canceled requests in Performance API

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -17,6 +17,7 @@ The `responseStart` property can have the following values:
 - A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the first byte of the response from the server.
 - `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
+- `0` if the resource is a canceled request.
 
 ## Examples
 


### PR DESCRIPTION
### Description
Clarifies in the Performance API documentation that canceled HTTP requests are still recorded as performance entries, but their `responseStart` timestamp will be 0. This update helps developers avoid calculation errors when analyzing performance metrics for canceled requests.
