### PR TITLE
added note about position-area, in ff148 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -34,7 +34,7 @@ Firefox 148 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### CSS
 
-- The [CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning) property {{cssxref("position-area")}} is now makes sure that the anchored element stays within the viewport.
+- The {{cssxref("position-area")}} property in [CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning) now correctly keeps the anchored element within the viewport.
   ([Firefox bug 2008537](https://bugzil.la/2008537)).
 
 <!-- #### Removals -->


### PR DESCRIPTION
### Description

- Release note for `position-area` for Firefox 148

### Motivation

- Working on [MDN issue #42750](https://github.com/mdn/content/issues/42750)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/28761)