### PR TITLE
docs: mark srcData as required in bufferSubData

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
@@ -45,7 +45,7 @@ bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
 - `dstByteOffset`
   - : A {{domxref("WebGL_API/Types", "GLintptr")}} specifying an offset in bytes where the data replacement
     will start.
-- `srcData` 
+- `srcData`
   - : A {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} that views an {{jsxref("ArrayBuffer")}} or {{jsxref("SharedArrayBuffer")}}
     that will be copied into the data store.
 - `srcOffset` {{optional_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

 Updated the WebGL2RenderingContext.bufferSubData() documentation to mark the srcData parameter as required.

### Motivation

The previous documentation incorrectly listed srcData as optional. According to the WebGL specification, this parameter is mandatory for the method to function, as it provides the data to be written into the buffer. This change ensures developers provide the necessary arguments to avoid runtime errors.

### Additional details

This correction was prompted by feedback from @AshleyScirra on a previous discussion/PR regarding the technical accuracy of WebGL buffer methods. Marking this as required aligns the MDN documentation with the actual WebGL 2 implementation and the Khronos specification.  

### Related issues and pull requests

Relates to mdn/content#42315



