### PR TITLE
Fix grammar and clarity issues in Array.prototype.indexOf documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.md
@@ -7,8 +7,7 @@ browser-compat: javascript.builtins.Array.indexOf
 sidebar: jsref
 ---
 
-The **`indexOf()`** method of {{jsxref("Array")}} instances returns the first index at which a
-given element can be found in the array, or -1 if it is not present.
+The **`indexOf()`** method of {{jsxref("Array")}} instances returns the first index at which an element can be found in the array, or -1 if it is not present.
 
 {{InteractiveExample("JavaScript Demo: Array.prototype.indexOf()")}}
 
@@ -36,10 +35,10 @@ indexOf(searchElement, fromIndex)
 ### Parameters
 
 - `searchElement`
-  - : Element to locate in the array.
+  - : The element to locate in the array.
 - `fromIndex` {{optional_inline}}
   - : Zero-based index at which to start searching, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
-    - Negative index counts back from the end of the array — if `-array.length <= fromIndex < 0`, `fromIndex + array.length` is used. Note, the array is still searched from front to back in this case.
+    - Negative index counts back from the end of the array — if `-array.length <= fromIndex < 0`, `fromIndex + array.length` is used. Note: the array is still searched from front to back in this case.
     - If `fromIndex < -array.length` or `fromIndex` is omitted, `0` is used, causing the entire array to be searched.
     - If `fromIndex >= array.length`, the array is not searched and `-1` is returned.
 
@@ -49,7 +48,7 @@ The first index of `searchElement` in the array; `-1` if not found.
 
 ## Description
 
-The `indexOf()` method compares `searchElement` to elements of the array using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same algorithm used by the `===` operator). [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) values are never compared as equal, so `indexOf()` always returns `-1` when `searchElement` is `NaN`.
+The `indexOf()` method compares `searchElement` to elements of the array using [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (the same algorithm used by the `===` operator). [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) values are never considered equal, so `indexOf()` always returns `-1` when `searchElement` is `NaN`.
 
 The `indexOf()` method skips empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).
 


### PR DESCRIPTION
### Description

This PR fixes minor grammar and clarity issues in the `Array.prototype.indexOf()` documentation.  
The updates improve sentence structure, parameter wording, and readability in the “fromIndex” explanation note.

### Motivation

These improvements make the documentation more natural and easier to read by:
- Replacing “a given element” with “an element”
- Changing “Element to locate in the array.” to “The element to locate in the array.”
- Updating “Note, the array…” to the clearer “Note: the array…”

All changes are non-functional documentation updates.

### Additional details

These updates follow MDN’s writing style guidelines for clarity and consistent phrasing.  
No code behavior or examples were modified.

### Related issues and pull requests

None.