### PR TITLE
Add note for exiting the text input example editor with keyboard

### DIFF
--- a/files/en-us/web/html/reference/elements/input/text/index.md
+++ b/files/en-us/web/html/reference/elements/input/text/index.md
@@ -37,6 +37,9 @@ label {
 }
 ```
 
+> [!NOTE]
+> To exit the editor above using your keyboard, press `Esc`, then press the `Tab` key.
+
 ## Value
 
 The [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) attribute is a string that contains the current value of the text entered into the text field. You can retrieve this using the {{domxref("HTMLInputElement")}} `value` property in JavaScript.


### PR DESCRIPTION
### Description

#### Changes

- Add note for exiting the text input example editor with keyboard

### Screenshots

### Before

<img width="1536" height="862" alt="image" src="https://github.com/user-attachments/assets/e7e92c73-2147-4aad-ab64-099fea146988" />

### After

<img width="1536" height="1018" alt="image" src="https://github.com/user-attachments/assets/5c6dc4b5-0027-4d83-aca6-6edc56d4a324" />


### Related issues and pull requests

- https://github.com/mdn/fred/issues/983