### PR TITLE
State Partitioning: List "Script cache" under permanently partitioned APIs

### DIFF
--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -90,6 +90,7 @@ As such, the following network APIs and caches are **permanently** partitioned b
 - Image Cache
 - Favicon Cache
 - Connection Pooling
+- Script Cache
 - Stylesheet Cache
 - [DNS](/en-US/docs/Glossary/DNS)
 - HTTP Authentication


### PR DESCRIPTION
The script cache was introduced in Firefox in Fx130 with [Bug 1896709](https://bugzilla.mozilla.org/show_bug.cgi?id=1896709). It is based on `SharedSubResourceCache` which is shared with the Stylesheet Cache and uses the partitioning concept.

I noticed some time after #40157, and just stumbled over my TODO note of adding it to the list :upside_down_face: