### PR TITLE
fix typo in `PeroformanceResourceTiming.requestStart`

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -8,7 +8,7 @@ browser-compat: api.PerformanceResourceTiming.requestStart
 
 {{APIRef("Performance API")}}{{AvailableInWorkers}}
 
-The **`requestStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} of the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.
+The **`requestStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} of the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retries the request, the value returned will be the start of the retry request.
 
 There is no _end_ property for `requestStart`. To measure the request time, calculate {{domxref("PerformanceResourceTiming.responseStart", "responseStart")}} - `requestStart` (see the example below).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR fixes a small typo in the description of the requestStart property.

### Motivation

`retires` is a typo and should be `retries`.
From the context and the intended behavior of `requestStart`, the sentence is clearly describing the case where the browser retries a request after a transport failure, and that `requestStart` reflects the start time of the retry request.

### Additional details

article link: https://developer.mozilla.org/de/docs/Web/API/PerformanceResourceTiming/requestStart
