### PR TITLE
docs(headers): clarify quotes requirement in Content-Disposition of multipart/form-data

### DIFF
--- a/files/en-us/web/http/reference/headers/content-disposition/index.md
+++ b/files/en-us/web/http/reference/headers/content-disposition/index.md
@@ -57,7 +57,9 @@ Browsers may apply transformations to conform to the file system requirements, s
 
 A `multipart/form-data` body requires a `Content-Disposition` header to provide information about each subpart of the form (e.g., for every form field and any files that are part of field data).
 The first directive is always `form-data`, and the header must also include a `name` parameter to identify the relevant field. Additional directives are case-insensitive.
-Their arguments usually use quoted-string syntax after the `=` sign; although the standard allows unquoted tokens here, many server implementations expect the values to be quoted.
+The value of any arguments (after the `=` sign) may be a either token or a quoted string.
+Quoted strings are recommended, and many server implementations require the values to be quoted.
+This is because a token must be US-ASCII for MIME type headers like `Content-Disposition`, and US-ASCII does not allow some characters that are common in filenames and other values.
 Multiple parameters are separated by a semicolon (`;`).
 
 ```http


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Clarify that quotes in Content-Disposition's directives are not required in the RFC standard but are encouraged for compatibility.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

The current content says the quotes in directives of multipart/form-data's Content-Disposition are required, but it's NOT required in the RFC standard. See the issue linked below for more details.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://www.rfc-editor.org/rfc/rfc7578#section-4.2
https://httpwg.org/specs/rfc6266.html#n-grammar

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

https://github.com/mdn/content/issues/41683

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
