### PR TITLE
fix: canonical preview URL casing (Web/JavaScript)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ This will make it easier to submit a pull request for your changes.
 1. When the server is running, make the changes you would like to make to one or more `index.md` files.
 
 2. Open a browser and navigate to the equivalent pages you've changed.
-   If you changed `files/en-us/web/javascript/index.md`, you would navigate to `http://localhost:5042/en-US/docs/web/javascript` in your browser, for example.
+   If you changed `files/en-us/web/javascript/index.md`, you would navigate to `http://localhost:5042/en-US/docs/Web/JavaScript` in your browser, for example.
 
 3. Check for detected flaws at the top of the previewed page. Some flaws may be automatically fixable.
 


### PR DESCRIPTION
Summary

Fix the example preview URL casing in [CONTRIBUTING.md] so it uses the canonical MDN path segments.
Problem

PR #43064 corrected locale casing but left the example path segment lowercase (/docs/web/javascript), which is inconsistent with MDN canonical URLs (/docs/Web/JavaScript) and led to confusion in review.
Change

Update [CONTRIBUTING.md] so the example full preview URL is:
http://localhost:5042/en-US/docs/Web/JavaScript
No other edits — the filesystem copyable path example  is unchanged.

Why

Keeps the contributor workflow unambiguous:
copy-paste the repository path when using the preview server; or
use the canonical MDN URL with correct casing when constructing a full preview URL.
Small, explicit change avoids mixed-convention examples that cause review friction.
Testing & safety

Docs-only change.
Local checks: markdownlint and prettier passed.
No content or build impact beyond the one-line example.