### PR TITLE
docs(ValidityState): clarify reference to validity states

### DIFF
--- a/files/en-us/web/api/validitystate/index.md
+++ b/files/en-us/web/api/validitystate/index.md
@@ -11,7 +11,7 @@ The **`ValidityState`** interface represents the _validity states_ that an eleme
 
 ## Instance properties
 
-Each validity state is represented by a Boolean property. A value of `true` indicates that the corresponding validation constraint has failed, except for the `valid` property, which is `true` when the element’s value obeys all constraints.
+Each validity state is represented by a Boolean property. A value of `true` indicates that the corresponding validation constraint has failed, except for the `valid` property, which is `true` when the element's value obeys all constraints.
 
 - {{domxref("ValidityState.badInput", "badInput")}} {{ReadOnlyInline}}
   - : A boolean value that is `true` if the user has provided input that the browser is unable to convert.


### PR DESCRIPTION
Clarifies that the Boolean properties in the Instance properties section
represent the validity states of the ValidityState interface.
