### PR TITLE
Fix default allowlist for gamepad policy-controlled feature

### DIFF
--- a/files/en-us/web/http/reference/headers/permissions-policy/gamepad/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/gamepad/index.md
@@ -6,6 +6,7 @@ page-type: http-permissions-policy-directive
 status:
   - experimental
 browser-compat: http.headers.Permissions-Policy.gamepad
+spec-urls: https://www.w3.org/TR/gamepad/#permission-policy
 sidebar: http
 ---
 


### PR DESCRIPTION
### Description

The default allowlist was changed from `self` to `*`. The spec and all 3 major browser implementations reflect this change.

### Additional details

- https://www.w3.org/TR/2025/WD-gamepad-20250710/#permission-policy
- https://github.com/w3c/gamepad/pull/156
- https://issues.chromium.org/issues/40101717#comment7
- https://phabricator.services.mozilla.com/D119471
- https://bugs.webkit.org/show_bug.cgi?id=230136#c2

### Related issues and pull requests

Relates to https://github.com/mdn/browser-compat-data/pull/11770