### PR TITLE
Fix documentation for rpId

### DIFF
--- a/files/en-us/web/api/publickeycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/index.md
@@ -60,7 +60,7 @@ It is used to request a {{domxref("PublicKeyCredential")}} provided by an {{glos
 
 - `rpId` {{optional_inline}}
   - : A string that specifies the relying party's identifier (for example `"login.example.org"`). For security purposes:
-    - The browser verifies that `rpId` matches the relying party's origin or is a domain suffix of the replying party's origin (for example, `example.org`).
+    - The browser verifies that `rpId` matches the relying party's origin or is a domain suffix of the relying party's origin (for example, `example.org`).
     - The authenticator verifies that `rpId` matches the `rpId` of the credential used for the authentication ceremony.
 
     This value defaults to the current origin's domain.


### PR DESCRIPTION
The page for [`PublicKeyCredentialRequestOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions) describes `rpId` as follows:

> A string that specifies the relying party's identifier (for example "login.example.org"). For security purposes:
>
> - The calling web app verifies that rpId matches the relying party's origin.
> - The authenticator verifies that rpId matches the rpId of the credential used for the authentication ceremony.
>
> This value defaults to the current origin's domain.

It's not "the calling web app" that does this, it's the browser[1]. AIUI this is important because the whole point of this is to defend against phishing. If it's left up to the caller to do the verifying, there's nothing to stop a phishing site from asking for credentials for any other RP.

Also it doesn't make sense that rpId must "match the relying party's origin" and that it "defaults to the current origin's domain". If the first is true, why have an option at all?

I think there is a concept of "scope" in which a page at, say, "login.example.org" is allowed to get a credential for "example.org" (https://w3c.github.io/webauthn/#rp-id, although this is hard to understand and I'm not sure of the exact rules.

We should cover scope properly in the WebAuthn docs. I'm intending to talk about it in my passkey guide, but I unfortunately don't have the time to overhaul the WebAuthn docs right now. But the first issue, about who does the verifying, really should be fixed.

[1] See https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-rpid: "The [client](https://w3c.github.io/webauthn/#client) MUST verify that the [Relying Party](https://w3c.github.io/webauthn/#relying-party)’s [origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin) matches the [scope](https://w3c.github.io/webauthn/#scope) of this [RP ID](https://w3c.github.io/webauthn/#rp-id)." and "client" is defined at https://w3c.github.io/webauthn/#client as "A [WebAuthn Client](https://w3c.github.io/webauthn/#webauthn-client) is an intermediary entity typically implemented in the user agent (in whole, or in part).".