### PR TITLE
Issue-42471 Clarify internationalization property fallback

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.md
@@ -15,7 +15,7 @@ sidebar: addonsidebar
     <tr>
       <th scope="row">Mandatory</th>
       <td>
-        Contingent: must be present if the _locales subdirectory is present,
+        Contingent: must be present if the <code>_locales</code> subdirectory is present,
         must be absent otherwise.
       </td>
     </tr>
@@ -26,9 +26,9 @@ sidebar: addonsidebar
   </tbody>
 </table>
 
-This key must be present if the extension contains the \_locales directory, and must be absent otherwise. It identifies a subdirectory of \_locales, and this subdirectory will be used to find the default strings for your extension.
+This key must be present if the extension contains the `\_locales` directory, and must be absent otherwise. It identifies a subdirectory of `\_locales` where the i18n system finds the extension's default localization strings.
 
-See [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization).
+See [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization) for more information.
 
 ## Example
 


### PR DESCRIPTION
### Description

This change cclarifies the fallback for discovery of localization strings. It includes a rewrite of the description and an expansion of the example.

### Motivation

To address feedback that it was unclear how the system retrieve strings when a string message isn't present in the manifest.json file for a localization.

### Related issues and pull requests

Fixes #42471