### PR TITLE
Fix hyphenation

### DIFF
--- a/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
@@ -45,13 +45,13 @@ Two important cases here are:
 
 Shorthands handling properties related to edges of a box, like {{cssxref("border-style")}}, {{cssxref("margin")}} or {{cssxref("padding")}}, always use a consistent 1-to-4-value syntax representing those edges:
 
-- **1-value syntax:** `border-width: 1em` — The single value represents all edges: ![Box edges with one-value syntax](border1.png)
+- **1-value syntax:** `border-width: 1em` — A single value represents all edges: ![Box edges with one-value syntax](border1.png)
 
-- **2-value syntax:** `border-width: 1em 2em` — The first value represents the vertical, that is top and bottom, edges, the second the horizontal ones, that is the left and right ones: ![Box edges with two-value syntax](border2.png)
+- **2-value syntax:** `border-width: 1em 2em` — The first value represents the top and bottom edges, and the second value represents the left and right edges: ![Box edges with two-value syntax](border2.png)
 
-- **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top edge, the second, the horizontal, that is left and right, ones, and the third value the bottom edge: ![Box edges with three-value syntax](border3.png)
+- **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top edge, the second value represents the left and right edges, and the third value represents the bottom edge: ![Box edges with three-value syntax](border3.png)
 
-- **4-value syntax:** `border-width: 1em 2em 3em 4em` — The four values represent the top, right, bottom and left edges respectively, always in that order, that is clock-wise starting at the top: ![Box edges with four-value syntax](border4.png) The initial letter of Top-Right-Bottom-Left matches the order of the consonant of the word _trouble_: TRBL. You can also remember it as the order that the hands would rotate on a clock: `1em` starts in the 12 o'clock position, then `2em` in the 3 o'clock position, then `3em` in the 6 o'clock position, and `4em` in the 9 o'clock position.
+- **4-value syntax:** `border-width: 1em 2em 3em 4em` — The four values represent the top, the right, the bottom, and the left edges, respectively, always in that order; that is, clock-wise starting at the top: ![Box edges with four-value syntax](border4.png) The initial letter of Top-Right-Bottom-Left matches the order of the consonant of the word _trouble_: TRBL. You can also remember it as the order that the hands would rotate on a clock: `1em` starts in the 12 o'clock position, then `2em` in the 3 o'clock position, then `3em` in the 6 o'clock position, and `4em` in the 9 o'clock position.
 
 #### Corners of a box
 
@@ -59,11 +59,11 @@ Similarly, shorthands handling properties related to corners of a box, like {{cs
 
 - **1-value syntax:** `border-radius: 1em` — A single value represents all corners: ![Box corners with one-value syntax](corner1.png)
 
-- **2-value syntax:** `border-radius: 1em 2em` — The first value represents the top-left and bottom-right corner and the second values represents the top-right and bottom-left corners: ![Box corners with two-value syntax](corner2.png)
+- **2-value syntax:** `border-radius: 1em 2em` — The first value represents the top-left and bottom-right corners, and the second value represents the top-right and bottom-left corners: ![Box corners with two-value syntax](corner2.png)
 
 - **3-value syntax:** `border-radius: 1em 2em 3em` — The first value represents the top-left corner, the second value represents the top-right and bottom-left corners, and the third value represents the bottom-right corner: ![Box corners with three-value syntax](corner3.png)
 
-- **4-value syntax:** `border-radius: 1em 2em 3em 4em` — The four values represent the top-left, top-right, bottom-right and bottom-left corners respectively, always in that order, that is clock-wise starting at the top-left: ![Box corners with four-value syntax](corner4.png)
+- **4-value syntax:** `border-radius: 1em 2em 3em 4em` — The four values represent the top-left, top-right, bottom-right, and bottom-left corners respectively, always in that order; that is, clock-wise starting at the top-left: ![Box corners with four-value syntax](corner4.png)
 
 ## Background properties
 


### PR DESCRIPTION
Hyphenated words and made a parallel structure.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Hyphenated compound words like top-left, etc.

Made the sentences have parallel structure.

### Motivation

The use of "top left" should be hyphenated to make a single compound modifier before the noun "corner".

Sentences should have parallel structure—"the first value represents..., the second value represents..."—to make the point clear and stronger.

### Additional details

[Purdue's OWL](https://owl.purdue.edu/owl/general_writing/punctuation/hyphen_use.html) on when to hyphenate.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
