### PR TITLE
Fix typos in Glossary/Percent-encoding

### DIFF
--- a/files/en-us/glossary/percent-encoding/index.md
+++ b/files/en-us/glossary/percent-encoding/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Percent-encoding** is a mechanism to encode 8-bit characters that have specific meaning in the context of {{Glossary("URL", "URLs")}}. It is sometimes called URL encoding. The encoding consists of substitution: A '%' followed by the hexadecimal representation of the ASCII value of the replace character.
+**Percent-encoding** is a mechanism to encode 8-bit characters that have specific meaning in the context of {{Glossary("URL", "URLs")}}. It is sometimes called URL encoding. The encoding consists of a substitution: A '%' followed by the hexadecimal representation of the ASCII value of the replaced character.
 
 Special characters needing encoding are: `':'`, `'/'`, `'?'`, `'#'`, `'['`, `']'`, `'@'`, `'!'`, `'$'`, `'&'`, `"'"`, `'('`, `')'`, `'*'`, `'+'`, `','`, `';'`, `'='`, as well as `'%'` itself. Other characters don't need to be encoded, though they could.
 


### PR DESCRIPTION
Fixes #42017

This PR fixes two typos in the Glossary/Percent-encoding page:
- "of substitution" → "of a substitution"
- "replace character" → "replaced character"