### PR TITLE
Insert required empty line in example HTTP message

### DIFF
--- a/files/en-us/web/http/guides/session/index.md
+++ b/files/en-us/web/http/guides/session/index.md
@@ -41,6 +41,7 @@ Fetching the root page of developer.mozilla.org, (`https://developer.mozilla.org
 GET / HTTP/1.1
 Host: developer.mozilla.org
 Accept-Language: fr
+
 ```
 
 Observe that final empty line, this separates the data block from the header block. As there is no `Content-Length` provided in an HTTP header, this data block is presented empty, marking the end of the headers, allowing the server to process the request the moment it receives this empty line.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In the description of the example HTTP message a reference is made to an empty line which doesn't exist. Inserting the missing empty line in the example HTTP message shows how the empty line properly terminates the header section as described in the page content.

### Motivation

The non-existence of the empty line should be fixed so that users are not confused by it being referred to, yet not being there. This contribution hopefully prevents such confusion.

### Additional details

They empty line is mentioned in [section 2.1 of RFC9112](https://datatracker.ietf.org/doc/html/rfc9112#section-2.1)

I also considered adding "[ empty line ]" or "CRLF" as shown in the RFC but decided not to as a simple empty line is consistent with the next example directly after it, which contains a similar empty line.

### Related issues and pull requests

N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
