### PR TITLE
Add Exceptions section to AudioBufferSourceNode.buffer

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -18,6 +18,11 @@ generates a single channel containing silence (that is, every sample is 0).
 An {{domxref("AudioBuffer")}} which contains the data representing the sound which the
 node will play.
 
+## Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the `buffer` property has already been set to a non-`null` value, and is then set to a non-`null` value again.
+
 ## Examples
 
 > [!NOTE]


### PR DESCRIPTION
### Description

Added the `Exceptions` section to the `AudioBufferSourceNode.buffer` documentation.

### Motivation

According to the [W3C Web Audio API specification](https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode-attributes), setting the `buffer` property can throw an `InvalidStateError` exception. This behavior is currently not mentioned in the MDN documentation.