### PR TITLE
Clarify `attr()` URL limitations and add `image-set()` example

### DIFF
--- a/files/en-us/web/css/reference/values/attr/index.md
+++ b/files/en-us/web/css/reference/values/attr/index.md
@@ -123,10 +123,9 @@ span[data-icon] {
 ```
 
 However, this restriction applies only to places that strictly require a `<url>` type.
-Some functions — such as {{CSSxRef("image/image-set","image-set()")}} — can accept a `<string>` value that is later interpreted as a URL, allowing `attr()` to work in those contexts:
+Some functions — such as {{CSSxRef("image/image-set","image-set()")}} — can accept a `<string>` value that is later interpreted as a URL, allowing `attr()` to work in those contexts, depending on browser support:
 
 ```css
-/* This may work, depending on browser support */
 span[data-icon] {
   background: image-set(attr(data-icon));
 }


### PR DESCRIPTION
### Description

This updates the explanation of how `attr()` behaves when used in URL-related contexts.
The previous text implied a general restriction, but the real limitation applies **only when the value is required to be a `<url>` type**.

The revised wording explains that:

* `attr()` values are *attr-tainted*.
* Using them in a context requiring a `<url>` (e.g. inside `url()` or `background-image`) results in IACVT.
* Some functions—such as `image-set()`—accept a `<string>` first, which is later interpreted as a URL. This can allow `attr()` to work **in shorthand properties like `background`**, although **it does not work in `background-image`**.

### Motivation

This update was made after watching a video by [zhangxinxu](https://space.bilibili.com/31556431) on bilibili:
[https://www.bilibili.com/video/BV1dPkzB3Esx](https://www.bilibili.com/video/BV1dPkzB3Esx)
I realized the documentation should more accurately reflect the difference between `<url>`-required contexts and cases where `<string>` is allowed before URL resolution.
