### PR TITLE
ci(workflows): run lint/checks on all PRs

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,8 +2,6 @@ name: Markdownlint (All files)
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .markdownlint-cli2.jsonc
       - .nvmrc

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -2,8 +2,6 @@ name: Lint and review content files
 
 on:
   pull_request_target:
-    branches:
-      - main
     paths:
       - .nvmrc
       - "*.md"

--- a/.github/workflows/pr-check_cspell_lists.yml
+++ b/.github/workflows/pr-check_cspell_lists.yml
@@ -2,8 +2,6 @@ name: Check cSpell lists
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .vscode/dictionaries/*
 

--- a/.github/workflows/pr-check_javascript.yml
+++ b/.github/workflows/pr-check_javascript.yml
@@ -2,8 +2,6 @@ name: JavaScript lint
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - "**/*.js"

--- a/.github/workflows/pr-check_json.yml
+++ b/.github/workflows/pr-check_json.yml
@@ -2,8 +2,6 @@ name: JSON lint
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - "**/*.json"

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -2,8 +2,6 @@ name: Check Redirects
 
 on:
   pull_request:
-    branches:
-      - main
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -2,8 +2,6 @@ name: Check scripts
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - package.json

--- a/.github/workflows/pr-check_url-issues.yml
+++ b/.github/workflows/pr-check_url-issues.yml
@@ -2,8 +2,6 @@ name: Check URL issues
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - "files/**/*.md"
 

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -2,8 +2,6 @@ name: Lint YAML
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - .nvmrc
       - yarn.lock

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,8 +8,6 @@ name: PR Test
 
 on:
   pull_request:
-    branches:
-      - main
 
 permissions:
   # Compare two commits.


### PR DESCRIPTION
### Description

Updates all `on: pull_request` workflows to run on all PRs, not just on PRs targeting `main`.

### Motivation

The condition is unnecessary, and might obfuscate test failures.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1020.