### PR TITLE
Update gradientTransform translation value

### DIFF
--- a/files/en-us/web/svg/reference/attribute/gradienttransform/index.md
+++ b/files/en-us/web/svg/reference/attribute/gradienttransform/index.md
@@ -47,7 +47,7 @@ svg {
     r="100"
     fx="100"
     fy="100"
-    gradientTransform="skewX(20) translate(-35, 0)">
+    gradientTransform="skewX(20) translate(185, 0)">
     <stop offset="0%" stop-color="darkblue" />
     <stop offset="50%" stop-color="skyblue" />
     <stop offset="100%" stop-color="darkblue" />


### PR DESCRIPTION
Fixing a bug that prevents the second (right-most) square to show the applied gradient transformation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Adjusted the x-value of the `translate` transformation to put the gradient into the right position to become visible.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The second (right) blue square which is supposed to show the gradient transform is flat blue. The issue is that it uses the `gradientUnits="userSpaceOnUse"` attribute but the values for cx, cy, etc. are still refering to the position of the first (left) square.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Fixing example at https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/gradientTransform#example

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
