### PR TITLE
Accessible name updates

### DIFF
--- a/files/en-us/web/css/guides/overflow/carousels/index.md
+++ b/files/en-us/web/css/guides/overflow/carousels/index.md
@@ -202,7 +202,7 @@ ul::scroll-button(right) {
 ```
 
 > [!NOTE]
-> The intent is that the scroll buttons are automatically given an appropriate accessible name, so they are announced appropriately by assistive technologies. No browser currently supports that, however. In the future, the above buttons will have an implicit [`role`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) of `button` and their {{glossary("accessible name", "accessible names")}} will be "scroll left" and "scroll right", respectively. Until then, you must add the alternative text.
+> User agents should automatically give an appropriate accessible name to generated scroll buttons so that assistive technologies can appropriately announced them and the buttons should have an implicit [`role`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles) of `button`. Providing [alternative text for generated content](/en-US/docs/Web/CSS/Reference/Properties/content#alternative_text_string_counter) ensures the buttons have the {{glossary("accessible name", "accessible names")}} of "scroll left" and "scroll right" in user agents that don't natively include scroll button accessibility features.
 
 ### Positioning scroll buttons
 


### PR DESCRIPTION
### Description

Addresses incorrect or absent guidance related to accessible names in the [Creating CSS carousels](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Overflow/Carousels) guide.

### Motivation

Devs are starting to try to implement these and creating WCAG violations without realizing it because this, along with lots of promotion in dev sites, wrongly claims these are "accessible" (without qualifying how or in what way).

### Additional details

Recent evidence of their baseline inaccessibility: https://www.sarasoueidan.com/blog/css-carousels-accessibility/

### Related issues and pull requests

Fixes #39125
