### PR TITLE
fix(cssref-sidebar): Flip the sequence in CSS sidebar to match sidebars in other technologies

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -5,65 +5,6 @@ sidebar:
     link: /Web/CSS
     title: CSS
   - type: section
-    link: /Web/CSS/Reference
-  - type: listSubPagesGrouped
-    path: /Web/CSS/Reference/Properties
-    tags:
-      - css-property
-      - css-shorthand-property
-    link: /Web/CSS/Reference/Properties
-    title: Properties
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/Reference/Selectors
-    tags: css-selector
-    link: /Web/CSS/Reference/Selectors
-    title: Selectors
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/Reference/Selectors
-    tags: css-combinator
-    link: /Web/CSS/Reference/Selectors/Combinators
-    title: Combinators
-    details: closed
-  - type: listSubPagesGrouped
-    path: /Web/CSS/Reference/Selectors
-    tags: css-pseudo-class
-    link: /Web/CSS/Reference/Selectors/Pseudo-classes
-    title: Pseudo-classes
-    details: closed
-  - type: listSubPagesGrouped
-    path: /Web/CSS/Reference/Selectors
-    tags: css-pseudo-element
-    link: /Web/CSS/Reference/Selectors/Pseudo-elements
-    title: Pseudo-elements
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/Reference/At-rules
-    tags: css-at-rule
-    link: /Web/CSS/Reference/At-rules
-    title: At-rules
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/Reference/Values
-    tags: css-keyword
-    link: /Web/CSS/Reference/Values
-    title: Values
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/Reference/Values
-    tags: css-type
-    link: /Web/CSS/Reference/Values/Data_types
-    title: Types
-    details: closed
-  - type: listSubPages
-    path: /Web/CSS/Reference/Values
-    tags: css-function
-    depth: 2
-    link: /Web/CSS/Reference/Values/Functions
-    title: Functions
-    details: closed
-  - type: section
     link: /Web/CSS/Guides
     title: Guides
   - type: listSubPages
@@ -355,6 +296,65 @@ sidebar:
       - /Web/CSS/Guides/Colors/Color_format_converter
       - /Web/CSS/Guides/Colors/Color_mixer
       - /Web/CSS/Guides/Shapes/Shape_generator
+  - type: section
+    link: /Web/CSS/Reference
+  - type: listSubPagesGrouped
+    path: /Web/CSS/Reference/Properties
+    tags:
+      - css-property
+      - css-shorthand-property
+    link: /Web/CSS/Reference/Properties
+    title: Properties
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/Reference/Selectors
+    tags: css-selector
+    link: /Web/CSS/Reference/Selectors
+    title: Selectors
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/Reference/Selectors
+    tags: css-combinator
+    link: /Web/CSS/Reference/Selectors/Combinators
+    title: Combinators
+    details: closed
+  - type: listSubPagesGrouped
+    path: /Web/CSS/Reference/Selectors
+    tags: css-pseudo-class
+    link: /Web/CSS/Reference/Selectors/Pseudo-classes
+    title: Pseudo-classes
+    details: closed
+  - type: listSubPagesGrouped
+    path: /Web/CSS/Reference/Selectors
+    tags: css-pseudo-element
+    link: /Web/CSS/Reference/Selectors/Pseudo-elements
+    title: Pseudo-elements
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/Reference/At-rules
+    tags: css-at-rule
+    link: /Web/CSS/Reference/At-rules
+    title: At-rules
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/Reference/Values
+    tags: css-keyword
+    link: /Web/CSS/Reference/Values
+    title: Values
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/Reference/Values
+    tags: css-type
+    link: /Web/CSS/Reference/Values/Data_types
+    title: Types
+    details: closed
+  - type: listSubPages
+    path: /Web/CSS/Reference/Values
+    tags: css-function
+    depth: 2
+    link: /Web/CSS/Reference/Values/Functions
+    title: Functions
+    details: closed
 l10n:
   de:
     Guides: Leitfäden


### PR DESCRIPTION
### Description

Sequence of top-level sections in other technology sidebars:
- [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML): Guides, How to, Reference
- [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript): Tutorials and guides, References
- [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP): Guides, Reference
- [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG): Tutorials, Guides, Reference
- [MathML](https://developer.mozilla.org/en-US/docs/Web/MathML): Tutorials, Guides, Examples, Reference


[Current CSS sidebar](https://developer.mozilla.org/en-US/docs/Web/CSS): Reference, Guides, How to, Tools
Updated CSS sidebar in this PR: Guides, How to, Tools, Reference

### Motivation

To align with the sidebar structure in other technology areas and to place learning content (Guides, How to) before reference documentation.

