### PR TITLE
docs: clarify requestStart behavior for canceled requests in Performance API

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -19,6 +19,7 @@ The `requestStart` property can have the following values:
 - A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the browser starts requesting the resource from the server.
 - `0` if the resource was instantaneously retrieved from a cache.
 - `0` if the resource is a cross-origin request and no {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header is used.
+- `0` if the resource is a canceled request.
 
 When the {{domxref("PerformanceResourceTiming.firstInterimResponseStart", "firstInterimResponseStart")}} is non-zero, that indicates it should be the same value as `requestStart` for [supporting browsers](#browser_compatibility).
 


### PR DESCRIPTION
### Description

Clarifies in the Performance API documentation that canceled HTTP requests are still recorded as performance entries, but their `requestStart` timestamp will be 0. This update helps developers avoid calculation errors when analyzing performance metrics for canceled requests.