### PR TITLE
fix(sidebar): fixing sidebar typo blocking sidebar display

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -268,8 +268,8 @@ sidebar:
     title: Scroll_anchoring
     details: closed
   - type: listSubPages
-    path: /Web/CSS/Guides/Scroll_driven_animations
-    title: Scroll_driven_animations
+    path: /Web/CSS/Guides/Scroll-driven_animations
+    title: Scroll-driven_animations
     details: closed
   - type: listSubPages
     path: /Web/CSS/Guides/Scroll_snap
@@ -426,7 +426,7 @@ l10n:
     Positioning: Positioning
     Selectors: Selectors
     Scroll_anchoring: Scroll anchoring
-    Scroll_driven_animations: Scroll-driven animations
+    Scroll-driven_animations: Scroll-driven animations
     Scroll_snap: Scroll snap
     Shapes: Shapes
     Syntax: Syntax


### PR DESCRIPTION
### Description

Recent change contain a typo creating en error on Production page, Localhost pages and Companion pages for CSS sections (Values).

### Motivation

Quick fix

### Additional details

_none_

### Related issues and pull requests

https://github.com/mdn/content/commit/01768f6dcc74acdbd32d2e91512939003b86ac6c
