### PR TITLE
chore(release-firefox): repeat sanitization

### DIFF
--- a/scripts/content/release-firefox.js
+++ b/scripts/content/release-firefox.js
@@ -156,8 +156,13 @@ async function updateReleaseNotes(version, newStatus, releaseDate) {
       "$1\n\n$2",
     );
 
-    // Remove all remaining HTML comments (including multi-line comments)
-    content = content.replace(/<!--[\s\S]*?-->\n?/g, "");
+    // Remove all remaining HTML comments (including multi-line comments).
+    // Apply repeatedly to avoid incomplete multi-character sanitization.
+    let previousContent;
+    do {
+      previousContent = content;
+      content = content.replace(/<!--[\s\S]*?-->\n?/g, "");
+    } while (content !== previousContent);
 
     // Clean up excessive blank lines (more than 2 consecutive)
     content = content.replace(/\n{3,}/g, "\n\n");


### PR DESCRIPTION
Potential fix for [https://github.com/mdn/content/security/code-scanning/56](https://github.com/mdn/content/security/code-scanning/56)

In general, to fix incomplete multi-character sanitization with regex replacements, you can either (a) use a dedicated sanitization library, or (b) apply the replacement repeatedly until no further changes occur, ensuring that patterns that reappear after replacement are also removed. Here, the goal is very narrow—removing all HTML comments from a markdown file—so the simplest robust fix is to repeatedly apply the existing comment-stripping regex until the string stabilizes.

Concretely, in `scripts/content/release-firefox.js`, inside `updateReleaseNotes`, in the `if (newStatus === "stable")` block, the line:

```js
content = content.replace(/<!--[\s\S]*?-->\n?/g, "");
```

should be replaced with a small loop that keeps applying this replacement until no more matches are found. This avoids any edge cases where removing one comment could create a new `<!--...-->` sequence that would otherwise be left behind. We don't need new imports or external libraries; just local logic in the same function. No other behavior of the script is changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
