### PR TITLE
Update template element description for CSS scoping

### DIFF
--- a/files/en-us/web/api/web_components/using_templates_and_slots/index.md
+++ b/files/en-us/web/api/web_components/using_templates_and_slots/index.md
@@ -232,7 +232,7 @@ First of all, we use the {{HTMLElement("slot")}} element within a {{HTMLElement(
 
 That {{HTMLElement("template")}} element has several features:
 
-- The {{HTMLElement("template")}} has a {{HTMLElement("style")}} element with a set of CSS styles that are scoped just to the document fragment the {{HTMLElement("template")}} creates.
+- The {{HTMLElement("template")}} has a {{HTMLElement("style")}} element with a set of CSS styles that are scoped just to the document fragment the {{HTMLElement("template")}} creates, These styles are scoped this way because that fragment will be inserted into a shadow root element.
 - The {{HTMLElement("template")}} uses {{HTMLElement("slot")}} and its [`name`](/en-US/docs/Web/HTML/Reference/Elements/slot#name) attribute to make three [named slots](/en-US/docs/Web/HTML/Reference/Elements/slot#name):
   - `<slot name="element-name">`
   - `<slot name="description">`


### PR DESCRIPTION
Clarified why the scoping of CSS styles in the template element happens.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Added a clarification of why the styles are scoped to the template fragment.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I was reading the documentation and I got confused as the JavaScript follow up was still below.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
