### PR TITLE
add more interesting example in getOrInsert

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/getorinsert/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/getorinsert/index.md
@@ -59,6 +59,14 @@ map.set(key, map.get(key) ?? defaultValue);
 
 ## Examples
 
+### Multimap
+
+In a map where each key is mapped to an array of values, you can use `getOrInsert()` to ensure that the array exists for a given key before attempting to push a new value to the array.
+
+```js
+map.getOrInsert(key, []).push(value);
+```
+
 ### Applying default values
 
 You can use `getOrInsert()` to ensure that a key exists in a map, even if you currently don't need its value. This is usually to normalize user input.


### PR DESCRIPTION
### Description

Adds another example for `Map.prototype.getOrInsert` where the return value is actually used.

### Motivation

The only existing example doesn't use the return value, so it's not clear why you'd want that.

### Additional details

### Related issues and pull requests

This was added in https://github.com/mdn/content/pull/41252.
