### PR TITLE
Add HTTP version in responses in HTTP header glossary page

### DIFF
--- a/files/en-us/glossary/http_header/index.md
+++ b/files/en-us/glossary/http_header/index.md
@@ -24,14 +24,14 @@ Host: example.com
 Redirects have mandatory headers ({{HTTPHeader("Location")}}):
 
 ```http
-302 Found
+HTTP/1.1 302 Found
 Location: /NewPage.html
 ```
 
 A typical set of headers:
 
 ```http
-304 Not Modified
+HTTP/1.1 304 Not Modified
 Access-Control-Allow-Origin: *
 Age: 2318192
 Cache-Control: public, max-age=315360000


### PR DESCRIPTION
### Description

In the HTTP header glossary page there are two HTTP response examples, but they are missing the HTTP version. This commit adds the version to produce a correct HTTP response message.

### Motivation

Since MDN is read not only by professionals but also by people who are just starting to learn how HTTP works, it may be better to be more precise when writing an example HTTP response.
