### PR TITLE
test(front-matter): update expectation

### DIFF
--- a/tests/front-matter_test_files/prettify.valid.md
+++ b/tests/front-matter_test_files/prettify.valid.md
@@ -1,7 +1,6 @@
 ---
-title: >-
-  some api method() with a very very too much very long title tile for the page
-  which doesn't fit 80 char per line constraint
+title: some api method() with a very very too much very long title tile for the
+  page which doesn't fit 80 char per line constraint
 slug: Web/api/method
 page-type: web-api-method
 status:
@@ -9,8 +8,7 @@ status:
   - experimental
   - non-standard
 browser-compat: api.method
-spec-urls: >-
-  https://www.w3c.org/api/method/long/long/too/much/very/long/url/tofit/in/a/line/long
+spec-urls: https://www.w3c.org/api/method/long/long/too/much/very/long/url/tofit/in/a/line/long
 ---
 
 Content


### PR DESCRIPTION
### Description

1. Fixes the front-matter test expectation.
2. Fixes the lefthook config, running `npm test`.

### Motivation

`npm test` was reporting errors, because the test expectation was no longer in sync with prettier.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/43035.