### PR TITLE
Add Fx146 rel note for contrast-color()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -34,7 +34,7 @@ Firefox 146 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### CSS
 
-- The {{cssxref("color_value/contrast-color()")}} [CSS function](/en-US/docs/Web/CSS/Reference/Values/Functions) is now supported. This function takes a {{cssxref("color_value","color")}} value and returns a contrasting color, which ensures at least [WCAG AA minimum contrast](https://w3c.github.io/wcag/guidelines/22/#contrast-minimum).
+- The {{cssxref("color_value/contrast-color()")}} [CSS function](/en-US/docs/Web/CSS/Reference/Values/Functions) is now supported. This function takes a {{cssxref("color_value","color")}} value and returns a contrasting color that ensures at least [WCAG AA minimum contrast](https://w3c.github.io/wcag/guidelines/22/#contrast-minimum).
   ([Firefox bug 1682439](https://bugzil.la/1682439)).
 
 - The {{cssxref("text-decoration-inset")}} property is now supported, which enables adjusting the start and end points of an element's {{cssxref("text-decoration")}} so it can be shortened, lengthened, or have its position shifted with respect to the rendered text.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 146 adds support for the [`contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color) function. This PR adds an Fx146 rel note for the function.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
