### PR TITLE
Fix incorrect inheritance description for Range interface

### DIFF
--- a/files/en-us/web/api/range/index.md
+++ b/files/en-us/web/api/range/index.md
@@ -17,7 +17,7 @@ There also is the {{domxref("Range.Range()", "Range()")}} constructor available.
 
 ## Instance properties
 
-_There are no inherited properties._
+_The properties below are inherited from its parent interface, {{domxref("AbstractRange")}}._
 
 - {{domxref("Range.collapsed")}} {{ReadOnlyInline}}
   - : Returns a boolean value indicating whether the range's start and end points are at the same position.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Corrected the inheritance information for the `Range` interface.  
This change updates it to reflect that `Range` inherits from the `AbstractRange` interface.

### Motivation

The previous documentation was inconsistent with the DOM specification and other MDN pages, such as `StaticRange`.  
Fixing this helps readers understand the correct inheritance hierarchy and ensures MDN remains accurate and reliable.


### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
Fixes #42547
