### PR TITLE
Update meta charset tag in HTML example

### DIFF
--- a/files/en-us/web/html/guides/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/guides/quirks_mode_and_standards_mode/index.md
@@ -20,7 +20,7 @@ For [HTML](/en-US/docs/Web/HTML) documents, browsers use a doctype in the beginn
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>Hello World!</title>
   </head>
   <body></body>


### PR DESCRIPTION
Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.

Not very critical, but good to model in our example demo of very minimal HTML.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This is a single character update I propose, because the trailing slash is not needed, and this demo example aims to be as simple as possible.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Motivation is to fine tune the examples around minimal working HTML examples, which I am investigating.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
