### PR TITLE
FF145 Expr Features: Storage Access headers 

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -767,11 +767,11 @@ When `Integrity-Policy` is used, the browser blocks the loading of styles refere
 - `security.integrity_policy.stylesheet.enabled`
   - : Set to `true` to enable.
 
-### Storage Access Headers
+### Storage Access headers
 
 The {{httpheader("Sec-Fetch-Storage-Access")}} and {{httpheader("Activate-Storage-Access")}} HTTP headers are now supported, enabling a more efficient [Storage Access API](/en-US/docs/Web/API/Storage_Access_API) workflow. ([Firefox bug 1991688](https://bugzil.la/1991688)).
 
-In the JavaScript-only workflow, a third party resource has to be requested and loaded in order to activate a storage-access permission for a particular context (such as a new browser tab), even if the permission has already been granted.
+In the JavaScript-only workflow, a third-party resource must be requested and loaded to activate a storage-access permission for a particular context (such as a new browser tab). This is required even if the permission has already been granted.
 The storage access headers allow the browser to advertise the permission state for the particular context, so the server can request activation of an already-granted permission.
 This avoids the overhead of unnecessarily fetching and loading the resource.
 

--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -129,6 +129,5 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   - Support for the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) and [`trusted-types`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types) directives, and the [`'trusted-types-eval'`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#trusted-types-eval) keyword, of the {{HTTPHeader("Content-Security-Policy")}} HTTP header.
     These can be used to enforce trusted types instead of strings, name the specific policies that are allowed, and to enable [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) and similar functions to be used when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are supported and enforced.
 
-- **Storage Access Headers:** (Nightly) and `dom.storage_access.headers.enabled`.
-
+- **Storage Access headers** (Nightly): `dom.storage_access.headers.enabled`.
   The {{httpheader("Sec-Fetch-Storage-Access")}} and {{httpheader("Activate-Storage-Access")}} HTTP headers are now supported, enabling a more efficient [Storage Access API](/en-US/docs/Web/API/Storage_Access_API) workflow. ([Firefox bug 1991688](https://bugzil.la/1991688)).


### PR DESCRIPTION
FF145 supports the HTTP headers `Activate-Storage-Access` and `Sec-Fetch-Storage-Access` in preview in https://bugzilla.mozilla.org/show_bug.cgi?id=1991688 (from 145)

This adds a simple release note and experimental features. I'm still working on docs, but since I've only got a few days in, wanted the essential thing out first.

Related docs work can be tracked in #41499

