### PR TITLE
WorkerGlobalScope.setInterval() - update for trusted types

### DIFF
--- a/files/en-us/web/api/workerglobalscope/setinterval/index.md
+++ b/files/en-us/web/api/workerglobalscope/setinterval/index.md
@@ -62,7 +62,7 @@ This identifier, often referred to as an "interval ID", can be passed to {{domxr
 - {{jsxref("SyntaxError")}}
   - : The `code` can't be parsed as a script.
 - {{jsxref("TypeError")}}
-  - : Thrown if the `code` parameter is set to a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by a CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
+  - : Thrown if the `code` parameter is set to a string when [Trusted Types](/en-US/docs/Web/API/Trusted_Types_API) are [enforced by CSP](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) and no default policy is defined.
     It is also thrown if the first parameter is not one of the supported types: a function, string or `TrustedScript`.
 
 ## Examples


### PR DESCRIPTION
This updates `WorkerGlobalScope.setInterval()` for trusted types.

This is virtually the same as  `Window.setInterval()` which has a lot of description. To reduce duplication I link to those docs for the description and examples (which this also did previously).

I added the Trusted type header but in it also link to `Window.setInterval()` for the security considerations.
Upshot, this highlights the main issue using the header but mostly users will need to go to the Window method for detailed information. I think this is the right level of docs.

Related work tracked in #41507