### PR TITLE
Fix syntax of example in Permissions-Policy: compute-pressure

### DIFF
--- a/files/en-us/web/http/reference/headers/permissions-policy/compute-pressure/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/compute-pressure/index.md
@@ -41,7 +41,7 @@ Third-party usage can be selectively enabled using the `allow` attribute on {{HT
 This HTTP response header disables compute pressure completely:
 
 ```http
-Permissions-Policy: {"compute-pressure": []}
+Permissions-Policy: compute-pressure=()
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

Simple syntax correction.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy#sect_2

### Related issues and pull requests

Originally part of #42534, being separated out to avoid undue delay in merging this change.