### PR TITLE
Fix incorrect @custom-media override behavior description

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@custom-media/index.md
+++ b/files/en-us/web/css/reference/at-rules/@custom-media/index.md
@@ -229,10 +229,6 @@ When multiple `@custom-media` rules use the same name, the rule that is in scope
 at the time a `@media` rule is evaluated is used. Earlier references are not
 retroactively updated when a later `@custom-media` rule is declared.
 
-When multiple `@custom-media` rules use the same name, the rule that is in scope
-at the time a `@media` rule is evaluated is used. Earlier references are not
-retroactively updated when a later `@custom-media` rule is declared.
-
 For example, in the code above, the `--mobile-breakpoint` reference inside the
 `@media` rule is evaluated as `(width < 320px)`, so the `.container` rule is only
 applied when the viewport is less than 320px wide, even though


### PR DESCRIPTION
MDN described @custom-media as last-declaration-wins, but Firefox (the only
current implementation, behind a flag) resolves custom media at evaluation time.

This updates the documentation to match real behavior and notes that the spec
is still under discussion.

Fixes mdn/content#42920