### PR TITLE
Fix rotationRate property descriptions order

### DIFF
--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.md
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.md
@@ -21,12 +21,12 @@ The `rotationRate` property is a read only object describing the rotation
 rates of the device around each of its axes:
 
 - `alpha`
+  - : The rate at which the device is rotating about its X axis; that is, front to back.
+- `beta`
+  - : The rate at which the device is rotating about its Y axis; that is, side to side.
+- `gamma`
   - : The rate at which the device is rotating about its Z axis; that is, being twisted
     about a line perpendicular to the screen.
-- `beta`
-  - : The rate at which the device is rotating about its X axis; that is, front to back.
-- `gamma`
-  - : The rate at which the device is rotating about its Y axis; that is, side to side.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Updated the order for the rotationRate property fields the match the definition in the standard.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current order does not follow what is defined in the W3S standard of the `DeviceMotionEvent` properties or the current documentation of the `acceleration` and `accelerationIncludingGravity` property.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Matches what is defined in the W3S standard: https://w3c.github.io/deviceorientation/#device-motion-event-rotation-rate-api
Aligns with the documentation of the acceleration property: https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent/acceleration
and accelerationIncludingGravity property: https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent/accelerationIncludingGravity

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

None that I can find
