### PR TITLE
Document RTCDataChannel.priority and RTCPeerConnectionIceEvent.url properties

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/index.md
+++ b/files/en-us/web/api/rtcdatachannel/index.md
@@ -58,6 +58,10 @@ _Also inherits properties from {{DOMxRef("EventTarget")}}._
 - {{DOMxRef("RTCDataChannel.ordered", "ordered")}} {{ReadOnlyInline}}
   - : Indicates whether or not the data channel guarantees in-order delivery of messages;
     the default is `true`, which indicates that the data channel is indeed ordered.
+- {{DOMxRef("RTCDataChannel.priority", "priority")}} {{ReadOnlyInline}}
+  - : Returns a string indicating the priority of the data channel,
+    as set when the data channel was created, or as assigned by the user agent.
+    Possible values are `"very-low"`, `"low"`, `"medium"`, or `"high"`.
 - {{DOMxRef("RTCDataChannel.protocol", "protocol")}} {{ReadOnlyInline}}
   - : Returns a string containing the name of the subprotocol in use.
     If no protocol was specified

--- a/files/en-us/web/api/rtcdatachannel/priority/index.md
+++ b/files/en-us/web/api/rtcdatachannel/priority/index.md
@@ -1,0 +1,50 @@
+---
+title: "RTCDataChannel: priority property"
+short-title: priority
+slug: Web/API/RTCDataChannel/priority
+page-type: web-api-instance-property
+browser-compat: api.RTCDataChannel.priority
+---
+
+{{APIRef("WebRTC")}}
+
+The read-only **`priority`** property of the {{domxref("RTCDataChannel")}} interface returns a string indicating the priority of the data channel. The priority is assigned by the user agent at channel creation time based on the `priority` option in the `dataChannelDict` parameter passed to {{domxref("RTCPeerConnection.createDataChannel()")}}, or from the remote peer for incoming data channels.
+
+## Value
+
+A string indicating the priority of the data channel. Possible values are, in order from lowest to highest priority:
+
+- `"very-low"`
+  - : The data channel has a very low priority.
+- `"low"`
+  - : The data channel has a low priority. This is the default value.
+- `"medium"`
+  - : The data channel has a medium priority.
+- `"high"`
+  - : The data channel has a high priority.
+
+## Examples
+
+### Checking the priority of a data channel
+
+```js
+const pc = new RTCPeerConnection();
+const dc = pc.createDataChannel("my channel", { priority: "high" });
+
+console.log(dc.priority); // "high"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)
+- [Using WebRTC data channels](/en-US/docs/Web/API/WebRTC_API/Using_data_channels)
+- {{domxref("RTCDataChannel")}}
+- {{domxref("RTCPeerConnection.createDataChannel()")}}

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
@@ -19,6 +19,8 @@ _A `RTCPeerConnectionIceEvent` being an {{domxref("Event")}}, this event also im
 
 - {{domxref("RTCPeerConnectionIceEvent.candidate")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("RTCIceCandidate")}} containing the candidate associated with the event, or `null` if this event indicates that there are no further candidates to come.
+- {{domxref("RTCPeerConnectionIceEvent.url")}} {{ReadOnlyInline}}
+  - : Contains a string indicating the URL of the {{Glossary("STUN")}} or {{Glossary("TURN")}} server used to gather the candidate, or `null` if the candidate was not gathered from a server.
 
 ## Constructors
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/url/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/url/index.md
@@ -1,0 +1,44 @@
+---
+title: "RTCPeerConnectionIceEvent: url property"
+short-title: url
+slug: Web/API/RTCPeerConnectionIceEvent/url
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionIceEvent.url
+---
+
+{{APIRef("WebRTC")}}
+
+The read-only **`url`** property of the {{domxref("RTCPeerConnectionIceEvent")}} interface returns the URL of the {{Glossary("STUN")}} or {{Glossary("TURN")}} server used to gather the ICE candidate that caused the event. If the candidate was not gathered from a {{Glossary("STUN")}} or {{Glossary("TURN")}} server, the value is `null`.
+
+> [!NOTE]
+> This property is considered deprecated by the specification in favor of the `url` property on the {{domxref("RTCIceCandidate")}} interface itself.
+
+## Value
+
+A string containing the URL of the {{Glossary("STUN")}} or {{Glossary("TURN")}} server used to gather this candidate, or `null` if the candidate was not gathered from a server (for example, a local host candidate).
+
+## Examples
+
+### Logging the ICE server URL
+
+```js
+pc.onicecandidate = (event) => {
+  if (event.candidate) {
+    console.log(`Candidate gathered from: ${event.url}`);
+  }
+};
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}}
+- {{domxref("RTCPeerConnectionIceEvent.candidate")}}
+- {{domxref("RTCPeerConnection")}}


### PR DESCRIPTION
### Description

**New pages**

- `/en-US/docs/Web/API/RTCDataChannel/priority` — The `priority` property
- `/en-US/docs/Web/API/RTCPeerConnectionIceEvent/url` — The `url` property

**Updated pages**

- `/en-US/docs/Web/API/RTCDataChannel` — Added `priority` to the list of instance properties
- `/en-US/docs/Web/API/RTCPeerConnectionIceEvent` — Added `url` to the list of instance properties, linked STUN and TURN to glossary entries

### Motivation

Document properties:

- `RTCDataChannel.priority` — supported since Safari 15
- `RTCPeerConnectionIceEvent.url` — supported since Safari 12

…according to BCD.

### Additional details

- [BCD: RTCDataChannel.priority](https://github.com/mdn/browser-compat-data/blob/main/api/RTCDataChannel.json#L716)
- [BCD: RTCPeerConnectionIceEvent.url](https://github.com/mdn/browser-compat-data/blob/main/api/RTCPeerConnectionIceEvent.json#L121)