### PR TITLE
Server timing duration - mention unit

### DIFF
--- a/files/en-us/web/api/performanceservertiming/duration/index.md
+++ b/files/en-us/web/api/performanceservertiming/duration/index.md
@@ -8,7 +8,7 @@ browser-compat: api.PerformanceServerTiming.duration
 
 {{APIRef("Performance API")}}{{AvailableInWorkers}}
 
-The **`duration`** read-only property returns a double that contains the server-specified metric duration, or the value `0.0`.
+The **`duration`** read-only property returns a double that contains the server-specified metric duration (usually in milliseconds), or the value `0.0`.
 
 ## Value
 


### PR DESCRIPTION
Based on [note in W3C spec](https://w3c.github.io/server-timing/#duration-attribute):
> Since duration is a DOMHighResTimeStamp, it usually represents a duration in milliseconds. Since this is not enforcable in practice, duration can represent any unit of time, and having it represent a duration in milliseconds is a recommendation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Currently there is no note about the unit of duration, it is helpful to the reader to have a note about thi. 

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Spec: https://w3c.github.io/server-timing/#duration-attribute

