### PR TITLE
ci(auto-merge): fix target-repo

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,6 +11,6 @@ jobs:
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main
     if: github.repository_owner == 'mdn'
     with:
-      target-repo: ${{ github.workflow }}
+      target-repo: ${{ github.repository }}
     secrets:
       GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

Updates the `auto-merge` workflow, correcting the `target-repo` input.

### Motivation

The workflow is currently always skipped.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/1255.