### PR TITLE
Fix Return Value for Writable Stream

### DIFF
--- a/files/en-us/web/api/writablestream/abort/index.md
+++ b/files/en-us/web/api/writablestream/abort/index.md
@@ -23,7 +23,7 @@ abort(reason)
 
 ### Return value
 
-A {{jsxref("Promise")}}, which fulfills with `undefined` value.
+A {{jsxref("Promise")}}, which fulfills with `undefined`.
 
 ### Exceptions
 


### PR DESCRIPTION
Update return value description to specify 'undefined' per #42173

### Description

Current return type of `reason` is incorrect as indicated by testing in #42173. Updated to `undefined`

### Motivation

Noticed the docs were wrong while trying to implement WritableStream.abort in my own code.

### Additional details/related issues and pull requests

Fixes #42173
