### PR TITLE
Fix URLPattern test cases for trailing slashes

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -389,8 +389,8 @@ console.log(patternSlash.test("https://example.com/books")); // false
 console.log(patternSlash.test("https://example.com/books/")); // true
 
 const patternNoSlash = new URLPattern({ pathname: "/books" });
-console.log(patternNoSlash.test("https://example.com/books")); // false
-console.log(patternNoSlash.test("https://example.com/books/")); // true
+console.log(patternNoSlash.test("https://example.com/books")); // true
+console.log(patternNoSlash.test("https://example.com/books/")); // false
 ```
 
 If you want to match both then you need to use a match pattern that allows either.


### PR DESCRIPTION
### Description

Corrects the code example. The description right before it is correct.

### Motivation

Simple correction.

### Additional details

```bash
$ node
Welcome to Node.js v24.9.0.
Type ".help" for more information.
> const patternSlash = new URLPattern({ pathname: "/books/" });
undefined
> console.log(patternSlash.test("https://example.com/books")); // false
false
undefined
> console.log(patternSlash.test("https://example.com/books/")); // true
true
undefined
>
> const patternNoSlash = new URLPattern({ pathname: "/books" });
undefined
> console.log(patternNoSlash.test("https://example.com/books")); // false
true
undefined
> console.log(patternNoSlash.test("https://example.com/books/")); // true
false
undefined
```

### Related issues and pull requests

Fixes #42055