### PR TITLE
Add example demonstrating creating and copying Path2D paths

### DIFF
--- a/files/en-us/web/api/path2d/index.md
+++ b/files/en-us/web/api/path2d/index.md
@@ -19,50 +19,25 @@ The **`Path2D`** interface of the Canvas 2D API is used to declare a path that c
 - {{domxref("Path2D.addPath()")}}
   - : Adds a path to the current path.
 - {{domxref("CanvasRenderingContext2D.closePath", "Path2D.closePath()")}}
-  - : Causes the point of the pen to move back to the start of the current sub-path.
+  - : Causes the point of the pen to move back to the start of the current sub-path. It tries to draw a straight line from the current point to the start. If the shape has already been closed or has only one point, this function does nothing.
 - {{domxref("CanvasRenderingContext2D.moveTo()", "Path2D.moveTo()")}}
   - : Moves the starting point of a new sub-path to the (`x, y`) coordinates.
 - {{domxref("CanvasRenderingContext2D.lineTo()", "Path2D.lineTo()")}}
   - : Connects the last point in the subpath to the (`x, y`) coordinates with a straight line.
 - {{domxref("CanvasRenderingContext2D.bezierCurveTo()", "Path2D.bezierCurveTo()")}}
-  - : Adds a cubic Bézier curve to the path.
+  - : Adds a cubic Bézier curve to the path. It requires three points. The first two points are control points and the third one is the end point. The starting point is the last point in the current path, which can be changed using `moveTo()` before creating the Bézier curve.
 - {{domxref("CanvasRenderingContext2D.quadraticCurveTo()", "Path2D.quadraticCurveTo()")}}
   - : Adds a quadratic Bézier curve to the current path.
 - {{domxref("CanvasRenderingContext2D.arc()", "Path2D.arc()")}}
-  - : Adds an arc to the path.
+  - : Adds an arc to the path which is centered at (`x, y`) position with radius `r` starting at `startAngle` and ending at `endAngle` going in the given direction by `counterclockwise` (defaulting to clockwise).
 - {{domxref("CanvasRenderingContext2D.arcTo()", "Path2D.arcTo()")}}
-  - : Adds a circular arc to the path.
+  - : Adds a circular arc to the path with the given control points and radius, connected to the previous point by a straight line.
 - {{domxref("CanvasRenderingContext2D.ellipse()", "Path2D.ellipse()")}}
-  - : Adds an elliptical arc to the path.
+  - : Adds an elliptical arc to the path which is centered at (`x, y`) position with the radii `radiusX` and `radiusY` starting at `startAngle` and ending at `endAngle` going in the given direction by `counterclockwise` (defaulting to clockwise).
 - {{domxref("CanvasRenderingContext2D.rect()", "Path2D.rect()")}}
-  - : Creates a rectangular path.
+  - : Creates a path for a rectangle at position (`x, y`) with a size that is determined by `width` and `height`.
 - {{domxref("CanvasRenderingContext2D.roundRect()", "Path2D.roundRect()")}}
-  - : Creates a rounded rectangle path.
-
-## Examples
-
-### Creating and copying paths
-
-This example demonstrates how a `Path2D` object can be copied and extended.
-
-First, `path1` creates a rectangle.
-Then, `path2` is created as a copy of `path1`.
-After that, `path2` is extended with a circle.
-Finally, only `path2` is drawn.
-
-```js
-const canvas = document.getElementById("canvas");
-const ctx = canvas.getContext("2d");
-
-const path1 = new Path2D();
-path1.rect(10, 10, 100, 100);
-
-const path2 = new Path2D(path1);
-path2.moveTo(220, 60);
-path2.arc(170, 60, 50, 0, 2 * Math.PI);
-
-ctx.stroke(path2);
-```
+  - : Creates a path for a rounded rectangle at position (`x, y`) with a size that is determined by `width` and `height` and the radii of the circular arc to be used for the corners of the rectangle is determined by `radii`.
 
 ## Specifications
 

--- a/files/en-us/web/api/path2d/path2d/index.md
+++ b/files/en-us/web/api/path2d/path2d/index.md
@@ -8,9 +8,7 @@ browser-compat: api.Path2D.Path2D
 
 {{APIRef("Canvas API")}}{{AvailableInWorkers}}
 
-The **`Path2D()`** constructor returns a newly instantiated
-`Path2D` object, optionally with another path as an argument (creates a
-copy), or optionally with a string consisting of [SVG path](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths) data.
+The **`Path2D()`** constructor returns a newly instantiated `Path2D` object, optionally with another path as an argument (creates a copy), or optionally with a string consisting of [SVG path](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths) data.
 
 ## Syntax
 
@@ -23,17 +21,15 @@ new Path2D(d)
 ### Parameters
 
 - `path` {{optional_inline}}
-  - : When invoked with another `Path2D` object, a copy of the
-    `path` argument is created.
+  - : When invoked with another `Path2D` object, a copy of the `path` argument is created.
 - `d` {{optional_inline}}
-  - : When invoked with a string consisting of [SVG path](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths) data, a new path is created
-    from that description.
+  - : When invoked with a string consisting of [SVG path](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths) data, a new path is created from that description.
 
 ## Examples
 
 ### Creating and copying paths
 
-This example creates and copies a `Path2D` path.
+This example creates and copies a `Path2D` path. First, `path1` is a rectangular path. Then, we copy `path1` into `path2` and add a circle to it. Finally, we stroke `path2`, which contains both the rectangle and the circle. Note that `path1` remains unchanged, although we never draw it to the canvas. Its only purpose is to show how you can build up a complex path by building on existing paths.
 
 ```html hidden
 <canvas id="canvas"></canvas>
@@ -43,10 +39,10 @@ This example creates and copies a `Path2D` path.
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
-let path1 = new Path2D();
+const path1 = new Path2D();
 path1.rect(10, 10, 100, 100);
 
-let path2 = new Path2D(path1);
+const path2 = new Path2D(path1);
 path2.moveTo(220, 60);
 path2.arc(170, 60, 50, 0, 2 * Math.PI);
 
@@ -57,10 +53,7 @@ ctx.stroke(path2);
 
 ### Using SVG paths
 
-This example creates a `Path2D` path using [SVG path data](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths). The path will move to
-point (`M10 10`) and then move horizontally 80 points to the right
-(`h 80`), then 80 points down (`v 80`), then 80 points to the left
-(`h -80`), and then back to the start (`Z`).
+This example creates a `Path2D` path using [SVG path data](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Paths). The path will move to point (`M10 10`) and then move horizontally 80 points to the right (`h 80`), then 80 points down (`v 80`), then 80 points to the left (`h -80`), and then back to the start (`Z`).
 
 ```html hidden
 <canvas id="canvas"></canvas>
@@ -70,7 +63,7 @@ point (`M10 10`) and then move horizontally 80 points to the right
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 
-let p = new Path2D("M10 10 h 80 v 80 h -80 Z");
+const p = new Path2D("M10 10 h 80 v 80 h -80 Z");
 ctx.fill(p);
 ```
 


### PR DESCRIPTION
This PR adds an example demonstrating how to create and copy Path2D paths.

Re-opening after an accidental branch reset while rebasing onto the latest main.
The content change itself is unchanged.

Happy to iterate based on feedback.

Fixes https://github.com/mdn/content/issues/41793
