### PR TITLE
COOP violation report

### DIFF
--- a/files/en-us/web/api/coopviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/columnnumber/index.md
@@ -1,0 +1,27 @@
+---
+title: "COOPViolationReportBody: columnNumber property"
+short-title: columnNumber
+slug: Web/API/COOPViolationReportBody/columnNumber
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.columnNumber
+---
+
+{{APIRef("Reporting API")}}
+
+The **`columnNumber`** read-only property of the {{domxref("COOPViolationReportBody")}} interface indicates the column number in the source file that triggered the [Cross-Origin-Opener-Policy (COEP)](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-OPener-Policy) violation.
+
+This property is used with {{domxref("COOPViolationReportBody.sourceFile")}} and {{domxref("COOPViolationReportBody.lineNumber")}} to indicate the location that triggered the violation.
+
+## Value
+
+An integer containing the column number that triggered the violation.
+
+## Examples
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/disposition/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/disposition/index.md
@@ -1,0 +1,49 @@
+---
+title: "COOPViolationReportBody: disposition property"
+short-title: disposition
+slug: Web/API/COOPViolationReportBody/disposition
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.disposition
+---
+
+{{APIRef("Reporting API")}}
+
+The **`disposition`** read-only property of the {{domxref("COOPViolationReportBody")}} dictionary indicates whether the report is for an enforced or report-only policy violation.
+
+Policy violations are enforced if the policy was set with {{httpheader("Cross-Origin-Opener-Policy")}}, and report-only if set with {{httpheader("Cross-Origin-Embedder-Policy-Report-Only")}}.
+
+## Value
+
+A string that can have one of the following values:
+
+- `"enforce"`
+  - : The report is for policy violation that was enforced.
+- `"reporting"`
+  - : The report is for policy violation that was report-only.
+
+## Examples
+
+### Get the disposition of a report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COOP violation reports, then log the value of `disposition` to the console.
+
+```js
+const options = {
+  types: ["coop"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coop
+  console.log(firstReport.body.disposition);
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/effectivepolicy/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/effectivepolicy/index.md
@@ -1,0 +1,47 @@
+---
+title: "COOPViolationReportBody: effectivePolicy property"
+short-title: effectivePolicy
+slug: Web/API/COOPViolationReportBody/effectivePolicy
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.effectivePolicy
+---
+
+{{APIRef("Reporting API")}}
+
+The **`effectivePolicy`** read-only property of the {{domxref("COOPViolationReportBody")}} dictionary indicates the COOP policy of the opened or opener document that triggered the report.
+It is present on all reports of type `coop`.
+
+Note that the term "effective" is used for the property because to indicate that it is a policy that is either enforced or reported.
+
+## Value
+
+A string that indicates the policy set in {{httpheader("Cross-Origin-Opener-Policy")}} or {{httpheader("Cross-Origin-Opener-Policy-Report-Only")}} for the document associated with the report.
+
+This will be one of the allowed directive values for [`Cross-Origin-Opener-Policy`](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy#directives).
+
+## Examples
+
+### Get the effectivePolicy of a COOP violation report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `effectivePolicy` to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport.body.effectivePolicy); // A COOP directive such as unsafe-none or same-site
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/index.md
@@ -1,0 +1,188 @@
+---
+title: COOPViolationReportBody
+slug: Web/API/COOPViolationReportBody
+page-type: web-api-interface
+browser-compat: api.COOPViolationReportBody
+---
+
+{{APIRef("Reporting API")}}
+
+The `COOPViolationReportBody` dictionary represents the {{domxref("Report.body","body")}} of a report with the {{domxref("Report.type","type")}} of `coop`.
+
+Reports with this type are used by the [Reporting API](/en-US/docs/Web/API/Reporting_API) to notify of violations of COOP policies set with the HTTP headers {{httpheader("Cross-Origin-Opener-Policy")}} and {{httpheader("Cross-Origin-Opener-Policy-Report-Only")}}.
+A serialized version of the same report structure may also be sent to [reporting server endpoints](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints).
+
+> [!NOTE]
+> This object does not derive from {{domxref("ReportBody")}} (unlike some other {{domxref("Report.body")}} values).
+
+## Instance properties
+
+- {{domxref("COOPViolationReportBody.disposition")}} {{ReadOnlyInline}}
+  - : A string indicating whether the report is for an `enforced` or a `reporting` policy violation.
+- {{domxref("COOPViolationReportBody.effectivePolicy")}} {{ReadOnlyInline}}
+  - : A string indicating the effective COOP policy of the document for which the violation report is being sent.
+    This may be an enforced or reporting-only policy, depending on the {{domxref("COOPViolationReportBody.disposition","disposition")}}.
+- {{domxref("COOPViolationReportBody.previousResponseURL")}} {{ReadOnlyInline}}
+  - : A string indicating the sanitized URL of the opener of a document.
+    This is reported for an opened document in a report with a body {{domxref("COOPViolationReportBody.type")}} of [`navigation-to-response`](#navigation-to-response_report).
+- {{domxref("COOPViolationReportBody.nextResponseURL")}} {{ReadOnlyInline}}
+  - : A string indicating the sanitized URL of the opened document.
+    This is reported for an opener document in a report with a body {{domxref("COOPViolationReportBody.type")}} of [`navigation-from-response`](#navigation-from-response_report).
+- {{domxref("COOPViolationReportBody.referrer")}} {{ReadOnlyInline}}
+  - : A string representing Xxxxxx
+- {{domxref("COOPViolationReportBody.type")}} {{ReadOnlyInline}}
+  - : A string indicating type of violation report: [`navigation-from-response`](#navigation-from-response_report), [`navigation-from-response`](#navigation-from-response_report), or `access-to-opener`.
+- {{domxref("COOPViolationReportBody.property")}} {{ReadOnlyInline}}
+  - : A string representing whether XXXX
+- {{domxref("COOPViolationReportBody.openerURL")}} {{ReadOnlyInline}}
+  - : A string representing whether XXXX
+- {{domxref("COOPViolationReportBody.sourceFile")}} {{ReadOnlyInline}}
+  - : A string indicating the URL of the script that triggered the violation report.
+- {{domxref("COOPViolationReportBody.lineNumber")}} {{ReadOnlyInline}}
+  - : A string indicating the line number in the script that triggered the violation report.
+- {{domxref("COOPViolationReportBody.columnNumber")}} {{ReadOnlyInline}}
+  - : A string indicating the column number in the script that triggered the violation report.
+- {{domxref("COOPViolationReportBody.openedWindowURL")}} {{ReadOnlyInline}}
+  - : A string representing whether XXXX
+- {{domxref("COOPViolationReportBody.openedWindowInitialURL")}} {{ReadOnlyInline}}
+  - : A string representing whether XXXX
+
+<!--
+// https://html.spec.whatwg.org/multipage/browsers.html#coop-violation-navigation-to
+// https://html.spec.whatwg.org/multipage/browsers.html#coop-violation-navigation-from
+// https://html.spec.whatwg.org/multipage/browsers.html#coop-violation-access-to-opener
+//https://html.spec.whatwg.org/multipage/browsers.html#coop-violation-access-from-opened
+/// https://html.spec.whatwg.org/multipage/browsers.html#coop-violation-access-to-opened
+There might be more
+-->
+
+## Description
+
+When navigating to a new document, or using {{domxref("window.open()")}} to open a document, the new document may be opened in the same {{glossary("Browsing context","browsing context group (BCG)")}} as the original document, or in a new BCG.
+If a document is opened in a new BCG it is [cross-origin isolated](/en-US/docs/Web/API/Window/crossOriginIsolated) from the original document, which closes a number of paths for malicious code.
+
+Whether or not a document is opened in a new BCG depends on the cross-origin opener policy of _both_ documents and may also depend on whether the documents are same-origin or cross-origin.
+Document policies can be set and enforced using the {{httpheader("Cross-Origin-Opener-Policy")}} HTTP header, or set and reported-on (but not enforced) using the {{httpheader("Cross-Origin-Opener-Policy-Report-Only")}} header.
+
+COOP policy violations may be reported using the [Reporting API](/en-US/docs/Web/API/Reporting_API) whenever a policy causes (or would cause) a document to be opened in a new BCG, or if the opened document attempts to access its opener.
+
+A COOP policy violation report is represented by a {{domxref("Report")}} instance that has the {{domxref("Report.type","type")}} of `coop` and a {{domxref("Report.body","body")}} property that is an object of this type.
+Reports can be returned via the {{domxref("ReportingObserver")}} interface or serialized and sent in a `POST` to a [reporting server endpoint](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints).
+
+To send to a reporting server endpoint the {{httpheader("Cross-Origin-Opener-Policy")}} and/or {{httpheader("Cross-Origin-Opener-Policy-Report-Only")}} headers used to set the policy must include the `report-to` parameter with a valid reporting endpoint name.
+Valid endpoint names are defined using the {{httpheader("Reporting-Endpoints")}} header.
+
+### Reporting enforcement and report-only policy violations
+
+The `Cross-Origin-Opener-Policy` header is used to enforce a COOP policy for a particular document.
+The policy effectively defines the policy(s) that other documents must have in order to open or navigate to the document in the same BCG, and in order to be opened or navigated from this document and remain in the same BCG.
+
+The `Cross-Origin-Opener-Policy-Report-Only` can be used to test the effect of enforcing a COOP policy for a particular document.
+When the document opens or is opened by another document its reporting-only policy is compared to the actual policy of the other document to determine if there would be a violation and send an appropriate report.
+
+A document can set `Cross-Origin-Opener-Policy` and/or `Cross-Origin-Opener-Policy-Report-Only` headers.
+These can have the same or different policies and reporting endpoints.
+
+### Types of reports
+
+Different reports are sent depending on whether the reporter is the opener or opened document in a navigation, or if the report is for a COOP access violation.
+The types of these reports is indicated by the body {{domxref("COOPViolationReportBody.type")}} property (the {{domxref("Report.type")}} is `coep` for all of these).
+
+#### `navigation-to-response` report
+
+This type of report is sent to the COOP reporting endpoint, if specified, of a document that is navigated-to (opened) in a navigation.
+
+For an enforced COOP policy, it indicates that the document was opened in a new BCG.
+This occurs when the COOP policy of the opened document is incompatible with that of its opener.
+For navigations this means that the opened document has a different COOP policy from its opener, or the same policy but they are not same-site (unless both documents have a COOP policy of [`unsafe-none`](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy#unsafe-none)).
+
+For a report-only COOP policy, it indicates the report-only COOP policy is incompatible with the (enforced) policy of its opener.
+In other words, that the report-only policy set in `Cross-Origin-Opener-Policy-Report-Only` would result in a violation if it was enforced.
+
+The report has the following properties:
+
+- {{domxref("COOPViolationReportBody.type","type")}}: `navigation-to-response`
+- {{domxref("COOPViolationReportBody.disposition","disposition")}}: Whether the report is for an `enforced` or `reporting` policy.
+- {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}}: The effective policy of the opened document.
+  This may be an enforced or reporting-only policy, depending on the {{domxref("COOPViolationReportBody.disposition","disposition")}}.
+- {{domxref("COOPViolationReportBody.previousResponseURL","previousResponseURL")}}: The sanitized URL of the previous document (that was navigated from), or `null` for cross-origin navigations.
+  This is the URL of the opener.
+  It might be the same URL as the {{domxref("COOPViolationReportBody.referrer","referrer")}} or it might be an intermediate redirect URL.
+- {{domxref("COOPViolationReportBody.referrer","referrer")}}: The original URL that started the navigation chain that resulted in this report.
+
+#### `navigation-from-response` report
+
+This type of report is sent to the COOP reporting endpoint, if specified, of an document that is navigated-from in a navigation.
+
+For an enforced COOP policy, it indicates that the document that was navigated to was opened in a new BCG.
+This occurs when the COOP policy of the opened document is incompatible with that of its opener.
+For navigations this means that the opened document has a different COOP policy from its opener, or the same policy but they are not same-site (unless both documents have a COOP policy of [`unsafe-none`](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy#unsafe-none)).
+
+For a report-only COOP policy, it indicates the report-only COOP policy of the opener is incompatible with the (enforced) policy of the page that is being navigated to.
+In other words, that the report-only policy set in `Cross-Origin-Opener-Policy-Report-Only` would result in a violation if it was enforced.
+
+Report of type `navigation-from-response` have the following propertiesL
+
+- {{domxref("COOPViolationReportBody.type","type")}}: `navigation-from-response`
+- {{domxref("COOPViolationReportBody.disposition","disposition")}}: Whether the report is for an `enforced` or `reporting` policy.
+- {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}}: The policy of the opener document.
+  This may be an enforced or reporting-only policy, depending on the {{domxref("COOPViolationReportBody.disposition","disposition")}}.
+- {{domxref("COOPViolationReportBody.nextResponseURL","nextResponseURL")}}: The sanitized URL of the opened document (that was navigated to), or `null` for cross origin navigations.
+
+#### `access-to-opener` report
+
+<!--
+
+- {{domxref("COOPViolationReportBody.disposition","disposition")}}
+- {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}}
+- {{domxref("COOPViolationReportBody.previousResponseURL","previousResponseURL")}}
+- {{domxref("COOPViolationReportBody.nextResponseURL","nextResponseURL")}}
+- {{domxref("COOPViolationReportBody.referrer","referrer")}}
+- {{domxref("COOPViolationReportBody.type","type")}}
+- {{domxref("COOPViolationReportBody.property","property")}}
+- {{domxref("COOPViolationReportBody.openerURL","openerURL")}}
+- {{domxref("COOPViolationReportBody.sourceFile","sourceFile")}}
+- {{domxref("COOPViolationReportBody.lineNumber","lineNumber")}}
+- {{domxref("COOPViolationReportBody.columnNumber","columnNumber")}}
+- {{domxref("COOPViolationReportBody.openedWindowURL","openedWindowURL")}}
+- {{domxref("COOPViolationReportBody.openedWindowInitialURL","openedWindowInitialURL")}}
+-->
+
+## Examples
+
+### COEP report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COOP reports, then log the first report to the console.
+
+```js
+const options = {
+  types: ["coop"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coop
+  console.log(firstReport);
+}, options);
+```
+
+The logged report object for a COOP violation from loading an iframe might look like this:
+
+```json
+
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{httpheader("Reporting-Endpoints")}}
+- [Reporting API](/en-US/docs/Web/API/Reporting_API)
+- [The Reporting API](https://developer.chrome.com/docs/capabilities/web-apis/reporting-api)

--- a/files/en-us/web/api/coopviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/linenumber/index.md
@@ -1,0 +1,27 @@
+---
+title: "COOPViolationReportBody: lineNumber property"
+short-title: lineNumber
+slug: Web/API/COOPViolationReportBody/lineNumber
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.lineNumber
+---
+
+{{APIRef("Reporting API")}}
+
+The **`lineNumber`** read-only property of the {{domxref("COOPViolationReportBody")}} interface indicates the line number in the source file that triggered the [Cross-Origin-Opener-Policy (COEP)](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-OPener-Policy) violation.
+
+This property is used with {{domxref("COOPViolationReportBody.sourceFile")}} and {{domxref("COOPViolationReportBody.columnNumber")}} to indicate the location that triggered the violation.
+
+## Value
+
+An integer containing the line number that triggered the violation.
+
+## Examples
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/nextresponseurl/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/nextresponseurl/index.md
@@ -1,0 +1,49 @@
+---
+title: "COOPViolationReportBody: nextResponseURL property"
+short-title: nextResponseURL
+slug: Web/API/COOPViolationReportBody/nextResponseURL
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.nextResponseURL
+---
+
+{{APIRef("Reporting API")}}
+
+The **`nextResponseURL`** read-only property of the {{domxref("COOPViolationReportBody")}} dictionary indicates the sanitized URL of the document opened by the current document for same-origin navigations.
+
+This is sent in a report for the navigated-from page in a navigation to indicate the URL of the document that was opened.
+The report has a {{domxref("COOPViolationReportBody.type","type")}} of [navigation-from-response](/en-US/docs/Web/API/COOPViolationReportBody/type#navigation-from-response).
+
+## Value
+
+This is a string indicating the URL of the opener document in a navigation, if the opener and opened documents are same-origin.
+If the documents are not same origin the value is `null`.
+
+The URL is sanitized of user credentials and any URL fragment is removed.
+
+## Examples
+
+### Get the nextResponseURL of a COOP violation report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `nextResponseURL` to the console.
+
+```js
+const options = {
+  types: ["coop"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coop
+  console.log(firstReport.body.type); // navigation-from-response
+  console.log(firstReport.body.nextResponseURL); // A sanitized URL or null
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/previousresponseurl/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/previousresponseurl/index.md
@@ -1,0 +1,50 @@
+---
+title: "COOPViolationReportBody: previousResponseURL property"
+short-title: previousResponseURL
+slug: Web/API/COOPViolationReportBody/previousResponseURL
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.previousResponseURL
+---
+
+{{APIRef("Reporting API")}}
+
+The **`previousResponseURL`** read-only property of the {{domxref("COOPViolationReportBody")}} dictionary indicates the sanitized URL of the opener of the current document for same-origin navigations.
+
+Note that if there are redirects, this may not be the original URL that triggered the navigation.
+
+This is sent in a report for a page opened in a navigation, with a body {{domxref("COOPViolationReportBody.type","type")}} of [navigation-to-response](/en-US/docs/Web/API/COOPViolationReportBody/type#navigation-to-response), to indicate the URL of its opener.
+
+## Value
+
+This is a string indicating the URL of the opener document in a navigation, if the opener and opened documents are same-origin.
+If the documents are not same origin the value is `null`.
+
+The URL is sanitized of user credentials and any URL fragment is removed.
+
+## Examples
+
+### Get the previousResponseURL of a COOP violation report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `previousResponseURL` to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport.body.type); // navigation-to-response
+  console.log(firstReport.body.previousResponseURL); // A sanitized URL or null
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/sourcefile/index.md
@@ -1,0 +1,27 @@
+---
+title: "COOPViolationReportBody: sourceFile property"
+short-title: sourceFile
+slug: Web/API/COOPViolationReportBody/sourceFile
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.sourceFile
+---
+
+{{APIRef("Reporting API")}}
+
+The **`sourceFile`** read-only property of the {{domxref("COOPViolationReportBody")}} interface indicates the URL of the source file that violated the [Cross-Origin-Opener-Policy (COEP)](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-OPener-Policy).
+
+This property is used with {{domxref("COOPViolationReportBody.lineNumber")}} and {{domxref("COOPViolationReportBody.columnNumber")}} to indicate the location that triggered the violation.
+
+## Value
+
+A string containing the URL of the file that triggered the violation.
+
+## Examples
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/coopviolationreportbody/type/index.md
+++ b/files/en-us/web/api/coopviolationreportbody/type/index.md
@@ -1,0 +1,118 @@
+---
+title: "COOPViolationReportBody: type property"
+short-title: type
+slug: Web/API/COOPViolationReportBody/type
+page-type: web-api-instance-property
+browser-compat: api.COOPViolationReportBody.type
+---
+
+{{APIRef("Reporting API")}}
+
+The **`type`** read-only property of the {{domxref("COOPViolationReportBody")}} dictionary returns a value that indicates whether the violation is reported by the opened or opener document, and whether it was triggered by a navigation or an attempt to access an opened document that is blocked by the policy.
+
+The fields present in the report depend on the type.
+
+## Value
+
+A string that can have one of the following values:
+
+- `"access-to-opener"`
+  - : The violation was caused Xxxxx
+
+    For more information see [`access-to-opener` report](access-to-opener_report).
+
+- `"navigation-to-response"`
+  - : This report is from the opened document (that was navigated to) and indicates a policy violation that caused by a COOP policy mismatch.
+
+    For more information see [`navigation-to-response` report](#navigation-to-response_report).
+
+- `"navigation-from-response"`
+  - : This report is from the opener document (that was navigated from) and indicates a policy violation that caused by a COOP policy mismatch.
+
+    For more information see [`navigation-from-response` report](#navigation-from-response_report).
+
+## Description
+
+The type indicates whether the report is due to a navigation, and is from the perspective of the opener or opened document, or is caused by an attempt to access the opener.
+It affects the properties that will be present in the reports.
+
+The report types are described in the following sections.
+
+### `navigation-to-response` report
+
+A report from the perspective of the document that was opened during a navigation.
+
+It indicates that the document that was navigated to was opened in a new {{glossary("Browsing context","browsing context group")}} (BCG) due to an enforced COOP, or should have been for a report-only COOP.
+
+This is caused when the COOP policy of the opened document is incompatible with its opener.
+For navigations this means that the opened document has a different COOP policy from its opener, or the same policy but they are not same-site (unless both documents have a COOP policy of [`unsafe-none`](/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy#unsafe-none)).
+
+Report of type `navigation-to-response` have the following properties
+
+- {{domxref("COOPViolationReportBody.disposition","disposition")}}: Whether the policy is enforced or reported.
+- {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}}: The policy of the opened document.
+- {{domxref("COOPViolationReportBody.previousResponseURL","previousResponseURL")}}: The sanitized URL of document that was navigated from for same-origin navigations.
+- {{domxref("COOPViolationReportBody.referrer","referrer")}} ????
+- {{domxref("COOPViolationReportBody.type","type")}}: `navigation-to-response`
+
+### `navigation-from-response` report
+
+A report from the perspective of the opener document in a navigation
+
+It indicates that the new document was, or should have been, opened in a new {{glossary("Browsing context","browsing context group")}} (BCG) due to a mismatch in policies.
+
+The only difference when compared to a report for `navigation-to-response` is that other properties are associated with the opener.
+For example, the {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}} is that of the opener rather than the opened document.
+
+Report of type `navigation-from-response` have the following properties
+
+- {{domxref("COOPViolationReportBody.disposition","disposition")}}: Whether the policy is enforced or reported.
+- {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}}: The policy of the opener document.
+- {{domxref("COOPViolationReportBody.nextResponseURL","nextResponseURL")}}: ???? If coopOrigin and nextResponseOrigin are same origin or isCOOPResponseNavigationSource is true, this is the sanitization of nextResponseURL, null otherwise.
+- {{domxref("COOPViolationReportBody.type","type")}}: `navigation-from-response`
+
+### `access-to-opener` report
+
+<!--
+
+- {{domxref("COOPViolationReportBody.disposition","disposition")}}
+- {{domxref("COOPViolationReportBody.effectivePolicy","effectivePolicy")}}
+- {{domxref("COOPViolationReportBody.previousResponseURL","previousResponseURL")}}
+- {{domxref("COOPViolationReportBody.nextResponseURL","nextResponseURL")}}
+- {{domxref("COOPViolationReportBody.referrer","referrer")}}
+- {{domxref("COOPViolationReportBody.type","type")}}
+- {{domxref("COOPViolationReportBody.property","property")}}
+- {{domxref("COOPViolationReportBody.openerURL","openerURL")}}
+- {{domxref("COOPViolationReportBody.sourceFile","sourceFile")}}
+- {{domxref("COOPViolationReportBody.lineNumber","lineNumber")}}
+- {{domxref("COOPViolationReportBody.columnNumber","columnNumber")}}
+- {{domxref("COOPViolationReportBody.openedWindowURL","openedWindowURL")}}
+- {{domxref("COOPViolationReportBody.openedWindowInitialURL","openedWindowInitialURL")}}
+-->
+
+## Examples
+
+### Get the type of a COOP violation report
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe COEP violation reports, then log the value of `type` to the console.
+
+```js
+const options = {
+  types: ["coep"],
+  buffered: true,
+};
+
+const observer = new ReportingObserver((reports, observer) => {
+  const firstReport = reports[0];
+  console.log(firstReport.type); // coep
+  console.log(firstReport.body.type); // access-to-opener or one of the other types
+}, options);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1420,6 +1420,7 @@
       "overview": ["Reporting API"],
       "guides": [],
       "interfaces": [
+        "COOPViolationReportBody",
         "CSPViolationReportBody",
         "DeprecationReportBody",
         "InterventionReportBody",


### PR DESCRIPTION
COOP uses the reporting API to report violations. This adds docs.

- [ ] COOPViolationReportBody - report structure for COOP violations
- [ ] Update Reporting API docs everywhere to include links to these 
- [ ] Cross-Origin-Opener-Policy - add report-to
- [ ] Cross-Origin-Opener-Policy-Report-Only - add report-to
- [ ] BCD everywhere https://github.com/mdn/browser-compat-data/issues/27021

Note, https://github.com/mdn/content/pull/39880/files#r2425080573 :

> COEP reports are visible to reporting observers.
> COOP property access reports are also visible to reporting observers. The navigation ones are not.

Also data mine or integrate with #42051 and see if there is anything additional to capture from https://github.com/mdn/content/pull/39880#discussion_r2151383496

Fixes #39814