### PR TITLE
TT: CSP trusted types/require-trusted... fixes

### DIFF
--- a/files/en-us/web/http/reference/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/require-trusted-types-for/index.md
@@ -10,7 +10,7 @@ sidebar: http
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`require-trusted-types-for`** directive instructs user agents to control the data passed to DOM XSS sink functions, like {{DOMxRef("Element.innerHTML")}} setter.
 
 When used, those functions only accept non-spoofable, typed values created by [Trusted Type](/en-US/docs/Web/API/Trusted_Types_API) policies, and reject strings.
-Together with **[`trusted-types`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types)** directive, which guards creation of Trusted Type policies, this allows authors to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack surface to small, isolated parts of the web application codebase, facilitating their monitoring and code review.
+Together with the **[`trusted-types`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/trusted-types)** directive, which guards creation of Trusted Type policies, this allows authors to define rules guarding writing values to the DOM and thus reducing the DOM XSS attack surface to small, isolated parts of the web application codebase, facilitating their monitoring and code review.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/trusted-types/index.md
@@ -11,9 +11,10 @@ The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`trusted-types`** dir
 
 This prevents website code from creating unexpected policies, making it easier to audit trusted type code (`createPolicy()` will throw an exception if it is passed a name which was not listed in `trusted-types`).
 
-Note that the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) directive must be set to enable enforcement of trusted types (at all), and the [`trusted-types-eval` keyword](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#trusted-types-eval) is used to relax restrictions on [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) and [`Function()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function) when trusted types are enabled.
-
-See [Trusted Type API](/en-US/docs/Web/API/Trusted_Types_API) for more information.
+> [!NOTE]
+> The [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) directive must be set to enable enforcement of trusted types, and the [`trusted-types-eval` keyword](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#trusted-types-eval) is used to relax restrictions on [`eval()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) and [`Function()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function) when trusted types are enabled.
+>
+> See [Trusted Type API](/en-US/docs/Web/API/Trusted_Types_API) for more information.
 
 ## Syntax
 


### PR DESCRIPTION
This improves CSP `require-trusted-types-for` and `trusted-types` directives by using more current internal links and better cross linking. The `trusted-types`  also wasn't very clear.

Path of work for #41507
