### PR TITLE
Add Japanese translation for CSS sidebar

### DIFF
--- a/files/jsondata/L10n-CSS.json
+++ b/files/jsondata/L10n-CSS.json
@@ -16,7 +16,7 @@
     "en-US": "At-Rules",
     "es": "Reglas",
     "fr": "Règles @",
-    "ja": "アット規則",
+    "ja": "アットルール",
     "ko": "@규칙",
     "pt-BR": "Regras @",
     "ru": "@-правила",

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -464,24 +464,31 @@ l10n:
     Animations: アニメーション
     Backgrounds_and_Borders: 背景と境界
     Box alignment: ボックス配置
+    Box sizing: ボックスサイズ指定
     Box_model: ボックスモデル
     Cascade: カスケード
+    Cascading variables: カスケード変数
     Colors: 色
     Color_contrast: "アクセシビリティ: 色のコントラスト"
     Columns: 段組み
     Combinators: 結合子
     Conditional_rules: 条件付きルール
     Containment: コンテナー
+    Coordinate_systems: 座標系 (API)
     CSSOM_view: CSSOM view
+    Custom_functions_and_mixins: カスタム関数とミックスイン
     Display: 表示方法
+    Environment_variables: 環境変数
     Filter_effects: フィルター効果
     Flexbox: フレックスボックス
     Fonts: フォント
     Functions: 関数
     Grid: グリッド
     Images: 画像
+    Layout cookbook: レイアウト料理帳
     Lists_and_counters: リストとカウンター
     Logical_properties: 論理的プロパティ
+    Masking: マスク
     Media_queries: メディアクエリー
     Modules: モジュール
     Nesting: 入れ子のスタイルルール
@@ -490,7 +497,8 @@ l10n:
     Properties: プロパティ
     Pseudo-classes: 擬似クラス
     Pseudo-elements: 擬似要素
-    Scroll_anchoring: スクロールアンカリング
+    Scroll_anchoring: スクロール固定
+    Scroll-driven_animations: スクロール駆動アニメーション
     Scroll_snap: スクロールスナップ
     Selectors: セレクター
     Shapes: シェイプ
@@ -501,7 +509,9 @@ l10n:
     Transitions: トランジション
     Tools: ツール
     Types: データ型
+    Values: 値
     Values and units: 値と単位
+    Writing modes: 書字方向
   ko:
     Guides: 안내서
     Animations: 애니메이션


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Add Japanese translation for CSS sidebar.
And fix a translation word of "at-rule".

### Motivation

Some of items in CSS sidebar are not translated.
So, I want to add them.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
