### PR TITLE
Fix units of spatial fragments

### DIFF
--- a/files/en-us/web/uri/reference/fragment/media_fragments/index.md
+++ b/files/en-us/web/uri/reference/fragment/media_fragments/index.md
@@ -79,9 +79,9 @@ The key parts of the syntax are:
   - : The start of the spatial dimension syntax. This must always be included after the hash/pound symbol.
 - `unit:` {{optional_inline}}
   - : The units to specify for the `xCoord`, `yCoord`, `width`, and `height`. Defaults to `pixel:` if omitted. Possible values are:
-    - `percent:`
-      - : Values signify an absolute number of pixels.
     - `pixel:`
+      - : Values signify an absolute number of pixels.
+    - `percent:`
       - : Values signify a percentage of the media's intrinsic width or height.
 - `xCoord`
   - : The horizontal distance of the displayed box's top-left corner from the top-left corner of the media.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix units of spatial fragments.

### Motivation

The two units are written with opposite meanings.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
