### PR TITLE
Fix typos in permissions and HTMLGeolocationElement docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -46,7 +46,7 @@ For advice on designing your request for runtime permissions, to maximize the li
 - {{WebExtAPIRef("permissions.getAll()")}}
   - : Retrieves all the permissions currently granted to the extension.
 - {{WebExtAPIRef("permissions.remove()")}}
-  - : Givew up a set of permissions.
+  - : Gives up a set of permissions.
 - {{WebExtAPIRef("permissions.request()")}}
   - : Asks for a set of permissions.
 

--- a/files/en-us/web/api/htmlgeolocationelement/index.md
+++ b/files/en-us/web/api/htmlgeolocationelement/index.md
@@ -86,7 +86,7 @@ See the [`<geolocation>`](/en-US/docs/Web/HTML/Reference/Elements/geolocation#ba
 
 ### Embedded map example
 
-This example uses the `<geolocation>` element to retrieve your current location, which is plotted on a map rendered using [Leaflet JS](https://leafletjs.com/). The example also uses a regular `<button>` fallback to retrive the location data in non-supporting browsers.
+This example uses the `<geolocation>` element to retrieve your current location, which is plotted on a map rendered using [Leaflet JS](https://leafletjs.com/). The example also uses a regular `<button>` fallback to retrieve the location data in non-supporting browsers.
 
 #### HTML
 

--- a/files/en-us/web/api/htmlgeolocationelement/invalidreason/index.md
+++ b/files/en-us/web/api/htmlgeolocationelement/invalidreason/index.md
@@ -23,7 +23,7 @@ The empty string (`""`) if the element does not have an active blocker, or one o
 
     Permanent blocker.
 
-- `unsuccesful_registration`
+- `unsuccessful_registration`
   - : More than three `<geolocation>` elements have been inserted into the same document.
 
     Temporary blocker.


### PR DESCRIPTION
Fixes typos reported by the weekly spelling check bot.

- Fix typo "Givew" -> "Gives" in permissions docs
- Fix typo "retrive" -> "retrieve" in HTMLGeolocationElement docs
- Fix typo "unsuccesful_registration" -> "unsuccessful_registration"
