### PR TITLE
FF147 Relnote: CompressionStream/DecompressionStream support brotli +…

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -62,6 +62,9 @@ Firefox 147 is the current [Nightly version of Firefox](https://www.firefox.com/
   This provides the ability to initiate, intercept, and manage browser navigation actions, and to examine an application's history entries. This is a successor to previous web platform features such as the {{domxref("History API", "", "", "nocode")}} and {{domxref("window.location")}}, which solves their shortcomings and is specifically aimed at the needs of {{glossary("SPA", "single-page applications (SPAs)")}}.
   ([Firefox bug 1997962](https://bugzil.la/1997962)).
 
+- Brotli compression is now supported for both [`CompressionStream`](/en-US/docs/Web/API/CompressionStream/CompressionStream#brotli) and [`DecompressionStream`](/en-US/docs/Web/API/DecompressionStream/DecompressionStream#brotli).
+  ([Firefox bug 1921583](https://bugzil.la/1921583)).
+
 <!-- #### DOM -->
 
 <!-- #### Media, WebRTC, and Web Audio -->

--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -20,6 +20,8 @@ new CompressionStream(format)
 
 - `format`
   - : One of the following allowed compression formats:
+    - `"brotli"`
+      - : Compresses the stream using the [Brotli](https://www.rfc-editor.org/rfc/rfc1952) algorithm.
     - `"gzip"`
       - : Compresses the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
     - `"deflate"`
@@ -27,6 +29,8 @@ new CompressionStream(format)
         The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
     - `"deflate-raw"`
       - : Compresses the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+    - `"zstd"`
+      - : Compresses the stream using the [ZSTD](https://datatracker.ietf.org/doc/html/rfc8478) algorithm.
 
 ### Exceptions
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -20,13 +20,17 @@ new DecompressionStream(format)
 
 - `format`
   - : One of the following compression formats:
+    - `"brotli"`
+      - : Decompress the stream using the [Brotli](https://www.rfc-editor.org/rfc/rfc1952) algorithm.
     - `"gzip"`
-      - : Decompress the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) format.
+      - : Decompress the stream using the [GZIP](https://www.rfc-editor.org/rfc/rfc1952) algorithm.
     - `"deflate"`
       - : Decompress the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1950) algorithm in ZLIB Compressed Data Format.
         The ZLIB format includes a header with information about the compression method and the uncompressed size of the data, and a trailing checksum for verifying the integrity of the data
     - `"deflate-raw"`
       - : Decompress the stream using the [DEFLATE](https://www.rfc-editor.org/rfc/rfc1951) algorithm without a header and trailing checksum.
+    - `"zstd"`
+      - : Decompress the stream using the [ZSTD](https://datatracker.ietf.org/doc/html/rfc8478) algorithm.
 
 ### Exceptions
 


### PR DESCRIPTION
FF147 supports brotli compression in [`CompressionStream` constructor](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream/CompressionStream) and [`DecompressionStream()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/DecompressionStream) in https://bugzilla.mozilla.org/show_bug.cgi?id=1921583

This adds a release note. It also updates the two constructors to include the brotli option and zstd option (which is also supported).

Related docs work: #42251