### PR TITLE
FF146 Relnote: WeakMap/WeakSet accept Symbol as keys

### DIFF
--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -51,7 +51,9 @@ Firefox 146 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### JavaScript -->
+### JavaScript
+
+- {{jsxref("WeakMap")}} and {{jsxref("WeakSet")}} now accept {{jsxref("Symbol")}} objects as keys, except for those that are [registered](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#shared_symbols_in_the_global_symbol_registry). ([Firefox bug 1966745](https://bugzil.la/1966745)).
 
 <!-- No notable changes. -->
 


### PR DESCRIPTION
FF146 adds support for using non-registered symbols as keys for WeakMap and WeakSet in https://bugzilla.mozilla.org/show_bug.cgi?id=1966745

This adds a release note.

Related docs work can be tracked in https://github.com/mdn/content/issues/41868