### PR TITLE
Enforce naming convention in `rel` attributes

### DIFF
--- a/files/en-us/web/html/reference/attributes/rel/prefetch/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/prefetch/index.md
@@ -1,5 +1,5 @@
 ---
-title: rel=prefetch
+title: rel="prefetch"
 slug: Web/HTML/Reference/Attributes/rel/prefetch
 page-type: html-attribute-value
 browser-compat: html.elements.link.rel.prefetch

--- a/files/en-us/web/html/reference/attributes/rel/preload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/preload/index.md
@@ -1,5 +1,5 @@
 ---
-title: rel=preload
+title: rel="preload"
 slug: Web/HTML/Reference/Attributes/rel/preload
 page-type: html-attribute-value
 browser-compat: html.elements.link.rel.preload

--- a/files/en-us/web/html/reference/attributes/rel/prerender/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/prerender/index.md
@@ -1,5 +1,5 @@
 ---
-title: rel=prerender
+title: rel="prerender"
 slug: Web/HTML/Reference/Attributes/rel/prerender
 page-type: html-attribute-value
 status:


### PR DESCRIPTION
### Description

Use consistent headings for `rel` attributes.

**Before:**

<img width="300" alt="before" src="https://github.com/user-attachments/assets/5be83178-0411-459a-9c40-2899a7418e0e" />


**After:**

<img width="300" alt="after" src="https://github.com/user-attachments/assets/33aa4768-10b4-4578-ac00-6080c9125592" />
