### PR TITLE
fix(webextensions): fix fragment links on "Anatomy of an extension"

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
@@ -13,13 +13,13 @@ This is the only file that must be present in every extension. It contains basic
 
 The manifest can also contain pointers to several other types of files:
 
-- [Background scripts](#background_scripts_2)
+- [Background scripts](#background_scripts)
   - : Scripts that respond to browser events.
 - Icons
   - : For the extension and any buttons it might define.
-- [Sidebars, popups, and options pages](#sidebars_popups_and_options_pages_2)
+- [Sidebars, popups, and options pages](#sidebars_popups_and_options_pages)
   - : HTML documents that provide content for various user interface components.
-- [Content scripts](#content_scripts_2)
+- [Content scripts](#content_scripts)
   - : JavaScript included with your extension, that you will inject into web pages.
 - [Web-accessible resources](#web_accessible_resources)
   - : Make packaged content accessible to web pages and content scripts.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes three fragment links on the "Anatomy of an extension" page.

### Motivation

The fragment links are effectively self-links, because the header fragments do not have the `_2` suffix.

### Additional details

Noticed while discussing https://github.com/mdn/fred/issues/716.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
