### PR TITLE
Fix getRed/setRed example to use HSL→RGB conversion

### DIFF
--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -313,14 +313,10 @@ class Color {
     // values is now an HSL array!
     this.values = rgbToHSL([r, g, b]);
   }
-
   getRed() {
-    // Convert HSL → RGB and return the red channel
     return hslToRGB(this.values)[0];
   }
-
   setRed(value) {
-    // Convert HSL → RGB, update red channel, convert back to HSL
     const rgb = hslToRGB(this.values);
     rgb[0] = value;
     this.values = rgbToHSL(rgb);
@@ -328,7 +324,7 @@ class Color {
 }
 
 const red = new Color(255, 0, 0);
-console.log(red.getRed()); // 255
+console.log(red.values[0]); // 0; It's not 255 anymore, because the H value for pure red is 0
 ```
 
 The user assumption that `values` means the RGB value suddenly collapses, and it may cause their logic to break. So, if you are an implementor of a class, you would want to hide the internal data structure of your instance from your user, both to keep the API clean and to prevent the user's code from breaking when you do some "harmless refactors". In classes, this is done through [_private fields_](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements).


### PR DESCRIPTION
Fixes mdn#42059

### Description
Updates the Color class example so that getRed() and setRed() correctly operate on the red
channel after the internal representation was changed from RGB to HSL. Previously, the example
incorrectly accessed values[0], which is the hue component in HSL.

### Motivation
The documentation states that the internal storage is changed to HSL using rgbToHSL().
Therefore, getRed() and setRed() must convert HSL → RGB when reading or modifying the red channel.
This PR aligns the example with the encapsulation explanation and corrects the logic.

### Additional details
- getRed() now returns the red component via hslToRGB(this.values)[0]
- setRed() now converts HSL → RGB, updates the red value, and converts back to HSL
- Example output updated to show 255
