### PR TITLE
Add Chrome's extension debugger API as not supported in Firefox

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -162,7 +162,7 @@ When calling `tabs.remove()`:
 
 #### Debugger API
 
-- **In Firefox:** Chrome's [debugger](https://developer.chrome.com/docs/extensions/reference/api/debugger) API [is not implemented](https://bugzilla.mozilla.org/show_bug.cgi?id=1316741).
+- **In Firefox:** Chrome's [debugger](https://developer.chrome.com/docs/extensions/reference/api/debugger) API [is not implemented](https://bugzil.la/1316741).
 
 #### DeclarativeContent API
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
[The Chrome Incompatibilities page for WebExtensions APIs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities) is missing Chrome's `debugger` API in its "Unsupported APIs" section. This will inform extension developers that the API is only available in Chrome.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I discovered that this API was missing Firefox support when developing an extension myself, so I want others to be informed.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
- [Chrome's debugger API documentation](https://developer.chrome.com/docs/extensions/reference/api/debugger)
- [Firefox's intention not to implement the API](https://bugzilla.mozilla.org/show_bug.cgi?id=1316741)

### Related issues and pull requests

None that I know of.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
