### PR TITLE
Fix reference to undefined variable.

### DIFF
--- a/files/en-us/web/api/readablestream/getreader/index.md
+++ b/files/en-us/web/api/readablestream/getreader/index.md
@@ -59,7 +59,7 @@ function fetchStream() {
     // value - some data. Always undefined when done is true.
     if (done) {
       console.log("Stream complete");
-      para.textContent = value;
+      para.textContent = result;
       return;
     }
 


### PR DESCRIPTION
### Description

It's already been fixed in the source code of the linked [Simple random stream example](https://mdn.github.io/dom-examples/streams/simple-random-stream/). (In general, the example should be reduced, I'd say. Without looking at the full source code, one doesn't know what `list2` and `result` are, e.g.)

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/42242.
