### PR TITLE
Clarify that loseContext also frees WebGL resources

### DIFF
--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -15,6 +15,10 @@ It triggers the steps described in the WebGL specification for handling context 
 The context will remain lost until {{domxref("WEBGL_lose_context.restoreContext()")}} is
 called.
 
+In addition to simulating context loss for debugging purposes, calling `loseContext()` destroys the underlying graphics context and all
+associated graphics resources. This is the recommended mechanism for applications to programmatically halt use of WebGL API and free GPU
+resources.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -8,9 +8,9 @@ browser-compat: api.WEBGL_lose_context.loseContext
 
 {{APIRef("WebGL")}}
 
-The **WEBGL_lose_context.loseContext()** method is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and allows you to simulate losing the context of a {{domxref("WebGLRenderingContext")}} context.
+The **`loseContext()`** method of the `WEBGL_lose_context` extension is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and allows you to simulate losing the context of a {{domxref("WebGLRenderingContext")}}.
 
-It triggers the steps described in the WebGL specification for handling context lost. The context will remain lost until {{domxref("WEBGL_lose_context.restoreContext()")}} is called. It also destroys the underlying graphics context and all graphics resources. This is the recommended mechanism for applications to programmatically halt their use of the WebGL API.
+It triggers the [steps described in the WebGL specification](https://registry.khronos.org/webgl/specs/latest/1.0/#5.15.2) for handling context lost. The context will remain lost until {{domxref("WEBGL_lose_context.restoreContext()")}} is called. It also destroys the underlying graphics context and all graphics resources. This is the recommended mechanism for applications to programmatically halt their use of the WebGL API.
 
 ## Syntax
 
@@ -28,9 +28,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-With this method, you can simulate the
-[`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)
-event:
+With this method, you can simulate the [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event) event:
 
 ```js
 const canvas = document.getElementById("canvas");
@@ -56,7 +54,4 @@ gl.getExtension("WEBGL_lose_context").loseContext();
 ## See also
 
 - {{domxref("WebGLRenderingContext.isContextLost()")}}
-- Events:
-  [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event),
-  [`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event),
-  [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)
+- Events: [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event), [`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event), [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -8,16 +8,9 @@ browser-compat: api.WEBGL_lose_context.loseContext
 
 {{APIRef("WebGL")}}
 
-The **WEBGL_lose_context.loseContext()** method is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and allows you to simulate losing
-the context of a {{domxref("WebGLRenderingContext")}} context.
+The **WEBGL_lose_context.loseContext()** method is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and allows you to simulate losing the context of a {{domxref("WebGLRenderingContext")}} context.
 
-It triggers the steps described in the WebGL specification for handling context lost.
-The context will remain lost until {{domxref("WEBGL_lose_context.restoreContext()")}} is
-called.
-
-In addition to simulating context loss for debugging purposes, calling `loseContext()` destroys the underlying graphics context and all
-associated graphics resources. This is the recommended mechanism for applications to programmatically halt use of WebGL API and free GPU
-resources.
+It triggers the steps described in the WebGL specification for handling context lost. The context will remain lost until {{domxref("WEBGL_lose_context.restoreContext()")}} is called. It also destroys the underlying graphics context and all graphics resources. This is the recommended mechanism for applications to programmatically halt their use of the WebGL API.
 
 ## Syntax
 

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -8,8 +8,9 @@ browser-compat: api.WEBGL_lose_context.restoreContext
 
 {{APIRef("WebGL")}}
 
-The **WEBGL_lose_context.restoreContext()** method is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and allows you to simulate
-restoring the context of a {{domxref("WebGLRenderingContext")}} object.
+The **`restoreContext()`** method of the `WEBGL_lose_context` extension is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and allows you to simulate restoring the context of a {{domxref("WebGLRenderingContext")}}.
+
+It triggers the [steps described in the WebGL specification](https://registry.khronos.org/webgl/specs/latest/1.0/#5.15.3) for handling context restored. The context is not usable until the {{domxref("HTMLCanvasElement.webglcontextrestored_event", "webglcontextrestored")}} event is fired.
 
 ## Syntax
 
@@ -34,9 +35,7 @@ Browsers may not report WebGL errors by default. WebGL's error reporting works b
 
 ## Examples
 
-With this method, you can simulate the
-[`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event)
-event:
+With this method, you can simulate the [`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event) event:
 
 ```js
 const canvas = document.getElementById("canvas");
@@ -60,7 +59,4 @@ gl.getExtension("WEBGL_lose_context").restoreContext();
 ## See also
 
 - {{domxref("WebGLRenderingContext.isContextLost()")}}
-- Events:
-  [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event),
-  [`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event),
-  [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)
+- Events: [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event), [`webglcontextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event), [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)


### PR DESCRIPTION
Fix #42833 

For the file --> https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_lose_context/loseContext
1. I have added a note explaining that loseContext frees WebGL resources, as per the requirement.

Thank you 😊.