### PR TITLE
Use waitUntil on response caching example

### DIFF
--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -320,6 +320,10 @@ const cacheFirst = async ({
   // First try to get the resource from the cache
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {
+    // Wait for preload to settle to avoid cancellation warning
+    if (preloadResponsePromise) {
+      preloadResponsePromise.catch(() => {});
+    }
     return responseFromCache;
   }
 


### PR DESCRIPTION
Hello,

Fix #43055 

for the file --> /files/en-us/web/api/service_worker_api/using_service_workers/index.md

1. I have updated the service worker example code with the suggested code change to fix the console warning.

Thank You 😊.