### PR TITLE
Reorder Scripting test your skills for consistency

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/arrays/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/arrays/index.md
@@ -51,7 +51,7 @@ p {
 
 <!-- Example-specific code -->
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("arrays-1", "100%", 60) }}
 
@@ -68,7 +68,7 @@ para1.textContent = `Array: ${myArray}`;
 section.appendChild(para1);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("arrays-1-finish", "100%", 60) }}
 
@@ -115,7 +115,7 @@ To complete the task:
 2. Store the length of the array in a variable called `arrayLength`.
 3. Store the last item in the array in a variable called `lastItem`.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("arrays-2", "100%", 60) }}
 
@@ -140,7 +140,7 @@ section.appendChild(para2);
 section.appendChild(para3);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("arrays-2-finish", "100%", 100) }}
 
@@ -191,7 +191,7 @@ For this array task, we provide you with a starting array, and you will work in 
 3. Iterate over each item in the array and add its index number after the name inside parentheses, for example `Ryu (0)`. Note that we don't teach how to do this in the Arrays article, so you'll have to do some research.
 4. Finally, join the array items together in a single string called `myString`, with a separator of `"-"`.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("arrays-3", "100%", 60) }}
 
@@ -219,7 +219,7 @@ para1.textContent = myString;
 section.appendChild(para1);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("arrays-3-finish", "100%", 60) }}
 
@@ -299,7 +299,7 @@ To complete the task:
 1. Find the index of the `"Eagles"` item, and use that to remove the `"Eagles"` item.
 2. Make a new array from this one, called `eBirds`, that contains only birds from the original array whose names begin with the letter "E". Note that {{jsxref("String.prototype.startsWith()", "startsWith()")}} is a great way to check whether a string starts with a given character.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("arrays-4", "100%", 60) }}
 
@@ -318,7 +318,7 @@ para1.textContent = eBirds;
 section.appendChild(para1);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("arrays-4-finish", "100%", 60) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/conditionals/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/conditionals/index.md
@@ -44,7 +44,7 @@ p {
 
 <!-- Example-specific code -->
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("conditionals-1", "100%", 60) }}
 
@@ -64,7 +64,7 @@ para1.textContent = response;
 section.appendChild(para1);
 ```
 
-The initial state of your finished output should look like this:
+The initial state of your updated output should look like this:
 
 {{ EmbedLiveSample("conditionals-1-finish", "100%", 60) }}
 
@@ -157,7 +157,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The initial state of your finished output should look like this:
+The initial state of your updated output should look like this:
 
 {{ EmbedLiveSample("conditionals-2-finish", "100%", 80) }}
 
@@ -243,7 +243,7 @@ To complete the task:
 1. Create an `if...else` structure that checks whether the machine is switched on and puts a message into the `machineResult` variable telling the user whether it is on or off.
 2. If the machine is on, we also want a second conditional to run that checks whether the `pwd` is equal to `cheese`. If so, it should assign a string to `pwdResult` telling the user they logged in successfully. If not, it should assign a different string to `pwdResult` telling the user their login attempt was not successful. We'd like you to do this in a single line, using something that isn't an `if...else` structure.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("conditionals-3", "100%", 60) }}
 
@@ -269,7 +269,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("conditionals-3-finish", "100%", 80) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/events/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/events/index.md
@@ -61,7 +61,7 @@ const btn = document.querySelector("button");
 // Add your code here
 ```
 
-The finished example should behave like this (try pressing the button):
+The updated example should behave like this (try pressing the button):
 
 {{ EmbedLiveSample("events-1-finish", "100%", 80) }}
 
@@ -143,7 +143,7 @@ drawCircle(x, y, size);
 // Add your code here
 ```
 
-The finished example should behave like this (click on it and then try the keyboard controls):
+The updated example should behave like this (click on it and then try the keyboard controls):
 
 {{ EmbedLiveSample("events-2-finish", "100%", 350) }}
 
@@ -267,7 +267,7 @@ const buttonBar = document.querySelector(".button-bar");
 // Add your code here
 ```
 
