### PR TITLE
Document KDE file configuration option for reduced motion

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
@@ -30,7 +30,7 @@ For Firefox, the `reduce` request is honoured if:
 
 - In Plasma/KDE: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to right to "Instant".
   - Alternatively, add `AnimationDurationFactor=0` to the `[KDE]` block of `~/.config/kdeglobals`.
-  - Or just run `kwriteconfig6 --key AnimationDurationFactor 0` in your favourite terminal emulator.
+  - Or just run `kwriteconfig6 --key AnimationDurationFactor 0` in your terminal.
 - In Windows 10: Settings > Ease of Access > Display > Show animations in Windows.
 - In Windows 11: Settings > Accessibility > Visual Effects > Animation Effects
 - In macOS: System Settings > Accessibility > Display > Reduce motion.


### PR DESCRIPTION
### Description

SSIA. The doc only mentions the UI-driven way of setting the reduced motion preference. This patch extends that with an equivalent entry to what's present under the GTK recommendations.

### Motivation

When on Linux, it's typical that some programs would use GTK while others will use Qt. And so it's reasonable to configure it for each of the frameworks together, not just your main one.

This info isn't really available in one place and requires research.

Many people automate their system configuration, which typically means modifying files to set up things in automated fashion. Clicking on the UI interfaces isn't really compatible with that. So I googled and experimented a bit.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://github.com/shalva97/kde-configuration-files?tab=readme-ov-file#appearance mentions `.config/kdeglobals` being responsible for appearence. https://discuss.kde.org/t/can-i-set-animation-speed-to-0-instant-when-on-battery/19370/3 shows the `kwriteconfig6 --key AnimationDurationFactor 0` command which I ran locally and it created `~/.config/kdeglobals` with the following contents, indeed:
```ini
[KDE]
AnimationDurationFactor=0
```

### Related issues and pull requests

N/A