### PR TITLE
Improve contrast on selectors/_colon_scope demo

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_scope/index.md
@@ -84,13 +84,13 @@ div {
   }
 
   a {
-    color: darkmagenta;
+    color: indigo;
   }
 }
 
 @scope (.dark-scheme) {
   :scope {
-    background-color: darkmagenta;
+    background-color: indigo;
     color: antiquewhite;
   }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The demo was using a `plum`/`darkmagenta` color/background for links, which has an inaccessible contrast of 4.11:1. This patch swaps `darkmagenta` for `indigo`, which gives us a contrast of 6.26:1 (AA)

### Motivation

The demo should be accessible

### Additional details

∅

### Related issues and pull requests

∅