### PR TITLE
Fix inherits value in @property definition

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@property/index.md
+++ b/files/en-us/web/css/reference/at-rules/@property/index.md
@@ -27,7 +27,7 @@ The **`@property`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/Gui
 
 @property --defaultSize {
   syntax: "<length> | <percentage>";
-  inherits: "true";
+  inherits: true;
   initial-value: 200px;
 }
 ```


### PR DESCRIPTION
inherits is a boolean value, it shouldn't be inside quote marks.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Remove quote marks from inherits value in the initial Syntax box

### Motivation
inherits requires a boolean value true or false.
The current demo gives the impression that having the value within quote marks is valid syntax whereas in reality it will cause it to fail.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
