### PR TITLE
Fix `checkVisibility` example typo `display: content` -> `contents`

### DIFF
--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -72,7 +72,7 @@ The first (default selected) values should result in `checkVisibility()` returni
 <select id="css_display" name="css_display">
   <option value="block" selected>display: block</option>
   <option value="none">display: none</option>
-  <option value="content">display: content</option>
+  <option value="contents">display: contents</option>
 </select>
 
 <select id="css_content_visibility" name="css_content_visibility">


### PR DESCRIPTION
### Description

Fix typo in `Element#checkVisibility` example `display: content` -> `display: contents`.

### Motivation

The live example currently doesn't properly demonstrate the intended behavior due to the typo. Setting `elementToCheck.style.display` to the invalid value `"content"` is a no-op, so it just remains as whatever the previous selection was.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/CSS/display#contents