### PR TITLE
Fix references for stroke and fill properties

### DIFF
--- a/files/en-us/web/css/reference/selectors/_doublecolon_highlight/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_highlight/index.md
@@ -20,7 +20,7 @@ Only certain CSS properties can be used with `::highlight()`:
 - {{CSSxRef("background-color")}}
 - {{CSSxRef("text-decoration")}} and its associated properties
 - {{CSSxRef("text-shadow")}}
-- {{CSSxRef("-webkit-text-stroke-color")}}, {{CSSxRef("-webkit-text-fill-color")}} and {{CSSxRef("-webkit-text-stroke-width")}}
+- {{CSSxRef("stroke-color")}}, {{CSSxRef("fill-color")}} and {{CSSxRef("stroke-width")}} <!-- NOT the -webkit- ones! -->
 
 In particular, {{CSSxRef("background-image")}} is ignored.
 


### PR DESCRIPTION
### Description

Fixed references for stroke and fill CSS properties.

### Motivation

The [standard](https://drafts.csswg.org/css-pseudo/#selectordef-highlight-custom-ident) says

> Vendor-prefixed properties such as [-webkit-text-fill-color](https://compat.spec.whatwg.org/#propdef--webkit-text-fill-color) are not applicable to the [highlight pseudo-elements](https://drafts.csswg.org/css-pseudo/#highlight-pseudo-element).

### Additional details

See https://bugzilla.mozilla.org/show_bug.cgi?id=2011655 for Firefox support

### Related issues and pull requests

~~Fixes~~ #42863