### PR TITLE
Update outdated information on border-width keywords

### DIFF
--- a/files/en-us/web/css/reference/properties/border-width/index.md
+++ b/files/en-us/web/css/reference/properties/border-width/index.md
@@ -102,8 +102,7 @@ The `border-width` property may be specified using one, two, three, or four valu
     - `medium`
     - `thick`
 
-> [!NOTE]
-> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern `thin ≤ medium ≤ thick`, and the values are constant within a single document.
+These keywords are equivalent to 1px, 3px, and 5px widths, respectively.
 
 ## Formal definition
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This changes the note about the meaning of the border-width values `thin`, `medium` and `thick` being implementation-defined to instead note their spec widths.

### Motivation

The spec defines this nowadays.

### Additional details

See https://drafts.csswg.org/css-backgrounds/#border-width

### Related issues and pull requests

None that I am aware of.