### PR TITLE
Soften the language around search engines and SEO impact of the HTTP …

### DIFF
--- a/files/en-us/web/http/reference/status/308/index.md
+++ b/files/en-us/web/http/reference/status/308/index.md
@@ -9,7 +9,6 @@ sidebar: http
 The HTTP **`308 Permanent Redirect`** [redirection response](/en-US/docs/Web/HTTP/Reference/Status#redirection_messages) status code indicates that the requested resource has been permanently moved to the URL given by the {{HTTPHeader("Location")}} header.
 
 A browser receiving this status will automatically request the resource at the URL in the `Location` header, redirecting the user to the new page.
-Some search engines receiving this response may attribute links to the original URL to the redirected resource, passing the {{Glossary("SEO")}} ranking to the new URL.
 
 The request method and the body **will not be modified** by the client in the redirected request.
 A {{HTTPStatus("301", "301 Moved Permanently")}} requires the request method and the body to remain unchanged when redirection is performed, but this is incorrectly handled by older clients to use the {{HTTPMethod("GET")}} method instead.


### PR DESCRIPTION
On the treatment of 308 response code in search engines.

### Description

At least for Google I can say that we don't treat it as the original sentence made it sound like. I would be surprised if other search engines did, but of course I can only say this for sure for Google.
I think this sentence should be removed or at least, as I did in this PR, softened.

### Motivation

Currently, it's misleading as search engine behavior (that doesn't exist) is given as a motivation to implement this HTTP code. People might waste time and effort on making their implementation use 308 based on this sentence.