### PR TITLE
Fx147: Add relnote for iterator sequencing support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -62,6 +62,8 @@ Firefox 147 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - CSS module scripts are now supported, allowing a stylesheet to be loaded into a script as a {{domxref("CSSStyleSheet")}} instance using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) keyword and the [`type` import attribute](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) set to `type="css"`.
   ([Firefox bug 1986681](https://bugzil.la/1986681)).
+- The {{jsxref("Iterator.concat()")}} method is now supported. This method enables you to create a new iterator that combines multiple input iterables into a single sequence.
+  ([Firefox bug 1986672](https://bugzil.la/1986672)).
 
 <!-- No notable changes. -->
 


### PR DESCRIPTION
### Description

Firefox 147 adds support for Iterator Sequencing proposal's `Iterator.concat()` method

### Related issues and pull requests

- Issue tracker: https://github.com/mdn/content/issues/42248
- Content PR: https://github.com/mdn/content/pull/42671
