### PR TITLE
Update CredentialsContainer.get() exceptions to reflect AbortSignal.reason

### DIFF
--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -99,7 +99,6 @@ If a single credential cannot be unambiguously obtained, the promise resolves wi
 
 - `AbortError` {{domxref("DOMException")}}
   - : The request was aborted by a call to the {{domxref("AbortController.abort", "abort()")}} method of the {{domxref("AbortController")}} associated with this method's [`signal`](#signal) option.
-  
     Note that if the caller of `abort()` provided a `reason` argument, then `get()` will be rejected with the value of `reason`, instead of an `AbortController` exception.
 
 - `TimeoutError` {{domxref("DOMException")}}


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Updated the `CredentialsContainer.get()` documentation to accurately describe the behavior when an `AbortSignal` is triggered with a custom reason. 

Current documentation suggests only a generic `AbortError` is thrown, but per the spec and browser implementation, the promise rejects with the value of `AbortSignal.reason`.

#### Changes
- **Parameters**: Updated the `signal` option description to mention that rejection uses the signal's `reason`.
- **Exceptions**: Revised the `AbortError` entry to explain that the rejection value mirrors `AbortSignal.reason` (which defaults to `AbortError`).
- **Examples**: Added a new example demonstrating how to handle a custom string reason (e.g., "TimeoutError").

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
- Verified the behavior against the [WebIDL/DOM specification](https://dom.spec.whatwg.org/#abortsignal-abort-reason).
- Verified that the logic aligns with the existing documentation for [`AbortSignal.abort()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_static#reason).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #42698
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
