### PR TITLE
Add link to Navigation API from 146 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -88,7 +88,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **Navigation API** (Nightly): `dom.navigation.webidl.enabled`
 
-  Nightly builds now support the Navigation API, which provides the ability to initiate, intercept, and manage browser navigation actions. It can also examine an application's history entries. This is a successor to previous web platform features such as the {{domxref("History API", "", "", "nocode")}} and {{domxref("window.location")}}, which solves their shortcomings and is specifically aimed at the needs of {{glossary("SPA", "single-page applications (SPAs)")}}.
+  Nightly builds now support the [Navigation API](/en-US/docs/Web/API/Navigation_API), which provides the ability to initiate, intercept, and manage browser navigation actions. It can also examine an application's history entries. This is a successor to previous web platform features such as the {{domxref("History API", "", "", "nocode")}} and {{domxref("window.location")}}, which solves their shortcomings and is specifically aimed at the needs of {{glossary("SPA", "single-page applications (SPAs)")}}.
   ([Firefox bug 1979288](https://bugzil.la/1979288)).
 
 - **Relative control points in CSS `shape()` curve commands**: `layout.css.basic-shape-shape.enabled`


### PR DESCRIPTION
### Description

Adds link to Navigation API from 146 release notes.

### Motivation

Otherwise, there’s nowhere to go to learn more.