### PR TITLE
Editorial review: Add information and example for counters in generated content alt text

### DIFF
--- a/files/en-us/web/css/reference/properties/content/index.md
+++ b/files/en-us/web/css/reference/properties/content/index.md
@@ -345,7 +345,7 @@ If using a screen reader, it should speak the word "MOZILLA" when it reaches the
 
 ### Including counters in alternative text
 
-This example includes a list of links to a set of book chapters, and specifies generated content before each one that includes a book icon and a counter, with alternative text that includes the literal word "Chapter" in place of the icon. This results in an elegant chapter number announcement for screenreader users before each link text is read out.
+This example features a list of links to a set of book chapters, and shows how to use generated content to include a book icon and a counter before each one, with alternative text that includes the literal word "Chapter" in place of the icon. This results in the word "chapter" and the chapter number preceding the text in each link's {{glossary("accessible name")}}, which will be announced to screenreader users when the link receives focus.
 
 #### HTML
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 140 adds support for `counter()` and `counters()` functions in `content` property alt text. See https://chromestatus.com/feature/5185442420621312. Note that the initial implementation was buggy; it is fixed now, but this functionality only really works in Canary at the moment. See the associated BCD for further details: https://github.com/mdn/browser-compat-data/pull/28763.

This PR adds a bit more information and an example to the `content` property page, showing how to use counters in content alt text.

I also took this opportunity to mention the fact that you can also use `attr()` functions in content alt text. I tested it, and it seems to work, but I didn't want to go much deeper on that, as it is not the central purpose of this PR.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
