### PR TITLE
Fix GainMode's channelInterpretation linking to channelCountMode.

### DIFF
--- a/files/en-us/web/api/gainnode/gainnode/index.md
+++ b/files/en-us/web/api/gainnode/gainnode/index.md
@@ -39,7 +39,7 @@ new GainNode(context, options)
       - : Represents an enumerated value describing the meaning of the channels. This
         interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
         The possible values are `"speakers"` or `"discrete"`. (See
-        {{domxref("AudioNode.channelCountMode")}} for more information including default
+        {{domxref("AudioNode.channelInterpretation")}} for more information including default
         values.)
 
 ### Return value


### PR DESCRIPTION
### Description

Looks like the channel count mode xref was copied and not updated for the following channel interpretation xref on the [GainMode](https://developer.mozilla.org/en-US/docs/Web/API/GainNode/GainNode) page.

### Motivation

Fix mis-targeted link.