### PR TITLE
Removed incorrect extra example for AES-CTR

### DIFF
--- a/files/en-us/web/api/subtlecrypto/encrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.md
@@ -162,34 +162,6 @@ function encryptMessage(key) {
 }
 ```
 
-```js
-let iv = window.crypto.getRandomValues(new Uint8Array(16));
-let key = window.crypto.getRandomValues(new Uint8Array(16));
-let data = new Uint8Array(12345);
-// crypto functions are wrapped in promises so we have to use await and make sure the function that
-// contains this code is an async function
-// encrypt function wants a cryptokey object
-const keyEncoded = await window.crypto.subtle.importKey(
-  "raw",
-  key.buffer,
-  "AES-CTR",
-  false,
-  ["encrypt", "decrypt"],
-);
-const encryptedContent = await window.crypto.subtle.encrypt(
-  {
-    name: "AES-CTR",
-    counter: iv,
-    length: 128,
-  },
-  keyEncoded,
-  data,
-);
-
-// Uint8Array
-console.log(encryptedContent);
-```
-
 ### AES-CBC
 
 This code fetches the contents of a text box, encodes it for encryption, and encrypts it using AES in CBC mode.


### PR DESCRIPTION
### Description

Removed an incorrect extra example for AES-CTR encryption

### Motivation

It is likely a leftover draft that doesn't have an equivalent in https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt and that doesn't follow the rest by not being based upon the full example code and that uses in window.crypto.subtle.encrypt's algorithm parameter a length of 128 instead of the recommended 64 according to https://developer.mozilla.org/en-US/docs/Web/API/AesCtrParams, it also uses window.crypto.getRandomValues and window.crypto.subtle.importKey to generate the key instead of just window.crypto.subtle.generateKey