### PR TITLE
Fix wrong interface name in NavigateEvent description

### DIFF
--- a/files/en-us/web/api/navigation_api/index.md
+++ b/files/en-us/web/api/navigation_api/index.md
@@ -24,7 +24,7 @@ The API is accessed via the {{domxref("Window.navigation")}} property, which ret
 
 The `navigation` interface has several associated events, the most notable being the {{domxref("Navigation/navigate_event", "navigate")}} event. This is fired when [any type of navigation](https://github.com/WICG/navigation-api#appendix-types-of-navigations) is initiated, meaning that you can control all page navigations from one central place, ideal for routing functionality in SPA frameworks. (This is not the case with the {{domxref("History API", "", "", "nocode")}}, where it is sometimes hard to detect and respond to all navigations.) The `navigate` event handler is passed a {{domxref("NavigateEvent")}} object, which contains detailed information including details around the navigation's destination, type, whether it contains `POST` form data or a download request, and more.
 
-The `NavigationEvent` object also provides two methods:
+The `NavigateEvent` object also provides two methods:
 
 - {{domxref("NavigateEvent.intercept", "intercept()")}} allows you to specify custom behavior for navigations, and can take the following as arguments:
   - Callback handler functions allowing you to specify what happens both _when_ the navigation is committed and _just before_ the navigation is committed. For example, you could load relevant new content into the UI based on the path of the URL navigated to, or redirect the browser to a sign-in page if the URL points to a restricted page and the user is not signed in.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR fixes a typo in the Navigation API page where `NavigationEvent` is referenced instead of the correct `NavigateEvent`.

### Motivation

There is no `NavigationEvent` interface in the specification or implementations. The methods described (`intercept()` and `scroll()`) are provided by `NavigateEvent`.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
