### PR TITLE
URLPattern test cases for trailing slashes - fix typo in result

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -389,8 +389,8 @@ console.log(patternSlash.test("https://example.com/books")); // false
 console.log(patternSlash.test("https://example.com/books/")); // true
 
 const patternNoSlash = new URLPattern({ pathname: "/books" });
-console.log(patternNoSlash.test("https://example.com/books")); // false
-console.log(patternNoSlash.test("https://example.com/books/")); // true
+console.log(patternNoSlash.test("https://example.com/books")); // true
+console.log(patternNoSlash.test("https://example.com/books/")); // false
 ```
 
 If you want to match both then you need to use a match pattern that allows either.


### PR DESCRIPTION
Fixes #42055

The matching url is the one that has the same trailing slash pattern as the test URL.