### PR TITLE
Clarify that scrollTo() is an alias of scroll()

### DIFF
--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -11,11 +11,7 @@ browser-compat: api.Element.scrollTo
 The **`scrollTo()`** method of the {{domxref("Element")}}
 interface scrolls to a particular set of coordinates inside a given element.
 
-> [!NOTE]
-> `Element.scrollTo()` is an alias for `Element.scroll()`.
-> Invoking `scrollTo()` has the same effect as calling `scroll()` with the same arguments.
->
-> See also: [Element.scroll()](/en-US/docs/Web/API/Element/scroll)
+This method is an alias for {{domxref("Element.scroll()")}}.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--

-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
This PR updates the Element.scrollTo() page to clarify that:

- `scrollTo()` is an alias for `Element.scroll()`.
- Invoking `scrollTo()` behaves identically to `scroll()`.
- Added a cross-link to the scroll() page for clarity

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes #42222 

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
