### PR TITLE
MouseEvent.movementX/Y - update events that set a value

### DIFF
--- a/files/en-us/web/api/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/index.md
@@ -52,9 +52,9 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 - {{domxref("MouseEvent.metaKey")}} {{ReadOnlyInline}}
   - : Returns `true` if the <kbd>meta</kbd> key was down when the mouse event was fired.
 - {{domxref("MouseEvent.movementX")}} {{ReadOnlyInline}}
-  - : The X coordinate of the mouse pointer relative to the position of the last {{domxref("Element/mousemove_event", "mousemove")}} event.
+  - : The X coordinate of the mouse pointer relative to the position of the last move event of the same type (a {{domxref("Element/mousemove_event", "mousemove")}}, {{domxref("Element/pointermove_event", "pointermove")}}, or {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}}).
 - {{domxref("MouseEvent.movementY")}} {{ReadOnlyInline}}
-  - : The Y coordinate of the mouse pointer relative to the position of the last {{domxref("Element/mousemove_event", "mousemove")}} event.
+  - : The Y coordinate of the mouse pointer relative to the position of the last move event of the same type (a {{domxref("Element/mousemove_event", "mousemove")}}, {{domxref("Element/pointermove_event", "pointermove")}}, or {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}}).
 - {{domxref("MouseEvent.offsetX")}} {{ReadOnlyInline}}
   - : The X coordinate of the mouse pointer relative to the position of the padding edge of the target node.
 - {{domxref("MouseEvent.offsetY")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/mouseevent/movementx/index.md
+++ b/files/en-us/web/api/mouseevent/movementx/index.md
@@ -8,27 +8,33 @@ browser-compat: api.MouseEvent.movementX
 
 {{APIRef("Pointer Lock API")}}
 
-The **`movementX`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the X coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
+The **`movementX`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the X coordinate of the mouse (or pointer) between the given move event and the previous move event of the same type.
+
 In other words, the value of the property is computed like this: `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
+The value is zero for all events other than {{domxref("Element/mousemove_event", "mousemove")}}, {{domxref("Element/pointermove_event", "pointermove")}}, and {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}}.
 
 > [!WARNING]
-> Browsers [use different units for `movementX` and `screenX`](https://github.com/w3c/pointerlock/issues/42) than what the specification defines. Depending on the browser and operating system, the `movementX` units may be a physical pixel, a logical pixel, or a CSS pixel. You may want to avoid the movement properties, and instead calculate the delta between the current client values ({{domxref("MouseEvent.screenX", "screenX")}}, {{domxref("MouseEvent.screenY", "screenY")}}) and the previous client values.
+> Browsers [use different units for `movementX` and `screenX`](https://github.com/w3c/pointerlock/issues/42) than what the specification defines.
+> Depending on the browser and operating system, the `movementX` units may be a physical pixel, a logical pixel, or a CSS pixel. You may want to avoid the movement properties, and instead calculate the delta between the current client values ({{domxref("MouseEvent.screenX", "screenX")}}, {{domxref("MouseEvent.screenY", "screenY")}}) and the previous client values.
 
 ## Value
 
-A number. Always zero on any {{domxref("MouseEvent")}} other than `mousemove`.
+A number.
+Always zero on any {{domxref("MouseEvent")}} other than `mousemove`, and any {{domxref("PointerEvent")}} other than `pointermove` or `pointerrawevent`.
 
 ## Examples
 
+### Log mouse movement for `mousemove` events
+
 This example logs the amount of mouse movement using `movementX` and {{domxref("MouseEvent.movementY", "movementY")}}.
 
-### HTML
+#### HTML
 
 ```html
 <p id="log">Move your mouse around.</p>
 ```
 
-### JavaScript
+#### JavaScript
 
 ```js
 const log = document.getElementById("log");
@@ -44,9 +50,9 @@ function logMovement(event) {
 document.addEventListener("mousemove", logMovement);
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Examples")}}
+{{EmbedLiveSample("### Log mouse movement for `mousemove` events")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/mouseevent/movementy/index.md
+++ b/files/en-us/web/api/mouseevent/movementy/index.md
@@ -8,27 +8,34 @@ browser-compat: api.MouseEvent.movementY
 
 {{APIRef("Pointer Lock API")}}
 
-The **`movementY`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the Y coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
+The **`movementY`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the Y coordinate of the mouse (or pointer) between the given move event and the previous move event of the same type.
+
 In other words, the value of the property is computed like this: `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
+The value is zero for all events other than {{domxref("Element/mousemove_event", "mousemove")}}, {{domxref("Element/pointermove_event", "pointermove")}}, and {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}}.
 
 > [!WARNING]
-> Browsers [use different units for `movementY` and `screenY`](https://github.com/w3c/pointerlock/issues/42) than what the specification defines. Depending on the browser and operating system, the `movementY` units may be a physical pixel, a logical pixel, or a CSS pixel. You may want to avoid the movement properties, and instead calculate the delta between the current client values ({{domxref("MouseEvent.screenX", "screenX")}}, {{domxref("MouseEvent.screenY", "screenY")}}) and the previous client values.
+> Browsers [use different units for `movementY` and `screenY`](https://github.com/w3c/pointerlock/issues/42) than what the specification defines.
+> Depending on the browser and operating system, the `movementY` units may be a physical pixel, a logical pixel, or a CSS pixel.
+> You may want to avoid the movement properties, and instead calculate the delta between the current client values ({{domxref("MouseEvent.screenX", "screenX")}}, {{domxref("MouseEvent.screenY", "screenY")}}) and the previous client values.
 
 ## Value
 
-A number. Always zero on any {{domxref("MouseEvent")}} other than `mousemove`.
+A number.
+Always zero on any {{domxref("MouseEvent")}} other than `mousemove`, and any {{domxref("PointerEvent")}} other than `pointermove` or `pointerrawevent`.
 
 ## Examples
 
+### Log mouse movement for `mousemove` events
+
 This example logs the amount of mouse movement using {{domxref("MouseEvent.movementX", "movementX")}} and `movementY`.
 
-### HTML
+#### HTML
 
 ```html
-<p id="log">Move your mouse around.</p>
+<p id="log">Move your mouse around inside this element.</p>
 ```
 
-### JavaScript
+#### JavaScript
 
 ```js
 const log = document.getElementById("log");
@@ -40,9 +47,9 @@ function logMovement(event) {
 document.addEventListener("mousemove", logMovement);
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Examples")}}
+{{EmbedLiveSample("Log mouse movement for `mousemove` events")}}
 
 ## Specifications
 


### PR DESCRIPTION
`MouseEvent.movementX` and `MouseEvent.movementY` state that the value is only set for `mousemove` event.  In fact it is also set for `pointermove` on Chrome and FF, and `pointerrawupdate` on Chrome and FF from version 148.

This adds the clarification. 

Related docs work can be tracked in #42752
