### PR TITLE
Add DeepWiki badge and link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to MDN Web Docs
 
+[![Ask DeepWiki][deepwiki-badge]][deepwiki]
+
 ![github-profile](https://user-images.githubusercontent.com/10350960/166113119-629295f6-c282-42c9-9379-af2de5ad4338.png)
 
 [MDN Web Docs][] is an open-source, collaborative project that documents web technologies including CSS, HTML, JavaScript, and Web APIs.
@@ -54,3 +56,5 @@ It can be replaced with the normal links syntax after successfully closing https
 
 [mdn web docs]: https://developer.mozilla.org
 [communication channels]: https://developer.mozilla.org/en-US/docs/MDN/Community/Communication_channels
+[deepwiki-badge]: https://deepwiki.com/badge.svg
+[deepwiki]: https://deepwiki.com/mdn/content


### PR DESCRIPTION
### Description

Add an DeepWiki badge to the README using reference-style link syntax.

### Motivation

1. It provides a direct entry point to an AI-powered documentation for this repository.
2. LLMs can use the [DeepWiki's free MCP server](https://docs.devin.ai/work-with-devin/deepwiki-mcp) to query any information about Web APIs using natural language.
3. According to this:

    <img width="364" height="206" alt="image" src="https://github.com/user-attachments/assets/d6ffead3-f79d-417b-a01d-d770577896cc" />

    Repositories that have this badge will be automatically reindexed weekly.

### Additional details

DeepWiki page: [https://deepwiki.com/mdn/content](https://deepwiki.com/mdn/content)

### Related issues and pull requests

Relates to: (none)
