### PR TITLE
Add trailing-slash example to URL href docs

### DIFF
--- a/files/en-us/web/api/url/href/index.md
+++ b/files/en-us/web/api/url/href/index.md
@@ -23,7 +23,7 @@ A string.
 const url = new URL(
   "https://developer.mozilla.org/en-US/docs/Web/API/URL/href",
 );
-console.log(url.href); // Logs: 'https://developer.mozilla.org/en-US/docs/Web/API/URL/href'
+console.log(url.href); // https://developer.mozilla.org/en-US/docs/Web/API/URL/href
 ```
 
 ### Origin-only URL
@@ -32,7 +32,7 @@ For [hierarchical schemes](https://www.rfc-editor.org/rfc/rfc3986#section-1.2.3)
 
 ```js
 const url = new URL("https://developer.mozilla.org");
-console.log(url.href); // Logs: 'https://developer.mozilla.org/'
+console.log(url.href); // https://developer.mozilla.org/
 ```
 
 ## Specifications


### PR DESCRIPTION
Hello,

Fix #43017 

For the file -> files/en-us/web/api/url/href/index.md
1. Added a second example to the URL href docs that shows when the logged URL has a trailing slash (origin-only URLs like https://developer.mozilla.org), and linked to the pathname docs for the full explanation.

Thank you 😊.