### PR TITLE
Fix wrong toHex link

### DIFF
--- a/files/en-us/web/api/subtlecrypto/digest/index.md
+++ b/files/en-us/web/api/subtlecrypto/digest/index.md
@@ -144,7 +144,7 @@ async function digestMessage(message) {
 digestMessage(text).then((digestHex) => console.log(digestHex));
 ```
 
-The above example uses {{jsxref("Uint8Array.fromHex()")}}, which became available in 2025.
+The above example uses {{jsxref("Uint8Array.toHex()")}}, which became available in 2025.
 To support older browsers, the following alternative can be used instead:
 
 ```js


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The crypto.subtle.digest example uses `Uint8Array.toHex()` but links to `Uint8Array.fromHex()`

### Motivation

It's just a small typo

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Relates to #41714

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
