### PR TITLE
FF147 Relnote/Expr features: Navigation API

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -419,21 +419,6 @@ The {{domxref("CloseWatcher")}} interface allows developers to implement UI comp
 - `dom.closewatcher.enabled`
   - : Set to `true` to enable.
 
-### Navigation API
-
-The Navigation API provides the ability to initiate, intercept, and manage browser navigation actions. It can also examine an application's history entries. This is a successor to previous web platform features such as the {{domxref("History API", "", "", "nocode")}} and {{domxref("window.location")}}, which solves their shortcomings and is specifically aimed at the needs of {{glossary("SPA", "single-page applications (SPAs)")}}.
-([Firefox bug 1979288](https://bugzil.la/1979288)).
-
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 146           | Yes                 |
-| Developer Edition | 146           | No                  |
-| Beta              | 146           | No                  |
-| Release           | 146           | No                  |
-
-- `dom.navigation.webidl.enabled`
-  - : Set to `true` to enable.
-
 ### Trusted Types API
 
 The [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API) provides mechanisms to ensure that functions that can potentially be used as vectors for XSS attacks are only able to be called with data that has been validated or sanitized.

--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -52,6 +52,10 @@ Firefox 147 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 <!-- ### APIs -->
 
+- The [Navigation API](/en-US/docs/Web/API/Navigation_API) is now supported.
+  This provides the ability to initiate, intercept, and manage browser navigation actions, and to examine an application's history entries. This is a successor to previous web platform features such as the {{domxref("History API", "", "", "nocode")}} and {{domxref("window.location")}}, which solves their shortcomings and is specifically aimed at the needs of {{glossary("SPA", "single-page applications (SPAs)")}}.
+  ([Firefox bug 1997962](https://bugzil.la/1997962)).
+
 <!-- #### DOM -->
 
 <!-- #### Media, WebRTC, and Web Audio -->

--- a/files/en-us/web/api/navigateevent/navigationtype/index.md
+++ b/files/en-us/web/api/navigateevent/navigationtype/index.md
@@ -19,10 +19,14 @@ An enumerated value representing the type of navigation.
 
 The possible values are:
 
-- `push`: A new location is navigated to, causing a new entry to be pushed onto the history list.
-- `reload`: The {{domxref("Navigation.currentEntry")}} is reloaded.
-- `replace`: The {{domxref("Navigation.currentEntry")}} is replaced with a new history entry. This new entry will reuse the same {{domxref("NavigationHistoryEntry.key", "key")}}, but be assigned a different {{domxref("NavigationHistoryEntry.id", "id")}}.
-- `traverse`: The browser navigates from one existing history entry to another existing history entry.
+- `push`
+  - : A new location is navigated to, causing a new entry to be pushed onto the history list.
+- `reload`
+  - : The {{domxref("Navigation.currentEntry")}} is reloaded.
+- `replace`
+  - : The {{domxref("Navigation.currentEntry")}} is replaced with a new history entry. This new entry will reuse the same {{domxref("NavigationHistoryEntry.key", "key")}}, but be assigned a different {{domxref("NavigationHistoryEntry.id", "id")}}.
+- `traverse`
+  - : The browser navigates from one existing history entry to another existing history entry.
 
 ## Examples
 

--- a/files/en-us/web/api/navigateevent/sourceelement/index.md
+++ b/files/en-us/web/api/navigateevent/sourceelement/index.md
@@ -26,6 +26,8 @@ An {{domxref("Element")}} object representing the element that initiated the nav
 
 ## Examples
 
+### Getting the `sourceElement` for an event
+
 ```js
 navigation.addEventListener("navigate", (event) => {
   console.log(event.sourceElement);

--- a/files/en-us/web/api/navigateevent/userinitiated/index.md
+++ b/files/en-us/web/api/navigateevent/userinitiated/index.md
@@ -22,6 +22,8 @@ A boolean value—`true` if the navigation is user-initiated, `false` if not.
 
 ## Examples
 
+### Getting `userInitiated` for an event
+
 ```js
 navigation.addEventListener("navigate", (event) => {
   console.log(event.userInitiated);

--- a/files/en-us/web/api/navigation_api/index.md
+++ b/files/en-us/web/api/navigation_api/index.md
@@ -24,7 +24,7 @@ The API is accessed via the {{domxref("Window.navigation")}} property, which ret
 
 ### Handling navigations
 
-The `navigation` interface has several associated events, the most notable being the {{domxref("Navigation/navigate_event", "navigate")}} event. This is fired when [any type of navigation](https://github.com/WICG/navigation-api#appendix-types-of-navigations) is initiated, meaning that you can control all page navigations from one central place, ideal for routing functionality in SPA frameworks. (This is not the case with the {{domxref("History API", "", "", "nocode")}}, where it is sometimes hard to figure out responding to all navigations.) The `navigate` event handler is passed a {{domxref("NavigateEvent")}} object, which contains detailed information including details around the navigation's destination, type, whether it contains `POST` form data or a download request, and more.
+The `navigation` interface has several associated events, the most notable being the {{domxref("Navigation/navigate_event", "navigate")}} event. This is fired when [any type of navigation](https://github.com/WICG/navigation-api#appendix-types-of-navigations) is initiated, meaning that you can control all page navigations from one central place, ideal for routing functionality in SPA frameworks. (This is not the case with the {{domxref("History API", "", "", "nocode")}}, where it is sometimes hard to detect and respond to all navigations.) The `navigate` event handler is passed a {{domxref("NavigateEvent")}} object, which contains detailed information including details around the navigation's destination, type, whether it contains `POST` form data or a download request, and more.
 
 The `NavigationEvent` object also provides two methods:
 
@@ -123,9 +123,14 @@ There are a few perceived limitations with the Navigation API:
 
 ```js
 navigation.addEventListener("navigate", (event) => {
-  // Exit early if this navigation shouldn't be intercepted,
-  // e.g. if the navigation is cross-origin, or a download request
-  if (shouldNotIntercept(event)) {
+  // We can't intercept some navigations, e.g. cross-origin navigations.
+  // Return early and let the browser handle them normally.
+  if (!event.canIntercept) {
+    return;
+  }
+
+  // We shouldn't intercept fragment navigations or downloads.
+  if (event.hashChange || event.downloadRequest !== null) {
     return;
   }
 
@@ -153,9 +158,15 @@ In this example of intercepting a navigation, the `handler()` function starts by
 
 ```js
 navigation.addEventListener("navigate", (event) => {
-  if (shouldNotIntercept(event)) {
+  // Return early if we can't/shouldn't intercept
+  if (
+    !event.canIntercept ||
+    event.hashChange ||
+    event.downloadRequest !== null
+  ) {
     return;
   }
+
   const url = new URL(event.destination.url);
 
   if (url.pathname.startsWith("/articles/")) {


### PR DESCRIPTION
FF147 ships the Navigation API in https://bugzilla.mozilla.org/show_bug.cgi?id=1997962

This adds a release note and removes the experimental features note. I also made a few small changes to content. These are mostly tweaks to closer match the Web API doc standards.

@chrisdavidmills I'm tagging you as reviewer since you were last editor.

Related works can be tracked in #42254
