### PR TITLE
Replace "edge" with "side" and clarify dsecriptions

### DIFF
--- a/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
@@ -45,13 +45,17 @@ Two important cases here are:
 
 Shorthands handling properties related to the sides of the box, like {{cssxref("border-style")}}, {{cssxref("margin")}} or {{cssxref("padding")}}, always use a consistent 1-to-4-value syntax representing those sides:
 
-- **1-value syntax:** `border-width: 1em` — A single value represents all edges: ![Box edges with one-value syntax](border1.png)
+- **1-value syntax:** `border-width: 1em` — A single value represents all sides: ![Box edges with one-value syntax](border1.png)
 
 - **2-value syntax:** `border-width: 1em 2em` — The first value represents the top and bottom edges, and the second value represents the left and right edges: ![Box edges with two-value syntax](border2.png)
 
 - **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top edge, the second value represents the left and right edges, and the third value represents the bottom edge: ![Box edges with three-value syntax](border3.png)
 
-- **4-value syntax:** `border-width: 1em 2em 3em 4em` — The four values represent the top, the right, the bottom, and the left edges, respectively, always in that order; that is, clock-wise starting at the top: ![Box edges with four-value syntax](border4.png) The initial letter of Top-Right-Bottom-Left matches the order of the consonant of the word _trouble_: TRBL. You can also remember it as the order that the hands would rotate on a clock: `1em` starts in the 12 o'clock position, then `2em` in the 3 o'clock position, then `3em` in the 6 o'clock position, and `4em` in the 9 o'clock position.
+- **2-value syntax:** `border-width: 1em 2em` — The first value represents the top and bottom sides, and the second value represents the left and right sides: ![Box edges with two-value syntax](border2.png)
+
+- **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top side, the second value represents the left and right sides, and the third value represents the bottom side: ![Box edges with three-value syntax](border3.png)
+
+- **4-value syntax:** `border-width: 1em 2em 3em 4em` — The four values represent the top, the right, the bottom, and the left sides, respectively, always in that order; that is, clock-wise starting at the top: ![Box edges with four-value syntax](border4.png) The initial letter of Top-Right-Bottom-Left matches the order of the consonant of the word _trouble_: TRBL. You can also remember it as the order that the hands would rotate on a clock: `1em` starts in the 12 o'clock position, then `2em` in the 3 o'clock position, then `3em` in the 6 o'clock position, and `4em` in the 9 o'clock position.
 
 #### Corners of the box
 


### PR DESCRIPTION
Changed edge to side.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Changed the article from "a" to "the".

Removed the words "horizontal" and "vertical".

Changed the word from "edge" to "side".

### Motivation

There is only one box model in CSS. You aren't choosing from different box models. When making a declaration you are stylizing what to do with the box of that selector.

Simplifies and clarifies the language to make it easier to translate. Also avoid unnecessary comma splicing.

It is more common to refer to sides of a box instead of edges in English. In American trigonometry our mnemonic is "side, angle, side" not "edge, angle, edge".

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
