### PR TITLE
Fixes div contents in hidden until-found example

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -149,7 +149,7 @@ The event handler changes the text content of the box to illustrate an action th
 
 <div>I'm not hidden</div>
 <div id="until-found-box" hidden="until-found">Hidden until found</div>
-<div>I'm hidden</div>
+<div>I'm not hidden</div>
 ```
 
 ```html hidden


### PR DESCRIPTION
In this section's example, the html shows two div elements that are not hidden.

One of these div elements contained the text "I'm hidden", even though it is always visible.

### Description

Updates the div content from "I'm hidden" to "I'm not hidden" in the hidden until-found example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It means the code example matches the description of what is being shown correctly.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes [#43022](https://github.com/mdn/content/issues/43022)

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
