### PR TITLE
docs(learn): remove invalid type attribute from video example

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/splash_page/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/splash_page/index.md
@@ -362,7 +362,6 @@ In this assessment we are presenting you with a mostly-finished splash page abou
 
 Just below the `<h1>`, add a `<video>` element that embeds our header video into the page. We'd like it to do the following:
 
-- If you provide multiple video sources, specify the media type using <source> elements.
 - Autoplay the video on load (for this to work in at least some browsers, you'll also need to specify that the video should be muted).
 - Loop endlessly rather than playing once.
 - Preload the video content.


### PR DESCRIPTION
Removes the invalid `type` attribute from the \<video> element in the
Creepy-crawly splash page solution and updates the instructions to avoid
misleading learners. The `type` attribute should only be used with
\<source> elements, not directly on \<video>.

