### PR TITLE
Drop 'read-only' from role

### DIFF
--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ElementInternals.role
 
 {{APIRef("Web Components")}}
 
-The **`role`** read-only property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) for the element. For example, a checkbox might have [`role="checkbox"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/checkbox_role). It reflects the `role` attribute; it does not return the element's implicit ARIA role, if any, unless explicitly set.
+The **`role`** property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) for the element. For example, a checkbox might have [`role="checkbox"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/checkbox_role). It reflects the `role` attribute; it does not return the element's implicit ARIA role, if any, unless explicitly set.
 
 ## Value
 


### PR DESCRIPTION
### Description

Removing the (incorrect) claim that the ElementInternals.role property is read-only.

### Motivation

This change avoids confusing readers who may think this property is read-only. It aligns with the spec (already referenced from this page) and the implementation of (at least several) browsers.
