### PR TITLE
fix: add missing CSSRule.MARGIN_RULE in CSSRULE.type

### DIFF
--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -41,6 +41,8 @@ for (const rule of rules) {
   - : The rule is a {{domxref("CSSKeyframesRule")}}.
 - `CSSRule.KEYFRAME_RULE` (`8`)
   - : The rule is a {{domxref("CSSKeyframeRule")}}.
+- `CSSRule.MARGIN_RULE` (`9`)
+  - : The rule is a {{domxref("CSSMarginRule")}}.
 - `CSSRule.NAMESPACE_RULE` (`10`)
   - : The rule is a {{domxref("CSSNamespaceRule")}}.
 - `CSSRule.COUNTER_STYLE_RULE` (`11`)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Add the missing `CSSRule.MARGIN_RULE (9)` entry to the value list for `CSSRule.type`.


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The `CSSRule.type` documentation omitted `MARGIN_RULE`, which is defined in the CSSOM specification and implemented in browsers. This change completes the value list so it accurately reflects the API.


### Additional details
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes #42494 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
