### PR TITLE
"how to fix" cors did not succeed error added

### DIFF
--- a/files/en-us/web/http/guides/cors/errors/corsdidnotsucceed/index.md
+++ b/files/en-us/web/http/guides/cors/errors/corsdidnotsucceed/index.md
@@ -26,7 +26,7 @@ In many cases, it is caused by a browser plugin (e.g., an ad blocker or privacy 
   Serve the API over HTTPS instead.
 - Confirm that the server is responding correctly and that the endpoint returns a response.
 
-If you are using `localhost`, ensure that the correct scheme and port are used and that the service is running.
+If you are using a local dev server, ensure that the correct scheme and port are used and that the service is running.
 
 Other possible causes include:
 


### PR DESCRIPTION
Description
This PR adds a "How to fix" section with practical troubleshooting steps for the
"CORS request did not succeed" error.

Motivation
The current page explains the causes of the error but does not provide actionable
guidance. Adding troubleshooting steps helps readers identify and resolve the
underlying network issues more effectively.

Additional details
Related issues and pull requests
Fixes #42716