### PR TITLE
Fix incorrect load_dotenv() usage in Django deployment guide

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
@@ -131,7 +131,6 @@ from dotenv import load_dotenv
 env_path = os.path.join(BASE_DIR, ".env")
 if os.path.exists(env_path):
     load_dotenv(env_path)
-
 ```
 
 This loads the `.env` file from the root of the web application.


### PR DESCRIPTION

### Description

Updates the Django deployment guide to correct the usage of `load_dotenv()`. The previous example treated `load_dotenv()` as if it returned a file path, but it actually returns a boolean.

### Motivation

This change aligns the documentation with the actual behaviour of `python-dotenv` and prevents confusion for learners following the Django deployment tutorial.

### Additional details

The updated snippet explicitly constructs the `.env` file path using `os.path.join` and checks for its existence before calling `load_dotenv()`. This keeps the logic consistent with the corrected implementation in the tutorial project.

### Related issues and pull requests

Relates to mdn/django-locallibrary-tutorial#175
