### PR TITLE
chore: Remove the macro and add the CSS sidebar in front matter

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@custom-media/index.md
+++ b/files/en-us/web/css/reference/at-rules/@custom-media/index.md
@@ -5,9 +5,10 @@ page-type: css-at-rule
 status:
   - experimental
 browser-compat: css.at-rules.custom-media
+sidebar: cssref
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 The **`@custom-media`** CSS [at-rule](/en-US/docs/Web/CSS/Reference/At-rules) defines aliases for long or complex [media queries](/en-US/docs/Web/CSS/Guides/Media_queries). Instead of repeating the same hardcoded `<media-query-list>` in multiple {{cssxref("@media")}} at-rules, it can be defined once in a `@custom-media` at-rule and referenced throughout the stylesheet whenever needed.
 

--- a/files/en-us/web/css/reference/properties/interactivity/index.md
+++ b/files/en-us/web/css/reference/properties/interactivity/index.md
@@ -5,9 +5,10 @@ page-type: css-property
 status:
   - experimental
 browser-compat: css.properties.interactivity
+sidebar: cssref
 ---
 
-{{CSSRef}}{{seecompattable}}
+{{seecompattable}}
 
 The **`interactivity`** [CSS](/en-US/docs/Web/CSS) property specifies whether an element and its descendant nodes are set to be [inert](/en-US/docs/Web/HTML/Reference/Global_attributes/inert).
 

--- a/files/en-us/web/css/reference/properties/object-view-box/index.md
+++ b/files/en-us/web/css/reference/properties/object-view-box/index.md
@@ -5,9 +5,10 @@ page-type: css-property
 status:
   - experimental
 browser-compat: css.properties.object-view-box
+sidebar: cssref
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{SeeCompatTable}}
 
 The **`object-view-box`** [CSS](/en-US/docs/Web/CSS) property defines a rectangle as a viewable area (viewbox) within a {{glossary("replaced elements", "replaced element")}}, enabling the content of the replaced element to be zoomed or panned. It works similarly to the SVG {{SVGAttr("viewBox")}} attribute.
 

--- a/files/en-us/web/css/reference/values/progress/index.md
+++ b/files/en-us/web/css/reference/values/progress/index.md
@@ -3,9 +3,8 @@ title: progress()
 slug: Web/CSS/Reference/Values/progress
 page-type: css-function
 browser-compat: css.types.progress
+sidebar: cssref
 ---
-
-{{CSSRef}}
 
 The **`progress()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) returns a {{cssxref("&lt;number>")}} value representing the position of one value (the progress value) relative to two other values (the progress start and end values).
 


### PR DESCRIPTION
### Description

Updating the front matter to include the `sidebar` key and CSS sidebar.
For reference: [How sidebars work](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Sidebars#how_sidebars_work)

### Motivation

Specifying sidebars in front matter is supported; the sidebar macro should not be used

### Related issues and pull requests

- https://github.com/mdn/content/pull/40356
