### PR TITLE
Document <script> support for SVG crossorigin

### DIFF
--- a/files/en-us/web/svg/reference/attribute/crossorigin/index.md
+++ b/files/en-us/web/svg/reference/attribute/crossorigin/index.md
@@ -9,7 +9,7 @@ browser-compat:
 sidebar: svgref
 ---
 
-The crossorigin attribute, valid on the {{SVGElement("image")}}, {{SVGElement("feImage")}} and {{SVGElement("script")}} elements, provides support for configuration of the Cross-Origin Resource Sharing ([CORS](/en-US/docs/Web/HTTP/Guides/CORS)) requests for the element's fetched data.
+The `crossorigin` attribute, valid on the {{SVGElement("image")}}, {{SVGElement("feImage")}}, and {{SVGElement("script")}} elements, provides support for configuration of Cross-Origin Resource Sharing ([CORS](/en-US/docs/Web/HTTP/Guides/CORS)) requests for the element's fetched data.
 
 This table shows possible keywords and their meaning:
 


### PR DESCRIPTION
Fix #42026 

### Description

Hello,.

For the file --> files/en-us/web/svg/reference/attribute/crossorigin/index.md

1. Updated the SVG crossorigin file to include the <script> alongside <image> and <feImage>.
2. Also added the corresponding browser-compat entry for the svg.elements.script.crossorigin.

Thank You ... 😊

