### PR TITLE
Update selectionend description to clarify that selectionEnd is the index immediately following the selection

### DIFF
--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLInputElement.selectionEnd
 
 {{ApiRef("HTML DOM")}}
 
-The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. When there is no selection, this returns the offset of the character immediately following the current text input cursor position.
+The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. That is, it represents the index of the character **immediately following** the selection. Likewise, when there is no selection, this returns the offset of the character immediately following the current text input cursor position.
 
 > [!NOTE]
 > According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Update selectionend description to clarify that selectionEnd is the index immediately following the selection.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The mdn article for selectionEnd currently does not make it clear at all that the index is always one greater than
the last selected character's index.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
