### PR TITLE
fix typo in RTCTransportStats

### DIFF
--- a/files/en-us/web/api/rtctransportstats/tlsversion/index.md
+++ b/files/en-us/web/api/rtctransportstats/tlsversion/index.md
@@ -18,7 +18,7 @@ For example, DTLS represents version 1.2 as `'FEFD'` which numerically is `{254,
 
 ## Value
 
-A string that indicates the negotiated DTS transport.
+A string that indicates the negotiated DTLS transport.
 
 ## Specifications
 


### PR DESCRIPTION
I do strongly consider this is a typo, as it's irrelevant with content above, and, with the whole repository.

`DTS transport` => `DTLS transport`
