### PR TITLE
Fix spelling typos in MDN content

### DIFF
--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -100,7 +100,7 @@ Module workers and their dependencies are loaded and executed using ECMAScript m
 Classic workers are fetched and executed as scripts:
 
 - Dependencies are imported using the {{domxref("WorkerGlobalScope.importScripts()")}} method
-- Fetched synchonously in `no-cors` mode
+- Fetched synchronously in `no-cors` mode
 
 ### Importing scripts or modules
 

--- a/files/en-us/web/api/workerglobalscope/importscripts/index.md
+++ b/files/en-us/web/api/workerglobalscope/importscripts/index.md
@@ -17,7 +17,7 @@ browser-compat: api.WorkerGlobalScope.importScripts
 
 The **`importScripts()`** method of the {{domxref("WorkerGlobalScope")}} interface synchronously imports one or more scripts into the scope of a [classic worker](/en-US/docs/Web/API/Worker/Worker#module_and_classic_workers) (a worker constructed from a classic script).
 
-Note that the method cannot be used in [module workers](/en-US/docs/Web/API/Worker/Worker#module_and_classic_workers), which instead load dependenices using [`import` statements](/en-US/docs/Web/JavaScript/Reference/Statements/import).
+Note that the method cannot be used in [module workers](/en-US/docs/Web/API/Worker/Worker#module_and_classic_workers), which instead load dependencies using [`import` statements](/en-US/docs/Web/JavaScript/Reference/Statements/import).
 
 ## Syntax
 


### PR DESCRIPTION
### Description
This PR fixes two spelling typos reported by the automated cspell check:
- dependenices → dependencies
- synchonously → synchronously

### Motivation
These fixes improve documentation readability and resolve spellcheck warnings without changing any technical identifiers.

### Additional details
Fixes #42905 
