### PR TITLE
Fx147 devtools edit pseudo element selector

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -18,7 +18,7 @@ Firefox 147 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ### Developer Tools
 
-- When [pseudo-element](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements) nodes are selected in the HTML pane of the Inspector — for example, those representing generated content created by {{cssxref("::before")}} and {{cssxref("::after")}} rules — you can now edit the selectors of the corresponding rules in the Rule view.
+- When you select a [pseudo-element](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements) (such as {{cssxref("::before")}} or {{cssxref("::after")}}) in the HTML pane of the Inspector, you can now edit the selector of the corresponding rule in the CSS pane.
   ([Firefox bug 1998704](https://bugzil.la/1998704)).
 
 <!-- ### HTML -->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In Firefox 147, when pseudo-element nodes are selected in the HTML pane of the Inspector — for example, those representing generated content created by `::before` and `::after` rules — you can now edit the selectors of the corresponding rules in the Rule view. See https://bugzilla.mozilla.org/show_bug.cgi?id=1998704.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
