### PR TITLE
docs: clarify <dialog> Esc close request behavior

### DIFF
--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -152,7 +152,7 @@ This example demonstrates the [`returnValue`](/en-US/docs/Web/API/HTMLDialogElem
 
 This example opens a modal dialog when the "Show the dialog" button is activated. The dialog contains a form with a {{HTMLElement("select")}} and two {{HTMLElement("button")}} elements, which default to `type="submit"`. An event listener updates the value of the "Confirm" button when the select option changes. If the "Confirm" button is activated to close the dialog, the current value of the button is the return value. If the dialog is closed by pressing the "Cancel" button, the `returnValue` is `cancel`.
 
-When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the `returnValue` is not updated, and the `close` event doesn't occur, so the text in the {{HTMLElement("output")}} is not updated.
+When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the dialog first triggers the [`cancel`](/en-US/docs/Web/API/HTMLDialogElement/cancel_event) event and then the [`close`](/en-US/docs/Web/API/HTMLDialogElement/close_event) event, leaving the `returnValue` as an empty string, so the {{HTMLElement("output")}} displays an empty return value.
 
 #### HTML
 

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -152,7 +152,7 @@ This example demonstrates the [`returnValue`](/en-US/docs/Web/API/HTMLDialogElem
 
 This example opens a modal dialog when the "Show the dialog" button is activated. The dialog contains a form with a {{HTMLElement("select")}} and two {{HTMLElement("button")}} elements, which default to `type="submit"`. An event listener updates the value of the "Confirm" button when the select option changes. If the "Confirm" button is activated to close the dialog, the current value of the button is the return value. If the dialog is closed by pressing the "Cancel" button, the `returnValue` is `cancel`.
 
-When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the dialog first triggers the [`cancel`](/en-US/docs/Web/API/HTMLDialogElement/cancel_event) event and then the [`close`](/en-US/docs/Web/API/HTMLDialogElement/close_event) event, leaving the `returnValue` as an empty string, so the {{HTMLElement("output")}} displays an empty return value.
+When the dialog is closed, the `returnValue` is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the dialog first triggers the [`cancel`](/en-US/docs/Web/API/HTMLDialogElement/cancel_event) event and then the [`close`](/en-US/docs/Web/API/HTMLDialogElement/close_event) event, leaving the `returnValue` as an empty string.
 
 #### HTML
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Corrects the explanation of how a modal `<dialog>` is dismissed when the user presses the Esc key. It clarifies the sequence of events, `cancel` followed by `close`, if not prevented, and explains that no explicit return value is provided in this case leaving `dialog.returnValue` as an empty string.

### Motivation

I would like to help and contribute to the MDN documentation and thought to give it a shot with this small issue first. 🙂 

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes #41656

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
