### PR TITLE
Fix issue 38238: IdP cookies must have SameSite=None

### DIFF
--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -117,7 +117,9 @@ Cookie: 0x23223
 Sec-Fetch-Dest: webidentity
 ```
 
-The request is credentialed: that is, it includes cookies for the IdP's site, which the IdP can use to identify which IdP accounts the user is signed into. Note that because the browser's request to this endpoint is a cross-site request, cookies will only be included if they have a [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute value of `None`.
+The request is credentialed: that is, it includes cookies for the IdP's site, which the IdP can use to identify which IdP accounts the user is signed into.
+
+Note that because the browser's request to this endpoint is a cross-site request, cookies will only be included if they have a [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) attribute value of `None`. This means that IdP's can't use `SameSite` as part of their defense against [Cross-Site Request Forgery(CSRF)](/en-US/docs/Web/Security/Attacks/CSRF) attacks, so they must implement alternative defenses.
 
 The response returns a list of all the IdP accounts that the user is currently signed in with (not specific to any particular RP), with a JSON structure that matches the following:
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/38238.

It looks like `SameSite=Lax` will eventually work as well, but not yet: https://github.com/httpwg/http-extensions/issues/3323.