### PR TITLE
fix: correct reference from WeakMap to Map in has() method description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/has/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Map.has
 sidebar: jsref
 ---
 
-The **`has()`** method of {{jsxref("WeakMap")}} instances returns a boolean indicating whether an entry with the specified key exists in this `WeakMap` or not.
+The **`has()`** method of {{jsxref("Map")}} instances returns a boolean indicating whether an entry with the specified key exists in this `Map` or not.
 
 {{InteractiveExample("JavaScript Demo: Map.prototype.has()")}}
 


### PR DESCRIPTION
- :memo: Updated the documentation for the `has()` method to reference `Map` instead of `WeakMap`.