### PR TITLE
Add note for embedding SVG files

### DIFF
--- a/files/en-us/web/svg/reference/element/svg/index.md
+++ b/files/en-us/web/svg/reference/element/svg/index.md
@@ -8,8 +8,7 @@ sidebar: svgref
 
 The **`<svg>`** [SVG](/en-US/docs/Web/SVG) element is a container that defines a new coordinate system and [viewport](/en-US/docs/Web/SVG/Reference/Attribute/viewBox). It is used as the outermost element of SVG documents, but it can also be used to embed an SVG fragment inside an SVG or HTML document.
 
-> [!NOTE]
-> The `svg` element is not required to put svg files in the document. Instead, the `img` element can be used for that. The `src` attribute of the `img` element will be equal to the path of the file.
+This element is for creating _new_ SVG documents. If you have an existing SVG document to embed in another document via URL, use {{HTMLElement("img")}}, {{HTMLElement("object")}}, or {{SVGElement("image")}}.
 
 > [!NOTE]
 > The `xmlns` attribute is only required on the outermost `svg` element of _SVG documents_, or inside HTML documents with XML serialization. It is unnecessary for inner `svg` elements or inside HTML documents with HTML serialization.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Readers may think that the `svg` element is used for putting svg files. But, the `img` element is used for that. To avoid this confusion, a note is added. 

### Motivation

I got confused and tried put a svg file using the `svg` element.



<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
