### PR TITLE
chore(scripts/analyze-pr-build): expand flaws if ≤5 docs/flaws

### DIFF
--- a/scripts/analyze-pr-build.js
+++ b/scripts/analyze-pr-build.js
@@ -379,12 +379,16 @@ function postAboutFlaws(docs, config) {
       ? `Note! *${docsWithZeroFlaws} document${docsWithZeroFlaws === 1 ? "" : "s"} with no flaws that don't need to be listed. 🎉*\n\n`
       : "";
 
+    const reportIssueNote =
+      "*Found an unexpected or unresolvable flaw? [Please report it here](https://github.com/mdn/rari/issues/new?template=bug.yml).*\n\n";
+
     return (
       "\n" +
       formatSection({
         title: "Flaws",
         count: totalFlaws,
-        body: zeroFlawsNote + perDocComments.join("\n\n---\n\n"),
+        body:
+          zeroFlawsNote + reportIssueNote + perDocComments.join("\n\n---\n\n"),
         expanded: docs.length <= 5 || totalFlaws <= 5,
       })
     );


### PR DESCRIPTION
### Description

Updates the `analyze-pr-build` script (responsible for posting PR Review Companion comments in PRs) to expand the flaws section if there are not more than 5 docs or flaws.

Also:

- Add link to Rari issue tracker for reporting unexpected/unresolvable flaws.
- Read built docs only once (instead of three times).
- Reuse the `Doc` type from Rari.

### Motivation

Increase visibility of flaws, now that most false-positive flaws are fixed in rari.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
