### PR TITLE
fix: remove stray '$' from Middle C comment

### DIFF
--- a/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
+++ b/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
@@ -216,7 +216,7 @@ When the user clicks the play/pause toggle button while the oscillators aren't p
 function startOscillators() {
   oscNode1 = new OscillatorNode(context, {
     type: "sine",
-    frequency: 261.6255653005986, // middle C$
+    frequency: 261.6255653005986, // middle C
   });
   oscNode1.connect(gainNode1);
 


### PR DESCRIPTION
Removes a stray $ character from a comment. The symbol has no meaning in music notation, Web Audio, or JavaScript comments, and does not correspond to the documented frequency value (C4 ≈ 261.63 Hz).

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
