### PR TITLE
ShadowRoot.referenceTarget is not read-only

### DIFF
--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -39,7 +39,7 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
   - : Returns the {{DOMxRef('Element')}} set as the target for mouse events while the pointer is locked.
     `null` if lock is pending, pointer is unlocked, or if the target is in another tree.
 - `ShadowRoot.referenceTarget` {{Experimental_Inline}} {{non-standard_inline}}
-  - : A string value that indicates the effective target of any element reference made against the shadow host from outside the host element. The value should be the ID of an element inside the shadow DOM. If set, target references to the host element from outside the shadow DOM will cause the referenced target element to become the effective target of the reference to the host element.
+  - : A nullable string value that indicates the effective target of any element reference made against the shadow host from outside the host element. The value should be the ID of an element inside the shadow DOM. If set, target references to the host element from outside the shadow DOM will cause the referenced target element to become the effective target of the reference to the host element.
 - {{DOMxRef("ShadowRoot.serializable")}} {{ReadOnlyInline}}
   - : A boolean that indicates whether the shadow root is serializable.
     A serializable shadow root inside an element will be serialized by {{DOMxRef('Element.getHTML()')}} or {{DOMxRef('ShadowRoot.getHTML()')}} when its [`options.serializableShadowRoots`](/en-US/docs/Web/API/Element/getHTML#serializableshadowroots) parameter is set `true`.


### PR DESCRIPTION
### Description

Remove the ReadOnly marker, and also note that it's nullable.

### Additional details

This is the PR against the DOM standard which specifies the `referenceTarget` IDL attribute: https://whatpr.org/dom/1353.html#interface-shadowroot