### PR TITLE
Add documentation for button `value` attribute with command

### DIFF
--- a/files/en-us/web/html/reference/elements/button/index.md
+++ b/files/en-us/web/html/reference/elements/button/index.md
@@ -64,7 +64,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
       - : The button will close a {{htmlelement("dialog")}} element.
         If the dialog is already closed, no action will be taken.
         This is a declarative equivalent of calling the {{domxref("HTMLDialogElement.close()")}} method on the `<dialog>` element.
-        When used with the `value` attribute, the button's value will be passed as the dialog's `returnValue` property.
+        When used with the `value` attribute, the button's value will be passed as the dialog's {{domxref("HTMLDialogElement.returnValue", "returnValue")}} property.
     - `"request-close"`
       - : The button will trigger a {{domxref("HTMLDialogElement.cancel_event", "cancel")}} event on a {{htmlelement("dialog")}} element to request that the browser dismiss it, followed by a {{domxref("HTMLDialogElement.close_event", "close")}} event.
         This differs from the `close` command in that authors can call {{domxref("Event.preventDefault()")}} on the `cancel` event to prevent the `<dialog>` from closing.
@@ -147,8 +147,8 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
 
 - `value`
   - : Defines the value associated with the button's `name` when it's submitted with the form data.
-     This value is passed to the server in params when the form is submitted using this button.
-     When used with the `close` or `request-close` commands, the `value` attribute sets the {{domxref("HTMLDialogElement.returnValue", "returnValue")}} of the {{htmlelement("dialog")}} element being controlled.
+    This value is passed to the server in params when the form is submitted using this button.
+    When used with the `close` or `request-close` commands, the `value` attribute sets the {{domxref("HTMLDialogElement.returnValue", "returnValue")}} of the {{htmlelement("dialog")}} element being controlled.
 
 ## Notes
 
@@ -317,7 +317,17 @@ When the event is `cancelable`, the value of the radio buttons is checked:
 
 ### Using the `value` attribute with dialog `close` command
 
-This example demonstrates how to use the `value` attribute with `close` command to determine which button was used to close a dialog.
+This example demonstrates how to use the button `value` attribute with `close` command to populate the value of a dialog's {{domxref("HTMLDialogElement.returnValue", "returnValue")}} property.
+
+When either the **Cancel** or **Delete** button is clicked, the dialog closes and sets its `returnValue` to the button's `value` attribute.
+The `close` event listener checks `dialog.returnValue` to determine which action the user chose and logs the result to the screen.
+
+#### HTML
+
+The HTML first defines a **Delete Record** button that uses the `commandfor` attribute to specify the dialog to be opened.
+
+Within the dialog **Cancel** and **Delete** buttons use the `commandfor` attribute to indicate that they apply to the current dialog.
+They also set the `command` attribute to "close" and set the `value` attribute to "cancel" and "delete" respectively — the value of the selected button is automatically copied to the dialog `returnValue` when the button is clicked.
 
 ```html
 <button commandfor="confirm-dialog" command="show-modal">Delete Record</button>
@@ -337,26 +347,47 @@ This example demonstrates how to use the `value` attribute with `close` command 
 </dialog>
 ```
 
+```html
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 20px;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = text;
+}
+```
+
+#### JavaScript
+
+The code uses a `close` event listener to log the dialog's `returnValue`.
+
 ```js
 const dialog = document.getElementById("confirm-dialog");
 
 dialog.addEventListener("close", () => {
   switch (dialog.returnValue) {
     case "cancel":
-      console.log("cancel was clicked");
+      log("Cancel was clicked");
       break;
     case "delete":
-      console.log("delete was clicked");
+      log("Delete was clicked");
       break;
     default:
-      console.log("Closed with value:", dialog.returnValue);
+      log("Closed with value:", dialog.returnValue);
   }
 });
 ```
 
-{{ EmbedLiveSample('using_the_value_attribute_with_dialog_close_command', 100, 200) }}
+#### Results
 
-In this example, when either the **Cancel** or **Delete** button is clicked, the dialog closes and sets its `returnValue` to the button's `value` attribute. The `close` event listener can then check `dialog.returnValue` to determine which action the user chose.
+{{ EmbedLiveSample('using_the_value_attribute_with_dialog_close_command', 100, 200) }}
 
 ## Technical summary
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
This PR adds missing documentation for the `value` attribute when used with `close` and `request-close` commands on `<button>` elements.

Changes:
- Updated `command` attribute documentation to mention `value` attribute behavior for `close` and `request-close` commands
- Enhanced `value` attribute description to explain its use with command invokers
- Added new example demonstrating `value` attribute usage with dialog close commands

The documentation now clearly explains how the `value` attribute sets the dialog's `returnValue`, allowing developers to determine which button closed the dialog.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
- https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element:~:text=The%20command%20steps%20for,element%20and%20source
- https://developer.chrome.com/blog/command-and-commandfor#comparing_command_and_commandfor_with_popovertargetaction_and_popovertarget

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #42808
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
