### PR TITLE
Clarify JavaScript MIME type parameter handling in script type

### DIFF
--- a/files/en-us/web/http/guides/mime_types/index.md
+++ b/files/en-us/web/http/guides/mime_types/index.md
@@ -149,9 +149,9 @@ All HTML content should be served with this type. Alternative MIME types for XHT
 JavaScript content should always be served with the MIME type `text/javascript`.
 For historic reasons, browsers may support some [legacy JavaScript types](#legacy_javascript_mime_types) listed below, but you should not assume scripts served with any MIME type other than `text/javascript` will always load or run.
 
-Note that in HTML the [`type`](/en-US/docs/Web/HTML/Reference/Elements/script/type) attribute for {{htmlelement("script")}} elements may only contain the **JavaScript MIME type essence**: `text/javascript`.
-Including any parameter, such as `charset=utf-8`, is the same as setting the `type` to [an unrecognized value](/en-US/docs/Web/HTML/Reference/Elements/script/type#any_other_value): the script content is treated as a data block and is not executed as JavaScript.
-(Note that setting the `type` to a JavaScript MIME type is a deprecated feature itself: you should omit the `type` in this case.)
+Note that in HTML the [`type`](/en-US/docs/Web/HTML/Reference/Elements/script/type) attribute for {{htmlelement("script")}} elements may only contain the **JavaScript MIME type essence**: `text/javascript` or one of the keywords `module` (for ES modules) or `importmap`.
+Including any parameter in the `type` attribute, such as `charset=utf-8`, is the same as setting the `type` to [an unrecognized value](/en-US/docs/Web/HTML/Reference/Elements/script/type#any_other_value): the script content is treated as a data block and is not executed as JavaScript.
+Note that setting `type="text/javascript"` is no longer necessary; this is the default for `<script>` elements, so you may omit the `type` attribute entirely in this case.
 In contrast, when using the HTTP {{httpheader("Content-Type")}} header you may optionally specify the `charset` parameter as usual.
 
 For more information see: [IANA Media Types registry](https://www.iana.org/assignments/media-types/media-types.xhtml#text), [RFC 9239](https://www.rfc-editor.org/rfc/rfc9239.html), and the [HTML specification](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages:text/javascript).


### PR DESCRIPTION
### Description

Updated the explanation regarding the use of parameters in the JavaScript MIME type for `<script type=...>`

### Motivation

Current wording is outdated, because `module` and `importmap` now exist.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type#value