### PR TITLE
docs: fix local preview URL casing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ This will make it easier to submit a pull request for your changes.
 1. When the server is running, make the changes you would like to make to one or more `index.md` files.
 
 2. Open a browser and navigate to the equivalent pages you've changed.
-   If you changed `files/en-us/web/javascript/index.md`, you would navigate to `http://localhost:5042/en-us/docs/web/javascript` in your browser, for example.
+   If you changed `files/en-us/web/javascript/index.md`, you would navigate to `http://localhost:5042/en-US/docs/web/javascript` in your browser, for example.
 
 3. Check for detected flaws at the top of the previewed page. Some flaws may be automatically fixable.
 


### PR DESCRIPTION
## Summary
- Update the local preview example URL in CONTRIBUTING.md to use the correct locale casing (en-US).

## Why
- The previous example used en-us, which does not match MDN locale casing and can lead to 404s when contributors copy/paste the URL.

## Testing
- Not required (docs-only change).
