### PR TITLE
Add external resource for WebCodecs codec string support across browsers/devices

### DIFF
--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -107,3 +107,8 @@ decoder.configure(config);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("VideoDecoder.isConfigSupported()")}}
+- [Codec String Support Table](https://webcodecsfundamentals.org/datasets/codec-support-table/)

--- a/files/en-us/web/api/videodecoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/videodecoder/isconfigsupported_static/index.md
@@ -80,3 +80,8 @@ for (const config of configs) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("VideoDecoder.configure()")}}
+- [Codec String Support Table](https://webcodecsfundamentals.org/datasets/codec-support-table/)

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -106,3 +106,8 @@ encoder.configure(config);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("VideoEncoder.isConfigSupported()")}}
+- [Codec String Support Table](https://webcodecsfundamentals.org/datasets/codec-support-table/)

--- a/files/en-us/web/api/videoencoder/isconfigsupported_static/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported_static/index.md
@@ -83,3 +83,8 @@ for (const config of configs) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("VideoEncoder.configure()")}}
+- [Codec String Support Table](https://webcodecsfundamentals.org/datasets/codec-support-table/)


### PR DESCRIPTION
### Description

Adds links to WebCodecs [codec string support tables](https://webcodecsfundamentals.org/datasets/codec-support-table/) under `VideoEncoder.configure` and `VideoDecoder.configure` and the static equivalents (`VideoEncoder.isConfigSupported`,  `VideoDecoder.isConfigSupported`)

### Motivation

The `configure()` method for `VideoEncoder` and `VideoDecoder` requires specifying a valid codec string like `avc1.42001E` but there's no actual list of valid codec strings, let alone which strings are supported by which browsers.

I used the W3C guidelines to generate all possible codec variants, tested them on 200k+ devices and published a [dataset](https://webcodecsfundamentals.org/datasets/codec-support/). 

Support tables are too big to fit on an MDN page (1000+ codec strings, each with their own matrix).  As an example, see https://webcodecsfundamentals.org/codecs/avc1.4d1033.html, which is one out of 1000+ pages.  

Hence the "See also" links. 

Webcodecsfundamentals is also on [caniuse/webcodecs](https://caniuse.com/webcodecs) and the [Chrome Developer docs](https://developer.chrome.com/docs/web-platform/best-practices/webcodecs#learn_more)

Helps developers know what valid values for `VideoEncoder.configure()` and `VideoDecoder.configure()` are.

### Additional details

- Source dataset: https://webcodecsfundamentals.org/datasets/codec-support/
- Repo: https://github.com/sb2702/webcodecs-fundamentals

