### PR TITLE
Update Firefox 147 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -95,11 +95,22 @@ Firefox 147 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Fixed the new session response to include the required `setWindowRect` property. ([Firefox bug 1916522](https://bugzil.la/1916522)).
+- Fixed JSON serialization of Chrome Windows. ([Firefox bug 2000801](https://bugzil.la/2000801)).
+
+#### WebDriver BiDi
+
+- Fixed an issue where `browsingContext.navigate` with `wait=none` didn't always contain the real target URL. ([Firefox bug 2004191](https://bugzil.la/2004191)).
+- Updated `script.evaluate` and `script.callFunction` to bypass Content Security Policy (CSP). ([Firefox bug 1941780](https://bugzil.la/1941780)).
+- Implemented the `input.fileDialogOpened` event. ([Firefox bug 1855045](https://bugzil.la/1855045)).
+- Updated the `emulation.setLocaleOverride` command to override the `Accept-Language` header. ([Firefox bug 1995691](https://bugzil.la/1995691)).
+- Implemented the `emulation.setScreenSettingsOverride` command. ([Firefox bug 2000651](https://bugzil.la/2000651)).
+- Fixed missing `script.realmCreated` event for new browsing contexts. ([Firefox bug 2002721](https://bugzil.la/2002721)).
+- Updated `emulation.setLocaleOverride` to throw an error when called with the `locale` argument equal to `undefined`. ([Firefox bug 2003992](https://bugzil.la/2003992)).
 
 <!-- #### Marionette -->
 


### PR DESCRIPTION
Release notes update based on the following list of [relnote worthy bugs](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox146&query_format=advanced&o1=equals&f1=cf_status_firefox147&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=17748021).