### PR TITLE
Revise `view-timeline` property

### DIFF
--- a/files/en-us/web/css/reference/properties/view-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/view-timeline/index.md
@@ -52,7 +52,7 @@ view-timeline: unset;
 
 ### Description
 
-The `view-timeline` shorthand property defines a _named view progress timeline_, which progresses based on changes to the visibility of an element (the _subject_) within a scrollable element (_scroller_). The `view-timeline` property is set on the subject.
+The `view-timeline` shorthand property defines a _named view progress timeline_, which progresses based on changes to the visibility of an element (the _subject_) within a scrollable element (_scroller_). The `view-timeline` property is set on the subject. If the scroller element does not overflow its container in the axis dimension or if the overflow is hidden or clipped, no scroll progress timeline will be created.
 
 The subject's visibility inside the scroller is tracked — by default, the timeline is at `0%` when the subject is first visible at one edge of the scroller and `100%` when it reaches the opposite edge.
 


### PR DESCRIPTION
Updated the description and syntax for the `view-timeline` property, clarifying its functionality and usage. Added notes on the constituent values and their order.