### PR TITLE
Fix misleading statement about omitted values in CSS shorthand properties

### DIFF
--- a/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
@@ -21,7 +21,6 @@ which may differ from the property's initial value.
 That means that it **overrides** previously set values.
 For example:
 
-
 ```css
 p {
   background-color: red;


### PR DESCRIPTION
This updates a misleading statement about omitted values in CSS shorthand properties.

Omitted values are set to defaults defined by the shorthand, which may differ from the property's initial value.

Refs #42514
