### PR TITLE
docs(WebExtensions): fix jQuery example typo, use $("<div>") instead …

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -46,7 +46,7 @@ Here, the contents of `data.className` or `data.color` could contain HTML that c
 When using jQuery, functions such as `attr()` and `text()` escape content as it's added to a DOM. So, the "favorite color" example from above, implemented in jQuery, would look like this:
 
 ```js example-good
-const node = $("<div>");
+let node = $("<div>");
 node.addClass(data.className);
 node.text(`Your favorite color is now ${data.color}`);
 ```


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
…of $("&lt;/div>")

Corrected HTML tag in jQuery example for clarity.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
