### PR TITLE
Fix typo in description of CSSStyleRule.style

### DIFF
--- a/files/en-us/web/api/cssstyleproperties/index.md
+++ b/files/en-us/web/api/cssstyleproperties/index.md
@@ -43,7 +43,7 @@ For an object representing an inline style declaration (not computed styles) thi
 
 - {{DOMxRef("HTMLElement.style")}}, {{domxref("SVGElement.style")}}, and {{domxref("MathMLElement.style")}}: Used to get and set the _inline style_ of a single element (e.g., `<div style="…">`).
 - {{DOMxRef("Window.getComputedStyle()")}}: Used to get the (read only) computed style of an element, which includes the effects of both inline and external styles.
-- {{DOMxRef("CSSStyleRule.style")}}: Used to get and set the styles of a stye rule ({{DOMxRef("CSSStyleRule")}}).
+- {{DOMxRef("CSSStyleRule.style")}}: Used to get and set the styles of a style rule ({{DOMxRef("CSSStyleRule")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -124,7 +124,7 @@ We also see that the {{cssxref("border-top")}} property corresponding to the ele
 {{EmbedLiveSample("Basic usage", "100", "280")}}
 
 Note that `font-weight` is defined on the `CSSStyleProperties` (as are all other CSS properties, though we have not logged them).
-However it is not an inline stye for the nested element, so its value is set to the empty string (`""`).
+However it is not an inline style for the nested element, so its value is set to the empty string (`""`).
 
 ### Enumerating style information
 

--- a/files/en-us/web/css/guides/anchor_positioning/using/index.md
+++ b/files/en-us/web/css/guides/anchor_positioning/using/index.md
@@ -308,7 +308,7 @@ If you only specify one value, the effect is different depending on which value 
 > [!NOTE]
 > See the [`<position-area>`](/en-US/docs/Web/CSS/Reference/Values/position-area_value) value reference page for a detailed description of all the available values. Mixing a logical value with a physical value will invalidate the declaration.
 
-Let's demonstrate some of these values; this example uses the same HTML and base CSS styes as the previous example, except that we've included a {{htmlelement("select")}} element to enable changing the positioned element's `position-area` value.
+Let's demonstrate some of these values; this example uses the same HTML and base CSS styles as the previous example, except that we've included a {{htmlelement("select")}} element to enable changing the positioned element's `position-area` value.
 
 ```html hidden
 <p>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Typo fix: `stye` -> `style`

### Motivation

Typos halt the flow of reading (brains often perform a double-take), which is counterproductive when consuming more complex documentation.

### Additional details

n/a

### Related issues and pull requests

n/a