### PR TITLE
Document rtcdegradationpreference maintain-framerate-and-resolution value

### DIFF
--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.md
@@ -4,6 +4,9 @@ short-title: getParameters()
 slug: Web/API/RTCRtpSender/getParameters
 page-type: web-api-instance-method
 browser-compat: api.RTCRtpSender.getParameters
+spec-urls:
+  - https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender-getparameters
+  - https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference
 ---
 
 {{APIRef("WebRTC")}}
@@ -128,10 +131,16 @@ An object indicating the current configuration of the sender. <!-- RTCRtpSendPar
     - `reducedSize`
       - : A read-only boolean that is `True` if reduced size RTCP is configured ({{rfc("5506")}}), and `False` if compound RTCP is specified ({{rfc("3550")}}).
 
-- `degradationPreference` {{deprecated_inline}} {{optional_inline}} <!-- removed from spec. May have been or be in chrome -->
-  - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations.
-    The possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`.
-    The default value is `balanced`.
+- `degradationPreference`
+  - : Specifies the preferred way in which the WebRTC layer should handle optimizing performance in constrained-bandwidth situations. The possible values are:
+    - `balanced`
+      - : The default value. The browser will balance degradation of framerate and resolution.
+    - `maintain-framerate`
+      - : The browser will degrade resolution to maintain framerate.
+    - `maintain-resolution`
+      - : The browser will degrade framerate to maintain resolution.
+    - `maintain-framerate-and-resolution`
+      - : The browser will maintain framerate and resolution regardless of video quality, which may cause frames to be dropped before encoding if necessary so as not to overuse network and encoder resources. This setting is useful for applications that implement their own video encoding quality and performance optimization mechanism, and don't want the browser's own internal mechanism to interfere with it.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -4,6 +4,9 @@ short-title: setParameters()
 slug: Web/API/RTCRtpSender/setParameters
 page-type: web-api-instance-method
 browser-compat: api.RTCRtpSender.setParameters
+spec-urls:
+  - https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender-setparameters
+  - https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference
 ---
 
 {{APIRef("WebRTC API")}}
@@ -127,10 +130,16 @@ setParameters(parameters)
         - `reducedSize`
           - : A read-only boolean that is `True` if reduced size RTCP is configured ({{rfc("5506")}}), and `False` if compound RTCP is specified ({{rfc("3550")}}).
 
-    - `degradationPreference` {{deprecated_inline}}
-      - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations.
-        The possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`.
-        The default value is `balanced`.
+    - `degradationPreference` {{optional_inline}}
+      - : Specifies the preferred way in which the WebRTC layer should handle optimizing performance in constrained-bandwidth situations. The possible values are:
+        - `balanced`
+          - : The default value. The browser will balance degradation of framerate and resolution.
+        - `maintain-framerate`
+          - : The browser will degrade resolution to maintain framerate.
+        - `maintain-resolution`
+          - : The browser will degrade framerate to maintain resolution.
+        - `maintain-framerate-and-resolution`
+          - : The browser will maintain framerate and resolution regardless of video quality, which may cause frames to be dropped before encoding if necessary so as not to overuse network and encoder resources. This setting is useful for applications that implement their own video encoding quality and performance optimization mechanism, and don't want the browser's own internal mechanism to interfere with it.
 
 ### Return value
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 144 adds support for the `maintain-framerate-and-resolution` value of the [`RTCDegradationPreference`](https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference) dictionary, which is used in the options object of the [`RTCRtpSender.setParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters) method, and available in the return value of the [`RTCRtpSender.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters) method.

See https://chromestatus.com/feature/5156290162720768 for the release details.

This PR updates the method pages linked above to document the `maintain-framerate-and-resolution` value, and generally clean up the `degredationPreference` description.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
