### PR TITLE
Add CSS styling examples to <hr> element documentation

### DIFF
--- a/files/en-us/web/html/reference/elements/hr/index.md
+++ b/files/en-us/web/html/reference/elements/hr/index.md
@@ -77,6 +77,7 @@ hr::after {
   padding: 0 0.3em;
 }
 ```
+
 ## Attributes
 
 This element's attributes include the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).


### PR DESCRIPTION
This pull request adds practical examples of “appropriate CSS” for styling the `<hr>` element. The new section demonstrates commonly used styles such as a simple solid line, a thicker line, a dashed line, and a decorative symbol using the ::after pseudo-element.

Motivation

The current documentation mentions that horizontal lines should be styled using CSS but does not provide examples. This update addresses mdn/content#42363 by giving clear, modern CSS examples that help readers understand how to style `<hr>` while preserving its semantic meaning.

Additional details

This update modifies only the documentation. No structural or behavioral changes were made to the page.
Live examples are unchanged; the update is purely educational.

Related issues and pull requests

Fixes mdn/content#42363