### PR TITLE
Update forbidden request headers in glossary

### DIFF
--- a/files/en-us/glossary/forbidden_request_header/index.md
+++ b/files/en-us/glossary/forbidden_request_header/index.md
@@ -28,7 +28,7 @@ Forbidden headers are one of the following:
 - {{HTTPHeader("Connection")}}
 - {{HTTPHeader("Content-Length")}}
 - {{HTTPHeader("Cookie")}}
-- {{HTTPHeader("Cookie2")}}
+- `Cookie2`
 - {{HTTPHeader("Date")}}
 - {{HTTPHeader("DNT")}}
 - {{HTTPHeader("Expect")}}


### PR DESCRIPTION
### Description

The spec says `Cookie2` and `Set-Cookie` are forbidden. Looking at the Chrome source code it also checks for `Access-Control-Request-Private-Network`, which is added to the list in [this draft spec](https://wicg.github.io/private-network-access/#forbidden-header-names).

You can try it out by opening https://example.com/ and doing

```js
await fetch('https://example.com', {
  headers: {
    'access-control-request-private-network': 'aaaaaaaaaaaaaa',
    'cookie2': 'bbbbbbbbbbbbbb',
    'set-cookie': 'ccccccccccccc',
    'Permissions-Policy': 'this one actually gets sent',
  }
});
```

and looking in the Network tab.

### Additional details

Chrome source code: https://source.chromium.org/chromium/chromium/src/+/main:net/http/http_util.cc;l=324-348;drc=c8dc70b538f1bb0862f1be58237d6e945ee81819

Spec: https://fetch.spec.whatwg.org/#forbidden-request-header