### PR TITLE
`:heading` pseudo-class

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_heading/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_heading/index.md
@@ -47,7 +47,7 @@ The document contains headings at three different levels, along with {{htmleleme
 </p>
 <h3>1.1 Pseudo-classes</h3>
 <p>
-  CSS pseudo classes enable selecting elements based on information that lies
+  CSS pseudo-classes enable selecting elements based on information that lies
   outside of the document tree.
 </p>
 ```


### PR DESCRIPTION
Examples need to use more than color 
Divided example into MDN standard sections
Added a description section 
Added specificity versus element selectors 
