### PR TITLE
Align DELETE request body semantics with GET per RFC 9110

### DIFF
--- a/files/en-us/web/http/reference/methods/delete/index.md
+++ b/files/en-us/web/http/reference/methods/delete/index.md
@@ -9,7 +9,7 @@ sidebar: http
 
 The **`DELETE`** HTTP method asks the server to delete a specified resource.
 
-Requests using `DELETE` may include a body, but it has no defined semantics.
+Requests using `DELETE` should only be used to delete data and shouldn't contain a body.
 
 > [!NOTE]
 > The semantics of sending a message body in `DELETE` requests are undefined.


### PR DESCRIPTION
Fixes #42511

Aligns DELETE request body documentation with GET semantics per RFC 9110.
Adds a warning callout and corrects the "Request has body" table entry.
