### PR TITLE
Clarify stacking context behavior when z-index is auto in Example 1

### DIFF
--- a/files/en-us/web/css/guides/positioned_layout/stacking_context/example_1/index.md
+++ b/files/en-us/web/css/guides/positioned_layout/stacking_context/example_1/index.md
@@ -8,9 +8,9 @@ sidebar: cssref
 
 ## Description
 
-Let's start with a basic example. In the root stacking context, there are two relatively positioned `<div>` elements (DIV #1 and DIV #3) without `z-index` properties. Inside DIV #1, there is an absolutely positioned DIV #2, while in DIV #3, there is an absolutely positioned DIV #4, both without `z-index` properties.
+Let's start with a basic example. In the root stacking context, there are two relatively positioned `<div>` elements (DIV #1 and DIV #3) with `z-index: auto`. Inside DIV #1, there is an absolutely positioned DIV #2, and inside DIV #3, there is an absolutely positioned DIV #4, both also with `z-index: auto`.
 
-The only stacking context is the root context. Without `z-index` values, elements are stacked in order of occurrence.
+The only stacking context is the root stacking context. Since no element establishes a new stacking context, all elements are painted in document order according to the standard stacking rules.
 
 ![Stacking context example 1](understanding_zindex_05a.png)
 


### PR DESCRIPTION
Fixes #42296

Clarifies that positioned elements with z-index: auto do not create a stacking context, and that the root stacking context is the only one present in Example 1. This avoids ambiguity in the previous wording.
