### PR TITLE
Revert Cookie2 added to list

### DIFF
--- a/files/en-us/glossary/forbidden_request_header/index.md
+++ b/files/en-us/glossary/forbidden_request_header/index.md
@@ -28,7 +28,6 @@ Forbidden headers are one of the following:
 - {{HTTPHeader("Connection")}}
 - {{HTTPHeader("Content-Length")}}
 - {{HTTPHeader("Cookie")}}
-- `Cookie2`
 - {{HTTPHeader("Date")}}
 - {{HTTPHeader("DNT")}}
 - {{HTTPHeader("Expect")}}


### PR DESCRIPTION
Remove `Cookie2` from a list, reverting its addition in https://github.com/mdn/content/pull/41830

The `Cookie2` was originally removed in https://github.com/mdn/content/pull/13965 because the header is not supported by any browser - where supported means "the browser actually does something to include it", not that it can be included by servers etc.
While we'd happily include something that has no browser integration, we don't include headers that are obsoleted and have no browser integration, because they are no longer considered part of the web platform,
