### PR TITLE
Remove extension enum value runtime.PlatformOs.FUCHSIA

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -26,8 +26,6 @@ Values of this type are strings. Possible values are:
   - : The underlying operating system is Linux.
 - `"openbsd"`
   - : The underlying operating system is Open/FreeBSD.
-- `"fuchsia"`
-  - : The underlying operating system is Fuchsia.
 
 {{WebExtExamples}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Remove extension API enum value `runtime.PlatformOs.FUCHSIA`.

### Motivation

No official browser build ever supported extensions on Fuchsia. Chromium 141 deprecated extension support on Fuchsia and removed the corresponding enum value[1].

### Additional details

[1] https://github.com/chromium/chromium/commit/77a4f5f4cad2256b66df05c9feac474a74b1ff74

### Related issues and pull requests

N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
