### PR TITLE
Reorder accessibility test your skills for consistency

### DIFF
--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/css_and_javascript/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/css_and_javascript/index.md
@@ -189,9 +189,9 @@ p {
 }
 ```
 
-The finished content should look like this:
+The updated content should look like this:
 
-{{ EmbedLiveSample("css-js-ally-2-finish", "100%", 300) }}
+{{ EmbedLiveSample("css-js-ally-2-finish", "100%", 600) }}
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -329,7 +329,7 @@ function handleSelection(e) {
 }
 ```
 
-We've not shown the finished content rendered, as it doesn't look significantly different to the starting state.
+We've not provided finished content for this task, as it looks the same as the starting point.
 
 <details>
 <summary>Click here to show the solution</summary>

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/html/index.md
@@ -43,7 +43,7 @@ body {
 
 The starting point of the task looks like this:
 
-{{ EmbedLiveSample("html-ally-1", "100%", 400) }}
+{{ EmbedLiveSample("html-ally-1", "100%", 630) }}
 
 Here's the underlying code for this starting point:
 
@@ -84,7 +84,7 @@ answer you're looking for.
 }
 ```
 
-We've not shown the finished content rendered, as it doesn't look significantly different to the starting state.
+We've not provided finished content for this task, as it doesn't look significantly different to the starting state.
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -177,7 +177,7 @@ li {
 }
 ```
 
-The finished form should look like this:
+The updated form should look like this:
 
 {{ EmbedLiveSample("html-ally-2-finish", "100%", 220) }}
 
@@ -240,7 +240,7 @@ Here's the underlying code for this starting point:
 > [!NOTE]
 > The links in the starting code have the `target="_blank"` attribute set on them, so that when you click on them, they try to open the linked pages in a new tab rather than the same tab. This is not strictly best practice, but we've done it here so that the pages don't open in the MDN Playground output `<iframe>`, getting rid of your example code in the process!
 
-We've not shown the finished content rendered, as it would give the answers away.
+We've not provided finished content for this task, as it would give the solution away.
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -314,7 +314,7 @@ header {
 }
 ```
 
-We've not shown the finished content rendered, as it doesn't look any different to the starting state.
+We've not provided finished content for this task, as it looks the same as the starting point.
 
 <details>
 <summary>Click here to show the solution</summary>

--- a/files/en-us/learn_web_development/core/accessibility/test_your_skills/wai-aria/index.md
+++ b/files/en-us/learn_web_development/core/accessibility/test_your_skills/wai-aria/index.md
@@ -77,7 +77,7 @@ div > div::before {
 }
 ```
 
-We've not shown the finished content rendered, as it doesn't look any different to the starting state.
+We've not provided finished content for this task, as it looks the same as the starting point.
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -119,7 +119,7 @@ Here's the underlying code for this starting point:
 </form>
 ```
 
-We've not shown the finished content rendered, as it doesn't look significantly different to the starting state.
+We've not provided finished content for this task, as it doesn't look significantly different to the starting state.
 
 <details>
 <summary>Click here to show the solution</summary>
@@ -224,7 +224,7 @@ function handleSelection(e) {
 }
 ```
 
-We've not shown the finished content rendered, as it doesn't look any different to the starting state.
+We've not provided finished content for this task, as it looks the same as the starting point.
 
 <details>
 <summary>Click here to show the solution</summary>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I got some feedback that the ordering of the "Test your skills" articles has become confusing since the last update. Specifically, in some of the tests, the "solution" live sample appears before the "starting state" live sample, so it is unclear which one to click on to start the test.

To remedy this, I have decided to go through all the "Test your skills" articles and make the structure as consistent as possible throughout, fixing the above issue in the process.

This PR in particular updates the structure of the [Accessibility on the web](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Accessibility) "Test your skills" articles.

Note: Not all of the tests show the finished state of the example. I have elected not to show it in cases where the before and after rendering look no different, where the final rendering gives away the answer, and where the question is freeform so there is no single answer.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
