### PR TITLE
Move two pages out of security top level

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -16304,12 +16304,14 @@
 /en-US/docs/Web/Security/Do_not_track_field_guide/Tutorials/3_Collecting_aggregate_data_based_on_DNT	/en-US/docs/Web/HTTP/Reference/Headers/DNT
 /en-US/docs/Web/Security/Do_not_track_field_guide/Tutorials/Additional_resources	/en-US/docs/Web/HTTP/Reference/Headers/DNT
 /en-US/docs/Web/Security/HTTP_strict_transport_security	/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security
+/en-US/docs/Web/Security/IFrame_credentialless	/en-US/docs/Web/HTTP/Guides/IFrame_credentialless
 /en-US/docs/Web/Security/Insecure_passwords	/en-US/docs/Web/Security/Authentication/Passwords
 /en-US/docs/Web/Security/Mixed_content	/en-US/docs/Web/Security/Defenses/Mixed_content
 /en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content	/en-US/docs/Web/Security/Defenses/Mixed_content#developer_console
 /en-US/docs/Web/Security/Practical_implementation_guides/CSRF_prevention	/en-US/docs/Web/Security/Attacks/CSRF
 /en-US/docs/Web/Security/Practical_implementation_guides/Clickjacking	/en-US/docs/Web/Security/Attacks/Clickjacking
 /en-US/docs/Web/Security/Public_Key_Pinning	/en-US/docs/Web/Security/Defenses/Certificate_Transparency
+/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns	/en-US/docs/Web/Privacy/Guides/Referer_header:_privacy_and_security_concerns
 /en-US/docs/Web/Security/Same-origin_policy	/en-US/docs/Web/Security/Defenses/Same-origin_policy
 /en-US/docs/Web/Security/Secure_Contexts	/en-US/docs/Web/Security/Defenses/Secure_Contexts
 /en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts	/en-US/docs/Web/Security/Defenses/Secure_Contexts/features_restricted_to_secure_contexts

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -121179,6 +121179,18 @@
       "antoinegrant"
     ]
   },
+  "Web/Privacy/Guides/Referer_header:_privacy_and_security_concerns": {
+    "modified": "2020-07-22T14:05:46.803Z",
+    "contributors": [
+      "mfuji09",
+      "bradyhanna",
+      "chrisdavidmills",
+      "..",
+      "vriojtg",
+      "cg",
+      "wbamberg"
+    ]
+  },
   "Web/Progressive_web_apps": {
     "modified": "2020-12-14T07:30:15.695Z",
     "contributors": [
@@ -124731,18 +124743,6 @@
       "VicMan",
       "Pmsyyz",
       "Mathieu Deaudelin"
-    ]
-  },
-  "Web/Security/Referer_header:_privacy_and_security_concerns": {
-    "modified": "2020-07-22T14:05:46.803Z",
-    "contributors": [
-      "mfuji09",
-      "bradyhanna",
-      "chrisdavidmills",
-      "..",
-      "vriojtg",
-      "cg",
-      "wbamberg"
     ]
   },
   "Web/URI": {

--- a/files/en-us/web/http/guides/iframe_credentialless/index.md
+++ b/files/en-us/web/http/guides/iframe_credentialless/index.md
@@ -1,12 +1,12 @@
 ---
 title: IFrame credentialless
-slug: Web/Security/IFrame_credentialless
+slug: Web/HTTP/Guides/IFrame_credentialless
 page-type: guide
 status:
   - experimental
 browser-compat: html.elements.iframe.credentialless
 spec-urls: https://wicg.github.io/anonymous-iframe/
-sidebar: security
+sidebar: http
 ---
 
 {{SeeCompatTable}}

--- a/files/en-us/web/privacy/guides/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/en-us/web/privacy/guides/referer_header_colon__privacy_and_security_concerns/index.md
@@ -1,8 +1,8 @@
 ---
 title: "Referer header: Privacy and security concerns"
-slug: Web/Security/Referer_header:_privacy_and_security_concerns
+slug: Web/Privacy/Guides/Referer_header:_privacy_and_security_concerns
 page-type: guide
-sidebar: security
+sidebar: privacy
 ---
 
 There are privacy and security risks associated with the [Referer HTTP header](/en-US/docs/Web/HTTP/Reference/Headers/Referer). This article describes them, and offers advice on mitigating those risks.

--- a/files/sidebars/http.yaml
+++ b/files/sidebars/http.yaml
@@ -41,6 +41,7 @@ sidebar:
       - /Web/Security/Practical_implementation_guides
       - /Web/HTTP/Guides/Permissions_Policy
       - /Web/HTTP/Guides/Cross-Origin_Resource_Policy
+      - /Web/HTTP/Guides/IFrame_credentialless
       - /Web/HTTP/Guides/CORS
       - type: listSubPages
         path: /Web/HTTP/Guides/CORS/Errors

--- a/files/sidebars/privacy.yaml
+++ b/files/sidebars/privacy.yaml
@@ -13,6 +13,7 @@ sidebar:
   - link: /Web/Privacy/Guides/Bounce_tracking_mitigations
   - link: /Web/Privacy/Guides/Redirect_tracking_protection
   - link: /Web/Privacy/Guides/State_Partitioning
+  - link: /Web/Privacy/Guides/Referer_header:_privacy_and_security_concerns
   - type: listSubPages
     path: /Web/Privacy/Guides/Storage_Access_Policy
     depth: 2

--- a/files/sidebars/security.yaml
+++ b/files/sidebars/security.yaml
@@ -22,6 +22,4 @@ sidebar:
     link: /Web/Security/Practical_implementation_guides
     title: Practical implementation guides
     details: closed
-  - /Web/Security/IFrame_credentialless
-  - /Web/Security/Referer_header:_privacy_and_security_concerns
   - /Web/Security/Firefox_Security_Guidelines


### PR DESCRIPTION
The second part of https://github.com/orgs/mdn/discussions/857, moving:

- https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns to Web/Privacy. We'll be revisiting the privacy docs in 2026, but it's OK there for now.
- https://developer.mozilla.org/en-US/docs/Web/Security/IFrame_credentialless to Web/HTTP

This leaves us with only the Firefox guide left, which I don't know if we can clean yet.