### PR TITLE
Add Specifications section to `content_scripts` manifest key

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -431,6 +431,10 @@ This injects two content scripts into all pages under `mozilla.org` or any of it
 
 The content scripts see the same view of the DOM and are injected in the order they appear in the array, so `borderify.js` can see global variables added by `jquery.js`.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
### Description

Adds a Specification section to the `content_scripts` manifest key page.

### Motivation

This follows a change in https://github.com/mdn/browser-compat-data/pull/28490 to add a specification link to BCD. Following discussion in the W3C WebExtensions Community Group, we have good language around this key in particular and would like to get into the habit of adding links to MDN.

### Additional details

N/A

### Related issues and pull requests

N/A
