### PR TITLE
Fix copy-pasta in break-inside example

### DIFF
--- a/files/en-us/web/css/reference/properties/break-inside/index.md
+++ b/files/en-us/web/css/reference/properties/break-inside/index.md
@@ -27,7 +27,7 @@ break-inside: avoid;
   <button id="print-btn">Show Print Preview</button>
   <div class="box-container">
     <div class="box">Content before the property</div>
-    <div class="box" id="example-element">Content with 'break-before'</div>
+    <div class="box" id="example-element">Content with 'break-inside'</div>
     <div class="box">Content after the property</div>
   </div>
 </div>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Pretty much a fix to a typo from a possible copy-paste of an example for break-before.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Fix a typo that was confusing to me.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

I checked the `break-after` example as well, that's already correct.
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

_None_
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
