### PR TITLE
Inform learners that preceeding pseudo-classes with `*` is rarely used

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/basic_selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/basic_selectors/index.md
@@ -8,7 +8,7 @@ sidebar: learnsidebar
 
 {{PreviousMenuNext("Learn_web_development/Core/Styling_basics/Styling_a_bio_page", "Learn_web_development/Core/Styling_basics/Attribute_selectors", "Learn_web_development/Core/Styling_basics")}}
 
-You've already seen how, in {{Glossary("CSS")}}, selectors are used to target the {{glossary("HTML")}} elements on our web pages that we want to style. There are a wide variety of CSS selectors available, allowing for fine-grained precision when selecting elements to style, and in the next few articles we'll look at the different types in depth. In this article we'll recap some selector fundamentals, including the basic type, class, and ID selectors, and selector lists. We'll also introduce the universal selector.
+You've already seen how, in {{Glossary("CSS")}}, selectors are used to target the {{glossary("HTML")}} elements on our web pages that we want to style. There is a wide variety of CSS selectors available, allowing for fine-grained precision when selecting elements to style, and in the next few articles, we'll look at the different types in depth. In this article, we'll recap some selector fundamentals, including the basic type, class, and ID selectors, and selector lists. We'll also introduce the universal selector.
 
 <table>
   <tbody>
@@ -38,15 +38,15 @@ You've already seen how, in {{Glossary("CSS")}}, selectors are used to target th
 
 ## What is a selector?
 
-A CSS selector is the first part of a CSS Rule. It is a pattern of elements and other terms that tell the browser which HTML elements should be selected to have the CSS property values inside the rule applied to them. The element or elements which are selected by the selector are referred to as the _subject of the selector_.
+A CSS selector is the first part of a CSS Rule. It is a pattern of elements and other terms that tell the browser which HTML elements should have the CSS property values inside the rule applied to them. The element or elements selected by the selector are referred to as the _subject of the selector_.
 
 ![Some code with the h1 highlighted.](selector.png)
 
-In earlier articles you may have met some different selectors, and learned that there are selectors that target the document in different ways — for example by selecting an element such as `h1`, or a class such as `.special`. Let's start off by recapping the main ones you've already seen.
+In earlier articles, you met various selectors and learned that there are selectors that target the document in different ways; for example, by selecting an element such as `h1`, or a class such as `.special`. Let's start by recapping the main ones you've already seen.
 
 ## Type selectors
 
-A **type selector** is sometimes referred to as a _tag name selector_ or _element selector_ because it selects an HTML tag/element in your document. In the example below, we have used the `span`, `em` and `strong` selectors.
+A **type selector** is sometimes called a _tag name selector_ or _element selector_ because it selects an HTML tag/element in your document. In the example below, we have used the `span`, `em` and `strong` selectors.
 
 Try editing the following example (click **"Play"** to open it in the MDN Playground) to add a CSS rule that selects the `<h1>` element and changes its color to blue:
 
