### PR TITLE
MIDI APIs now use `NotAllowedError` instead of `InvalidAccessError`

### DIFF
--- a/files/en-us/web/api/midioutput/send/index.md
+++ b/files/en-us/web/api/midioutput/send/index.md
@@ -32,7 +32,7 @@ None ({{jsxref("undefined")}}).
 
 - {{jsxref("TypeError")}}
   - : Thrown if `data` is not a valid sequence, or does not contain a valid MIDI message.
-- `InvalidAccessError` {{domxref("DOMException")}}
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if `data` is a system exclusive message, and the {{domxref("MIDIAccess")}} did not enable exclusive access.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the port is disconnected.

--- a/files/en-us/web/api/midiport/open/index.md
+++ b/files/en-us/web/api/midiport/open/index.md
@@ -30,7 +30,7 @@ A {{jsxref("Promise")}} which resolves once access to the port has been successf
 
 ### Exceptions
 
-- `InvalidAccessError` {{domxref("DOMException")}}
+- `NotAllowedError` {{domxref("DOMException")}}
   - : The promise is rejected with this error if the port is unavailable and cannot be opened.
 
 ## Examples


### PR DESCRIPTION
### Motivation

Quoted from https://github.com/WebAudio/web-midi-api/pull/278 PR description:

> According to [Web IDL spec on `InvalidAccessError`](https://webidl.spec.whatwg.org/#invalidaccesserror):
> > Deprecated. Use [TypeError](https://webidl.spec.whatwg.org/#exceptiondef-typeerror) for invalid arguments, "[NotSupportedError](https://webidl.spec.whatwg.org/#notsupportederror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException) for unsupported operations, and "[NotAllowedError](https://webidl.spec.whatwg.org/#notallowederror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException) for denied requests instead.
> 
> Previously, while trying to open `MIDIPort`, `"InvalidAccessError" DOMException` was thrown when...
> > the device is unavailable (e.g., is already in use by another process and cannot be opened, or is disconnected)
> 
> In this case, I believe `NotAllowedError` fits well, according to its [Web IDL spec  description](https://webidl.spec.whatwg.org/#notallowederror):
> > The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
> 
> Security and permissions reasons are only a subset of the appropriate causes, according to this definition. An attempt to `open` the port can fail. Somebody's exclusive lock on the port, or the port being disconnected, <ins>is</ins> the <ins>current context</ins> driving the platform's decision not to allow the operation.
> 
> And in the context of forbidden `.send` calls:
> > If data is a [System Exclusive](https://webaudio.github.io/web-midi-api/#dfn-system-exclusive) message, and the [`MIDIAccess`](https://webaudio.github.io/web-midi-api/#dom-midiaccess) did not enable [System Exclusive](https://webaudio.github.io/web-midi-api/#dfn-system-exclusive) access, throw an `InvalidAccessError` exception.
> 
> `NotAllowedError` fits even better, because it fits an explicitly defined subset of permission errors.

### Related issues and pull requests

The change in spec: https://github.com/WebAudio/web-midi-api/commit/3795f22

This PR should not be confused with https://github.com/mdn/content/pull/41956, which talks about `SecurityError`s instead