### PR TITLE
Update grammar in WeakMap toy implementation warning

### DIFF
--- a/files/en-us/web/javascript/guide/memory_management/index.md
+++ b/files/en-us/web/javascript/guide/memory_management/index.md
@@ -212,7 +212,7 @@ If `key` is stored as an actual reference, it would create a cyclic reference an
 As a rough mental model, think of a `WeakMap` as the following implementation:
 
 > [!WARNING]
-> This is not a polyfill nor is anywhere close to how it's implemented in the engine (which hooks into the garbage collection mechanism).
+> This is not a polyfill, nor is it anywhere close to how it's implemented in the engine (which hooks into the garbage collection mechanism).
 
 ```js
 class MyWeakMap {


### PR DESCRIPTION
### Description
This PR adds the missing word "to" and adds a comma to the warning about the toy implementation of WeakMap under [WeakMaps and WeakSets](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/guide/memory_management/index.md#weakmaps-and-weaksets).

### Motivation
The updated text is more grammatically correct.

### Additional details
Documentation-only change; no examples or functionality descriptions were modified.

### Related issues and pull requests
None.
