### PR TITLE
Added example showing normal text characters can also be percent-encoded

### DIFF
--- a/files/en-us/web/uri/reference/schemes/data/index.md
+++ b/files/en-us/web/uri/reference/schemes/data/index.md
@@ -32,7 +32,7 @@ A few examples:
 - `data:,Hello%2C%20World%21`
   - : The text/plain data `Hello, World!`. Note how the comma is {{Glossary("Percent-encoding", "percent-encoded")}} as `%2C`, and the space character as `%20`.
 - `data:text/plain,Hello%2C%20%57%6F%72%6C%64%21`
-  - : The text/plain data `Hello, World!` that also has `World` escaped. Similar to {{jsxref("decodeURIComponent()")}}, it decodes all {{Glossary("Percent-encoding", "percent-encoded")}} characters, even if they don't have to be escaped.
+  - : The text/plain data `Hello, World!` that also has `World` escaped. Similar to {{jsxref("decodeURIComponent()")}}, it decodes all {{Glossary("Percent-encoding", "percent-encoded")}} characters, even if they don't have to be escaped.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`

--- a/files/en-us/web/uri/reference/schemes/data/index.md
+++ b/files/en-us/web/uri/reference/schemes/data/index.md
@@ -31,6 +31,8 @@ A few examples:
 
 - `data:,Hello%2C%20World%21`
   - : The text/plain data `Hello, World!`. Note how the comma is {{Glossary("Percent-encoding", "percent-encoded")}} as `%2C`, and the space character as `%20`.
+- `data:text/plain,Hello%2C%20%57%6F%72%6C%64%21`
+  - : The text/plain data `Hello, World!` that also has `World` escaped. Similar to {{jsxref("decodeURIComponent()")}}, it decodes all {{Glossary("Percent-encoding", "percent-encoded")}} characters, even if they don't have to be escaped.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`

--- a/files/en-us/web/uri/reference/schemes/data/index.md
+++ b/files/en-us/web/uri/reference/schemes/data/index.md
@@ -32,7 +32,7 @@ A few examples:
 - `data:,Hello%2C%20World%21`
   - : The text/plain data `Hello, World!`. Note how the comma is {{Glossary("Percent-encoding", "percent-encoded")}} as `%2C`, and the space character as `%20`.
 - `data:text/plain,Hello%2C%20%57%6F%72%6C%64%21`
-  - : The text/plain data `Hello, World!` that also has `World` escaped. Similar to {{jsxref("decodeURIComponent()")}}, it decodes all {{Glossary("Percent-encoding", "percent-encoded")}} characters, even if they don't have to be escaped.
+  - : The text/plain data `Hello, World!`, with the `World` characters percent-encoded as well as the comma and space characters: you can percent-encode any characters, if they don't need to be encoded. Note that {{jsxref("decodeURIComponent()")}} can be used to decode all encoded characters.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Added an example showing that normal text characters can also be percent-encoded, even if they don't have to.

### Motivation

```js
const hex = [];
hex.length = 256;
for (let i = 0; i < 256; i++) {
  hex[i] = i.toString(16).padStart(2, "0");
}
console.log(hex);
fetch(`data:application/octet-stream;,%${hex.join("%")}`)
  .then((resp) => resp.arrayBuffer())
  .then((buf) => {
    const bytes = new Uint8Array(buf);
    console.log([...bytes]);
    for (let i = 0; i < 256; i++) {
      if (bytes[i] !== i) {
        console.log(`buf[${i}] !== ${i}`);
      }
    }
    console.log("finished");
  });
```

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
