### PR TITLE
chore(deps): set packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/mdn/content.git"
   },
+  "packageManager": "npm@11.6.2",
   "engines": {
     "node": ">=24"
   },
@@ -77,6 +78,5 @@
     "tempy": "^3.1.0",
     "yaml": "^2.8.2",
     "yargs": "^18.0.0"
-  },
-  "packageManager": "npm@11.6.2"
+  }
 }


### PR DESCRIPTION
### Description

Sets the `packageManager` field in the `package.json`.

### Motivation

Prevents contributors from running `yarn`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/mdn/issues/772.