### PR TITLE
fix(docs): Add inline technology status in the at-rules page

### DIFF
--- a/files/en-us/web/css/reference/at-rules/index.md
+++ b/files/en-us/web/css/reference/at-rules/index.md
@@ -25,7 +25,7 @@ sidebar: cssref
   - {{cssxref("@counter-style/suffix")}}
   - {{cssxref("@counter-style/symbols")}}
   - {{cssxref("@counter-style/system")}}
-- {{cssxref("@document")}}
+- {{cssxref("@document")}} {{non-standard_inline}} {{deprecated_inline}}
 - {{cssxref("@font-face")}}
   - {{cssxref("@font-face/ascent-override")}}
   - {{cssxref("@font-face/descent-override")}}
@@ -46,7 +46,7 @@ sidebar: cssref
   - {{cssxref("@font-palette-values/base-palette")}}
   - {{cssxref("@font-palette-values/font-family")}}
   - {{cssxref("@font-palette-values/override-colors")}}
-- {{cssxref("@function")}}
+- {{cssxref("@function")}} {{experimental_inline}}
 - {{cssxref("@import")}}
 - {{cssxref("@keyframes")}}
 - {{cssxref("@layer")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR follows up on https://github.com/mdn/content/pull/41801 and adds the missing inline technology statuses to the newly added listing page.

