### PR TITLE
Fix the description of the range `exit`

### DIFF
--- a/files/en-us/web/css/reference/values/timeline-range-name/index.md
+++ b/files/en-us/web/css/reference/values/timeline-range-name/index.md
@@ -31,7 +31,7 @@ Valid `<timeline-range-name>` values:
   - : Represents the range of a view progress timeline from the point where the subject element first starts to enter the scroll port, to the point where it has completely entered the scrollport. `0%` is equivalent to `0%` of the `cover` range. `100%` is equivalent to `0%` of the `contain` range.
 
 - `exit`
-  - : Represents the range of a view progress timeline from the point where the subject element first starts to exit the scroll port, to the point where it has completely exited the scrollport. `0%` is equivalent to `0%` of the `contain` range. `100%` is equivalent to `0%` of the `cover` range.
+  - : Represents the range of a view progress timeline from the point where the subject element first starts to exit the scroll port, to the point where it has completely exited the scrollport. `0%` is equivalent to `100%` of the `contain` range. `100%` is equivalent to `100%` of the `cover` range.
 
 - `entry-crossing`
   - : Represents the range during which the principal box crosses the end border edge. The start (0% progress) of the range occurs when the start border edge of the element's principal box coincides with the end edge of its view progress visibility range. The end (100%) of the range is the point at which the end border edge of the element's principal box coincides with the end edge of its view progress visibility range. The size of the range is the size of the element's principle box in the scroll direction.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix the description of the range `exit`

### Motivation

According to <https://drafts.csswg.org/scroll-animations/#valdef-animation-timeline-range-exit>, `exit` should be between `100%` of the `contain` range and `100%` of the `cover`.

### Additional details

Reference: https://drafts.csswg.org/scroll-animations/#valdef-animation-timeline-range-exit

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
