### PR TITLE
Fix an interface name this property belongs to

### DIFF
--- a/files/en-us/web/api/csskeyframesrule/length/index.md
+++ b/files/en-us/web/api/csskeyframesrule/length/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSKeyframesRule.length
 
 {{APIRef("CSSOM") }}
 
-The read-only **`length`** property of the {{domxref("CSSKeyframeRule")}} interface returns the number of {{domxref("CSSKeyframeRule")}} objects in its list. You can then access each keyframe rule by its index directly on the `CSSKeyframeRule` object.
+The read-only **`length`** property of the {{domxref("CSSKeyframesRule")}} interface returns the number of {{domxref("CSSKeyframeRule")}} objects in its list. You can then access each keyframe rule by its index directly on the `CSSKeyframeRule` object.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix an interface name this property belongs to.

### Motivation

It should be `CSSKeyframesRule`, not `CSSKeyframeRule`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
