### PR TITLE
Fix inaccurate wording about cubic-bezier validity

### DIFF
--- a/files/en-us/web/css/reference/values/easing-function/cubic-bezier/index.md
+++ b/files/en-us/web/css/reference/values/easing-function/cubic-bezier/index.md
@@ -41,7 +41,8 @@ A cubic Bézier curve is defined by four points: P0, P1, P2, and P3. The points 
 
 ![Graph of Input progress to Output progress showing an S-shaped line curving from the origin to (1, 1) with the Bezier control points P1(0.1, 0.6) and P2(0.7, 0.2).](cubic-bezier.svg)
 
-Not all cubic Bézier curves are suitable as easing functions because not all are [mathematical functions](https://en.wikipedia.org/wiki/Function_%28mathematics%29); i.e., curves that for a given x-axis coordinate have zero or one value. With P0 and P3 fixed as defined by CSS, a cubic Bézier curve is a function, and is therefore valid, if and only if the x-axis coordinates of P1 and P2 are both in the `[0, 1]` range.
+Not all cubic Bézier curves are suitable as easing functions because not all are [mathematical functions](https://en.wikipedia.org/wiki/Function_%28mathematics%29); i.e., curves that for a given x-axis coordinate have zero or one value. With P0 and P3 fixed as defined by CSS, a cubic Bézier curve is a function, and is therefore generally valid when the x-axis coordinates of P1 and P2 are both in the [0, 1] range.
+
 
 Cubic Bézier curves with the P1 or P2 ordinate outside the `[0, 1]` range can cause the value to go farther than the final state and then return. In animations, this creates a kind of "bouncing" effect.
 


### PR DESCRIPTION
This PR removes an overly strong “if and only if” claim in the cubic-bezier documentation.

The CSS specification does not guarantee this condition, so the wording has been softened to avoid a mathematically incorrect statement.

#42526
