### PR TITLE
Fix glossary redirect warning

### DIFF
--- a/files/en-us/web/http/reference/headers/prefer/index.md
+++ b/files/en-us/web/http/reference/headers/prefer/index.md
@@ -24,10 +24,7 @@ The HTTP **`Prefer`** header allows clients to indicate preferences for specific
       </td>
     </tr>
     <tr>
-      <tr>
-      <th scope="row">{{Glossary("Forbidden request header", "Forbidden header name")}}</th>
-      <td>No</td>
-    </tr>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Updated the glossary macro to point directly to "Forbidden request header" to resolve the build warning about the redirect.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
