### PR TITLE
ci(workflows): specify `pull_request_target` branches

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -3,6 +3,8 @@ name: "PR conflicts"
 on:
   push:
   pull_request_target:
+    branches:
+      - main
     types: [synchronize]
 
 permissions:

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -2,6 +2,8 @@ name: System file changes
 
 on:
   pull_request_target:
+    branches:
+      - main
     paths:
       - ".github/workflows/**"
       - ".github/CODEOWNERS"


### PR DESCRIPTION
### Description

Update all workflows using `pull_request_target` to specify trusted target branches, such as `main`.

### Motivation

Security best practice to limit `pull_request_target` workflows to trusted branches, reducing the attack surface for malicious pull requests.

The `pull_request_target` trigger causes the workflow to run in the context of the base branch with access to secrets, so it's important:

- to specify **only** trusted branches, to avoid that the workflow runs on an untrusted branch,
- to specify **all** trusted branches, to avoid that the workflow is skipped on PRs targeting a trusted branch.

### Additional details

See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1021.