### PR TITLE
docs(HTTP): X-Content-Type-Options — mention impact on document sniffing

### DIFF
--- a/files/en-us/web/http/reference/headers/x-content-type-options/index.md
+++ b/files/en-us/web/http/reference/headers/x-content-type-options/index.md
@@ -8,12 +8,14 @@ sidebar: http
 ---
 
 The HTTP **`X-Content-Type-Options`** {{Glossary("response header")}} indicates that the [MIME types](/en-US/docs/Web/HTTP/Guides/MIME_types) advertised in the {{HTTPHeader("Content-Type")}} headers should be respected and not changed.
-The header allows you to avoid [MIME type sniffing](/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing) by specifying that the MIME types are deliberately configured. Developers and server operators should ensure that their servers send the correct {{HTTPHeader("Content-Type")}} for every response; using `X-Content-Type-Options: nosniff` complements accurate server configuration rather than replacing it.
+The header allows you to avoid [MIME type sniffing](/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing) by specifying that the MIME types are deliberately configured.
+Developers and server operators should ensure that their servers send the correct {{HTTPHeader("Content-Type")}} for every response; using `X-Content-Type-Options: nosniff` complements accurate server configuration rather than replacing it.
 
 Site security testers usually expect this header to be set.
 
 > [!NOTE]
-> The `X-Content-Type-Options` header only applies to request blocking [due to `nosniff`](https://fetch.spec.whatwg.org/#ref-for-determine-nosniff) for [request destinations](/en-US/docs/Web/API/Request/destination) of `"script"` and `"style"`. This check happens during the Fetch process; browser navigations are not blocked by `nosniff`, so responses (especially documents) must always be served with the correct `Content-Type`.
+> The `X-Content-Type-Options` header only applies to request blocking [due to `nosniff`](https://fetch.spec.whatwg.org/#ref-for-determine-nosniff) for [request destinations](/en-US/docs/Web/API/Request/destination) of `"script"` and `"style"`.
+> This check happens during the [Fetch](/en-US/docs/Web/API/Fetch_API) process; browser navigations are not blocked by `nosniff`, so responses (especially documents) must always be served with the correct `Content-Type`.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
What
- Clarify that `X-Content-Type-Options: nosniff` also affects document navigations:
  user agents should avoid sniffing and treating content as HTML when the `Content-Type` is incorrect or missing.
- Add a short subsection “Effect on HTML document sniffing” with references.

Why
- The current page focuses on scripts and styles; this update reflects the MIME sniffing algorithm behavior for documents as discussed in WHATWG.

How to verify
- Run `yarn start` and preview /en-US/docs/Web/HTTP/Headers/X-Content-Type-Options.
- Confirm the new subsection is rendered and links work.

References
- WHATWG MIME Sniffing algorithm: https://mimesniff.spec.whatwg.org/#mime-type-sniffing-algorithm
- Discussion: https://github.com/whatwg/mimesniff/issues/98

Fixes #41745