### PR TITLE
small wording change to clarify `commandfor`

### DIFF
--- a/files/en-us/web/api/invoker_commands_api/index.md
+++ b/files/en-us/web/api/invoker_commands_api/index.md
@@ -21,7 +21,7 @@ Historically creating these kinds of controls has required JavaScript event list
 ## HTML attributes
 
 - [`commandfor`](/en-US/docs/Web/HTML/Reference/Elements/button#commandfor)
-  - : Turns a {{htmlelement("button")}} element into a button, controlling the given interactive element; takes the ID of the element to control as its value.
+  - : Turns a {{htmlelement("button")}} element into a command invoker, controlling the given interactive element; takes the ID of the element to control as its value.
 - [`command`](/en-US/docs/Web/HTML/Reference/Elements/button#command)
   - : Specifies the action to be performed on an element being controlled by a control `<button>`, specified via the `commandfor` attribute.
 


### PR DESCRIPTION
### Description

Changed the description of the `commandfor` attribute to use the words "command invoker".

### Motivation

"Turns a `<button>` element into a button" reads weird, it's already a button.

### Additional details

N/A

### Related issues and pull requests

N/A