### PR TITLE
Fix about Japanese vertical writing mode

### DIFF
--- a/files/en-us/web/css/guides/writing_modes/writing_mode_systems/index.md
+++ b/files/en-us/web/css/guides/writing_modes/writing_mode_systems/index.md
@@ -54,7 +54,7 @@ Arabic-based systems are typically written using a right-to-left inline directio
 Han-based systems are commonly written using a left-to-right inline direction with a top-to-bottom block flow direction, or a top-to-bottom inline direction with a right-to-left block flow direction. Traditionally, Chinese, Vietnamese, Korean, and Japanese are written vertically in columns, going from top to bottom, with a right-to-left block direction, but will often be rendered horizontally online, going from left to right.
 
 ```html
-<p lang="jp-JP" dir="auto">これは日本語で書かれています</p>
+<p lang="ja-JP" dir="auto">これは日本語で書かれています</p>
 ```
 
 Mongolian-based systems are typically written vertically, top to bottom, in columns that flow left to right; a top-to-bottom inline direction with a left-to-right block flow direction. This differs from Chinese, Japanese, and Korean, whose vertical text columns are read right to left. It derives from the fact that Mongolian script descended from Old Uyghur, which was written left-to-right.
@@ -68,7 +68,7 @@ To render the writing modes correctly, we use the global HTML [`dir`](/en-US/doc
 For vertical languages, we use the {{cssxref("writing-mode")}} and {{cssxref("text-orientation")}} properties:
 
 ```css
-[lang|="jp"] {
+[lang|="ja"] {
   writing-mode: vertical-rl;
   text-orientation: upright;
 }
@@ -81,7 +81,7 @@ For vertical languages, we use the {{cssxref("writing-mode")}} and {{cssxref("te
 {{EmbedLiveSample("Writing system modes", "100%", "500")}}
 
 ```css hidden
-[lang|="jp"],
+[lang|="ja"],
 [lang|="mn"] {
   float: left;
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

- Fix ベトナム語 (Vietnamese) with 日本語 (Japanese) because the sentence is written in Japanese.
- Fix `text-orientation` as `upright` for the Japanese example.
- Fix language code `jp` to `ja`. (`jp` is a country code)

### Motivation

- To be show correct language name. And Vietnamese rarely use the vertical writing mode.
- Japanese in vertical writing is mostly written in `upright`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
