### PR TITLE
Change event listener from `onchange` to `oninput`

### DIFF
--- a/files/en-us/web/css/reference/values/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/reference/values/color_value/contrast-color/index.md
@@ -37,7 +37,7 @@ The `contrast-color()` function returns a value of `white` or `black`, depending
 
 ### Contrasting text for a button
 
-In the following example, the browser automatically applies a contrasting color to the submit {{htmlelement("button")}} text when you change its background color.
+In the following example, the browser automatically applies the selected color to the background of the "Button" {{htmlelement("button")}}, and the contrasting color (black or white) to its text.
 
 ```html hidden
 <label>
@@ -45,7 +45,7 @@ In the following example, the browser automatically applies a contrasting color 
   <input type="color" id="colorPicker" value="#660066" />
 </label>
 <br />
-<button>Submit</button>
+<button>Button</button>
 ```
 
 ```css


### PR DESCRIPTION
### Description

Switching from the `change` event to the `input` event allows the visitor to see color contrast changes in real time as they edit the color.

### Motivation

More immediate visual feedback to the user!
