### PR TITLE
Document that an attribute selector can also be used for this

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_open/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_open/index.md
@@ -6,7 +6,7 @@ browser-compat: css.selectors.open
 sidebar: cssref
 ---
 
-The **`:open`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an element that has open and closed states, only when it is currently in the open state. For {{htmlelement("details")}} elements, this selection can also be done using an attribute selector: `details[open]`.
+The **`:open`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an element that has open and closed states, only when it is currently in the open state.
 
 ## Syntax
 
@@ -20,7 +20,7 @@ The **`:open`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Re
 
 The `:open` pseudo-class selects any element currently in the open state, which includes the following elements:
 
-- {{htmlelement("details")}} and {{htmlelement("dialog")}} elements that are in an open state, that is, they have the `open` attribute set.
+- {{htmlelement("details")}} and {{htmlelement("dialog")}} elements that are in an open state, that is, they have the `open` attribute set. This selection can also be done using an attribute selector: `details[open]`.
 - {{htmlelement("input")}} elements that display a picker interface for the user to choose a value from (for example [`<input type="color">`](/en-US/docs/Web/HTML/Reference/Elements/input/color)), when the picker is displayed.
 - {{htmlelement("select")}} elements that display a drop-down picker for the user to choose a value from, when the picker is displayed. Note that when implementing [customizable select elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select), the picker itself can be selected using the {{cssxref("::picker()", "::picker(select)")}} pseudo-element.
 


### PR DESCRIPTION
### Description

Document that the attribute selector `[open]` can be used in place of `:open`.

### Motivation

`:open` has limited availability. This makes the difference between the two more clear suggests this alternative for those who do not think of it.