### PR TITLE
Update definition of CSS pseudo-classes

### DIFF
--- a/files/en-us/web/css/reference/selectors/pseudo-classes/index.md
+++ b/files/en-us/web/css/reference/selectors/pseudo-classes/index.md
@@ -10,7 +10,7 @@ spec-urls:
 sidebar: cssref
 ---
 
-A [CSS](/en-US/docs/Web/CSS) **_pseudo-class_** is a keyword added to a selector that lets you select elements based on information that lies outside of the document tree, such as by a specific state of the selected element(s). For example, the pseudo-class {{CSSxRef(":hover")}} can be used to select a button when a user's pointer hovers over the button and this selected button can then be styled.
+A [CSS](/en-US/docs/Web/CSS) **_pseudo-class_** is a keyword added to a selector that lets you select elements based on information that lies outside of the document tree, such as a specific state of the selected element(s). For example, the pseudo-class {{CSSxRef(":hover")}} can be used to style a button when a user's pointer hovers over it.
 
 ```css
 /* Any button over which the user's pointer is hovering */


### PR DESCRIPTION
Clarified the definition of CSS pseudo-classes to include selection based on external information; original seemed to be when we were limited to links and form control states

