### PR TITLE
FF148 Relnote: pointerrawupdate event populates movementX/Y properties

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -55,6 +55,9 @@ Firefox 148 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("Location.ancestorOrigins")}} property is now supported, which enables you to determine whether a document is being embedded in an {{htmlelement("iframe")}} and, if so, by which site(s).
   ([Firefox bug 1085214](https://bugzil.la/1085214)).
 
+- The {{domxref("MouseEvent.movementX", "movementX")}} and {{domxref("MouseEvent.movementY", "movementY")}} properties on the {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}} event are now populated when the pointer is moved — previously these were set to zero.
+  ([Firefox bug 1987671](https://bugzil.la/1987671)).
+
 <!-- #### DOM -->
 
 <!-- #### Media, WebRTC, and Web Audio -->


### PR DESCRIPTION
FF148 updates  `pointerrawupdate` to populate `MouseEvent.movementX` and `MouseEvent.movementY` values on movement in https://bugzilla.mozilla.org/show_bug.cgi?id=1987671

This adds a release note.

Related docs work can be tracked in #42752
