### PR TITLE
FF148 Relnote: JS Iterator.zip(), Iterator.zipKeyed()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -39,7 +39,12 @@ Firefox 148 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### JavaScript -->
+### JavaScript
+
+- The {{jsxref("Iterator.zip()")}} and {{jsxref("Iterator.zipKeyed()")}} static methods are now supported.
+  These "zip" together multiple input iterators, returning a new iterator that yields the group of input elements at each iteration step.
+  They are useful when you need to combine data from multiple input iterators that are positionally aligned (the first value yielded by the first iterator corresponds to the first value yielded by the other iterators, and so on).
+  ([Firefox bug 2003333](https://bugzil.la/2003333)).
 
 <!-- No notable changes. -->
 


### PR DESCRIPTION
FF148 ships the TC39 [joint iteration](https://github.com/tc39/proposal-joint-iteration) proposal in https://bugzilla.mozilla.org/show_bug.cgi?id=2003333.

This adds a release note for the two new methods: `Iterator.zip()`, `Iterator.zipKeyed()`

Related docs work can be tracked in #42743