### PR TITLE
Add glossary entry for nonce

### DIFF
--- a/files/en-us/glossary/nonce/index.md
+++ b/files/en-us/glossary/nonce/index.md
@@ -4,6 +4,6 @@ slug: Glossary/Nonce
 page-type: glossary-definition
 ---
 
-A **nonce** (short for *number used once*) is a value used in cryptography to ensure that a specific message or operation is performed only once. Nonces help protect against replay attacks by making each request or cryptographic operation unique.
+A **nonce** (short for _number used once_) is a value used in cryptography to ensure that a specific message or operation is performed only once. Nonces help protect against replay attacks by making each request or cryptographic operation unique.
 
 Nonces are commonly used in authentication protocols, encryption schemes, digital signatures, and secure communication mechanisms. They may be generated randomly or sequentially, but they must never be reused within the same context.


### PR DESCRIPTION
Adds a glossary definition for the cryptographic term “nonce”, which was missing from the MDN glossary.

Fixes #42367