### PR TITLE
Clarify finally block control-flow timing in try...catch

### DIFF
--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -122,7 +122,7 @@ The `finally` block contains statements to execute after the `try` block and `ca
 
 - Immediately after the `try` block finishes execution normally (and no exceptions were thrown);
 - Immediately after the `catch` block finishes execution normally;
-- Immediately before the execution of a control-flow statement (`return`, `throw`, `break`, `continue`) in the `try` block or `catch` block that would exit the block.
+- When a control-flow statement (`return`, `throw`, `break`, or `continue`) in the `try` or `catch` block would transfer control out of the surrounding `try...finally` or `try...catch...finally` statement.
 
 If an exception is thrown from the `try` block, even when there's no `catch` block to handle the exception, the `finally` block still executes, in which case the exception is still thrown immediately after the `finally` block finishes executing.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR makes a small wording clarification in the **“The finally block”** section of the `try...catch` reference to better reflect control-flow timing.

It updates one bullet in `files/en-us/web/javascript/reference/statements/try...catch/index.md`.

* From: “Immediately before the execution of a control-flow statement (`return`, `throw`, `break`, `continue`) …”
* To: “When control flow exits the `try` block or `catch` block through a control-flow statement (`return`, `throw`, `break`, `continue`).”

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The previous wording can read as if `finally` runs *before* the control-flow statement executes.

For `return`, the expression is evaluated first (including side effects), and then `finally` runs before completion leaves the `try...catch...finally` construct.

This tweak keeps the explanation accurate while staying concise.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

- No API or behavior changes.
- No example updates needed.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->

Fixes #43122

<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
