### PR TITLE
ci(CODEOWNERS): add Engineering for .vscode/tests/package.json/yarn.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@
 /*.md @mdn/content-team
 # Scripts and Tests
 /scripts @mdn/engineering
-/tests @mdn/engineering
+/tests   @mdn/engineering
 
 # These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
 # If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Puts the `/.vscode` and `/tests` folders under @mdn/engineering code ownership.

Also adds @mdn/engineering as code owner for `package.json` and `yarn.lock`.

### Motivation

Ensures that changes to these paths are reviewed by the MDN Engineering team, before they land in `main`, i.e. before their code may be executed in privileged workflows.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/872.