### PR TITLE
Remove incorrect claim that URL inputs support 'multiple' attribute

### DIFF
--- a/files/en-us/web/html/guides/constraint_validation/index.md
+++ b/files/en-us/web/html/guides/constraint_validation/index.md
@@ -35,7 +35,7 @@ The intrinsic constraints for the [`type`](/en-US/docs/Web/HTML/Reference/Elemen
 | [`<input type="URL">`](/en-US/docs/Web/HTML/Reference/Elements/input/url)     | The value must be an absolute [URL](/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL), as defined in the [URL Living Standard](https://url.spec.whatwg.org/). | **[TypeMismatch](/en-US/docs/Web/API/ValidityState/typeMismatch)** constraint violation |
 | [`<input type="email">`](/en-US/docs/Web/HTML/Reference/Elements/input/email) | The value must be a syntactically valid email address, which generally has the format `username@hostname.tld` but can also be local such as `username@hostname`.                 | **[TypeMismatch](/en-US/docs/Web/API/ValidityState/typeMismatch)** constraint violation |
 
-For the `email` input type, if the [`multiple`](/en-US/docs/Web/HTML/Reference/Elements/input#multiple) attribute is set, several values can be set, as a comma-separated list. If any of these do not satisfy the condition described here, the **Type mismatch** constraint violation is triggered.
+For the `email` input type, if the [`multiple`](/en-US/docs/Web/HTML/Reference/Elements/input#multiple) attribute is set, several values can be set as a comma-separated list. If any of the values in the list do not satisfy the condition described here, the **Type mismatch** constraint violation is triggered.
 
 Note that most input types don't have intrinsic constraints, as some are barred from constraint validation or have a sanitization algorithm transforming incorrect values to a correct default.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Corrected the [Semantic input types](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Constraint_validation#semantic_input_types)  section to clarify that the multiple attribute applies to email inputs but not url inputs.

### Motivation

The documentation previously stated both email and url inputs support the multiple attribute for comma-separated lists.  However, according to the HTML Standard, the multiple attribute is not supported for `<input type="url">`. This update aligns the guide with the specification.

### Related issues and pull requests
Fixes  [https://github.com/mdn/content/issues/42005](https://github.com/mdn/content/issues/42005)
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
