### PR TITLE
Make Transfer-Encoding example clear hex is used

### DIFF
--- a/files/en-us/web/http/reference/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/reference/headers/transfer-encoding/index.md
@@ -85,9 +85,9 @@ Content-Type: text/plain
 Transfer-Encoding: chunked
 
 7\r\n
-Mozilla\r\n
-11\r\n
-Developer Network\r\n
+Welcome\r\n
+1c\r\n
+to Mozilla Developer Network\r\n
 0\r\n
 \r\n
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
This changes the chunked Transfer-Encoding example to use lengths that include hex digits to make it clear that these are hex numbers being used.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Often the first thing people look at is the example, but all the digits of the hex numbers were decimal digits (`7` for 7 and `11` for 17).  So to make this clearer, this PR changes these to `7` and `1c` respectively.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
