### PR TITLE
chore(scripts): add notice about upcoming switch from Yarn to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "type": "module",
   "scripts": {
     "info:fred": "node -e \"process.stderr.write('\\n🐥 This command is now using fred: https://github.com/mdn/fred\\n🐞 Please report any issues here:  https://github.com/mdn/fred/issues/new?template=bug.yml\\n\\n')\"",
+    "info:npm": "node -e \"process.stderr.write('\\nℹ️  Notice: On December 1, 2025 at 12:00 UTC, mdn/content and mdn/translated-content will switch from Yarn to npm.\\n           Please continue using \\`yarn\\` until that time.\\n\\n')\"",
     "info:rari": "node -e \"process.stderr.write('\\n🐥 This command is now using rari: https://github.com/mdn/rari\\n🐞 Please report any issues here:  https://github.com/mdn/rari/issues/new?template=bug.yml\\n\\n')\"",
     "build": "yarn -s info:rari && env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build rari build",
     "content": "yarn -s info:rari && env-cmd --silent cross-env CONTENT_ROOT=files rari content",
@@ -37,7 +38,8 @@
     "lint:typos-group-by-file": "cspell --no-progress --gitignore --quiet --reporter cspell-group-by-file-reporter --config .vscode/cspell.json \"**/*.md\"",
     "lint:typos-words-only": "cspell --no-progress --gitignore --words-only --unique --config .vscode/cspell.json \"**/*.md\"",
     "lint:yml": "prettier -c \"**/*.yml\"",
-    "start": "yarn -s info:fred && yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files NODE_ENV=production FRED_PLAYGROUND_LOCAL=true FRED_PLAYGROUND_PORT=5043 FRED_PORT=5042 FRED_WRITER_MODE=true fred-server",
+    "prepare": "yarn -s info:npm",
+    "start": "yarn -s info:npm && yarn -s info:fred && yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files NODE_ENV=production FRED_PLAYGROUND_LOCAL=true FRED_PLAYGROUND_PORT=5043 FRED_PORT=5042 FRED_WRITER_MODE=true fred-server",
     "test": "node --test",
     "up-to-date-check": "node scripts/up-to-date-check.js"
   },


### PR DESCRIPTION
### Description

Adds notice about upcoming switch from Yarn to npm that is shown when running `yarn install` and `yarn start`.

### Motivation

Make content contributors aware of this upcoming change:


### Additional details

We want to avoid that users run `npm install` before that switch (which would change `yarn.lock`, and create `package-lock.json`), and avoid that users run `yarn install` after the switch (which would re-create `yarn.lock`).

#### Before

```sh
% yarn -s start

🐥 This command is now using fred: https://github.com/mdn/fred
🐞 Please report any issues here:  https://github.com/mdn/fred/issues/new?template=bug.yml

$ node scripts/up-to-date-check.js
```

#### After

```sh
% yarn -s start

ℹ️  Notice: On December 1, 2025 at 12:00 UTC, mdn/content and mdn/translated-content will switch from Yarn to npm.
           Please continue using `yarn` until that time.


🐥 This command is now using fred: https://github.com/mdn/fred
🐞 Please report any issues here:  https://github.com/mdn/fred/issues/new?template=bug.yml

$ node scripts/up-to-date-check.js
[rari] Rari server started on http://0.0.0.0:8083
```

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1106.