### PR TITLE
AudioNode::disconnect signatures

### DIFF
--- a/files/en-us/web/api/audionode/disconnect/index.md
+++ b/files/en-us/web/api/audionode/disconnect/index.md
@@ -14,6 +14,10 @@ The **`disconnect()`** method of the {{ domxref("AudioNode") }} interface lets y
 
 ```js-nolint
 disconnect()
+disconnect(output)
+disconnect(destination)
+disconnect(destination, output)
+disconnect(destination, output, input)
 ```
 
 ### Parameters
@@ -25,7 +29,7 @@ There are several versions of the `disconnect()` method, which accept different 
 - `output` {{optional_inline}}
   - : An index describing which output from the current `AudioNode` is to be disconnected. The index numbers are defined according to the number of output channels (see [Audio channels](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#audio_channels)).
 - `input` {{optional_inline}}
-  - : An index describing which input into the specified destination `AudioNode` is to be disconnected. The index numbers are defined according to the number of input channels (see [Audio channels](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#audio_channels)).
+  - : An index describing which input into the specified destination `AudioNode` is to be disconnected. The index numbers are defined according to the number of input channels (see [Audio channels](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#audio_channels)). Not applicable if `destination` is an `AudioParam`.
 
 ### Return value
 


### PR DESCRIPTION
Add other missing method signatures to AudioNode disconnect() method, according to specification

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
The `AudioNode` `disconnect` method description was missing several signatures indicated by the specification, which this PR adds.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I came to MDN looking for the full set of signature overloads, but had to skip to the specification instead.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Specification signatures: https://webaudio.github.io/web-audio-api/#dom-audionode-disconnect

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
