### PR TITLE
Clarify fetch() error handling behavior for Response

### DIFF
--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -70,9 +70,6 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 In our [basic fetch example](https://github.com/mdn/dom-examples/tree/main/fetch/basic-fetch) ([run example live](https://mdn.github.io/dom-examples/fetch/basic-fetch/)) we use a simple `fetch()` call to grab an image and display it in an {{htmlelement("img")}} element.
 The `fetch()` call returns a promise, which resolves to the `Response` object associated with the resource fetch operation.
 
-> [!NOTE]
-> The `fetch()` promise only rejects on network errors (such as connection failures). HTTP error responses (like 404 or 500) still resolve successfully. You should check {{domxref("Response.ok")}} or {{domxref("Response.status")}} to handle HTTP errors.
-
 You'll notice that since we are requesting an image, we need to run {{domxref("Response.blob")}} to give the response its correct MIME type.
 
 ```js


### PR DESCRIPTION
This PR adds a small clarification note explaining that fetch() only
rejects on network errors and that HTTP error responses should be
handled using Response.ok or Response.status.
