### PR TITLE
FF147 WebGPU supported on all versions macOS on apple silicon

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -511,7 +511,7 @@ When this preference is enabled, any WebGL extensions currently in "draft" statu
 
 The [WebGPU API](/en-US/docs/Web/API/WebGPU_API) provides low-level support for performing computation and graphics rendering using the [Graphics Processing Unit](https://en.wikipedia.org/wiki/Graphics_Processing_Unit) (GPU) of the user's device or computer.
 From version 142 this is enabled in on Windows in all contexts except service workers.
-From version 147 this is enabled in on macOS on Apple Silicon in all contexts except service workers.
+From version 147 this is enabled in on macOS on Apple Silicon in all browsing contexts except service workers.
 For other platforms such as Linux and macOS on Intel Silicon it is enabled in nightly.
 See [Firefox bug 1602129](https://bugzil.la/1602129) for our progress on this API.
 

--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -56,7 +56,7 @@ Firefox 147 is the current [Nightly version of Firefox](https://www.firefox.com/
 ### APIs
 
 - The {{domxref("Document.activeViewTransition")}} property is now supported, which returns a {{domxref("ViewTransition")}} instance representing the [view transition](/en-US/docs/Web/API/View_Transition_API) currently active on the document. This provides a consistent way to access an active view transition in any context without having to manually store a reference to it for later use. ([Firefox bug 2001836](https://bugzil.la/2001836)).
-- [WebGPU API](/en-US/docs/Web/API/WebGPU_API) support is now enabled for all macOS versions on devices with Apple Silicon processors (previously only on macOS Tahoe support was enabled). ([Firefox bug 1993341](https://bugzil.la/1993341)).
+- [WebGPU API](/en-US/docs/Web/API/WebGPU_API) support is now enabled for all macOS versions on devices with Apple Silicon processors (previously only macOS Tahoe support was enabled). ([Firefox bug 1993341](https://bugzil.la/1993341)).
 
 <!-- #### DOM -->
 


### PR DESCRIPTION
FF147 adds support for macOS on all versions (not just Tahoe) on apple silicon in https://bugzilla.mozilla.org/show_bug.cgi?id=1993341

This adds a release note.

Related work can be tracked in #42247