### PR TITLE
Fix formenctype attribute description to reference enctype instead of…

### DIFF
--- a/files/en-us/web/html/reference/elements/input/image/index.md
+++ b/files/en-us/web/html/reference/elements/input/image/index.md
@@ -76,7 +76,7 @@ A string that identifies the encoding method to use when submitting the form dat
 - `text/plain`
   - : Plain text; mostly useful only for debugging, so you can easily see the data that's to be submitted.
 
-If specified, the value of the `formenctype` attribute overrides the owning form's [`action`](/en-US/docs/Web/HTML/Reference/Elements/form#action) attribute.
+If specified, the value of the `formenctype` attribute overrides the owning form's [`enctype`](/en-US/docs/Web/HTML/Reference/Elements/form#enctype) attribute.
 
 This attribute is also available on [`<input type="submit">`](/en-US/docs/Web/HTML/Reference/Elements/input/submit) and {{HTMLElement("button")}} elements.
 


### PR DESCRIPTION
### Description

Fix typo in `<input type="image">` documentation where `formenctype` was incorrectly described as overriding the form's `action` attribute instead of `enctype`.

### Motivation

The incorrect reference to `action` instead of `enctype` could confuse developers trying to understand how form attribute overrides work. The `formenctype` attribute overrides the encoding type (`enctype`), not the submission URL (`action`).

### Additional details

- MDN form enctype reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form#enctype

### Related issues and pull requests

Fixes #42616

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234