### PR TITLE
relnote(Fx145): BTP runs in 'stateless' mode by default now

### DIFF
--- a/files/en-us/mozilla/firefox/releases/145/index.md
+++ b/files/en-us/mozilla/firefox/releases/145/index.md
@@ -40,7 +40,7 @@ No notable changes.
 ### Security
 
 - When Bounce Tracking Protection (BTP) is enabled, it now runs in "stateless" mode by default.
-  In "stateless" mode, the browser no longer flags only sites that are part of a "bounce" that set state information (such as a cookie); it flags _all_ sites that are part of a "bounce". See [Bounce tracking mitigations](/en-US/docs/Web/Privacy/Guides/Bounce_tracking_mitigations) for more information on how BTP works.
+  In "stateless" mode, the browser no longer only flags sites that are part of a "bounce" that set state information (such as a cookie); it flags _all_ sites that are part of a "bounce". See [Bounce tracking mitigations](/en-US/docs/Web/Privacy/Guides/Bounce_tracking_mitigations) for more information on how BTP works.
   ([Firefox bug 1990831](https://bugzil.la/1990831)).
 
 ### APIs


### PR DESCRIPTION
### Description

Relnote for BTP which runs in 'stateless' mode by default in Fx145

- https://bugzilla.mozilla.org/show_bug.cgi?id=1990831
- Explainer: https://github.com/privacycg/nav-tracking-mitigations/blob/b28a3a7479f6f5c68ebfe344f53fb924cc093065/explainers/bounce-tracking-mitigations.md

### Related issues and pull requests

- [x] parent: https://github.com/mdn/content/issues/41819