### PR TITLE
Add Firefox 148 rel note for Location.ancestorOrigins support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -52,7 +52,7 @@ Firefox 148 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
-- The {{domxref("Location.ancestorOrigins")}} property is now supported, which enables a document to determine whether it is being embedded in an {{htmlelement("iframe")}} and, if so, by which site(s).
+- The {{domxref("Location.ancestorOrigins")}} property is now supported, which enables you to determine whether a document is being embedded in an {{htmlelement("iframe")}} and, if so, by which site(s).
   ([Firefox bug 1085214](https://bugzil.la/1085214)).
 
 <!-- #### DOM -->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 148 adds support for the [`Location.ancestorOrigins`](https://developer.mozilla.org/en-US/docs/Web/API/Location/ancestorOrigins) property; see https://bugzilla.mozilla.org/show_bug.cgi?id=1085214.

The feature is already documented; this PR adds an appropriate note to the Firefox 148 rel notes.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
