### PR TITLE
Remove commented-out reference to 'scroller'

### DIFF
--- a/files/en-us/web/css/guides/scroll-driven_animations/index.md
+++ b/files/en-us/web/css/guides/scroll-driven_animations/index.md
@@ -128,8 +128,7 @@ Scroll the element in the inline direction to see its background color change. S
 
 ### Data types and values
 
-- [`<axis>`](/en-US/docs/Web/CSS/Reference/Values/axis) <!---
-- {{cssxref("scroller")}} -->
+- [`<axis>`](/en-US/docs/Web/CSS/Reference/Values/axis)
 - [`<timeline-range-name>`](/en-US/docs/Web/CSS/Reference/Properties/animation-range#timeline-range-name)
 
 ### Functions


### PR DESCRIPTION
i'll add it back in this week, but right now it's broken and visible