### PR TITLE
Clarify default automationRate behavior in AudioWorklet guide

### DIFF
--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -250,6 +250,7 @@ class MyAudioProcessor extends AudioWorkletProcessor {
   }
 }
 ```
+
 If `automationRate` is not specified in a parameter descriptor, it defaults to
 `"a-rate"` (sample-accurate updates).
 


### PR DESCRIPTION
This PR clarifies that AudioWorklet parameter automationRate defaults to
"a-rate" when omitted, and that "k-rate" must be explicitly requested.

Fixes mdn#42584
