### PR TITLE
Fixes div contents in hidden until-found example

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/hidden/index.md
+++ b/files/en-us/web/html/reference/global_attributes/hidden/index.md
@@ -149,7 +149,7 @@ The event handler changes the text content of the box to illustrate an action th
 
 <div>I'm not hidden</div>
 <div id="until-found-box" hidden="until-found">Hidden until found</div>
-<div>I'm hidden</div>
+<div>I'm not hidden, either</div>
 ```
 
 ```html hidden


### PR DESCRIPTION
In this section's example, the html shows two div elements that are not hidden.

One of these div elements contained the text "I'm hidden", even though it is always visible.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Updates the div content from "I'm hidden" to "I'm not hidden, either" in the hidden until-found example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

It means the code example matches the description of what is being shown correctly.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes [#43022](https://github.com/mdn/content/issues/43022) 

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
