### PR TITLE
Fix order of arguments in SpeechRecognitionPhrase ctor

### DIFF
--- a/files/en-us/web/api/speechrecognitionphrase/speechrecognitionphrase/index.md
+++ b/files/en-us/web/api/speechrecognitionphrase/speechrecognitionphrase/index.md
@@ -30,7 +30,6 @@ new SpeechRecognitionPhrase(phrase, boost)
     > [!NOTE]
     > A high value such as `9.0` or `10.0` might make the recognition engine erroneously recognize other phrases as the specified phrase. Therefore, such values should be used rarely when constructing `SpeechRecognitionPhrase` objects.
 
-
 ### Return value
 
 A new {{domxref("SpeechRecognitionPhrase")}} object.


### PR DESCRIPTION

### Description

Fix order of arguments in `SpeechRecognitionPhrase` ctor

### Motivation

It was wrong

### Additional details

Source: I am editor and reviewer and implementor of this spec, and it is here: https://webaudio.github.io/web-speech-api/#dom-speechrecognitionphrase-speechrecognitionphrase
