### PR TITLE
Fix: Gamepad API no longer requires secure context

### DIFF
--- a/files/en-us/web/api/gamepad/axes/index.md
+++ b/files/en-us/web/api/gamepad/axes/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.axes
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad.axes`** property of the {{domxref("Gamepad") }}
 interface returns an array representing the controls with axes present on the device

--- a/files/en-us/web/api/gamepad/buttons/index.md
+++ b/files/en-us/web/api/gamepad/buttons/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.buttons
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`buttons`** property of the {{domxref("Gamepad")}} interface returns an array of {{domxref("GamepadButton")}} objects representing the buttons present on the device.
 

--- a/files/en-us/web/api/gamepad/connected/index.md
+++ b/files/en-us/web/api/gamepad/connected/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.connected
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad.connected`** property of the
 {{domxref("Gamepad") }} interface returns a boolean indicating whether the gamepad is

--- a/files/en-us/web/api/gamepad/hand/index.md
+++ b/files/en-us/web/api/gamepad/hand/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Gamepad.hand
 ---
 
-{{APIRef("Gamepad")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("Gamepad")}}{{SeeCompatTable}}
 
 The **`hand`** read-only property of the {{domxref("Gamepad")}} interface returns an enum defining what hand the controller is being held in, or is most likely to be held in.
 

--- a/files/en-us/web/api/gamepad/hapticactuators/index.md
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Gamepad.hapticActuators
 ---
 
-{{APIRef("Gamepad")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("Gamepad")}}{{SeeCompatTable}}
 
 The **`hapticActuators`** read-only property of the {{domxref("Gamepad")}} interface returns an array containing {{domxref("GamepadHapticActuator")}} objects, each of which represents haptic feedback hardware available on the controller.
 

--- a/files/en-us/web/api/gamepad/id/index.md
+++ b/files/en-us/web/api/gamepad/id/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.id
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad.id`** property of the {{domxref("Gamepad") }}
 interface returns a string containing some information about the controller.

--- a/files/en-us/web/api/gamepad/index.md
+++ b/files/en-us/web/api/gamepad/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.Gamepad
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad`** interface of the [Gamepad API](/en-US/docs/Web/API/Gamepad_API) defines an individual gamepad or other controller, allowing access to information such as button presses, axis positions, and id.
 

--- a/files/en-us/web/api/gamepad/index/index.md
+++ b/files/en-us/web/api/gamepad/index/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.index
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad.index`** property of the {{domxref("Gamepad") }}
 interface returns an integer that is auto-incremented to be unique for each device

--- a/files/en-us/web/api/gamepad/mapping/index.md
+++ b/files/en-us/web/api/gamepad/mapping/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.mapping
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad.mapping`** property of the
 {{domxref("Gamepad")}} interface returns a string indicating whether the browser has

--- a/files/en-us/web/api/gamepad/pose/index.md
+++ b/files/en-us/web/api/gamepad/pose/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Gamepad.pose
 ---
 
-{{APIRef("Gamepad")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("Gamepad")}}{{SeeCompatTable}}
 
 The **`pose`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadPose")}} object representing the pose information associated with a WebVR controller (e.g., its position and orientation in 3D space).
 

--- a/files/en-us/web/api/gamepad/timestamp/index.md
+++ b/files/en-us/web/api/gamepad/timestamp/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.timestamp
 ---
 
-{{APIRef("Gamepad API")}}{{SecureContext_Header}}
+{{APIRef("Gamepad API")}}
 
 The **`Gamepad.timestamp`** property of the
 {{domxref("Gamepad")}} interface returns a {{domxref("DOMHighResTimeStamp")}}

--- a/files/en-us/web/api/gamepad/vibrationactuator/index.md
+++ b/files/en-us/web/api/gamepad/vibrationactuator/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Gamepad.vibrationActuator
 ---
 
-{{APIRef("Gamepad")}}{{SecureContext_Header}}
+{{APIRef("Gamepad")}}
 
 The **`vibrationActuator`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadHapticActuator")}} object, which represents haptic feedback hardware available on the controller.
 

--- a/files/en-us/web/api/gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/index.md
@@ -5,7 +5,7 @@ page-type: web-api-overview
 browser-compat: api.Gamepad
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Gamepad API")}}
+{{DefaultAPISidebar("Gamepad API")}}
 
 The **Gamepad API** is a way for developers to access and respond to signals from gamepads and other game controllers in a simple, consistent way. It contains three interfaces, two events and one specialist function, to respond to gamepads being connected and disconnected, and to access other information about the gamepads themselves, and what buttons and other controls are currently being pressed.
 

--- a/files/en-us/web/api/gamepadbutton/index.md
+++ b/files/en-us/web/api/gamepadbutton/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.GamepadButton
 ---
 
-{{APIRef("Gamepad API")}}{{securecontext_header}}
+{{APIRef("Gamepad API")}}
 
 The **`GamepadButton`** interface defines an individual button of a gamepad or other controller, allowing access to the current state of different types of buttons available on the control device.
 

--- a/files/en-us/web/api/gamepadevent/index.md
+++ b/files/en-us/web/api/gamepadevent/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.GamepadEvent
 ---
 
-{{APIRef("Gamepad API")}}{{securecontext_header}}
+{{APIRef("Gamepad API")}}
 
 The GamepadEvent interface of the Gamepad API contains references to gamepads connected to the system, which is what the gamepad events {{domxref("Window.gamepadconnected_event", "gamepadconnected")}} and {{domxref("Window.gamepaddisconnected_event", "gamepaddisconnected")}} are fired in response to.
 

--- a/files/en-us/web/api/gamepadhapticactuator/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.GamepadHapticActuator
 ---
 
-{{APIRef("Gamepad API")}}{{securecontext_header}}
+{{APIRef("Gamepad API")}}
 
 The **`GamepadHapticActuator`** interface of the [Gamepad API](/en-US/docs/Web/API/Gamepad_API) represents hardware in the controller designed to provide haptic feedback to the user (if available), most commonly vibration hardware.
 

--- a/files/en-us/web/api/gamepadpose/index.md
+++ b/files/en-us/web/api/gamepadpose/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.GamepadPose
 ---
 
-{{securecontext_header}}{{APIRef("Gamepad API")}}{{SeeCompatTable}}
+{{APIRef("Gamepad API")}}{{SeeCompatTable}}
 
 The **`GamepadPose`** interface of the [Gamepad API](/en-US/docs/Web/API/Gamepad_API) represents the pose of a [WebVR](/en-US/docs/Web/API/WebVR_API) controller at a given timestamp (which includes orientation, position, velocity, and acceleration information).
 

--- a/files/en-us/web/api/navigator/getgamepads/index.md
+++ b/files/en-us/web/api/navigator/getgamepads/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Navigator.getGamepads
 ---
 
-{{APIRef("Gamepad API")}}{{securecontext_header}}
+{{APIRef("Gamepad API")}}
 
 The **`Navigator.getGamepads()`** method returns an array of
 {{domxref("Gamepad")}} objects, one for each gamepad connected to the device.


### PR DESCRIPTION
### Description

The Gamepad API's secure context requirement was reverted.

### Additional details

- https://github.com/w3c/gamepad/pull/194
- https://issues.chromium.org/issues/40221455#comment7
- https://bugzilla.mozilla.org/show_bug.cgi?id=1870037
- https://github.com/WebKit/WebKit/pull/24550

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/7269

Relates to https://github.com/mdn/browser-compat-data/pull/11771 (and browser compatibility data does need to be updated alongside this pull request)