### PR TITLE
fix grammer and typo animating=>animation

### DIFF
--- a/files/en-us/web/css/guides/animations/index.md
+++ b/files/en-us/web/css/guides/animations/index.md
@@ -13,7 +13,7 @@ The **CSS animations** module lets you animate the values of CSS properties, suc
 
 ## Animations in action
 
-To view the animation in the box below, click the checkbox 'Play the animation' or hover the cursor over the box. When the animation is active, the cloud at the top changes shape, snowflakes fall, and the snow level at the bottom rises.
+To view the animation in the box below, click the checkbox 'Play the animation' or hover the cursor over the box. When the animation is active, the cloud at the top changes shape, snowflakes fall, and the snow level at the bottom rises. To pause the animation, uncheck the checkbox or move your cursor away from the box.
 
 ```html hidden live-sample___animation
 <!-- See aria-label: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label -->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

fix: change "animating" to "animation" in CSS animations guide


### Description

Change "When the animating is active" to "When the animation is active"
in the CSS animations guide

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
