### PR TITLE
Update narrow style example for month representation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -113,7 +113,7 @@ Intl.DateTimeFormat(locales, options)
     - `"short"`
       - : E.g., `Mar`
     - `"narrow"`
-      - : E.g., `M`). Two months may have the same narrow style for some locales (e.g., `May`'s narrow style is also `M`).
+      - : E.g., `M`. Two months may have the same narrow style for some locales (e.g., both `March`'s and `May`'s narrow styles are `M` in the `en-US` locale).
 - `day`
   - : The representation of the day. Possible values are `"numeric"` and `"2-digit"`.
 - `dayPeriod`


### PR DESCRIPTION
### Description

Clarified the example for the narrow style of month representation in the en-US locale.

### Motivation

Originally, the text had an extraneous closing parenthesis and did not fully provide two examples where the narrow style of month representation was the same, which was slightly confusing.

### Additional details

_None_

### Related issues and pull requests
_None_
