### PR TITLE
getOrInsertComputed: add exceptions

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/getorinsertcomputed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/getorinsertcomputed/index.md
@@ -43,6 +43,11 @@ getOrInsertComputed(key, callback)
 
 The value associated with the specified key in the `Map` object. If the key can't be found, the result of `callback(key)` is inserted and returned.
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if `callback` isn't callable.
+
 ## Examples
 
 ### Avoiding unnecessary default computation

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/getorinsertcomputed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/getorinsertcomputed/index.md
@@ -48,7 +48,9 @@ The value associated with the specified key in the `WeakMap` object. If the key 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if `key` is not an object or a [non-registered symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#shared_symbols_in_the_global_symbol_registry), or if the `callback` isn't callable.
+  - : Thrown in one of the following cases:
+    - `key` is not an object or a [non-registered symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#shared_symbols_in_the_global_symbol_registry).
+    - `callback` isn't callable.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Add a section of "Exceptions" and write about an exception the method can throw.

### Motivation

According the spec (see "Additional detail"), this method can throw `TypeError` in two conditions.
- given key isn't an object nor a non-registered symbol.
- given callback isn't callable.

### Additional details

https://tc39.es/proposal-upsert/#sec-weakmap.prototype.getOrInsertComputed

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
