### PR TITLE
Explain value repetition when fewer background values are specified

### DIFF
--- a/files/en-us/web/css/guides/backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/en-us/web/css/guides/backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -55,6 +55,7 @@ For example:
 }
 ```
 
+
 This is equivalent to:
 
 ```css


### PR DESCRIPTION
This PR adds a short section explaining how background-related properties
repeat their values when fewer comma-separated values are provided than
the number of background layers, with a concrete example.

This clarifies expected behavior when using multiple backgrounds.

Fixes #42539
