### PR TITLE
FF146 Expr Feat: Sanitizer API in preview

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -432,7 +432,7 @@ The [HTML Sanitizer API](/en-US/docs/Web/API/HTML_Sanitizer_API) allow developer
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 138           | No                  |
+| Nightly           | 146           | Yes                 |
 | Developer Edition | 138           | No                  |
 | Beta              | 138           | No                  |
 | Release           | 138           | No                  |


### PR DESCRIPTION
FF146 enables the HTML Sanitizer API by default on nightly. This updates the Experimental features page. 

Note that this isn't released and this was previously noted in the FF136 release note, so I haven't added it to the relnote page again.

Related docs work can be tracked in #41649
