### PR TITLE
 Replace short-note by a detailed section to clarify some vars scope inconsistency

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/functions/index.md
+++ b/files/en-us/learn_web_development/core/scripting/functions/index.md
@@ -467,7 +467,7 @@ Let's look at a real example to demonstrate scoping.
 > [!NOTE]
 > The [ReferenceError: "x" is not defined](/en-US/docs/Web/JavaScript/Reference/Errors/Not_defined) error is one of the most common you'll encounter. If you get this error and you are sure that you have defined the variable in question, check what scope it is in.
 
-#### an aside on loop and conditional scope
+#### An aside on loop and conditional scope
 
 It is worth noting that the scope of values declared inside [conditionals](/en-US/docs/Learn_web_development/Core/Scripting/Conditionals) and [loops](/en-US/docs/Learn_web_development/Core/Scripting/Loops) works the same as function scope when declaring values with `let` and `const`. For example, if you added the following blocks to the above example:
 
@@ -483,21 +483,23 @@ for (let i = 0; i <= 1; i++) {
 }
 ```
 
-Calling `output(c)`, `output(d)`, `output(e)`, and `output(f)` would result in the same **"ReferenceError: [variable-name] is not defined"** error seen earlier. The `output()` function cannot access these variables because they are locked inside their own scope.
+Calling `output(c)`, `output(d)`, `output(e)`, or `output(f)` would result in the same **"ReferenceError: [variable-name] is not defined"** error seen earlier. The `output()` function cannot access these variables because they are locked inside their own scope.
 
-The legacy `var` keyword works differently. If `c` and `e` were declared using `var`:
+The legacy `var` keyword works differently. If `c`, `d`, `e`, and `f` were declared using `var`:
 
 ```js
 if (x === 1) {
   var c = 4;
+  var d = 5;
 }
 
 for (let i = 0; i <= 1; i++) {
-  var e = 5;
+  var e = 6;
+  var f = 7;
 }
 ```
 
-they would be hoisted to the global scope; therefore, `output(c)` and `output(e)` would result in their values being output to the console. Variables declared with `var` inside functions, however, still have their scope limited to those functions.
+they would be hoisted to the global scope; therefore, outputting them to the console (for example, with `output(c)`) would work. Variables declared with `var` inside functions, however, still have their scope limited to those functions.
 
 This inconsistency can cause confusion and errors, and is another reason why you should use `let` and `const` instead of `var`.
 


### PR DESCRIPTION
The previous note was stating that loops and conditional block scope behaves differently than the function scope, which I think is only true when declaring variables with `var`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The removed note was accurate when there was only `var`, but not today .. when we almost never use `var`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
The content in this PR is written by @chrisdavidmills in the following comment: https://github.com/mdn/content/pull/42164#pullrequestreview-3524303530
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
