### PR TITLE
Editorial review: Add note about bgra8unorm read-only storage textures bring deprecated

### DIFF
--- a/files/en-us/web/api/gpudevice/createbindgrouplayout/index.md
+++ b/files/en-us/web/api/gpudevice/createbindgrouplayout/index.md
@@ -84,6 +84,8 @@ The resource layout object can be one of the following (see also {{domxref("GPUD
 
   - `format`
     - : An enumerated value specifying the required format of texture views bound to this binding. See the specification's [Texture Formats](https://gpuweb.github.io/gpuweb/#enumdef-gputextureformat) section for all the available `format` values. Also see [Tier 1 and Tier 2 texture formats](/en-US/docs/Web/API/GPUDevice/createTexture#tier_1_and_tier_2_texture_formats).
+      > [!NOTE]
+      > Use of the `bgra8unorm` format for read-only storage textures is deprecated. The specification explicitly disallows this, as this format is intended for write-only access and is not portable. Any browser support for this combination is considered a bug.
   - `viewDimension` {{optional_inline}}
     - : An enumerated value specifying the required dimension for texture views bound to this binding. Possible values are:
       - `"1d"`: The texture is viewed as a one-dimensional image.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Use of the `bgra8unorm` format for read-only storage textures is deprecated. The specification explicitly disallows this, as this format is intended for write-only access and is not portable. Any browser support for this combination is considered a bug.

Chrome previously allowed this, but it is deprecated from version 140 onwards. See https://developer.chrome.com/blog/new-in-webgpu-140#deprecate_bgra8unorm_read-only_storage_texture_usage.

This PR adds a note to make the deprecation clear. Note that I'm not intending to add a browser compat data point for this change, as:

- It is expected behavior anyway.
- We don't really want to encourage people to use it in browsers that wrongly allow it.


<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
