### PR TITLE
Fix positioning example in using anchor positioning guide

### DIFF
--- a/files/en-us/web/css/guides/anchor_positioning/using/index.md
+++ b/files/en-us/web/css/guides/anchor_positioning/using/index.md
@@ -253,11 +253,11 @@ Both will place the positioned element `50px` above the bottom of the element's 
 
 The most common `anchor()` parameters you'll use will refer to a side of the default anchor. You will also often either add a {{cssxref("margin")}} to create spacing between the edge of the anchor and positioned element or use `anchor()` within a `calc()` function to add that spacing.
 
-For example, this rule positions the right edge of the positioned element flush to the anchor element's left edge, then adds some `margin-left` to make some space between the edges:
+For example, this rule positions the left edge of the positioned element flush to the anchor element's right edge, then adds some `margin-left` to make some space between the edges:
 
 ```css
 .positionedElement {
-  right: anchor(left);
+  left: anchor(right);
   margin-left: 10px;
 }
 ```


### PR DESCRIPTION
### Description

Corrected the description of the positioning rule to specify the left edge instead of the right edge.

### Motivation

That wrong example made me so confused while learning CSS anchor positioning

### Additional details

https://github.com/mdn/content/blob/2b9e1f24f660e3cf52539b7b8a7fc94085e8814d/files/en-us/web/css/guides/anchor_positioning/using/index.md?plain=1#L256-L263


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
