### PR TITLE
Fix "physical" to "logical" in the `corner-block-*-shape` and `corner-inline-*-shape` properties.

### DIFF
--- a/files/en-us/web/css/reference/properties/corner-block-end-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-block-end-shape/index.md
@@ -16,7 +16,7 @@ For a full description of corner shape behavior and multiple examples, see the {
 
 ## Constituent properties
 
-The `corner-block-end-shape` property is a shorthand for the following physical properties:
+The `corner-block-end-shape` property is a shorthand for the following logical properties:
 
 - {{cssxref("corner-end-start-shape")}}
 - {{cssxref("corner-end-end-shape")}}

--- a/files/en-us/web/css/reference/properties/corner-block-start-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-block-start-shape/index.md
@@ -16,7 +16,7 @@ For a full description of corner shape behavior and multiple examples, see the {
 
 ## Constituent properties
 
-The `corner-block-start-shape` property is a shorthand for the following physical properties:
+The `corner-block-start-shape` property is a shorthand for the following logical properties:
 
 - {{cssxref("corner-start-start-shape")}}
 - {{cssxref("corner-start-end-shape")}}

--- a/files/en-us/web/css/reference/properties/corner-inline-end-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-inline-end-shape/index.md
@@ -16,7 +16,7 @@ For a full description of corner shape behavior and multiple examples, see the {
 
 ## Constituent properties
 
-The `corner-inline-end-shape` property is a shorthand for the following physical properties:
+The `corner-inline-end-shape` property is a shorthand for the following logical properties:
 
 - {{cssxref("corner-start-end-shape")}}
 - {{cssxref("corner-end-end-shape")}}

--- a/files/en-us/web/css/reference/properties/corner-inline-start-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-inline-start-shape/index.md
@@ -16,7 +16,7 @@ For a full description of corner shape behavior and multiple examples, see the {
 
 ## Constituent properties
 
-The `corner-inline-start-shape` property is a shorthand for the following physical properties:
+The `corner-inline-start-shape` property is a shorthand for the following logical properties:
 
 - {{cssxref("corner-start-start-shape")}}
 - {{cssxref("corner-end-start-shape")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix "physical properties" to "logical properties" in the `corner-block-*-shape` and `corner-inline-*-shape` properties.

### Motivation

I think `corner-end-*-shape` and `corner-start-*-shape` properties are logical properties, not physical.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
