### PR TITLE
[WebExtensions] Document runtime.getVersion() method

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.runtime.getManifest
 sidebar: addonsidebar
 ---
 
-Get the object representation of [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file. This representation is produced from browser-internal data structures and may differ from what would be produced by running `JSON.parse()` on the actual file within extension.
+Get the extension's [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file as an object. The object is created from browser-internal data structures and can differ from a representation produced by running `JSON.parse()` on the file in the extension.
 
 ## Syntax
 
@@ -39,7 +39,7 @@ console.log(manifest.name);
 
 ## See also
 
-- {{WebExtAPIRef("runtime.getVersion()")}} method which returns value of [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) manifest key
+- The {{WebExtAPIRef("runtime.getVersion()")}} method, which returns the value of the [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) manifest key.
 
 > [!NOTE]
 > This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getManifest) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getversion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getversion/index.md
@@ -6,12 +6,12 @@ browser-compat: webextensions.api.runtime.getVersion
 sidebar: addonsidebar
 ---
 
-Returns the extension's version as declared by developer in the [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) [manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) key.
+Returns the extension's version from the [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) [manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) key.
 
 ## Syntax
 
 ```js-nolint
-browser.runtime.getVersion()
+let extensionVersion = await browser.runtime.getVersion()
 ```
 
 ### Parameters
@@ -21,6 +21,9 @@ None.
 ### Return value
 
 A `string` containing the extension's version as declared in the manifest.
+
+> [!NOTE]
+> The returned version may differ from the string in the file because the browser can parse and serialize it.
 
 ## Examples
 
@@ -39,5 +42,5 @@ console.log(version);
 
 ## See also
 
-- {{WebExtAPIRef("runtime.getManifest()")}} method which returns representation of the entire manifest
+- The {{WebExtAPIRef("runtime.getManifest()")}} method, which returns the entire manifest as an object.
 - Manifest [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) key

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -57,11 +57,11 @@ It also provides messaging APIs enabling you to:
 - {{WebExtAPIRef("runtime.getFrameId()")}}
   - : Gets the frame ID of any window global or frame element.
 - {{WebExtAPIRef("runtime.getManifest()")}}
-  - : Gets the object representation of complete [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
+  - : Gets an object representation of the complete [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
 - {{WebExtAPIRef("runtime.getURL()")}}
   - : Given a relative path from the [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) to a resource packaged with the extension, returns a fully-qualified URL.
 - {{WebExtAPIRef("runtime.getVersion()")}}
-  - : Gets the extension version string from [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) field. The returned version may be distinct from the actual string in the file, because it may be parsed and then serializad by the browser.
+  - : Gets the extension version string from the [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) key. The returned version may differ from the string in the file because the browser can parse and serialize it.
 - {{WebExtAPIRef("runtime.setUninstallURL()")}}
   - : Sets a URL to be visited when the extension is uninstalled.
 - {{WebExtAPIRef("runtime.reload()")}}

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.md
@@ -72,5 +72,5 @@ You see this in the console log:
 
 ## See also
 
-- {{WebExtAPIRef("runtime.getVersion()")}} method
-- [`version_name`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name) manifest key
+- The {{WebExtAPIRef("runtime.getVersion()")}} method
+- The [`version_name`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name) manifest key

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
@@ -27,9 +27,9 @@ sidebar: addonsidebar
   </tbody>
 </table>
 
-In addition to the [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) field, which is used for update purposes, `version_name` can be set to a descriptive version string and will be used for display purposes if present.
+In addition to the [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) key, which is used for update purposes, `version_name` can be set to a descriptive version string and is used as the displayed version value.
 
-If no `version_name` is present, the `version` field will be used for display purposes as well.
+If `version_name` isn't present, the `version` property is used as the displayed version.
 
 ## Browser compatibility
 
@@ -37,4 +37,4 @@ If no `version_name` is present, the `version` field will be used for display pu
 
 ## See also
 
-- [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) manifest key
+- The [`version`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) manifest key


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Add documentation for the new `runtime.getVersion()` method, supported on Chrome 143+[1], Safari 26.2[2][3]. Firefox does not support it yet[4]. Cross-link with other files. Update related sections in other documents.

### Motivation

This method was created in W3C WECG as a standard way to access extension version, and an alternative to implementation-dependent runtime.getManifest().version[5][6]

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Sources:
[1] https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getVersion
[2] https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes
[3] https://github.com/WebKit/WebKit/pull/51763
[4] https://bugzilla.mozilla.org/show_bug.cgi?id=1992418
[5] https://github.com/w3c/webextensions/issues/878
[6] https://github.com/w3c/webextensions/issues/400

### Related issues and pull requests

Companion BCD PR: https://github.com/mdn/browser-compat-data/pull/28942
Companion BCD data released in 7.3.1: https://github.com/mdn/browser-compat-data/releases/tag/v7.3.1

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
