### PR TITLE
Remove incorrect bubbling/cancelable info for IDBRequest error event

### DIFF
--- a/files/en-us/web/api/idbrequest/error_event/index.md
+++ b/files/en-us/web/api/idbrequest/error_event/index.md
@@ -10,8 +10,6 @@ browser-compat: api.IDBRequest.error_event
 
 The `error` handler is executed when an error caused a request to fail. In the `error` event handler, you can access the error of the request, as well as place more requests to the same transaction.
 
-This event is not cancelable and does not bubble.
-
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.


### PR DESCRIPTION
Fixes #42650

Removes an incorrect statement claiming the IDBRequest error event
does not bubble and is not cancelable.
