### PR TITLE
Improve parameter documentation of `transferFromImageBitmap()`

### DIFF
--- a/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.md
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.md
@@ -25,7 +25,7 @@ transferFromImageBitmap(bitmap)
 ### Parameters
 
 - `bitmap`
-  - : An {{domxref("ImageBitmap")}} object to transfer.
+  - : An {{domxref("ImageBitmap")}} object to transfer, or `null`. If the value is `null`, the canvas is reset to blank.
 
 ### Return value
 


### PR DESCRIPTION
### Description

Methods to blank a canvas with a `bitmaprenderer` context aren't obvious while reading MDN, according to the spec a `null` bitmap is the way to go.

### Motivation

This conveys a way to clear the canvas directly from the main drawing method.

### Additional details

[Web reference link](https://html.spec.whatwg.org/multipage/canvas.html#dom-imagebitmaprenderingcontext-transferfromimagebitmap)
