### PR TITLE
Update CSSxRef macros for `fit-content()`

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -95,7 +95,7 @@ The {{cssxref("initial-letter")}} CSS property is part of the [CSS Inline Layout
 
 ### fit-content() function
 
-The {{cssxref("fit-content_function", "fit-content()")}} function as it applies to {{cssxref("width")}} and other sizing properties. This function is already well-supported for CSS Grid Layout track sizing. (See [Firefox bug 1312588](https://bugzil.la/1312588) for more details.)
+The {{cssxref("fit-content()")}} function as it applies to {{cssxref("width")}} and other sizing properties. This function is already well-supported for CSS Grid Layout track sizing. (See [Firefox bug 1312588](https://bugzil.la/1312588) for more details.)
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |

--- a/files/en-us/web/css/guides/grid_layout/index.md
+++ b/files/en-us/web/css/guides/grid_layout/index.md
@@ -101,7 +101,7 @@ This sample animation uses {{cssxref("display")}}, {{cssxref("grid-template-colu
 
 - {{cssxref("repeat()")}}
 - {{cssxref("minmax()")}}
-- {{cssxref("fit-content_function", "fit-content()")}}
+- {{cssxref("fit-content()")}}
 
 ### Data types and values
 
@@ -197,7 +197,7 @@ This sample animation uses {{cssxref("display")}}, {{cssxref("grid-template-colu
 - {{cssxref("min-content")}} value
 - {{cssxref("max-content")}} value
 - {{cssxref("fit-content")}} value
-- {{cssxref("fit-content_function", "fit-content()")}} function
+- {{cssxref("fit-content()")}} function
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/fit-content/index.md
+++ b/files/en-us/web/css/reference/values/fit-content/index.md
@@ -10,7 +10,7 @@ The `fit-content` sizing keyword represents an element size that adapts to its c
 The keyword ensures that the element is never smaller than its minimum intrinsic size ({{cssxref("min-content")}}) or larger than its maximum intrinsic size ({{cssxref("max-content")}}).
 
 > [!NOTE]
-> This keyword is different from the {{cssxref("fit-content_function", "fit-content()")}} function. The function is used for grid track sizing (for example in {{cssxref("grid-template-columns")}} and {{cssxref("grid-auto-rows")}}) and for laid-out box sizing for properties such as {{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, and {{cssxref("max-height")}}.
+> This keyword is different from the {{cssxref("fit-content()")}} function. The function is used for grid track sizing (for example in {{cssxref("grid-template-columns")}} and {{cssxref("grid-auto-rows")}}) and for laid-out box sizing for properties such as {{cssxref("width")}}, {{cssxref("height")}}, {{cssxref("min-width")}}, and {{cssxref("max-height")}}.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/functions/index.md
+++ b/files/en-us/web/css/reference/values/functions/index.md
@@ -305,7 +305,7 @@ The following functions are used as a value of properties to reference a value d
 
 The following functions are used to define a [CSS grid](/en-US/docs/Web/CSS/Guides/Grid_layout):
 
-- {{cssxref("fit-content_function", "fit-content()")}}
+- {{cssxref("fit-content()")}}
   - : Clamps a given size to an available size according to the formula `min(maximum size, max(minimum size, argument))`.
 - {{cssxref("minmax()")}}
   - : Defines a size range greater-than or equal-to _min_ and less-than or equal-to _max_.
@@ -401,7 +401,7 @@ The following functions return an integer value based on the DOM tree, rather th
 - {{cssxref("basic-shape/ellipse", "ellipse()")}}
 - {{cssxref("env")}}
 - {{cssxref("exp")}}
-- {{cssxref("fit-content_function", "fit-content()")}}
+- {{cssxref("fit-content()")}}
 - {{cssxref("filter-function/grayscale", "grayscale()")}}
 - {{cssxref("color_value/hsl", "hsl()")}}
 - {{cssxref("filter-function/hue-rotate", "hue-rotate()")}}

--- a/files/en-us/web/css/reference/values/repeat/index.md
+++ b/files/en-us/web/css/reference/values/repeat/index.md
@@ -144,7 +144,7 @@ There is a fourth form, `<name-repeat>`, which is used to add line names to subg
     - a {{cssxref("minmax()")}} function with:
       - `min` given as a {{cssxref("&lt;length-percentage&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
       - `max` given as a {{cssxref("&lt;length-percentage&gt;")}} value, a {{cssxref("&lt;flex&gt;")}} value, or one of the following keywords: [`min-content`](#min-content), [`max-content`](#max-content), or [`auto`](#auto)
-    - a {{cssxref("fit-content_function", "fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.
+    - a {{cssxref("fit-content()")}} function, passed a {{cssxref("&lt;length-percentage&gt;")}} value.
 - `auto`
   - : As a maximum, identical to `max-content`. As a minimum it represents the largest minimum size (as specified by {{cssxref("min-width")}}/{{cssxref("min-height")}}) of the grid items occupying the grid track.
 - `auto-fill`


### PR DESCRIPTION
### Description

Updates CSSxRef macro invocations for `fit-content()` to use the short form.

### Motivation

This was previously not working, but was meanwhile fixed in https://github.com/mdn/rari/pull/431, which landed in rari 0.2.9.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

See: https://github.com/mdn/rari/issues/475
