### PR TITLE
JSON: Correct the ABNF to use RFC 8259

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/index.md
@@ -32,7 +32,7 @@ The same text may represent different values in JavaScript object literals vs. J
 Valid JSON syntax is formally defined by the following grammar, expressed in [ABNF](https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form), and copied from [IETF JSON standard (RFC)](https://datatracker.ietf.org/doc/html/rfc8259):
 
 ```plain
-JSON-text = object / array
+JSON-text = ws value ws
 begin-array     = ws %x5B ws  ; [ left square bracket
 begin-object    = ws %x7B ws  ; { left curly bracket
 end-array       = ws %x5D ws  ; ] right square bracket


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Change the JSON ABNF to use the one described in RFC 8259 instead of the obsoleted RFC 4627.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
RFC 4627 has been obsoleted by RFC 8259 (through RFC 7158/7159).

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
RFC 4627: https://datatracker.ietf.org/doc/html/rfc4627
RFC 8259: https://datatracker.ietf.org/doc/html/rfc8259

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
Fixes #42035

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
