### PR TITLE
Fix the <em> and <i> demos

### DIFF
--- a/files/en-us/web/html/reference/elements/em/index.md
+++ b/files/en-us/web/html/reference/elements/em/index.md
@@ -22,6 +22,10 @@ The **`<em>`** [HTML](/en-US/docs/Web/HTML) element marks text that has stress e
 em {
   /* Add your styles here */
 }
+
+p {
+  font-family: reset;
+}
 ```
 
 ## Attributes

--- a/files/en-us/web/html/reference/elements/i/index.md
+++ b/files/en-us/web/html/reference/elements/i/index.md
@@ -28,6 +28,10 @@ The **`<i>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text th
 i {
   /* Add your styles here */
 }
+
+p {
+  font-family: reset;
+}
 ```
 
 ## Attributes


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Fixes the demos on https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em and https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/i.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The demos claim to how the elements mark text that has stress emphasis, but in fact all the text in the demos looks the same. At least on macOS.

<img width="768" height="353" alt="image" src="https://github.com/user-attachments/assets/f1f337d6-c9ca-46f9-bb7a-24c5e607b49b" />

<img width="768" height="353" alt="image" src="https://github.com/user-attachments/assets/04cfed24-6785-4e20-8be6-0dbe60c33ec5" />

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

The solution is not very good because it's ad-hoc. That is, the demos receive an irrelevant `p { ... }` CSS rule just to fix the bug. Ideally, the default `font-family` of the demos should be modified to support all font styles.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
