### PR TITLE
Document position-anchor: none and add Fx147 rel note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -40,6 +40,8 @@ Firefox 147 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 2001878](https://bugzil.la/2001878)).
 - The {{cssxref("counter-increment")}}, {{cssxref("counter-reset")}}, {{cssxref("counter-set")}}, and {{cssxref("quotes")}} properties are now supported on the {{cssxref("::marker")}} pseudo-element.
   ([Firefox bug 2000404](https://bugzil.la/2000404)).
+- The {{cssxref("position-anchor")}} value `none` is now supported, which enables an implicit or explicit association between a [CSS anchor](/en-US/docs/Web/CSS/Guides/Anchor_positioning) and a positioned element to be removed.
+  ([Firefox bug 1999972](https://bugzil.la/1999972)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/web/css/guides/anchor_positioning/using/index.md
+++ b/files/en-us/web/css/guides/anchor_positioning/using/index.md
@@ -107,15 +107,15 @@ In some cases, an implicit anchor reference will be made between two elements, d
 If you wish to remove an explicit anchor association previously made between an anchor element and a positioned element, you can do one of the following:
 
 1. Set the anchor's `anchor-name` property value to `none`, or to a different `<dashed-ident>`, if you want a different element to be anchored to it.
-2. Set the `position-anchor` property of the positioned element to an anchor name that doesn't exist in the current document, such as `--not-an-anchor-name`.
+2. Set the `position-anchor` property of the positioned element to `none`, or to an anchor name that doesn't exist in the current document, such as `--not-an-anchor-name`.
 
-However, in the case of implicit anchor associations, you'll need to use the second method — the first method doesn't work. This is because the association is controlled internally, and you can't remove the `anchor-name` via CSS.
+In the case of implicit anchor associations, you'll need to use the second method — the first method doesn't work. This is because the association is controlled internally, and you can't remove the `anchor-name` via CSS.
 
 For example, to stop a customizable `<select>` element's picker from being anchored to the `<select>` element itself, you could use the following rule:
 
 ```css
 ::picker(select) {
-  position-anchor: --not-an-anchor-name;
+  position-anchor: none;
 }
 ```
 

--- a/files/en-us/web/css/reference/properties/position-anchor/index.md
+++ b/files/en-us/web/css/reference/properties/position-anchor/index.md
@@ -13,6 +13,7 @@ The **`position-anchor`** [CSS](/en-US/docs/Web/CSS) property specifies the anch
 ```css
 /* Single values */
 position-anchor: auto;
+position-anchor: none;
 position-anchor: --anchor-name;
 
 /* Global values */
@@ -28,18 +29,23 @@ position-anchor: unset;
 - `auto`
   - : Associates a positioned element with its implicit anchor element, if it has one — for example as set by the non-standard HTML [`anchor`](/en-US/docs/Web/HTML/Reference/Global_attributes/anchor) attribute.
 
+- `none`
+  - : The initial (default) value. The positioned element is not associated with an anchor element.
+
 - {{cssxref("dashed-ident")}}
   - : The name of the anchor element to associate the positioned element with, as listed in the anchor element's {{cssxref("anchor-name")}} property. This is known as the **default anchor specifier**.
 
 ## Description
 
-This property is only relevant to "positioned" elements — elements and pseudo elements that have a {{cssxref("position")}} of `absolute` or `fixed` set.
+This property is only relevant to "positioned" elements — elements and pseudo-elements that have a {{cssxref("position")}} of `absolute` or `fixed` set.
 
 To position an element relative to an anchor element, the positioned element requires three features: an association, a position, and a location. The `position-anchor` and {{cssxref("anchor-name")}} properties provide an explicit association.
 
 The anchor element accepts one or more `<dashed-ident>` anchor names set on it via the `anchor-name` property. When one of those names is then set as the value of the positioned element's `position-anchor` property, the two elements are associated.
 
 If there are multiple anchor elements with the anchor name listed in the `position-anchor` property, the positioned element will be associated with the last anchor element in the source order with that anchor name.
+
+To cancel a previously-made association between an anchor-positioned element and an anchor, you can set the anchor-positioned element's `position-anchor` value to `none`.
 
 To tether a positioned element to its anchor, it must be placed relative to an anchor element using an anchor positioning feature, such as the {{cssxref("anchor()")}} function (set as a value on {{glossary("inset properties")}}) or the {{cssxref("position-area")}} property.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 147 adds support for the new `none` value of the [`position-anchor`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-anchor) CSS property. See https://bugzilla.mozilla.org/show_bug.cgi?id=1999972.

This PR documents the new value and adds a Firefox rel note to cover it.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
