### PR TITLE
Fix incorrect inherited properties note in Range documentation

### DIFF
--- a/files/en-us/web/api/range/index.md
+++ b/files/en-us/web/api/range/index.md
@@ -17,7 +17,7 @@ There also is the {{domxref("Range.Range()", "Range()")}} constructor available.
 
 ## Instance properties
 
-_There are no inherited properties._
+The following properties are inherited from the parent interface, {{DOMxRef("AbstractRange")}}.
 
 - {{domxref("Range.collapsed")}} {{ReadOnlyInline}}
   - : Returns a boolean value indicating whether the range's start and end points are at the same position.


### PR DESCRIPTION
### Description

This pull request fixes incorrect information in the Instance Properties section
of the Range interface documentation by clarifying that properties are inherited
from AbstractRange.

### Motivation

The documentation previously stated that the Range interface has no inherited
properties, which was inconsistent with related interfaces and could confuse
developers. This change aligns the documentation with the actual inheritance
behavior.

### Related issues and pull requests

Fixes #42547
