### PR TITLE
Remove a condition which does not really occur.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/weakmap/getorinsert/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/getorinsert/index.md
@@ -37,7 +37,7 @@ getOrInsert(key, defaultValue)
 
 ### Return value
 
-The value associated with the specified key in the `WeakMap` object.
+The value associated with the specified key in the `WeakMap` object. If the key can't be found, `defaultValue` is inserted and returned.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Remove a condition which does not really occur.

> If the key can't be found, `undefined` is returned.

### Motivation

If the given key is not found within the `WeakMap`, this method inserts a new entry with that key. Therefore, unless an exception occurs, the key will always be found when the value is returned.
Of course, if the value of the entry for the given key is `undefined`, this method may return `undefined`, but this is unrelated to the condition described above.

### Additional details

https://tc39.es/proposal-upsert/#sec-weakmap.prototype.getOrInsert

The spec doesn't define that the method returns `undefined` when the given key isn't found.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
