### PR TITLE
Remove Chrome and Edge specifics from datetime-local behavior

### DIFF
--- a/files/en-us/web/html/reference/elements/input/datetime-local/index.md
+++ b/files/en-us/web/html/reference/elements/input/datetime-local/index.md
@@ -226,7 +226,7 @@ You can use the [`min`](/en-US/docs/Web/HTML/Reference/Elements/input#min) and [
 
 Only days in June 2025 can be selected. Depending on what browser you are using, times outside the specified values might not be selectable. In other browsers, invalid dates and times are selectable but will match {{CSSXref(":invalid")}} and {{CSSXref(":out-of-range")}} and will fail [validation](#validation).
 
-In some browsers (Chrome and Edge), only the "days" part of the date value will be editable, and dates outside June can't be scrolled. In others (Safari), the date picker will appear to allow any date, but the value will be clamped to the valid range when a date is selected.
+In some browsers (Safari), the date picker will appear to allow any date, but the value will be clamped to the valid range when a date is selected.
 
 The valid range included all times between the `min` and `max` values; the time of day is only constrained on the first and last dates in the range.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This change updates `datetime-local` behavior notes by removing Chrome and Edge specific descriptions. Chrome now behaves consistently with Firefox for this case.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

[The issue](https://issues.chromium.org/issues/442293382) was fixed in Chrome M143, aligning `datetime-local` behavior with Firefox. Since Chrome M143 has already reached the Stable release channel, keeping Chrome and Edge specific notes may cause unnecessary confusion for developers.

### Related issues and pull requests
- https://issues.chromium.org/issues/442293382

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
