### PR TITLE
position-anchor slider demo: adjust position and add support note

### DIFF
--- a/files/en-us/web/css/reference/properties/position-anchor/index.md
+++ b/files/en-us/web/css/reference/properties/position-anchor/index.md
@@ -237,7 +237,7 @@ We include an [`<input type="range">`](/en-US/docs/Web/HTML/Reference/Elements/i
 
 #### CSS
 
-We give the thumb, represented by the {{cssxref("::-webkit-slider-thumb")}} pseudo-element, an anchor name of `--thumb`. We then set that name as the value of the `<output>` element's `position-anchor` property, and give it a {{cssxref("position")}} value of `fixed`. These steps associated the `<output>` with the thumb.
+We give the thumb, represented by the {{cssxref("::-webkit-slider-thumb")}} and {{cssxref("::-moz-range-thumb")}} pseudo-elements, an anchor name of `--thumb`. We then set that name as the value of the `<output>` element's `position-anchor` property, and give it a {{cssxref("position")}} value of `fixed`. These steps associated the `<output>` with the thumb.
 
 Finally, we use {{cssxref("left")}} and {{cssxref("top")}} properties with {{cssxref("anchor()")}} values to position the `<output>` relative to the thumb.
 
@@ -263,6 +263,10 @@ output {
 
 ```css
 input::-webkit-slider-thumb {
+  anchor-name: --thumb;
+}
+
+input::-moz-range-thumb {
   anchor-name: --thumb;
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As per https://github.com/mdn/content/issues/42767, The thumb-slider anchor positioning demo on the `position-anchor` reference page doesn't work properly. This is because the -webkit-prefixed thumb pseudo-element doesn't work in Firefox. We could add in the -moz-prefixed version, but that still doesn't fix it because it is currently not anchorable (see https://bugzilla.mozilla.org/show_bug.cgi?id=1993699).

As a temporary fix, I have elected to move that demo to the end of the demos list, so it isn't quite so prominent, and add a note to explain the current support issue. I don't think we can really add this into BCD comfortably without lots of hassle, and hopefully we can just remove the note and update the demo once the bug is fixed.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/42767

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
