### PR TITLE
chore(npm): enable engine-strict, disable audit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+audit=false
+engine-strict=true


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Adds `.npmrc` enabling `engine-strict` and disabling `audit`.

### Motivation

1. Enabling `engine-strict` prevents `npm install` with npm 10, which changes the `package-lock.json`.
2. Disabling `audit` suppresses the misleading audit message.

Note: With disabled `audit`, dependencies can still be audited via `npm install --audit` or `npm audit`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of:

- https://github.com/mdn/fred/issues/1121
