### PR TITLE
fix: readEntries compatibility desc

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
@@ -52,7 +52,7 @@ See [`DataTransferItem.webkitGetAsEntry()`](/en-US/docs/Web/API/DataTransferItem
 
 {{Compat}}
 
-On Chrome 77, `readEntries()` will only return the first 100 `FileSystemEntry` instances. In order to obtain all of the
+In Chromium-based browsers, `readEntries()` will only return the first 100 `FileSystemEntry` instances. In order to obtain all of the
 instances, `readEntries()` must be called multiple times.
 
 ## See also


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Testing revealed that the number of items returned at a time is not related to the version; in the latest version of the Chrome browser, the maximum number of items returned is 100.
https://github.com/mdn/content/blob/ee2371afd0015d3208b22ca1dea6bbdb464de3ad/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md?plain=1#L96
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
