### PR TITLE
Add PUT request example for 204 No Content status

### DIFF
--- a/files/en-us/web/http/reference/status/204/index.md
+++ b/files/en-us/web/http/reference/status/204/index.md
@@ -65,6 +65,7 @@ Authorization: Bearer 1234abcd
 
 After successfully updating the user profile, the server responds with a `204` response.
 The {{HTTPHeader("ETag")}} header contains the entity tag for the updated resource:
+
 ```http
 HTTP/1.1 204 No Content
 Date: Wed, 26 Jun 2024 12:00:00 GMT

--- a/files/en-us/web/http/reference/status/204/index.md
+++ b/files/en-us/web/http/reference/status/204/index.md
@@ -50,6 +50,7 @@ Server: Apache/2.4.1 (Unix)
 
 In this example, the client sends a `PUT` request to update a user's profile information.
 The request includes an {{HTTPHeader("Authorization")}} header with a token to authenticate the request:
+
 ```http
 PUT /users/123 HTTP/1.1
 Host: example.com

--- a/files/en-us/web/http/reference/status/204/index.md
+++ b/files/en-us/web/http/reference/status/204/index.md
@@ -46,6 +46,31 @@ Date: Wed, 26 Jun 2024 12:00:00 GMT
 Server: Apache/2.4.1 (Unix)
 ```
 
+### Receiving a response after updating with PUT
+
+In this example, the client sends a `PUT` request to update a user's profile information.
+The request includes an {{HTTPHeader("Authorization")}} header with a token to authenticate the request:
+```http
+PUT /users/123 HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Authorization: Bearer 1234abcd
+
+{
+  "name": "Jane Doe",
+  "email": "jane@example.com"
+}
+```
+
+After successfully updating the user profile, the server responds with a `204` response.
+The {{HTTPHeader("ETag")}} header contains the entity tag for the updated resource:
+```http
+HTTP/1.1 204 No Content
+Date: Wed, 26 Jun 2024 12:00:00 GMT
+ETag: "33a64df551425fcc55e4d42a148795d9f25f89d4"
+Server: Apache/2.4.1 (Unix)
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
Added a PUT request example to complement the existing DELETE example. This demonstrates how 204 responses work with PUT requests and shows the ETag header usage as mentioned in the documentation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
