### PR TITLE
Add documentation for CSS font-width propertyAdd documentation for CSS font-width property

### DIFF
--- a/files/en-us/web/css/font-width/index.md
+++ b/files/en-us/web/css/font-width/index.md
@@ -1,0 +1,20 @@
+---
+title: font-width
+slug: Web/CSS/font-width
+page-type: css-property
+status:
+  - experimental
+browser-compat: css.properties.font-width
+---
+
+# `font-width`
+
+The **`font-width`** CSS property allows authors to specify a preferred width for glyphs in a font. It is primarily intended for variable fonts that support width axes, enabling text to appear condensed or expanded without changing the font family.
+
+## Syntax
+
+```css
+font-width: normal;
+font-width: condensed;
+font-width: expanded;
+font-width: 75%;


### PR DESCRIPTION

### Description

This pull request adds a new MDN reference page for the CSS `font-width` property, including syntax, values, examples, and specification links.

### Motivation

The `font-width` property was missing from MDN’s CSS reference. Adding this documentation helps developers understand how to control glyph width, especially when working with variable fonts that support width axes.

### Additional details

- The content follows the structure of other CSS property reference pages on MDN.
- The property is marked as experimental, consistent with the CSS Fonts Module Level 4 specification.

### Related issues and pull requests

Fixes https://github.com/openwebdocs/project/issues/234
