### PR TITLE
Add no support for generic() in CSS fonts module

### DIFF
--- a/files/en-us/web/css/guides/fonts/index.md
+++ b/files/en-us/web/css/guides/fonts/index.md
@@ -80,6 +80,10 @@ The CSS fonts module also defines the {{cssxref("@font-feature-values/font-displ
     - {{cssxref("@font-palette-values/font-family", "font-family")}}
     - {{cssxref("@font-palette-values/override-colors", "override-colors")}}
 
+### Functions
+
+The CSS fonts module defines the `generic()` function. Currently, no browsers support this feature.
+
 ### Data types
 
 `font-size` types:


### PR DESCRIPTION
Add section on generic() function in CSS fonts module.
just want to make sure people find it and can stop looking if they are indeed looking for it.
https://drafts.csswg.org/css-fonts/#typedef-generic-script-specific