### PR TITLE
Add release date info and autocomplete="off" change

### DIFF
--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -6,7 +6,7 @@ page-type: firefox-release-notes
 sidebar: firefox
 ---
 
-Firefox 30 was released on June 10th, 2014. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.
+Firefox 30 was released on [June 10th, 2014](https://whattrainisitnow.com/release/?version=30). This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.
 
 ## Changes for Web developers
 
@@ -65,7 +65,7 @@ _No change._
 
 ## Security
 
-- `<form autocomplete="off">` no longer prevents passwords from being saved ([Firefox bug 956906](https://bugzil.la/956906)).
+- `<form autocomplete="off">` no longer prevents passwords from being saved. See [Managing autofill for login fields](/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion#managing_autofill_for_login_fields) for more information. ([Firefox bug 956906](https://bugzil.la/956906)).
 
 ## Changes for add-on and Mozilla developers
 


### PR DESCRIPTION
Adding this information from https://web.archive.org/web/20150905152554/https://developer.mozilla.org/en-US/Firefox/Releases/30/Site_Compatibility - more could be merged in still

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Adding in release date for Firefox 30 to the page, like later versions have. Also adding a reference to the change in `autocomplete="off"` functionality in password fields.

### Motivation

Been investigating when the `autocomplete="off"` change happened, would've been much easier if it were on this page!

### Additional details

This was previously in the old [Site Compatibility for Firefox 30](https://web.archive.org/web/20150905152554/https://developer.mozilla.org/en-US/Firefox/Releases/30/Site_Compatibility) page, but this content does not seem to have fully been merged into the single-page release notes.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
