### PR TITLE
expand link referrerpolicy docs with strict-origin values and Referrerpolicy link

### DIFF
--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -452,4 +452,4 @@ the rendering of the page will be blocked till the resource and its critical sub
 ## See also
 
 - {{HTTPHeader("Link")}} HTTP header
-- {{HTTPHeader("Referrer-Policy")}}
+- {{HTTPHeader("Referrer-Policy")}} HTTP header


### PR DESCRIPTION
Hello,

For the issue - #42969 

for the file --> files/en-us/web/html/reference/elements/link/index.md

1. I have Added strict-origin, strict-origin-when-cross-origin, and same-origin, which are standard and widely supported but were not listed.
2. For strict-origin and strict-origin-when-cross-origin, I have clarified how they behave with HTTPS.
3. Also added link at the start of the referrerpolicy section to the Referrer-Policy header for full explanations and examples. Link to Referrer-Policy in the see also section.

Thank You 😊