### PR TITLE
Better error handling for WebGPU feature testing

### DIFF
--- a/files/en-us/web/api/webgpu_api/index.md
+++ b/files/en-us/web/api/webgpu_api/index.md
@@ -59,7 +59,12 @@ async function init() {
     throw Error("WebGPU not supported.");
   }
 
-  const adapter = await navigator.gpu.requestAdapter();
+  let adapter;
+  try {
+    adapter = await navigator.gpu.requestAdapter();
+  } catch (error) {
+    console.error(error);
+  }
   if (!adapter) {
     throw Error("Couldn't request WebGPU adapter.");
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Added error handling for requestAdapter example call.

### Motivation

See https://bugzilla.mozilla.org/show_bug.cgi?id=2008734
Firefox seems to throw during the `navigator.gpu.requestAdapter()` call when WebGPU is disabled by a blocklist, so I think it's better to be explicitly demonstrate this behaviour here. We used this snippet to feature test webgpu support and fallback to webgl if it wasn't supported, so this change in Firefox broke some of our sites.

### Additional details

[<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->](https://bugzilla.mozilla.org/show_bug.cgi?id=2008734)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
