### PR TITLE
Expected behavior - confuse text at Closures #41788

### DIFF
--- a/files/en-us/web/javascript/guide/closures/index.md
+++ b/files/en-us/web/javascript/guide/closures/index.md
@@ -74,7 +74,7 @@ myFunc();
 
 Running this code has exactly the same effect as the previous example of the `init()` function above. What's different (and interesting) is that the `displayName()` inner function is returned from the outer function _before being executed_.
 
-At first glance, it might seem unintuitive that this code still works. In some programming languages, the local variables within a function exist for just the duration of that function's execution. Once `makeFunc()` finishes executing, you might expect that the `name` variable would no longer be accessible. However, because the code still works as expected, this is obviously not the case in JavaScript.
+At first glance, it might seem unintuitive that this code still works. In some programming languages, the local variables within a function exist for just the duration of that function's execution. Once `makeFunc()` finishes executing, you might expect that the `name` variable would no longer be accessible. However, because the code still works, this is obviously not the case in JavaScript.
 
 The reason is that functions in JavaScript form closures. A _closure_ is the combination of a function and the lexical environment within which that function was declared. This environment consists of any variables that were in-scope at the time the closure was created. In this case, `myFunc` is a reference to the instance of the function `displayName` that is created when `makeFunc` is run. The instance of `displayName` maintains a reference to its lexical environment, within which the variable `name` exists. For this reason, when `myFunc` is invoked, the variable `name` remains available for use, and "Mozilla" is passed to `console.log`.
 


### PR DESCRIPTION
### Description

"Once makeFunc() finishes executing, you might **expect** that the name variable would no longer be accessible. However, because the code still works _as **expected**_, this is obviously not the case in JavaScript."

This two sentences are a little bit confused me because this text uses the "expected behavior" two different meaning. I suggest to remove the "as expected" in the second sentence.


### Related issues and pull requests

Fixes #41788
