### PR TITLE
CSS: registerProperty() links to explanations

### DIFF
--- a/files/en-us/web/api/css/registerproperty_static/index.md
+++ b/files/en-us/web/api/css/registerproperty_static/index.md
@@ -28,10 +28,11 @@ CSS.registerProperty(propertyDefinition)
   - : An object containing the following properties:
     - `name`
       - : A string representing the
-        name of the property being defined.
+        {{cssxref("dashed-ident")}} name of the property being defined.
     - `syntax` {{optional_inline}}
       - : A string representing
         the expected syntax of the defined property. Defaults to `"*"`.
+        See the {{cssxref("@property/syntax", "syntax")}}.
     - `inherits`
       - : A boolean value defining whether the defined property should be inherited
         (`true`), or not (`false`). Defaults to `false`.
@@ -71,8 +72,8 @@ window.CSS.registerProperty({
 
 In this example, the custom property `--my-color` has been registered using
 the syntax `<color>`. We can now use that property to transition a
-gradient on hover or focus. Notice that with the registered property the transition
-works, but that it doesn't with the unregistered property!
+gradient on hover or focus. Notice that with the registered property, the transition
+works, but it doesn't work with the unregistered property!
 
 ```css
 .registered {


### PR DESCRIPTION
Updated descriptions and syntax references in the documentation for the registerProperty static API linking to CSS explanations
