### PR TITLE
Update LayoutShiftAttribution documentation for impact-area ordering

### DIFF
--- a/files/en-us/web/api/layoutshiftattribution/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/index.md
@@ -29,7 +29,7 @@ Instances of `LayoutShiftAttribution` are returned in an array by calling {{domx
 
 ## Examples
 
-The following example observes layout shifts and identifies the most impactful element. The `sources` array is sorted by impact area in descending order, so the first element (`sources[0]`) represents the element that contributed most to the layout shift. For more detail on this see [Debug Web Vitals in the field](https://web.dev/articles/debug-performance-in-the-field).
+The following example observes layout shifts and identifies the most impactful element. The `sources` array is sorted by impact area, in descending order — so the first element (`sources[0]`) represents the element that contributed most to the layout shift. For more detail on that, see [Debug Web Vitals in the field](https://web.dev/articles/debug-performance-in-the-field).
 
 ```js
 const observer = new PerformanceObserver((list) => {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Updates the `LayoutShiftAttribution` interface documentation to reflect the standardization of impact-area ordering for `LayoutShift.sources`, as implemented in Chrome 143.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The Chromium team has defined a standardized ordering for `LayoutShiftAttribution` entries based on impact area to ensure consistent and predictable behavior across browser implementations.
This documentation update helps developers understand how layout shift sources are ordered and what behavior they can reliably expect when using the Performance API to analyze layout shifts.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
  - Chromium Issue: https://issues.chromium.org/issues/450950606
  - Chromium Patch: https://chromium-review.googlesource.com/c/chromium/src/+/7196706
  - Target Milestone: Chrome 143
  - Component: Blink > PerformanceAPIs
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
