### PR TITLE
Replace `console.log` with `log` in HTMLElement toggle event

### DIFF
--- a/files/en-us/web/api/htmlelement/toggle_event/index.md
+++ b/files/en-us/web/api/htmlelement/toggle_event/index.md
@@ -78,9 +78,9 @@ const popover = document.getElementById("mypopover");
 
 popover.addEventListener("toggle", (event) => {
   if (event.newState === "open") {
-    console.log("Popover has been shown");
+    log("Popover has been shown");
   } else {
-    console.log("Popover has been hidden");
+    log("Popover has been hidden");
   }
 });
 ```


### PR DESCRIPTION
### Description

Replace `console.log` with `log` in the HTMLElement toggle event page.

### Motivation

No text is displayed in the log pre element after clicking the toggle button.

A explicit `log` function is defined but not used.

### Additional details

The `beforetoggle_event` page uses the explicit `log` function.

https://github.com/mdn/content/blob/39070892d5d1a5cc55312a0ac10c97f4c339384f/files/en-us/web/api/htmlelement/beforetoggle_event/index.md?plain=1#L84-L92