### PR TITLE
FedCM deprecated the nonce parameter

### DIFF
--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -134,7 +134,9 @@ async function signIn() {
         {
           configURL: "https://accounts.idp.example/config.json",
           clientId: "********",
-          nonce: "******",
+          params: {
+            /* IdP-specific parameters */
+          },
         },
       ],
     },
@@ -155,7 +157,9 @@ async function signIn() {
         {
           configURL: "https://accounts.idp.example/config.json",
           clientId: "********",
-          nonce: "******",
+          params: {
+            /* IdP-specific parameters */
+          },
           loginHint: "user1@example.com",
         },
       ],
@@ -175,7 +179,9 @@ async function signIn() {
           {
             configURL: "https://accounts.idp.example/config.json",
             clientId: "********",
-            nonce: "******",
+            params: {
+              /* IdP-specific parameters */
+            },
           },
         ],
       },

--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -254,7 +254,7 @@ Origin: https://rp.example/
 Content-Type: application/x-www-form-urlencoded
 Cookie: 0x23223
 Sec-Fetch-Dest: webidentity
-account_id=123&client_id=client1234&nonce=Ct60bD&disclosure_text_shown=true&is_auto_selected=true
+account_id=123&client_id=client1234&disclosure_text_shown=true&is_auto_selected=true
 ```
 
 A request to this endpoint is sent as a result of the user choosing an account to sign in with from the relevant browser UI. When sent valid user credentials, this endpoint should respond with a validation token that the RP can use to validate the user on its own server, according to the usage instructions outlined by the IdP they are using for identity federation. Once the RP validates the user, they can sign them in, sign them up to their service, etc.
@@ -271,8 +271,8 @@ The request payload contains the following params:
   - : The RP's client identifier (which matches the `clientId` from the original `get()` request).
 - `account_id`
   - : The unique ID of the user account to be signed in (which matches the user's `id` from the accounts list endpoint response).
-- `nonce` {{optional_inline}}
-  - : The request nonce, provided by the RP.
+- `params` {{optional_inline}}
+  - : The serialization of the `params` object from the original `get()` request.
 - `disclosure_text_shown`
   - : A string of `"true"` or `"false"` indicating whether the disclosure text was shown or not. The disclosure text is the information shown to the user (which can include the terms of service and privacy policy links, if provided) if the user is signed in to the IdP but doesn't have an account specifically on the current RP (in which case they'd need to choose to "Continue as..." their IdP identity and then create a corresponding account on the RP).
 - `is_auto_selected`

--- a/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
+++ b/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
@@ -32,7 +32,9 @@ async function signIn() {
         {
           configURL: "https://accounts.idp.example/config.json",
           clientId: "********",
-          nonce: "******",
+          params: {
+            /* IdP-specific parameters */
+          },
           loginHint: "user1@example.com",
         },
         {
@@ -49,7 +51,7 @@ The `identity.providers` property takes an array containing one or more objects 
 The previous example also includes some optional features:
 
 - `identity.context` specifies the context in which the user is authenticating with FedCM. For example, is it a first-time signup for this account, or a sign-in with an existing account? The browser uses this information to vary the text in its FedCM UI to better suit the context.
-- The `nonce` property provides a random {{Glossary("Nonce")}} value that ensures the response is issued for this specific request, preventing {{glossary("replay attack", "replay attacks")}}.
+- The `params` property contains any parameters that this IdP needs. Its structure and content is determined by the specific IdP.
 - The `loginHint` property provides a hint about the account option(s) the browser should present for user sign-in. This hint is matched against the `login_hints` values that the IdP provides at the [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint).
 
 The browser requests the IdP config files and carries out the sign-in flow detailed below. For more information on the kind of interaction a user might expect from the browser-supplied UI, see [Implement an identity solution with FedCM on the Relying Party side](https://developer.chrome.com/docs/identity/fedcm/implement/relying-party).

--- a/files/en-us/web/api/identitycredential/configurl/index.md
+++ b/files/en-us/web/api/identitycredential/configurl/index.md
@@ -32,7 +32,9 @@ async function signIn() {
         {
           configURL: "https://accounts.idp.example/config.json",
           clientId: "********",
-          nonce: "******",
+          params: {
+            /* IdP-specific parameters */
+          },
         },
       ],
     },

--- a/files/en-us/web/api/identitycredential/index.md
+++ b/files/en-us/web/api/identitycredential/index.md
@@ -45,7 +45,9 @@ async function signIn() {
         {
           configURL: "https://accounts.idp.example/config.json",
           clientId: "********",
-          nonce: "******",
+          params: {
+            /* IdP-specific parameters */
+          },
         },
       ],
     },

--- a/files/en-us/web/api/identitycredential/token/index.md
+++ b/files/en-us/web/api/identitycredential/token/index.md
@@ -39,7 +39,9 @@ async function signIn() {
         {
           configURL: "https://accounts.idp.example/config.json",
           clientId: "********",
-          nonce: "******",
+          params: {
+            /* IdP-specific parameters */
+          },
         },
       ],
     },

--- a/files/en-us/web/api/identitycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/identitycredentialrequestoptions/index.md
@@ -63,8 +63,12 @@ When an `identity` option is provided in a `get()` call made on a {{glossary("Re
       - : A string providing a hint about the account option(s) the browser should provide for the user to sign in with. This is useful in cases where the user has already signed in and the site asks them to reauthenticate. Otherwise, the reauthentication process can be confusing when a user has multiple accounts and can't remember which one they used to sign in previously. The value for the `loginHint` property can be taken from the user's previous sign-in, and is matched against the `login_hints` values provided by the IdP in the array of user information returned from the IdP's [accounts list endpoint](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint).
     - `nonce` {{optional_inline}}
       - : A random string that can be included to ensure the response is issued specifically for this request and prevent {{glossary("replay attack", "replay attacks")}}.
+
+        > [!NOTE]
+        > This property has been removed from the specification, because not all the protocols that use the FedCM API require a nonce. If the RP does need to include a nonce, it should be provided in the [`params`](#params) property.
+
     - `params` {{optional_inline}}
-      - : A custom object used to specify any additional key-value parameters that RP needs to send to the IdP. This will vary by IdP and could include, for example, additional permission requests such as `admin: true`, or `calendar: "readonly"`.
+      - : Any additional parameters that the RP needs to pass to the IdP.
 
 ## Specifications
 


### PR DESCRIPTION
The `nonce` property of [IdentityProviderRequestOptions](https://w3c-fedid.github.io/FedCM/#dictdef-identityproviderrequestoptions) has been deprecated and removed from the spec:

https://w3c-fedid.github.io/FedCM/#dictdef-identityproviderrequestoptions
https://github.com/w3c-fedid/custom-requests/issues/3
https://github.com/w3c-fedid/FedCM/pull/768/

If the RP needs to provide a nonce they should pass it in the `params` object.

BCD update: https://github.com/mdn/browser-compat-data/pull/28684.