### PR TITLE
Fix broken internal links in CSS Colors guide index

### DIFF
--- a/files/en-us/web/css/guides/colors/index.md
+++ b/files/en-us/web/css/guides/colors/index.md
@@ -135,7 +135,7 @@ The CSS color module also introduces the `CSSColorProfileRule` interface. Curren
 - {{cssxref("gradient")}} defined in [CSS images](/files/en-us/web/css/guides/images/index.md) module
 - The [`VideoColorSpace`](files/en-US/web/api/videocolorspace/index.md) interface
 - [`<feColorMatrix>`](/files/en-us/web/svg/reference/element/fecolormatrix/index.md) SVG element
-- [Canvas API: applying styles and colors](/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md) 
+- [Canvas API: applying styles and colors](/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md)
 - Tools:
   - [Color format converter](/files/en-us/web/css/guides/colors/color_format_converter/index.md)
   - [Color mixer](/files/en-us/web/css/guides/colors/color_mixer/index.md)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Fixes multiple broken internal links in the CSS Colors guide index by updating outdated /en-US/docs/... paths to their correct current locations in the MDN content structure.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Several links in the Colors guide were returning 404 errors due to legacy paths and directory restructuring in the mdn/content repository. Updating these links ensures readers can reliably navigate to related CSS color references, guides, accessibility docs, and APIs without encountering dead links.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

- Changes are documentation-only; no content or examples were modified.
- All updated links now align with the current files/en-us/.../index.md structure used by MDN.
- This improves maintainability and prevents broken navigation in the Colors guide.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
Summary

This PR fixes multiple broken internal links in
files/en-us/web/css/guides/colors/index.md.

Several links were pointing to outdated or incorrect paths under
/en-US/docs/..., which resulted in 404 errors on GitHub and during MDN builds.
All affected links have been updated to their correct canonical locations based on the current files/en-us/... content structure.
