### PR TITLE
Fix flex-basis example and IDBFactory.deleteDatabase documentation issues

### DIFF
--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -98,6 +98,7 @@ request.onsuccess = () => {
   console.log("Database deleted successfully.");
 };
 ```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -86,7 +86,7 @@ const request = indexedDB.deleteDatabase("toDoList");
 
 request.onblocked = () => {
   console.warn(
-    "Database deletion is blocked. Close all open connections to proceed."
+    "Database deletion is blocked. Close all open connections to proceed.",
   );
 };
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -22,6 +22,17 @@ method.
 When `deleteDatabase()` is called, any other open connections to this
 particular database will get a [versionchange](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event.
 
+If there are open connections to the database when `deleteDatabase()` is called, the
+deletion request may become blocked. In this case, the returned
+{{DOMxRef("IDBOpenDBRequest")}} will fire a
+[`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event until all existing
+connections to the database are closed.
+
+During this blocked state, existing {{DOMxRef("IDBDatabase")}} connections continue to
+operate normally, but no new operations that open or delete the same database will succeed until the deletion completes.
+
+
+
 ## Syntax
 
 ```js-nolint
@@ -48,9 +59,11 @@ deleteDatabase(name, options)
 
 ### Return value
 
-An {{DOMxRef("IDBOpenDBRequest")}} on which subsequent events related to this request are fired.
+An {{DOMxRef("IDBOpenDBRequest")}} on which `success`, `error`, and `blocked` events related
+to this request are fired.
 
-If the operation is successful, the value of the request's {{domxref("IDBRequest.result", "result")}} property is `null`.
+If the operation is successful, the value of the request's {{domxref("IDBRequest.result", "result")}} property is `undefined`.
+
 
 ## Examples
 
@@ -68,6 +81,28 @@ DBDeleteRequest.onsuccess = (event) => {
 };
 ```
 
