### PR TITLE
Clarify parent-to-child DOM access with allow-same-origin

### DIFF
--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -126,7 +126,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
     - `allow-same-origin`
       - : If this token is not used, the resource is treated as being from a special origin that always fails the {{Glossary("same-origin policy")}} (potentially preventing access to [data storage/cookies](/en-US/docs/Web/Security/Defenses/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).
         > [!NOTE]
-        > When `allow-same-origin` is present, a same-origin parent document can access and interact with the iframe's DOM even if `allow-scripts` is not set. The `allow-scripts` token only controls script execution within the embedded browsing context and does not affect DOM access from the parent.
+        > When `allow-same-origin` is present, a same-origin parent document can still access and interact with the iframe's DOM even if `allow-scripts` is not set. The `allow-scripts` token only controls script execution within the embedded browsing context and does not affect DOM access from the parent.
     - `allow-scripts`
       - : Allows the page to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed.
     - `allow-storage-access-by-user-activation` {{experimental_inline}}


### PR DESCRIPTION
Adds a note under the allow-same-origin token explaining that a same-origin parent document can still access and manipulate the iframe's DOM even if allow-scripts is not set. The allow-scripts token only controls script execution inside the embedded document and does not affect parent-to-iframe DOM interactions.

Fixes #42633

### Description

Clarifies the distinction between internal script execution within a sandboxed <iframe> and parent-side DOM access. This helps developers understand that allow-same-origin is sufficient for same-origin parent access, and allow-scripts only governs scripts running inside the iframe itself.


### Motivation

Many developers assume that allowing scripts inside the iframe (allow-scripts) is required to access or measure DOM properties like scrollHeight from the parent. This PR clears up that misconception, supporting the Principle of Least Privilege by avoiding unnecessary enablement of allow-scripts.

### Additional details

Minimal reproducible example:
```html
<iframe id="myIframe" sandbox="allow-same-origin" src="content.html"></iframe>
```
A same-origin parent can read or manipulate the iframe's DOM without setting allow-scripts.

### Related issues and pull requests
Fixes #42633
