### PR TITLE
Update wording around multi-keyword syntax for the `display` property

### DIFF
--- a/files/en-us/web/css/reference/properties/display/index.md
+++ b/files/en-us/web/css/reference/properties/display/index.md
@@ -130,7 +130,7 @@ The keyword values can be grouped into six value categories.
       - : The element generates one or more inline boxes that do not generate line breaks before or after themselves. In normal flow, the next element will be on the same line if there is space.
 
 > [!NOTE]
-> When a display property is set with only an **outer** value (e.g., `display: block` or `display: inline`), the inner value defaults to `flow` (e.g., `display: block flow` and `display: inline flow`).
+> When a display property is specified with only an **outer** value (e.g., `display: block` or `display: inline`), the inner value defaults to `flow` (e.g., `display: block flow` and `display: inline flow`).
 
 > [!NOTE]
 > You may use the single-value syntax as a fallback for multi-keyword syntax, for example `display: inline flex` could have the following fallback
@@ -167,7 +167,7 @@ The keyword values can be grouped into six value categories.
       - : The element behaves like an inline-level element and lays out its content according to the ruby formatting model. It behaves like the corresponding HTML {{HTMLElement("ruby")}} elements.
 
 > [!NOTE]
-> When a display property is set with only an **inner** value (e.g., `display: flex` or `display: grid`), the outer value defaults to `block` (e.g., `display: block flex` and `display: block grid`).
+> When a display property is specified with only an **inner** value (e.g., `display: flex` or `display: grid`), the outer value defaults to `block` (e.g., `display: block flex` and `display: block grid`).
 
 ### List Item
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

The current docs for `display` warn slightly against using the multi-keyword syntax and have some incorrect content (e.g. `block` is not a precomposed value, only `inline-block` is).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Given that multi-keyword syntax is now Baseline Widely Available it seems a good time to update the wording to promote this syntax a bit more.

The multi-keyword syntax makes it easier to fully understand how both inner and outer display modes function.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://drafts.csswg.org/css-display-3/#the-display-properties

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->


None