-The finished example should behave like this (try clicking the buttons):
+The updated example should behave like this (try clicking the buttons):
 
 {{ EmbedLiveSample("events-3-finish", "100%", 80) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/functions/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/functions/index.md
@@ -53,7 +53,7 @@ p {
 
 <!-- Example-specific code -->
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("functions-1", "100%", 60) }}
 
@@ -77,7 +77,7 @@ const para = document.querySelector("p");
 // Add your code here
 ```
 
-Your finished code should output a random name:
+Your updated code should output a random name:
 
 {{ EmbedLiveSample("functions-1-finish", "100%", 60) }}
 
@@ -125,7 +125,7 @@ chooseName();
 
 ## Functions 2
 
-This task requires you to create a function that draws a rectangle on the provided `<canvas>` (reference variable `canvas`, context available in `ctx`), based on the five provided input variables:
+This task requires you to create a function that draws a rectangle on the provided `<canvas>` element (reference variable `canvas`, context available in `ctx`), based on the five provided input variables:
 
 - `x` — the x coordinate of the rectangle.
 - `y` — the y coordinate of the rectangle.
@@ -133,7 +133,7 @@ This task requires you to create a function that draws a rectangle on the provid
 - `height` — the height of the rectangle.
 - `color` — the color of the rectangle.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet in the `<canvas>`):
 
 {{ EmbedLiveSample("functions-2", "100%", 180) }}
 
@@ -163,7 +163,7 @@ const color = "blue";
 // Add your code here
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("functions-2-finish", "100%", 180) }}
 
@@ -249,7 +249,7 @@ function chooseName() {
 chooseName();
 ```
 
-We've not shown the output of the finished code, as it is identical to the starting point. The code has just been refactored.
+We've not provided finished content for this task, as it looks the same as the starting point. The code has just been refactored.
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -338,7 +338,7 @@ const shortNames = names.filter(isShort);
 para.textContent = shortNames;
 ```
 
-We've not shown the output of the finished code, as it is identical to the starting point. The code structure has just been updated.
+We've not provided finished content for this task, as it looks the same as the starting point. The code has just been refactored.
 
 <details>
 <summary>Click here to show the solution</summary>

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/json/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/json/index.md
@@ -80,7 +80,7 @@ function displayCatInfo(catString) {
 }
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("json-1-finish", "100%", 80) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/loops/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/loops/index.md
@@ -42,7 +42,7 @@ p {
 
 <!-- Example-specific code -->
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("loops-1", "100%", 60) }}
 
@@ -59,7 +59,7 @@ section.appendChild(list);
 // Add your code here
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("loops-1-finish", "100%", 150) }}
 
@@ -113,7 +113,7 @@ To complete the task:
 2. If the `name` is found, write it and the associated `number` into the `textContent` of the provided paragraph (`para`), in the form "&lt;name>'s number is &lt;number>." After that, exit the loop before it has run its course.
 3. If none of the objects contain the `name`, print "Name not found in the phonebook" into the `textContent` of the provided paragraph.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("loops-2", "100%", 60) }}
 
@@ -142,7 +142,7 @@ section.appendChild(para);
 // Add your code here
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("loops-2-finish", "100%", 60) }}
 
@@ -216,7 +216,7 @@ To complete the task:
 
 You should use a type of loop that you've not used in the previous two tasks.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("loops-3", "100%", 60) }}
 
@@ -243,7 +243,7 @@ function isPrime(num) {
 section.appendChild(para);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("loops-3-finish", "100%", 120) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/math/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/math/index.md
@@ -79,7 +79,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("math-1-finish", "100%", 80) }}
 
@@ -154,7 +154,7 @@ To complete the task:
 
 To pass this test, `finalNumber` should have a result of `4633.33`. You might need to consider operator precedence and add or modify some parentheses to the input expressions to get the correct output.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("math-2", "100%", 80) }}
 
@@ -183,7 +183,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("math-2-finish", "100%", 80) }}
 
@@ -240,7 +240,7 @@ To complete the task:
 1. There are three groups, each consisting of a statement and two variables. For each one, write a test that proves or disproves the statement made.
 2. Store the results of those tests in variables called `weightComparison`, `heightComparison`, and `pwdMatch`, respectively.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("math-3", "100%", 80) }}
 
@@ -284,7 +284,7 @@ para3.textContent = pwdTest;
 section.appendChild(para3);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("math-3-finish", "100%", 100) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/object_basics/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/object_basics/index.md
@@ -42,7 +42,7 @@ p {
 
 <!-- Example-specific code -->
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("objects-1", "100%", 60) }}
 
@@ -73,7 +73,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("objects-1-finish", "100%", 80) }}
 
@@ -139,7 +139,7 @@ To complete the task:
        > Include at least two albums in the `albums` array.
 2. Write a string to the variable `bandInfo`, which will contain a small biography detailing their name, nationality, years active, and style, and the title and release date of their first album.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("objects-2", "100%", 60) }}
 
@@ -160,7 +160,7 @@ para1.textContent = bandInfo;
 section.appendChild(para1);
 ```
 
-The finished output should look something like this:
+The updated output should look something like this:
 
 {{ EmbedLiveSample("objects-2-finish", "100%", 60) }}
 
@@ -256,7 +256,7 @@ To complete the task:
 2. Write your own object called `cat2`, which has the same structure and `greeting()` method, but a different `name`, `breed`, and `color`.
 3. Call both `greeting()` methods to check that they log appropriate greetings to the console.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown):
 
 {{ EmbedLiveSample("objects-3", "100%", 60) }}
 
