### PR TITLE
The note makes more sense as a warning

### DIFF
--- a/files/en-us/web/api/selection/addrange/index.md
+++ b/files/en-us/web/api/selection/addrange/index.md
@@ -28,7 +28,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-Only Firefox supports multiple selection ranges. Other browsers will not add new ranges to the selection if it already contains one.
+Note that only Firefox supports multiple selection ranges. In this example, other browsers will not add new ranges to the selection if it already contains one.
 
 ### HTML
 


### PR DESCRIPTION
Notes are easy to miss because they are meant to show information that is good to know. Warnings on the other hand are pieces of information people pay more attention to because they are more important, and this detail is very important to keep in mind.

https://developer.mozilla.org/en-US/docs/Web/API/Selection/addRange#examples