### PR TITLE
fix(jsondata/SVGData): remove discard

### DIFF
--- a/files/jsondata/SVGData.json
+++ b/files/jsondata/SVGData.json
@@ -203,21 +203,6 @@
       "attributes": ["coreAttributes", "'class'", "'style'"],
       "interfaces": ["SVGDescElement"]
     },
-    "discard": {
-      "categories": ["animationElement"],
-      "content": {
-        "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["descriptiveElements"]
-      },
-      "attributes": [
-        "conditionalProcessingAttributes",
-        "coreAttributes",
-        "ariaAttributes",
-        "'begin'",
-        "'href'"
-      ],
-      "interfaces": ["SVGDiscardElement"]
-    },
     "ellipse": {
       "categories": ["basicShapeElement", "graphicsElement", "shapeElement"],
       "content": {
@@ -244,7 +229,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -262,7 +247,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -301,7 +286,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -323,7 +308,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -370,7 +355,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -390,7 +375,7 @@
       "categories": ["lightSourceElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "'azimuth'", "'elevation'"],
       "interfaces": ["SVGFEDistantLightElement"]
@@ -399,12 +384,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": [
-          "&lt;animate&gt;",
-          "&lt;discard&gt;",
-          "&lt;script&gt;",
-          "&lt;set&gt;"
-        ]
+        "elements": ["&lt;animate&gt;", "&lt;script&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -423,7 +403,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -440,7 +420,7 @@
       "categories": ["noCategory"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "transferFunctionAttributes"],
       "interfaces": ["SVGFEFuncAElement"]
@@ -449,7 +429,7 @@
       "categories": ["noCategory"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "transferFunctionAttributes"],
       "interfaces": ["SVGFEFuncBElement"]
@@ -458,7 +438,7 @@
       "categories": ["noCategory"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "transferFunctionAttributes"],
       "interfaces": ["SVGFEFuncGElement"]
@@ -467,7 +447,7 @@
       "categories": ["noCategory"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "transferFunctionAttributes"],
       "interfaces": ["SVGFEFuncRElement"]
@@ -476,7 +456,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -496,7 +476,7 @@
         "elements": [
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
-          "&lt;discard&gt;",
+
           "&lt;set&gt;"
         ]
       },
@@ -532,7 +512,7 @@
       "categories": ["noCategory"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "'in'"],
       "interfaces": ["SVGFEMergeNodeElement"]
@@ -541,7 +521,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -559,7 +539,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -577,7 +557,7 @@
       "categories": ["lightSourceElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": ["coreAttributes", "'x'", "'y'", "'z'"],
       "interfaces": ["SVGFEPointLightElement"]
@@ -609,7 +589,7 @@
       "categories": ["lightSourceElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -628,7 +608,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -644,7 +624,7 @@
       "categories": ["filterPrimitiveElement"],
       "content": {
         "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["&lt;animate&gt;", "&lt;discard&gt;", "&lt;set&gt;"]
+        "elements": ["&lt;animate&gt;", "&lt;set&gt;"]
       },
       "attributes": [
         "coreAttributes",
@@ -668,7 +648,7 @@
           "descriptiveElements",
           "filterPrimitiveElements",
           "&lt;animate&gt;",
-          "&lt;discard&gt;",
+
           "&lt;set&gt;"
         ]
       },
@@ -757,7 +737,7 @@
           "&lt;animate&gt;",
           "&lt;animateMotion&gt;",
           "&lt;animateTransform&gt;",
-          "&lt;discard&gt;",
+
           "&lt;script&gt;",
           "&lt;set&gt;",
           "&lt;style&gt;"
@@ -809,7 +789,7 @@
           "descriptiveElements",
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
-          "&lt;discard&gt;",
+
           "&lt;script&gt;",
           "&lt;set&gt;",
           "&lt;stop&gt;",
@@ -1044,7 +1024,7 @@
           "descriptiveElements",
           "&lt;animate&gt;",
           "&lt;animateTransform&gt;",
-          "&lt;discard&gt;",
+
           "&lt;script&gt;",
           "&lt;set&gt;",
           "&lt;stop&gt;",
@@ -1130,7 +1110,7 @@
         "description": "anyNumberOfElementsAnyOrder",
         "elements": [
           "&lt;animate&gt;",
-          "&lt;discard&gt;",
+
           "&lt;script&gt;",
           "&lt;set&gt;",
           "&lt;style&gt;"
@@ -1305,7 +1285,7 @@
           "descriptiveElements",
           "&lt;a&gt;",
           "&lt;animate&gt;",
-          "&lt;discard&gt;",
+
           "&lt;set&gt;",
           "&lt;tspan&gt;"
         ]
@@ -1342,7 +1322,7 @@
           "descriptiveElements",
           "&lt;a&gt;",
           "&lt;animate&gt;",
-          "&lt;discard&gt;",
+
           "&lt;set&gt;",
           "&lt;tspan&gt;"
         ]


### PR DESCRIPTION
### Description

Removes the SVG `<discard>` element from `SVGData.json`.

### Motivation

This was causing issues/flaws, because the discard element page got removed, and now redirects to the SVG Element overview.

(This also means `<discard>` in https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/linearGradient#usage_context points to the overview.)

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Noticed in https://github.com/mdn/content/pull/42834.

Related to https://github.com/mdn/content/issues/39618.