### PR TITLE
Add Query to the list of URI components

### DIFF
--- a/files/en-us/web/uri/index.md
+++ b/files/en-us/web/uri/index.md
@@ -24,6 +24,9 @@ The [URI reference](/en-US/docs/Web/URI/Reference) provides details about the co
 - [Path](/en-US/docs/Web/URI/Reference/Path)
   - : The section after the authority.
     Contains data, usually organized in hierarchical form, to identify a resource within the scope of the URI's scheme and authority.
+- [Query](/en-US/docs/Web/URI/Reference/Query)
+  - : The section after the path.
+    Contains non-hierarchical data to identify a resource within the scope of the URI's scheme and naming authority along with data in the path component.
 - [Fragment](/en-US/docs/Web/URI/Reference/Fragment)
   - : An optional part at the end of a URI starting with a `#` character.
     It is used to identify a specific part of the resource, such as a section of a document or a position in a video.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Added Query to the list of URI components on the URI index page under the Reference section.

### Motivation

The URI reference page (`/en-US/docs/Web/URI/Reference`) has the list of links to all the URI components using the macro `{{SubpagesWithSummaries}}`.
However, the index page for URI (`/en-US/docs/Web/URI`) is missing Query in the list under the Reference section.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