@@ -93,7 +93,7 @@ em {
 
 ## Class selectors
 
-The case-sensitive class selector starts with a dot (`.`) character. It will select everything in the document with that class applied to it. In the live example below we have created a class called `highlight`, and have applied it to several places in my document. All of the elements that have the class applied are highlighted.
+The case-sensitive class selector starts with a dot (`.`) character. It will select everything in the document with that class applied to it. In the live example below, we have created a class called `highlight` and applied it to several places in the document. All elements with that class are highlighted.
 
 ```html live-sample___class
 <h1 class="highlight">Class selectors</h1>
@@ -126,13 +126,13 @@ body {
 
 Try editing the above example (using MDN Playground) to make the following changes:
 
-1. Edit the HTML to change the content the `.highlight` styles are applied to. You could for example add some `<span>` elements to wrap different parts of the existing content and apply the `highlight` class to those, remove some existing `highlight` classes, or add some new content to apply the `highlight` class to.
+1. Edit the HTML to change the content that the `.highlight` styles are applied to. You could, for example, add some `<span>` elements to wrap different parts of the existing content and apply the `highlight` class to them, remove some existing `highlight` classes, or add some new content to apply the `highlight` class to.
 2. Edit the CSS to modify the declarations inside the `.highlight` rule, adding new ones if you feel like it, and note how this affects the styling of all elements that have the `highlight` class applied.
 3. Create a new class rule inside the CSS with different declarations inside it (for example, with a selector of `.highlight2`), then try applying that to some of your HTML.
 
 ### Targeting classes on particular elements
 
-You can create a selector that will target specific elements with the class applied. In this next example, we will highlight a `<span>` with a class of `highlight` differently to an `<h1>` heading with a class of `highlight`. We do this by using the type selector for the element we want to target, with the class appended using a dot, with no white space in between.
+You can create a selector that will target specific elements with the class applied. In this next example, we will highlight a `<span>` with a class of `highlight` differently from an `<h1>` heading with a class of `highlight`. We do this by using the type selector for the element we want to target, with the class appended using a dot, with no white space in between.
 
 ```html live-sample___class-type
 <h1 class="highlight">Class selectors</h1>
@@ -165,7 +165,7 @@ h1.highlight {
 
 {{EmbedLiveSample("class-type", "", "200px")}}
 
-This approach reduces the scope of a rule. The rule will only apply to that particular element and class combination. You would need to add another selector if you decided the rule should apply to other elements too.
+This approach reduces the scope of a rule. The rule will only apply to that particular element and class combination. You would need to add another selector if you wanted the rule to apply to other elements.
 
 ### Target an element if it has more than one class applied
 
@@ -173,7 +173,7 @@ You can apply multiple classes to an element and target them individually, or on
 
 In the example below, we have a `<div>` that contains a note. The grey border is applied when the box has a class of `notebox`. If it also has a class of `warning` or `danger`, we change the {{cssxref("border-color")}}.
 
-We can tell the browser that we only want to match the element if it has two classes applied by chaining them together with no white space between them. You'll see that the last `<div>` doesn't get any styling applied, as it only has the `danger` class; it needs `notebox` as well to get anything applied.
+We can tell the browser that we only want to match the element if it has two classes applied by chaining them together with no white space between them. You'll see that the last `<div>` doesn't get any styling applied, as it only has the `danger` class. To get any styles applied, it needs the `notebox` class as well.
 
 ```html live-sample___class-many
 <div class="notebox">This is an informational note.</div>
@@ -213,7 +213,7 @@ body {
 
 ## ID selectors
 
-The case-sensitive ID selector begins with a `#` rather than a dot character, but is used in the same way as a class selector. The difference is that an ID can be used only once per page, and elements can only have a single `id` value applied to them. It can select an element that has the `id` set on it, and you can precede the ID with a type selector to only target the element if both the element and ID match. You can see both of these uses in the following example:
+The case-sensitive ID selector begins with a `#` rather than a dot character, but is used in the same way as a class selector. The difference is that an ID can be used only once per page, and elements can only have a single `id` value. An ID selector selects an element with a specific `id`, and you can precede the ID with a type selector to only target the element if both the element and ID match. You can see both of these uses in the following example:
 
 ```html live-sample___id
 <h1 id="heading">ID selector</h1>
@@ -246,7 +246,7 @@ h1#heading {
 {{EmbedLiveSample("id", "", "200px")}}
 
 > [!WARNING]
-> Using the same ID multiple times in a document may appear to work for styling purposes, but don't do this. It results in invalid code, and will cause strange behavior in many places.
+> Using the same ID multiple times in a document may appear to work for styling purposes, but don't do this. It results in invalid code and will cause strange behavior in many places.
 
 ### Playing with ID selectors
 
@@ -257,7 +257,7 @@ Try editing the above example to make the following changes:
 
 ## Selector lists
 
-If you have more than one thing that uses the same CSS then the individual selectors can be combined into a _selector list_ so that the rule is applied to all of the individual selectors. For example, if I have the same CSS for an `h1` and also a class of `.special`, I could write this as two separate rules.
+If you want to apply the same CSS to multiple items, you can combine individual selectors into a _selector list_. The rule is then applied to all the individual selectors. For example, if I have the same CSS for an `h1` and a `.special` selector, I could write this as two separate rules.
 
 ```css
 h1 {
@@ -269,7 +269,7 @@ h1 {
 }
 ```
 
-I could also combine these into a selector list, by adding a comma between them.
+I could also combine these into a selector list by adding a comma between them.
 
 ```css-nolint
 h1, .special {
@@ -288,7 +288,7 @@ h1,
 
 ### Playing with selector lists
 
-In the example below, try combining the two selectors which have identical declarations. The visual display should be the same after combining them.
+In the example below, try combining the two selectors that have identical declarations. The visual display should be the same afterwards.
 
 ```html live-sample___selector-list
 <h1>Type selectors</h1>
@@ -346,7 +346,7 @@ h1 {
 }
 ```
 
-When combined however, neither the `h1` nor the class will be styled as the entire rule is deemed invalid.
+When combined, however, neither the `h1` nor the class will be styled as the entire rule is deemed invalid.
 
 ```css-nolint
 h1, ..special {
@@ -391,7 +391,7 @@ This kind of behavior can sometimes be seen in "reset stylesheets", which strip 
 
 ### Using the universal selector to make your selectors easier to read
 
-One use of the universal selector is to make selectors easier to read and more obvious in terms of what they are doing. For example, if we wanted to select any descendant elements of an `<article>` element that are the first child of their parent, including direct children, and make them bold, we could use the {{cssxref(":first-child")}} pseudo-class. We will learn more about this in the lesson on [pseudo-classes and pseudo-elements](/en-US/docs/Learn_web_development/Core/Styling_basics/Pseudo_classes_and_elements):
+One use of the universal selector is to make selectors easier to read and more intuitive. For example, if we wanted to select all descendant elements of an `<article>` element that are the first child of their parent, including direct children, we could use the {{cssxref(":first-child")}} pseudo-class. We will learn more about this in [pseudo-classes and pseudo-elements](/en-US/docs/Learn_web_development/Core/Styling_basics/Pseudo_classes_and_elements):
 
 ```css
 article :first-child {
@@ -401,7 +401,7 @@ article :first-child {
 
 However, this selector could be confused with `article:first-child`, which will select any `<article>` element that is the first child of another element.
 
-To avoid this confusion, we can add the universal selector to the `:first-child` pseudo-class, so it is more obvious what the selector is doing. It is selecting _any_ element which is the first-child of an `<article>` element, or the first-child of any descendant element of `<article>`:
+To avoid this confusion, we could add the universal selector to the `:first-child` pseudo-class, so it is more obvious what the selector is doing. It is selecting _any_ element that is the first-child of an `<article>` element, or the first-child of any descendant element of `<article>`:
 
 ```css
 article *:first-child {
@@ -409,14 +409,14 @@ article *:first-child {
 }
 ```
 
-Although both do the same thing, the readability is significantly improved.
+Both are equivalent, but some people find the second option easier to read.
 
 > [!NOTE]
-> Although this technique of preceding pseudo-classes with `*` seems very useful, it is rarely used in real code. It is worth noting that the same thing applies here in MDN docs: we almost never use it. However, that takes nothing from its value, and that shouldn't discourage you from using it in your code if you like.
+> You are unlikely to see this technique used much in published websites. We don't use it much on MDN, for example. However, you should still consider using it in your code if you find it easier to understand.
 
 ## Summary
 
-In this article we've recapped CSS selectors, which enable you to target particular HTML elements, looking at type, class, and ID selectors in a bit more depth than we did previously. In the next article we will dive into attribute selectors.
+In this article, we've recapped CSS selectors, which enable you to target particular HTML elements, looking at type, class, and ID selectors in a bit more depth than we did previously. In the next article, we will dive into attribute selectors.
 
 > [!NOTE]
 > For a complete list of selectors, see our [CSS selectors reference](/en-US/docs/Web/CSS/Guides/Selectors).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->
The content of this PR is a result of what I understood from @chrisdavidmills [comment](https://github.com/mdn/content/pull/42208#pullrequestreview-3534226479)

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Adding a note to inform the learners of the rarity of using that technique (_preceding pseudo-codes with `*` for readability improvement_ ) in real code, and also that that syntax is not adopted in MDN docs.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
- To give an idea about the usage of that syntax in real code.
-  To avoid PRs that suggests adopting it, PRs similar to  #42208 .
### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
Relates to #42208
<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
