### PR TITLE
Add valid technical terms to spelling dictionaries

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -75,9 +75,8 @@ beforeinstallprompt
 beforematch
 beforescriptexecute
 beforexrselect
-beforexrselect
-bgtest
 BGRX
+bgtest
 bhks
 biske
 bmatrix

--- a/.vscode/dictionaries/terms-abbreviations.txt
+++ b/.vscode/dictionaries/terms-abbreviations.txt
@@ -909,6 +909,7 @@ Videobridge
 Viewmodel
 virosa
 virtualizes
+VOPRF
 WAAPI
 wallclock
 WAMP
@@ -960,4 +961,3 @@ zoomable
 ZQSD
 ZWNBSP
 ZWSP
-VOPRF


### PR DESCRIPTION


### Description

Add valid technical terms to the MDN spelling dictionaries to prevent false-positive spellcheck warnings.

### Motivation

VOPRF is a cryptographic abbreviation used in specifications, and bgtest is a CSS class name used in a code example. Adding them to the appropriate dictionaries improves the contributor experience and avoids unnecessary lint errors without changing page content.

### Additional details

No content changes; dictionary-only update.

### Related issues and pull requests

Fixes #42492

