### PR TITLE
gutters definition issue expanded

### DIFF
--- a/files/en-us/glossary/gutters/index.md
+++ b/files/en-us/glossary/gutters/index.md
@@ -5,9 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**Gutters** or _alleys_ are spacing between content {{glossary("grid_tracks", "tracks")}}.
-These can be created in CSS grid layout, flex layout, and multi-column layout using the
-{{cssxref("column-gap")}}, {{cssxref("row-gap")}}, or {{cssxref("gap")}} properties.
+**Gutters** or _alleys_ are spacing between content {{glossary("grid_tracks", "tracks")}}. These can be created in [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout), [flex layout](/en-US/docs/Web/CSS/Guides/Flexible_box_layout), and [multi-column layout](/en-US/docs/Web/CSS/Guides/Multicol_layout) using the {{cssxref("column-gap")}}, {{cssxref("row-gap")}}, or {{cssxref("gap")}} properties.
 
 ## Example
 


### PR DESCRIPTION
### Description

This PR updates the Gutters glossary entry to clarify that gaps are supported not only in CSS Grid,
but also in Flexbox and multi-column layouts.

### Motivation

The current text implies that gutters are specific to CSS Grid. However, the `gap`, `row-gap`, and
`column-gap` properties are also supported in Flexbox and multi-column layouts. This change improves
technical accuracy and prevents confusion for readers.

### Additional details

No additional details.

### Related issues and pull requests

Fixes #42727