### PR TITLE
MIDI APIs now use NotAllowedError instead of SecurityError

### DIFF
--- a/files/en-us/web/api/navigator/requestmidiaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmidiaccess/index.md
@@ -42,7 +42,7 @@ A {{jsxref('Promise')}} that resolves with a [`MIDIAccess`](/en-US/docs/Web/API/
   - : Thrown if the underlying system raises any errors.
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the feature or options are not supported by the system.
-- `SecurityError` {{domxref("DOMException")}}
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if the user or system denies the application from creating a [MIDIAccess](/en-US/docs/Web/API/MIDIAccess) object with the requested options, or if the document is not allowed to use the feature (for example, because of a [Permission Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy), or because the user previously denied a permission request).
 
 ## Security requirements

--- a/files/en-us/web/http/reference/headers/permissions-policy/midi/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/midi/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `midi` directive controls whether the current document is allowed to use the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API).
 
-Specifically, where a defined policy blocks use of this feature, {{domxref("Navigator.requestMIDIAccess()")}} calls will return a {{jsxref("Promise")}} that rejects with a {{domxref("DOMException")}} of type `SecurityError`.
+Specifically, where a defined policy blocks use of this feature, {{domxref("Navigator.requestMIDIAccess()")}} calls will return a {{jsxref("Promise")}} that rejects with a {{domxref("DOMException")}} of type `NotAllowedError`.
 
 ## Syntax
 


### PR DESCRIPTION
### Motivation

From issue [WebAudio/web-midi-api#261](https://github.com/WebAudio/web-midi-api/issues/261)
> [webaudio.github.io/web-midi-api#dom-navigator-requestmidiaccess](https://webaudio.github.io/web-midi-api/#dom-navigator-requestmidiaccess)
> 
> At the moment a [SecurityError](https://webidl.spec.whatwg.org/#securityerror) (_The operation is insecure._) is thrown when a user rejects a permissions prompt for MIDI access requested through the `requestMIDIAccess()` method, but it would make more sense to use a [NotAllowedError](https://webidl.spec.whatwg.org/#notallowederror) (_The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission._) for this.

### Related issues and pull requests

The change in spec: https://github.com/WebAudio/web-midi-api/commit/b7806b8
According to PR: [WebAudio/web-midi-api#267](https://github.com/WebAudio/web-midi-api/pull/267)