### PR TITLE
docs: clarify download limitation in <a> canvas example

### DIFF
--- a/files/en-us/web/html/reference/elements/a/index.md
+++ b/files/en-us/web/html/reference/elements/a/index.md
@@ -389,6 +389,13 @@ To save a {{HTMLElement("canvas")}} element's contents as an image, you can crea
 
 #### Example painting app with save link
 
+> [!NOTE]
+> The download link in this example may not work when viewed on MDN.
+> MDN interactive examples run inside a sandboxed iframe with strict
+> Content Security Policy (CSP) restrictions, which prevent file downloads.
+> This example will work as expected when used in a regular web page
+> outside of the MDN environment.
+
 ##### HTML
 
 ```html


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Fixes #42463

This PR adds a note to the "Example painting app with save link" section
explaining that file downloads are blocked in MDN interactive examples
due to iframe sandboxing and Content Security Policy (CSP) restrictions.

This helps prevent confusion while clarifying that the example works
correctly when used in a regular web page outside of the MDN environment.


<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
