### PR TITLE
Docs: Clarify cloneNode() deep parameter defaults to false

### DIFF
--- a/files/en-us/web/api/node/clonenode/index.md
+++ b/files/en-us/web/api/node/clonenode/index.md
@@ -41,12 +41,13 @@ cloneNode(deep)
 ### Parameters
 
 - `deep` {{optional_inline}}
-  - : If `true`, then the node and its whole subtree,
-    including text that may be in child {{domxref("Text")}} nodes,
-    is also copied.
-
-    If `false`, only the node will be cloned.
-    The subtree, including any text that the node contains, is not cloned.
+  - : A boolean value indicating whether to clone the subtree rooted by the node.
+    If the parameter is omitted, it defaults to `false`.
+    - If `true`, then the node and its whole subtree,
+      including text that may be in child {{domxref("Text")}} nodes,
+      is also copied.
+    - If `false`, only the node will be cloned.
+      The subtree, including any text that the node contains, is not cloned.
 
     Note that `deep` has no effect on {{glossary("void element", "void elements")}},
     such as the {{HTMLElement("img")}} and {{HTMLElement("input")}} elements.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Clarifies that the deep parameter for the Node.cloneNode() method defaults to false when omitted.

### Motivation

The documentation for the deep parameter noted it was optional but did not specify what value it defaults to. This change adds that missing information to prevent developer confusion, as discussed in the related issue.

### Additional details

As per the WHATWG DOM specification, the default value is false: https://dom.spec.whatwg.org/#ref-for-dom-node-clonenode%E2%91%A0

### Related issues and pull requests

Fixes #41749
