### PR TITLE
Swap assertion/attestation in authenticator data source

### DIFF
--- a/files/en-us/web/api/web_authentication_api/authenticator_data/index.md
+++ b/files/en-us/web/api/web_authentication_api/authenticator_data/index.md
@@ -12,8 +12,8 @@ The authenticator data structure contains information from the authenticator abo
 
 Authenticator data is made available to the browser as an {{jsxref("ArrayBuffer")}}, and can be accessed in multiple ways. The two most convenient are:
 
-- In the {{domxref("AuthenticatorAttestationResponse.authenticatorData", "PublicKeyCredential.response.authenticatorData")}} property made available on the {{domxref("PublicKeyCredential")}} returned from a successful {{domxref("CredentialsContainer.create", "navigator.credentials.create()")}} (credential creation) call.
-- Via the {{domxref("AuthenticatorAssertionResponse.getAuthenticatorData", "PublicKeyCredential.response.getAuthenticatorData()")}} method made available on the {{domxref("PublicKeyCredential")}} returned from a successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} (authentication) call.
+- Via the {{domxref("AuthenticatorAttestationResponse.getAuthenticatorData", "PublicKeyCredential.response.getAuthenticatorData()")}} method made available on the {{domxref("PublicKeyCredential")}} returned from a successful {{domxref("CredentialsContainer.create", "navigator.credentials.create()")}} (credential creation) call.
+- In the {{domxref("AuthenticatorAssertionResponse.authenticatorData", "PublicKeyCredential.response.authenticatorData")}} property made available on the {{domxref("PublicKeyCredential")}} returned from a successful {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} (authentication) call.
 
 ## Data structure
 


### PR DESCRIPTION
This PR fixes two incorrect internal links in the "Accessing authenticator data"
section of the Authenticator Data guide.

The previous version mixed up the attestation and assertion APIs:

• The link for `authenticatorData` in the context of
  `navigator.credentials.create()` incorrectly pointed to
  `AuthenticatorAssertionResponse.authenticatorData`.

• The link for `getAuthenticatorData()` in the context of
  `navigator.credentials.get()` incorrectly pointed to
  `AuthenticatorAttestationResponse.getAuthenticatorData`.

These were reversed: `create()` returns an attestation response, while `get()` returns an assertion response.

This PR corrects both domxref links:

• `AuthenticatorAttestationResponse.authenticatorData` for
  credential creation (`navigator.credentials.create()`)

• `AuthenticatorAssertionResponse.getAuthenticatorData` for
  authentication (`navigator.credentials.get()`)

No content changes were made beyond correcting these two links.

---

### Description

This PR updates two `domxref` links in the Authenticator Data guide to point to
their correct WebAuthn response types. The previous links incorrectly swapped
assertion and attestation references.

### Motivation

This fixes reader confusion and ensures that developers are directed to the
correct documentation for attestation (credential creation) and assertion
(authentication). It aligns the guide with the WebAuthn specification.

### Additional details

• Attestation corresponds to `navigator.credentials.create()`  
• Assertion corresponds to `navigator.credentials.get()`  
• Corrected links now match the expected WebAuthn object model

### Related issues and pull requests

Fixes #41937
