### PR TITLE
Update and clarify Permissions-Policy usage

### DIFF
--- a/files/en-us/web/http/reference/headers/permissions-policy/bluetooth/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/bluetooth/index.md
@@ -49,11 +49,11 @@ SecureCorp Inc. must also include an {{HTMLElement('iframe','allow','#Attributes
 ```
 
 > [!NOTE]
-> Specifying the `Permissions-Policy` header in this manner disallows `bluetooth` for other origins, even if they were allowed by the `<iframe>` `allow` attribute.
+> Specifying the `Permissions-Policy` header in this manner disallows `bluetooth` for other origins, even if they are allowed by the `<iframe>` `allow` attribute.
 
 ### Using the default policy
 
-Without delivering an HTTP response header defining a Permissions Policy for `bluetooth`, user agents will apply the default allowlist `self`. In this mode, `bluetooth` is automatically allowed in the top-level browsing context and same-origin iframes, but not in cross-origin iframes.
+If an allowlist for `bluetooth` is not defined by a `Permissions-Policy` response header, user agents will apply the default allowlist `self`. In this mode, `bluetooth` is automatically allowed in the top-level browsing context and same-origin iframes, but not in cross-origin iframes.
 
 To allow `bluetooth` in a cross-origin iframe, include an {{HTMLElement('iframe','allow','#Attributes')}} attribute on the `<iframe>` element:
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/fullscreen/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/fullscreen/index.md
@@ -48,11 +48,11 @@ SecureCorp Inc. must also include an {{HTMLElement('iframe','allow','#Attributes
 ```
 
 > [!NOTE]
-> Specifying the `Permissions-Policy` header in this manner disallows `fullscreen` for other origins, even if they were allowed by the `<iframe>` `allow` attribute.
+> Specifying the `Permissions-Policy` header in this manner disallows `fullscreen` for other origins, even if they are allowed by the `<iframe>` `allow` attribute.
 
 ### Using the default policy
 
-Without delivering an HTTP response header defining a Permissions Policy for `fullscreen`, user agents will apply the default allowlist `self`. In this mode, `fullscreen` is automatically allowed in the top-level browsing context and same-origin iframes, but not in cross-origin iframes.
+If an allowlist for `fullscreen` is not defined by a `Permissions-Policy` response header, user agents will apply the default allowlist `self`. In this mode, `fullscreen` is automatically allowed in the top-level browsing context and same-origin iframes, but not in cross-origin iframes.
 
 To allow `fullscreen` in a cross-origin iframe, include an {{HTMLElement('iframe','allow','#Attributes')}} attribute on the `<iframe>` element:
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/geolocation/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/geolocation/index.md
@@ -51,11 +51,11 @@ SecureCorp Inc. must also include an {{HTMLElement('iframe','allow','#Attributes
 ```
 
 > [!NOTE]
-> Specifying the `Permissions-Policy` header in this manner disallows `geolocation` for other origins, even if they were allowed by the `<iframe>` `allow` attribute.
+> Specifying the `Permissions-Policy` header in this manner disallows `geolocation` for other origins, even if they are allowed by the `<iframe>` `allow` attribute.
 
 ### Using the default policy
 
-Without delivering an HTTP response header defining a Permissions Policy for `geolocation`, user agents will apply the default allowlist `self`. In this mode, `geolocation` is automatically allowed in the top-level browsing context and same-origin iframes, but not in cross-origin iframes.
+If an allowlist for `geolocation` is not defined by a `Permissions-Policy` response header, user agents will apply the default allowlist `self`. In this mode, `geolocation` is automatically allowed in the top-level browsing context and same-origin iframes, but not in cross-origin iframes.
 
 To allow `geolocation` in a cross-origin iframe, include an {{HTMLElement('iframe','allow','#Attributes')}} attribute on the `<iframe>` element:
 


### PR DESCRIPTION
### Description + Motivation

Regarding the [Permissions-Policy: fullscreen directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/fullscreen) page:

- The "General example" is incomplete. Cross-origin iframes **must** have `allow="fullscreen"` in addition to their origin being allowlisted in the Permissions-Policy HTTP response header.

- The "With an \<iframe> element" example is invalid. The `Permissions-Policy: fullscreen=(self)` HTTP response header prevents other origins from using fullscreen. The iframe `allow` attribute cannot grant fullscreen access because that would violate the [_most restrictive subset_ inheritance strategy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy#inheritance_of_policies_for_embedded_content).

After correcting the above, it seemed appropriate to recategorize which one is the "general example" (more widely applicable) and which is the secondary example (more niche).

### Additional details

I tested both Chromium and Firefox to confirm the updated examples are correct (aside from Firefox ignoring the `Permissions-Policy` header due to lack of support).