### PR TITLE
Fix typo in Looping Code article

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/loops/index.md
+++ b/files/en-us/learn_web_development/core/scripting/loops/index.md
@@ -589,7 +589,7 @@ To complete the exercise:
 
 1. Click **"Play"** in the code block below to edit the example in the MDN Playground.
 2. Add code to loop from 10 down to 0. We've provided you with an initializer — `let i = 10;`.
-3. For each iteration, create a new paragraph and append it to the output `<div>`, which we've selected using `const output = document.querySelector('.output');`. We've provided you with three code lines inside comment that need to be used somewhere inside the loop:
+3. For each iteration, create a new paragraph and append it to the output `<div>`, which we've selected using `const output = document.querySelector('.output');`. We've provided you with three code lines inside comments that need to be used somewhere inside the loop:
    1. `const para = document.createElement('p');` — creates a new paragraph.
    2. `output.appendChild(para);` — appends the paragraph to the output `<div>`.
    3. `para.textContent =` — makes the text inside the paragraph equal to whatever you put on the right-hand side, after the equals sign.


### PR DESCRIPTION
### Description

The "comment" referred to in the article is actually three separate comments on three separate lines in the provided [example](https://developer.mozilla.org/en-US/play?uuid=18d38c459f59693872a62093bc6fe224584b1734&state=XVDLbsIwEPyVlasKKjUhqfrCAS6oX9CrLybZJC6OndoOkCL%2BvXZDEOVmz85jZ4%2Bkdo0klCwKsYNccmuXjOjOtZ1jZLWYeXjFFHkkubWeFthwZAqg1MpFJW%2BE7ClYrmxk0YgyY%2BrEFFP10xXNih%2BkkL62h3Ec8zTtI8k3eLZruKmEopBk4efw4CIuReURI6raZTdeSfxmsPlD96JwNYX5%2B%2F1ovtFF%2F981Tf6iATY831ZGd6qgcFe%2BlPOSX1YaWg%2FCGkMqheeLUu%2FQlFLvKfDO6UHkz%2FIVrpJrZR2c9UsodN41qFz83aHpP1Fi7rSZMhKPh33w%2BuEdh6prX8zzvZQRRrKwzWwGEh0Ij6XJiAw5LTf8OiU3yB1%2BSAy%2F6aSdBHfPDrwb%2B2FwTuZti6pY10IW08ANMt%2FI1d7Ilyq42ZLTLw%3D%3D&srcPrefix=%2Fen-US%2Fdocs%2FLearn_web_development%2FCore%2FScripting%2FLoops%2F). This change adds the appropriate pluralization.

### Motivation

Fixing a minor typo for clarity and ease of reading.

### Additional details

Changes the article [Looping Code](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Loops).

### Related issues and pull requests

N/A