### PR TITLE
Update BobPay -> BobBucks

### DIFF
--- a/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
@@ -248,7 +248,7 @@ function onServerCheckoutDetailsRetrieved(checkoutObject) {
 
 ## Recommending a payment app when user has no apps
 
-If you select to pay with the BobPay demo payment provider on this merchant page, it tries to call `PaymentRequest.show()`, while intercepting the `NotSupportedError` {{domxref("DOMException")}}. If this payment method is not supported, it redirects to the signup page for BobPay.
+If you select to pay with the BobBucks demo payment provider on this merchant page, it tries to call `PaymentRequest.show()`, while intercepting the `NotSupportedError` {{domxref("DOMException")}}. If this payment method is not supported, it redirects to the signup page for BobBucks.
 
 The code looks something like this:
 


### PR DESCRIPTION
### Description

Update the reference to "BobPay" to the proper demo app name+location - BobBucks and https://bobbucks.dev .

### Motivation

The old name hasn't been used in years, and actually https://bobpay.xyz results in a GoDaddy for-sale page!

### Additional details

N/A

### Related issues and pull requests

N/A
