### PR TITLE
Document 64 KiB payload limit for sendBeacon()

### DIFF
--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -72,6 +72,36 @@ This means:
 
 The data is sent as an [HTTP POST](/en-US/docs/Web/HTTP/Reference/Methods/POST) request.
 
+### Payload size limit
+
+The `sendBeacon()` method is subject to a **64 KiB** (65,536 bytes) payload size limit for queued keepalive requests. This limit is enforced differently across browsers:
+
+**Chrome and Safari:**
+
+- Enforce a strict **64 KiB** (65,536 bytes) cumulative limit for all queued keepalive requests
+- If the total size of queued data exceeds this limit, `sendBeacon()` returns `false`
+- This limit is defined by the [Fetch specification](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch)
+
+**Firefox:**
+
+- **Does not currently enforce** the 64 KiB limit (as of Firefox 147)
+- `sendBeacon()` will return `true` even for payloads larger than 64 KiB
+- This behavior differs from the Fetch specification's requirements
+
+**Example:**
+
+```js
+const LIMIT_64_KiB = 65536; // 64 * 1024 bytes
+
+// At the limit - succeeds in all browsers
+const atLimit = "Z".repeat(LIMIT_64_KiB);
+navigator.sendBeacon("https://example.com", atLimit); // returns true
+
+// Over the limit - fails in Chrome/Safari
+const overLimit = "Z".repeat(LIMIT_64_KiB + 1);
+navigator.sendBeacon("https://example.com", overLimit); // Chrome/Safari: false, Firefox: true
+```
+
 ### Sending analytics at the end of a session
 
 Websites often want to send analytics or diagnostics to the server when the user has finished with the page.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Document the 64 KiB payload size limit for `sendBeacon()` and clarify browser-specific implementation differences.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

- **Fetch specification reference**: [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) defines the 64 KiB limit for keepalive requests
- [Firefox bug 2008613](https://bugzilla.mozilla.org/show_bug.cgi?id=2008613)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #42932 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
Relates to mdn/browser-compat-data#20721
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
