### PR TITLE
Media Capabilities API: Fix Incorrect Word Choice

### DIFF
--- a/files/en-us/web/api/media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/index.md
@@ -19,7 +19,7 @@ The Media Capabilities API provide more powerful features than say {{DOMxref("Me
 
 To test support, smoothness, and power efficiency for encoding and decoding video or audio content, you use the {{DOMxRef("MediaCapabilities")}} interface's {{DOMxRef("MediaCapabilities.encodingInfo()","encodingInfo()")}} and {{DOMxRef("MediaCapabilities.decodingInfo()","decodingInfo()")}} methods.
 
-Media capabilities information enables websites to enable adaptive streaming to alter the quality of content based on actual user-perceived quality, and react to a pick of CPU/GPU usage in real time.
+Media capabilities information enables websites to enable adaptive streaming to alter the quality of content based on actual user-perceived quality, and react to peaks of CPU/GPU usage in real time.
 
 ## Interfaces
 


### PR DESCRIPTION
### Description

Surgical replacement of incorrect word choice.

### Motivation

Original words were "_a pick_" (choice, selection), but from the surrounding text (CPU/GPU usage), probably the intention was to use "_peak_" (relating to the highest level, price, rate, etc. that something reaches). 
