### PR TITLE
Typo fix on What is CSS? index.md

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/what_is_css/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/what_is_css/index.md
@@ -72,7 +72,7 @@ The CSS language is organized into _modules_ that contain related functionality.
 
 ## CSS syntax basics
 
-CSS is a rule-based language — you define rules by specifying groups of styles that should be applied to particular element or groups of elements on your web page.
+CSS is a rule-based language — you define rules by specifying groups of styles that should be applied to a particular element or groups of elements on your web page.
 
 For example, you might decide to style the main heading on your page as large red text. The following code shows a very simple CSS rule that would achieve this:
 


### PR DESCRIPTION
No article/plural on the phrase 'particular element'; added an article

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

Typo correction.

### Description

in ##CSS Syntax Basics:
applied to particular element or groups of elements -> applied to **a** particular element or groups of elements

### Motivation

Clarity

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
