### PR TITLE
Mention cloneNode parameter default value

### DIFF
--- a/files/en-us/web/api/node/clonenode/index.md
+++ b/files/en-us/web/api/node/clonenode/index.md
@@ -45,7 +45,7 @@ cloneNode(deep)
     including text that may be in child {{domxref("Text")}} nodes,
     is also copied.
 
-    If `false`, only the node will be cloned.
+    If `false` or omitted, only the node will be cloned.
     The subtree, including any text that the node contains, is not cloned.
 
     Note that `deep` has no effect on {{glossary("void element", "void elements")}},


### PR DESCRIPTION
Fixes #41749

## Description

This PR clarifies that when the `deep` parameter is omitted from `cloneNode()`, it defaults to `false`, matching the behavior described in the [DOM specification](https://dom.spec.whatwg.org/#ref-for-dom-node-clonenode%E2%91%A0).

## Changes

Updated the Parameters section to explicitly state: "If `false` or omitted, only the node will be cloned."

This makes it clear that omitting the parameter is equivalent to passing `false`, addressing the issue reported where the documentation didn't specify what happens when the optional parameter is not provided.

## Related Issue

- Closes #41749