### PR TITLE
Update narrow style example for weekdays

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -91,7 +91,7 @@ Intl.DateTimeFormat(locales, options)
     - `"short"`
       - : E.g., `Thu`
     - `"narrow"`
-      - : E.g., `T`. Two weekdays may have the same narrow style for some locales (e.g., both `Tuesday`'s and `Thursday`'s narrow style are `T` in the `en-US` locale).
+      - : E.g., `T`. Two weekdays may have the same narrow style for some locales (e.g., both `Tuesday`'s and `Thursday`'s narrow styles are `T` in the `en-US` locale).
 - `era`
   - : The representation of the era. Possible values are:
     - `"long"`


### PR DESCRIPTION
### Description

Clarified the example for the narrow style of weekdays.

### Motivation

The original text was unclear/confusing in its example.

### Additional details

_None_

### Related issues and pull requests

Relates to #42854, `Update narrow style example for month representation`
