### PR TITLE
Remove passkeys recommendation

### DIFF
--- a/files/en-us/web/security/authentication/passkeys/index.md
+++ b/files/en-us/web/security/authentication/passkeys/index.md
@@ -7,8 +7,6 @@ sidebar: security
 
 Passkeys enable websites to authenticate users without the user having to enter any passwords or other secret codes on the site itself. They address [many of the most serious weaknesses of other authentication methods](#security_properties_of_passkeys) such as passwords.
 
-They're considered [the most secure authentication method available to websites](#security_properties_of_passkeys), and we recommend that sites should adopt passkeys as their preferred authentication method, and [phase out the use of passwords](#migrating_from_passwords).
-
 Instead of a shared secret, passkeys rely on public-key cryptography. A passkey is a {{glossary("Public-key cryptography", "public/private key pair")}} bound to a specific user's account on a particular website.
 
 The private key is stored in a module called an _authenticator_, that's [in, or attached to, the user's device](#platform_and_roaming_authenticators). An authenticator might be built into the platform, or a separate hardware key like a [YubiKey](https://en.wikipedia.org/wiki/YubiKey), or a credential manager app like [KeePassXC](https://keepassxc.org/).


### PR DESCRIPTION
In some kind of Freudian slip, I did not actually remove the recommendation to adopt passkeys in my https://github.com/mdn/content/pull/42338/commits/dda66554ce5edd08ccc7a45a8bd49d306448128c, I just added an extra sentence.

This PR actually removes it.