### PR TITLE
reorder CSS layout test your skills for consistency

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/flexbox/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/flexbox/index.md
@@ -21,9 +21,15 @@ Watch the embedded scrim, and complete all the tasks on the timeline (the little
 
 <mdn-scrim-inline url="https://scrimba.com/frontend-path-c0j/~03a" scrimtitle="Flexbox alignment challenges" survey="true"></scrim-inline>
 
-## Task 1
+## Flexbox 1
 
 In this task, we use some list items to create the navigation for a site. To complete the task, use flexbox to lay out the list items as a row, with an equal amount of space between each item.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("flexbox1-start", "", "240px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___flexbox1-start live-sample___flexbox1-finish
 <nav>
@@ -62,10 +68,6 @@ nav ul {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("flexbox1-start", "", "240px")}}
-
 When the task is complete, the items should look like this:
 
 {{EmbedLiveSample("flexbox1-finish", "", "100px")}}
@@ -84,11 +86,17 @@ nav ul {
 
 </details>
 
-## Task 2
+## Flexbox 2
 
 In this task, the list items are all different sizes, but we want them to be displayed as three equal-sized columns, no matter the content in each item.
 
 **Bonus question:** Can you now make the first item twice the size of the other items?
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("flexbox2-start", "", "240px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___flexbox2-start live-sample___flexbox2-finish
 <ul>
@@ -130,10 +138,6 @@ li {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("flexbox2-start", "", "240px")}}
-
 When the task is complete, the items should look like this:
 
 {{EmbedLiveSample("flexbox2-finish", "", "380px")}}
@@ -163,9 +167,15 @@ li:first-child {
 
 </details>
 
-## Task 3
+## Flexbox 3
 
 In this task, we'd like you to arrange the list items into rows.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("flexbox3-start", "", "260px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___flexbox3-start live-sample___flexbox3-finish
 <ul>
@@ -211,11 +221,7 @@ li {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("flexbox3-start", "", "260px")}}
-
-The finished task should look like this:
+When the task is complete, the items should look like this:
 
 {{EmbedLiveSample("flexbox3-finish", "", "260px")}}
 

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/floats/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/floats/index.md
@@ -13,9 +13,15 @@ The aim of this skill test is to help you assess whether you understand [floats 
 > [!NOTE]
 > To get help, read our [Test your skills](/en-US/docs/Learn_web_development#test_your_skills) usage guide. You can also reach out to us using one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
-## Task 1
+## Floats 1
 
-To complete this task, float the two elements with a class of `float1` and `float2` left and right, respectively. The text should then appear between the two boxes.
+To complete this task, float the two elements with classes of `float1` and `float2` to the left and right, respectively. The text should then appear between the two elements.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("float1-start", "", "440px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___float1-start live-sample___float1-finish
 <div class="box">
@@ -57,11 +63,7 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("float1-start", "", "210px")}}
-
-The finished task should look like this:
+The layout should look like this once the task is complete:
 
 {{EmbedLiveSample("float1-finish", "", "210px")}}
 
@@ -82,12 +84,18 @@ You can use `float` for both boxes:
 
 </details>
 
-## Task 2
+## Floats 2
 
 To complete this task:
 
 1. Float the element with a class of `float` to the left.
 2. Update the code so that the first line of text displays next to that element, but the following line of text (which has a class of `below`) displays underneath it.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("float2-start", "", "300px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___float2-start live-sample___float2-finish
 <div class="box">
@@ -129,11 +137,7 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("float2-start", "", "300px")}}
-
-The finished task should look like this:
+The finished layout should look like this:
 
 {{EmbedLiveSample("float2-finish", "", "300px")}}
 
@@ -154,11 +158,17 @@ You need to flow the item left, then add `clear: left` to the class for the seco
 
 </details>
 
-## Task 3
+## Floats 3
 
 In this task, we have a floated element. The background box that wraps the float and the text does not currently extend underneath the floated element.
 
 To complete this task, use the most up-to-date method to ensure the background box contains the floated element and extends underneath it.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("float3-start", "", "220px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___float3-start live-sample___float3-finish
 <div class="box">
@@ -204,10 +214,6 @@ body {
   /* Add styles here */
 }
 ```
-
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("float3-start", "", "220px")}}
 
 When you complete the task, the background box and floated element should look like this:
 

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/grid/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/grid/index.md
@@ -13,9 +13,15 @@ The aim of this skill test is to help you assess whether you understand how a [g
 > [!NOTE]
 > To get help, read our [Test your skills](/en-US/docs/Learn_web_development#test_your_skills) usage guide. You can also reach out to us using one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
-## Task 1
+## CSS grids 1
 
-In this task, we want you to create a grid into which the four child elements will auto-place. The grid should have three columns sharing the available space equally and a 20 pixel gap between the column and row tracks. After that, try adding more child containers inside the parent container with the class of `grid` and see how they behave by default.
+In this task, we want you to create a grid into which the four child elements will be auto-placed. The grid should have three columns that share the available space equally, with a `20px` gap between the column and row tracks. After that, try adding more child elements inside the parent container with the `grid` class and see how they behave by default.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("grid1-start", "", "220px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___grid1-start live-sample___grid1-finish
 <div class="grid">
@@ -44,11 +50,7 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("grid1-start", "", "220px")}}
-
-The finished task should look like this:
+The finished layout should look like this:
 
 {{EmbedLiveSample("grid1-finish", "", "160px")}}
 
@@ -67,11 +69,17 @@ Create a grid using `display: grid` with three columns using `grid-template-colu
 
 </details>
 
-## Task 2
+## CSS grids 2
 
 In this task, we already have a grid defined. We want you to edit the CSS rules for the two child elements so that each one spans several grid tracks. The second item should overlay the first.
 
 **Bonus question:** Can you now cause the first item to display on top without changing the order of items in the source?
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("grid2-start", "", "340px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___grid2-start live-sample___grid2-finish
 <div class="grid">
@@ -116,11 +124,7 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("grid2-start", "", "340px")}}
-
-The finished task should look like this:
+The layout should look like this after you complete the task:
 
 {{EmbedLiveSample("grid2-finish", "", "340px")}}
 
@@ -160,9 +164,15 @@ Another valid solution is to use `z-index`:
 
 </details>
 
-## Task 3
+## CSS grids 3
 
 In this task, the grid contains four direct children. They are currently auto-placed in the grid.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("grid3-start", "", "200px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___grid3-start live-sample___grid3-finish
 <div class="grid">
@@ -191,10 +201,6 @@ body {
   gap: 10px;
 }
 ```
-
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("grid3-start", "", "200px")}}
 
 To complete this task, use the `grid-area` and `grid-template-areas` properties to lay out the items as shown here:
 
@@ -235,9 +241,15 @@ Each part of the layout needs a name using the `grid-area` property and `grid-te
 
 </details>
 
-## Task 4
+## CSS grids 4
 
 In this task, you will need to use both grid layout and flexbox to recreate the finished layout. The gap between the column and row tracks should be `10px`. You do not need to make any changes to the HTML in order to achieve this.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("grid4-start", "", "400px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___grid4-start live-sample___grid4-finish
 <div class="container">
@@ -330,11 +342,7 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("grid4-start", "", "400px")}}
-
-The finished task should look like this:
+The layout should look like this after you complete the task:
 
 {{EmbedLiveSample("grid4-finish", "", "400px")}}
 

--- a/files/en-us/learn_web_development/core/css_layout/test_your_skills/position/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/test_your_skills/position/index.md
@@ -13,11 +13,17 @@ The aim of this skill test is to help you assess whether you understand [positio
 > [!NOTE]
 > To get help, read our [Test your skills](/en-US/docs/Learn_web_development#test_your_skills) usage guide. You can also reach out to us using one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
-## Task 1
+## Positioning 1
 
 To complete this task, position the element with the `target` class at the top-right corner of the container that has a `5px` gray border.
 
 **Bonus question:** Can you change the target so it displays underneath the text?
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("position1-start", "", "400px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___position1-start live-sample___position1-finish
 <div class="container">
@@ -66,10 +72,6 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("position1-start", "", "400px")}}
-
 When you complete this task, the placement of the target should look like this:
 
 {{EmbedLiveSample("position1-finish", "", "250px")}}
@@ -96,9 +98,15 @@ For the bonus question, you need to add a negative `z-index` to the target, for 
 
 </details>
 
-## Task 2
+## Positioning 2
 
 In the starting state of this task, if you scroll the content, the sidebar scrolls with the content. We want you to update the code so that the sidebar (`<div class="sidebar">`) stays in place and only the content scrolls.
+
+The starting point of the task looks like this:
+
+{{EmbedLiveSample("position2-start", "", "400px")}}
+
+Here's the underlying code for this starting point:
 
 ```html live-sample___position2-start live-sample___position2-finish
 <div class="container">
@@ -165,11 +173,7 @@ body {
 }
 ```
 
-The starting point of the task looks like this:
-
-{{EmbedLiveSample("position2-start", "", "400px")}}
-
-The finished layout should look like this:
+The finished layout should render like this (scroll to see the behavior):
 
 {{EmbedLiveSample("position2-finish", "", "400px")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I got some feedback that the ordering of the "Test your skills" articles has become confusing since the last update. Specifically, in some of the tests, the "solution" live sample appears before the "starting state" live sample, so it is unclear which one to click on to start the test.

To remedy this, I have decided to go through all the "Test your skills" articles and make the structure as consistent as possible throughout, fixing the above issue in the process.

This PR in particular updates the structure of the [CSS layout](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout) "Test your skills" articles.

Note: Not all of the tests show the finished state of the example. I have elected not to show it in cases where the before and after rendering look no different, where the final rendering gives away the answer, and where the question is freeform so there is no single answer.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
