### PR TITLE
Reorder basic CSS test your skills for consistency

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/backgrounds_and_borders/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/backgrounds_and_borders/index.md
@@ -62,7 +62,7 @@ h2 {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("backgrounds1-finish", "", "160px")}}
 
@@ -137,7 +137,7 @@ h2 {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("backgrounds2-finish", "", "220px")}}
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/box_model/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/box_model/index.md
@@ -54,7 +54,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("box-model1-finish", "", "540px")}}
 
@@ -102,7 +102,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("box-model2-finish", "100%", "140px")}}
 
@@ -162,7 +162,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("box-model3-finish", "100%", "260px")}}
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/cascade/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/cascade/index.md
@@ -49,7 +49,7 @@ div div li a {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("cascade1-finish", "100%", "110px")}}
 
@@ -115,7 +115,7 @@ Here's the underlying code for this starting point:
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("cascade2-finish", "100%", "110px")}}
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/images/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/images/index.md
@@ -15,7 +15,7 @@ The aim of this skill test is to assess whether you understand how special eleme
 
 ## Images and forms 1
 
-In this task, you have an image that is overflowing the box. We want the image to scale down to fit inside the box without any extra white space, but we do not mind if some part of the image is cropped. Update the CSS to achieve this.
+In this task, you have an image that is overflowing the box. We want you to scale down the image so that it fits inside the box without any extra white space; we don't mind if some part of the image is cropped. Update the CSS to achieve this.
 
 The starting point of the task looks like this:
 
@@ -43,7 +43,7 @@ img {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("images-forms1-finish", "", "260px")}}
 
@@ -100,7 +100,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("images-forms2-finish", "", "80px")}}
 
@@ -203,7 +203,7 @@ body {
 /* Add your code here */
 ```
 
-We've not shown the finished styling, as the solution to this task will vary so much from person to person.
+We've not provided finished content for this task, as many valid solutions are possible.
 
 <details>
 <summary>Click here to show the solution</summary>

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/overflow/index.md
@@ -19,8 +19,8 @@ In this task, the content is overflowing the box because it has a fixed height.
 
 To complete the task:
 
-1. Update the CSS so that the height is maintained and the box will have scrollbars only if there is enough text to cause an overflow.
-2. Test your solution by removing some of the text from the HTML and checking that if there is only a small amount of text that does not overflow, no scrollbar appears.
+1. Update the CSS so that the box height is maintained and scrollbars appear only when there is enough text to cause an overflow.
+2. Test your solution by removing some text from the HTML and checking that no scrollbar appears when there is only a small amount of text.
 
 The starting point of the task looks like this:
 
@@ -56,7 +56,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("overflow1-finish", "", "300px")}}
 
@@ -102,7 +102,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("overflow2-finish", "", "260px")}}
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
@@ -53,7 +53,7 @@ body {
 /* Add styles here */
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("selectors1-finish", "", "400px")}}
 
@@ -120,7 +120,7 @@ body {
 /* Add styles here */
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("selectors2-finish", "", "480px")}}
 
@@ -228,7 +228,7 @@ th {
 /* Add styles here */
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("selectors3-finish", "", "540px")}}
 
@@ -312,7 +312,7 @@ body {
 /* Add styles here */
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("selectors4-finish", "", "500px")}}
 
@@ -385,7 +385,7 @@ a {
 /* Add styles here */
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("selectors5-finish", "", "300px")}}
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/sizing/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/sizing/index.md
@@ -68,7 +68,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("sizing1-finish", "", "460px")}}
 
@@ -136,7 +136,7 @@ body {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("sizing2-finish", "", "220px")}}
 
@@ -197,7 +197,7 @@ img {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("sizing3-finish", "", "720px")}}
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/values/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/values/index.md
@@ -21,7 +21,7 @@ In this task, the first list item has been given a background color using a hex 
 - The third should use HSL color.
 - The fourth should use RGB color but with the alpha channel set to `0.6`.
 
-You [can convert the hex color at convertingcolors.com](https://convertingcolors.com/hex-color-86DEFA.html). You need to figure out how to use the values in CSS.
+You can convert the hex color using [convertingcolors.com](https://convertingcolors.com/hex-color-86DEFA.html). You need to figure out how to use the values in CSS.
 
 The starting point of the task looks like this:
 
@@ -60,7 +60,7 @@ li {
 /* Add styles here */
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("values1-finish", "", "300px")}}
 
@@ -136,9 +136,9 @@ h1 + p {
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
-{{EmbedLiveSample("values2-finish", "", "420px")}}
+{{EmbedLiveSample("values2-finish", "", "430px")}}
 
 Here's the underlying code for this starting point:
 
@@ -193,7 +193,7 @@ Here's the underlying code for this starting point:
 }
 ```
 
-The finished styling should look like this:
+The updated styling should look like this:
 
 {{EmbedLiveSample("values3-finish", "", "400px")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I got some feedback that the ordering of the "Test your skills" articles has become confusing since the last update. Specifically, in some of the tests, the "solution" live sample appears before the "starting state" live sample, so it is unclear which one to click on to start the test.

To remedy this, I have decided to go through all the "Test your skills" articles and make the structure as consistent as possible throughout, fixing the above issue in the process.

This PR in particular updates the structure of the [CSS styling basics](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics) "Test your skills" articles.

Note: Not all of the tests show the finished state of the example. I have elected not to show it in cases where the before and after rendering look no different, where the final rendering gives away the answer, and where the question is freeform so there is no single answer.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
