### PR TITLE
remove -webkit- from -moz- explanation

### DIFF
--- a/files/en-us/web/css/reference/properties/position-anchor/index.md
+++ b/files/en-us/web/css/reference/properties/position-anchor/index.md
@@ -298,7 +298,7 @@ The output is anchored to the thumb. Change the value and the output will remain
 {{ EmbedLiveSample("A range thumb as anchor", "100%", "225") }}
 
 > [!NOTE]
-> The anchor positioning CSS for this demo currently doesn't work in Firefox as the slider's thumb, targeted via the {{cssxref("::-moz-range-thumb")}} pseudo-element, is currently not anchorable (see [Firefox bug 1993699](https://bugzil.la/1993699)).
+> The anchor positioning CSS for this demo currently doesn't work in Firefox. The slider's thumb can be targeted via the {{cssxref("::-moz-range-thumb")}} pseudo-element in Firefox, but it is currently not anchorable (see [Firefox bug 1993699](https://bugzil.la/1993699)).
 
 ## Specifications
 


### PR DESCRIPTION
I re-read the note , and figured we should future proof it 