### PR TITLE
Make GTK reduced motion config instructions comprehensive

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
+++ b/files/en-us/web/css/reference/at-rules/@media/prefers-reduced-motion/index.md
@@ -26,7 +26,8 @@ For Firefox, the `reduce` request is honoured if:
 
 - In GTK/GNOME: Settings > Accessibility > Seeing > Reduced animation is turned on.
   - In older versions of GNOME, GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
-  - Alternatively, add `gtk-enable-animations = false` to the `[Settings]` block of [the GTK 3 configuration file](https://wiki.archlinux.org/title/GTK#Configuration). Additionally run `gsettings set org.gnome.desktop.interface enable-animations false` to make programs pick up the settings faster.
+  - Alternatively, add `gtk-enable-animations = false` to the `[Settings]` block of [the GTK 3 configuration file](https://wiki.archlinux.org/title/GTK#Configuration).
+  - Additionally, try running `gsettings set org.gnome.desktop.interface enable-animations false` to make Firefox (and other programs relying on GTK version 4) respect the `reduce` setting.
 
 - In Plasma/KDE: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to right to "Instant".
   - Alternatively, add `AnimationDurationFactor=0` to the `[KDE]` block of `~/.config/kdeglobals`.


### PR DESCRIPTION
This patch adds a `gsettings` command that is respected by some applications better than the file config [[1]].

[1]: https://wiki.archlinux.org/title/Talk:GTK#c-Arash-20240319042700-Affaisseras-20240309232500

### Description

`gsettings set org.gnome.desktop.interface enable-animations false` is needed to cover a variaty of apps and GTK versions consistently, which this change documents.

### Motivation

When I was typing out the config, some apps didn't pick it up when I added the documented setting to the configs. 

### Additional details

It's probably because of GTK 3 vs. GTK 4 difference. But configuring it in the files *and* in `gsettings` did help immediately.

### Related issues and pull requests

N/A