### PR TITLE
Firefox 146 hides unused CSS variables in the devtools inspector

### DIFF
--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -16,7 +16,10 @@ Firefox 146 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
+### Developer Tools
+
+- In the Rule view of the Inspector, when a displayed ruleset declares 10 or more [CSS custom properties](/en-US/docs/Web/CSS/Reference/Properties/--*) that are unused, those properties are hidden by default. This reduces clutter, and in some cases also speeds up the rendering of the Inspector panel. In such cases, the hidden properties can be displayed via a "Show..." button provided at the bottom of the ruleset.
+  ([Firefox bug 1719461](https://bugzil.la/1719461)).
 
 <!-- ### HTML -->
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 146 adds a feature whereby large numbers of unused CSS variables are hidden in the devtools rules view. See https://bugzilla.mozilla.org/show_bug.cgi?id=1719461.

I've done some testing and have found that:

1. The feature is enabled by default in nightly 147 and beta 146, so it isn't hidden behind a pref, and isn't a nightly-only feature.
2. The number of unused variables that causes the feature to kick in is 10, so I've reported it as "10 or more".

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
