### PR TITLE
Fix incorrect error explanation in Error handling section

### DIFF
--- a/files/en-us/web/javascript/guide/resource_management/index.md
+++ b/files/en-us/web/javascript/guide/resource_management/index.md
@@ -293,7 +293,7 @@ async function readUntil(stream, text) {
 }
 ```
 
-Suppose that `chunk` turns out to be `null`. Then `toUpperCase()` will throw a `TypeError`, causing the function to terminate. Before the function exits, `stream[Symbol.dispose]()` is called, which releases the lock on the stream.
+Suppose that `chunk` turns out to be `null`. Then `!chunk.done` will throw a `TypeError`, causing the function to terminate. Before the function exits, `stream[Symbol.dispose]()` is called, which releases the lock on the stream.
 
 ```js
 const stream = new ReadableStream({


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The docs state that a TypeError occurs due to calling toUpperCase() when chunk is null.
However, the real error occurs earlier — when the code tries to access chunk.done in the while loop condition. This throws the TypeError before toUpperCase() is reached



### Related issues and pull requests
Fixes #42070 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
