### PR TITLE
Fix incorrect inheritance for Range interface

### DIFF
--- a/files/en-us/web/api/range/index.md
+++ b/files/en-us/web/api/range/index.md
@@ -3,6 +3,8 @@ title: Range
 slug: Web/API/Range
 page-type: web-api-interface
 browser-compat: api.Range
+api-inheritance:
+  - AbstractRange
 ---
 
 {{APIRef("DOM")}}


### PR DESCRIPTION
This PR fixes the incorrect inheritance shown for the Range interface
by declaring AbstractRange in the page frontmatter.

Fixes: https://github.com/mdn/content/issues/42547