### PR TITLE
Enhance cookie documentation with Domain and Path notes

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -49,7 +49,6 @@ You can also assign to this property a string of the form `"key=value"`, specify
 
   > [!NOTE]
   > If the `Path` attribute is omitted, the browser assigns a default path derived from the request URL.
-
   - `;samesite`: The `SameSite` attribute of a {{httpheader("Set-Cookie")}} header can be set by a server to specify when the cookie will be sent. Possible values are `lax`, `strict` or `none` (see also [Controlling third-party cookies with `SameSite`](/en-US/docs/Web/HTTP/Guides/Cookies#controlling_third-party_cookies_with_samesite)).
     - The `lax` value will send the cookie for all same-site requests and top-level navigation GET requests.
       This is sufficient for user tracking, but it will prevent many [Cross-Site Request Forgery](/en-US/docs/Glossary/CSRF) (CSRF) attacks.


### PR DESCRIPTION
Added notes about Domain and Path attributes for cookies.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
When writing cookies with `document.cookies` if you don't specify a Domain or Path attribute, it's set for you by the browser. This PR adds that information to the docs.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
They inform readers that a Domain and Path attribute is set on the cookie even if they don't specify it.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
