### PR TITLE
Fix macros linking to `fit-content()` and `url()`

### DIFF
--- a/files/en-us/web/css/guides/grid_layout/index.md
+++ b/files/en-us/web/css/guides/grid_layout/index.md
@@ -101,7 +101,7 @@ This sample animation uses {{cssxref("display")}}, {{cssxref("grid-template-colu
 
 - {{cssxref("repeat()")}}
 - {{cssxref("minmax()")}}
-- {{cssxref("fit-content()")}}
+- {{cssxref("fit-content_function", "fit-content()")}}
 
 ### Data types and values
 
@@ -197,7 +197,7 @@ This sample animation uses {{cssxref("display")}}, {{cssxref("grid-template-colu
 - {{cssxref("min-content")}} value
 - {{cssxref("max-content")}} value
 - {{cssxref("fit-content")}} value
-- {{cssxref("fit-content()")}} function
+- {{cssxref("fit-content_function", "fit-content()")}} function
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/functions/index.md
+++ b/files/en-us/web/css/reference/values/functions/index.md
@@ -305,7 +305,7 @@ The following functions are used as a value of properties to reference a value d
 
 The following functions are used to define a [CSS grid](/en-US/docs/Web/CSS/Guides/Grid_layout):
 
-- {{cssxref("fit-content()")}}
+- {{cssxref("fit-content_function", "fit-content()")}}
   - : Clamps a given size to an available size according to the formula `min(maximum size, max(minimum size, argument))`.
 - {{cssxref("minmax()")}}
   - : Defines a size range greater-than or equal-to _min_ and less-than or equal-to _max_.
@@ -401,7 +401,7 @@ The following functions return an integer value based on the DOM tree, rather th
 - {{cssxref("basic-shape/ellipse", "ellipse()")}}
 - {{cssxref("env")}}
 - {{cssxref("exp")}}
-- {{cssxref("fit-content()")}}
+- {{cssxref("fit-content_function", "fit-content()")}}
 - {{cssxref("filter-function/grayscale", "grayscale()")}}
 - {{cssxref("color_value/hsl", "hsl()")}}
 - {{cssxref("filter-function/hue-rotate", "hue-rotate()")}}
@@ -477,7 +477,7 @@ The following functions return an integer value based on the DOM tree, rather th
 - {{cssxref("transform-function/translateY", "translateY()")}}
 - {{cssxref("transform-function/translateZ", "translateZ()")}}
 - {{cssxref("type")}} {{experimental_inline}}
-- {{cssxref("url_function")}}
+- {{cssxref("url_function", "url()")}}
 - {{cssxref("var")}}
 - {{cssxref("animation-timeline/view", "view()")}}
 - {{cssxref("basic-shape/xywh", "xywh()")}}

--- a/files/en-us/web/css/reference/values/repeat/index.md
+++ b/files/en-us/web/css/reference/values/repeat/index.md
@@ -144,7 +144,7 @@ There is a fourth form, `<name-repeat>`, which is used to add line names to subg
     - a {{cssxref("minmax()")}} function with:
       - `min` given as a {{cssxref("&lt;length-percentage&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
       - `max` given as a {{cssxref("&lt;length-percentage&gt;")}} value, a {{cssxref("&lt;flex&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
-    - a {{cssxref("fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.
+    - a {{cssxref("fit-content_function", "fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.
 - `auto`
   - : As a maximum, identical to `max-content`. As a minimum it represents the largest minimum size (as specified by {{cssxref("min-width")}}/{{cssxref("min-height")}}) of the grid items occupying the grid track.
 - `auto-fill`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix macros linking to `fit-content()` and `url()`.

### Motivation

To link to `fit-content()` page,
`{{cssxref("fit-content_function", "fit-content()")}}` is needed.
To link to `url()` page,
`{{cssxref("url_function", "url()")}}` is needed or it is shown wrongly.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
