### PR TITLE
Document ARIA attributes for SVG element

### DIFF
--- a/files/en-us/web/svg/reference/element/svg/index.md
+++ b/files/en-us/web/svg/reference/element/svg/index.md
@@ -17,7 +17,7 @@ The **`<svg>`** [SVG](/en-US/docs/Web/SVG) element is a container that defines a
 
 ## Attributes
 
-This element's attributes include the ARIA [role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) attribute and various [aria-*](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes) attributes.
+This element's attributes include the ARIA [role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) attribute and various [aria-\*](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes) attributes.
 
 - {{SVGAttr("baseProfile")}} {{deprecated_inline}}
   - : The minimum SVG language profile that the document requires.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Documents that various ARIA-attributes are valid for the `<svg>` element.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It is not clear on this page if the `<svg>` element supports any other attributes than the ones listed. Most other pages have something along the lines of:

> This element's attributes include the [global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes).

(see e.g. [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#attributes),  [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div#attributes))

I saw some examples on MDN (e.g. on the [`aria-label` page](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)) use ARIA labels on the `<svg>` element, but it's not clear on this page if this is supported or not. I had to go into the specification to find out.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

The ARIA-attributes are listed as supported in the [specification](https://svgwg.org/svg2-draft/struct.html#SVGElement).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
None
