### PR TITLE
Update CPG email

### DIFF
--- a/files/en-us/mdn/community/community_participation_guidelines/index.md
+++ b/files/en-us/mdn/community/community_participation_guidelines/index.md
@@ -70,7 +70,7 @@ Below is a summary of severity levels and enforcement actions.
 
 ### Reporting violations
 
-Reports can be sent to mdn-cpg-report@mozilla.com.
+Reports can be sent to cpg-report@mozilla.com.
 To report a violation or abuse on GitHub, see [GitHub's content reporting guide](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam).
 The **"Report to repository admins"** option must be checked for the MDN team to see a content report.
 
@@ -88,7 +88,7 @@ MDN Community Management assesses the severity of the violation, applies the enf
 
 ### Appeals
 
-Once an incident has been investigated and a decision has been communicated to the relevant parties, all have the opportunity to appeal this decision by sending an email to mdn-cpg-report@mozilla.com.
+Once an incident has been investigated and a decision has been communicated to the relevant parties, all have the opportunity to appeal this decision by sending an email to cpg-report@mozilla.com.
 Appeals are reviewed by a separate, impartial panel.
 
 ### Documentation and record keeping


### PR DESCRIPTION
Updating the email for the MDN CPG form. In the text there is a reference for mdn-cpg-report@mozilla.com but such an email doesn't exist. I am proposign to send to the regular cpg-report instead

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Updated the email for reporting cpg cases in MDN

### Motivation

The current email doesn't work. A user reported this on SUMO forums


