### PR TITLE
Navigation.reload() does not trigger popstate event

### DIFF
--- a/files/en-us/web/api/navigation/reload/index.md
+++ b/files/en-us/web/api/navigation/reload/index.md
@@ -30,7 +30,7 @@ reload(options)
     - `info` {{optional_inline}}
       - : Developer-defined information to be passed along to the {{domxref("Navigation/navigate_event", "navigate")}} event, made available in {{domxref("NavigateEvent.info")}}.
         This can be any data type. You might, for example, wish to display newly-navigated content with a different animation depending on how it was navigated to (swipe left, swipe right, or go home).
-        A string indicating which animation to use could be passed in as `info`.
+        A string indicating which animation to use may be passed in as `info`.
 
 ### Return value
 


### PR DESCRIPTION
Fixes #38229

[`Navigation.reload()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/reload) reloads the current page - a soft navigation because data is not fetched from the server. This change adds a note that this action does not fire the `popstate` event.
@noamr Points out that it does fire for other soft navigations, so people might expect it to fire for this one.

I "weakly" disagree. If you look at the documentation of `popstate` it pretty clearly requires a modification to the history stack, which this does not cause. That said, I'm not an expert, and I don't think this does harm.
If the reviewer rejects this I will not be unhappy.

This is part of work for #42254
