### PR TITLE
URL Pattern API incorrect example

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -145,11 +145,11 @@ const pattern2 = new URLPattern({ pathname: "(/path)" });
 console.log(pattern2.test("https://example.com/path")); // true
 
 // with `$` in hash
-const pattern3 = new URLPattern({ hash: "(/hash$)" });
+const pattern3 = new URLPattern({ hash: "(hash$)" });
 console.log(pattern3.test("https://example.com/#hash")); // true
 
 // without `$` in hash
-const pattern4 = new URLPattern({ hash: "(/hash)" });
+const pattern4 = new URLPattern({ hash: "(hash)" });
 console.log(pattern4.test("https://example.com/#hash")); // true
 ```
 


### PR DESCRIPTION
### Description

The leading slash should not exist when looking at a hash. The current example will return false.

### Motivation

I was reading the examples and thought it didn't make sense, tested it and it was wrong

### Additional details

N/A

### Related issues and pull requests

N/A
