### PR TITLE
Fix typo in queuingStrategy variable name

### DIFF
--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
@@ -47,7 +47,7 @@ const readableStream = new ReadableStream(
   queuingStrategy,
 );
 
-const size = queueingStrategy.size(chunk);
+const size = queuingStrategy.size(chunk);
 ```
 
 ## Specifications


### PR DESCRIPTION
Fixes a Typo