### PR TITLE
Article element in a wrong implementation #38324

### DIFF
--- a/files/en-us/web/html/reference/elements/article/index.md
+++ b/files/en-us/web/html/reference/elements/article/index.md
@@ -13,18 +13,21 @@ The **`<article>`** [HTML](/en-US/docs/Web/HTML) element represents a self-conta
 ```html interactive-example
 <article class="forecast">
   <h1>Weather forecast for Seattle</h1>
-  <article class="day-forecast">
+
+  <section class="day-forecast">
     <h2>03 March 2018</h2>
     <p>Rain.</p>
-  </article>
-  <article class="day-forecast">
+  </section>
+
+  <section class="day-forecast">
     <h2>04 March 2018</h2>
     <p>Periods of rain.</p>
-  </article>
-  <article class="day-forecast">
+  </section>
+
+  <section class="day-forecast">
     <h2>05 March 2018</h2>
     <p>Heavy rain.</p>
-  </article>
+  </section>
 </article>
 ```
 


### PR DESCRIPTION
This PR updates the interactive example for the <article> element.
The original code used nested <article> elements for each daily weather forecast, which is semantically incorrect because these items are not independently meaningful or distributable.

Each day’s forecast depends on the main forecast, so they should be grouped using <section> elements instead.


<img width="783" height="513" alt="image" src="https://github.com/user-attachments/assets/d09bdc2b-12c4-428b-bd89-8bac2c69c5fc" />
