### PR TITLE
Added note for options regarding oAuth tests

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
@@ -54,7 +54,6 @@ This will tend to be specific to the service provider, but in general it means c
 >
 > To simplify testing, you can use a mock OAuth server like [oAuth-mock](https://github.com/atagon-GmbH/oAuth-mock). This allows you to simulate a successful login flow by simply replacing the provider's authorization URL with the mock server URL (e.g., `https://oauth.kogiqa.com/`), without needing to register a real client application or bypass security challenges.
 
-
 ## Functions
 
 - {{WebExtAPIRef("identity.getRedirectURL()")}}


### PR DESCRIPTION
### Description
I added a brief note referencing the option to use an OAuth mock server for End-to-End (E2E) testing

### Motivation
It's a pain to test, so I wrote an open-source tool that mocks the OAuth server for the biggest providers. I hope it helps other people as well.
