### PR TITLE
Fix ABSN.start()'s 'duration' parameter description

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/start/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.md
@@ -43,7 +43,7 @@ start(when, offset, duration)
   - : The duration of the audio data to be played, specified as seconds of total buffer content.
     If this parameter isn't specified, the sound plays until it reaches its natural conclusion or
     is stopped using the {{domxref("AudioScheduledSourceNode.stop", "stop()")}} method. The
-    value is independent of the {{domxref("AudioBufferSourceNode.playbackRate")}}, so e.g. a
+    value is independent of the {{domxref("AudioBufferSourceNode.playbackRate")}}, so e.g., a
     `duration` of 2 seconds with a `playbackRate` of `2` will play 2 seconds of the source,
     producing a 1 second audio output.
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes the description of the AudioBufferSourceNode `start()`'s `duration` parameter so it's not said to be similar to calling `stop(duration)`.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Since this specs change [1] (in 2018) the `duration` argument is specced [2] as being the duration of the buffer's content to be played, and not necessarily the one of the AudioContext's clock. So if the source node has a `playbackRate` that is not `1`, using this parameter will not be the same as using `stop(duration)`.  
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

I based the wordings on the specs text, but I don't mind another formulation altogether.

Might also be noted that there is an interop issue here, where only Firefox does follow the specs. I'll open issues to get this sorted out though.

[1]: https://github.com/WebAudio/web-audio-api/pull/1681
[2]: https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start-when-offset-duration-duration
- https://github.com/WebAudio/web-audio-api/pull/1681
- https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start-when-offset-duration-duration

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
