### PR TITLE
Revise: `autofocus` attribute & property Docs

### DIFF
--- a/files/en-us/web/api/htmlelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlelement/autofocus/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLElement.autofocus
 
 The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus) HTML global attribute. This indicates whether the element should be focused on page load or, if it is nested inside a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, when the `<dialog>` or popover is shown.
 
-Only one element inside a document, or part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, may have this attribute specified. If applied to multiple elements the first focusable one will receive focus.
+Only one element inside a document, `<dialog>` element, or popover may have this attribute specified. If applied to multiple elements, the first focusable one will receive focus.
 
 > [!NOTE]
 > Setting this property doesn't set the focus to the associated element: it merely tells the browser to focus to it when _the element is inserted_ in the document. Setting it after the insertion, that is most of the time after the document load, has no visible effect.

--- a/files/en-us/web/api/htmlelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlelement/autofocus/index.md
@@ -8,9 +8,9 @@ browser-compat: api.HTMLElement.autofocus
 
 {{APIRef("HTML DOM")}}
 
-The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Elements/select#autofocus) HTML global attribute, which indicates whether the control should be focused when the page loads, or when dialog or popover become shown if specified in an element inside {{htmlelement("dialog")}} elements or elements whose popover attribute is set.
+The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Elements/select#autofocus) HTML global attribute, which indicates whether the element should be focused on page load, or when it is part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element that becomes shown.
 
-Only one form-associated element inside a document, or a {{htmlelement("dialog")}} element, or an element whose `popover` attribute is set, can have this attribute specified. If there are several, the first element with the attribute set inserted, usually the first such element on the page, gets the initial focus.
+Only one element inside a document, or part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, may have this attribute specified. If applied to multiple elements the first focusable one will receive focus.
 
 > [!NOTE]
 > Setting this property doesn't set the focus to the associated element: it merely tells the browser to focus to it when _the element is inserted_ in the document. Setting it after the insertion, that is most of the time after the document load, has no visible effect.

--- a/files/en-us/web/api/htmlelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlelement/autofocus/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLElement.autofocus
 
 {{APIRef("HTML DOM")}}
 
-The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus) HTML global attribute, which indicates whether the element should be focused on page load, or when it is part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element that becomes shown.
+The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus) HTML global attribute. This indicates whether the element should be focused on page load or, if it is nested inside a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, when the `<dialog>` or popover is shown.
 
 Only one element inside a document, or part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, may have this attribute specified. If applied to multiple elements the first focusable one will receive focus.
 

--- a/files/en-us/web/api/htmlelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlelement/autofocus/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLElement.autofocus
 
 {{APIRef("HTML DOM")}}
 
-The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Elements/select#autofocus) HTML global attribute, which indicates whether the element should be focused on page load, or when it is part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element that becomes shown.
+The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus) HTML global attribute, which indicates whether the element should be focused on page load, or when it is part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element that becomes shown.
 
 Only one element inside a document, or part of a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, may have this attribute specified. If applied to multiple elements the first focusable one will receive focus.
 

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -19,7 +19,8 @@ Only one element inside a document, `<dialog>` element, or popover may have this
 > The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) area.
 
 > [!NOTE]
-> On page load, when a [URI fragment](/en-US/docs/Web/URI/Reference/Fragment) points to a focusable element, that element usually receives focus instead of the one indicated by the `autofocus` attribute.
+> On page load, if a [URI fragment identifier](/en-US/docs/Web/URI/Reference/Fragment#fragment) is specified and identifies an element, 
+> the element with the `autofocus` attribute does not receive focus via the `autofocus` attribute.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -13,7 +13,7 @@ The **`autofocus`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_att
 <input name="q" autofocus />
 ```
 
-Only one element in the document, or part of a dialog or popover element, may have this attribute specified. If applied to multiple elements the first focusable one will receive focus.
+Only one element inside a document, `<dialog>` element, or popover may have this attribute specified. If applied to multiple elements, the first focusable one will receive focus.
 
 > [!NOTE]
 > The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) area.

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -7,13 +7,13 @@ browser-compat: html.global_attributes.autofocus
 sidebar: htmlsidebar
 ---
 
-The **`autofocus`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a Boolean attribute indicating that an element should be focused on page load, or when the {{HTMLElement("dialog")}} that it is part of is displayed.
+The **`autofocus`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a Boolean attribute indicating that an element should be focused on page load, or when the {{HTMLElement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element that it is part of is displayed.
 
 ```html
 <input name="q" autofocus />
 ```
 
-No more than one element in the document or dialog may have the autofocus attribute. If applied to multiple elements the first one will receive focus.
+Only one element in the document, or part of a dialog or popover element, may have this attribute specified. If applied to multiple elements the first focusable one will receive focus.
 
 > [!NOTE]
 > The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) area.

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -19,8 +19,7 @@ Only one element inside a document, `<dialog>` element, or popover may have this
 > The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) area.
 
 > [!NOTE]
-> On page load, if a [URI fragment identifier](/en-US/docs/Web/URI/Reference/Fragment#fragment) is specified and identifies an element,
-> the element with the `autofocus` attribute does not receive focus via the `autofocus` attribute.
+> On page load, if a [URI fragment identifier](/en-US/docs/Web/URI/Reference/Fragment) is specified and identifies an element, the element with the `autofocus` attribute does not receive focus via the `autofocus` attribute. Generally, the element indicated by the fragment receives focus instead.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -18,6 +18,9 @@ Only one element in the document, or part of a dialog or popover element, may ha
 > [!NOTE]
 > The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) area.
 
+> [!NOTE]
+> On page load, when a [URI fragment](/en-US/docs/Web/URI/Reference/Fragment) points to a focusable element, that element usually receives focus instead of the one indicated by the `autofocus` attribute.
+
 ## Accessibility concerns
 
 Automatically focusing a form control can confuse visually-impaired people using screen-reading technology and people with cognitive impairments. When `autofocus` is assigned, screen-readers "teleport" their user to the form control without warning them beforehand.

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -7,7 +7,7 @@ browser-compat: html.global_attributes.autofocus
 sidebar: htmlsidebar
 ---
 
-The **`autofocus`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a Boolean attribute indicating that an element should be focused on page load, or when the {{HTMLElement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element that it is part of is displayed.
+The **`autofocus`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a Boolean attribute indicating whether the element should be focused on page load or, if it is nested inside a {{htmlelement("dialog")}} or [`popover`](/en-US/docs/Web/HTML/Reference/Global_attributes/popover) element, when the `<dialog>` or popover is shown.
 
 ```html
 <input name="q" autofocus />

--- a/files/en-us/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/reference/global_attributes/autofocus/index.md
@@ -19,7 +19,7 @@ Only one element inside a document, `<dialog>` element, or popover may have this
 > The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) area.
 
 > [!NOTE]
-> On page load, if a [URI fragment identifier](/en-US/docs/Web/URI/Reference/Fragment#fragment) is specified and identifies an element, 
+> On page load, if a [URI fragment identifier](/en-US/docs/Web/URI/Reference/Fragment#fragment) is specified and identifies an element,
 > the element with the `autofocus` attribute does not receive focus via the `autofocus` attribute.
 
 ## Accessibility concerns


### PR DESCRIPTION
### Description

- Added case where a popover is displayed.
- Added a note about URI fragment identifier, disabling autofocus for page load.
- Fix attribute link.