+The following example shows how to handle the case where database deletion is blocked
+due to existing open connections.
+
+
+```js
+const request = indexedDB.deleteDatabase("toDoList");
+
+request.onblocked = () => {
+  console.warn(
+    "Database deletion is blocked. Close all open connections to proceed."
+  );
+};
+
+request.onerror = () => {
+  console.error("Error deleting database.");
+};
+
+request.onsuccess = () => {
+  console.log("Database deleted successfully.");
+};
+
+```
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -81,7 +81,6 @@ DBDeleteRequest.onsuccess = (event) => {
 The following example shows how to handle the case where database deletion is blocked
 due to existing open connections.
 
-
 ```js
 const request = indexedDB.deleteDatabase("toDoList");
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -62,7 +62,6 @@ to this request are fired.
 
 If the operation is successful, the value of the request's {{domxref("IDBRequest.result", "result")}} property is `undefined`.
 
-
 ## Examples
 
 ```js

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -97,7 +97,6 @@ request.onerror = () => {
 request.onsuccess = () => {
   console.log("Database deleted successfully.");
 };
-
 ```
 ## Specifications
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -31,8 +31,6 @@ connections to the database are closed.
 During this blocked state, existing {{DOMxRef("IDBDatabase")}} connections continue to
 operate normally, but no new operations that open or delete the same database will succeed until the deletion completes.
 
-
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/css/reference/properties/flex-basis/index.md
+++ b/files/en-us/web/css/reference/properties/flex-basis/index.md
@@ -217,22 +217,22 @@ We include two same-structure flex containers, which will be styled similarly ex
 <div class="container basis-0">
   <div>heading</div>
   <section>
-    flex-basis: 0;
-    <div class="content"></div>
-  </section>
+  <div class="content">flex-basis: 0;</div>
+</section>
+
 </div>
 <div class="container basis-0-percent">
   <div>heading</div>
   <section>
-    flex-basis: 0%;
-    <div class="content"></div>
-  </section>
+  <div class="content">flex-basis: 0%;</div>
+</section>
+
 </div>
 ```
 
 #### CSS
 
-We style the containers as inline flex containers that will appear side by side to better enable comparing them. We set the `flex-direction` to `column`. The first container's flex items have a `flex-basis` value of `0`, while the second container's flex items have a `flex-basis` value of `0%`. Neither the flex containers nor their flex items have a height explicitly set, but the heights of `section` elements cannot exceed `200px` and their children have a height of `300px`.
+We style the containers as inline flex containers that will appear side by side to better enable comparing them. We set the flex-direction to column. The first container's flex items have a flex-basis value of 0, while the second container's flex items have a flex-basis value of 0%. Neither the flex containers nor their flex items have a height explicitly set, but the heights of section elements cannot be lower than 200px, and their children have a height of 300px.
 
 ```css
 .container {
@@ -245,11 +245,12 @@ We style the containers as inline flex containers that will appear side by side 
 }
 
 section {
-  border: 1px solid red;
-
+  outline: 1px solid red;
+  
   overflow: auto;
   min-height: 200px;
 }
+
 
 .content {
   background: wheat;
@@ -268,7 +269,7 @@ section {
 
 {{EmbedLiveSample('flex_basis_0_vs_0', '100%', '400')}}
 
-In the first container, with `flex-basis: 0`, the `<section>` element has an initial main size of zero, and it grows to the `200px` height limit. In the second container, with `flex-basis: 0%`, the `<section>` element has an initial main size of `300px` because, as the flex container doesn't have a set height, the percentage flex-basis values resolve to the [`content`](#content) value.
+In the first container, with `flex-basis: 0`, the `<section>` element has an initial main size of zero, and it grows to the 200px minimum height. In the second container, with `flex-basis: 0%`, the `<section>` element has an initial main size of `300px` because, as the flex container doesn't have a set height, the percentage flex-basis values resolve to the [`content`](#content) value.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/flex-basis/index.md
+++ b/files/en-us/web/css/reference/properties/flex-basis/index.md
@@ -217,9 +217,8 @@ We include two same-structure flex containers, which will be styled similarly ex
 <div class="container basis-0">
   <div>heading</div>
   <section>
-  <div class="content">flex-basis: 0;</div>
-</section>
-
+    <div class="content">flex-basis: 0;</div>
+  </section>
 </div>
 <div class="container basis-0-percent">
   <div>heading</div>

--- a/files/en-us/web/css/reference/properties/flex-basis/index.md
+++ b/files/en-us/web/css/reference/properties/flex-basis/index.md
@@ -251,7 +251,6 @@ section {
   min-height: 200px;
 }
 
-
 .content {
   background: wheat;
   height: 300px;


### PR DESCRIPTION
This PR addresses two separate documentation improvements on MDN Web Docs:

1. **Flex-basis `0` vs `0%` example (#42775)**

   - Corrects the wording in the example to reflect that `<section>` elements grow to the `min-height` of 200px, not a height limit.
   - Updates the demo markup so that text content is contained within `.content` elements, ensuring alignment between explanation and actual layout.
   - Replaces `border` with `outline` on `<section>` elements so that visual styling does not interfere with layout sizing.

2. **IDBFactory.deleteDatabase() blocked state (#42779)**

   - Adds an explanation that `deleteDatabase()` may become blocked if there are existing open connections to the database.
   - Clarifies that during this blocked state, existing `IDBDatabase` connections continue to operate normally, but no new operations on the same database will succeed until deletion completes.
   - Updates the Return value section to explicitly mention `blocked` events along with `success` and `error`.
   - Adds a practical example showing how to handle the `onblocked` event.
   - Corrects the `result` value on success to `undefined`, aligning with specification and browser behavior.

These changes ensure the documentation for both CSS Flexbox and IndexedDB is accurate, clear, and reflective of real-world usage and browser behavior.

**Related issues:**
- #42775
- #42779