@@ -277,7 +277,7 @@ const cat = {
 // Add your code here
 ```
 
-We've not shown the output of the finished code, as it doesn't print anything to the DOM. The output is all logged to the console.
+We've not provided finished content for this task, as it doesn't print anything to the DOM. The output is all logged to the console.
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -335,7 +335,7 @@ To complete the task:
 1. Create a JavaScript class that defines cat instances
 2. Use your class along with the `new` keyword to create the `cat` and `cat2` instances.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown):
 
 {{ EmbedLiveSample("objects-4", "100%", 60) }}
 
@@ -366,7 +366,7 @@ cat.greeting();
 cat2.greeting();
 ```
 
-We've not shown the output of the finished code, as it doesn't print anything to the DOM. The output is all logged to the console.
+We've not provided finished content for this task, as it doesn't print anything to the DOM. The output is all logged to the console.
 
 <details>
 <summary>Click here to show the solution</summary>

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/strings/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/strings/index.md
@@ -42,7 +42,7 @@ p {
 
 <!-- Example-specific code -->
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("strings-1", "100%", 60) }}
 
@@ -61,7 +61,7 @@ para1.textContent = finalQuote;
 section.appendChild(para1);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("strings-1-finish", "100%", 60) }}
 
@@ -109,7 +109,7 @@ To complete the task:
 2. Find the index position where `substring` appears in `quote`, and store that value in a variable called `index`.
 3. Use a combination of the variables you have and available string properties/methods to trim down the original quote to "I do not like green eggs and ham.", and store it in a variable called `revisedQuote`.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("strings-2", "100%", 60) }}
 
@@ -135,7 +135,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("strings-2-finish", "100%", 80) }}
 
@@ -186,7 +186,7 @@ To complete the task:
 2. In `fixedQuote`, replace "green eggs and ham" with another food that you really don't like.
 3. There is one more small fix to do — add a period to the end of the quote, and save the final version in a variable called `finalQuote`.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("strings-3", "100%", 60) }}
 
@@ -207,7 +207,7 @@ para1.textContent = finalQuote;
 section.appendChild(para1);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("strings-3-finish", "100%", 60) }}
 
@@ -285,7 +285,7 @@ para1.textContent = myString;
 section.appendChild(para1);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("strings-4-finish", "100%", 60) }}
 

--- a/files/en-us/learn_web_development/core/scripting/test_your_skills/variables/index.md
+++ b/files/en-us/learn_web_development/core/scripting/test_your_skills/variables/index.md
@@ -65,7 +65,7 @@ para.textContent = myName;
 section.appendChild(para);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("variables-1-finish", "100%", 60) }}
 
@@ -101,7 +101,7 @@ section.appendChild(para);
 
 The final task for now — in this case you are provided with some existing code, which has two errors present in it. The results panel should be outputting the name `Chris`, and a statement about how old Chris will be in 20 years' time. We want you to fix the problem and correct the output.
 
-The starting point of the task looks like this:
+The starting point of the task looks like this (nothing is shown yet):
 
 {{ EmbedLiveSample("variables-2", "100%", 60) }}
 
@@ -126,7 +126,7 @@ section.appendChild(para1);
 section.appendChild(para2);
 ```
 
-The finished output should look like this:
+The updated output should look like this:
 
 {{ EmbedLiveSample("variables-2-finish", "100%", 80) }}
 
@@ -165,6 +165,6 @@ section.appendChild(para2);
 
 ## See also
 
-Also check out [Practice time - Part 3: let and const](https://scrimba.com/learn-javascript-c0v/~059?via=mdn) <sup>[_MDN learning partner_](/en-US/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> from Scrimba: An interactive challenge providing multiple tests concerning `let` and `const`.
+Check out [Practice time - Part 3: let and const](https://scrimba.com/learn-javascript-c0v/~059?via=mdn) <sup>[_MDN learning partner_](/en-US/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> from Scrimba: An interactive challenge providing multiple tests concerning `let` and `const`.
 
 {{PreviousMenuNext("Learn_web_development/Core/Scripting/Variables", "Learn_web_development/Core/Scripting/Math", "Learn_web_development/Core/Scripting")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I got some feedback that the ordering of the "Test your skills" articles has become confusing since the last update. Specifically, in some of the tests, the "solution" live sample appears before the "starting state" live sample, so it is unclear which one to click on to start the test.

To remedy this, I have decided to go through all the "Test your skills" articles and make the structure as consistent as possible throughout, fixing the above issue in the process.

This PR in particular updates the structure of the [Dynamic scripting with JavaScript](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting) "Test your skills" articles.

Note: Not all of the tests show the finished state of the example. I have elected not to show it in cases where the before and after rendering look no different, where the final rendering gives away the answer, and where the question is freeform so there is no single answer.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
