### PR TITLE
Docs: Add Exceptions section to Request.arrayBuffer()

### DIFF
--- a/files/en-us/web/api/request/arraybuffer/index.md
+++ b/files/en-us/web/api/request/arraybuffer/index.md
@@ -29,8 +29,8 @@ A promise that resolves with an {{jsxref("ArrayBuffer")}}.
 
 - `TypeError`
   : Thrown for one of the following reasons:
-  _ The response body is [disturbed or locked](/en-US/docs/Web/API/Fetch_API/Using_Fetch#locked_and_disturbed_streams).
-  _ There was an error decoding the body content (for example, because the {{httpheader("Content-Encoding")}} header is incorrect).
+  - The response body is [disturbed or locked](/en-US/docs/Web/API/Fetch_API/Using_Fetch#locked_and_disturbed_streams).
+  - There was an error decoding the body content (for example, because the {{httpheader("Content-Encoding")}} header is incorrect).
 - `RangeError`
   : Thrown if there is a problem creating the associated `ArrayBuffer` (for example, if the data size is too large).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Adds the missing `Exceptions` section to `Request.arrayBuffer()`, as per the WHATWG specification (which mentions `RangeError` and `TypeError`).

This fix is part of a set of 3 PRs to align the `Body` methods for `Request`:

* Fix for `.json()`: See PR #41782
* Fix for `.bytes()`: See PR #41827
* Fix for `.arrayBuffer()`: (This PR)

This aligns the `Request` documentation with the `Response` documentation (which is already correct) and follows up on the suggestion in issue #41689.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
We left `AbortError` out based on the original investigation in issue #41689, where it was confirmed that `AbortError` doesn't apply to `Request` body methods (only to `Response`). This logic applies to `.bytes()` and `.arrayBuffer()` as well.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
