### PR TITLE
fix(html/reference/elements/input/number): remove outdated blog article link

### DIFF
--- a/files/en-us/web/html/reference/elements/input/number/index.md
+++ b/files/en-us/web/html/reference/elements/input/number/index.md
@@ -493,4 +493,3 @@ After declaring a few variables, an event listener is added to the `button` to c
 - [HTML forms guide](/en-US/docs/Learn_web_development/Extensions/Forms)
 - {{HTMLElement("input")}}
 - [`<input type="tel">`](/en-US/docs/Web/HTML/Reference/Elements/input/tel)
-- [Article: Why Gov.UK changed the input type for numbers](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This removes an outdated blog article link from "See Also" section of the [number input reference page](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/number)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

An outdated link in "See also" section can be misleading for the users

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #41883
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
