### PR TITLE
Compression Dictionary Guide: update spec URL to RFC 9842

### DIFF
--- a/files/en-us/web/http/guides/compression_dictionary_transport/index.md
+++ b/files/en-us/web/http/guides/compression_dictionary_transport/index.md
@@ -13,7 +13,7 @@ browser-compat:
   - http.headers.Content-Encoding.dcz
   - http.headers.Dictionary-ID
   - http.headers.Use-As-Dictionary
-spec-urls: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-compression-dictionary
+spec-urls: https://www.rfc-editor.org/rfc/rfc9842
 sidebar: http
 ---
 
@@ -212,5 +212,5 @@ In particular, when loading a [separate dictionary](#separate_dictionary) using 
 - {{HTTPHeader("Available-Dictionary")}}
 - {{HTTPHeader("Dictionary-ID")}}
 - {{HTTPHeader("Use-As-Dictionary")}}
-- [Draft specification](https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/)
+- [RFC 9842: Compression Dictionary Transport](https://www.rfc-editor.org/rfc/rfc9842)
 - [Resources for Compression Dictionary Transport](https://use-as-dictionary.com/)


### PR DESCRIPTION
### Description

This updates the spec link in the Compression Dictionary Guide from the draft version to the RFC version (RFC 9842)

### Motivation

Compression Dictionary Transport has now been published as RFC 9842, while the links in the guide pointed to the old draft, causing the title in the spec link "Unknown specification". 

### Additional details

https://datatracker.ietf.org/doc/rfc9842/

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
