### PR TITLE
Clarify that multipart Content-Disposition parameters need not be quoted

### DIFF
--- a/files/en-us/web/http/reference/headers/content-disposition/index.md
+++ b/files/en-us/web/http/reference/headers/content-disposition/index.md
@@ -57,10 +57,7 @@ Browsers may apply transformations to conform to the file system requirements, s
 
 A `multipart/form-data` body requires a `Content-Disposition` header to provide information about each subpart of the form (e.g., for every form field and any files that are part of field data).
 The first directive is always `form-data`, and the header must also include a `name` parameter to identify the relevant field. Additional directives are case-insensitive.
-The value of any arguments (after the `=` sign) may be a either token or a quoted string.
-Quoted strings are recommended, and many server implementations require the values to be quoted.
-This is because a token must be US-ASCII for MIME type headers like `Content-Disposition`, and US-ASCII does not allow some characters that are common in filenames and other values.
-Multiple parameters are separated by a semicolon (`;`).
+The value of any arguments (after the = sign) can be either a token or a quoted string. This means that the HTTP specification does not require parameter values to be quoted. However, quoted strings are recommended in practice, and many server implementations expect parameters such as name and filename to be quoted, especially when they contain non-ASCII or special characters. This is because a token must be US-ASCII for MIME type headers like Content-Disposition, and US-ASCII does not allow some characters that are common in filenames and other values. Multiple parameters are separated by a semicolon (;).
 
 ```http
 Content-Disposition: form-data; name="fieldName"


### PR DESCRIPTION
Fixes mdn/content#41683
Clarify quoting rules for multipart Content-Disposition parameters

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
