### PR TITLE
Trusted Types: ServiceWorkerContainer.register()

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -99,7 +99,7 @@ This ensures that only one service worker runs for each document.
 
 ### Security considerations
 
-The `scriptURL` parameter specifies the script for service worker, which can intercept network requests for pages within its scope and return respones that are fresh, cached, new, or modified.
+The `scriptURL` parameter specifies the script for the service worker, which can intercept network requests for pages within its scope and return respones that are fresh, cached, new, or modified.
 If the input is provided by a user, this is a possible vector for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks.
 
 It is extremely risky to accept and execute arbitrary URLs from untrusted origins.
@@ -148,7 +148,7 @@ const policy = trustedTypes.createPolicy("script-url-policy", {
 });
 ```
 
-Then we use the `policy` object to create a `trustedScript` object from a potentially unsafe input string:
+Then we use the `policy` object to create a `TrustedScriptURL` object from a potentially unsafe input string:
 
 ```js
 // The potentially malicious string
@@ -159,7 +159,7 @@ const untrustedScript = "https://evil.example.com/service_worker.js";
 const trustedScriptURL = policy.createScriptURL(untrustedScript);
 ```
 
-The `trustedScriptURL` property can now be used to register our service worker.
+We can now pass the `TrustedScriptURL` object into `register()`:
 
 ```js
 navigator.serviceWorker.register(trustedScriptURL).


### PR DESCRIPTION
[`ServiceWorkerContainer.register()`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register) takes a scriptURL defining the service worker. This updates the docs to reflect that the scriptURL can be a trusted type. 

As per our pattern, this adds a top header and a security considerations section. To make that "work" I pushed most of the original top level overview down into a Description section.
I also added just the first example showing how to use TT.

Related docs work can be tracked in:
- #37518
- #41507
