### PR TITLE
Add 'json' as a value for Sec-Fetch-Dest

### DIFF
--- a/files/en-us/web/http/reference/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/reference/headers/sec-fetch-dest/index.md
@@ -44,6 +44,7 @@ Sec-Fetch-Dest: font
 Sec-Fetch-Dest: frame
 Sec-Fetch-Dest: iframe
 Sec-Fetch-Dest: image
+Sec-Fetch-Dest: json
 Sec-Fetch-Dest: manifest
 Sec-Fetch-Dest: object
 Sec-Fetch-Dest: paintworklet
@@ -86,6 +87,8 @@ Servers should ignore this header if it contains any other value.
   - : The destination is an iframe. This might originate from an HTML {{HTMLElement("iframe")}} tag.
 - `image`
   - : The destination is an image. This might originate from an HTML {{HTMLElement("img")}}, SVG {{SVGElement("image")}}, CSS {{cssxref("background-image")}}, CSS {{cssxref("cursor")}}, CSS {{cssxref("list-style-image")}}, etc.
+- `json`
+  - : The destination is JSON. This might originate from [importing a module from JavaScript with the `type: "json"` attribute](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#importing_json_modules_with_the_type_attribute).
 - `manifest`
   - : The destination is a manifest. This might originate from an HTML [\<link rel=manifest>](/en-US/docs/Web/HTML/Reference/Attributes/rel/manifest).
 - `object`


### PR DESCRIPTION
### Description

The [docs for the Sec-Fetch-Dest header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest) were missing the valid value `json`. This fixes adds it.

I wasn't totally sure how best to link to the docs for JSON imports. I did something which works but if there's a better way feel free to push it up.

### Motivation

Match spec.

### Additional details

See [fetch spec](https://fetch.spec.whatwg.org/#concept-request-destination) for request destinations, and [fetch metadata spec](https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-dest-header) for the bit which says that this is reflected in the Sec-Fetch-Dest header.

### Related issues and pull requests

None that I could find.