### PR TITLE
Editorial review: GPUAdapter.requestDevice() consumes adapter

### DIFF
--- a/files/en-us/web/api/gpuadapter/requestdevice/index.md
+++ b/files/en-us/web/api/gpuadapter/requestdevice/index.md
@@ -39,12 +39,14 @@ Not all features and limits will be available to WebGPU in all browsers that sup
 
 A {{jsxref("Promise")}} that fulfills with a {{domxref("GPUDevice")}} object instance.
 
-If you make a duplicate call, i.e., call `requestDevice()` on a {{domxref("GPUAdapter")}} that `requestDevice()` was already called on, the promise fulfills with a device that is immediately lost. You can then get information on how the device was lost via {{domxref("GPUDevice.lost")}}.
+If you make a duplicate call, i.e., call `requestDevice()` on a {{domxref("GPUAdapter")}} that `requestDevice()` was already called on, the promise rejects with an `OperationError` because the associated `GPUAdapter` is consumed when a `GPUDevice` is created.
 
 ### Exceptions
 
 - `OperationError` {{domxref("DOMException")}}
-  - : The promise rejects with an `OperationError` if the limits included in the `requiredLimits` property are not supported by the {{domxref("GPUAdapter")}}, either because they are not valid limits, or because their values are higher than the adapter's values for those limits.
+  - : The promise rejects with an `OperationError` if either:
+    - The limits included in the `requiredLimits` property are not supported by the {{domxref("GPUAdapter")}}, either because they are not valid limits, or because their values are higher than the adapter's values for those limits.
+    - The `GPUAdapter` has been consumed by having `requestDevice()` called on it previously.
 - `TypeError` {{domxref("DOMException")}}
   - : The promise rejects with a `TypeError` if the features included in the `requiredFeatures` property are not supported by the {{domxref("GPUAdapter")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

From Chrome 140 onwards, calling `GPUAdapter.requestDevice()` multiple times on the same adapter causes the returned promise to reject. This is because the adapter is consumed by the first call. See https://developer.chrome.com/blog/new-in-webgpu-140#device_requests_consume_adapter.

Previously, you could call `GPUAdapter.requestDevice()` multiple times on the same adapter, but multiple calls would result in lost devices.

This PR documents this new behavior. 



<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
