### PR TITLE
docs: fix punctuation in TCP port sentence

### DIFF
--- a/files/en-us/web/http/guides/session/index.md
+++ b/files/en-us/web/http/guides/session/index.md
@@ -17,7 +17,7 @@ As of HTTP/1.1, the connection is no longer closed after completing the third ph
 
 In client-server protocols, it is the client which establishes the connection. Opening a connection in HTTP means initiating a connection in the underlying transport layer, usually this is TCP.
 
-With TCP the default port, for an HTTP server on a computer, is port 80. Other ports can also be used, like 8000 or 8080. The URL of a page to fetch contains both the domain name, and the port number, though the latter can be omitted if it is 80. See [the URL reference](/en-US/docs/Web/URI) for more details.
+With TCP, the default port for an HTTP server on a computer is port 80. Other ports can also be used, like 8000 or 8080. The URL of a page to fetch contains both the domain name, and the port number, though the latter can be omitted if it is 80. See [the URL reference](/en-US/docs/Web/URI) for more details.
 
 > [!NOTE]
 > The client-server model does not allow the server to send data to the client without an explicit request for it. However, various Web APIs enable this use case, including the [Push API](/en-US/docs/Web/API/Push_API), [Server-sent events](/en-US/docs/Web/API/Server-sent_events), and the [WebSockets API](/en-US/docs/Web/API/WebSockets_API).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Fixed a punctuation error in the HTTP overview documentation by removing unnecessary commas that separated the subject from the verb.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The original sentence contained multiple commas that disrupted the reading flow and made the technical explanation grammatically incorrect. Removing these commas clarifies that "port 80" is the specific default for the described context.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

The corrected sentence now reads: "With TCP, the default port for an HTTP server on a computer is port 80." This follows standard English grammar rules regarding introductory phrases and subject-verb agreement.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
