### PR TITLE
Ff146 Relnote - SubtleCrypto.importKey() supports ECc compressed points import

### DIFF
--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -67,7 +67,7 @@ Firefox 146 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
-- {{domxref("SubtleCrypto.importKey()")}} now allows you to import keys defined as compressed elliptic curve points, when using the [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh) algorithms. ([Firefox bug 1971499](https://bugzil.la/1971499)).
+- {{domxref("SubtleCrypto.importKey()")}} now allows you to import keys defined as compressed elliptic curve points when using the [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh) algorithms. ([Firefox bug 1971499](https://bugzil.la/1971499)).
 
 <!-- #### DOM -->
 

--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -82,7 +82,7 @@ You can use this format to import or export AES or HMAC secret keys, or Elliptic
 
 In this format the key is supplied as an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) containing the raw bytes for the key.
 
-Note that when importing Elliptic Curve public keys the data may contain _compressed_ elliptic curve points.
+Note that when importing Elliptic Curve public keys, the data may contain _compressed_ elliptic curve points.
 
 ### PKCS #8
 


### PR DESCRIPTION
WebCrytpo supports EC compressed points in FF145 in https://bugzilla.mozilla.org/show_bug.cgi?id=1971499.

More specifically, I think "support" means "can import keys defined as such points" - am checking.

This adds a release note and comment in body of docs.

Related docs work can be tracked in #41870

NOTE, first commit is a layout change only - so you can review actual changes just by looking at the second commit