### PR TITLE
Fix Firefox release script time zone issue

### DIFF
--- a/scripts/content/release-firefox.js
+++ b/scripts/content/release-firefox.js
@@ -55,6 +55,7 @@ function formatDate(dateString) {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   }).format(date);
 }
 


### PR DESCRIPTION
### Description

Fixes release script timezone issue: without a specified time zone, the local one is used.

### Motivation

Otherwise, the dates are off.

### Additional details

Follow up for https://github.com/mdn/content/pull/41897