### PR TITLE
Fix variable name in `NavigateEvent` interface

### DIFF
--- a/files/en-us/web/api/navigateevent/index.md
+++ b/files/en-us/web/api/navigateevent/index.md
@@ -89,7 +89,7 @@ In this example of intercepting a navigation, the `handler()` function starts by
 
 ```js
 navigation.addEventListener("navigate", (event) => {
-  if (shouldNotIntercept(navigateEvent)) return;
+  if (shouldNotIntercept(event)) return;
   const url = new URL(event.destination.url);
 
   if (url.pathname.startsWith("/articles/")) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In the navigate event listener, the code was calling `shouldNotIntercept(navigateEvent)`, but `navigateEvent` is not defined in this scope. The correct variable is the event parameter passed to the `event`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/NavigateEvent

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
