### PR TITLE
Link to Promises/A+ for thenable behavior

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -138,6 +138,8 @@ The JavaScript ecosystem had made multiple Promise implementations long before i
 To interoperate with the existing Promise implementations, the language allows using thenables in place of promises. For example, [`Promise.resolve`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve) will not only resolve promises, but also trace thenables.
 
 ```js
+// This is not a Promises/A+ compliant thenable! It calls onFulfilled
+// synchronously. For demonstration only.
 const thenable = {
   then(onFulfilled, onRejected) {
     onFulfilled({
@@ -152,22 +154,7 @@ const thenable = {
 Promise.resolve(thenable); // A promise fulfilled with 42
 ```
 
-A thenable's `.then()` method is expected to call its fulfillment or rejection handlers synchronously.
-Implementing `.then()` as an `async` function is incorrect and can cause errors to escape Promise error handling.
-
-This is because `async` functions always wrap thrown errors in a returned `Promise`, while Promise resolution expects thenables to signal errors either by throwing synchronously or by explicitly calling the rejection handler.
-
-For example, using an `async` `.then()` method can result in thrown errors not being handled as expected during Promise resolution:
-
-```js
-const badThenable = {
-  async then(onFulfilled, onRejected) {
-    throw new Error("This error may not be handled as a rejection");
-  },
-};
-
-Promise.resolve(badThenable);
-```
+The `then()` method is responsible for scheduling the execution of the provided `onFulfilled` and `onRejected` callbacks. Its semantics, including error handling and asynchronicity, are precisely defined in the [Promises/A+ specification](https://promisesaplus.com/), and we shall not repeat them here. It's very rare that you need to implement a thenable yourself; even if you are not using native promises, you would probably be using a Promise library such as [Bluebird](http://bluebirdjs.com/).
 
 ### Promise concurrency
 


### PR DESCRIPTION
### Description

This PR clarifies the requirements for implementing thenables in the Promise documentation, explicitly noting that a thenable’s `.then()` method must not be `async`.

A warning and example have been added to explain how using `async` can cause thrown errors to escape Promise error handling, leading to unexpected behavior during Promise resolution.

### Motivation

The Promise specification expects thenables to signal fulfillment or rejection synchronously, either by throwing or by explicitly calling the rejection handler. Using an `async` function for `.then()` violates this expectation because `async` functions always wrap errors in a returned Promise.

This change helps readers avoid subtle bugs when implementing custom thenables and aligns the documentation with the actual Promise resolution semantics.

Fixes #42193
