### PR TITLE
Strikes accessibility claims from CSS carousel

### DIFF
--- a/files/en-us/web/css/guides/overflow/carousels/index.md
+++ b/files/en-us/web/css/guides/overflow/carousels/index.md
@@ -23,7 +23,7 @@ Users can move through the items by clicking or activating navigational buttons 
 
 A key feature of carousels is **pagination** — the items feel like separate pieces of content that are moved between rather than forming one continuous section of content. You might show one item at a time or several items on each carousel "page". When several items are visible, you might show an entirely new group of items each time the "next" or "previous" button is pressed. Alternatively, you could add a single new item to one end of the list while moving the item at the other end out of view.
 
-Carousels can be quite brittle and challenging to implement with JavaScript. They require scripts to associate scroll markers with the items they represent while continuously updating the scroll buttons to keep them operating correctly. 
+Carousels can be quite brittle and challenging to implement with JavaScript. They require scripts to associate scroll markers with the items they represent while continuously updating the scroll buttons to keep them operating correctly.
 
 Fortunately, we can create carousels with associated controls without the use of JavaScript, using CSS carousel features.
 


### PR DESCRIPTION
### Description

This MDN article is making some unfounded claims about the baseline accessibility of CSS carousels, so this PR strikes them. I've left the other statements about what considerations and concerns are in place for accessibility.

### Motivation

Devs are starting to try to implement these and creating WCAG violations without realizing it because this, along with lots of promotion in dev sites, wrongly claims these are "accessible" (without qualifying how or in what way).

### Additional details

Recent evidence of their baseline inaccessibility: https://www.sarasoueidan.com/blog/css-carousels-accessibility/


