### PR TITLE
Avoid reference error in kanban demo

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/kanban_board/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/kanban_board/index.md
@@ -183,15 +183,16 @@ function makePlaceholder(draggedTask) {
 }
 ```
 
-This indicator will be moved around on {{domxref("HTMLElement/dragover_event", "dragover")}}. This is the most complex of all, so we've extracted it into a separate function. The previous code for the `dragover` event has been moved to this function. We first get the elements we need, safely aborting if `draggedTask` is `null` (which happens if the drag is not a task):
+This indicator will be moved around on {{domxref("HTMLElement/dragover_event", "dragover")}}. This is the most complex of all, so we've extracted it into a separate function. The previous code for the `dragover` event has been moved to this function. We first get the elements we need, safely aborting if the drag is not a task:
 
 ```js live-sample___kanban
 function movePlaceholder(event) {
-  if (event.dataTransfer.types.includes("task")) {
-    event.preventDefault();
+  if (!event.dataTransfer.types.includes("task")) {
+    return;
   }
+  event.preventDefault();
+  // Must exist because the ID is added for all drag events with a "task" data entry
   const draggedTask = document.getElementById("dragged-task");
-  if (!draggedTask) return;
   const column = event.currentTarget;
   const tasks = column.children[1];
   const existingPlaceholder = column.querySelector(".placeholder");


### PR DESCRIPTION
### Description

The pull request fixes cases where the user drops in something invalid such as an image to the drag-and-drop container, causing `droppedTask` to become `null`. Also, code from the previous “dragover” event has been merged with the `movePlaceholder` function.

### Motivation

This prevents dozens of errors from appearing in the console. The merge of the previous "dragover" event code also makes the code cleaner.

### Additional details

None

### Related issues and pull requests

Fixes #41852
