### PR TITLE
fix a custom property name

### DIFF
--- a/files/en-us/web/css/guides/images/using_object-view-box/index.md
+++ b/files/en-us/web/css/guides/images/using_object-view-box/index.md
@@ -94,7 +94,7 @@ img {
 
 ### JavaScript
 
-We add an event listener to the slider that updates the value of the `--boxSize` custom property when the user interacts with it. To increase the zoom-in effect when the slider is moved to the right, the slider's value is inverted by subtracting it from `500px`, as reducing the view box size increases the zoom-in effect.
+We add an event listener to the slider that updates the value of the `--box-size` custom property when the user interacts with it. To increase the zoom-in effect when the slider is moved to the right, the slider's value is inverted by subtracting it from `500px`, as reducing the view box size increases the zoom-in effect.
 
 ```js
 const img = document.querySelector("img");


### PR DESCRIPTION
The property name is `--boxSize` in the description, but `--box-size` is used in the code.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix a custom property name `--boxSize` to `--box-size`.

### Motivation

The actual CSS and JavaScript codes use `--box-size`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
