### PR TITLE
Fix redefinitions of legacy iframe attributes

### DIFF
--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -48,13 +48,13 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   - : Set to `true` if the `<iframe>` can activate fullscreen mode by calling the {{domxref("Element.requestFullscreen", "requestFullscreen()")}} method.
 
     > [!NOTE]
-    > This attribute is considered a legacy attribute and redefined as `allow="fullscreen"`.
+    > This attribute is considered a legacy attribute and redefined as `allow="fullscreen *"`.
 
 - `allowpaymentrequest` {{deprecated_inline}} {{non-standard_inline}}
   - : Set to `true` if a cross-origin `<iframe>` should be allowed to invoke the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API).
 
     > [!NOTE]
-    > This attribute is considered a legacy attribute and redefined as `allow="payment"`.
+    > This attribute is considered a legacy attribute and redefined as `allow="payment *"`.
 
 - `browsingtopics` {{non-standard_inline}} {{deprecated_inline}}
   - : A boolean attribute that, if present, specifies that the selected topics for the current user should be sent with the request for the `<iframe>`'s source. See [Using the Topics API](/en-US/docs/Web/API/Topics_API/Using) for more details.


### PR DESCRIPTION
### Description

Correct the stated redefinitions of `allowfullscreen` and `allowpaymentrequest` as per the relevant specs.

### Motivation

The existing text states that `allowfullscreen` is redefined as `allow="fullscreen"` (shorthand for `allow="fullscreen 'src'"`) and `allowpaymentrequest` is redefined as `allow="payment"` (shorthand for `allow="payment 'src'"`). In reality, both have allowlists of `*`, which makes a difference if the iframe is navigated away from the origin defined in its `src` attribute.

### Additional details

`allowfullscreen`:
- https://fullscreen.spec.whatwg.org/commit-snapshots/13d795ced89c6fd0077b4fff4a065f24f5b37421/#permissions-policy-integration
- https://www.w3.org/TR/2025/WD-permissions-policy-1-20251006/#iframe-allowfullscreen-attribute
- https://html.spec.whatwg.org/commit-snapshots/0aa021ab4f21a6550f1591a9cc98449aaea9eefa/#attr-iframe-allowfullscreen

`allowpaymentrequest`:
- https://www.w3.org/TR/2020/WD-permissions-policy-1-20200716/#iframe-allowpaymentrequest-attribute
- https://www.w3.org/TR/2019/CR-payment-request-20191212/#feature-policy (erroneously states `allowpaymentrequest` is equivalent to `allow="fullscreen *"` instead of `allow="payment *"`)
- https://html.spec.whatwg.org/commit-snapshots/bf2ceeb0f435c9aa01e9fefdfe2082368bedce50/#attr-iframe-allowpaymentrequest