### PR TITLE
Change href in link element example to .ico file

### DIFF
--- a/files/en-us/web/api/htmllinkelement/sizes/index.md
+++ b/files/en-us/web/api/htmllinkelement/sizes/index.md
@@ -19,7 +19,7 @@ A {{domxref("DOMTokenList")}}
 ## Examples
 
 ```html
-<link rel="icon" sizes="72x72 114x114" href="smallish.png" />
+<link rel="icon" sizes="72x72 114x114" href="smallish.ico" />
 ```
 
 ```js


### PR DESCRIPTION
Fixes #42100

### Description
Changed the example file reference from `smallish.png` to `smallish.ico` in the HTMLLinkElement.sizes documentation.

### Motivation
The original example used a PNG file (`smallish.png`) which is technically incorrect because PNG files don't support multiple sizes. The `sizes` attribute is only meaningful for formats like `.ico` that can contain multiple icon sizes in a single file.

### Additional details
- Changed `href="smallish.png"` to `href="smallish.ico"` on line 22
- This makes the example more accurate and less confusing for developers learning about the sizes attribute