### PR TITLE
Update Fx148 relnotes to include initial about:blank

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -18,9 +18,9 @@ Firefox 148 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- ### Developer Tools -->
 
-<!-- ### HTML -->
+### HTML
 
-<!-- No notable changes. -->
+- The initial `about:blank` document now loads synchronously. A browsing context's first navigation may resolve to `about:blank` (for example, when the initial URL is empty or explicitly set to `about:blank`). In these cases, Firefox no longer replaces the initial empty document with a second, asynchronously loaded one, and instead fires the `load` event synchronously on the initial document. ([Firefox bug 543435](https://bugzil.la/543435)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Quoting from the change:
> The initial `about:blank` document now loads synchronously. A browsing context's first navigation may resolve to `about:blank` (for example, when the initial URL is empty or explicitly set to `about:blank`). In these cases, Firefox no longer replaces the initial empty document with a second, asynchronously loaded one, and instead fires the `load` event synchronously on the initial document.

### Motivation

Changing the timing of `about:blank` loads solves a long-standing web-compat issue. But we've seen web pages or addons break, so developers might want to know about this change.

To name some examples of what changed:
- `window.open("about:blank").onload = handler` the handler won't run anymore because load already fired
- The same with `ifr = document.createElement("iframe"); document.body.append(ifr); ifr.onload = handler;`
- If an empty iframe is appended and synchronously removed, declarative extension content scripts could execute in it anyway.
- `ifr = document.createElement("iframe"); ifr.onload = handler; document.body.append(ifr); ifr.src = other` will observe two load events now because `src` was set too late.

### Related issues and pull requests

- https://bugzilla.mozilla.org/show_bug.cgi?id=543435
- https://www.firefox.com/en-US/firefox/148.0beta/releasenotes/
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
