### PR TITLE
docs: fix hyphenation in DNS glossary entry.

### DIFF
--- a/files/en-us/glossary/dns/index.md
+++ b/files/en-us/glossary/dns/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**DNS** (Domain Name System) is a hierarchical and decentralized naming system for Internet connected resources. DNS maintains a list of {{Glossary("domain name","domain names")}} along with the resources, such as IP addresses, that are associated with them.
+**DNS** (Domain Name System) is a hierarchical and decentralized naming system for Internet-connected resources. DNS maintains a list of {{Glossary("domain name","domain names")}} along with the resources, such as IP addresses, that are associated with them.
 
 The most prominent function of DNS is the translation of human-friendly domain names (such as mozilla.org) to a numeric {{Glossary("IP address")}} (such as 192.0.2.172); this process of mapping a domain name to the appropriate IP address is known as a **DNS lookup**. By contrast, a **reverse DNS lookup** (rDNS) is used to determine the domain name associated with an IP address.
 


### PR DESCRIPTION
This PR fixes several minor issues in the DNS glossary entry:

• Added a missing hyphen in “Internet-connected”.

These changes improve grammar, readability, and markdown consistency across the page.