### PR TITLE
Fix(HTTP): Update Prefer header syntax to allow lists

### DIFF
--- a/files/en-us/web/http/reference/headers/prefer/index.md
+++ b/files/en-us/web/http/reference/headers/prefer/index.md
@@ -33,7 +33,7 @@ The HTTP **`Prefer`** header allows clients to indicate preferences for specific
 ## Syntax
 
 ```http
-Prefer: <preference>
+Prefer: <preference>, <preference>, ...
 ```
 
 ## Directives


### PR DESCRIPTION
Updated the syntax block to show that multiple preferences are allowed as per the RFC. Added an example demonstrating multiple preferences in a single header. Fixes #42535

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
 I updated the "Syntax" section to reflect that the `Prefer` header accepts a comma-separated list of preferences. I also added a new "Providing multiple preferences" example to demonstrate this behavior.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The RFC 7240 specification defines the `Prefer` header grammar as `1#preference`, meaning multiple preferences are allowed in a comma-separated list. The previous documentation implied only a single preference was valid, which was misleading for developers trying to set multiple directives (e.g., `respond-async` and `wait`).

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Reference: [RFC 7240 Section 2 - The Prefer Header Field](https://datatracker.ietf.org/doc/html/rfc7240#section-2)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
