### PR TITLE
FF147 Relnote - better cross link to css type import assertion

### DIFF
--- a/files/en-us/mozilla/firefox/releases/147/index.md
+++ b/files/en-us/mozilla/firefox/releases/147/index.md
@@ -50,7 +50,7 @@ No notable changes.
 
 ### JavaScript
 
-- CSS module scripts are now supported, allowing a stylesheet to be loaded into a script as a {{domxref("CSSStyleSheet")}} instance using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) keyword and the [`type` import attribute](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) set to `type="css"`.
+- CSS module scripts are now supported, allowing a stylesheet to be loaded into a script as a {{domxref("CSSStyleSheet")}} instance using the [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) keyword and the `type` [import attribute](/en-US/docs/Web/JavaScript/Reference/Statements/import/with) set to [`type="css"`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#css_modules_type_css).
   ([Firefox bug 1986681](https://bugzil.la/1986681)).
 - The {{jsxref("Iterator.concat()")}} method is now supported. This method enables you to create a new iterator that combines multiple input iterables into a single sequence.
   ([Firefox bug 1986672](https://bugzil.la/1986672)).


### PR DESCRIPTION
This adds a better cross link from the FF147 release note for CSS modules (`{ type: "css" }`) - following merging of #42309.

Related docs work can be tracked in #42255