### PR TITLE
Fix incorrect wording of min-height behavior

### DIFF
--- a/files/en-us/web/css/reference/properties/flex-basis/index.md
+++ b/files/en-us/web/css/reference/properties/flex-basis/index.md
@@ -217,22 +217,20 @@ We include two same-structure flex containers, which will be styled similarly ex
 <div class="container basis-0">
   <div>heading</div>
   <section>
-    flex-basis: 0;
-    <div class="content"></div>
+    <div class="content">flex-basis: 0;</div>
   </section>
 </div>
 <div class="container basis-0-percent">
   <div>heading</div>
   <section>
-    flex-basis: 0%;
-    <div class="content"></div>
+    <div class="content">flex-basis: 0%;</div>
   </section>
 </div>
 ```
 
 #### CSS
 
-We style the containers as inline flex containers that will appear side by side to better enable comparing them. We set the `flex-direction` to `column`. The first container's flex items have a `flex-basis` value of `0`, while the second container's flex items have a `flex-basis` value of `0%`. Neither the flex containers nor their flex items have a height explicitly set, but the heights of `section` elements cannot be lower than `200px` and their children have a height of `300px`.
+We style the containers as inline flex containers that will appear side by side to better enable comparing them. We set the `flex-direction` to `column`. The first container's flex items have a `flex-basis` value of `0`, while the second container's flex items have a `flex-basis` value of `0%`. Neither the flex containers nor their flex items have a height explicitly set; however, the heights of `section` elements must be at least `200px`, and their children have a height of `300px`.
 
 ```css
 .container {
@@ -245,7 +243,7 @@ We style the containers as inline flex containers that will appear side by side 
 }
 
 section {
-  border: 1px solid red;
+  outline: 1px solid red;
 
   overflow: auto;
   min-height: 200px;
@@ -268,7 +266,7 @@ section {
 
 {{EmbedLiveSample('flex_basis_0_vs_0', '100%', '400')}}
 
-In the first container, with `flex-basis: 0`, the `<section>` element has an initial main size of zero, and it grows to the `200px` height limit. In the second container, with `flex-basis: 0%`, the `<section>` element has an initial main size of `300px` because, as the flex container doesn't have a set height, the percentage flex-basis values resolve to the [`content`](#content) value.
+In the first container, with `flex-basis: 0`, the `<section>` element has an initial main size of zero, and it grows to the `200px` minimum height. In the second container, with `flex-basis: 0%`, the `<section>` element has an initial main size of `300px` because, as the flex container doesn't have a set height, the percentage flex-basis values resolve to the [`content`](#content) value.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes an incorrect sentence in the `flex-basis` documentation example.
The example uses `min-height: 200px`, but the text incorrectly stated that the height cannot exceed 200px.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

This change aligns the description with the actual CSS behavior, reducing confusion for readers learning flexbox.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Fixes #42775

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
