### PR TITLE
Marker pseudo-element counter and quote property support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -38,6 +38,8 @@ Firefox 147 is the current [Nightly version of Firefox](https://www.firefox.com/
   ([Firefox bug 1362499](https://bugzil.la/1362499)).
 - [View transition types](/en-US/docs/Web/API/View_Transition_API/Using_types) are now supported, which provide a mechanism by which different **types** can be specified for active view transitions. CSS can then be used to apply animations to DOM elements when their content updates, depending on the transition type specified. Firefox 147 adds support for single-page app (SPA) view transition types only, not cross-document view transition types.
   ([Firefox bug 2001878](https://bugzil.la/2001878)).
+- The {{cssxref("counter-increment")}}, {{cssxref("counter-reset")}}, {{cssxref("counter-set")}}, and {{cssxref("quotes")}} properties are now supported on the {{cssxref("::marker")}} pseudo-element.
+  ([Firefox bug 2000404](https://bugzil.la/2000404)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/web/css/reference/selectors/_doublecolon_marker/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_marker/index.md
@@ -34,12 +34,14 @@ li::marker {
 
 The `::marker` pseudo-element supports a limited number of CSS properties, including:
 
-- All [font properties](/en-US/docs/Web/CSS/Guides/Fonts)
-- The {{CSSxRef("white-space")}} property
-- {{CSSxRef("color")}}
-- {{CSSxRef("text-combine-upright")}}, {{CSSxRef("unicode-bidi")}}, and {{CSSxRef("direction")}} properties
-- The {{CSSxRef("content")}} property
 - All [animation](/en-US/docs/Web/CSS/Guides/Animations#properties) and [transition](/en-US/docs/Web/CSS/Guides/Transitions#properties) properties
+- All [font properties](/en-US/docs/Web/CSS/Guides/Fonts)
+- {{CSSxRef("color")}}
+- {{CSSxRef("content")}}
+- {{cssxref("counter-increment")}}, {{cssxref("counter-reset")}}, and {{cssxref("counter-set")}}
+- {{cssxref("quotes")}}
+- {{CSSxRef("text-combine-upright")}}, {{CSSxRef("unicode-bidi")}}, and {{CSSxRef("direction")}}
+- {{CSSxRef("white-space")}}
 
 > [!NOTE]
 > The specification states that additional CSS properties may be supported in the future.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 147 adds support for the [`counter-*`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/counter-increment) and [`quotes`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/quotes) properties on the [`::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::marker) pseudo-element. See https://bugzilla.mozilla.org/show_bug.cgi?id=2000404.

This PR adds this information to the `::marker` page, and also adds a Fx147 rel note to cover it.

#### Test results and supporting details

I have created a test case at https://codepen.io/Chris-Mills/pen/yyOGdGJ?editors=1100. In testing, I found that the features:

- Work in Firefox 147, but not 146
- Don't work in Chrome Canary or Safari technology preview.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
