### PR TITLE
added await-import examples for importing json modules

### DIFF
--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -116,6 +116,14 @@ import(`/my-module.js?t=${Date.now()}`);
 
 Note that this can lead to memory leaks in a long-running application, because the engine cannot safely garbage-collect any module namespace objects. Currently, there is no way to manually clear the cache of module namespace objects.
 
+You can also use the [Fetch API](/en-US/docs/Web/API/Fetch_API) to fetch module source code as text, and then evaluate the module manually depending on the module type:
+
+- For JavaScript modules, you can dynamically import the source code as a [`blob:` URL](/en-US/docs/Web/API/URL/createObjectURL) in browsers, or use [`vm.Module`](/en-US/docs/Web/Node.js/vm/Module) to evaluate it in Node.js.
+- For JSON modules, you can parse the source code using {{jsxref("JSON.parse()")}}.
+- For CSS modules, you can create a new {{domxref("CSSStyleSheet")}} object and use its [`replace()`](/en-US/docs/Web/API/CSSStyleSheet/replace) method to populate it with the source code.
+
+However, this is semantically not the same as dynamic import, because user-agent settings like [fetch destination](/en-US/docs/Web/API/Request/destination), [CSP](/en-US/docs/Web/HTTP/Guides/CSP), or [module resolution](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve) may not be applied correctly.
+
 Module namespace object caching only applies to modules that are loaded and linked _successfully_. A module is imported in three steps: loading (fetching the module), linking (mostly, parsing the module), and evaluating (executing the parsed code). Only evaluation failures are cached; if a module fails to load or link, the next import may try to load and link the module again. The browser may or may not cache the result of the fetch operation, but it should follow typical HTTP semantics, so handling such network failures should not be different from handling {{domxref("Window/fetch", "fetch()")}} failures.
 
 ## Examples
@@ -198,6 +206,16 @@ Promise.all(
     (_, index) => import(`/modules/module-${index}.js`),
   ),
 ).then((modules) => modules.forEach((module) => module.load()));
+```
+
+### Using import attributes with dynamic import
+
+[Import attributes](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) are accepted as the second parameter of the `import()` syntax.
+
+```js
+const data = await import("./data.json", {
+  with: { type: "json" },
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -273,6 +273,14 @@ setTimeout(() => {
 }, 1000);
 ```
 
+### Importing non-JavaScript modules
+
+Non-JavaScript modules can also be imported using the `import` statement, but their types need to be explicitly declared using [import attributes](/en-US/docs/Web/JavaScript/Reference/Statements/import/with). For example, to import a JSON module, you need to specify the `type: "json"` attribute.
+
+```js
+import data from "./data.json" with { type: "json" };
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/statements/import/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/with/index.md
@@ -136,7 +136,7 @@ Start a local HTTP server (see [troubleshooting](/en-US/docs/Web/JavaScript/Guid
 Import attributes are also accepted as the second parameter of the `import()` syntax.
 
 ```js
-const data = await import("https://example.com/data.json", {
+const data = await import("./data.json", {
   with: { type: "json" },
 });
 ```


### PR DESCRIPTION
### Description

I added the await-import syntax for completeness sake, I believe this syntax is likely to be used in the await-import syntax much more as compared to it's use on the top-level (I can be mistaken), due to it being simpler compared to fetching an object and converting it into json

### Motivation

I suspect people are far more likely to use the await-import syntax as a replacement to fetch() due to fewer lines of code, as opposed to using import at the top level

### Additional details

this simply adds the same top-level import specifications as await-imports as well

so for example
```js
import data from "https://example.com/data.json" with { type: "json" };
```

can also be

```js
const data = await import("https://example.com/data.json", { with: { type: "json" } });
``` 