### PR TITLE
Add note on revoking invalid object URLs

### DIFF
--- a/files/en-us/web/api/url/revokeobjecturl_static/index.md
+++ b/files/en-us/web/api/url/revokeobjecturl_static/index.md
@@ -18,6 +18,8 @@ Call this method when you've finished
 using an object URL to let the browser know not to keep the reference to the file any
 longer.
 
+If the `objectURL` argument passed is not a currently-active object URL — for example if it is an invalid URL, non-object URL, or is already revoked — then calling this method does nothing.
+
 > [!NOTE]
 > This method is _not_ available in [Service Workers](/en-US/docs/Web/API/Service_Worker_API), due to
 > issues with the {{domxref("Blob")}} interface's life cycle and the potential for leaks.


### PR DESCRIPTION
### Description

Clarify behavior when passing an invalid or revoked object URL.

### Motivation

Currently this info is not specified, and one might expect the method to throw in such cases. It turns out it's quite useful that it _doesn't_ throw, as it allows common patterns such as revoking any extant object URL before creating a new one:

```js
let currentObjectUrl = ''

function doSomething(blob) {
    URL.revokeObjectURL(currentObjectUrl)
    currentObjectUrl = URL.createObjectURL(blob)
    // use currentObjectUrl for something
}
```

### Additional details

https://w3c.github.io/FileAPI/#dfn-revokeObjectURL

> Note: This means that rather than throwing some kind of error, attempting to revoke a URL that isn’t registered or that was registered from an environment in a different storage partition will silently fail. User agents might display a message on the error console if this happens.

In practice, no browser/environment I checked actually does print a console message on failure.
