### PR TITLE
Fix `document.styleSheets` index in CSSLayerBlockRule example

### DIFF
--- a/files/en-us/web/api/csslayerblockrule/index.md
+++ b/files/en-us/web/api/csslayerblockrule/index.md
@@ -44,9 +44,7 @@ _Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxre
 
 ```js
 const item = document.getElementsByTagName("p")[0];
-const rules = document.styleSheets[2].cssRules;
-// Note that stylesheet #2 is the stylesheet associated with this embedded example,
-// while stylesheet #0 and #1 are the stylesheets associated with the whole MDN page
+const rules = document.getElementById("css-output").sheet.cssRules;
 
 const layer = rules[0]; // A CSSLayerBlockRule
 

--- a/files/en-us/web/api/csslayerblockrule/name/index.md
+++ b/files/en-us/web/api/csslayerblockrule/name/index.md
@@ -47,9 +47,7 @@ output {
 ```js
 const item1 = document.getElementsByTagName("output")[0];
 const item2 = document.getElementsByTagName("output")[1];
-const rules = document.styleSheets[1].cssRules;
-// Note that stylesheet #1 is the stylesheet associated with this embedded example,
-// while stylesheet #0 is the stylesheet associated with the whole MDN page
+const rules = document.getElementById("css-output").sheet.cssRules;
 
 const layer = rules[1]; // A CSSLayerBlockRule
 const anonymous = rules[2]; // An anonymous CSSLayerBlockRule

--- a/files/en-us/web/api/csslayerstatementrule/index.md
+++ b/files/en-us/web/api/csslayerstatementrule/index.md
@@ -38,9 +38,7 @@ _Also inherits properties from its parent interface, {{DOMxRef("CSSRule")}}._
 
 ```js
 const item = document.getElementsByTagName("p")[0];
-const rules = document.styleSheets[1].cssRules;
-// Note that stylesheet #1 is the stylesheet associated with this embedded example,
-// while stylesheet #0 is the stylesheet associated with the whole MDN page
+const rules = document.getElementById("css-output").sheet.cssRules;
 
 const layer = rules[0]; // A CSSLayerStatementRule
 

--- a/files/en-us/web/api/csslayerstatementrule/namelist/index.md
+++ b/files/en-us/web/api/csslayerstatementrule/namelist/index.md
@@ -38,9 +38,7 @@ An {{jsxref("Array")}} of strings, each representing a cascade layer represented
 
 ```js
 const item = document.getElementsByTagName("div")[0];
-const rules = document.styleSheets[1].cssRules;
-// Note that stylesheet #1 is the stylesheet associated with this embedded example,
-// while stylesheet #0 is the stylesheet associated with the whole MDN page
+const rules = document.getElementById("css-output").sheet.cssRules;
 
 const layerStatementRule = rules[0]; // A CSSLayerStatementRule
 const layerBlockRule = rules[1]; // A CSSLayerBlockRule; no nameList property.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I've switched the stylesheet index from 1 to 2, as [the original playground](https://developer.mozilla.org/en-US/play?uuid=87ce142c92ee7e20266d81b349da954386031336&state=jVFNTwIxEP0rk%2BJBE7ILV1iIgh5MlINwoySU7rhb7Ve2JUAI%2F93pbkwwevDUZua9N%2FPenFkdjWYjVvjpMwgDpQpeixOWoCwU0pU4lU67ZgQN7lBK4feN11jkbSsrcj%2FllvWZDIFU7hO1geBRKqHhzC2A7x6Av3TGqXXh9tKKfCQN6WyIoCIamEDp5N6gjVmF8Ulj%2BobZaSWqhTB4y5nn7G492JBMR2v2GsM1L8STxmWNGMN6uMlozbcEIUKew8JFhFiLCC0sJBj0hqACVfG6KEJwZClSLgcVa2oTBs0Oy5JKeBSGzPRb0UOt9A9ub%2FAvQSSmI%2Bbr4wK8qJDbb1NdqJPOXHILNOYB5svlS%2BrMtJOfyVVipNyyiMc4dzZSAETbrkj7Fzjt9O6adjBnN%2Bd2SGYp1gtn3cjtuL0KIQzSYbSq6sguXw%3D%3D&srcPrefix=%2Fen-US%2Fdocs%2FWeb%2FAPI%2FCSSLayerBlockRule%2F) was outputting `undefined` for the `name` property. This happened because the referenced rule was not a `CSSLayerBlockRule`. The currently referenced stylesheet seemingly contains the main styles for the playground, while the first one (at index 0) contains only color variables.

### Motivation

Currently, the playground on [the affected page](https://developer.mozilla.org/en-US/docs/Web/API/CSSLayerBlockRule#result) outputs `The CSSLayerBlockRule is for the "undefined" layer`, which is confusing considering the preceding code implies the "special" layer name should be output.

### Additional details

Below is a screenshot of the playground's `document.styleSheets`, showing that `document.styleSheets[2]` is the desired `CSSRuleList`, not `document.styleSheets[1]`.

<img width="2572" height="1510" alt="Screenshot of the MDN playground, with the CSSLayerBlockRule playground loaded. The output incorrectly says 'The CSSLayerBlockRule is for the undefined layer'. Firefox developer tools are open over the page, with JavaScript output in the console showing each computed stylesheet for the playground document. There is a total of three style sheets. The first one contains only CSS variables with hex colors defined on the :root element, the second contains the playground's default styles, and the third is the layer rule relevant for the example." src="https://github.com/user-attachments/assets/e187c4e0-55ab-4b60-85e7-ca2b70ed7841" />

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
