### PR TITLE
relnote(Fx145): Firefox for Android hr in select

### DIFF
--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -40,7 +40,7 @@ Firefox 145 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 1788937](https://bugzil.la/1788937)).
 
 - Separators can appear in {{htmlelement("select")}} menus since {{htmlelement("hr")}} in `<select>` was implemented.
-  These are now also supported in Firefox for Android. ([Firefox bug 1867045](https://bugzil.la/1867045), [Firefox bug 1830909](https://bugzil.la/1830909))
+  These are now also supported in Firefox for Android. ([Firefox bug 1867045](https://bugzil.la/1867045), [Firefox bug 1830909](https://bugzil.la/1830909)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
### Description

Fx 145 renders separators in `<select>` menus in Firefox for Android.

### Related issues and pull requests

- [ ] parent: https://github.com/mdn/content/issues/41817