### PR TITLE
Fix declarativeNetRequest ruleset precedence note

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md
@@ -138,7 +138,7 @@ When the browser evaluates how to handle requests, it checks each extension's ru
 > To control the order in which actions are applied, assign distinct `priority` values to rules whose order of precedence is important.
 
 > [!NOTE]
-> After rule priority and rule action, Firefox considers the ruleset the rule belongs to, in this order of precedence: session > dynamic > session rulesets.
+> After rule priority and rule action, Firefox considers the ruleset the rule belongs to, in this order of precedence: session > dynamic > static rulesets.
 > This cannot be relied upon across browsers, see [WECG issue 280](https://github.com/w3c/webextensions/issues/280).
 
 If only one extension provides a rule for the request, that rule is applied. However, where more than one extension has a matching rule, the browser chooses the one to apply in this order of precedence:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Fixes a typo in the `declarativeNetRequest` "Matching precedence" note by changing:

`session > dynamic > session rulesets`

to:

`session > dynamic > static rulesets`.


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The previous text duplicated `session` and conflicted with the referenced precedence order, which could mislead readers.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

- Content-only change in `files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/index.md`.
- No API behavior changes.


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->

Fixes #43132

<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
