### PR TITLE
Use descriptive canvas id in basic example

### DIFF
--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -28,6 +28,7 @@ The {{domxref("Document.getElementById()")}} method gets a reference to the HTML
 
 The actual drawing is done using the {{domxref("CanvasRenderingContext2D")}} interface. The {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} property makes the rectangle green. The {{domxref("CanvasRenderingContext2D.fillRect()", "fillRect()")}} method places its top-left corner at (10, 10), and gives it a size of 150 units wide by 100 tall.
 
+
 ```js
 const canvas = document.getElementById("drawingCanvas");
 const ctx = canvas.getContext("2d");


### PR DESCRIPTION
### Description

This PR updates the Canvas API basic example to use a more descriptive canvas element ID, improving clarity and readability for beginners.

### Motivation

Using a generic ID like `canvas` is not a best practice. A descriptive ID makes the example easier to understand and aligns with recommended coding conventions in documentation.

### Additional details

N/A

### Related issues and pull requests

Fixes #42155
