### PR TITLE
Update definitions of border width keywords

### DIFF
--- a/files/en-us/web/css/reference/properties/border-bottom-width/index.md
+++ b/files/en-us/web/css/reference/properties/border-bottom-width/index.md
@@ -75,11 +75,11 @@ border-bottom-width: unset;
 - `<line-width>`
   - : Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
     - `thin`
+      - Same as `1px`.
     - `medium`
+      - Same as `3px`.
     - `thick`
-
-> [!NOTE]
-> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern `thin ≤ medium ≤ thick`, and the values are constant within a single document.
+      - Same as `5px`.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/border-left-width/index.md
+++ b/files/en-us/web/css/reference/properties/border-left-width/index.md
@@ -75,11 +75,11 @@ border-left-width: unset;
 - `<line-width>`
   - : Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
     - `thin`
+      - Same as `1px`.
     - `medium`
+      - Same as `3px`.
     - `thick`
-
-> [!NOTE]
-> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern `thin ≤ medium ≤ thick`, and the values are constant within a single document.
+      - Same as `5px`.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/border-right-width/index.md
+++ b/files/en-us/web/css/reference/properties/border-right-width/index.md
@@ -75,11 +75,11 @@ border-right-width: unset;
 - `<line-width>`
   - : Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
     - `thin`
+      - Same as `1px`.
     - `medium`
+      - Same as `3px`.
     - `thick`
-
-> [!NOTE]
-> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern `thin ≤ medium ≤ thick`, and the values are constant within a single document.
+      - Same as `5px`.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/border-top-width/index.md
+++ b/files/en-us/web/css/reference/properties/border-top-width/index.md
@@ -75,11 +75,11 @@ border-top-width: unset;
 - `<line-width>`
   - : Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
     - `thin`
+      - Same as `1px`.
     - `medium`
+      - Same as `3px`.
     - `thick`
-
-> [!NOTE]
-> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern `thin ≤ medium ≤ thick`, and the values are constant within a single document.
+      - Same as `5px`.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/border-width/index.md
+++ b/files/en-us/web/css/reference/properties/border-width/index.md
@@ -99,11 +99,11 @@ The `border-width` property may be specified using one, two, three, or four valu
 - `<line-width>`
   - : Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
     - `thin`
+      - Same as `1px`.
     - `medium`
+      - Same as `3px`.
     - `thick`
-
-> [!NOTE]
-> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern `thin ≤ medium ≤ thick`, and the values are constant within a single document.
+      - Same as `5px`.
 
 ## Formal definition
 


### PR DESCRIPTION
### Description

Updates the locations describing the border-width keyword values (thin, medium thick) to call out the values they correspond to, rather than the (old, no longer valid) claim that the values are not defined by the spec.

### Motivation

Theses values did start out without crisp equivalents, but in 2022 they were updated to have these specific definitions.

https://github.com/w3c/csswg-drafts/issues/7254
> RESOLVED: thin, medium, and thick will be defined as 1px, 3px, and 5px respectively.

https://drafts.csswg.org/css-borders-4/#border-width
> The thin, medium, and thick keywords are equivalent to 1px, 3px, and 5px, respectively.