### PR TITLE
Fix wording in Array.prototype.map() description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -49,7 +49,7 @@ A new array with each element being the result of the callback function.
 
 ## Description
 
-The `map()` method is an [iterative method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods). It calls a provided `callbackFn` function once for each element in an array and constructs a new array from the results. Read the [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods) section for more information about how these methods work in general.
+The `map()` method is an [iterative method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods). It calls a provided `callbackFn` function once for every element in an array and constructs a new array from the results. Read the [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods) section for more information about how these methods work in general.
 
 `callbackFn` is invoked only for array indexes which have assigned values. It is not invoked for empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays).
 


### PR DESCRIPTION
Description

Fix wording in Array.prototype.map() description for better clarity and readability.

Motivation

Improve the documentation to make it easier for readers to understand how the map() method works.

Additional details

None.

Related issues and pull requests

None.