### PR TITLE
Restructure import assertions description to ease maintainability

### DIFF
--- a/files/en-us/web/javascript/reference/statements/import/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/with/index.md
@@ -41,7 +41,8 @@ export { names } from "module-name" with { key: "data", key2: "data2", /* …, *
 
 - {{jsxref("TypeError")}}
   - : An unsupported `key` was specified in a _dynamic import_.
-Note that the behaviour for unsupported keys is undefined, but might result in an exception on some browsers.
+
+Note that specifying an unsupported value for a supported key may also result in an exception in some cases, depending on the key.
 
 ## Description
 


### PR DESCRIPTION
As discussed in https://github.com/mdn/content/pull/42306#issuecomment-3629944371 the description of import assertions does not provide an easy way to link to particular parts of the concepts, such as a definition of CSS Modules imported using `with { type: "css"}`.

This restructures the existing material to provide some headings. Should allow clean linking to the doc, easier parsing for readers, and maintenance if we later add other module types.

@Josh-Cena Obviously "for discussion and iteration". It is almost all a restructure, with only a tiny amount of new content, which I will highlight.

Related docs work being done in #42255