### PR TITLE
Compare Error.cause and SuppressedError use cases

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.md
@@ -8,6 +8,8 @@ sidebar: jsref
 
 The **`AggregateError`** object represents an error when several errors need to be wrapped in a single error. It is thrown when multiple errors need to be reported by an operation, for example by {{jsxref("Promise.any()")}}, when all promises passed to it reject.
 
+Compared to {{jsxref("SuppressedError")}}, `AggregateError` represents a list of unrelated errors, while `SuppressedError` represents an error that happened during the handling of another error.
+
 `AggregateError` is a subclass of {{jsxref("Error")}}.
 
 ## Constructor

--- a/files/en-us/web/javascript/reference/global_objects/suppressederror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/suppressederror/index.md
@@ -8,7 +8,7 @@ sidebar: jsref
 
 The **`SuppressedError`** object represents an error generated while handing another error. It is generated during resource disposal using {{jsxref("Statements/using", "using")}} or {{jsxref("Statements/await_using", "await using")}}.
 
-Compared to {{jsxref("AggregateError")}}, `SuppressedError` is used to represent a single error that is suppressed by another error, while `AggregateError` represents a list of unrelated errors. It is possible, though, for a `SuppressedError` to contain a chain of suppressed errors (`e.suppressed.suppressed.suppressed...`). It is also semantically different from {{jsxref("Error/cause", "cause")}} because the error is not _caused_ by another error, but _happens when_ handling another error.
+Compared to {{jsxref("AggregateError")}}, `SuppressedError` represents an error that happened during the handling of another error, while `AggregateError` represents a list of unrelated errors. It is possible, though, for a `SuppressedError` to contain a chain of suppressed errors (`e.suppressed.suppressed.suppressed...`). It is also semantically different from {{jsxref("Error/cause", "cause")}} because the error is not _caused_ by another error, but _happens when_ handling another error.
 
 `SuppressedError` is a subclass of {{jsxref("Error")}}.
 


### PR DESCRIPTION
### Description

Adds a new section comparing `Error.cause` and `SuppressedError`, explaining when each API should be used and how they differ in practice. Includes a concise comparison table and concrete examples for both patterns.

### Motivation

Readers may be unsure whether to use `Error.cause` or `SuppressedError` when handling multiple or related errors. This change clarifies their intended use cases and helps developers choose the correct API based on real-world scenarios.

Fixes #42130
