### PR TITLE
Use cartesian distance for pinch zoom gesture

### DIFF
--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -100,7 +100,10 @@ function pointermoveHandler(ev) {
   // If two pointers are down, check for pinch gestures
   if (evCache.length === 2) {
     // Calculate the distance between the two pointers
-    const curDiff = Math.hypot(evCache[0].clientX - evCache[1].clientX, evCache[0].clientY - evCache[1].clientY);
+    const curDiff = Math.hypot(
+      evCache[0].clientX - evCache[1].clientX,
+      evCache[0].clientY - evCache[1].clientY,
+    );
 
     if (prevDiff > 0) {
       if (curDiff > prevDiff) {


### PR DESCRIPTION
Pinch zoom gestures should use cartesian distance, because they are usually executed diagonally, and so that they can optionally be combined with a rotate gesture.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The previous code used the following distance calculation that only looks at the horizontal component of the pinch:

```js
const curDiff = Math.abs(evCache[0].clientX - evCache[1].clientX);
```

If you actually try to zoom like this, it's very challenging ergonomically: your thumb, index finger, hand and forearm and all on the same line, your arm wants to be perpendicular to your body and the trackpad, so doing a pinch zoom horizontally requires your forearm to be almost parallel to the trackpad. In other words, the vertical component is the primary component for a pinch zoom and the horizontal component is secondary.

Usually a pinch zoom is implemented as cartesian distance because it is complemented by the rotate gesture. So a 1 dimensional pinch zoom is inconsistent with user expectations.
