### PR TITLE
Fix misuse of JSON

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -95,9 +95,9 @@ console.log(array.filter(isPrime)); // [2, 3, 5, 7, 11, 13]
 > [!NOTE]
 > The `isPrime()` implementation is for demonstration only. For a real-world application, you would want to use a heavily memoized algorithm such as the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes) to avoid repeated calculations.
 
-### Filtering invalid entries from JSON
+### Filtering invalid objects from an array of objects
 
-The following example uses `filter()` to create a filtered JSON of all elements with non-zero, numeric `id`.
+The following example uses `filter()` to create a filtered array of all objects with non-zero, numeric `id`.
 
 ```js
 const arr = [
@@ -134,7 +134,7 @@ console.log("Number of Invalid Entries =", invalidEntries);
 
 ### Searching in array
 
-Following example uses `filter()` to filter array content based on search criteria.
+The following example uses `filter()` to filter array content based on search criteria.
 
 ```js
 const fruits = ["apple", "banana", "grapes", "mango", "orange"];


### PR DESCRIPTION
Description
Removes the term JSON in favor of "array of objects" to more precisely describe what's going on and avoid the misuse of "JSON".

Motivation
Using better terms to avoid confusion.