### PR TITLE
Fix WeakMap equivalent emulating private members with private fields …

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -193,6 +193,8 @@ class Thing {
   }
 }
 
+const thing = new Thing();
+
 console.log(thing);
 // Thing {someProperty: "foo"}
 


### PR DESCRIPTION
…example missing Thing instantiation

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Add the missing `Thing` instantiation to the example of emulating private members with private fields. Without it, the example on this page https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap throws a ReferenceError when run because thing is not defined


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Users copying the example as-is will encounter a runtime error

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
