### PR TITLE
FF148 Document.execCommand() with paste option - FF/Safari updates

### DIFF
--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -263,8 +263,8 @@ pasteButton.addEventListener("click", () => {
 
 #### Result
 
-On browsers that implement this feature using the [Clipboard API](/en-US/docs/Web/API/Clipboard_API#security_considerations) you should be able to copy same-origin content (such as text from the text area) and paste it into the box.
-Cross origin content, copied from any other page or location, can be copied, but when you try to paste it a permission prompt may be displayed.
+On browsers that implement this feature using the [Clipboard API](/en-US/docs/Web/API/Clipboard_API#security_considerations) you should be able to copy same-origin content, such as text from the text area, and then paste it to replace any selected content.
+When you try to paste cross-origin content, such as text copied from any other page or location, you will first need to select the "Paste" UI that is displayed.
 
 {{EmbedLiveSample("Using paste", 100, 300)}}
 


### PR DESCRIPTION
FF148 Supports using Document.execCommand with option "paste" in web content in https://bugzilla.mozilla.org/show_bug.cgi?id=1998195#c18

Previously this would only work on extensions. The change in FF is a reimplementation of the feature using the Clipboard API. So basically you can now paste in web content as well. Transient activation is required. same origin content can paste without anything else, but for cross origin content you get a paste-prompt UI that you have to use to grant the permission. 

With a readClipboard permission an extension can read cross-origin content without the prompt or transient activation. This is as documented in https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations.

Safari seems to use the same model as FF and testing using the example I added here shows support is at least similarl. 

Anyway, this updates the `paste` option to note that this is supported in content, and how, and point to browser compat. There is also an example that eases testing.

Related docs work can be tracked in https://github.com/mdn/content/issues/42747