### PR TITLE
Update VS Code link

### DIFF
--- a/files/en-us/learn_web_development/howto/tools_and_setup/what_software_do_i_need/index.md
+++ b/files/en-us/learn_web_development/howto/tools_and_setup/what_software_do_i_need/index.md
@@ -76,7 +76,7 @@ All desktop operating systems come with a basic text editor. These editors are a
         <ul>
           <li><a href="https://notepad-plus-plus.org/">Notepad++</a></li>
           <li>
-            <a href="https://visualstudio.microsoft.com/">Visual Studio Code</a>
+            <a href="https://code.visualstudio.com/">Visual Studio Code</a>
           </li>
           <li><a href="https://www.jetbrains.com/webstorm/">Web Storm</a></li>
           <li><a href="https://brackets.io/">Brackets</a></li>
@@ -104,7 +104,7 @@ All desktop operating systems come with a basic text editor. These editors are a
             >
           </li>
           <li>
-            <a href="https://visualstudio.microsoft.com/">Visual Studio Code</a>
+            <a href="https://code.visualstudio.com/">Visual Studio Code</a>
           </li>
           <li><a href="https://brackets.io/">Brackets</a></li>
           <li><a href="https://shiftedit.net/">ShiftEdit</a></li>
@@ -147,7 +147,7 @@ All desktop operating systems come with a basic text editor. These editors are a
           <li><a href="https://www.gnu.org/software/emacs/">Emacs</a></li>
           <li><a href="https://www.vim.org/" rel="external">VIM</a></li>
           <li>
-            <a href="https://visualstudio.microsoft.com/">Visual Studio Code</a>
+            <a href="https://code.visualstudio.com/">Visual Studio Code</a>
           </li>
           <li><a href="https://brackets.io/">Brackets</a></li>
           <li><a href="https://shiftedit.net/">ShiftEdit</a></li>


### PR DESCRIPTION
### Description

Changed URLs for VS Code from visualstudio.microsoft.com to code.visualstudio.com to fix issue [#41934](https://github.com/mdn/content/issues/41934)

### Motivation

To make a contribution to a resource I use regularly and specifically to resolve issue [#41934](https://github.com/mdn/content/issues/41934)

### Additional details

[What software do I need to build a website?](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Tools_and_setup/What_software_do_I_need)

### Related issues and pull requests

Fixes #41934 - Visual studio code url is inaccurate
https://github.com/mdn/content/issues/41934
